### PR TITLE
Asynchronous RPC syscalls for Graphene-SGX

### DIFF
--- a/Pal/src/host/Linux-SGX/Makefile
+++ b/Pal/src/host/Linux-SGX/Makefile
@@ -9,9 +9,9 @@ defs	= -DIN_PAL -DPAL_DIR=$(PAL_DIR) -DRUNTIME_DIR=$(RUNTIME_DIR)
 enclave-objs = $(addprefix db_,files devices pipes sockets streams memory \
 		 threading mutex events process object main rtld \
 		 exception misc ipc spinlock) \
-	       $(addprefix enclave_,ocalls ecalls framework pages untrusted) 
+	       $(addprefix enclave_,ocalls ecalls framework pages untrusted rpcqueue)
 enclave-asm-objs = enclave_entry 
-urts-objs = $(addprefix sgx_,enclave framework main rtld thread process exception graphene)
+urts-objs = $(addprefix sgx_,enclave framework main rtld thread process exception graphene rpcqueue)
 urts-asm-objs = sgx_entry
 graphene_lib = ../../.lib/graphene-lib.a
 headers	= $(wildcard *.h) $(wildcard ../../*.h) $(wildcard ../../../lib/*.h) \

--- a/Pal/src/host/Linux-SGX/ecall_types.h
+++ b/Pal/src/host/Linux-SGX/ecall_types.h
@@ -13,4 +13,5 @@ typedef struct {
     const char ** ms_arguments;
     const char ** ms_environments;
     struct pal_sec * ms_sec_info;
+    void * rpc_queue;
 } ms_ecall_enclave_start_t;

--- a/Pal/src/host/Linux-SGX/enclave_ecalls.c
+++ b/Pal/src/host/Linux-SGX/enclave_ecalls.c
@@ -7,8 +7,11 @@
 #include <api.h>
 
 #include "ecall_types.h"
+#include "rpcqueue.h"
 
 #define SGX_CAST(type, item) ((type) (item))
+
+extern rpc_queue_t * rpc_queue;  /* pointer to untrusted queue */
 
 void pal_linux_main (const char ** arguments, const char ** environments,
                      struct pal_sec * sec_info);
@@ -44,6 +47,8 @@ int handle_ecall (long ecall_index, void * ecall_args, void * exit_target,
                     (ms_ecall_enclave_start_t *) ecall_args;
 
             if (!ms) return -PAL_ERROR_INVAL;
+
+            rpc_queue = (rpc_queue_t*) ms->rpc_queue;
 
             pal_linux_main(ms->ms_arguments, ms->ms_environments,
                            ms->ms_sec_info);

--- a/Pal/src/host/Linux-SGX/enclave_rpcqueue.c
+++ b/Pal/src/host/Linux-SGX/enclave_rpcqueue.c
@@ -1,0 +1,46 @@
+#include <stddef.h>
+#include "rpcqueue.h"
+
+void rpc_spin_lock(int volatile *p) {
+    while (!__sync_bool_compare_and_swap(p, 0, 1)) {
+        while (*p)
+            __asm__("pause");
+    }
+}
+
+void rpc_spin_unlock(int volatile *p) {
+    asm volatile (""); // acts as a memory barrier
+    *p = 0;
+}
+
+rpc_request_t* rpc_enqueue(rpc_queue_t* q, int ocall_index, void* data) {
+    rpc_spin_lock(&q->_lock);
+
+    if (q->rear - q->front == RPC_QUEUE_SIZE) {
+        rpc_spin_unlock(&q->_lock);
+        return NULL;
+    }
+
+    rpc_request_t* req = q->q[q->rear % RPC_QUEUE_SIZE];
+    req->ocall_index = ocall_index;
+    req->buffer      = data;
+    req->in_progress = 1;
+    q->rear++;
+
+    rpc_spin_unlock(&q->_lock);
+    return req;
+}
+
+rpc_request_t* rpc_dequeue(rpc_queue_t* q) {
+    rpc_spin_lock(&q->_lock);
+
+    if (q->front == q->rear) {
+        rpc_spin_unlock(&q->_lock);
+        return NULL;
+    }
+    rpc_request_t* req = q->q[q->front % RPC_QUEUE_SIZE];
+    q->front++;
+
+    rpc_spin_unlock(&q->_lock);
+    return req;
+}

--- a/Pal/src/host/Linux-SGX/rpcqueue.h
+++ b/Pal/src/host/Linux-SGX/rpcqueue.h
@@ -1,0 +1,77 @@
+/*
+ * RPC threads are helper threads that run in untrusted mode alongside
+ * enclave threads. RPC threads issue system calls on behalf of enclave
+ * threads. This allows "exitless" design when app threads never leave
+ * the enclave (except for a few syscalls that have to be synchronous).
+ *
+ * "Exitless" design alleviates expensive OCALLs/ECALLs. This was first
+ * proposed by SCONE (by Arnautov et al at OSDI 2016) and by Eleos
+ * (by Orenbach et al at EuroSys 2017).
+ *
+ * Brief description: user must specify "sgx.rpc_thread_num = 2" in manifest
+ * to create two RPC threads. If user specifies "0" or omits this directive,
+ * then no RPC threads are created and all syscalls are done synchronously
+ * (as in previous versions of Graphene-SGX).
+ *
+ * All enclave and RPC threads work on a single shared RPC queue (global
+ * variable `rpc_queue`). To issue syscall, enclave thread enqueues syscall
+ * request in the queue and spins waiting for result. RPC threads spin
+ * waiting for syscall requests; when request comes, first lucky RPC thread
+ * grabs request, issues syscall to OS, and notifies enclave thread by
+ * releasing the `in_progress` lock.
+ *
+ * RPC queue can have up to RPC_QUEUE_SIZE requests simultaneously. All
+ * requests are pre-allocated for performance.
+ *
+ * In addition to handling usual syscalls, we implement special logic for
+ * `gettimeofday` syscall. Since it is so frequent, we introduce fast path:
+ * global variable `untrusted_time` is updated by each RPC thread periodically
+ * and enclave threads read it using `time_ptr` instead of enqueueing request.
+ *
+ * Some syscalls must be synchronous, in this case enclave thread exits enclave,
+ * performs syscall, and goes back into enclave mode. Examples of such syscalls
+ * include futex and exit. Poll is a special case: it is used by Graphene-SGX
+ * during init, so we only make it asynchronous after app starts serving
+ * network connections.
+ *
+ * NOTE: number of created RPC threads must match max number of simultaneous
+ * enclave threads. If there are more RPC threads, CPU time is wasted. If there
+ * are less, some enclave threads may starve, especially if there are many
+ * blocking syscalls by other enclave threads.
+ *
+ * TODO: Currently we use one global lock on RPC queue. Could be optimized.
+ *
+ * Prototype code was written by Meni Orenbach and adapted to Graphene-SGX
+ * by Dmitrii Kuvaiskii.
+ */
+#ifndef QUEUE_H_
+#define QUEUE_H_
+
+#define RPC_QUEUE_SIZE 1024 /* num requests in rpc queue */
+#define MAX_RPC_THREADS 64   /* max number of RPC threads */
+
+typedef struct {
+    int result;
+    int ocall_index;
+    void* buffer;
+    int volatile in_progress;
+} rpc_request_t;
+
+typedef struct {
+    unsigned long front, rear;
+    rpc_request_t* q[RPC_QUEUE_SIZE]; /* queue of syscall requests */
+    int rpc_threads[MAX_RPC_THREADS];  /* RPC threads (thread IDs) */
+    volatile int rpc_threads_num;     /* number of RPC threads */
+    unsigned long * time_ptr;         /* untrusted gettime result */
+    int do_async_poll;                /* asynchronous poll() */
+    int in_signal_handler; /* prevents deadlock on queue when handling signals
+                            * which do syscalls, e.g., logging via write() */
+    int volatile _lock;    /* global lock for enclave and RPC threads */
+} rpc_queue_t;
+
+void rpc_spin_lock(int volatile *p);
+void rpc_spin_unlock(int volatile *p);
+rpc_request_t* rpc_enqueue(rpc_queue_t* q, int ocall_index, void* data);
+rpc_request_t* rpc_dequeue(rpc_queue_t* q);
+
+#endif /* QUEUE_H_ */

--- a/Pal/src/host/Linux-SGX/sgx_internal.h
+++ b/Pal/src/host/Linux-SGX/sgx_internal.h
@@ -67,6 +67,7 @@ struct pal_enclave {
     unsigned long baseaddr;
     unsigned long size;
     unsigned long thread_num;
+    unsigned long rpc_thread_num;
     unsigned long ssaframesize;
 
     /* files */
@@ -121,7 +122,7 @@ int clone_thread (void);
 
 void create_tcs_mapper (void * tcs_base, unsigned int thread_num);
 void map_tcs (unsigned int tid);
-void unmap_tcs (void);
+int unmap_tcs (void);
 
 extern __thread struct pal_enclave * current_enclave;
 

--- a/Pal/src/host/Linux-SGX/sgx_main.c
+++ b/Pal/src/host/Linux-SGX/sgx_main.c
@@ -7,6 +7,7 @@
 #include "sgx_tls.h"
 #include "sgx_enclave.h"
 #include "debugger/sgx_gdb.h"
+#include "rpcqueue.h"
 
 #include <asm/fcntl.h>
 #include <asm/socket.h>
@@ -284,6 +285,16 @@ int initialize_enclave (struct pal_enclave * enclave)
 
     if (enclave_thread_num > MAX_DBG_THREADS) {
         SGX_DBG(DBG_E, "Too many threads to debug\n");
+        ret = -EINVAL;
+        goto err;
+    }
+
+    /* Reading sgx.rpc_thread_num from manifest */
+    if (get_config(enclave->config, "sgx.rpc_thread_num", cfgbuf, CONFIG_MAX) > 0)
+        enclave->rpc_thread_num = parse_int(cfgbuf);
+
+    if (enclave->rpc_thread_num > MAX_RPC_THREADS) {
+        SGX_DBG(DBG_E, "Too many RPC threads specified\n");
         ret = -EINVAL;
         goto err;
     }

--- a/Pal/src/host/Linux-SGX/sgx_rpcqueue.c
+++ b/Pal/src/host/Linux-SGX/sgx_rpcqueue.c
@@ -1,0 +1,4 @@
+#include "rpcqueue.h"
+
+/* duplicates functionality outside of enclave */
+#include "enclave_rpcqueue.c"

--- a/Pal/src/host/Linux-SGX/sgx_thread.c
+++ b/Pal/src/host/Linux-SGX/sgx_thread.c
@@ -12,6 +12,7 @@
 
 #include "sgx_enclave.h"
 #include "debugger/sgx_gdb.h"
+#include "rpcqueue.h"
 
 __thread struct pal_enclave * current_enclave;
 __thread sgx_arch_tcs_t * current_tcs;
@@ -48,17 +49,27 @@ void map_tcs (unsigned int tid)
         }
 }
 
-void unmap_tcs (void)
+int unmap_tcs (void)
 {
     int index = current_tcs - enclave_tcs;
     struct thread_map * map = &enclave_thread_map[index];
     if (index >= enclave_thread_num)
-        return;
+        return 0;
     SGX_DBG(DBG_I, "unmap TCS at 0x%08lx\n", map->tcs);
     current_tcs = NULL;
     ((struct enclave_dbginfo *) DBGINFO_ADDR)->thread_tids[index] = 0;
     map->tid = 0;
     map->tcs = NULL;
+
+    /* return number of live enclave threads */
+    static volatile int exclusion = 0;
+    rpc_spin_lock(&exclusion);
+    int res = 0;
+    for (int i = 0; i < enclave_thread_num; i++)
+        if (enclave_thread_map[i].tid)
+            res++;
+    rpc_spin_unlock(&exclusion);
+    return res;
 }
 
 static void * thread_start (void * arg)


### PR DESCRIPTION
This PR adds the ability to invoke system calls asynchronously, similar to solutions from [Eleos by Orenbach](https://dl.acm.org/citation.cfm?id=3064219) and [SCONE by Arnautov et al](https://dl.acm.org/citation.cfm?id=3026930).

New directive `sgx.rpc_thread_num = X` in the manifest instructs Graphene-SGX to create X outside-enclave RPC threads that spin-wait for syscalls (and any OCALLs in general) on a shared queue. In-enclave threads do not exit the enclave now but instead enqueue the syscall in the queue and spin-wait for it to be processed by an RPC thread.

Omitting `sgx.rpc_thread_num` defaults to the old, synchronous way of executing syscalls.

This PR works on single-process applications and can provide 2-3X performance improvement.

The patch has the following issues:

1. Graphene-SGX uses `poll()` system call during initialization (and during IPC communication?). Currently, this syscall "becomes" asynchronous only after the enclave accepts some connection (which hints that initialization phase is over). The correct way would be to distinguish between Graphene's internal usage of `poll()` and original app's usage, and use async version only for app's usage. However, I didn't find an easy way to propagate this info to `ocall_poll`.

2. For correctness, whenever a signal is delivered to the enclave, we must abort blocking syscalls in RPC threads. Otherwise the RPC thread could become stuck in the blocking syscall while the corresponding enclave thread handles the signal and assumes that its syscall was aborted. Currently, we send dummy `SIGUSR1` to all RPC threads whenever termination signal is received (so they abort their blocking syscall). This could be implemented in a cleaner way.

3. If original app has a signal handler that uses syscalls (e.g., to dump logs), we switch to old synchronous way of invoking syscalls for safety. If issue 2 is solved in a clean way, this safety measure can be removed.

4. RPC threads are killed using `exit_group()` when all enclave threads are finished. This is probably not a clean way to close the app.

5. Currently I run into bugs in multi-process applications, most probably because of the Graphene-SGX IPC thread which is not aware of the changes. Not sure how to debug these issues.

I thought I will push it now so that people suggest how to solve above issues.