### PR TITLE
Fixes for the allocator/VMA code

### DIFF
--- a/LibOS/shim/include/shim_checkpoint.h
+++ b/LibOS/shim/include/shim_checkpoint.h
@@ -50,7 +50,7 @@ extern char __migratable_end;
 /* TSAI 7/11/2012:
    The checkpoint scheme we are expecting is to support an easy syntax to
    implement migration procedure. A migration procedure can be written
-   in teh following syntax:
+   in the following syntax:
 
    BEGIN_CP_DEFINITION(exec)
    {
@@ -85,7 +85,7 @@ struct shim_cp_entry
     union
     {
         ptr_t cp_val;   /* interger value */
-        /* orignally there is a pointer, now we don't need them */
+        /* originally there is a pointer, now we don't need them */
     } cp_un;
 };
 

--- a/LibOS/shim/include/shim_internal.h
+++ b/LibOS/shim/include/shim_internal.h
@@ -657,9 +657,11 @@ static inline int __ref_dec (REFTYPE * ref)
     register int _c;
     do {
         _c = atomic_read(ref);
-        assert(_c > 0);
-        if (!_c)
+        if (!_c) {
+            debug("Fail: Trying to drop reference count below 0\n");
+            bug();
             return 0;
+        }
     } while (atomic_cmpxchg(ref, _c, _c - 1) != _c);
     return _c - 1;
 }
@@ -708,8 +710,8 @@ extern void * migrated_memory_start;
 extern void * migrated_memory_end;
 
 #define MEMORY_MIGRATED(mem)                                    \
-        ((void *) mem >= migrated_memory_start &&               \
-         (void *) mem < migrated_memory_end)
+        ((void *) (mem) >= migrated_memory_start &&             \
+         (void *) (mem) < migrated_memory_end)
 
 extern void * __load_address, * __load_address_end;
 extern void * __code_address, * __code_address_end;

--- a/LibOS/shim/include/shim_vma.h
+++ b/LibOS/shim/include/shim_vma.h
@@ -118,9 +118,6 @@ void unmap_all_vmas (void);
 /* Debugging */
 void debug_print_vma_list (void);
 
-void print_vma_hash (struct shim_vma * vma, void * addr, uint64_t len,
-                     bool force_protect);
-
 /* Constants */
 extern unsigned long mem_max_npages;
 extern unsigned long brk_max_size;

--- a/LibOS/shim/include/shim_vma.h
+++ b/LibOS/shim/include/shim_vma.h
@@ -94,15 +94,18 @@ int bkeep_mmap (void * addr, uint64_t length, int prot, int flags,
                 struct shim_handle * file, uint64_t offset, const char * comment);
 
 /* Bookkeeping munmap() system call */
-int bkeep_munmap (void * addr, uint64_t length, const int * flags);
+int bkeep_munmap (void * addr, uint64_t length, int flags);
 
 /* Bookkeeping mprotect() system call */
-int bkeep_mprotect (void * addr, uint64_t length, int prot, const int * flags);
+int bkeep_mprotect (void * addr, uint64_t length, int prot, int flags);
 
 /* Get vma bookkeeping handle */
 void get_vma (struct shim_vma * vma);
 void put_vma (struct shim_vma * vma);
 
+/* Returns 0 on success, -E* on failure.
+   Calls `get_vma` on the result before returning it.
+*/
 int lookup_supervma (const void * addr, uint64_t len, struct shim_vma ** vma);
 int lookup_overlap_vma (const void * addr, uint64_t len, struct shim_vma ** vma);
 

--- a/LibOS/shim/src/bookkeep/shim_vma.c
+++ b/LibOS/shim/src/bookkeep/shim_vma.c
@@ -1411,34 +1411,3 @@ void debug_print_vma_list (void)
                    vma->comment[0] ? vma->comment : "");
     }
 }
