### PR TITLE
Socket Handle Waiting Fixes

### DIFF
--- a/Jenkinsfiles/ubuntu-16.04.dockerfile
+++ b/Jenkinsfiles/ubuntu-16.04.dockerfile
@@ -19,6 +19,7 @@ RUN apt-get update \
        python-protobuf \
        python3-minimal \
        python3-pytest \
+       telnet \
        texinfo \
        wget \
        libomp-dev \

--- a/LibOS/shim/test/regression/80_sockets.py
+++ b/LibOS/shim/test/regression/80_sockets.py
@@ -19,20 +19,16 @@ except OSError:
     ## some debug output
     sys.exit(1)
 if pid == 0:
-    ## eventually use os.putenv(..) to set environment variables
-    ## os.execv strips of args[0] for the arguments
-    os.system("sleep 2 && telnet localhost 8001 2>&1 >/dev/null")
+    # wait till epoll_socket warms up and run telnet client
+    os.system("sleep 10 && telnet localhost 8000 >/dev/null 2>/dev/null")
     sys.exit(0)
 
-
-regression = Regression(loader, "epoll_socket", None)
-
+regression = Regression(loader, "epoll_socket", None, 50000)
 
 regression.add_check(name="Epoll on a writable socket",
-                     args = ['8001'],
+                     args = ['8000'],
                      check=lambda res: "Accepted connection" in res[0].out and
                      "socket is writable" in res[0].out)
 
 rv = regression.run_checks()
-
 if rv: sys.exit(rv)

--- a/LibOS/shim/test/regression/80_sockets.py
+++ b/LibOS/shim/test/regression/80_sockets.py
@@ -1,0 +1,38 @@
+import os, sys, mmap
+from regression import Regression
+
+loader = sys.argv[1]
+
+# Running getsockopt
+regression = Regression(loader, "getsockopt", None)
+
+regression.add_check(name="getsockopt",
+    check=lambda res: "getsockopt: Got socket type OK" in res[0].out)
+
+rv = regression.run_checks()
+if rv: sys.exit(rv)
+
+# Run epoll_socket
+try:
+    pid = os.fork()
+except OSError:
+    ## some debug output
+    sys.exit(1)
+if pid == 0:
+    ## eventually use os.putenv(..) to set environment variables
+    ## os.execv strips of args[0] for the arguments
+    os.system("sleep 2 && telnet localhost 8001 2>&1 >/dev/null")
+    sys.exit(0)
+
+
+regression = Regression(loader, "epoll_socket", None)
+
+
+regression.add_check(name="Epoll on a writable socket",
+                     args = ['8001'],
+                     check=lambda res: "Accepted connection" in res[0].out and
+                     "socket is writable" in res[0].out)
+
+rv = regression.run_checks()
+
+if rv: sys.exit(rv)

