### PR TITLE
Deprecating RSA enclave keys

### DIFF
--- a/Pal/src/host/Linux-SGX/db_process.c
+++ b/Pal/src/host/Linux-SGX/db_process.c
@@ -161,9 +161,9 @@ static int check_child_mrenclave (sgx_arch_hash_t * mrenclave,
     memset(&check_data, 0, sizeof(struct proc_attestation_data));
 
     lib_AESCMAC((void *) &param->mac_key, AES_CMAC_KEY_LEN,
-                remote_state->enclave_keyhash,
-                sizeof(remote_state->enclave_keyhash),
-                check_data.keyhash_mac, sizeof check_data.keyhash_mac);
+                remote_state->enclave_identifier,
+                sizeof(remote_state->enclave_identifier),
+                check_data.keyhash_mac, sizeof(check_data.keyhash_mac));
 
     if (memcmp(data, &check_data, sizeof(struct proc_attestation_data)))
         return 1;
@@ -232,9 +232,9 @@ int _DkProcessCreate (PAL_HANDLE * handle, const char * uri,
     memset(&data, 0, sizeof(struct proc_attestation_data));
 
     lib_AESCMAC((void *) &param.mac_key, AES_CMAC_KEY_LEN,
-                pal_enclave_state.enclave_keyhash,
-                sizeof(pal_enclave_state.enclave_keyhash),
-                data.keyhash_mac, sizeof data.keyhash_mac);
+                pal_enclave_state.enclave_identifier,
+                sizeof(pal_enclave_state.enclave_identifier),
+                data.keyhash_mac, sizeof(data.keyhash_mac));
 
     SGX_DBG(DBG_P|DBG_S, "Attestation data: %s\n",
             alloca_bytes2hexstr(data.keyhash_mac));
@@ -266,9 +266,9 @@ static int check_parent_mrenclave (sgx_arch_hash_t * mrenclave,
     memset(&check_data, 0, sizeof(struct proc_attestation_data));
 
     lib_AESCMAC((void *) &param->mac_key, AES_CMAC_KEY_LEN,
-                remote_state->enclave_keyhash,
-                sizeof(remote_state->enclave_keyhash),
-                check_data.keyhash_mac, sizeof check_data.keyhash_mac);
+                remote_state->enclave_identifier,
+                sizeof(remote_state->enclave_identifier),
+                check_data.keyhash_mac, sizeof(check_data.keyhash_mac));
 
     if (memcmp(data, &check_data, sizeof(struct proc_attestation_data)))
         return 1;
@@ -302,9 +302,9 @@ int init_child_process (PAL_HANDLE * parent_handle)
     memset(&data, 0, sizeof(struct proc_attestation_data));
 
     lib_AESCMAC((void *) &param.mac_key, AES_CMAC_KEY_LEN,
-                pal_enclave_state.enclave_keyhash,
-                sizeof(pal_enclave_state.enclave_keyhash),
-                data.keyhash_mac, sizeof data.keyhash_mac);
+                pal_enclave_state.enclave_identifier,
+                sizeof(pal_enclave_state.enclave_identifier),
+                data.keyhash_mac, sizeof(data.keyhash_mac));
 
     SGX_DBG(DBG_P|DBG_S, "Attestation data: %s\n",
             alloca_bytes2hexstr(data.keyhash_mac));

--- a/Pal/src/host/Linux-SGX/pal_linux.h
+++ b/Pal/src/host/Linux-SGX/pal_linux.h
@@ -163,9 +163,7 @@ extern struct pal_enclave_state {
                                        enclave */
     uint8_t  data[PAL_ATTESTATION_DATA_SIZE];
                                     /* reserved for filling other data */
-    sgx_arch_hash_t enclave_keyhash;   /* SHA256 digest of enclave's public key
-                                       can also be used as an identifier of the
-                                       enclave */
+    sgx_arch_hash_t enclave_identifier;  /* unique identifier of the enclave */
 } __attribute__((packed, aligned (128))) pal_enclave_state;
 
 #include "sgx_arch.h"


### PR DESCRIPTION
Generation of a unique RSA key significantly slows down the startup time of Graphene-SGX. Hereby we deprecate this key and replace it with a simple random number. The performance improvement is as follows:

For creating a 256MB enclave:

- With RSA key generation: 1.01-1.05 seconds
- Without the key: 0.43 seconds

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/233)
<!-- Reviewable:end -->
