### PR TITLE
Fix the build for linux driver 1.8

### DIFF
--- a/Pal/src/host/Linux-SGX/sgx-driver/graphene-sgx.h
+++ b/Pal/src/host/Linux-SGX/sgx-driver/graphene-sgx.h
@@ -16,11 +16,13 @@
 #define __packed __attribute__((packed))
 #endif
 
+#if SDK_DRIVER_VERSION > KERNEL_VERSION(1, 8, 0)
 #include "linux-sgx-driver/sgx_user.h"
+#else // 1.8
+#include "linux-sgx-driver/isgx_user.h"
+#endif 
 
-#endif
-
-#if SDK_DRIVER_VERSION < KERNEL_VERSION(1, 8, 0)
+#else // SDK_DRIVER_VERSION < KERNEL_VERSION(1, 8, 0)
 
 #include "linux-sgx-driver/isgx_user.h"
 


### PR DESCRIPTION
When I check out tag sgx_driver_1.8 of the intel driver, the current master branch doesn't build properly.

This fix builds with sgx_driver_1.7, sgx_driver_1.8, and sgx_driver_1.9 for me.