### PR TITLE
Improving handle polling semantics

### DIFF
--- a/LibOS/shim/src/sys/shim_poll.c
+++ b/LibOS/shim/src/sys/shim_poll.c
@@ -117,6 +117,7 @@ static int __do_poll (int npolls, struct poll_handle * polls,
     struct poll_handle * polling = NULL;
     struct poll_handle * p, ** n, * q;
     PAL_HANDLE * pals = NULL;
+    PAL_FLG * pal_events = NULL, * ret_events;
     int ret = 0;
 
 #ifdef PROFILE
@@ -289,8 +290,8 @@ done_finding:
     }
 
     pals = __try_alloca(cur, sizeof(PAL_HANDLE) * npals);
-    PAL_FLG * pal_events = __try_alloca(cur, sizeof(PAL_FLG) * npals);
-    PAL_FLG * ret_events = __try_alloca(cur, sizeof(PAL_FLG) * npals);
+    pal_events = __try_alloca(cur, sizeof(PAL_FLG) * npals * 2);
+    ret_events = pal_events + npals;
     npals = 0;
 
     n = &polling;
@@ -368,6 +369,8 @@ done_polling:
 
     if (pals)
         __try_free(cur, pals);
+    if (pal_events)
+        __try_free(cur, pal_events);
 
     return ret;
 }

--- a/LibOS/shim/src/sys/shim_poll.c
+++ b/LibOS/shim/src/sys/shim_poll.c
@@ -289,6 +289,8 @@ done_finding:
     }
 
     pals = __try_alloca(cur, sizeof(PAL_HANDLE) * npals);
+    PAL_FLG * pal_events = __try_alloca(cur, sizeof(PAL_FLG) * npals);
+    PAL_FLG * ret_events = __try_alloca(cur, sizeof(PAL_FLG) * npals);
     npals = 0;
 
     n = &polling;
@@ -302,75 +304,57 @@ done_finding:
             continue;
         }
 
-        pals[npals++] = p->handle->pal_handle;
+        pals[npals] = p->handle->pal_handle;
+        pal_events[npals] = ((p->flags & POLL_R) ? PAL_WAIT_READ  : 0) |
+                            ((p->flags & POLL_W) ? PAL_WAIT_WRITE : 0);
+        ret_events[npals] = 0;
+        npals++;
         n = &p->next;
     }
 
     SAVE_PROFILE_INTERVAL(do_poll_second_loop);
 
