### PR TITLE
[Urgent!!] Bugs caused by merging #87

### DIFF
--- a/LibOS/glibc-2.19.patch
+++ b/LibOS/glibc-2.19.patch
@@ -664,41 +664,10 @@ index 6dcbabc..c87c773 100644
    LIBC_PROBE (init_start, 2, LM_ID_BASE, r);
  
    /* Auditing checkpoint: we are ready to signal that the initial map
-@@ -1605,140 +1654,11 @@ ERROR: ld.so: object '%s' cannot be loaded as audit interface: %s; ignored.\n",
+@@ -1636,89 +1654,6 @@ ERROR: ld.so: object '%s' cannot be loaded as audit interface: %s; ignored.\n",
  	}
      }
  
--  /* We have two ways to specify objects to preload: via environment
--     variable and via the file /etc/ld.so.preload.  The latter can also
--     be used when security is enabled.  */
--  assert (*first_preload == NULL);
--  struct link_map **preloads = NULL;
--  unsigned int npreloads = 0;
--
--  if (__builtin_expect (preloadlist != NULL, 0))
--    {
--      /* The LD_PRELOAD environment variable gives list of libraries
--	 separated by white space or colons that are loaded before the
--	 executable's dependencies and prepended to the global scope
--	 list.  If the binary is running setuid all elements
--	 containing a '/' are ignored since it is insecure.  */
--      char *list = strdupa (preloadlist);
--      char *p;
--
--      HP_TIMING_NOW (start);
--
--      /* Prevent optimizing strsep.  Speed is not important here.  */
--      while ((p = (strsep) (&list, " :")) != NULL)
--	if (p[0] != '\0'
--	    && (__builtin_expect (! INTUSE(__libc_enable_secure), 1)
--		|| strchr (p, '/') == NULL))
--	  npreloads += do_preload (p, main_map, "LD_PRELOAD");
--
--      HP_TIMING_NOW (stop);
--      HP_TIMING_DIFF (diff, start, stop);
--      HP_TIMING_ACCUM_NT (load_time, diff);
--    }
--
 -  /* There usually is no ld.so.preload file, it should only be used
 -     for emergencies and testing.  So the open call etc should usually
 -     fail.  Using access() on a non-existing file is faster than using
@@ -782,30 +751,9 @@ index 6dcbabc..c87c773 100644
 -	  __munmap (file, file_size);
 -	}
 -    }
--
--  if (__builtin_expect (*first_preload != NULL, 0))
--    {
--      /* Set up PRELOADS with a vector of the preloaded libraries.  */
--      struct link_map *l = *first_preload;
--      preloads = __alloca (npreloads * sizeof preloads[0]);
--      i = 0;
--      do
--	{
--	  preloads[i++] = l;
--	  l = l->l_next;
--	} while (l);
--      assert (i == npreloads);
--    }
--
-   /* Load all the libraries specified by DT_NEEDED entries.  If LD_PRELOAD
-      specified some libraries to load, these are inserted before the actual
-      dependencies in the executable's searchlist for symbol resolution.  */
-   HP_TIMING_NOW (start);
--  _dl_map_object_deps (main_map, preloads, npreloads, mode == trace, 0);
-+  _dl_map_object_deps (main_map, NULL, 0, mode == trace, 0);
-   HP_TIMING_NOW (stop);
-   HP_TIMING_DIFF (diff, start, stop);
-   HP_TIMING_ACCUM_NT (load_time, diff);
+
+  if (__builtin_expect (*first_preload != NULL, 0))
+    {
 @@ -2301,7 +2221,7 @@ ERROR: ld.so: object '%s' cannot be loaded as audit interface: %s; ignored.\n",
       the address since by now the variable might be in another object.  */
    r = _dl_debug_initialize (0, LM_ID_BASE);

--- a/LibOS/shim/include/shim_ipc.h
+++ b/LibOS/shim/include/shim_ipc.h
@@ -600,9 +600,9 @@ int do_ipc_duplex (struct shim_ipc_msg_obj * msg,
                    void * private_data);
 
 void ipc_parent_exit  (struct shim_ipc_port * port, IDTYPE vmid,
-                       unsigned int exitcode, unsigned int term_signal);
+                       unsigned int exitcode);
 void ipc_child_exit   (struct shim_ipc_port * port, IDTYPE vmid,
-                       unsigned int exitcode, unsigned int term_signal);
+                       unsigned int exitcode);
 
 int exit_with_ipc_helper (bool handover);
 

--- a/LibOS/shim/src/fs/shim_fs.c
+++ b/LibOS/shim/src/fs/shim_fs.c
@@ -191,10 +191,13 @@ static int __mount_others (void)
     if (!root_config)
         return 0;
 
-    int nkeys;
-    char * keybuf = __alloca(get_config_entries_size(root_config, "fs.mount"));
+    int nkeys, keybuf_size;
+    keybuf_size = get_config_entries_size(root_config, "fs.mount");
+    if (keybuf_size < 0)
+        return 0;
 
-    nkeys = get_config_entries(root_config, "fs.mount", keybuf);
+    char * keybuf = __alloca(keybuf_size);
+    nkeys = get_config_entries(root_config, "fs.mount", keybuf, keybuf_size);
 
     if (nkeys < 0)
         return 0;

--- a/LibOS/shim/src/fs/shim_fs.c
+++ b/LibOS/shim/src/fs/shim_fs.c
@@ -191,7 +191,8 @@ static int __mount_others (void)
     if (!root_config)
         return 0;
 
-    int nkeys, keybuf_size;
+    int nkeys;
+    ssize_t keybuf_size;
     keybuf_size = get_config_entries_size(root_config, "fs.mount");
     if (keybuf_size < 0)
         return 0;

--- a/LibOS/shim/src/ipc/shim_ipc_child.c
+++ b/LibOS/shim/src/ipc/shim_ipc_child.c
@@ -82,7 +82,7 @@ static int ipc_thread_exit (IDTYPE vmid, IDTYPE ppid, IDTYPE tid,
 }
 
 void ipc_parent_exit (struct shim_ipc_port * port, IDTYPE vmid,
-                      unsigned int exitcode, unsigned int term_signal)
+                      unsigned int exitcode)
 {
     debug("ipc port %p of process %u closed suggests parent exiting\n",
           port, vmid);
@@ -159,12 +159,19 @@ int remove_child_thread (IDTYPE vmid, unsigned int exitcode, unsigned int term_s
 }
 
 void ipc_child_exit (struct shim_ipc_port * port, IDTYPE vmid,
-                     unsigned int exitcode, unsigned int term_signal)
+                     unsigned int exitcode)
 {
     debug("ipc port %p of process %u closed suggests child exiting\n",
           port, vmid);
 
-    remove_child_thread(vmid, 0, term_signal);
+    /*
+     * Chia-Che 12/12/2017:
+     * Can't assume there is a termination signal. this callback
+     * is only called when the child process is not responding, and
+     * under this circumstance can only assume the child process
+     * has encountered severe failure, hence SIGKILL.
+     */
+    remove_child_thread(vmid, exitcode, SIGKILL);
 }
 
 static struct shim_ipc_port * get_parent_port (IDTYPE * dest)

