### PR TITLE
Fix signess bug in the syscall dispatcher

### DIFF
--- a/LibOS/shim/src/syscallas.S
+++ b/LibOS/shim/src/syscallas.S
@@ -41,7 +41,7 @@ syscalldb:
         pushq %rbx
 
         cmp $LIBOS_SYSCALL_BOUND, %rax
-        jge isundef
+        jae isundef
 
         leaq shim_table(%rip), %rbx
         movq (%rbx,%rax,8), %rbx


### PR DESCRIPTION
This code generates a SIGSEGV when user's code executes a syscall with a negative index (such syscall is invalid, but shouldn't cause a SIGSEGV).