### PR TITLE
Removed 'input' line when running the tests

### DIFF
--- a/Jenkinsfiles/Jenkinsfile
+++ b/Jenkinsfiles/Jenkinsfile
@@ -47,7 +47,6 @@ pipeline {
                             make
                             ./syscalls.sh
                             '''
-                        input 'Tests complete. Do you wish to deploy?'
                     }
                 }
                 stage('Deploy') {


### PR DESCRIPTION
You need to press 'Proceed' or 'Abort' with this input line. Nothing happens after this line on the Jenkins side, so all it does it block the job from finishing.