### PR TITLE
No suffix to integer literals cause overflow

### DIFF
--- a/Pal/src/host/Linux-SGX/sgx_framework.c
+++ b/Pal/src/host/Linux-SGX/sgx_framework.c
@@ -90,7 +90,7 @@ static size_t get_ssaframesize (uint64_t xfrm)
     xfrm_ex = ((uint64_t) cpuinfo[3] << 32) + cpuinfo[2];
 
     for (int i = 2; i < 64; i++)
-        if ((xfrm & (1 << i)) || (xfrm_ex & (1 << i))) {
+        if ((xfrm & (1ULL << i)) || (xfrm_ex & (1ULL << i))) {
             cpuid(0xd, i, cpuinfo);
             if (cpuinfo[0] + cpuinfo[1] > xsave_size)
                 xsave_size = cpuinfo[0] + cpuinfo[1];


### PR DESCRIPTION
a left shift operator applys on a literal number 1 cause overflow
so unsigned long long type suffix should be appended to that literal
that makes it has same type as xfrm and xfrm for safety

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/251)
<!-- Reviewable:end -->
