### PR TITLE
Adding a manifest option to allow graphene-sgx to run on non-avx platforms

### DIFF
--- a/Pal/regression/06_AvxDisable.py
+++ b/Pal/regression/06_AvxDisable.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python2
+
+import os, sys, mmap
+from regression import Regression
+
+loader = os.environ['PAL_LOADER']
+
+sgx = os.environ.get('SGX_RUN', False)
+
+def manifest_file(file):
+    if sgx:
+        return file + '.manifest.sgx'
+    else:
+        return file + '.manifest'
+
+if not sgx:
+  sys.exit(0)
+# Running AvxDisable 
+regression = Regression(loader, "AvxDisable")
+
+regression.add_check(name="Disable AVX bit in XFRM",
+    check=lambda res: "Illegal instruction executed in enclave" in res[0].log)
+
+rv = regression.run_checks()
+if rv: sys.exit(rv)

--- a/Pal/regression/AvxDisable.c
+++ b/Pal/regression/AvxDisable.c
@@ -1,0 +1,23 @@
+#include "pal.h"
+#include "pal_debug.h"
+#include <immintrin.h>
+#include <stdio.h>
+
+int main(){
+    /* Initialize the two argument vectors */
+  __m256 evens = _mm256_set_ps(2.0, 4.0, 6.0, 8.0, 10.0, 12.0, 14.0, 16.0);
+  __m256 odds = _mm256_set_ps(1.0, 3.0, 5.0, 7.0, 9.0, 11.0, 13.0, 15.0);
+
+  /* Compute the difference between the two vectors */
+  __m256 result = _mm256_sub_ps(evens, odds);
+
+  /* Display the elements of the result vector */
+  float f = result[0];
+  
+  PAL_HANDLE file1 = DkStreamOpen("file:avxRes", PAL_ACCESS_RDWR, 0, 0, 0); 
+  if (file1) {
+    DkStreamWrite(file1, 0, sizeof(f), &f, NULL);
+    DkObjectClose(file1);
+  }
+  return 1;
+}

--- a/Pal/regression/AvxDisable.manifest.template
+++ b/Pal/regression/AvxDisable.manifest.template
@@ -1,0 +1,2 @@
+sgx.disable_avx = 1
+sgx.allowed_files.res = file:avxRes

--- a/Pal/regression/Makefile
+++ b/Pal/regression/Makefile
@@ -1,7 +1,7 @@
 include ../src/Makefile.Host
 
 CC	= gcc
-CFLAGS	= -Wall -O2 -std=gnu99 -fgnu89-inline -fno-builtin -nostdlib \
+CFLAGS	= -Wall -O2 -std=gnu99 -fgnu89-inline -fno-builtin -nostdlib -mavx\
 	  -I../include/pal -I../lib
 
 preloads    = $(patsubst %.c,%,$(wildcard *.so.c))

--- a/Pal/src/host/Linux-SGX/db_exception.c
+++ b/Pal/src/host/Linux-SGX/db_exception.c
@@ -241,6 +241,8 @@ void _DkExceptionHandler (unsigned int exit_info, sgx_context_t * uc)
             restore_sgx_context(uc);
             return;
         }
+        SGX_DBG(DBG_E, "Illegal instruction executed in enclave\n");    
+        ocall_exit(1);
     }
 
     switch (ei.info.vector) {

--- a/Pal/src/host/Linux-SGX/signer/pal-sgx-sign
+++ b/Pal/src/host/Linux-SGX/signer/pal-sgx-sign
@@ -176,6 +176,9 @@ def get_enclave_attributes(manifest):
                 if manifest_options[opt] in attributes:
                     attributes.pop(manifest_options[opt])
 
+    if manifest.get('sgx.disable_avx') == '1':
+      attributes.remove('XFRM_AVX')
+
     flags_raw = struct.pack("<Q", 0)
     xfrms_raw = struct.pack("<Q", 0)
     miscs_raw = struct.pack("<L", 0)


### PR DESCRIPTION
By default, Graphene-SGX always enables AVX when generating XFRM attribute in SECS. There is no option to disable it. However, on some Intel platforms such as Intel NUC with SGX2 supported, AVX is not available, which causes the enclave creation failure raised up by the SGX driver. 

This PR adds an option named "sgx.disable_avx" to allow user to disable AVX in XFRM in manifest file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/218)
<!-- Reviewable:end -->
