### PR TITLE
Fix segfault in apache

### DIFF
--- a/LibOS/shim/src/elf/shim_rtld.c
+++ b/LibOS/shim/src/elf/shim_rtld.c
@@ -704,9 +704,7 @@ postmap:
         /* DEP 3/12/18: This string is not stable; copy it. */
         char * tmp = (char *) (D_PTR (l->l_info[DT_STRTAB])
                               + D_PTR (l->l_info[DT_SONAME]));
-        size_t len = strlen(tmp);
-        l->l_soname = malloc(len+1);
-        memcpy(l->l_soname, tmp, len+1);
+        l->l_soname = remalloc(tmp, strlen(tmp) + 1);
     }
 
     if (l->l_phdr == NULL) {

--- a/LibOS/shim/src/elf/shim_rtld.c
+++ b/LibOS/shim/src/elf/shim_rtld.c
@@ -700,9 +700,14 @@ postmap:
 
     /* When we profile the SONAME might be needed for something else but
        loading.  Add it right away.  */
-    if (l->l_info[DT_STRTAB] && l->l_info[DT_SONAME])
-        l->l_soname = (char *) (D_PTR (l->l_info[DT_STRTAB])
+    if (l->l_info[DT_STRTAB] && l->l_info[DT_SONAME]) {
+        /* DEP 3/12/18: This string is not stable; copy it. */
+        char * tmp = (char *) (D_PTR (l->l_info[DT_STRTAB])
                               + D_PTR (l->l_info[DT_SONAME]));
+        size_t len = strlen(tmp);
+        l->l_soname = malloc(len+1);
+        memcpy(l->l_soname, tmp, len+1);
+    }
 
     if (l->l_phdr == NULL) {
         /* The program header is not contained in any of the segments.


### PR DESCRIPTION
The ubiquitous segfault in apache seems to be that the elf header goes away after a while, causing a segfault on checkpoint (for fork).  I suspect this may be related to #95 , as a lot of the elf code is set to PROT_NONE, and we may need to unset this parameter.

In particular, l_soname ends up pointing to inaccessible memory.

I am not sure this really fixes the root issue, but it does at least get apache running again on the non-SGX build.  I'd welcome any input on a better way to fix this.