### PR TITLE
Update README by reorganize the section of building Graphene-SGX

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ To build Graphene library OS with debug symbols, run "make DEBUG=1" instead of
 
 __** Note: this step is optional. **__
 
-__** Note: for building with Intel:registered: SGX support, skip this step. **__
+__** Note: for building with Intel:registered: SGX support, skip this step, go to section 2.2 **__
 
 __** Disclaimer: this feature is experimental and may contain bugs. Please do
    no use in production system before further assessment.__
@@ -103,25 +103,26 @@ For more details about the building and installation, see the Graphene github
 Wiki page: <https://github.com/oscarlab/graphene/wiki>.
 
 
-### 2-1. BUILD WITH INTEL:registered: SGX SUPPORT
+### 2.2 BUILD WITH INTEL:registered: SGX SUPPORT
 
-To build Graphene Library OS with Intel SGX support, run "make SGX=1" instead
-of "make". "DEBUG=1" can be used to build with debug symbols. Using "make SGX=1"
-in the test or regression directory will automatically generate the enclave
-signatures (in .sig files).
+2.1.1 Prerequisites 
 
+(1) Generating signing keys
 A 3072-bit RSA private key (PEM format) is required for signing the enclaves.
-The default enclave key is placed in 'host/Linux-SGX/signer/enclave-key.pem',
-or the key can be specified through environment variable 'SGX_ENCLAVE_KEY'
-when building Graphene with Intel SGX support. If you don't have a private key,
-create it with the following command:
+If you don't have a private key, create it with the following command:
 
     openssl genrsa -3 -out enclave-key.pem 3072
 
+You could put the generated enclave key to the default place'host/Linux-SGX/signer/enclave-key.pem',
+or the key can be specified through environment variable 'SGX_ENCLAVE_KEY'
+when building Graphene with Intel SGX support. 
+
 After signing the enclaves, users may ship the application files with the
 built Graphene Library OS, along with a SGX-specific manifest (.manifest.sgx
-files) and the signatures, to the Intel SGX-enabled hosts. The Intel SGX
-Linux SDK is required for running Graphene Library OS. Download and install
+files) and the signatures, to the Intel SGX-enabled hosts.
+
+(2) Installing Intel SGX SDK and driver
+The Intel SGX Linux SDK is required for running Graphene Library OS. Download and install
 from the official Intel github repositories:
 
    - <https://github.com/01org/linux-sgx>
@@ -139,10 +140,43 @@ __** Please make sure the GCC version is either 4 or 5 **__
     (The console will be prompted to ask for the path of Intel SGX driver code)
     sudo ./load.sh
 
-Finally generating the runtime enclave tokens by running "make SGX_RUN=1".
+2.1.2 Building Graphene-SGX
 
+To build Graphene Library OS with Intel SGX support, in the root directory of Graphene repo, run following command:
 
+    make SGX=1
 
+To build with debug symbols, run the command:
+
+    make SGX=1 DEBUG=1
+
+Using "make SGX=1" in the test or regression directory will automatically generate the enclave signatures (in .sig files). It takes you around 10 minutes to get Graphene-SGX ready to use
+
+2.1.3 Run Built-in Examples in Graphene-SGX
+
+There are a few built-in examples under LibOS/shim/test/. The "native" folder includes a rich set of C programs and "apps" folder includes a few real software applications, such as python, memcached, and so on.
+
+(1) Build and run C-based Hello World programs in Graphene-SGX
+- go to LibOS/shim/test/native, build the enclaves via command:
+    
+      make SGX=1
+  
+  The command will build enclaves for all the programs in the folder
+- Generate the token from aesmd service, via command:
+
+      make SGX_RUN=1
+
+- Run Hello World program with Graphene-SGX:
+  
+      SGX=1 ./pal_loader HelloWorld
+  
+(2) Build and run python helloworld script in Graphene-SGX
+- go to LibOS/shim/test/apps/python, build the enclave:
+  make SGX=1
+- Generate token:
+  make SGX_RUN=1
+- Run python helloworld with Graphene-SGX via:
+  SGX=1 ./python.manifest.sgx scripts/helloworld.py
 
 ## 3. HOW TO RUN AN APPLICATION IN GRAPHENE?
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Wiki page: <https://github.com/oscarlab/graphene/wiki>.
 
 ### 2.2 BUILD WITH INTEL:registered: SGX SUPPORT
 
-2.1.1 Prerequisites 
+__2.1.1 Prerequisites 
 
 (1) Generating signing keys
 A 3072-bit RSA private key (PEM format) is required for signing the enclaves.
@@ -128,8 +128,6 @@ from the official Intel github repositories:
    - <https://github.com/01org/linux-sgx>
    - <https://github.com/01org/linux-sgx-driver>
 
-__(The SDK and driver version must be 1.9 or LOWER)__
-
 A Linux driver must be installed before runing Graphene Library OS in enclaves.
 Simply run the following command to build the driver:
 
@@ -140,7 +138,7 @@ __** Please make sure the GCC version is either 4 or 5 **__
     (The console will be prompted to ask for the path of Intel SGX driver code)
     sudo ./load.sh
 