-
-void print_vma_hash (struct shim_vma * vma, void * addr, uint64_t len,
-                     bool force_protect)
-{
-    if (!addr)
-        addr = vma->addr;
-    if (!len)
-        len = vma->length - (addr - vma->addr);
-
-    if (addr < vma->addr || addr + len > vma->addr + vma->length)
-        return;
-
-    if (!(vma->prot & PROT_READ)) {
-        if (!force_protect)
-            return;
-        DkVirtualMemoryProtect(vma->addr, vma->length, PAL_PROT_READ);
-    }
-
-    for (uint64_t p = (uint64_t) addr ;
-         p < (uint64_t) addr + len ; p += allocsize) {
-            uint64_t hash = 0;
-            struct shim_md5_ctx ctx;
-            md5_init(&ctx);
-            md5_update(&ctx, (void *) p, allocsize);
-            md5_final(&ctx);
-            memcpy(&hash, ctx.digest, sizeof(uint64_t));
-        }
-
-    if (!(vma->prot & PROT_READ))
-        DkVirtualMemoryProtect(vma->addr, vma->length, vma->prot);
-}

--- a/LibOS/shim/src/bookkeep/shim_vma.c
+++ b/LibOS/shim/src/bookkeep/shim_vma.c
@@ -866,7 +866,7 @@ int lookup_overlap_vma (const void * addr, uint64_t length,
     debug("vma overlapped at %p-%p\n", tmp_addr, tmp_addr + tmp_length);
     if (res_vma)
         *res_vma = vma;
-    return vma;
+    return 0;
 }
 
 static struct shim_vma * __lookup_vma (const void * addr, uint64_t length)

--- a/LibOS/shim/src/elf/shim_rtld.c
+++ b/LibOS/shim/src/elf/shim_rtld.c
@@ -575,7 +575,7 @@ map_error:
 #endif
                 bkeep_mprotect((void *) RELOCATE(l, c->mapend),
                                l->loadcmds[l->nloadcmds - 1].mapstart -
-                               c->mapend, PROT_NONE, &flags);
+                               c->mapend, PROT_NONE, flags);
             }
         }
 

--- a/LibOS/shim/src/fs/chroot/fs.c
+++ b/LibOS/shim/src/fs/chroot/fs.c
@@ -623,8 +623,7 @@ static int chroot_flush (struct shim_handle * hdl)
 
         if (mapbuf) {
             DkStreamUnmap(mapbuf, mapsize);
-            int flags = VMA_INTERNAL;
-            bkeep_munmap(mapbuf, mapsize, &flags);
+            bkeep_munmap(mapbuf, mapsize, VMA_INTERNAL);
         }
     }
 
@@ -641,8 +640,7 @@ static inline int __map_buffer (struct shim_handle * hdl, int size)
             return 0;
 
         DkStreamUnmap(file->mapbuf, file->mapsize);
-        int flags = VMA_INTERNAL;
-        bkeep_munmap(file->mapbuf, file->mapsize, &flags);
+        bkeep_munmap(file->mapbuf, file->mapsize, VMA_INTERNAL);
 
         file->mapbuf    = NULL;
         file->mapoffset = 0;

