### PR TITLE
Fixing memory corruption during exception handling 

### DIFF
--- a/LibOS/shim/test/native/cpuid.c
+++ b/LibOS/shim/test/native/cpuid.c
@@ -1,0 +1,28 @@
+#include <stdio.h>
+
+static inline void native_cpuid(unsigned int *eax, unsigned int *ebx,
+                                unsigned int *ecx, unsigned int *edx)
+{
+        /* ecx is often an input as well as an output. */
+        asm volatile("cpuid"
+            : "=a" (*eax),
+              "=b" (*ebx),
+              "=c" (*ecx),
+              "=d" (*edx)
+            : "0" (*eax), "2" (*ecx));
+}
+
+int main(int argc, char **argv)
+{
+  unsigned eax, ebx, ecx, edx;
+
+  eax = 1; /* processor info and feature bits */
+  native_cpuid(&eax, &ebx, &ecx, &edx);
+
+  printf("stepping %d\n", eax & 0xF);
+  printf("model %d\n", (eax >> 4) & 0xF);
+  printf("family %d\n", (eax >> 8) & 0xF);
+  printf("processor type %d\n", (eax >> 12) & 0x3);
+  printf("extended model %d\n", (eax >> 16) & 0xF);
+  printf("extended family %d\n", (eax >> 20) & 0xFF);
+}

--- a/LibOS/shim/test/native/cpuid.c
+++ b/LibOS/shim/test/native/cpuid.c
@@ -3,26 +3,26 @@
 static inline void native_cpuid(unsigned int *eax, unsigned int *ebx,
                                 unsigned int *ecx, unsigned int *edx)
 {
-        /* ecx is often an input as well as an output. */
-        asm volatile("cpuid"
-            : "=a" (*eax),
-              "=b" (*ebx),
-              "=c" (*ecx),
-              "=d" (*edx)
-            : "0" (*eax), "2" (*ecx));
+    /* ecx is often an input as well as an output. */
+    asm volatile("cpuid"
+        : "=a" (*eax),
+        "=b" (*ebx),
+        "=c" (*ecx),
+        "=d" (*edx)
+        : "0" (*eax), "2" (*ecx));
 }
 
 int main(int argc, char **argv)
 {
-  unsigned eax, ebx, ecx, edx;
+    unsigned eax, ebx, ecx, edx;
 
-  eax = 1; /* processor info and feature bits */
-  native_cpuid(&eax, &ebx, &ecx, &edx);
+    eax = 1; /* processor info and feature bits */
+    native_cpuid(&eax, &ebx, &ecx, &edx);
 
-  printf("stepping %d\n", eax & 0xF);
-  printf("model %d\n", (eax >> 4) & 0xF);
-  printf("family %d\n", (eax >> 8) & 0xF);
-  printf("processor type %d\n", (eax >> 12) & 0x3);
-  printf("extended model %d\n", (eax >> 16) & 0xF);
-  printf("extended family %d\n", (eax >> 20) & 0xFF);
+    printf("stepping %d\n", eax & 0xF);
+    printf("model %d\n", (eax >> 4) & 0xF);
+    printf("family %d\n", (eax >> 8) & 0xF);
+    printf("processor type %d\n", (eax >> 12) & 0x3);
+    printf("extended model %d\n", (eax >> 16) & 0xF);
+    printf("extended family %d\n", (eax >> 20) & 0xFF);
 }

