### PR TITLE
Add supplementary groups support for graphene

### DIFF
--- a/LibOS/shim/include/shim_table.h
+++ b/LibOS/shim/include/shim_table.h
@@ -434,6 +434,8 @@ uid_t shim_do_getuid (void);
 gid_t shim_do_getgid (void);
 int shim_do_setuid (uid_t uid);
 int shim_do_setgid (gid_t gid);
+int shim_do_setgroups (int gidsetsize, gid_t * grouplist);
+int shim_do_getgroups (int gidsetsize, gid_t * grouplist);
 uid_t shim_do_geteuid (void);
 gid_t shim_do_getegid (void);
 pid_t shim_do_getppid (void);

--- a/LibOS/shim/include/shim_thread.h
+++ b/LibOS/shim/include/shim_thread.h
@@ -15,11 +15,18 @@
 #include <pal.h>
 #include <list.h>
 
+#define NGROUPS_MAX    65536 /* supplemental group IDs are available */
+
 struct shim_handle;
 struct shim_fd_map;
 struct shim_dentry;
 struct shim_signal_handle;
 struct shim_signal_log;
+
+struct groups_info {
+    int size;
+    IDTYPE * spl_gid;
+};
 
 DEFINE_LIST(shim_thread);
 DEFINE_LISTP(shim_thread);
@@ -32,6 +39,8 @@ struct shim_thread {
 
     /* credentials */
     IDTYPE uid, gid, euid, egid;
+    /* Supplementary groups list; protected by thread->lock */
+    struct groups_info * groups;
 
     /* thread pal handle */
     PAL_HANDLE pal_handle;

--- a/LibOS/shim/src/shim_syscalls.c
+++ b/LibOS/shim/src/shim_syscalls.c
@@ -508,6 +508,14 @@ DEFINE_SHIM_SYSCALL (setuid, 1, shim_do_setuid, int, uid_t, uid)
 /* setgid: sys/shim_getpid.c */
 DEFINE_SHIM_SYSCALL (setgid, 1, shim_do_setgid, int, gid_t, gid)
 
+/* setgroups: sys/shim_getpid.c */
+DEFINE_SHIM_SYSCALL (setgroups, 2, shim_do_setgroups, int, int,
+                     gidsetsize, gid_t *, grouplist)
+
+/* getgroups: sys/shim_getpid.c */
+DEFINE_SHIM_SYSCALL (getgroups, 2, shim_do_getgroups, int, int,
+                     gidsetsize, gid_t *, grouplist)
+
 /* geteuid: sys/shim_getpid.c */
 DEFINE_SHIM_SYSCALL (geteuid, 0, shim_do_geteuid, uid_t)
 
@@ -529,12 +537,6 @@ DEFINE_SHIM_SYSCALL (setsid, 0, shim_do_setsid, int)
 SHIM_SYSCALL_PASSTHROUGH (setreuid, 2, int, uid_t, ruid, uid_t, euid)
 
 SHIM_SYSCALL_PASSTHROUGH (setregid, 2, int, gid_t, rgid, gid_t, egid)
-
-SHIM_SYSCALL_PASSTHROUGH (getgroups, 2, int, int, gidsetsize, gid_t *,
-                          grouplist)
-
-SHIM_SYSCALL_PASSTHROUGH (setgroups, 2, int, int, gidsetsize, gid_t *,
-                          grouplist)
 
 SHIM_SYSCALL_PASSTHROUGH (setresuid, 3, int, uid_t, ruid, uid_t, euid, uid_t,
                           suid)


### PR DESCRIPTION
We tested memcached in graphene meets one issue:
The integrate tested version can running in graphene
(https://github.com/memcached/memcached/archive/master.zip),
but the latest version can not running in graphene(1.5.10).

It always print like that:
failed to drop supplementary groups

And memcached can't working.

We investigated the latest version of memcached and found that
it used the setgroups syscall lead to this problem. This syscall is not
supported by graphene in wiki page.
In this series, we add two new syscall for graphene:"setgroups" and "getgroups"
to solve this problem.

Signed-off-by: Zhang Chen <chen.zhang@intel.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/255)
<!-- Reviewable:end -->
