### PR TITLE
Correct definition of bits per word, as reported in #196.

### DIFF
--- a/LibOS/shim/include/shim_signal.h
+++ b/LibOS/shim/include/shim_signal.h
@@ -13,7 +13,7 @@ struct shim_signal_handle {
     struct __kernel_sigaction * action;
 };
 
-# define BITS_PER_WORD sizeof(unsigned long)
+# define BITS_PER_WORD (8 * sizeof(unsigned long))
 /* The standard def of this macro is dumb */
 #undef _SIGSET_NWORDS
 # define _SIGSET_NWORDS (NUM_SIGS / BITS_PER_WORD)


### PR DESCRIPTION
This seems like a pretty clear error in this definition.  I am not sure what a good unit test for the fix is, but I don't see a lot of downside to correcting this, and at least one user reported that this created problems.