--- a/LibOS/shim/test/regression/epoll_socket.c
+++ b/LibOS/shim/test/regression/epoll_socket.c
@@ -1,0 +1,233 @@
+// Copied from
+// https://banu.com/blog/2/how-to-use-epoll-a-complete-example-in-c/epoll-example.c
+
+// Meant to be used for edge triggered epoll
+
+#include <errno.h>
+#include <fcntl.h>
+#include <netdb.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/epoll.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#define MAXEVENTS 64
+
+static int make_socket_non_blocking(int sfd) {
+    int flags, s;
+
+    flags = fcntl(sfd, F_GETFL, 0);
+    if (flags == -1) {
+        perror("fcntl");
+        return -1;
+    }
+
+    flags |= O_NONBLOCK;
+    s = fcntl(sfd, F_SETFL, flags);
+    if (s == -1) {
+        perror("fcntl");
+        return -1;
+    }
+
+    return 0;
+}
+
+static int create_and_bind(int port) {
+    struct sockaddr_in serv_addr;
+
+    int sfd = socket(AF_INET, SOCK_STREAM, 0);
+
+    if (sfd == -1)
+        return -1;
+
+    serv_addr.sin_family      = AF_INET;
+    serv_addr.sin_addr.s_addr = INADDR_ANY;
+    serv_addr.sin_port        = htons(port);
+
+    int s = bind(sfd, (struct sockaddr*)&serv_addr, sizeof(serv_addr));
+    if (s != 0)
+        perror("bind failed\n");
+
+    return sfd;
+}
+
+int main(int argc, char* argv[]) {
+    int sfd, s;
+    int efd;
+    struct epoll_event event;
+    struct epoll_event* events;
+    int loops = 5;
+
+    // Default to 8001
+    int port = 8001;
+    // The only argument we take is an optional port
+    if (argc > 1)
+        port = atoi(argv[1]);
+
+    sfd = create_and_bind(port);
+    if (sfd == -1)
+        abort();
+
+    s = make_socket_non_blocking(sfd);
+    if (s == -1)
+        abort();
+
+    s = listen(sfd, SOMAXCONN);
+    if (s == -1) {
+        perror("listen");
+        abort();
+    }
+
+    efd = epoll_create1(0);
+    if (efd == -1) {
+        perror("epoll_create");
+        abort();
+    }
+
+    event.data.fd = sfd;
+    event.events  = EPOLLIN | EPOLLOUT;
+    s             = epoll_ctl(efd, EPOLL_CTL_ADD, sfd, &event);
+    if (s == -1) {
+        perror("epoll_ctl");
+        abort();
+    }
+
+    /* Buffer where events are returned */
+    events = calloc(MAXEVENTS, sizeof(*events));
+
+    /* The event loop */
+    for (int j = 0; j < loops; j++) {
+        int n, i;
+
+        n = epoll_wait(efd, events, MAXEVENTS, -1);
+
+        if (n == -1) {
+            perror("epoll_wait failed");
+            abort();
+        }
+
+        for (i = 0; i < n; i++) {
+            // MODIFICATION 1
+            if (events[i].events & EPOLLOUT) {
+                printf("socket is writable\n");
+                continue;
+            }
+
+            if ((events[i].events & EPOLLERR) || (events[i].events & EPOLLHUP) ||
+                (!(events[i].events & EPOLLIN))) {
+                /* An error has occured on this fd, or the socket is not
+                   ready for reading (why were we notified then?) */
+                fprintf(stderr, "epoll error\n");
+
+                // MODIFICATION 2
+                // don't close the socket here, might be writable
+                // close(events[i].data.fd);
+                continue;
+            }
+
+            else if (sfd == events[i].data.fd) {
+                /* We have a notification on the listening socket, which
+                   means one or more incoming connections. */
+                while (1) {
+                    struct sockaddr in_addr;
+                    socklen_t in_len;
+                    int infd;
+                    char hbuf[NI_MAXHOST], sbuf[NI_MAXSERV];
+
+                    in_len = sizeof in_addr;
+                    infd   = accept(sfd, &in_addr, &in_len);
+                    if (infd == -1) {
+                        if ((errno == EAGAIN) || (errno == EWOULDBLOCK)) {
+                            /* We have processed all incoming
+                               connections. */
+                            break;
+                        } else {
+                            perror("accept");
+                            break;
+                        }
+                    }
+
+                    s = getnameinfo(&in_addr, in_len, hbuf, sizeof hbuf, sbuf, sizeof sbuf,
+                                    NI_NUMERICHOST | NI_NUMERICSERV);
+                    if (s == 0)
+                        printf("Accepted connection\n");
+                    else {
+                        perror("getnameinfo failed");
+                        abort();
+                    }
+
+                    /* Make the incoming socket non-blocking and add it to the
+                       list of fds to monitor. */
+                    s = make_socket_non_blocking(infd);
+                    if (s == -1)
+                        abort();
+
+                    event.data.fd = infd;
+
+                    // MODIFICATION 3
+                    // event.events = EPOLLIN | EPOLLET;
+                    event.events = EPOLLIN | EPOLLOUT;
+
+                    s = epoll_ctl(efd, EPOLL_CTL_ADD, infd, &event);
+                    if (s == -1) {
+                        perror("epoll_ctl");
+                        abort();
+                    }
+                }
+                continue;
+            } else {
+                /* We have data on the fd waiting to be read. Read and
+                   display it. We must read whatever data is available
+                   completely, as we are running in edge-triggered mode
+                   and won't get a notification again for the same
+                   data. */
+                int done = 0;
+
+                while (1) {
+                    ssize_t count;
+                    char buf[512];
+
+                    count = read(events[i].data.fd, buf, sizeof buf);
+                    if (count == -1) {
+                        /* If errno == EAGAIN, that means we have read all
+                           data. So go back to the main loop. */
+                        if (errno != EAGAIN) {
+                            perror("read");
+                            done = 1;
+                        }
+                        break;
+                    } else if (count == 0) {
+                        /* End of file. The remote has closed the
+                           connection. */
+                        done = 1;
+                        break;
+                    }
+
+                    /* Write the buffer to standard output */
+                    s = write(1, buf, count);
+                    if (s == -1) {
+                        perror("write");
+                        abort();
+                    }
+                }
+
+                if (done) {
+                    printf("Closed connection on descriptor %d\n", events[i].data.fd);
+
+                    /* Closing the descriptor will make epoll remove it
+                       from the set of descriptors which are monitored. */
+                    close(events[i].data.fd);
+                }
+            }
+        }
+    }
+
+ done:
+    free(events);
+    close(sfd);
+
+    return 0;
+}

