### PR TITLE
Apply the fix suggested for uninitialized pipe non-blocking (#219)

### DIFF
--- a/Pal/src/host/FreeBSD/db_pipes.c
+++ b/Pal/src/host/FreeBSD/db_pipes.c
@@ -169,6 +169,7 @@ static int pipe_waitforclient (PAL_HANDLE handle, PAL_HANDLE * client)
     SET_HANDLE_TYPE(clnt, pipecli);
     clnt->__in.flags |= RFD(0)|WFD(0)|WRITEABLE(0);
     clnt->pipe.fd = newfd;
+    clnt->pipe.nonblocking = PAL_FALSE;
     clnt->pipe.pipeid = handle->pipe.pipeid;
     *client = clnt;
 #endif

--- a/Pal/src/host/Linux-SGX/db_pipes.c
+++ b/Pal/src/host/Linux-SGX/db_pipes.c
@@ -105,6 +105,7 @@ static int pipe_waitforclient (PAL_HANDLE handle, PAL_HANDLE * client)
     SET_HANDLE_TYPE(clnt, pipecli);
     HANDLE_HDR(clnt)->flags |= RFD(0)|WFD(0)|WRITEABLE(0);
     clnt->pipe.fd = ret;
+    clnt->pipe.nonblocking = PAL_FALSE;
     clnt->pipe.pipeid = handle->pipe.pipeid;
     *client = clnt;
 

--- a/Pal/src/host/Linux/db_pipes.c
+++ b/Pal/src/host/Linux/db_pipes.c
@@ -169,6 +169,7 @@ static int pipe_waitforclient (PAL_HANDLE handle, PAL_HANDLE * client)
     HANDLE_HDR(clnt)->flags |= RFD(0)|WFD(0)|WRITEABLE(0);
     clnt->pipe.fd = newfd;
     clnt->pipe.pipeid = handle->pipe.pipeid;
+    clnt->pipe.nonblocking = PAL_FALSE;
     *client = clnt;
 #endif
 


### PR DESCRIPTION
In some code paths, the pipe.nonblocking field is not initialized, which can lead to obvious problems after memory has been recycled for a bit.

It is not clear to me if there is an easy unit test, other than perhaps in a debugging mode with memory poisoning enabled.  I think this is a bit beyond the scope of this simple PR.