--- a/LibOS/shim/src/shim_async.c
+++ b/LibOS/shim/src/shim_async.c
@@ -105,8 +105,6 @@ int install_async_event (PAL_HANDLE object, unsigned long time,
         free(event);
     else
         listp_add_tail(event, &async_list, list);   
-    
-    unlock(async_helper_lock);
 
     if (async_helper_state == HELPER_NOTALIVE)
         create_async_helper();

--- a/LibOS/shim/src/shim_async.c
+++ b/LibOS/shim/src/shim_async.c
@@ -108,7 +108,7 @@ int install_async_event (PAL_HANDLE object, unsigned long time,
     
     unlock(async_helper_lock);
 
-    if (atomic_read(&async_helper_state) == HELPER_NOTALIVE)
+    if (async_helper_state == HELPER_NOTALIVE)
         create_async_helper();
 
     unlock(async_helper_lock);

--- a/LibOS/shim/src/shim_init.c
+++ b/LibOS/shim/src/shim_init.c
@@ -433,7 +433,7 @@ int read_environs (const char ** envp)
 
 struct config_store * root_config = NULL;
 
-static void * __malloc (int size)
+static void * __malloc (size_t size)
 {
     return malloc(size);
 }

--- a/LibOS/shim/src/shim_init.c
+++ b/LibOS/shim/src/shim_init.c
@@ -154,8 +154,8 @@ long int glibc_option (const char * opt)
     char cfg[CONFIG_MAX];
 
     if (strcmp_static(opt, "heap_size")) {
-        int ret = get_config(root_config, "glibc.heap_size", cfg, CONFIG_MAX);
-        if (ret < 0) {
+        ssize_t ret = get_config(root_config, "glibc.heap_size", cfg, CONFIG_MAX);
+        if (ret <= 0) {
             debug("no glibc option: %s (err=%d)\n", opt, ret);
             return -ENOENT;
         }

--- a/LibOS/shim/src/sys/shim_sandbox.c
+++ b/LibOS/shim/src/sys/shim_sandbox.c
@@ -73,10 +73,13 @@ static int isolate_fs (struct config_store * cfg, const char * path)
     bool root_created = false;
     char t[CONFIG_MAX], u[CONFIG_MAX];
 
-    int nkeys;
-    char * keybuf = __alloca(get_config_entries_size(cfg, "fs.mount.other"));
+    int nkeys, keybuf_size;
+    keybuf_size = get_config_entries_size(cfg, "fs.mount.other");
+    if (keybuf_size <= 0)
+        goto root;
 
-    nkeys = get_config_entries(cfg, "fs.mount.other", keybuf);
+    char * keybuf = __alloca(keybuf_size);
+    nkeys = get_config_entries(cfg, "fs.mount.other", keybuf, keybuf_size);
 
     if (nkeys <= 0)
         goto root;
@@ -183,11 +186,15 @@ root:
 
 static int isolate_net (struct config_store * cfg, struct net_sb * sb)
 {
-    int nkeys;
-    char k[CONFIG_MAX];
-    char * keybuf = __alloca(get_config_entries_size(cfg, "net.rules"));
+    int nkeys, keybuf_size;
+    char k[CONFIG_MAX], * keybuf;
 
-    nkeys = get_config_entries(cfg, "net.rules", keybuf);
+    keybuf_size = get_config_entries_size(cfg, "net.rules");
+    if (keybuf_size <= 0)
+        goto add;
+
+    keybuf = __alloca(keybuf_size);
+    nkeys = get_config_entries(cfg, "net.rules", keybuf, keybuf_size);
 
     if (nkeys <= 0)
         goto add;
@@ -277,7 +284,7 @@ next:
     return 0;
 }
 
-static void * __malloc (int size)
+static void * __malloc (size_t size)
 {
     return malloc(size);
 }

--- a/LibOS/shim/src/sys/shim_socket.c
+++ b/LibOS/shim/src/sys/shim_socket.c
@@ -838,8 +838,8 @@ int __do_accept (struct shim_handle * hdl, int flags, struct sockaddr * addr,
     PAL_HANDLE accepted = NULL;
 
     if (sock->sock_type != SOCK_STREAM) {
-        debug("shim_listen: not a stream socket\n");
-        return -EINVAL;
+        debug("shim_accept: not a stream socket\n");
+        return -EOPNOTSUPP;
     }
 
     lock(hdl->lock);

--- a/LibOS/shim/test/apps/ltp/PASSED
+++ b/LibOS/shim/test/apps/ltp/PASSED
@@ -1,6 +1,11 @@
 Test,Subtest number
 accept01,1
 accept01,2
+accept01,3
+accept01,4
+accept01,5
+accept01,6
+accept01,7
 accept4_01,1
 accept4_01,2
 accept4_01,3

--- a/LibOS/shim/test/apps/ltp/PASSED
+++ b/LibOS/shim/test/apps/ltp/PASSED
@@ -22,6 +22,7 @@ asyncio02,5
 asyncio02,6
 brk01,1
 chdir01,1
+chdir02,1
 chmod01,1
 chmod01,2
 chmod01,3
@@ -81,6 +82,7 @@ confstr01,16
 confstr01,17
 confstr01,18
 confstr01,19
+connect01,1
 creat01,2
 creat01,3
 creat01,4
@@ -91,8 +93,12 @@ creat03,3
 dup01,1
 dup02,1
 dup02,2
+dup04,1
+dup04,2
 dup07,1
 dup07,2
+dup201,1
+dup201,2
 dup202,1
 dup202,2
 dup203,1
@@ -236,6 +242,8 @@ getitimer01,5
 getpagesize01,1
 getpeername01,1
 getpeername01,2
+getpeername01,3
+getpeername01,4
 getpgid01,1
 getpgid01,2
 getpgrp01,1
@@ -248,8 +256,14 @@ getrlimit01,6
 getrlimit01,8
 getrlimit01,10
 getsid01,1
+getsockname01,3
+getsockname01,4
 getsockopt01,1
 getsockopt01,2
+getsockopt01,3
+getsockopt01,4
+getsockopt01,8
+getsockopt01,9
 gettid01,1
 getuid01,1
 getuid03,1
@@ -324,6 +338,7 @@ nanosleep03,1
 newuname01,1
 open01,2
 open03,1
+open08,1
 open09,1
 open09,2
 pathconf01,1
@@ -398,6 +413,12 @@ read04,1
 readdir01,1
 readv01,1
 readv01,2
+recv01,1
+recv01,2
+recvfrom01,1
+recvfrom01,2
+recvmsg01,1
+recvmsg01,2
 rmdir01,1
 rmdir04,1
 rt_sigaction01,1
@@ -727,6 +748,8 @@ semget03,1
 semop01,1
 semop04,1
 semop04,2
+send01,1
+send01,2
 sendfile03,1
 sendfile03,2
 sendfile03,3
@@ -735,6 +758,9 @@ sendfile03_64,2
 sendfile03_64,3
 sendfile05,1
 sendfile05_64,1
+sendto01,1
+sendto01,2
+sendto01,3
 setgid01,1
 setitimer01,1
 setpgid01,1
@@ -744,6 +770,11 @@ setpgrp02,1
 setrlimit01,1
 setsockopt01,1
 setsockopt01,2
+setsockopt01,3
+setsockopt01,5
+setsockopt01,6
+setsockopt01,7
+setsockopt01,8
 set_tid_address01,1
 settimeofday01,3
 setuid01,1

--- a/LibOS/shim/test/apps/ltp/manifest.template
+++ b/LibOS/shim/test/apps/ltp/manifest.template
@@ -1,6 +1,8 @@
 loader.preload = file:$(SHIMPATH)
 loader.env.LD_LIBRARY_PATH = /lib:/lib/x86_64-linux-gnu:/usr/lib:/usr/lib64
 loader.env.PATH = /bin:/usr/bin:.
+loader.env.LD_PRELOAD = /usr/lib/x86_64-linux-gnu/coreutils/libstdbuf.so
+loader.env._STDBUF_O = L
 loader.debug_type = none
 
 fs.mount.shm.type = chroot
@@ -31,5 +33,6 @@ sgx.trusted_files.libc = file:$(LIBCDIR)/libc.so.6
 sgx.trusted_files.libdl = file:$(LIBCDIR)/libdl.so.2
 sgx.trusted_files.libm = file:$(LIBCDIR)/libm.so.6
 sgx.trusted_files.libpthread = file:$(LIBCDIR)/libpthread.so.0
+sgx.trusted_files.libstdbuf = file:/usr/lib/x86_64-linux-gnu/coreutils/libstdbuf.so
 
 sgx.allowed_files.tmp = file:/tmp

--- a/LibOS/shim/test/native/tcp.c
+++ b/LibOS/shim/test/native/tcp.c
@@ -15,6 +15,7 @@
 #include <sys/stat.h>
 #include <sys/wait.h>
 
+#define SRV_BIND_IP "0.0.0.0"
 #define SRV_IP "127.0.0.1"
 #define PORT 9930
 #define BUFLEN 512
@@ -38,7 +39,7 @@ int server(void)
         printf("The socket was created\n");
 
     address.sin_family = AF_INET;
-    inet_pton(AF_INET, SRV_IP, &(address.sin_addr));
+    inet_pton(AF_INET, SRV_BIND_IP, &(address.sin_addr));
     address.sin_port = htons(PORT);
 
     if (bind(create_socket, (struct sockaddr *) &address,

--- a/Pal/lib/api.h
+++ b/Pal/lib/api.h
@@ -132,7 +132,7 @@ int write_config (void * file, int (*write) (void *, void *, int),
 int get_config (struct config_store * cfg, const char * key,
                 char * val_buf, int size);
 int get_config_entries (struct config_store * cfg, const char * key,
-                        char * key_buf);
+                        char * key_buf, int key_bufsize);
 int get_config_entries_size (struct config_store * cfg, const char * key);
 int set_config (struct config_store * cfg, const char * key, const char * val);
 

--- a/Pal/lib/api.h
+++ b/Pal/lib/api.h
@@ -24,6 +24,11 @@
 #include <stdint.h>
 #include <stdarg.h>
 
+/* WARNING: this declaration may conflict with some header files */
+#ifndef ssize_t
+typedef ptrdiff_t ssize_t;
+#endif
+
 /* Macros */
 
 #ifndef likely
@@ -129,11 +134,11 @@ int free_config (struct config_store * store);
 int copy_config (struct config_store * store, struct config_store * new_store);
 int write_config (void * file, int (*write) (void *, void *, int),
                   struct config_store * store);
-int get_config (struct config_store * cfg, const char * key,
-                char * val_buf, int size);
+ssize_t get_config (struct config_store * cfg, const char * key,
+                    char * val_buf, size_t size);
 int get_config_entries (struct config_store * cfg, const char * key,
-                        char * key_buf, int key_bufsize);
-int get_config_entries_size (struct config_store * cfg, const char * key);
+                        char * key_buf, size_t key_bufsize);
+ssize_t get_config_entries_size (struct config_store * cfg, const char * key);
 int set_config (struct config_store * cfg, const char * key, const char * val);
 
 #define CONFIG_MAX      4096

--- a/Pal/lib/graphene/config.c
+++ b/Pal/lib/graphene/config.c
@@ -147,7 +147,7 @@ int get_config (struct config_store * store, const char * key,
 }
 
 int get_config_entries (struct config_store * store, const char * key,
-                        char * key_buf)
+                        char * key_buf, int key_bufsize)
 {
     struct config * e = __get_config(store, key);
 
@@ -158,15 +158,20 @@ int get_config_entries (struct config_store * store, const char * key,
     int nentries = 0;
 
     listp_for_each_entry(e, children, siblings) {
+        if (e->klen + 1 > key_bufsize)
+            return -PAL_ERROR_TOOLONG;
         memcpy(key_buf, e->key, e->klen);
         key_buf[e->klen] = 0;
         key_buf += e->klen + 1;
+        key_bufsize -= e->klen + 1;
         nentries++;
     }
 
     return nentries;
 }
-int get_config_entries_size (struct config_store * store, const char * key)
+
+int get_config_entries_size (struct config_store * store,
+                             const char * key)
 {
     struct config * e = __get_config(store, key);
 

--- a/Pal/src/db_main.c
+++ b/Pal/src/db_main.c
@@ -47,7 +47,7 @@ static void load_libraries (void)
 {
     /* we will not make any assumption for where the libraries are loaded */
     char cfgbuf[CONFIG_MAX];
-    int len, ret = 0;
+    ssize_t len, ret = 0;
 
     /* loader.preload:
        any other libraries to preload. The can be multiple URIs,
@@ -98,7 +98,7 @@ static void read_environments (const char *** envpp)
     if (!pal_state.root_config)
         return;
 
-    int cfgsize = get_config_entries_size(store, "loader.env");
+    ssize_t cfgsize = get_config_entries_size(store, "loader.env");
     if (cfgsize < 0)
         return;
 
@@ -114,7 +114,7 @@ static void read_environments (const char *** envpp)
     setenvs = __alloca(sizeof(struct setenv) * nsetenvs);
     char * cfg = cfgbuf;
     for (int i = 0 ; i < nsetenvs ; i++) {
-        int len = strlen(cfg);
+        size_t len = strlen(cfg);
         char * str = __alloca(len + 1);
         setenvs[i].str = str;
         setenvs[i].len = len;
@@ -151,7 +151,7 @@ static void read_environments (const char *** envpp)
         const char * str = setenvs[i].str;
         int len = setenvs[i].len;
         int idx = setenvs[i].idx;
-        int bytes;
+        ssize_t bytes;
         ptr = &envp[(idx == -1) ? nenvs++ : idx];
         memcpy(key + prefix_len, str, len + 1);
         if ((bytes = get_config(store, key, cfgbuf, CONFIG_MAX)) > 0) {
@@ -175,7 +175,7 @@ static void read_environments (const char *** envpp)
 static void set_debug_type (void)
 {
     char cfgbuf[CONFIG_MAX];
-    int ret = 0;
+    ssize_t ret = 0;
 
     if (!pal_state.root_config)
         return;
@@ -258,7 +258,7 @@ void pal_main (
 
     char uri_buf[URI_MAX];
     char * manifest_uri = NULL, * exec_uri = NULL;
-    int ret;
+    ssize_t ret;
 
     if (exec_handle) {
         ret = _DkStreamGetName(exec_handle, uri_buf, URI_MAX);

--- a/Pal/src/host/FreeBSD/db_sockets.c
+++ b/Pal/src/host/FreeBSD/db_sockets.c
@@ -279,54 +279,56 @@ PAL_HANDLE socket_create_handle (int type, int fd, int options,
     return hdl;
 }
 
-static int check_zero (void * mem, int size)
+#if ALLOW_BIND_ANY == 1
+static bool check_zero (void * mem, int size)
 {
     void * p = mem, * q = mem + size;
 
     while (p < q) {
         if (p <= q - sizeof(long)) {
             if (*(long *) p)
-                return 1;
+                return false;
             p += sizeof(long);
         } else if (p <= q - sizeof(int)) {
             if (*(int *) p)
-                return 1;
+                return false;
             p += sizeof(int);
         } else if (p <= q - sizeof(short)) {
             if (*(short *) p)
-                return 1;
+                return false;
             p += sizeof(short);
         } else {
             if (*(char *) p)
-                return 1;
+                return false;
             p++;
         }
     }
 
-    return 0;
+    return true;
 }
 
 /* check if an address is "Any" */
-static int addr_check_any (struct sockaddr * addr)
+static bool check_any_addr (struct sockaddr * addr)
 {
     if (addr->sa_family == AF_INET) {
         struct sockaddr_in * addr_in =
                         (struct sockaddr_in *) addr;
 
-        return addr_in->sin_port ||
+        return addr_in->sin_port == 0 &&
                check_zero(&addr_in->sin_addr,
                           sizeof(addr_in->sin_addr));
     } else if (addr->sa_family == AF_INET6) {
         struct sockaddr_in6 * addr_in6 =
                         (struct sockaddr_in6 *) addr;
 
-        return addr_in6->sin6_port ||
+        return addr_in6->sin6_port == 0 &&
                check_zero(&addr_in6->sin6_addr,
                           sizeof(addr_in6->sin6_addr));
     }
 
-    return -PAL_ERROR_NOTSUPPORT;
+    return false;
 }
+#endif
 
 /* listen on a tcp socket */
 static int tcp_listen (PAL_HANDLE * handle, char * uri, int options)
@@ -338,8 +340,15 @@ static int tcp_listen (PAL_HANDLE * handle, char * uri, int options)
     if ((ret = socket_parse_uri(uri, &bind_addr, &bind_addrlen,
                                 NULL, NULL)) < 0)
         return ret;
-    
-	options = HOST_SOCKET_OPTIONS(options);
+
+#if ALLOW_BIND_ANY == 1
+    /* the socket need to have a binding address, a null address or an
+       any address is not allowed */
+    if (addr_check_any(bind_addr))
+       return -PAL_ERROR_INVAL;
+#endif
+
+    options = HOST_SOCKET_OPTIONS(options);
     /* the socket need to have a binding address, a null address or an
        any address is not allowed */
     if (!bind_addr || addr_check_any(bind_addr) == 0)
@@ -459,6 +468,13 @@ static int tcp_connect (PAL_HANDLE * handle, char * uri, int options)
 
     if (bind_addr && bind_addr->sa_family != dest_addr->sa_family)
         return -PAL_ERROR_INVAL;
+
+#if ALLOW_BIND_ANY == 1
+    /* the socket need to have a binding address, a null address or an
+       any address is not allowed */
+    if (bind_addr && addr_check_any(bind_addr))
+       return -PAL_ERROR_INVAL;
+#endif
 
     fd = INLINE_SYSCALL(socket, 3, dest_addr->sa_family,
                         SOCK_STREAM|SOCK_CLOEXEC|options, 0);
@@ -630,7 +646,14 @@ static int udp_bind (PAL_HANDLE * handle, char * uri, int options)
 
     assert(bind_addr);
     assert(bind_addrlen == addr_size(bind_addr));
-	
+
+#if ALLOW_BIND_ANY == 1
+    /* the socket need to have a binding address, a null address or an
+       any address is not allowed */
+    if (addr_check_any(bind_addr))
+       return -PAL_ERROR_INVAL;
+#endif
+
     options = HOST_SOCKET_OPTIONS(options);
     fd = INLINE_SYSCALL(socket, 3, bind_addr->sa_family,
                         SOCK_DGRAM|SOCK_CLOEXEC|options, 0);
@@ -680,6 +703,13 @@ static int udp_connect (PAL_HANDLE * handle, char * uri, int options)
     if ((ret = socket_parse_uri(uri, &bind_addr, &bind_addrlen,
                                 &dest_addr, &dest_addrlen)) < 0)
         return ret;
+
+#if ALLOW_BIND_ANY == 1
+    /* the socket need to have a binding address, a null address or an
+       any address is not allowed */
+    if (bind_addr && addr_check_any(bind_addr))
+       return -PAL_ERROR_INVAL;
+#endif
 
     options = HOST_SOCKET_OPTIONS(options);
 	

--- a/Pal/src/host/FreeBSD/db_sockets.c
+++ b/Pal/src/host/FreeBSD/db_sockets.c
@@ -280,7 +280,7 @@ PAL_HANDLE socket_create_handle (int type, int fd, int options,
 }
 
 #if ALLOW_BIND_ANY == 0
-static bool check_zero (void * mem, int size)
+static bool check_zero (void * mem, size_t size)
 {
     void * p = mem, * q = mem + size;
 

--- a/Pal/src/host/FreeBSD/db_sockets.c
+++ b/Pal/src/host/FreeBSD/db_sockets.c
@@ -279,7 +279,7 @@ PAL_HANDLE socket_create_handle (int type, int fd, int options,
     return hdl;
 }
 
-#if ALLOW_BIND_ANY == 1
+#if ALLOW_BIND_ANY == 0
 static bool check_zero (void * mem, int size)
 {
     void * p = mem, * q = mem + size;
@@ -341,7 +341,7 @@ static int tcp_listen (PAL_HANDLE * handle, char * uri, int options)
                                 NULL, NULL)) < 0)
         return ret;
 
-#if ALLOW_BIND_ANY == 1
+#if ALLOW_BIND_ANY == 0
     /* the socket need to have a binding address, a null address or an
        any address is not allowed */
     if (addr_check_any(bind_addr))
@@ -469,7 +469,7 @@ static int tcp_connect (PAL_HANDLE * handle, char * uri, int options)
     if (bind_addr && bind_addr->sa_family != dest_addr->sa_family)
         return -PAL_ERROR_INVAL;
 
-#if ALLOW_BIND_ANY == 1
+#if ALLOW_BIND_ANY == 0
     /* the socket need to have a binding address, a null address or an
        any address is not allowed */
     if (bind_addr && addr_check_any(bind_addr))
@@ -647,7 +647,7 @@ static int udp_bind (PAL_HANDLE * handle, char * uri, int options)
     assert(bind_addr);
     assert(bind_addrlen == addr_size(bind_addr));
 
-#if ALLOW_BIND_ANY == 1
+#if ALLOW_BIND_ANY == 0
     /* the socket need to have a binding address, a null address or an
        any address is not allowed */
     if (addr_check_any(bind_addr))
@@ -704,7 +704,7 @@ static int udp_connect (PAL_HANDLE * handle, char * uri, int options)
                                 &dest_addr, &dest_addrlen)) < 0)
         return ret;
 
-#if ALLOW_BIND_ANY == 1
+#if ALLOW_BIND_ANY == 0
     /* the socket need to have a binding address, a null address or an
        any address is not allowed */
     if (bind_addr && addr_check_any(bind_addr))

--- a/Pal/src/host/Linux-SGX/db_sockets.c
+++ b/Pal/src/host/Linux-SGX/db_sockets.c
@@ -273,7 +273,7 @@ PAL_HANDLE socket_create_handle (int type, int fd, int options,
     return hdl;
 }
 
-#if ALLOW_BIND_ANY == 1
+#if ALLOW_BIND_ANY == 0
 static bool check_zero (void * mem, int size)
 {
     void * p = mem, * q = mem + size;
@@ -342,7 +342,7 @@ static int tcp_listen (PAL_HANDLE * handle, char * uri, int options)
                                 NULL, NULL)) < 0)
         return ret;
 
-#if ALLOW_BIND_ANY == 1
+#if ALLOW_BIND_ANY == 0
     /* the socket need to have a binding address, a null address or an
        any address is not allowed */
     if (addr_check_any(bind_addr))
@@ -423,7 +423,7 @@ static int tcp_connect (PAL_HANDLE * handle, char * uri, int options)
     if (bind_addr && bind_addr->sa_family != dest_addr->sa_family)
         return -PAL_ERROR_INVAL;
 
-#if ALLOW_BIND_ANY == 1
+#if ALLOW_BIND_ANY == 0
     /* the socket need to have a binding address, a null address or an
        any address is not allowed */
     if (bind_addr && addr_check_any(bind_addr))
@@ -532,7 +532,7 @@ static int udp_bind (PAL_HANDLE * handle, char * uri, int options)
     assert(bind_addr);
     assert(bind_addrlen == addr_size(bind_addr));
 
-#if ALLOW_BIND_ANY == 1
+#if ALLOW_BIND_ANY == 0
     /* the socket need to have a binding address, a null address or an
        any address is not allowed */
     if (addr_check_any(bind_addr))
@@ -570,7 +570,7 @@ static int udp_connect (PAL_HANDLE * handle, char * uri, int options)
                                 &dest_addr, &dest_addrlen)) < 0)
         return ret;
 