--- a/LibOS/shim/test/regression/epoll_socket.c
+++ b/LibOS/shim/test/regression/epoll_socket.c
@@ -1,7 +1,4 @@
-// Copied from
-// https://banu.com/blog/2/how-to-use-epoll-a-complete-example-in-c/epoll-example.c
-
-// Meant to be used for edge triggered epoll
+// Copied from https://banu.com/blog/2/how-to-use-epoll-a-complete-example-in-c/epoll-example.c
 
 #include <errno.h>
 #include <fcntl.h>
@@ -61,8 +58,7 @@ int main(int argc, char* argv[]) {
     struct epoll_event* events;
     int loops = 5;
 
-    // Default to 8001
-    int port = 8001;
+    int port = 8000;
     // The only argument we take is an optional port
     if (argc > 1)
         port = atoi(argv[1]);
@@ -225,7 +221,6 @@ int main(int argc, char* argv[]) {
         }
     }
 
- done:
     free(events);
     close(sfd);
 

--- a/Pal/regression/02_Socket.py
+++ b/Pal/regression/02_Socket.py
@@ -1,0 +1,59 @@
+import os, sys, mmap
+from regression import Regression
+
+loader = os.environ['PAL_LOADER']
+
+regression = Regression(loader, "Socket")
+
+regression.add_check(name="TCP Socket Creation",
+    check=lambda res: "TCP Creation 1 OK" in res[0].log)
+
+regression.add_check(name="TCP Socket Connection",
+    check=lambda res: "TCP Connection 1 OK" in res[0].log)
+
+regression.add_check(name="TCP Socket Transmission",
+    check=lambda res: "TCP Write 1 OK" in res[0].log and
+                      "TCP Read 1: Hello World 1" in res[0].log and
+                      "TCP Write 2 OK" in res[0].log and
+                      "TCP Read 2: Hello World 2" in res[0].log)
+
+regression.add_check(name="TCP Socket Wait",
+    check=lambda res: all([x in res[0].log for x in [
+        "DkObjectsWaitAny tcp was able to wait on tcp handle, iteration 0.",
+        "DkObjectsWaitAny tcp was able to wait on tcp handle, iteration 1.",
+        "DkObjectsWaitAny tcp was able to wait on tcp handle, iteration 2.",
+        "DkObjectsWaitAny(2) tcp was able to wait on tcp handle, iteration 0.",
+        "DkObjectsWaitAny(2) tcp was able to wait on tcp handle, iteration 1.",
+        "DkObjectsWaitAny(2) tcp was able to wait on tcp handle, iteration 2."]]))
+
+
+regression.add_check(name="UDP Socket Creation",
+    check=lambda res: "UDP Creation 1 OK" in res[0].log)
+
+regression.add_check(name="UDP Socket Connection",
+    check=lambda res: "UDP Connection 1 OK" in res[0].log)
+
+regression.add_check(name="UDP Socket Transmission",
+    check=lambda res: "UDP Write 1 OK" in res[0].log and
+                      "UDP Read 1: Hello World 1" in res[0].log and
+                      "UDP Write 2 OK" in res[0].log and
+                      "UDP Read 2: Hello World 2" in res[0].log)
+
+regression.add_check(name="Bound UDP Socket Transmission",
+    check=lambda res: "UDP Write 3 OK" in res[0].log and
+                      "UDP Read 3: Hello World 1" in res[0].log and
+                      "UDP Write 4 OK" in res[0].log and
+                      "UDP Read 4: Hello World 2" in res[0].log)
+
+regression.add_check(name="UDP Socket Wait",
+    check=lambda res: all([x in res[0].log for x in [
+        "DkObjectsWaitAny udp was able to wait on udp handle, iteration 0.",
+        "DkObjectsWaitAny udp was able to wait on udp handle, iteration 1.",
+        "DkObjectsWaitAny udp was able to wait on udp handle, iteration 2.",
+        "DkObjectsWaitAny(2) udp was able to wait on udp handle, iteration 0.",
+        "DkObjectsWaitAny(2) udp was able to wait on udp handle, iteration 1.",
+        "DkObjectsWaitAny(2) udp was able to wait on udp handle, iteration 2."]]))
+
+
+rv = regression.run_checks()
+if rv: sys.exit(rv)

