### PR TITLE
A manifest option allowing applications to create files which are not in trusted/allowed file lists

### DIFF
--- a/Pal/src/host/Linux-SGX/db_files.c
+++ b/Pal/src/host/Linux-SGX/db_files.c
@@ -67,7 +67,7 @@ static int file_open (PAL_HANDLE * handle, const char * type, const char * uri,
 
     sgx_stub_t * stubs;
     uint64_t total;
-    int ret = load_trusted_file(hdl, &stubs, &total);
+    int ret = load_trusted_file(hdl, &stubs, &total, create);
     if (ret < 0) {
         SGX_DBG(DBG_E, "Accessing file:%s is denied. (%s) "
                 "This file is not trusted or allowed.\n", hdl->file.realpath,

--- a/Pal/src/host/Linux-SGX/enclave_framework.c
+++ b/Pal/src/host/Linux-SGX/enclave_framework.c
@@ -156,6 +156,7 @@ int load_trusted_file (PAL_HANDLE file, sgx_stub_t ** stubptr,
        The created file is added to allowed_file list for later access */
     if (create && allow_file_creation) {
        register_trusted_file(uri, NULL);
+       *sizeptr = 0;
        return 0;
     }
 

--- a/Pal/src/host/Linux-SGX/enclave_framework.c
+++ b/Pal/src/host/Linux-SGX/enclave_framework.c
@@ -124,6 +124,19 @@ static struct spinlock trusted_file_lock = LOCK_INIT;
 static int trusted_file_indexes = 0;
 static int allow_file_creation = 0;
 
+
+/* Function: load_trusted_file
+ * checks if the file to be opened is trusted or allowed,
+ * according to the setting in manifest
+ *
+ * file:     file handle to be opened
+ * stubptr:  buffer for catching matched file stub.
+ * sizeptr:  size pointer
+ * create:   this file is newly created or not
+ *
+ * return:  0 succeed
+ */
+
 int load_trusted_file (PAL_HANDLE file, sgx_stub_t ** stubptr,
                        uint64_t * sizeptr, int create)
 {
@@ -139,10 +152,13 @@ int load_trusted_file (PAL_HANDLE file, sgx_stub_t ** stubptr,
     if (uri_len < 0)
         return uri_len;
 
+    /* Allow to create the file when allow_file_creation is turned on;
+       The created file is added to allowed_file list for later access */
     if (create && allow_file_creation) {
        register_trusted_file(uri, NULL);
        return 0;
     }
+
     /* Normalize the uri */
     if (!strpartcmp_static(uri, "file:")) {
         SGX_DBG(DBG_E, "Invalid URI [%s]: Trusted files must start with 'file:'\n", uri);;

--- a/Pal/src/host/Linux-SGX/pal_linux.h
+++ b/Pal/src/host/Linux-SGX/pal_linux.h
@@ -104,8 +104,22 @@ typedef struct { char bytes[32]; } sgx_checksum_t;
 typedef struct { char bytes[16]; } sgx_stub_t;
 
 int init_trusted_files (void);
+
+/* Function: load_trusted_file
+ * checks if the file to be opened is trusted or allowed,
+ * according to the setting in manifest
+ *
+ * file:     file handle to be opened
+ * stubptr:  buffer for catching matched file stub.
+ * sizeptr:  size pointer
+ * create:   this file is newly created or not
+ *
+ * return:  0 succeed
+ */
+
 int load_trusted_file
     (PAL_HANDLE file, sgx_stub_t ** stubptr, uint64_t * sizeptr, int create);
+
 int verify_trusted_file
     (const char * uri, void * mem, uint64_t offset, uint64_t size,
      sgx_stub_t * stubs, uint64_t total_size);

--- a/Pal/src/host/Linux-SGX/pal_linux.h
+++ b/Pal/src/host/Linux-SGX/pal_linux.h
@@ -105,7 +105,7 @@ typedef struct { char bytes[16]; } sgx_stub_t;
 
 int init_trusted_files (void);
 int load_trusted_file
-    (PAL_HANDLE file, sgx_stub_t ** stubptr, uint64_t * sizeptr);
+    (PAL_HANDLE file, sgx_stub_t ** stubptr, uint64_t * sizeptr, int create);
 int verify_trusted_file
     (const char * uri, void * mem, uint64_t offset, uint64_t size,
      sgx_stub_t * stubs, uint64_t total_size);

--- a/Pal/test/File.c
+++ b/Pal/test/File.c
@@ -15,7 +15,7 @@ int main (int argc, char ** argv, char ** envp)
     pal_printf("Enter Main Thread\n");
 
     PAL_HANDLE out = DkStreamOpen(file_uri, PAL_ACCESS_RDWR,
-                                  PAL_SHARE_OWNER_W,
+                                  PAL_SHARE_OWNER_W | PAL_SHARE_OWNER_R,
                                   PAL_CREAT_TRY, 0);
 
     if (out == NULL) {

--- a/Pal/test/manifest.template
+++ b/Pal/test/manifest.template
@@ -9,3 +9,6 @@
 net.allow_bind.1 = 127.0.0.1:8000
 # allow to connect to port 8000
 net.allow_peer.1 = 127.0.0.1:8000
+
+# allow files are newly created
+sgx.allow_file_creation = 1


### PR DESCRIPTION
The PR includes a new option named "sgx.allow_file_creation", which is disabled by default. By turning on this option, users could allow the application to create the files which are not in trusted and allowed file lists. After the file is created, following open/read/write are allowed. 