### PR TITLE
Signal not handled properly when the current thread is dead

### DIFF
--- a/LibOS/Makefile
+++ b/LibOS/Makefile
@@ -30,10 +30,17 @@ else
 	./buildglibc.py --quiet
 endif
 
+GLIBC_MIRRORS = http://ftp.gnu.org/gnu/ \
+		https://mirrors.kernel.org/gnu/ \
+		http://mirrors.ocf.berkeley.edu/gnu/
+
 ifeq ($(shell git ls-files $(GLIBC_SRC)/configure),)
 $(GLIBC_SRC)/configure: $(GLIBC_SRC).patch
 	[ -f $(GLIBC_SRC).tar.gz ] || \
-	wget http://ftp.gnu.org/gnu/glibc/$(GLIBC_SRC).tar.gz
+	for MIRROR in $(GLIBC_MIRRORS); do \
+		wget --timeout=10 $${MIRROR}glibc/$(GLIBC_SRC).tar.gz \
+		&& break; \
+	done
 	tar -xzf $(GLIBC_SRC).tar.gz
 	cd $(GLIBC_SRC) && patch -p1 < ../$(GLIBC_SRC).patch
 	cd $(GLIBC_SRC) && patch -p1 < ../glibc-fix-warning.patch

--- a/LibOS/Makefile
+++ b/LibOS/Makefile
@@ -36,6 +36,7 @@ $(GLIBC_SRC)/configure: $(GLIBC_SRC).patch
 	wget http://ftp.gnu.org/gnu/glibc/$(GLIBC_SRC).tar.gz
 	tar -xzf $(GLIBC_SRC).tar.gz
 	cd $(GLIBC_SRC) && patch -p1 < ../$(GLIBC_SRC).patch
+	cd $(GLIBC_SRC) && patch -p1 < ../glibc-fix-warning.patch
 endif
 
 .PHONY: clean

--- a/LibOS/buildglibc.py
+++ b/LibOS/buildglibc.py
@@ -100,7 +100,7 @@ if True:
 
     os.chdir(buildDir)
 
-    cflags = '{0} -O2 -U_FORTIFY_SOURCE -fno-stack-protector'.format(debug_flags)
+    cflags = '{0} -O2 -U_FORTIFY_SOURCE -fno-stack-protector -Wno-unused-value'.format(debug_flags)
     extra_defs = ''
     disabled_features = { 'nscd' }
     extra_flags = '--with-tls --enable-add-ons=nptl --without-selinux --disable-test {0}'.format(' '.join(['--disable-' + f for f in disabled_features]))

