### PR TITLE
Create index.md with a redirect

### DIFF
--- a/index.md
+++ b/index.md
@@ -1,0 +1,10 @@
+ <html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <title>Graphene Library OS</title>
+    <meta http-equiv="refresh" content="0;URL='https://oscarlab.github.io/projects/graphene/'" />
+  </head>
+  <body>
+    <p>This page has moved. Click <a href="https://oscarlab.github.io/projects/graphene/">
+      here</a> to go to the new location, if you aren't automatically redirected.</p>
+  </body>
+</html>


### PR DESCRIPTION
Adding this index.md file that just contains a meta refresh tag to forward people to the graphene project page on the main website.
Remove this when replacing with an actual website..