--- a/LibOS/shim/src/ipc/shim_ipc_child.c
+++ b/LibOS/shim/src/ipc/shim_ipc_child.c
@@ -192,7 +192,7 @@ DEFINE_PROFILE_INTERVAL(ipc_cld_exit_callback, ipc);
 
 int ipc_cld_exit_send (IDTYPE ppid, IDTYPE tid, unsigned int exitcode, unsigned int term_signal)
 {
-    unsigned long send_time = GET_PROFILE_INTERVAL();
+    __attribute__((unused)) unsigned long send_time = GET_PROFILE_INTERVAL();
     BEGIN_PROFILE_INTERVAL_SET(send_time);
     int ret = 0;
 

--- a/LibOS/shim/src/shim_checkpoint.c
+++ b/LibOS/shim/src/shim_checkpoint.c
@@ -819,6 +819,8 @@ static void * cp_alloc (struct shim_cp_store * store, void * addr, int size)
                                     PAL_PROT_READ|PAL_PROT_WRITE);
     } else {
         // Alloc on any address, with specified size.
+        // We need to retry because `get_unmapped_vma_for_cp` is randomized.
+        // TODO: Fix this to remove the need for retrying.
         while (true) {
             addr = get_unmapped_vma_for_cp(size);
             if (!addr)

--- a/LibOS/shim/src/sys/shim_exec.c
+++ b/LibOS/shim/src/sys/shim_exec.c
@@ -121,9 +121,8 @@ int shim_do_execve_rtld (struct shim_handle * hdl, const char ** argv,
 
     DkVirtualMemoryFree(old_stack, old_stack_top - old_stack);
     DkVirtualMemoryFree(old_stack_red, old_stack - old_stack_red);
-    int flags = 0;
-    bkeep_munmap(old_stack, old_stack_top - old_stack, &flags);
-    bkeep_munmap(old_stack_red, old_stack - old_stack_red, &flags);
+    bkeep_munmap(old_stack, old_stack_top - old_stack, /*flags=*/0);
+    bkeep_munmap(old_stack_red, old_stack - old_stack_red, /*flags=*/0);
 
     remove_loaded_libraries();
     clean_link_map_list();

--- a/LibOS/shim/src/sys/shim_mmap.c
+++ b/LibOS/shim/src/sys/shim_mmap.c
@@ -134,7 +134,7 @@ void * shim_do_mmap (void * addr, size_t length, int prot, int flags, int fd,
 
 free_reserved:
     if (reserved)
-        bkeep_munmap((void *) mapped, mapped_end - mapped, &flags);
+        bkeep_munmap((void *) mapped, mapped_end - mapped, flags);
     return (void *) ret;
 }
 
@@ -142,9 +142,7 @@ int shim_do_mprotect (void * addr, size_t len, int prot)
 {
     uintptr_t mapped = ALIGN_DOWN((uintptr_t) addr);
     uintptr_t mapped_end = ALIGN_UP((uintptr_t) addr + len);
-    int flags = 0;
-
-    if (bkeep_mprotect((void *) mapped, mapped_end - mapped, prot, &flags) < 0)
+    if (bkeep_mprotect((void *) mapped, mapped_end - mapped, prot, /*flags=*/0) < 0)
         return -EACCES;
 
     if (!DkVirtualMemoryProtect((void *) mapped, mapped_end - mapped, prot))
@@ -167,9 +165,7 @@ int shim_do_munmap (void * addr, size_t len)
 
     uintptr_t mapped = ALIGN_DOWN((uintptr_t) addr);
     uintptr_t mapped_end = ALIGN_UP((uintptr_t) addr + len);
-    int flags = 0;
-
-    if (bkeep_munmap((void *) mapped, mapped_end - mapped, &flags) < 0)
+    if (bkeep_munmap((void *) mapped, mapped_end - mapped, /*flags=*/0) < 0)
         return -EACCES;
 
     DkVirtualMemoryFree((void *) mapped, mapped_end - mapped);

--- a/LibOS/shim/test/apps/ltp/FLAKY
+++ b/LibOS/shim/test/apps/ltp/FLAKY
@@ -23,6 +23,8 @@ Prone to hanging - I think a memory corruption issue that may have a pending fix
 recvfrom01,1
 recvfrom01,2
 
+futex_wait03,1 (see https://github.com/oscarlab/graphene/pull/180#issuecomment-368970338)
+
 Intermittent seg fault
 kill03,1
 

--- a/LibOS/shim/test/apps/ltp/PASSED
+++ b/LibOS/shim/test/apps/ltp/PASSED
@@ -212,7 +212,6 @@ futex_wait01,1
 futex_wait01,2
 futex_wait01,3
 futex_wait01,4
-futex_wait03,1
 futex_wait04,1
 futex_wait05,1
 futex_wait_bitset01,1

--- a/Pal/src/host/Linux-SGX/db_memory.c
+++ b/Pal/src/host/Linux-SGX/db_memory.c
@@ -85,6 +85,12 @@ int _DkVirtualMemoryAlloc (void ** paddr, uint64_t size, int alloc_type, int pro
     mem = get_reserved_pages(addr, size);
     if (!mem)
         return addr ? -PAL_ERROR_DENIED : -PAL_ERROR_NOMEM;
+    if (addr && mem != addr) {
+        // TODO: This case should be made impossible by fixing
+        // `get_reserved_pages` semantics.
+        free_pages(mem, size);
+        return -PAL_ERROR_INVAL; // `addr` was unaligned.
+    }
 
     memset(mem, 0, size);
 

--- a/Pal/src/host/Linux-SGX/enclave_framework.c
+++ b/Pal/src/host/Linux-SGX/enclave_framework.c
@@ -444,6 +444,11 @@ int init_trusted_files (void)
     }
 
     cfgbuf = malloc(CONFIG_MAX);
+    if (!cfgbuf) {
+        ret = -PAL_ERROR_NOMEM;
+        goto out;
+    }
+
     ssize_t len = get_config(store, "loader.preload", cfgbuf, CONFIG_MAX);
     if (len > 0) {
         int npreload = 0;
@@ -471,6 +476,12 @@ int init_trusted_files (void)
 
     free(cfgbuf);
     cfgbuf = malloc(cfgsize);
+    if (!cfgbuf) {
+        ret = -PAL_ERROR_NOMEM;
+        goto out;
+    }
+
+
     nuris = get_config_entries(store, "sgx.trusted_files", cfgbuf, cfgsize);
     if (nuris <= 0)
         goto no_trusted;
@@ -502,6 +513,11 @@ no_trusted:
 
     free(cfgbuf);
     cfgbuf = malloc(cfgsize);
+    if (!cfgbuf) {
+        ret = -PAL_ERROR_NOMEM;
+        goto out;
+    }
+
     nuris = get_config_entries(store, "sgx.allowed_files", cfgbuf, cfgsize);
     if (nuris <= 0)
         goto no_allowed;
@@ -544,6 +560,9 @@ int init_trusted_children (void)
         return 0;
 
     char * cfgbuf = malloc(cfgsize);
+    if (!cfgbuf)
+        return -PAL_ERROR_NOMEM;
+
     int nuris = get_config_entries(store, "sgx.trusted_mrenclave",
                                    cfgbuf, cfgsize);
     if (nuris > 0) {

--- a/Pal/src/host/Linux-SGX/enclave_framework.c
+++ b/Pal/src/host/Linux-SGX/enclave_framework.c
@@ -433,7 +433,7 @@ static int init_trusted_file (const char * key, const char * uri)
 int init_trusted_files (void)
 {
     struct config_store * store = pal_state.root_config;
-    char * cfgbuf;
+    char * cfgbuf = NULL;
     ssize_t cfgsize;
     int nuris, ret;
 
@@ -443,7 +443,7 @@ int init_trusted_files (void)
             goto out;
     }
 
-    cfgbuf = __alloca(CONFIG_MAX);
+    cfgbuf = malloc(CONFIG_MAX);
     ssize_t len = get_config(store, "loader.preload", cfgbuf, CONFIG_MAX);
     if (len > 0) {
         int npreload = 0;
@@ -469,7 +469,8 @@ int init_trusted_files (void)
     if (cfgsize <= 0)
         goto no_trusted;
 
-    cfgbuf = __alloca(cfgsize);
+    free(cfgbuf);
+    cfgbuf = malloc(cfgsize);
     nuris = get_config_entries(store, "sgx.trusted_files", cfgbuf, cfgsize);
     if (nuris <= 0)
         goto no_trusted;
@@ -499,7 +500,8 @@ no_trusted:
     if (cfgsize <= 0)
         goto no_allowed;
 
-    cfgbuf = __alloca(cfgsize);
+    free(cfgbuf);
+    cfgbuf = malloc(cfgsize);
     nuris = get_config_entries(store, "sgx.allowed_files", cfgbuf, cfgsize);
     if (nuris <= 0)
         goto no_allowed;
@@ -523,6 +525,7 @@ no_trusted:
 no_allowed:
     ret = 0;
 out:
+    free(cfgbuf);
     return ret;
 }
 
@@ -540,7 +543,7 @@ int init_trusted_children (void)
     if (cfgsize <= 0)
         return 0;
 
-    char * cfgbuf = __alloca(cfgsize);
+    char * cfgbuf = malloc(cfgsize);
     int nuris = get_config_entries(store, "sgx.trusted_mrenclave",
                                    cfgbuf, cfgsize);
     if (nuris > 0) {
@@ -560,7 +563,7 @@ int init_trusted_children (void)
                 register_trusted_child(uri, mrenclave);
         }
     }
-
+    free(cfgbuf);
     return 0;
 }
 

--- a/Pal/src/host/Linux-SGX/enclave_framework.c
+++ b/Pal/src/host/Linux-SGX/enclave_framework.c
@@ -924,13 +924,13 @@ int _DkStreamAttestationRespond (PAL_HANDLE stream, void * data,
     }
 
     if (ret == 1) {
-        SGX_DBG(DBG_S, "Not an allowed encalve (mrenclave = %s)\n",
+        SGX_DBG(DBG_S, "Not an allowed enclave (mrenclave = %s)\n",
                 hex2str(att.mrenclave));
         ret = -PAL_ERROR_DENIED;
         goto out;
     }
 
-    SGX_DBG(DBG_S, "Remote attestation succeed!\n");
+    SGX_DBG(DBG_S, "Remote attestation succeeded!\n");
     return 0;
 
 out:

--- a/Pal/src/host/Linux-SGX/enclave_pages.c
+++ b/Pal/src/host/Linux-SGX/enclave_pages.c
@@ -68,6 +68,8 @@ static void assert_vma_list (void)
 #endif
 }
 
+// TODO: This function should be fixed to always either return exactly `addr` or
+// fail.
 void * get_reserved_pages(void * addr, uint64_t size)
 {
     if (!size)

--- a/Pal/src/pal.h
+++ b/Pal/src/pal.h
@@ -30,7 +30,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
-typedef uint64_t PAL_NUM;
+typedef uint64_t      PAL_NUM;
 typedef const char *  PAL_STR;
 typedef void *        PAL_PTR;
 typedef uint32_t      PAL_FLG;
@@ -217,6 +217,7 @@ PAL_CONTROL * pal_control_addr (void);
 #define PAL_PROT_WRITECOPY  0x8     /* 0x8 Copy on write */
 
 
+// If addr != NULL, then the returned region is always exactly at addr.
 PAL_PTR
 DkVirtualMemoryAlloc (PAL_PTR addr, PAL_NUM size, PAL_FLG alloc_type,
                       PAL_FLG prot);

--- a/Pal/src/slab.c
+++ b/Pal/src/slab.c
@@ -41,8 +41,8 @@ static PAL_LOCK slab_mgr_lock = LOCK_INIT;
 #if STATIC_SLAB == 1
 # define POOL_SIZE 64 * 1024 * 1024 /* 64MB by default */
 static char mem_pool[POOL_SIZE];
-static char *bump = mem_pool;
-static char *mem_pool_end = &mem_pool[POOL_SIZE];
+static void *bump = mem_pool;
+static void *mem_pool_end = &mem_pool[POOL_SIZE];
 #else
 # define PAGE_SIZE (slab_alignment)
 #endif
@@ -71,7 +71,7 @@ static inline void * __malloc (int size)
 static inline void __free (void * addr, int size)
 {
 #if STATIC_SLAB == 1
-    if ((char *) addr >= (char *) mem_pool && (char *) addr + size <= (char *) mem_pool_end)
+    if (addr >= (void *)mem_pool && addr < mem_pool_end)
         return;
 #endif
 


### PR DESCRIPTION
Small fixups:
* Replaced `alloca` with `malloc` for potentially large buffers in `enclave_framework.c` (partially fixes #173).
* Many minor code readability improvements (e.g. removed a `while` loop implemented using `goto`...).
* Fixed int overflow in `calloc`.
* Fixed a few resource leaks (including two unreleased locks).
* Added `__attribute__((unused))` to a variable used in an ifdefed code to remove a compiler warning.
* Removed `print_vma_hash`, this function looks like it never worked (it doesn't even print anything?).
* Fixed many typos.