### PR TITLE
Use a temp file for the signature

### DIFF
--- a/Pal/src/host/Linux-SGX/signer/pal-sgx-sign
+++ b/Pal/src/host/Linux-SGX/signer/pal-sgx-sign
@@ -9,6 +9,7 @@ import subprocess
 import hashlib
 import binascii
 import shutil
+import tempfile
 
 """ Default / Architectural Options """
 
@@ -394,7 +395,7 @@ def generate_measurement(attr, areas):
     class mrenclave_digest:
         def __init__(self):
             self.digest = hashlib.sha256()
-            self.file = open("/tmp/hash", "wb")
+            self.file = tempfile.TemporaryFile()
 
         def update(self, payload):
             for er in range(0, len(payload), 64):


### PR DESCRIPTION
On a multi user machine reuse of the /tmp/hash file
by multiple users will cause the build to fail as they
do not have the permission to replace a file created by
another user.

Signed-off-by: Brian McGillion <brian.mcgillion@intel.com>