--- a/Pal/src/host/Linux-SGX/db_main.c
+++ b/Pal/src/host/Linux-SGX/db_main.c
@@ -147,6 +147,10 @@ void pal_linux_main(const char ** arguments, const char ** environments,
     init_pages();
     init_enclave_key();
 
+    /* Init memory for storing reg states in exception */
+    void * sgx_gpr_mem = malloc(SGX_GPR_SIZE);
+    SET_ENCLAVE_TLS(sgx_gpr_state, sgx_gpr_mem);
+
     /* now we can add a link map for PAL itself */
     setup_pal_map(&pal_map);
 

--- a/Pal/src/host/Linux-SGX/db_threading.c
+++ b/Pal/src/host/Linux-SGX/db_threading.c
@@ -56,6 +56,10 @@ void pal_start_thread (void)
 {
     struct pal_handle_thread *new_thread = NULL, *tmp;
 
+    /* Init memory for storing reg states in exception */
+    void * sgx_gpr_mem = malloc(SGX_GPR_SIZE);
+    SET_ENCLAVE_TLS(sgx_gpr_state, sgx_gpr_mem);
+
     _DkInternalLock(&thread_list_lock);
     listp_for_each_entry(tmp, &thread_list, list)
         if (!tmp->tcs) {

--- a/Pal/src/host/Linux-SGX/enclave_entry.S
+++ b/Pal/src/host/Linux-SGX/enclave_entry.S
@@ -180,8 +180,13 @@ enclave_entry:
 	mov SGX_GPR_RIP(%rbx), %rdi
 	mov %rdi, 0x88(%rsi)
 
-	mov %rsi, SGX_GPR_RSP(%rbx)
 	mov %rsi, SGX_GPR_RSI(%rbx)
+	
+        # leave a gap for exception stack
+	mov SGX_GPR_RSP(%rbx), %rsi
+        sub $0x60, %rsi
+
+	mov %rsi, SGX_GPR_RSP(%rbx)
 
 	# new RIP is the exception handler
 	lea _DkExceptionHandler(%rip), %rdi

--- a/Pal/src/host/Linux-SGX/enclave_entry.S
+++ b/Pal/src/host/Linux-SGX/enclave_entry.S
@@ -136,8 +136,8 @@ enclave_entry:
 #endif
 
 .Lhandle_exception:
-	mov SGX_GPR_RSP(%rbx), %rsi
-	sub $0x90, %rsi
+	# Save SGX States
+	mov %gs:SGX_GPR_STATE, %rsi
 
 	# we have exitinfo in RDI, swap with the one on GPR
 	# and dump into the context

--- a/Pal/src/host/Linux-SGX/sgx_main.c
+++ b/Pal/src/host/Linux-SGX/sgx_main.c
@@ -430,6 +430,7 @@ int initialize_enclave (struct pal_enclave * enclave)
                     enclave_secs.baseaddr;
                 gs->gpr = gs->ssa +
                     enclave->ssaframesize - sizeof(sgx_arch_gpr_t);
+				gs->sgx_gpr_state = NULL;
             }
 
             goto add_pages;

--- a/Pal/src/host/Linux-SGX/sgx_main.c
+++ b/Pal/src/host/Linux-SGX/sgx_main.c
@@ -430,7 +430,7 @@ int initialize_enclave (struct pal_enclave * enclave)
                     enclave_secs.baseaddr;
                 gs->gpr = gs->ssa +
                     enclave->ssaframesize - sizeof(sgx_arch_gpr_t);
-				gs->sgx_gpr_state = NULL;
+                gs->sgx_gpr_state = NULL;
             }
 
             goto add_pages;

--- a/Pal/src/host/Linux-SGX/sgx_tls.h
+++ b/Pal/src/host/Linux-SGX/sgx_tls.h
@@ -19,7 +19,11 @@ struct enclave_tls {
     void *   ustack_top;
     void *   ustack;
     void *   thread;
+    void *   sgx_gpr_state;
 };
+
+/* The size of memory for storing SGX states during exceptions */
+#define SGX_GPR_SIZE 				0x100
 
 #ifndef DEBUG
 extern uint64_t dummy_debug_variable;
@@ -56,6 +60,7 @@ extern uint64_t dummy_debug_variable;
 #define SGX_USTACK_TOP              0x48
 #define SGX_USTACK                  0x50
 #define SGX_THREAD                  0x58
+#define SGX_GPR_STATE		    	0x60
 
 #endif
 

--- a/Pal/src/host/Linux-SGX/sgx_tls.h
+++ b/Pal/src/host/Linux-SGX/sgx_tls.h
@@ -23,7 +23,7 @@ struct enclave_tls {
 };
 
 /* The size of memory for storing SGX states during exceptions */
-#define SGX_GPR_SIZE 				0x100
+#define SGX_GPR_SIZE                0x100
 
 #ifndef DEBUG
 extern uint64_t dummy_debug_variable;
@@ -60,7 +60,7 @@ extern uint64_t dummy_debug_variable;
 #define SGX_USTACK_TOP              0x48
 #define SGX_USTACK                  0x50
 #define SGX_THREAD                  0x58
-#define SGX_GPR_STATE		    	0x60
+#define SGX_GPR_STATE               0x60
 
 #endif
 


### PR DESCRIPTION
This PR fixes the potential memory corruption in the in-enclave exception handler. The in-enclave exception handler uses the memory below RSP register to store the sgx register context: 
```
.Lhandle_exception:
	mov SGX_GPR_RSP(%rbx), %rsi
	sub $0x90, %rsi
```
It assumes the memory below the stack top won't be used. However, this is not always true. For example, The function native_cpuid:
```
static inline void native_cpuid(unsigned int *eax, unsigned int *ebx,
                                unsigned int *ecx, unsigned int *edx)
{
    /* ecx is often an input as well as an output. */
    asm volatile("cpuid"
        : "=a" (*eax),
        "=b" (*ebx),
        "=c" (*ecx),
        "=d" (*edx)
        : "0" (*eax), "2" (*ecx));
}
```
Will be compiled to:
```
   ...
   0x000000000040059b <+5>:     mov    %rdi,-0x10(%rbp)
   0x000000000040059f <+9>:     mov    %rsi,-0x18(%rbp)
   0x00000000004005a3 <+13>:    mov    %rdx,-0x20(%rbp)
   0x00000000004005a7 <+17>:    mov    %rcx,-0x28(%rbp)
   0x00000000004005ab <+21>:    mov    -0x10(%rbp),%rax
   0x00000000004005af <+25>:    mov    (%rax),%ecx
   0x00000000004005b1 <+27>:    mov    -0x20(%rbp),%rax
   0x00000000004005b5 <+31>:    mov    (%rax),%edx
   0x00000000004005b7 <+33>:    mov    %ecx,%eax
   0x00000000004005b9 <+35>:    mov    %edx,%ecx
   0x00000000004005bb <+37>:    cpuid
   0x00000000004005bd <+39>:    mov    %ebx,%esi
   0x00000000004005bf <+41>:    mov    -0x10(%rbp),%rdi
   0x00000000004005c3 <+45>:    mov    %eax,(%rdi)
   0x00000000004005c5 <+47>:    mov    -0x18(%rbp),%rax
   0x00000000004005c9 <+51>:    mov    %esi,(%rax)
   0x00000000004005cb <+53>:    mov    -0x20(%rbp),%rax
   0x00000000004005cf <+57>:    mov    %ecx,(%rax)
 =>  0x00000000004005d1 <+59>:    mov    -0x28(%rbp),%rax
   0x00000000004005d5 <+63>:    mov    %edx,(%rax)
   ...
```
The code the arrow points to will cause segmentation fault as it uses the memory below RSP/RBP to retrieve the values stored before exception (cpuid) but the memory has already been corrupted during the exception handling. 

This PR includes: 

(1) The implementation of using a per-thread memory (TLS field) to store sgx context and the app could retrieve after the exception;

(2) A test case for testing cpuid functionality and reproducing the issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/245)
<!-- Reviewable:end -->
