### PR TITLE
gcc -dumpmachine returns x86_64-xxx-linux-gnu

### DIFF
--- a/LibOS/Makefile
+++ b/LibOS/Makefile
@@ -12,7 +12,7 @@ GLIBC_TARGET = $(addprefix $(BUILD_DIR)/,libc.so.6 ld-linux-x86-64.so.2 libpthre
 all: $(GLIBC_TARGET)
 	$(MAKE) -C $(SHIM_DIR) all
 
-ifeq ($(SYS),x86_64-linux-gnu)
+ifeq ($(findstring linux,$(SYS)),linux)
 
 .INTERMEDIATE: $(BUILD_DIR)/Build.success
 

--- a/LibOS/Makefile
+++ b/LibOS/Makefile
@@ -12,7 +12,7 @@ GLIBC_TARGET = $(addprefix $(BUILD_DIR)/,libc.so.6 ld-linux-x86-64.so.2 libpthre
 all: $(GLIBC_TARGET)
 	$(MAKE) -C $(SHIM_DIR) all
 
-ifeq ($(findstring linux,$(SYS)),linux)
+ifeq ($(findstring x86_64,$(SYS))$(findstring linux,$(SYS)),x86_64linux)
 
 .INTERMEDIATE: $(BUILD_DIR)/Build.success
 

--- a/LibOS/shim/Makefile
+++ b/LibOS/shim/Makefile
@@ -4,7 +4,7 @@ SYS ?= $(shell gcc -dumpmachine)
 export SYS
 
 targets = all debug clean
-ifeq ($(findstring linux,$(SYS)),linux)
+ifeq ($(findstring x86_64,$(SYS))$(findstring linux,$(SYS)),x86_64linux)
 targets += pack
 endif
 

--- a/LibOS/shim/Makefile
+++ b/LibOS/shim/Makefile
@@ -4,7 +4,7 @@ SYS ?= $(shell gcc -dumpmachine)
 export SYS
 
 targets = all debug clean
-ifeq ($(SYS),x86_64-linux-gnu)
+ifeq ($(findstring linux,$(SYS)),linux)
 targets += pack
 endif
 

--- a/LibOS/shim/src/Makefile
+++ b/LibOS/shim/src/Makefile
@@ -65,7 +65,7 @@ endif
 $(files_to_install): $(RUNTIME_DIR)/%: %
 	cp -f $< $@
 
-ifeq ($(findstring linux,$(SYS)),linux)
+ifeq ($(findstring x86_64,$(SYS))$(findstring linux,$(SYS)),x86_64linux)
 libsysdb.so: $(addsuffix .o,$(objs)) $(filter %.map %.lds,$(LDFLAGS)) \
 	     $(graphene_lib) $(pal_lib)
 	@echo [ $@ ]

--- a/LibOS/shim/src/Makefile
+++ b/LibOS/shim/src/Makefile
@@ -65,7 +65,7 @@ endif
 $(files_to_install): $(RUNTIME_DIR)/%: %
 	cp -f $< $@
 
-ifeq ($(SYS),x86_64-linux-gnu)
+ifeq ($(findstring linux,$(SYS)),linux)
 libsysdb.so: $(addsuffix .o,$(objs)) $(filter %.map %.lds,$(LDFLAGS)) \
 	     $(graphene_lib) $(pal_lib)
 	@echo [ $@ ]

--- a/LibOS/shim/test/benchmark/Makefile
+++ b/LibOS/shim/test/benchmark/Makefile
@@ -13,7 +13,7 @@ include ../Makefile
 	rm -rf $@
 	cp $@.template $@
 
-ifeq ($(findstring linux,$(SYS)),linux)
+ifeq ($(findstring x86_64,$(SYS))$(findstring linux,$(SYS)),x86_64linux)
 $(c_executables): %: %.c
 	@echo [ $@ ]
 	@$(CC) $(CFLAGS) $(if $(findstring .libos,$@),$(CFLAGS-libos),) -o $@ $< \

--- a/LibOS/shim/test/benchmark/Makefile
+++ b/LibOS/shim/test/benchmark/Makefile
@@ -13,7 +13,7 @@ include ../Makefile
 	rm -rf $@
 	cp $@.template $@
 
-ifeq ($(SYS),x86_64-linux-gnu)
+ifeq ($(findstring linux,$(SYS)),linux)
 $(c_executables): %: %.c
 	@echo [ $@ ]
 	@$(CC) $(CFLAGS) $(if $(findstring .libos,$@),$(CFLAGS-libos),) -o $@ $< \

--- a/LibOS/shim/test/inline/Makefile
+++ b/LibOS/shim/test/inline/Makefile
@@ -8,7 +8,7 @@ include ../Makefile
 
 CFLAGS-debug += -fno-builtin -nostdlib
 
-ifeq ($(SYS),x86_64-linux-gnu)
+ifeq ($(findstring linux,$(SYS)),linux)
 $(c_executables): %: %.c $(libs) $(level)../../../Pal/src/user_start.o
 	@echo [ $@ ]
 	$(CC) $(CFLAGS-debug) $(LDFLAGS-debug) -o $@ $^ -lpal -lsysdb_debug

--- a/LibOS/shim/test/inline/Makefile
+++ b/LibOS/shim/test/inline/Makefile
@@ -8,7 +8,7 @@ include ../Makefile
 
 CFLAGS-debug += -fno-builtin -nostdlib
 
-ifeq ($(findstring linux,$(SYS)),linux)
+ifeq ($(findstring x86_64,$(SYS))$(findstring linux,$(SYS)),x86_64linux)
 $(c_executables): %: %.c $(libs) $(level)../../../Pal/src/user_start.o
 	@echo [ $@ ]
 	$(CC) $(CFLAGS-debug) $(LDFLAGS-debug) -o $@ $^ -lpal -lsysdb_debug

--- a/LibOS/shim/test/native/Makefile
+++ b/LibOS/shim/test/native/Makefile
@@ -11,7 +11,7 @@ include ../Makefile
 
 CFLAGS-libos = -I$(SHIMDIR)/../include -L$(SHIMDIR)/../../glibc-build/libos
 
-ifeq ($(findstring linux,$(SYS)),linux)
+ifeq ($(findstring x86_64,$(SYS))$(findstring linux,$(SYS)),x86_64linux)
 $(c_executables): %: %.c
 	@echo [ $@ ]
 	@$(CC) $(CFLAGS) $(if $(findstring .libos,$@),$(CFLAGS-libos),) -o $@ $< \

--- a/LibOS/shim/test/native/Makefile
+++ b/LibOS/shim/test/native/Makefile
@@ -1,4 +1,4 @@
-special_executables = static pie 
+special_executables = static pie
 c_executables = $(filter-out $(special_executables),$(patsubst %.c,%,$(wildcard *.c)))
 cxx_executables = $(patsubst %.cpp,%,$(wildcard *.cpp))
 manifests = $(patsubst %.template,%,$(wildcard *.manifest.template)) manifest
@@ -11,7 +11,7 @@ include ../Makefile
 
 CFLAGS-libos = -I$(SHIMDIR)/../include -L$(SHIMDIR)/../../glibc-build/libos
 
-ifeq ($(SYS),x86_64-linux-gnu)
+ifeq ($(findstring linux,$(SYS)),linux)
 $(c_executables): %: %.c
 	@echo [ $@ ]
 	@$(CC) $(CFLAGS) $(if $(findstring .libos,$@),$(CFLAGS-libos),) -o $@ $< \

--- a/LibOS/shim/test/regression/Makefile
+++ b/LibOS/shim/test/regression/Makefile
@@ -16,7 +16,7 @@ default: all
 level = ../
 include ../Makefile
 
-ifeq ($(findstring linux,$(SYS)),linux)
+ifeq ($(findstring x86_64,$(SYS))$(findstring linux,$(SYS)),x86_64linux)
 $(c_executables): %: %.c
 	@echo [ $@ ]
 	@$(CC) $(CFLAGS) $(if $(findstring .libos,$@),$(CFLAGS-libos),) -o $@ $< \

--- a/LibOS/shim/test/regression/Makefile
+++ b/LibOS/shim/test/regression/Makefile
@@ -16,7 +16,7 @@ default: all
 level = ../
 include ../Makefile
 
-ifeq ($(SYS),x86_64-linux-gnu)
+ifeq ($(findstring linux,$(SYS)),linux)
 $(c_executables): %: %.c
 	@echo [ $@ ]
 	@$(CC) $(CFLAGS) $(if $(findstring .libos,$@),$(CFLAGS-libos),) -o $@ $< \

--- a/Pal/regression/Makefile
+++ b/Pal/regression/Makefile
@@ -46,7 +46,7 @@ manifest: manifest.template
 ../src/user_shared_start.o ../src/user_start.o: ../src/user_start.S
 	$(MAKE) -C ../src $(notdir $@)
 
-ifeq ($(SYS),x86_64-linux-gnu)
+ifeq ($(findstring linux,$(SYS)),linux)
 $(preloads): %.so: %.so.c ../src/user_shared_start.o \
 	$(graphene_lib) $(pal_lib) ../include/pal/pal.h
 	@echo [ $@ ]

--- a/Pal/regression/Makefile
+++ b/Pal/regression/Makefile
@@ -46,7 +46,7 @@ manifest: manifest.template
 ../src/user_shared_start.o ../src/user_start.o: ../src/user_start.S
 	$(MAKE) -C ../src $(notdir $@)
 
-ifeq ($(findstring linux,$(SYS)),linux)
+ifeq ($(findstring x86_64,$(SYS))$(findstring linux,$(SYS)),x86_64linux)
 $(preloads): %.so: %.so.c ../src/user_shared_start.o \
 	$(graphene_lib) $(pal_lib) ../include/pal/pal.h
 	@echo [ $@ ]

--- a/Pal/src/Makefile
+++ b/Pal/src/Makefile
@@ -39,7 +39,7 @@ graphene_lib = .lib/graphene-lib.a
 host_lib = host/$(PAL_HOST)/libpal-$(PAL_HOST).a
 headers	= $(wildcard *.h) $(wildcard ../lib/*.h) host/$(PAL_HOST)/pal_host.h
 
-ifeq ($(findstring linux,$(SYS)),linux)
+ifeq ($(findstring x86_64,$(SYS))$(findstring linux,$(SYS)),x86_64linux)
 files_to_build += user_start.o user_shared_start.o
 endif
 

--- a/Pal/src/Makefile
+++ b/Pal/src/Makefile
@@ -39,7 +39,7 @@ graphene_lib = .lib/graphene-lib.a
 host_lib = host/$(PAL_HOST)/libpal-$(PAL_HOST).a
 headers	= $(wildcard *.h) $(wildcard ../lib/*.h) host/$(PAL_HOST)/pal_host.h
 
-ifeq ($(SYS),x86_64-linux-gnu)
+ifeq ($(findstring linux,$(SYS)),linux)
 files_to_build += user_start.o user_shared_start.o
 endif
 

--- a/Pal/src/Makefile.Host
+++ b/Pal/src/Makefile.Host
@@ -2,7 +2,7 @@ all_hosts = Skeleton Linux Linux-SGX FreeBSD
 
 ifeq ($(PAL_HOST),)
 SYS := $(shell gcc -dumpmachine)
-ifeq ($(findstring linux,$(SYS)),linux)
+ifeq ($(findstring x86_64,$(SYS))$(findstring linux,$(SYS)),x86_64linux)
 PAL_HOST := Linux
 else ifeq ($(findstring freebsd,$(SYS)),freebsd)
 PAL_HOST := FreeBSD

--- a/Pal/src/Makefile.Host
+++ b/Pal/src/Makefile.Host
@@ -2,7 +2,7 @@ all_hosts = Skeleton Linux Linux-SGX FreeBSD
 
 ifeq ($(PAL_HOST),)
 SYS := $(shell gcc -dumpmachine)
-ifeq ($(SYS),x86_64-linux-gnu)
+ifeq ($(findstring linux,$(SYS)),linux)
 PAL_HOST := Linux
 else ifeq ($(findstring freebsd,$(SYS)),freebsd)
 PAL_HOST := FreeBSD

--- a/Pal/test/Makefile
+++ b/Pal/test/Makefile
@@ -36,7 +36,7 @@ manifest: manifest.template
 %.manifest: %.manifest.template
 	cp -f $< $@
 
-ifeq ($(SYS),x86_64-linux-gnu)
+ifeq ($(findstring linux,$(SYS)),linux)
 $(executables): %: %.c $(graphene_lib) $(pal_lib) ../src/user_start.o
 	@echo [ $@ ]
 	@$(CC) $(CFLAGS) $(if $(filter Pie,$@),-fPIC -pie,) $^ -o $@

--- a/Pal/test/Makefile
+++ b/Pal/test/Makefile
@@ -36,7 +36,7 @@ manifest: manifest.template
 %.manifest: %.manifest.template
 	cp -f $< $@
 
-ifeq ($(findstring linux,$(SYS)),linux)
+ifeq ($(findstring x86_64,$(SYS))$(findstring linux,$(SYS)),x86_64linux)
 $(executables): %: %.c $(graphene_lib) $(pal_lib) ../src/user_start.o
 	@echo [ $@ ]
 	@$(CC) $(CFLAGS) $(if $(filter Pie,$@),-fPIC -pie,) $^ -o $@


### PR DESCRIPTION
On Linux Desktop, ```gcc -dumpmachine``` will return ```x86_64-xxx-linux-gnu``` instead of ```x86_64-linux-gnu```.

OS: Ubuntu Desktop 16.04
gcc version: 5.3.0
```gcc -dumpmachine``` returns ```x86_64-unknown-linux-gnu```

OS: Ubuntu Server 16.04
gcc version: 5.4.0
```gcc -dumpmachine``` returns ```x86_64-linux-gnu```

OS: Manjaro Linux
gcc version: 5.5.0
```gcc -dumpmachine``` returns ```x86_64-pc-linux-gnu```