--- a/LibOS/glibc-fix-warning.patch
+++ b/LibOS/glibc-fix-warning.patch
@@ -1,0 +1,50 @@
+2015-08-09  Mike Frysinger  <vapier@gentoo.org>
+
+	* nptl/tst-cancel-wrappers.sh: Change 3rd arg to gensub to 1.
+	* scripts/sysd-rules.awk: Likewise.
+---
+ nptl/tst-cancel-wrappers.sh | 2 +-
+ scripts/sysd-rules.awk      | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/nptl/tst-cancel-wrappers.sh b/nptl/tst-cancel-wrappers.sh
+index b2d8302..d492a54 100644
+--- a/nptl/tst-cancel-wrappers.sh
++++ b/nptl/tst-cancel-wrappers.sh
+@@ -74,7 +74,7 @@ C["__xpg_sigpause"]=1
+   seen=""
+   seen_enable=""
+   seen_disable=""
+-  object=gensub(/^.*\[(.*)\]:$/,"\\1","",$0)
++  object=gensub(/^.*\[(.*)\]:$/, "\\1", 1, $0)
+   next
+ }
+ {
+diff --git a/scripts/sysd-rules.awk b/scripts/sysd-rules.awk
+index cc14334..cebc9d3 100644
+--- a/scripts/sysd-rules.awk
++++ b/scripts/sysd-rules.awk
+@@ -53,7 +53,7 @@ BEGIN {
+         if (target_pattern == "%") {
+           command_suffix = "";
+         } else {
+-          prefix = gensub(/%/, "", "", target_pattern);
++          prefix = gensub(/%/, "", 1, target_pattern);
+           command_suffix = " $(" prefix  "CPPFLAGS)";
+         }
+         target = "$(objpfx)" target_pattern o ":";
+diff --git a/Makerules b/Makerules
+--- a/Makerules
++++ b/Makerules
+@@ -718,7 +718,7 @@ verbose	:=
+ endif						# not -s
+ 
+ ARFLAGS := r$(verbose)
+-CREATE_ARFLAGS := cru$(verbose)
++CREATE_ARFLAGS := cruU$(verbose)
+ 
+ # This makes all the object files in the parent library archive.
+ 
+-- 
+2.4.4
+

--- a/LibOS/shim/include/shim_handle.h
+++ b/LibOS/shim/include/shim_handle.h
@@ -383,8 +383,10 @@ struct shim_fd_handle {
     struct shim_handle * handle;
 };
 
-#define MAX_MAX_FDS         (65536)
-#define DEFAULT_MAX_FDS     (1024)
+#define MAX_MAX_FDS         (65535)     /* Hard limit on the maximum
+                                           number of file descriptors */
+#define DEFAULT_MAX_FDS     (1024)      /* Soft limit on the maximum
+                                           number of file descriptors */
 extern unsigned int max_fds;
 
 struct shim_handle_map {

--- a/LibOS/shim/include/shim_internal.h
+++ b/LibOS/shim/include/shim_internal.h
@@ -431,6 +431,8 @@ static inline PAL_HANDLE thread_create (void * func, void * arg, int option)
 static inline void __disable_preempt (shim_tcb_t * tcb)
 {
     //tcb->context.syscall_nr += SYSCALL_NR_PREEMPT_INC;
+    /* Assert if this counter overflows */
+    assert((tcb->context.preempt & ~SIGNAL_DELAYED) != ~SIGNAL_DELAYED);
     tcb->context.preempt++;
     //debug("disable preempt: %d\n", tcb->context.preempt & ~SIGNAL_DELAYED);
 }
@@ -446,6 +448,8 @@ static inline void disable_preempt (shim_tcb_t * tcb)
 static inline void __enable_preempt (shim_tcb_t * tcb)
 {
     //tcb->context.syscall_nr -= SYSCALL_NR_PREEMPT_INC;
+    /* Assert if this counter underflows */
+    assert(tcb->context.preempt > 0);
     tcb->context.preempt--;
     //debug("enable preempt: %d\n", tcb->context.preempt & ~SIGNAL_DELAYED);
 }

--- a/LibOS/shim/include/shim_thread.h
+++ b/LibOS/shim/include/shim_thread.h
@@ -164,6 +164,14 @@ struct shim_thread * get_cur_thread (void)
 
 static inline
 __attribute__((always_inline))
+bool cur_thread_is_alive (void)
+{
+    struct shim_thread * thread = get_cur_thread();
+    return thread ? thread->is_alive : false;
+}
+
+static inline
+__attribute__((always_inline))
 void set_cur_thread (struct shim_thread * thread)
 {
     shim_tcb_t * tcb = SHIM_GET_TLS();

--- a/LibOS/shim/src/bookkeep/shim_handle.c
+++ b/LibOS/shim/src/bookkeep/shim_handle.c
@@ -402,8 +402,21 @@ extend:
     }
 
     if (handle_map->fd_top == FD_NULL ||
-        fd > handle_map->fd_top)
+        fd > handle_map->fd_top) {
+        /* (FDTYPE) -1 is an invalid file descriptor. */
+        if (fd == FD_NULL) {
+            ret = -EBADF;
+            goto out;
+        }
+
+        /* File descriptor must not exceed the system limit. */
+        if (fd >= max_fds) {
+            ret = -EMFILE;
+            goto out;
+        }
+
         handle_map->fd_top = fd;
+    }
 
     struct shim_fd_handle * new_handle = handle_map->map[fd];
 

--- a/LibOS/shim/src/bookkeep/shim_signal.c
+++ b/LibOS/shim/src/bookkeep/shim_signal.c
@@ -484,6 +484,10 @@ static void resume_upcall (PAL_PTR event, PAL_NUM arg, PAL_CONTEXT * context)
         goto ret_exception;
 
     shim_tcb_t * tcb = SHIM_GET_TLS();
+
+    if (!tcb || !tcb->tp)
+        return;
+
     __disable_preempt(tcb);
 
     if ((tcb->context.preempt & ~SIGNAL_DELAYED) > 1) {

--- a/LibOS/shim/src/bookkeep/shim_thread.c
+++ b/LibOS/shim/src/bookkeep/shim_thread.c
@@ -755,6 +755,8 @@ BEGIN_RS_FUNC(running_thread)
             assert(tcb->context.sp);
             tcb->debug_buf = SHIM_GET_TLS()->debug_buf;
             allocate_tls(libc_tcb, thread->user_tcb, thread);
+            /* Temporarily disable preemption until the thread resumes. */
+            __disable_preempt(tcb);
             debug_setprefix(tcb);
             debug("after resume, set tcb to %p\n", libc_tcb);
         } else {
@@ -764,7 +766,7 @@ BEGIN_RS_FUNC(running_thread)
         thread->in_vm = thread->is_alive = true;
         thread->pal_handle = PAL_CB(first_thread);
     }
-    
+
     DEBUG_RS("tid=%d", thread->tid);
 }
 END_RS_FUNC(running_thread)

--- a/LibOS/shim/src/bookkeep/shim_thread.c
+++ b/LibOS/shim/src/bookkeep/shim_thread.c
@@ -148,6 +148,7 @@ static IDTYPE get_internal_pid (void)
     internal_tid_alloc_idx++;
     IDTYPE idx = internal_tid_alloc_idx;
     unlock(thread_list_lock);
+    assert(IS_INTERNAL_TID(idx));
     return idx;
 }
 