--- a/Pal/regression/Socket.c
+++ b/Pal/regression/Socket.c
@@ -1,9 +1,8 @@
+#include "api.h"
 #include "pal.h"
 #include "pal_debug.h"
-#include "api.h"
 
-int main (int argc, char ** argv, char ** envp)
-{
+int main(int argc, char** argv, char** envp) {
     char buffer1[20] = "Hello World 1", buffer2[20] = "Hello World 2";
     char buffer3[20], buffer4[20];
     int ret;
@@ -40,6 +39,44 @@ int main (int argc, char ** argv, char ** envp)
                 if (ret > 0)
                     pal_printf("TCP Read 2: %s\n", buffer4);
 
+                for (int i = 0; i < 3; i++) {
+                    // Test waiting on the handle
+                    PAL_HANDLE rv = DkObjectsWaitAny(1, &tcp2, 0);
+                    if (rv == NULL)
+                        pal_printf("DkObjectsWaitAny tcp timed out, iteration %d.\n", i);
+                    else if (rv == tcp2)
+                        pal_printf(
+                            "DkObjectsWaitAny tcp was able to wait on tcp handle, iteration %d.\n",
+                            i);
+                    else
+                        pal_printf(
+                            "DkObjectsWaitAny tcp got bad return value after waiting on tcp "
+                            "handle, iteration %d.\n",
+                            i);
+                }
+
+                for (int i = 0; i < 3; i++) {
+                    PAL_HANDLE handles[2];
+                    handles[0] = tcp2;
+                    handles[1] = tcp3;
+                    // Test waiting on the handle
+                    PAL_HANDLE rv = DkObjectsWaitAny(2, handles, 0);
+                    if (rv == NULL)
+                        pal_printf("DkObjectsWaitAny(2) tcp timed out, iteration %d.\n", i);
+                    else if (rv == tcp2 || rv == tcp3)  // right answer is not
+                                                        // defined, as long as
+                                                        // one is writable
+                        pal_printf(
+                            "DkObjectsWaitAny(2) tcp was able to wait on tcp handle, iteration "
+                            "%d.\n",
+                            i);
+                    else
+                        pal_printf(
+                            "DkObjectsWaitAny(2) tcp got bad return value after waiting on tcp "
+                            "handle, iteration %d.\n",
+                            i);
+                }
+
                 DkObjectClose(tcp3);
             }
 
@@ -50,14 +87,12 @@ int main (int argc, char ** argv, char ** envp)
         DkObjectClose(tcp1);
     }
 
