### PR TITLE
Uninitialized hdl_hdr.fds bugfixes (#246)

### DIFF
--- a/Pal/src/host/FreeBSD/db_streams.c
+++ b/Pal/src/host/FreeBSD/db_streams.c
@@ -284,6 +284,7 @@ int _DkSendHandle (PAL_HANDLE hdl, PAL_HANDLE cargo)
     if (ret < 0)
         return ret;
 
+    hdl_hdr.fds = 0;
     hdl_hdr.data_size = ret;
     int fds[MAX_FDS];
     int nfds = 0;

--- a/Pal/src/host/Linux-SGX/db_streams.c
+++ b/Pal/src/host/Linux-SGX/db_streams.c
@@ -274,6 +274,7 @@ int _DkSendHandle (PAL_HANDLE hdl, PAL_HANDLE cargo)
     if (ret < 0)
         return ret;
 
+    hdl_hdr.fds = 0;
     hdl_hdr.data_size = ret;
     unsigned int fds[MAX_FDS];
     unsigned int nfds = 0;

--- a/Pal/src/host/Linux/db_streams.c
+++ b/Pal/src/host/Linux/db_streams.c
@@ -287,6 +287,7 @@ int _DkSendHandle (PAL_HANDLE hdl, PAL_HANDLE cargo)
     if (ret < 0)
         return ret;
 
+    hdl_hdr.fds = 0;
     hdl_hdr.data_size = ret;
     int fds[MAX_FDS];
     int nfds = 0;


### PR DESCRIPTION
In the Pal source files
Pal/src/host/FreeBSD/db_streams.c:292
Pal/src/host/Linux-SGX/db_streams.c:282
Pal/src/host/Linux/db_streams.c:295
1)	The struct hdl_hdr is defined as local variable
2)	The ‘fds’ member of struct hdl_hdr is used without Initialization
3)	The pointer to struct hdl_hdr is assigned to iov[0]
4)	The iov is assigned to struct hdr as hdr.msg_iov
5)	Do syscall with struct hdr as one of parameters
The bug may cause the unexpected result from syscall.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/247)
<!-- Reviewable:end -->