--- a/LibOS/shim/src/elf/shim_rtld.c
+++ b/LibOS/shim/src/elf/shim_rtld.c
@@ -1573,6 +1573,10 @@ int execute_elf_object (struct shim_handle * exec, int argc, const char ** argp,
 
     ElfW(Addr) entry = interp_map ? interp_map->l_entry : exec_map->l_entry;
 
+    /* Ready to start execution, re-enable preemption. */
+    shim_tcb_t * tcb = SHIM_GET_TLS();
+    __enable_preempt(tcb);
+
 #if defined(__x86_64__)
     asm volatile (
                     "movq %%rbx, %%rsp\r\n"

--- a/LibOS/shim/src/fs/shim_namei.c
+++ b/LibOS/shim/src/fs/shim_namei.c
@@ -394,6 +394,13 @@ int __path_lookupat (struct shim_dentry * start, const char * path, int flags,
                 }
             }
 
+            /* If one of the components is not a directory, return -ENOTDIR
+             * and abort lookup. */
+            if (!(my_dent->state & DENTRY_ISDIRECTORY)) {
+                err = -ENOTDIR;
+                goto out;
+            }
+
             /* Although this is slight over-kill, let's just always increment the
              * mount ref count on a recursion, for easier bookkeeping */
             get_mount(my_dent->fs);

--- a/LibOS/shim/src/ipc/shim_ipc.c
+++ b/LibOS/shim/src/ipc/shim_ipc.c
@@ -396,9 +396,10 @@ int send_ipc_message (struct shim_ipc_msg * msg, struct shim_ipc_port * port)
 int close_ipc_message_duplex (struct shim_ipc_msg_obj * msg,
                               struct shim_ipc_port * port)
 {
-    if (port && !list_empty(msg, list)) {
+    if (port) {
         lock(port->msgs_lock);
-        listp_del_init(msg, &port->msgs, list);
+        if (!list_empty(msg, list))
+            listp_del_init(msg, &port->msgs, list);
         unlock(port->msgs_lock);
     }
 

--- a/LibOS/shim/src/ipc/shim_ipc_helper.c
+++ b/LibOS/shim/src/ipc/shim_ipc_helper.c
@@ -411,6 +411,16 @@ static bool __del_ipc_port (struct shim_ipc_port * port, int type)
         __put_ipc_port(port);
     }
 
+    /* Need to clean up threads that are currently waiting on this port. */
+    struct shim_ipc_msg_obj * tmp;
+    lock(port->msgs_lock);
+    listp_for_each_entry(tmp, &port->msgs, list) {
+        tmp->retval = -ECONNRESET;
+        if (tmp->thread)
+            thread_wakeup(tmp->thread);
+    }
+    unlock(port->msgs_lock);
+
 out:
     port->update = true;
     return need_restart;

--- a/LibOS/shim/src/ipc/shim_ipc_pid.c
+++ b/LibOS/shim/src/ipc/shim_ipc_pid.c
@@ -158,7 +158,7 @@ int ipc_pid_kill_callback (IPC_CALLBACK_ARGS)
             break;
     }
 
-    assert(ret != -ESRCH);
+    //assert(ret != -ESRCH);
 
     SAVE_PROFILE_INTERVAL(ipc_pid_kill_callback);
     return ret < 0 ? ret : RESPONSE_CALLBACK;

--- a/LibOS/shim/src/shim_checkpoint.c
+++ b/LibOS/shim/src/shim_checkpoint.c
@@ -1256,6 +1256,10 @@ void restore_context (struct shim_context * context)
     regs[nregs] = (void *) context->sp - 8;
     *(void **) (context->sp - 8) = context->ret_ip;
 
+    /* Ready to resume execution, re-enable preemption. */
+    shim_tcb_t * tcb = SHIM_GET_TLS();
+    __enable_preempt(tcb);
+
     memset(context, 0, sizeof(struct shim_context));
 
     asm volatile("movq %0, %%rsp\r\n"

--- a/LibOS/shim/src/shim_init.c
+++ b/LibOS/shim/src/shim_init.c
@@ -671,6 +671,9 @@ int shim_init (int argc, void * args, void ** return_stack)
     __libc_tcb_t tcb;
     memset(&tcb, 0, sizeof(__libc_tcb_t));
     allocate_tls(&tcb, false, NULL);
+    /* Temporarily disable preemption for delaying any signal that arrives
+     * during initialization. */
+    __disable_preempt(&tcb.shim_tcb);
     debug_setbuf(&tcb.shim_tcb, true);
     debug("set tcb to %p\n", &tcb);
 

--- a/LibOS/shim/src/sys/shim_clone.c
+++ b/LibOS/shim/src/sys/shim_clone.c
@@ -110,6 +110,7 @@ int clone_implementation_wrapper(struct clone_args * arg)
     }
     allocate_tls(my_thread->tcb, my_thread->user_tcb, my_thread);
     shim_tcb_t * tcb = &((__libc_tcb_t *) my_thread->tcb)->shim_tcb;
+    __disable_preempt(tcb);
     debug_setbuf(tcb, true);
     debug("set tcb to %p (stack allocated? %d)\n", my_thread->tcb, stack_allocated);
 

--- a/LibOS/shim/src/sys/shim_dup.c
+++ b/LibOS/shim/src/sys/shim_dup.c
@@ -38,6 +38,7 @@
 int shim_do_dup (int fd)
 {
     struct shim_handle_map * handle_map = get_cur_handle_map(NULL);
+    assert(handle_map);
     int flags = 0;
 
     struct shim_handle * hdl = get_fd_handle(fd, &flags, handle_map);
@@ -52,6 +53,7 @@ int shim_do_dup (int fd)
 int shim_do_dup2 (int oldfd, int newfd)
 {
     struct shim_handle_map * handle_map = get_cur_handle_map(NULL);
+    assert(handle_map);
 
     struct shim_handle * hdl = get_fd_handle(oldfd, NULL, handle_map);
     if (!hdl)
@@ -70,6 +72,8 @@ int shim_do_dup2 (int oldfd, int newfd)
 int shim_do_dup3 (int oldfd, int newfd, int flags)
 {
     struct shim_handle_map * handle_map = get_cur_handle_map(NULL);
+    assert(handle_map);
+
     struct shim_handle * hdl = get_fd_handle(oldfd, NULL, handle_map);
     if (!hdl)
         return -EBADF;

--- a/LibOS/shim/src/sys/shim_exec.c
+++ b/LibOS/shim/src/sys/shim_exec.c
@@ -91,6 +91,9 @@ int shim_do_execve_rtld (struct shim_handle * hdl, const char ** argv,
         return -ENOMEM;
 
     populate_tls(tcb, false);
+    /* Temporarily disable preemption for delaying any signal that arrives
+     * during execve(). */
+    __disable_preempt(&((__libc_tcb_t *) tcb)->shim_tcb);
     debug("set tcb to %p\n", tcb);
 
     put_handle(cur_thread->exec);

--- a/LibOS/shim/src/sys/shim_exec.c
+++ b/LibOS/shim/src/sys/shim_exec.c
@@ -268,7 +268,9 @@ int shim_do_execve (const char * file, const char ** argv,
 
     BEGIN_PROFILE_INTERVAL();
 
-    
+    if (file && test_user_string(file))
+        return -EFAULT;
+
     DEFINE_LIST(sharg);
     struct sharg {
         LIST_TYPE(sharg)  list;

--- a/LibOS/shim/src/sys/shim_poll.c
+++ b/LibOS/shim/src/sys/shim_poll.c
@@ -139,7 +139,7 @@ no_op:
         }
 
         struct shim_handle * hdl = __get_fd_handle(p->fd, NULL, map);
-        if (!hdl->fs || !hdl->fs->fs_ops)
+        if (!hdl || !hdl->fs || !hdl->fs->fs_ops)
             goto no_op;
 
         SAVE_PROFILE_INTERVAL(do_poll_get_handle);

--- a/LibOS/shim/src/sys/shim_sched.c
+++ b/LibOS/shim/src/sys/shim_sched.c
@@ -39,6 +39,8 @@ int shim_do_sched_yield (void)
 int shim_do_sched_getaffinity (pid_t pid, size_t len,
                                __kernel_cpu_set_t * user_mask_ptr)
 {
+    if (test_user_memory(user_mask_ptr, len, true))
+        return -EFAULT;
     int ncpus = PAL_CB(cpu_info.cpu_num);
     memset(user_mask_ptr, 0, len);
     for (int i = 0 ; i < ncpus ; i++)

--- a/LibOS/shim/src/sys/shim_semget.c
+++ b/LibOS/shim/src/sys/shim_semget.c
@@ -359,6 +359,12 @@ static int __do_semop (int semid, struct sembuf * sops, unsigned int nsops,
     struct shim_sem_handle * sem;
     int nsems = 0;
 
+    if (!sops || !nsops)
+        return -EINVAL;
+
+    if (test_user_memory(sops, sizeof(sops[0]) * nsops, false))
+        return -EFAULT;
+
     for (int i = 0 ; i < nsops ; i++)
         if (sops[i].sem_num >= nsems)
             nsems = sops[i].sem_num + 1;

--- a/LibOS/shim/src/sys/shim_socket.c
+++ b/LibOS/shim/src/sys/shim_socket.c
@@ -1415,7 +1415,7 @@ out:
 
 int shim_do_getsockname (int sockfd, struct sockaddr * addr, int * addrlen)
 {
-    if (!addr || !addrlen)
+    if (!addr || !addrlen || test_user_memory(addrlen, sizeof(int), true))
         return -EFAULT;
 
     if (*addrlen <= 0)
@@ -1455,7 +1455,7 @@ out:
 
 int shim_do_getpeername (int sockfd, struct sockaddr * addr, int * addrlen)
 {
-    if (!addr || !addrlen)
+    if (!addr || !addrlen || test_user_memory(addrlen, sizeof(int), true))
         return -EFAULT;
 
     if (*addrlen <= 0)


### PR DESCRIPTION
I suspect this might be the cause of the heisenbugs that happen during Jenkins test. When a signal was caught after a thread or a process is in the middle of termination, the internal signal handler continues to process the signal, either triggering an internal segfault or calling the user handler. The right behavior should be to ignore the signal completely.

Testing if this PR passes the Jenkins test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/237)
<!-- Reviewable:end -->