-    PAL_HANDLE udp1 = DkStreamOpen("udp.srv:127.0.0.1:3000",
-                                   PAL_ACCESS_RDWR, 0, 0, 0);
+    PAL_HANDLE udp1 = DkStreamOpen("udp.srv:127.0.0.1:3000", PAL_ACCESS_RDWR, 0, 0, 0);
 
     if (udp1) {
         pal_printf("UDP Creation 1 OK\n");
 
-        PAL_HANDLE udp2 = DkStreamOpen("udp:127.0.0.1:3000",
-                                       PAL_ACCESS_RDWR, 0, 0, 0);
+        PAL_HANDLE udp2 = DkStreamOpen("udp:127.0.0.1:3000", PAL_ACCESS_RDWR, 0, 0, 0);
 
         if (udp2) {
             pal_printf("UDP Connection 1 OK\n");
@@ -86,8 +121,8 @@ int main (int argc, char ** argv, char ** envp)
             DkObjectClose(udp2);
         }
 
-        PAL_HANDLE udp3 = DkStreamOpen("udp:127.0.0.1:3001:127.0.0.1:3000",
-                                       PAL_ACCESS_RDWR, 0, 0, 0);
+        PAL_HANDLE udp3 =
+            DkStreamOpen("udp:127.0.0.1:3001:127.0.0.1:3000", PAL_ACCESS_RDWR, 0, 0, 0);
 
         if (udp3) {
             pal_printf("UDP Connection 2 OK\n");
@@ -112,6 +147,41 @@ int main (int argc, char ** argv, char ** envp)
             ret = DkStreamRead(udp3, 0, 20, buffer4, NULL, 0);
             if (ret > 0)
                 pal_printf("UDP Read 4: %s\n", buffer4);
+
+            for (int i = 0; i < 3; i++) {
+                // Test waiting on the handle
+                PAL_HANDLE rv = DkObjectsWaitAny(1, &udp3, 0);
+                if (rv == NULL)
+                    pal_printf("DkObjectsWaitAny udp timed out, iteration %d.\n", i);
+                else if (rv == udp3)
+                    pal_printf(
+                        "DkObjectsWaitAny udp was able to wait on udp handle, iteration %d.\n", i);
+                else
+                    pal_printf(
+                        "DkObjectsWaitAny udp got bad return value after waiting on udp handle, "
+                        "iteration %d.\n",
+                        i);
+            }
+
+            for (int i = 0; i < 3; i++) {
+                PAL_HANDLE handles[2];
+                handles[0] = udp1;
+                handles[1] = udp3;
+                // Test waiting on the handle
+                PAL_HANDLE rv = DkObjectsWaitAny(2, handles, 0);
+                if (rv == NULL)
+                    pal_printf("DkObjectsWaitAny(2) udp timed out, iteration %d.\n", i);
+                else if (rv == udp1 || rv == udp3)  // right answer is not defined,
+                                                    // as long as one is writable
+                    pal_printf(
+                        "DkObjectsWaitAny(2) udp was able to wait on udp handle, iteration %d.\n",
+                        i);
+                else
+                    pal_printf(
+                        "DkObjectsWaitAny(2) udp got bad return value after waiting on udp handle, "
+                        "iteration %d.\n",
+                        i);
+            }
 
             DkObjectClose(udp3);
         }

--- a/Pal/src/host/Linux-SGX/db_object.c
+++ b/Pal/src/host/Linux-SGX/db_object.c
@@ -20,50 +20,69 @@
  * This file contains APIs for closing or polling PAL handles.
  */
 
-#include "pal_defs.h"
-#include "pal_linux_defs.h"
+#include "api.h"
 #include "pal.h"
+#include "pal_debug.h"
+#include "pal_defs.h"
+#include "pal_error.h"
 #include "pal_internal.h"
 #include "pal_linux.h"
 #include "pal_linux_error.h"
 #include "pal_error.h"
 #include "pal_debug.h"
 #include "api.h"
+#include "pal_linux_defs.h"
 
-#include <linux/time.h>
-#include <linux/poll.h>
-#include <linux/wait.h>
 #include <atomic.h>
+#include <linux/poll.h>
+#include <linux/time.h>
+#include <linux/wait.h>
 
 #define DEFAULT_QUANTUM 500
 
 /* internally to wait for one object. Also used as a shortcut to wait
    on events and semaphores */
-static int _DkObjectWaitOne (PAL_HANDLE handle, PAL_NUM timeout)
-{
+static int _DkObjectWaitOne(PAL_HANDLE handle, PAL_NUM timeout) {
+    int writable_fd = -1;
+
     /* only for all these handle which has a file descriptor, or
        a eventfd. events and semaphores will skip this part */
     if (HANDLE_HDR(handle)->flags & HAS_FDS) {
         struct pollfd fds[MAX_FDS];
         int off[MAX_FDS];
         int nfds = 0;
-        for (int i = 0 ; i < MAX_FDS ; i++) {
+        for (int i = 0; i < MAX_FDS; i++) {
             int events = 0;
 
-            if ((HANDLE_HDR(handle)->flags & RFD(i)) &&
-                !(HANDLE_HDR(handle)->flags & ERROR(i)))
+            /* DEP 4/2/18: Go ahead and check for POLLOUT even if
+             * we have already cached the WRITABLE property.
+             * It should go quickly.  Or, we could quit early.
+             */
+
+            if ((HANDLE_HDR(handle)->flags & RFD(i)) && !(HANDLE_HDR(handle)->flags & ERROR(i)))
                 events |= POLLIN;
 
-            if ((HANDLE_HDR(handle)->flags & WFD(i)) &&
-                !(HANDLE_HDR(handle)->flags & WRITABLE(i)) &&
-                !(HANDLE_HDR(handle)->flags & ERROR(i)))
-                events |= POLLOUT;
+            if ((HANDLE_HDR(handle)->flags & WFD(i))) {
+                if (!(HANDLE_HDR(handle)->flags & WRITABLE(i)) &&
+                    !(HANDLE_HDR(handle)->flags & ERROR(i)))
+                    events |= POLLOUT;
+                else if (events && !(HANDLE_HDR(handle)->flags & ERROR(i))) {
+                    // We should be able to at least return that this handle
+                    // is writable, if anyone cares.  We only need to return
+                    // one, so it is ok to set the last one.
+                    timeout = 0;
+                    // DEP 2/5/19: This works out because the next `if` statement
+                    // will populate this field.  This function really needs a
+                    // major overhaul for clarity
+                    writable_fd = nfds;
+                }
+            }
 
             if (events) {
-                fds[nfds].fd = handle->generic.fds[i];
-                fds[nfds].events = events|POLLHUP|POLLERR;
+                fds[nfds].fd      = handle->generic.fds[i];
+                fds[nfds].events  = events | POLLHUP | POLLERR;
                 fds[nfds].revents = 0;
-                off[nfds] = i;
+                off[nfds]         = i;
                 nfds++;
             }
         }
@@ -76,10 +95,16 @@ static int _DkObjectWaitOne (PAL_HANDLE handle, PAL_NUM timeout)
         if (IS_ERR(ret))
             return unix_to_pal_error(ERRNO(ret));
 
-        if (!ret)
-            return -PAL_ERROR_TRYAGAIN;
+        if (!ret) {
+            // DEP 4/2/18: Patch up the case where a WRITABLE socket can
+            // return immediately
+            if (writable_fd != -1) {
+                fds[writable_fd].revents |= POLLOUT;
+            } else
+                return -PAL_ERROR_TRYAGAIN;
+        }
 
-        for (int i = 0 ; i < nfds ; i++) {
+        for (int i = 0; i < nfds; i++) {
             if (!fds[i].revents)
                 continue;
             if (fds[i].revents & POLLOUT)
@@ -91,7 +116,7 @@ static int _DkObjectWaitOne (PAL_HANDLE handle, PAL_NUM timeout)
         return 0;
     }
 
-    const struct handle_ops * ops = HANDLE_OPS(handle);
+    const struct handle_ops* ops = HANDLE_OPS(handle);
 
     if (!ops || !ops->wait)
         return -PAL_ERROR_NOTSUPPORT;
@@ -101,9 +126,8 @@ static int _DkObjectWaitOne (PAL_HANDLE handle, PAL_NUM timeout)
 
 /* _DkObjectsWaitAny for internal use. The function wait for any of the handle
    in the handle array. timeout can be set for the wait. */
-int _DkObjectsWaitAny (int count, PAL_HANDLE * handleArray, PAL_NUM timeout,
-                       PAL_HANDLE * polled)
-{
+int _DkObjectsWaitAny(int count, PAL_HANDLE* handleArray, PAL_NUM timeout, PAL_HANDLE* polled) {
+    int writable_fd = -1;
     if (count <= 0)
         return 0;
 
@@ -124,7 +148,7 @@ int _DkObjectsWaitAny (int count, PAL_HANDLE * handleArray, PAL_NUM timeout,
     /* we are not gonna to allow any polling on muliple synchronous
        objects, doing this is simply violating the division of
        labor between PAL and library OS */
-    for (i = 0 ; i < count ; i++) {
+    for (i = 0; i < count; i++) {
         PAL_HANDLE hdl = handleArray[i];
 
         if (!hdl)
@@ -134,48 +158,64 @@ int _DkObjectsWaitAny (int count, PAL_HANDLE * handleArray, PAL_NUM timeout,
             return -PAL_ERROR_NOTSUPPORT;
 
         /* eliminate repeated entries */
-        for (j = 0 ; j < i ; j++)
+        for (j = 0; j < i; j++)
             if (hdl == handleArray[j])
                 break;
         if (j == i) {
-            for (j = 0 ; j < MAX_FDS ; j++)
-                if (HANDLE_HDR(hdl)->flags & (RFD(j)|WFD(j)))
+            for (j = 0; j < MAX_FDS; j++)
+                if (HANDLE_HDR(hdl)->flags & (RFD(j) | WFD(j)))
                     maxfds++;
         }
     }
 
-    struct pollfd * fds = __alloca(sizeof(struct pollfd) * maxfds);
-    PAL_HANDLE * hdls = __alloca(sizeof(PAL_HANDLE) * maxfds);
+    struct pollfd* fds = __alloca(sizeof(struct pollfd) * maxfds);
+    PAL_HANDLE* hdls   = __alloca(sizeof(PAL_HANDLE) * maxfds);
 
-    for (i = 0 ; i < count ; i++) {
+    for (i = 0; i < count; i++) {
         PAL_HANDLE hdl = handleArray[i];
 
         if (!hdl)
             continue;
 
-        for (j = 0 ; j < i ; j++)
+        for (j = 0; j < i; j++)
             if (hdl == handleArray[j])
                 break;
         if (j < i)
             continue;
 
-        for (j = 0 ; j < MAX_FDS ; j++) {
+        for (j = 0; j < MAX_FDS; j++) {
             int events = 0;
 
-            if ((HANDLE_HDR(hdl)->flags & RFD(j)) &&
-                !(HANDLE_HDR(hdl)->flags & ERROR(j)))
+            if ((HANDLE_HDR(hdl)->flags & RFD(j)) && !(HANDLE_HDR(hdl)->flags & ERROR(j)))
                 events |= POLLIN;
 
-            if ((HANDLE_HDR(hdl)->flags & WFD(j)) &&
-                !(HANDLE_HDR(hdl)->flags & WRITABLE(j)) &&
-                !(HANDLE_HDR(hdl)->flags & ERROR(j)))
-                events |= POLLOUT;
+            /* DEP 4/2/18: Go ahead and check for POLLOUT even if
+             * we have already cached the WRITABLE property.
+             * It should go quickly.  Or, we could quit early.
+             */
+
+            if ((HANDLE_HDR(hdl)->flags & WFD(j))) {
+                if (!(HANDLE_HDR(hdl)->flags & WRITABLE(j)) &&
+                    !(HANDLE_HDR(hdl)->flags & ERROR(j)))
+                    events |= POLLOUT;
+                else if (events && hdl->generic.fds[j] != PAL_IDX_POISON &&
+                         !(HANDLE_HDR(hdl)->flags & ERROR(j))) {
+                    // We should be able to at least return that this handle
+                    // is writable, if anyone cares.  We only need to return
+                    // one, so it is ok to set the last one.
+                    timeout = 0;
+                    // DEP 2/5/19: This works out because the next `if` statement
+                    // will populate this field.  This function really needs a
+                    // major overhaul for clarity
+                    writable_fd = nfds;
+                }
+            }
 
             if (events && hdl->generic.fds[j] != PAL_IDX_POISON) {
-                fds[nfds].fd = hdl->generic.fds[j];
-                fds[nfds].events = events|POLLHUP|POLLERR;
+                fds[nfds].fd      = hdl->generic.fds[j];
+                fds[nfds].events  = events | POLLHUP | POLLERR;
                 fds[nfds].revents = 0;
-                hdls[nfds] = hdl;
+                hdls[nfds]        = hdl;
                 nfds++;
             }
         }
@@ -189,12 +229,18 @@ int _DkObjectsWaitAny (int count, PAL_HANDLE * handleArray, PAL_NUM timeout,
     if (IS_ERR(ret))
         return unix_to_pal_error(ERRNO(ret));
 
-    if (!ret)
-        return -PAL_ERROR_TRYAGAIN;
+    if (!ret) {
+        // DEP 4/2/18: Patch up the case where a WRITABLE socket can
+        // return immediately
+        if (writable_fd != -1) {
+            fds[writable_fd].revents |= POLLOUT;
+        } else
+            return -PAL_ERROR_TRYAGAIN;
+    }
 
     PAL_HANDLE polled_hdl = NULL;
 
-    for (i = 0 ; i < nfds ; i++) {
+    for (i = 0; i < nfds; i++) {
         if (!fds[i].revents)
             continue;
 


### PR DESCRIPTION
This PR addresses the bug raised in #192 (the second issue), where a repeated wait on a writeable handle was hanging rather than returning that the handle is writeable.  This is a bug in the DkObjectsWaitAny function.

Add unit tests at PAL and LibOS level for this behavior.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/197)
<!-- Reviewable:end -->
