### PR TITLE
Detecting invalid user memory given as system call inputs

### DIFF
--- a/LibOS/shim/include/shim_internal.h
+++ b/LibOS/shim/include/shim_internal.h
@@ -760,4 +760,7 @@ int init_internal_map (void);
 int init_loader (void);
 int init_manifest (PAL_HANDLE manifest_handle);
 
+bool test_user_memory (void * addr, size_t size, bool write);
+bool test_user_string (void * addr);
+
 #endif /* _PAL_INTERNAL_H_ */

--- a/LibOS/shim/include/shim_tls.h
+++ b/LibOS/shim/include/shim_tls.h
@@ -73,6 +73,10 @@ typedef struct {
     void *                  debug_buf;
     int                     last_lock;
     struct lock_record      held_locks[NUM_LOCK_RECORD];
+    struct {
+        void * start, * end;
+        void * cont_addr;
+    } test_range;
 } shim_tcb_t;
 
 #ifdef IN_SHIM

--- a/LibOS/shim/src/sys/shim_access.c
+++ b/LibOS/shim/src/sys/shim_access.c
@@ -40,6 +40,9 @@ int shim_do_access (const char * file, mode_t mode)
     if (!file)
         return -EINVAL;
 
+    if (test_user_string(file))
+        return -EFAULT;
+
     struct shim_dentry * dent = NULL;
     int ret = 0;
 
@@ -54,6 +57,9 @@ int shim_do_faccessat (int dfd, const char * filename, mode_t mode)
 {
     if (!filename)
         return -EINVAL;
+
+    if (test_user_string(filename))
+        return -EFAULT;
 
     if (*filename == '/')
         return shim_do_access(filename, mode);

--- a/LibOS/shim/src/sys/shim_alarm.c
+++ b/LibOS/shim/src/sys/shim_alarm.c
@@ -81,6 +81,10 @@ int shim_do_setitimer (int which, struct __kernel_itimerval * value,
 
     if (!value)
         return -EFAULT;
+    if (test_user_memory(value, sizeof(*value), false))
+        return -EFAULT;
+    if (ovalue && test_user_memory(ovalue, sizeof(*ovalue), true))
+        return -EFAULT;
 
     unsigned long setup_time = DkSystemTimeQuery();
 
@@ -124,6 +128,8 @@ int shim_do_getitimer (int which, struct __kernel_itimerval * value)
         return -ENOSYS;
 
     if (!value)
+        return -EFAULT;
+    if (test_user_memory(value, sizeof(*value), true))
         return -EFAULT;
 
     unsigned long setup_time = DkSystemTimeQuery();

--- a/LibOS/shim/src/sys/shim_fs.c
+++ b/LibOS/shim/src/sys/shim_fs.c
@@ -49,6 +49,9 @@ int shim_do_unlink (const char * file)
     if (!file)
         return -EINVAL;
 
+    if (test_user_string(file))
+        return -EFAULT;
+
     struct shim_dentry * dent = NULL;
     int ret = 0;
 
@@ -77,6 +80,9 @@ int shim_do_unlinkat (int dfd, const char * pathname, int flag)
 {
     if (!pathname)
         return -EINVAL;
+
+    if (test_user_string(pathname))
+        return -EFAULT;
 
     if (*pathname == '/')
         return (flag & AT_REMOVEDIR) ? shim_do_rmdir(pathname) :
@@ -133,6 +139,9 @@ int shim_do_mkdirat (int dfd, const char * pathname, int mode)
     if (!pathname)
         return -EINVAL;
 
+    if (test_user_string(pathname))
+        return -EFAULT;
+
     if (*pathname == '/')
         return shim_do_mkdir(pathname, mode);
 
@@ -153,6 +162,12 @@ int shim_do_rmdir (const char * pathname)
 {
     int ret = 0;
     struct shim_dentry * dent = NULL;
+
+    if (!pathname)
+        return -EINVAL;
+
+    if (test_user_string(pathname))
+        return -EFAULT;
 
     if ((ret = path_lookupat(NULL, pathname, LOOKUP_OPEN|LOOKUP_DIRECTORY,
                              &dent, NULL)) < 0)
@@ -197,6 +212,9 @@ int shim_do_chmod (const char * path, mode_t mode)
     struct shim_dentry * dent = NULL;
     int ret = 0;
 
+    if (test_user_string(path))
+        return -EFAULT;
+
     if ((ret = path_lookupat(NULL, path, LOOKUP_OPEN, &dent, NULL)) < 0)
         return ret;
 
@@ -217,6 +235,9 @@ int shim_do_fchmodat (int dfd, const char * filename, mode_t mode)
 {
     if (!filename)
         return -EINVAL;
+
+    if (test_user_string(filename))
+        return -EFAULT;
 
     if (*filename == '/')
         return shim_do_chmod(filename, mode);
@@ -272,6 +293,12 @@ int shim_do_chown (const char * path, uid_t uid, gid_t gid)
     struct shim_dentry * dent = NULL;
     int ret = 0;
 
+    if (!path)
+        return -EINVAL;
+
+    if (test_user_string(path))
+        return -EFAULT;
+
     if ((ret = path_lookupat(NULL, path, LOOKUP_OPEN, &dent, NULL)) < 0)
         return ret;
 
@@ -285,6 +312,9 @@ int shim_do_fchownat (int dfd, const char * filename, uid_t uid, gid_t gid,
 {
     if (!filename)
         return -EINVAL;
+
+    if (test_user_string(filename))
+        return -EFAULT;
 
     if (*filename == '/')
         return shim_do_chown(filename, uid, gid);

--- a/LibOS/shim/src/sys/shim_time.c
+++ b/LibOS/shim/src/sys/shim_time.c
@@ -39,6 +39,12 @@ int shim_do_gettimeofday (struct __kernel_timeval * tv,
     if (!tv)
         return -EINVAL;
 
+    if (test_user_memory(tv, sizeof(*tv), true))
+        return -EFAULT;
+
+    if (tz && test_user_memory(tz, sizeof(*tz), true))
+        return -EFAULT;
+
     long time = DkSystemTimeQuery();
 
     if (time == -1)
@@ -56,6 +62,9 @@ time_t shim_do_time (time_t * tloc)
     if (time == -1)
         return -PAL_ERRNO;
 
+    if (tloc && test_user_memory(tloc, sizeof(*tloc), true))
+        return -EFAULT;
+
     time_t t = time / 1000000;
 
     if (tloc)
@@ -71,6 +80,9 @@ int shim_do_clock_gettime (clockid_t which_clock,
 
     if (!tp)
         return -EINVAL;
+
+    if (test_user_memory(tp, sizeof(*tp), true))
+        return -EFAULT;
 
     long time = DkSystemTimeQuery();
 
@@ -89,6 +101,9 @@ int shim_do_clock_getres (clockid_t which_clock,
 
     if (!tp)
         return -EINVAL;
+
+    if (test_user_memory(tp, sizeof(*tp), true))
+        return -EFAULT;
 
     tp->tv_sec  = 0;
     tp->tv_nsec = 1000;


### PR DESCRIPTION
This PR introduces two APIs, `test_user_memory()` and `test_user_string()`, to check if user inputs point to readable / writable virtual memory regions. If the tests failed, the system calls should return -EFAULT or -EINVAL according to the Linux specification.