-    while (npals) {
-        int pal_timeout = (has_r && !has_known) ? timeout : 0;
-        PAL_HANDLE polled = DkObjectsWaitAny(npals, pals, pal_timeout);
+    int pal_timeout = (has_r && !has_known) ? timeout : 0;
+    PAL_BOL polled = DkObjectsWaitEvents(npals, pals,
+                                         pal_events, ret_events,
+                                         pal_timeout);
 
-        if (pal_timeout)
-            SAVE_PROFILE_INTERVAL(do_poll_wait_any);
-        else
-            SAVE_PROFILE_INTERVAL(do_poll_wait_any_peek);
+    if (pal_timeout)
+        SAVE_PROFILE_INTERVAL(do_poll_wait_any);
+    else
+        SAVE_PROFILE_INTERVAL(do_poll_wait_any_peek);
 
-        if (!polled)
-            break;
+    if (!polled) {
+        ret = -PAL_ERRNO;
+        goto done_polling;
+    }
 
-        PAL_STREAM_ATTR attr;
-        if (!DkStreamAttributesQuerybyHandle(polled, &attr))
-            break;
+    p = polling;
+    for (int i = 0 ; p ; i++, p = p->next) {
+        assert(p->handle->pal_handle == pals[i]);
 
-        n = &polling;
-        for (p = polling ; p ; p = p->next) {
-            if (p->handle->pal_handle == polled)
-                break;
-            n = &p->next;
-        }
-
-        if (!p)
-            break;
+        if (!ret_events[i])
+            continue;
 
         debug("handle %s is polled\n", qstrgetstr(&p->handle->uri));
 
         p->flags |= KNOWN_R|KNOWN_W;
 
-        if (attr.disconnected) {
+        if (ret_events[i] & PAL_WAIT_ERROR) {
             debug("handle is polled to be disconnected\n");
             p->flags |= RET_E;
         }
-        if (attr.readable) {
+        if (ret_events[i] & PAL_WAIT_READ) {
             debug("handle is polled to be readable\n");
             p->flags |= RET_R;
         }
-        if (attr.writeable) {
+        if (ret_events[i] & PAL_WAIT_WRITE) {
             debug("handle is polled to be writeable\n");
             p->flags |= RET_W;
         }
 
         for (q = p->children ; q ; q = q->next)
             q->flags |= p->flags & (KNOWN_R|KNOWN_W|RET_W|RET_R|RET_E);
-
-        if ((p->flags & (POLL_R|KNOWN_R)) != (POLL_R|KNOWN_R) &&
-            (p->flags & (POLL_W|KNOWN_W)) != (POLL_W|KNOWN_W))
-            continue;
-
-        has_known = true;
-        *n = p->next;
-        put_handle(p->handle);
-        p->handle = NULL;
-
-        int nskip = 0;
-        for (int i = 0 ; i < npals ; i++)
-            if (pals[i] == polled) {
-                nskip = 1;
-            } else if (nskip) {
-                pals[i - nskip] = pals[i];
-            }
-        npals -= nskip;
 
         SAVE_PROFILE_INTERVAL(do_poll_third_loop);
     }

--- a/LibOS/shim/src/sys/shim_poll.c
+++ b/LibOS/shim/src/sys/shim_poll.c
@@ -325,7 +325,7 @@ done_finding:
         SAVE_PROFILE_INTERVAL(do_poll_wait_any_peek);
 
     if (!polled) {
-        ret = -PAL_ERRNO;
+        ret = (PAL_NATIVE_ERRNO == PAL_ERROR_TRYAGAIN) ? 0 : -PAL_ERRNO;
         goto done_polling;
     }
 

--- a/Pal/src/db_object.c
+++ b/Pal/src/db_object.c
@@ -105,3 +105,34 @@ DkObjectsWaitAny (PAL_NUM count, PAL_HANDLE * handleArray, PAL_NUM timeout)
 
     LEAVE_PAL_CALL_RETURN(polled);
 }
+
+/* PAL call DkObjectsWaitEvents: wait for user-specified events of handles
+   in the handle array. The wait can be timed out, unless NO_TIMEOUT is given
+   for the timeout argument. */
+PAL_BOL
+DkObjectsWaitEvents (PAL_NUM count, PAL_HANDLE * handleArray, PAL_FLG * events,
+                     PAL_FLG * ret_events, PAL_NUM timeout)
+{
+    ENTER_PAL_CALL(DkObjectsWaitAny);
+
+    if (!count || !handleArray || !events) {
+        _DkRaiseFailure(PAL_ERROR_INVAL);
+        LEAVE_PAL_CALL_RETURN(NULL);
+    }
+
+    for (int i = 0 ; i < count ; i++)
+        // We modify the caller's handleArray?
+        if (UNKNOWN_HANDLE(handleArray[i]))
+            handleArray[i] = NULL;
+
+    int ret = _DkObjectsWaitEvents(count, handleArray, events, ret_events,
+                                   timeout == NO_TIMEOUT ?
+                                   (uint64_t) -1 : timeout);
+
+    if (ret < 0) {
+        _DkRaiseFailure(-ret);
+        return PAL_FALSE;
+    }
+
+    LEAVE_PAL_CALL_RETURN(PAL_TRUE);
+}

--- a/Pal/src/host/Linux-SGX/db_object.c
+++ b/Pal/src/host/Linux-SGX/db_object.c
@@ -180,7 +180,7 @@ int _DkObjectsWaitAny (int count, PAL_HANDLE * handleArray, uint64_t timeout,
         return -PAL_ERROR_TRYAGAIN;
 
     uint64_t waittime = timeout;
-    ret = ocall_poll(fds, nfds, timeout >= 0 ? &waittime : NULL);
+    ret = ocall_poll(fds, nfds, timeout != (uint64_t) -1 ? &waittime : NULL);
     if (ret < 0)
         return ret;
 
@@ -220,6 +220,10 @@ int _DkObjectsWaitAny (int count, PAL_HANDLE * handleArray, uint64_t timeout,
     return polled_hdl ? 0 : -PAL_ERROR_TRYAGAIN;
 }
 
+/* _DkObjectsWaitEvents is a new version of _DkObjectsWaitAny. This function
+ * can select specific IO events to poll (read / write) and return multiple
+ * events (including errors) that occurs simutaneously. The rest of semantics
+ * is the same as _DkObjectWaitAny. */
 int _DkObjectsWaitEvents (int count, PAL_HANDLE * handleArray, PAL_FLG * events,
                           PAL_FLG * ret_events, uint64_t timeout)
 {
@@ -304,7 +308,7 @@ int _DkObjectsWaitEvents (int count, PAL_HANDLE * handleArray, PAL_FLG * events,
         return -PAL_ERROR_TRYAGAIN;
 
     uint64_t waittime = timeout;
-    ret = ocall_poll(fds, nfds, timeout >= 0 ? &waittime : NULL);
+    ret = ocall_poll(fds, nfds, timeout != (uint64_t) -1 ? &waittime : NULL);
     if (ret < 0)
         return ret;
 

--- a/Pal/src/host/Linux-SGX/db_object.c
+++ b/Pal/src/host/Linux-SGX/db_object.c
@@ -219,3 +219,111 @@ int _DkObjectsWaitAny (int count, PAL_HANDLE * handleArray, uint64_t timeout,
     *polled = polled_hdl;
     return polled_hdl ? 0 : -PAL_ERROR_TRYAGAIN;
 }
+
+int _DkObjectsWaitEvents (int count, PAL_HANDLE * handleArray, PAL_FLG * events,
+                          PAL_FLG * ret_events, uint64_t timeout)
+{
+    if (count <= 0)
+        return 0;
+
+    int i, j, ret, maxfds = 0, nfds = 0;
+
+    if (count == 1) {
+        const struct handle_ops * ops = HANDLE_OPS(handleArray[0]);
+
+        if (ops->wait) {
+            ret = ops->wait(handleArray[0], timeout);
+            if (!ret)
+                ret_events[0] = PAL_WAIT_SIGNAL;
+            return ret;
+        }
+    }
+
+    /* we are not gonna to allow any polling on muliple synchronous
+       objects, doing this is simply violating the division of
+       labor between PAL and library OS */
+    for (i = 0 ; i < count ; i++) {
+        PAL_HANDLE hdl = handleArray[i];
+
+        if (!hdl)
+            continue;
+
+        if (!(HANDLE_HDR(hdl)->flags & HAS_FDS))
+            return -PAL_ERROR_NOTSUPPORT;
+
+        /* eliminate repeated entries */
+        for (j = 0 ; j < i ; j++)
+            if (hdl == handleArray[j])
+                break;
+        if (j == i) {
+            for (j = 0 ; j < MAX_FDS ; j++)
+                if (HANDLE_HDR(hdl)->flags & (RFD(j)|WFD(j)))
+                    maxfds++;
+        }
+    }
+
+    struct pollfd * fds = __alloca(sizeof(struct pollfd) * maxfds);
+    int * offsets = __alloca(sizeof(int) * maxfds);
+
+    for (i = 0 ; i < count ; i++) {
+        PAL_HANDLE hdl = handleArray[i];
+        ret_events[i] = 0;
+
+        if (!hdl)
+            continue;
+
+        for (j = 0 ; j < i ; j++)
+            if (hdl == handleArray[j])
+                break;
+        if (j < i)
+            continue;
+
+        for (j = 0 ; j < MAX_FDS ; j++) {
+            fds[nfds].events = 0;
+
+            if ((HANDLE_HDR(hdl)->flags & RFD(i)) &&
+                (events[i] & PAL_WAIT_READ))
+                fds[nfds].events |= POLLIN;
+
+            if ((HANDLE_HDR(hdl)->flags & WFD(i)) &&
+                (events[i] & PAL_WAIT_WRITE))
+                fds[nfds].events |= POLLOUT;
+
+            if (events[i] & PAL_WAIT_ERROR)
+                fds[nfds].events |= POLLHUP|POLLERR;
+
+            if (fds[nfds].events) {
+                fds[nfds].fd = hdl->generic.fds[i];
+                fds[nfds].revents = 0;
+                offsets[nfds] = i;
+                nfds++;
+            }
+        }
+    }
+
+    if (!nfds)
+        return -PAL_ERROR_TRYAGAIN;
+
+    uint64_t waittime = timeout;
+    ret = ocall_poll(fds, nfds, timeout >= 0 ? &waittime : NULL);
+    if (ret < 0)
+        return ret;
+
+    if (!ret)
+        return -PAL_ERROR_TRYAGAIN;
+
+    for (i = 0 ; i < nfds ; i++) {
+        if (!fds[i].revents)
+            continue;
+
+        j = offsets[i];
+        if (fds[i].revents & POLLIN)
+            ret_events[j] |= PAL_WAIT_READ;
+        if (fds[i].revents & POLLOUT)
+            ret_events[j] |= PAL_WAIT_WRITE;
+        if (fds[i].revents & (POLLHUP|POLLERR))
+            ret_events[j] |= PAL_WAIT_ERROR;
+    }
+
+    return 0;
+}

--- a/Pal/src/host/Linux-SGX/db_object.c
+++ b/Pal/src/host/Linux-SGX/db_object.c
@@ -289,8 +289,7 @@ int _DkObjectsWaitEvents (int count, PAL_HANDLE * handleArray, PAL_FLG * events,
                 (events[i] & PAL_WAIT_WRITE))
                 fds[nfds].events |= POLLOUT;
 
-            if (events[i] & PAL_WAIT_ERROR)
-                fds[nfds].events |= POLLHUP|POLLERR;
+            /* POLLERR, POLLHUP, POLLNVAL are ignored in fds[nfds].events */
 
             if (fds[nfds].events) {
                 fds[nfds].fd = hdl->generic.fds[i];
@@ -321,7 +320,7 @@ int _DkObjectsWaitEvents (int count, PAL_HANDLE * handleArray, PAL_FLG * events,
             ret_events[j] |= PAL_WAIT_READ;
         if (fds[i].revents & POLLOUT)
             ret_events[j] |= PAL_WAIT_WRITE;
-        if (fds[i].revents & (POLLHUP|POLLERR))
+        if (fds[i].revents & (POLLHUP|POLLERR|POLLNVAL))
             ret_events[j] |= PAL_WAIT_ERROR;
     }
 

--- a/Pal/src/host/Linux-SGX/pal.map
+++ b/Pal/src/host/Linux-SGX/pal.map
@@ -10,6 +10,7 @@ PAL {
         DkMutexRelease;
         DkEventSet;  DkEventClear;
         DkObjectsWaitAny;
+        DkObjectsWaitEvents;
 
         DkStreamOpen; DkStreamRead; DkStreamWrite;
         DkStreamMap; DkStreamUnmap; DkStreamSetLength;

--- a/Pal/src/host/Linux/db_object.c
+++ b/Pal/src/host/Linux/db_object.c
@@ -211,7 +211,7 @@ int _DkObjectsWaitAny (int count, PAL_HANDLE * handleArray, uint64_t timeout,
     }
 
     ret = INLINE_SYSCALL(ppoll, 5, fds, nfds,
-                         timeout >= 0 ? &timeout_ts : NULL,
+                         timeout != (uint64_t) -1 ? &timeout_ts : NULL,
                          NULL, 0);
 
     if (IS_ERR(ret))
@@ -259,8 +259,10 @@ int _DkObjectsWaitAny (int count, PAL_HANDLE * handleArray, uint64_t timeout,
     return polled_hdl ? 0 : -PAL_ERROR_TRYAGAIN;
 }
 
-/* _DkObjectsWaitAny for internal use. The function wait for any of the handle
-   in the handle array. timeout can be set for the wait. */
+/* _DkObjectsWaitEvents is a new version of _DkObjectsWaitAny. This function
+ * can select specific IO events to poll (read / write) and return multiple
+ * events (including errors) that occurs simutaneously. The rest of semantics
+ * is the same as _DkObjectWaitAny. */
 int _DkObjectsWaitEvents (int count, PAL_HANDLE * handleArray, PAL_FLG * events,
                           PAL_FLG * ret_events, uint64_t timeout)
 {
@@ -355,7 +357,7 @@ int _DkObjectsWaitEvents (int count, PAL_HANDLE * handleArray, PAL_FLG * events,
     }
 
     ret = INLINE_SYSCALL(ppoll, 5, fds, nfds,
-                         timeout >= 0 ? &timeout_ts : NULL,
+                         timeout != (uint64_t) -1 ? &timeout_ts : NULL,
                          NULL, 0);
 
     if (IS_ERR(ret))

--- a/Pal/src/host/Linux/db_object.c
+++ b/Pal/src/host/Linux/db_object.c
@@ -38,8 +38,6 @@
 #include <atomic.h>
 #include <asm/errno.h>
 
-#define DEFAULT_QUANTUM 500
-
 /* internally to wait for one object. Also used as a shortcut to wait
  *  on events and semaphores.
  *
@@ -259,6 +257,134 @@ int _DkObjectsWaitAny (int count, PAL_HANDLE * handleArray, uint64_t timeout,
 
     *polled = polled_hdl;
     return polled_hdl ? 0 : -PAL_ERROR_TRYAGAIN;
+}
+
+/* _DkObjectsWaitAny for internal use. The function wait for any of the handle
+   in the handle array. timeout can be set for the wait. */
+int _DkObjectsWaitEvents (int count, PAL_HANDLE * handleArray, PAL_FLG * events,
+                          PAL_FLG * ret_events, uint64_t timeout)
+{
+    if (count <= 0)
+        return 0;
+
+
+    int i, j, ret, maxfds = 0, nfds = 0;
+
+    if (count == 1) {
+        const struct handle_ops * ops = HANDLE_OPS(handleArray[0]);
+
+        if (ops->wait) {
+            ret = ops->wait(handleArray[0], timeout);
+            if (!ret)
+                ret_events[0] = PAL_WAIT_SIGNAL;
+            return ret;
+        }
+    }
+
+    /* we are not gonna to allow any polling on muliple synchronous
+       objects, doing this is simply violating the division of
+       labor between PAL and library OS */
+    for (i = 0 ; i < count ; i++) {
+        PAL_HANDLE hdl = handleArray[i];
+
+        if (!hdl)
+            continue;
+
+        if (!(HANDLE_HDR(hdl)->flags & HAS_FDS))
+            return -PAL_ERROR_NOTSUPPORT;
+
+        /* eliminate repeated entries */
+        for (j = 0 ; j < i ; j++)
+            if (hdl == handleArray[j])
+                break;
+        if (j == i) {
+            for (j = 0 ; j < MAX_FDS ; j++)
+                if (HANDLE_HDR(hdl)->flags & (RFD(j)|WFD(j)))
+                    maxfds++;
+        }
+    }
+
+    struct pollfd * fds = __alloca(sizeof(struct pollfd) * maxfds);
+    int * offsets = __alloca(sizeof(int) * maxfds);
+
+    for (i = 0 ; i < count ; i++) {
+        PAL_HANDLE hdl = handleArray[i];
+        ret_events[i] = 0;
+
+        if (!hdl)
+            continue;
+
+        for (j = 0 ; j < i ; j++)
+            if (hdl == handleArray[j])
+                break;
+        if (j < i)
+            continue;
+
+        for (j = 0 ; j < MAX_FDS ; j++) {
+            fds[nfds].events = 0;
+
+            if ((HANDLE_HDR(hdl)->flags & RFD(i)) &&
+                (events[i] & PAL_WAIT_READ))
+                fds[nfds].events |= POLLIN;
+
+            if ((HANDLE_HDR(hdl)->flags & WFD(i)) &&
+                (events[i] & PAL_WAIT_WRITE))
+                fds[nfds].events |= POLLOUT;
+
+            if (events[i] & PAL_WAIT_ERROR)
+                fds[nfds].events |= POLLHUP|POLLERR;
+
+            if (fds[nfds].events) {
+                fds[nfds].fd = hdl->generic.fds[i];
+                fds[nfds].revents = 0;
+                offsets[nfds] = i;
+                nfds++;
+            }
+        }
+    }
+
+    if (!nfds)
+        return -PAL_ERROR_TRYAGAIN;
+
+    struct timespec timeout_ts;
+
+    if (timeout >= 0) {
+        long sec = (unsigned long) timeout / 1000000;
+        long microsec = (unsigned long) timeout - (sec * 1000000);
+        timeout_ts.tv_sec = sec;
+        timeout_ts.tv_nsec = microsec * 1000;
+    }
+
+    ret = INLINE_SYSCALL(ppoll, 5, fds, nfds,
+                         timeout >= 0 ? &timeout_ts : NULL,
+                         NULL, 0);
+
+    if (IS_ERR(ret))
+        switch (ERRNO(ret)) {
+            case EINTR:
+            case ERESTART:
+                return -PAL_ERROR_INTERRUPTED;
+            default:
+                return unix_to_pal_error(ERRNO(ret));
+        }
+
+    if (!ret)
+        return -PAL_ERROR_TRYAGAIN;
+
+    for (i = 0 ; i < nfds ; i++) {
+        if (!fds[i].revents)
+            continue;
+
+        j = offsets[i];
+        if (fds[i].revents & POLLIN)
+            ret_events[j] |= PAL_WAIT_READ;
+        if (fds[i].revents & POLLOUT)
+            ret_events[j] |= PAL_WAIT_WRITE;
+        if (fds[i].revents & (POLLHUP|POLLERR))
+            ret_events[j] |= PAL_WAIT_ERROR;
+    }
+
+    return 0;
 }
 
 #if TRACE_HEAP_LEAK == 1

--- a/Pal/src/host/Linux/db_object.c
+++ b/Pal/src/host/Linux/db_object.c
@@ -331,8 +331,7 @@ int _DkObjectsWaitEvents (int count, PAL_HANDLE * handleArray, PAL_FLG * events,
                 (events[i] & PAL_WAIT_WRITE))
                 fds[nfds].events |= POLLOUT;
 
-            if (events[i] & PAL_WAIT_ERROR)
-                fds[nfds].events |= POLLHUP|POLLERR;
+            /* POLLERR, POLLHUP, POLLNVAL are ignored in fds[nfds].events */
 
             if (fds[nfds].events) {
                 fds[nfds].fd = hdl->generic.fds[i];
@@ -380,7 +379,7 @@ int _DkObjectsWaitEvents (int count, PAL_HANDLE * handleArray, PAL_FLG * events,
             ret_events[j] |= PAL_WAIT_READ;
         if (fds[i].revents & POLLOUT)
             ret_events[j] |= PAL_WAIT_WRITE;
-        if (fds[i].revents & (POLLHUP|POLLERR))
+        if (fds[i].revents & (POLLHUP|POLLERR|POLLNVAL))
             ret_events[j] |= PAL_WAIT_ERROR;
     }
 

--- a/Pal/src/host/Linux/pal.map
+++ b/Pal/src/host/Linux/pal.map
@@ -14,6 +14,7 @@ PAL {
         DkMutexRelease;
         DkEventSet;  DkEventClear;
         DkObjectsWaitAny;
+        DkObjectsWaitEvents;
 
         DkStreamOpen; DkStreamRead; DkStreamWrite;
         DkStreamMap; DkStreamUnmap; DkStreamSetLength;

--- a/Pal/src/pal.h
+++ b/Pal/src/pal.h
@@ -470,7 +470,7 @@ DkObjectsWaitAny (PAL_NUM count, PAL_HANDLE * handleArray, PAL_NUM timeout);
 #define PAL_WAIT_SIGNAL     1   /* ignored in events */
 #define PAL_WAIT_READ       2
 #define PAL_WAIT_WRITE      4
-#define PAL_WAIT_ERROR      8   /* ignored in evnets */
+#define PAL_WAIT_ERROR      8   /* ignored in events */
 
 PAL_BOL
 DkObjectsWaitEvents (PAL_NUM count, PAL_HANDLE * handleArray, PAL_FLG * events,

--- a/Pal/src/pal.h
+++ b/Pal/src/pal.h
@@ -467,6 +467,16 @@ DkEventClear (PAL_HANDLE eventHandle);
 PAL_HANDLE
 DkObjectsWaitAny (PAL_NUM count, PAL_HANDLE * handleArray, PAL_NUM timeout);
 
+#define PAL_WAIT_SIGNAL     1
+#define PAL_WAIT_READ       2
+#define PAL_WAIT_WRITE      4
+#define PAL_WAIT_ERROR      8
+
+PAL_BOL
+DkObjectsWaitEvents (PAL_NUM count, PAL_HANDLE * handleArray, PAL_FLG * events,
+                     PAL_FLG * ret_events, PAL_NUM timeout);
+
+
 /* Deprecate DkObjectReference */
 
 void DkObjectClose (PAL_HANDLE objectHandle);

--- a/Pal/src/pal.h
+++ b/Pal/src/pal.h
@@ -467,10 +467,10 @@ DkEventClear (PAL_HANDLE eventHandle);
 PAL_HANDLE
 DkObjectsWaitAny (PAL_NUM count, PAL_HANDLE * handleArray, PAL_NUM timeout);
 
-#define PAL_WAIT_SIGNAL     1
+#define PAL_WAIT_SIGNAL     1   /* ignored in events */
 #define PAL_WAIT_READ       2
 #define PAL_WAIT_WRITE      4
-#define PAL_WAIT_ERROR      8
+#define PAL_WAIT_ERROR      8   /* ignored in evnets */
 
 PAL_BOL
 DkObjectsWaitEvents (PAL_NUM count, PAL_HANDLE * handleArray, PAL_FLG * events,

--- a/Pal/src/pal_internal.h
+++ b/Pal/src/pal_internal.h
@@ -330,7 +330,7 @@ int _DkObjectClose (PAL_HANDLE objectHandle);
 int _DkObjectsWaitAny (int count, PAL_HANDLE * handleArray, uint64_t timeout,
                        PAL_HANDLE * polled);
 int _DkObjectsWaitEvents (int count, PAL_HANDLE * handleArray, PAL_FLG * events,
-                          PAL_FLG * ret_evetns, uint64_t timeout);
+                          PAL_FLG * ret_events, uint64_t timeout);
 
 
 /* DkException calls & structures */

--- a/Pal/src/pal_internal.h
+++ b/Pal/src/pal_internal.h
@@ -329,6 +329,9 @@ int _DkObjectReference (PAL_HANDLE objectHandle);
 int _DkObjectClose (PAL_HANDLE objectHandle);
 int _DkObjectsWaitAny (int count, PAL_HANDLE * handleArray, uint64_t timeout,
                        PAL_HANDLE * polled);
+int _DkObjectsWaitEvents (int count, PAL_HANDLE * handleArray, PAL_FLG * events,
+                          PAL_FLG * ret_evetns, uint64_t timeout);
+
 
 /* DkException calls & structures */
 PAL_EVENT_HANDLER _DkGetExceptionHandler (PAL_NUM event_num);

--- a/index.md
+++ b/index.md
@@ -1,0 +1,10 @@
+ <html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <title>Graphene Library OS</title>
+    <meta http-equiv="refresh" content="0;URL='https://oscarlab.github.io/projects/graphene/'" />
+  </head>
+  <body>
+    <p>This page has moved. Click <a href="https://oscarlab.github.io/projects/graphene/">
+      here</a> to go to the new location, if you aren't automatically redirected.</p>
+  </body>
+</html>


### PR DESCRIPTION
This PR addresses the performance issues of #228. The existing PAL call DkObjectsWaitAny() is too restrictive for specifying the polling events and being unable to return multiple simultaneous events. The new DkObjectsWaitEvents() accepts additional arguments to specific and return various events (signal, read, write, and error).

For incremental development, the old DkObjectsWaitAny() is kept for compatibility against the library OS. Eventually we will replace the API with DkObjectsWaitEvents().

This PR is not complete yet; remaining to-dos:
- Reimplement epoll_wait() using DkObjectsWaitEvents()
- Evaluate performance improvements
- Writing a regression test for DkObjectsWaitEvents()

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/229)
<!-- Reviewable:end -->
