### PR TITLE
Fix assert for SGX=1 and DEBUG=1 (Issue #97)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,15 +8,15 @@ before_script:
   - git clone https://github.com/01org/linux-sgx-driver.git -b sgx_driver_$ISGX_DRIVER_VERSION
 
 script:
-  - make
+  - make 
   - cd $TRAVIS_BUILD_DIR/Pal/src && make clean && make SGX=1
+  - cd $TRAVIS_BUILD_DIR/Pal/src && make clean && make DEBUG=1
+  - cd $TRAVIS_BUILD_DIR/Pal/src && make clean && make SGX=1 DEBUG=1
   - cd $TRAVIS_BUILD_DIR/Pal/src/host/Linux-SGX/sgx-driver && make
   - cd $TRAVIS_BUILD_DIR/Pal/regression && make regression
   - cd $TRAVIS_BUILD_DIR/LibOS/shim/test/regression && make regression
   - cd $TRAVIS_BUILD_DIR/LibOS/shim/test/apps/ltp && make regression
-  - make clean && make DEBUG=1
-  - make clean && make SGX=1
-  - make clean && make SGX=1 DEBUG=1
+
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,9 @@ script:
   - cd $TRAVIS_BUILD_DIR/Pal/regression && make regression
   - cd $TRAVIS_BUILD_DIR/LibOS/shim/test/regression && make regression
   - cd $TRAVIS_BUILD_DIR/LibOS/shim/test/apps/ltp && make regression
+  - make clean && make DEBUG=1
+  - make clean && make SGX=1
+  - make clean && make SGX=1 DEBUG=1
 
 matrix:
   include:

--- a/Pal/src/host/Linux-SGX/debugger/sgx_gdb.c
+++ b/Pal/src/host/Linux-SGX/debugger/sgx_gdb.c
@@ -25,9 +25,9 @@
 static
 long int __host_ptrace (enum __ptrace_request request, va_list * ap)
 {
-    pid_t pid = va_arg(ap, pid_t);
-    void * addr = va_arg(ap, void *);
-    void * data = va_arg(ap, void *);
+    pid_t pid = va_arg(*ap, pid_t);
+    void * addr = va_arg(*ap, void *);
+    void * data = va_arg(*ap, void *);
     long int res, ret;
 
     if (request > 0 && request < 4)

--- a/Pal/src/host/Linux-SGX/sgx_enclave.c
+++ b/Pal/src/host/Linux-SGX/sgx_enclave.c
@@ -709,3 +709,7 @@ int ecall_thread_start (void)
     EDEBUG(ECALL_THREAD_START, NULL);
     return sgx_ecall(ECALL_THREAD_START, NULL);
 }
+
+void __abort(void) {
+    INLINE_SYSCALL(exit_group, 1, -1); 
+}

--- a/Pal/src/host/Linux-SGX/sgx_enclave.h
+++ b/Pal/src/host/Linux-SGX/sgx_enclave.h
@@ -4,9 +4,6 @@
 #include "pal_linux.h"
 #include "pal_security.h"
 
-#define assert(cond) \
-    do { if (!(cond)) INLINE_SYSCALL(exit_group, 1, 0); } while (0);
-
 int ecall_enclave_start (const char ** arguments, const char ** environments);
 
 int ecall_thread_start (void);


### PR DESCRIPTION
This adds a proper definition of __assert to the SGX urts, as well as extends the travis job to always test that DEBUG=1 variants at least build - I hope catching this sort of issue in the future.