-#if ALLOW_BIND_ANY == 1
+#if ALLOW_BIND_ANY == 0
     /* the socket need to have a binding address, a null address or an
        any address is not allowed */
     if (bind_addr && addr_check_any(bind_addr))

--- a/Pal/src/host/Linux-SGX/db_sockets.c
+++ b/Pal/src/host/Linux-SGX/db_sockets.c
@@ -274,7 +274,7 @@ PAL_HANDLE socket_create_handle (int type, int fd, int options,
 }
 
 #if ALLOW_BIND_ANY == 0
-static bool check_zero (void * mem, int size)
+static bool check_zero (void * mem, size_t size)
 {
     void * p = mem, * q = mem + size;
 

--- a/Pal/src/host/Linux-SGX/enclave_framework.c
+++ b/Pal/src/host/Linux-SGX/enclave_framework.c
@@ -446,7 +446,7 @@ int init_trusted_files (void)
 
     cfgbuf = __alloca(CONFIG_MAX);
     ssize_t len = get_config(store, "loader.preload", cfgbuf, CONFIG_MAX);
-    if (len <= 0) {
+    if (len > 0) {
         int npreload = 0;
         char key[10];
         const char * start, * end;

--- a/Pal/src/host/Linux-SGX/enclave_framework.c
+++ b/Pal/src/host/Linux-SGX/enclave_framework.c
@@ -412,7 +412,7 @@ static int init_trusted_file (const char * key, const char * uri)
     tmp = strcpy_static(cskey, "sgx.trusted_checksum.", URI_MAX);
     memcpy(tmp, key, strlen(key) + 1);
 
-    int len = get_config(pal_state.root_config, cskey, checksum, CONFIG_MAX);
+    ssize_t len = get_config(pal_state.root_config, cskey, checksum, CONFIG_MAX);
     if (len < 0)
         return 0;
 
@@ -435,8 +435,8 @@ int init_trusted_files (void)
 {
     struct config_store * store = pal_state.root_config;
     char * cfgbuf;
-    int cfgsize, nuris;
-    int ret;
+    ssize_t cfgsize;
+    int nuris, ret;
 
     if (pal_sec.exec_fd != PAL_IDX_POISON) {
         ret = init_trusted_file("exec", pal_sec.exec_name);
@@ -445,8 +445,8 @@ int init_trusted_files (void)
     }
 
     cfgbuf = __alloca(CONFIG_MAX);
-    int len = get_config(store, "loader.preload", cfgbuf, CONFIG_MAX);
-    if (len) {
+    ssize_t len = get_config(store, "loader.preload", cfgbuf, CONFIG_MAX);
+    if (len <= 0) {
         int npreload = 0;
         char key[10];
         const char * start, * end;
@@ -497,7 +497,7 @@ int init_trusted_files (void)
 no_trusted:
 
     cfgsize = get_config_entries_size(store, "sgx.allowed_files");
-    if (cfgsize < 0)
+    if (cfgsize <= 0)
         goto no_allowed;
 
     cfgbuf = __alloca(cfgsize);
@@ -537,7 +537,7 @@ int init_trusted_children (void)
     char * tmp1 = strcpy_static(key, "sgx.trusted_children.", CONFIG_MAX);
     char * tmp2 = strcpy_static(mrkey, "sgx.trusted_mrenclave.", CONFIG_MAX);
 
-    int cfgsize = get_config_entries_size(store, "sgx.trusted_mrenclave");
+    ssize_t cfgsize = get_config_entries_size(store, "sgx.trusted_mrenclave");
     if (cfgsize <= 0)
         return 0;
 
@@ -552,7 +552,7 @@ int init_trusted_children (void)
             memcpy(tmp2, k, len + 1);
             k += len + 1;
 
-            int ret = get_config(store, key, uri, CONFIG_MAX);
+            ssize_t ret = get_config(store, key, uri, CONFIG_MAX);
             if (ret < 0)
                 continue;
 

--- a/Pal/src/host/Linux-SGX/enclave_framework.c
+++ b/Pal/src/host/Linux-SGX/enclave_framework.c
@@ -433,7 +433,9 @@ static int init_trusted_file (const char * key, const char * uri)
 
 int init_trusted_files (void)
 {
-    char *cfgbuf;
+    struct config_store * store = pal_state.root_config;
+    char * cfgbuf;
+    int cfgsize, nuris;
     int ret;
 
     if (pal_sec.exec_fd != PAL_IDX_POISON) {
@@ -443,8 +445,7 @@ int init_trusted_files (void)
     }
 
     cfgbuf = __alloca(CONFIG_MAX);
-    int len = get_config(pal_state.root_config, "loader.preload",
-                         cfgbuf, CONFIG_MAX);
+    int len = get_config(store, "loader.preload", cfgbuf, CONFIG_MAX);
     if (len) {
         int npreload = 0;
         char key[10];
@@ -465,14 +466,16 @@ int init_trusted_files (void)
         }
     }
 
-    cfgbuf = __alloca(get_config_entries_size(pal_state.root_config,
-                                              "sgx.trusted_files"));
-    int nuris = get_config_entries(pal_state.root_config, "sgx.trusted_files",
-                                   cfgbuf);
-    if (nuris == -PAL_ERROR_INVAL)
-        nuris = 0;
+    cfgsize = get_config_entries_size(store, "sgx.trusted_files");
+    if (cfgsize <= 0)
+        goto no_trusted;
 
-    if (nuris >= 0) {
+    cfgbuf = __alloca(cfgsize);
+    nuris = get_config_entries(store, "sgx.trusted_files", cfgbuf, cfgsize);
+    if (nuris <= 0)
+        goto no_trusted;
+
+    {
         char key[CONFIG_MAX], uri[CONFIG_MAX];
         char * k = cfgbuf, * tmp;
 
@@ -482,26 +485,27 @@ int init_trusted_files (void)
             len = strlen(k);
             memcpy(tmp, k, len + 1);
             k += len + 1;
-            len = get_config(pal_state.root_config, key, uri, CONFIG_MAX);
+            len = get_config(store, key, uri, CONFIG_MAX);
             if (len > 0) {
                 ret = init_trusted_file(key + 18, uri);
                 if (ret < 0)
                     goto out;
             }
         }
-    } else {
-        ret = nuris;
-        goto out;
     }
 
-    cfgbuf = __alloca(get_config_entries_size(pal_state.root_config,
-                                              "sgx.allowed_files"));
-    nuris = get_config_entries(pal_state.root_config, "sgx.allowed_files",
-                               cfgbuf);
-    if (nuris == -PAL_ERROR_INVAL)
-        nuris = 0;
+no_trusted:
 
-    if (nuris >= 0) {
+    cfgsize = get_config_entries_size(store, "sgx.allowed_files");
+    if (cfgsize < 0)
+        goto no_allowed;
+
+    cfgbuf = __alloca(cfgsize);
+    nuris = get_config_entries(store, "sgx.allowed_files", cfgbuf, cfgsize);
+    if (nuris <= 0)
+        goto no_allowed;
+
+    {
         char key[CONFIG_MAX], uri[CONFIG_MAX];
         char * k = cfgbuf, * tmp;
 
@@ -511,33 +515,35 @@ int init_trusted_files (void)
             len = strlen(k);
             memcpy(tmp, k, len + 1);
             k += len + 1;
-            len = get_config(pal_state.root_config, key, uri, CONFIG_MAX);
+            len = get_config(store, key, uri, CONFIG_MAX);
             if (len > 0)
                 register_trusted_file(uri, NULL);
         }
-    } else {
-        ret = nuris;
-        goto out;
     }
-    ret = 0;
 
+no_allowed:
+    ret = 0;
 out:
     return ret;
 }
 
 int init_trusted_children (void)
 {
-    char *cfgbuf;
+    struct config_store * store = pal_state.root_config;
+
     char key[CONFIG_MAX], mrkey[CONFIG_MAX];
     char uri[CONFIG_MAX], mrenclave[CONFIG_MAX];
 
     char * tmp1 = strcpy_static(key, "sgx.trusted_children.", CONFIG_MAX);
     char * tmp2 = strcpy_static(mrkey, "sgx.trusted_mrenclave.", CONFIG_MAX);
 
-    cfgbuf = __alloca(get_config_entries_size(pal_state.root_config,
-                                              "sgx.trusted_mrenclave"));
-    int nuris = get_config_entries(pal_state.root_config,
-                                   "sgx.trusted_mrenclave", cfgbuf);
+    int cfgsize = get_config_entries_size(store, "sgx.trusted_mrenclave");
+    if (cfgsize <= 0)
+        return 0;
+
+    char * cfgbuf = __alloca(cfgsize);
+    int nuris = get_config_entries(store, "sgx.trusted_mrenclave",
+                                   cfgbuf, cfgsize);
     if (nuris > 0) {
         char * k = cfgbuf;
         for (int i = 0 ; i < nuris ; i++) {
@@ -546,12 +552,11 @@ int init_trusted_children (void)
             memcpy(tmp2, k, len + 1);
             k += len + 1;
 
-            int ret = get_config(pal_state.root_config, key, uri, CONFIG_MAX);
+            int ret = get_config(store, key, uri, CONFIG_MAX);
             if (ret < 0)
                 continue;
 
-            ret = get_config(pal_state.root_config, mrkey, mrenclave,
-                             CONFIG_MAX);
+            ret = get_config(store, mrkey, mrenclave, CONFIG_MAX);
             if (ret > 0)
                 register_trusted_child(uri, mrenclave);
         }

--- a/Pal/src/host/Linux/db_sockets.c
+++ b/Pal/src/host/Linux/db_sockets.c
@@ -290,54 +290,56 @@ PAL_HANDLE socket_create_handle (int type, int fd, int options,
     return hdl;
 }
 
-static int check_zero (void * mem, int size)
+#if ALLOW_BIND_ANY == 1
+static bool check_zero (void * mem, int size)
 {
     void * p = mem, * q = mem + size;
 
     while (p < q) {
         if (p <= q - sizeof(long)) {
             if (*(long *) p)
-                return 1;
+                return false;
             p += sizeof(long);
         } else if (p <= q - sizeof(int)) {
             if (*(int *) p)
-                return 1;
+                return false;
             p += sizeof(int);
         } else if (p <= q - sizeof(short)) {
             if (*(short *) p)
-                return 1;
+                return false;
             p += sizeof(short);
         } else {
             if (*(char *) p)
-                return 1;
+                return false;
             p++;
         }
     }
 
-    return 0;
+    return true;
 }
 
 /* check if an address is "Any" */
-static int addr_check_any (struct sockaddr * addr)
+static bool check_any_addr (struct sockaddr * addr)
 {
     if (addr->sa_family == AF_INET) {
         struct sockaddr_in * addr_in =
                         (struct sockaddr_in *) addr;
 
-        return addr_in->sin_port ||
+        return addr_in->sin_port == 0 &&
                check_zero(&addr_in->sin_addr,
                           sizeof(addr_in->sin_addr));
     } else if (addr->sa_family == AF_INET6) {
         struct sockaddr_in6 * addr_in6 =
                         (struct sockaddr_in6 *) addr;
 
-        return addr_in6->sin6_port ||
+        return addr_in6->sin6_port == 0 &&
                check_zero(&addr_in6->sin6_addr,
                           sizeof(addr_in6->sin6_addr));
     }
 
-    return -PAL_ERROR_NOTSUPPORT;
+    return false;
 }
+#endif
 
 /* listen on a tcp socket */
 static int tcp_listen (PAL_HANDLE * handle, char * uri, int options)
@@ -350,10 +352,15 @@ static int tcp_listen (PAL_HANDLE * handle, char * uri, int options)
                                 NULL, NULL)) < 0)
         return ret;
 
+    assert(bind_addr);
+    assert(bind_addrlen == addr_size(bind_addr));
+
+#if ALLOW_BIND_ANY == 1
     /* the socket need to have a binding address, a null address or an
        any address is not allowed */
-    if (!bind_addr || addr_check_any(bind_addr) == 0)
-        return -PAL_ERROR_INVAL;
+    if (addr_check_any(bind_addr))
+       return -PAL_ERROR_INVAL;
+#endif
 
     fd = INLINE_SYSCALL(socket, 3, bind_addr->sa_family,
                         SOCK_STREAM|SOCK_CLOEXEC|options, 0);
@@ -656,6 +663,13 @@ static int udp_bind (PAL_HANDLE * handle, char * uri, int options)
     assert(bind_addr);
     assert(bind_addrlen == addr_size(bind_addr));
 
+#if ALLOW_BIND_ANY == 1
+    /* the socket need to have a binding address, a null address or an
+       any address is not allowed */
+    if (addr_check_any(bind_addr))
+       return -PAL_ERROR_INVAL;
+#endif
+
     fd = INLINE_SYSCALL(socket, 3, bind_addr->sa_family,
                         SOCK_DGRAM|SOCK_CLOEXEC|options, 0);
 
@@ -710,6 +724,13 @@ static int udp_connect (PAL_HANDLE * handle, char * uri, int options)
     if ((ret = socket_parse_uri(uri, &bind_addr, &bind_addrlen,
                                 &dest_addr, &dest_addrlen)) < 0)
         return ret;
+
+#if ALLOW_BIND_ANY == 1
+    /* the socket need to have a binding address, a null address or an
+       any address is not allowed */
+    if (bind_addr && addr_check_any(bind_addr))
+       return -PAL_ERROR_INVAL;
+#endif
 
     fd = INLINE_SYSCALL(socket, 3, dest_addr ? dest_addr->sa_family : AF_INET,
                         SOCK_DGRAM|SOCK_CLOEXEC|options, 0);

--- a/Pal/src/host/Linux/db_sockets.c
+++ b/Pal/src/host/Linux/db_sockets.c
@@ -290,7 +290,7 @@ PAL_HANDLE socket_create_handle (int type, int fd, int options,
     return hdl;
 }
 
-#if ALLOW_BIND_ANY == 1
+#if ALLOW_BIND_ANY == 0
 static bool check_zero (void * mem, int size)
 {
     void * p = mem, * q = mem + size;
@@ -355,7 +355,7 @@ static int tcp_listen (PAL_HANDLE * handle, char * uri, int options)
     assert(bind_addr);
     assert(bind_addrlen == addr_size(bind_addr));
 
-#if ALLOW_BIND_ANY == 1
+#if ALLOW_BIND_ANY == 0
     /* the socket need to have a binding address, a null address or an
        any address is not allowed */
     if (addr_check_any(bind_addr))
@@ -663,7 +663,7 @@ static int udp_bind (PAL_HANDLE * handle, char * uri, int options)
     assert(bind_addr);
     assert(bind_addrlen == addr_size(bind_addr));
 
-#if ALLOW_BIND_ANY == 1
+#if ALLOW_BIND_ANY == 0
     /* the socket need to have a binding address, a null address or an
        any address is not allowed */
     if (addr_check_any(bind_addr))
@@ -725,7 +725,7 @@ static int udp_connect (PAL_HANDLE * handle, char * uri, int options)
                                 &dest_addr, &dest_addrlen)) < 0)
         return ret;
 
-#if ALLOW_BIND_ANY == 1
+#if ALLOW_BIND_ANY == 0
     /* the socket need to have a binding address, a null address or an
        any address is not allowed */
     if (bind_addr && addr_check_any(bind_addr))

--- a/Pal/src/host/Linux/db_sockets.c
+++ b/Pal/src/host/Linux/db_sockets.c
@@ -291,7 +291,7 @@ PAL_HANDLE socket_create_handle (int type, int fd, int options,
 }
 
 #if ALLOW_BIND_ANY == 0
-static bool check_zero (void * mem, int size)
+static bool check_zero (void * mem, size_t size)
 {
     void * p = mem, * q = mem + size;
 

--- a/Pal/src/pal_defs.h
+++ b/Pal/src/pal_defs.h
@@ -18,7 +18,7 @@
 #define URI_MAX                  256
 
 /* allow binding sockets to ANY addresses (e.g., 0.0.0.0:0) */
-#define ALLOW_BIND_ANY           0
+#define ALLOW_BIND_ANY           1
 
 /* turn on the following option to trace heap memory leak */
 #define TRACE_HEAP_LEAK          0

--- a/Pal/src/pal_defs.h
+++ b/Pal/src/pal_defs.h
@@ -17,6 +17,9 @@
 /* maximum length of URIs */
 #define URI_MAX                  256
 
+/* allow binding sockets to ANY addresses (e.g., 0.0.0.0:0) */
+#define ALLOW_BIND_ANY           0
+
 /* turn on the following option to trace heap memory leak */
 #define TRACE_HEAP_LEAK          0
 

--- a/Pal/src/security/Linux/manifest.c
+++ b/Pal/src/security/Linux/manifest.c
@@ -104,7 +104,8 @@ next:
 int get_fs_paths (struct config_store * config, const char *** paths)
 {
     char * keys;
-    int nkeys, cfgsize;
+    int nkeys;
+    ssize_t cfgsize;
 
     cfgsize = get_config_entries_size(config, "fs.mount");
     if (cfgsize)
@@ -150,7 +151,8 @@ int get_net_rules (struct config_store * config,
 {
     char * binds, * peers;
     int nbinds, npeers;
-    int nrules = 0, cfgsize;
+    int nrules = 0;
+    ssize_t cfgsize;
 
     cfgsize = get_config_entries_size(config, "net.allow_bind");
     if (cfgsize < 0)
@@ -202,7 +204,7 @@ int get_net_rules (struct config_store * config,
             memcpy(tmp, k, len + 1);
             tmp[len] = 0;
 
-            int cfglen = get_config(config, key, cfgbuf, CONFIG_MAX);
+            ssize_t cfglen = get_config(config, key, cfgbuf, CONFIG_MAX);
             if (cfglen <= 0)
                 goto next;
 

--- a/Pal/src/security/Linux/manifest.c
+++ b/Pal/src/security/Linux/manifest.c
@@ -103,11 +103,15 @@ next:
 
 int get_fs_paths (struct config_store * config, const char *** paths)
 {
-    char *keys;
-    int nkeys;
+    char * keys;
+    int nkeys, cfgsize;
 
-    keys = __alloca(get_config_entries_size(config, "fs.mount"));
-    if ((nkeys = get_config_entries(config, "fs.mount", keys)) < 0)
+    cfgsize = get_config_entries_size(config, "fs.mount");
+    if (cfgsize)
+        return 0;
+
+    keys = __alloca(cfgsize);
+    if ((nkeys = get_config_entries(config, "fs.mount", keys, cfgsize)) < 0)
         nkeys = 0;
 
     *paths = malloc(sizeof(const char *) * (1 + nkeys));
@@ -144,16 +148,24 @@ int get_net_rules (struct config_store * config,
                    struct graphene_net_rule ** net_rules,
                    int * nbind_rules)
 {
-    char *binds, *peers;
+    char * binds, * peers;
     int nbinds, npeers;
-    int nrules = 0;
+    int nrules = 0, cfgsize;
 
-    binds = __alloca(get_config_entries_size(config, "net.allow_bind"));
-    if ((nbinds = get_config_entries(config, "net.allow_bind", binds)) < 0)
+    cfgsize = get_config_entries_size(config, "net.allow_bind");
+    if (cfgsize < 0)
         return 0;
 
-    peers = __alloca(get_config_entries_size(config, "net.allow_peer"));
-    if ((npeers = get_config_entries(config, "net.allow_peer", peers)) < 0)
+    binds = __alloca(cfgsize);
+    if ((nbinds = get_config_entries(config, "net.allow_bind", binds, cfgsize)) < 0)
+        return 0;
+
+    cfgsize = get_config_entries_size(config, "net.allow_peer");
+    if (cfgsize < 0)
+        return 0;
+
+    peers = __alloca(cfgsize);
+    if ((npeers = get_config_entries(config, "net.allow_peer", peers, cfgsize)) < 0)
         return 0;
 
     struct graphene_net_rule * rules =

--- a/Pal/src/slab.c
+++ b/Pal/src/slab.c
@@ -105,7 +105,6 @@ void init_slab_mgr (int alignment)
 
 void * malloc (size_t size)
 {
-    assert(size > 0 && size < 65536);
 #if PROFILING == 1
     unsigned long before_slab = _DkSystemTimeQuery();
 #endif

--- a/Pal/src/slab.c
+++ b/Pal/src/slab.c
@@ -105,6 +105,7 @@ void init_slab_mgr (int alignment)
 
 void * malloc (size_t size)
 {
+    assert(size > 0 && size < 65536);
 #if PROFILING == 1
     unsigned long before_slab = _DkSystemTimeQuery();
 #endif

--- a/Scripts/regression.py
+++ b/Scripts/regression.py
@@ -88,7 +88,7 @@ class Regression:
                             if timed_out : print 'Test timed out!'
                             keep_log = True
                             if flaky:
-                                print '   This test is kown  not to work, but should be fixed'
+                                print '   This test is known not to work, but should be fixed'
                             else:
                                 something_failed = 1
                             


### PR DESCRIPTION
- Fix a severe bug caused by merging #87. The patch does not check the return values from get_config_entries_size(), while the return values can easily be negative (-PAL_ERROR_INVAL). Any usage of this function should carefully check the return values and also pass the size into get_config_entries() to prevent buffer overflow.

- Fix a minor bug in handling IPC disconnection. The callback ipc_child_exit() never receives a "term_signal" parameter. The callback is called when the pipe to a child process unexpectedly terminates, which can only mean the child process has crashed. I believe the proper signal to send is SIGKILL.

- Remove a compilation warning caused by type mismatch of __malloc().

**[Notice!]** Adding three bugfixes:

- Fixing socket implementation to accept ANY address (e.g., 0.0.0.0:0)

- Enabling LD_PRELOAD in ld.so (previously removed by glibc-2.19.patch)

- Disable IO buffering in LTP tests; several LTP programs panic in the middle of execution and do not print out passed tests. This fix is based on stdbuf in coreutils: Using LD_PRELOAD to load libstdbuf.so, with _STDBUF_O=L given in the environment variables.