-2.1.2 Building Graphene-SGX
+__2.1.2 Building Graphene-SGX
 
 To build Graphene Library OS with Intel SGX support, in the root directory of Graphene repo, run following command:
 
@@ -152,7 +150,7 @@ To build with debug symbols, run the command:
 
 Using "make SGX=1" in the test or regression directory will automatically generate the enclave signatures (in .sig files). It takes you around 10 minutes to get Graphene-SGX ready to use
 
-2.1.3 Run Built-in Examples in Graphene-SGX
+__2.1.3 Run Built-in Examples in Graphene-SGX
 
 There are a few built-in examples under LibOS/shim/test/. The "native" folder includes a rich set of C programs and "apps" folder includes a few real software applications, such as python, memcached, and so on.
 
@@ -168,15 +166,20 @@ There are a few built-in examples under LibOS/shim/test/. The "native" folder in
 
 - Run Hello World program with Graphene-SGX:
   
-      SGX=1 ./pal_loader HelloWorld
+      SGX=1 ./pal_loader helloworld
   
 (2) Build and run python helloworld script in Graphene-SGX
 - go to LibOS/shim/test/apps/python, build the enclave:
-  make SGX=1
+  
+      make SGX=1
+      
 - Generate token:
-  make SGX_RUN=1
+
+      make SGX_RUN=1
+      
 - Run python helloworld with Graphene-SGX via:
-  SGX=1 ./python.manifest.sgx scripts/helloworld.py
+
+      SGX=1 ./python.manifest.sgx scripts/helloworld.py
 
 ## 3. HOW TO RUN AN APPLICATION IN GRAPHENE?
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ variable 'SGX_ENCLAVE_KEY' when building Graphene with SGX support.
 
 After signing the enclaves, users may ship the application files with the
 built Graphene Library OS, along with a SGX-specific manifest (.manifest.sgx
-files) and the signatures, to the Intel SGX-enabled hosts.
+files) and the signatures, to the SGX-enabled hosts.
 
 (2) Installing Intel SGX SDK and driver
 The Intel SGX Linux SDK is required for running Graphene Library OS. Download and install
@@ -148,13 +148,13 @@ To build with debug symbols, run the command:
 
     make SGX=1 DEBUG=1
 
-Using "make SGX=1" in the test or regression directory will automatically generate the enclave signatures (in .sig files). It takes you around 10 minutes to get Graphene-SGX ready to use
+Using "make SGX=1" in the test or regression directory will automatically generate the enclave signatures (.sig files).
 
 __2.1.3 Run Built-in Examples in Graphene-SGX
 
-There are a few built-in examples under LibOS/shim/test/. The "native" folder includes a rich set of C programs and "apps" folder includes a few real software applications, such as python, memcached, and so on.
+There are a few built-in examples under LibOS/shim/test/. The "native" folder includes a rich set of C programs and "apps" folder includes a few tested applications, such as GCC, Python, and Apache.
 
-(1) Build and run C-based Hello World programs in Graphene-SGX
+(1) Build and run a Hello World program with Graphene on SGX
 - go to LibOS/shim/test/native, build the enclaves via command:
     
       make SGX=1
@@ -164,11 +164,11 @@ There are a few built-in examples under LibOS/shim/test/. The "native" folder in
 
       make SGX_RUN=1
 
-- Run Hello World program with Graphene-SGX:
+- Run Hello World program with Graphene on SGX:
   
-      SGX=1 ./pal_loader helloworld
+      SGX=1 ./pal_loader helloworld   or  ./pal_loader SGX helloworld
   
-(2) Build and run python helloworld script in Graphene-SGX
+(2) Build and run python helloworld script in Graphene on SGX
 - go to LibOS/shim/test/apps/python, build the enclave:
   
       make SGX=1
@@ -180,6 +180,7 @@ There are a few built-in examples under LibOS/shim/test/. The "native" folder in
 - Run python helloworld with Graphene-SGX via:
 
       SGX=1 ./python.manifest.sgx scripts/helloworld.py
+       
 
 ## 3. HOW TO RUN AN APPLICATION IN GRAPHENE?
 

--- a/README.md
+++ b/README.md
@@ -113,9 +113,9 @@ If you don't have a private key, create it with the following command:
 
     openssl genrsa -3 -out enclave-key.pem 3072
 
-You could put the generated enclave key to the default place'host/Linux-SGX/signer/enclave-key.pem',
-or the key can be specified through environment variable 'SGX_ENCLAVE_KEY'
-when building Graphene with Intel SGX support. 
+You could either put the generated enclave key to the default path,
+'host/Linux-SGX/signer/enclave-key.pem', or specify the key through environment
+variable 'SGX_ENCLAVE_KEY' when building Graphene with SGX support. 
 
 After signing the enclaves, users may ship the application files with the
 built Graphene Library OS, along with a SGX-specific manifest (.manifest.sgx


### PR DESCRIPTION
Through a few users' feedback, current section of building Graphene-SGX is not quite intuitive and lack of  details instructions about how to run examples so the users can test Graphene-SGX is correctly installed. This PR reorganizing the flows and adding instructions of running built-in examples.