### PR TITLE
Fix an error test on the result of mmap syscall

### DIFF
--- a/Pal/src/security/Linux/main.c
+++ b/Pal/src/security/Linux/main.c
@@ -300,7 +300,7 @@ static int load_static (const char * filename, void ** load_addr,
     base = INLINE_SYSCALL(mmap, 6, NULL, maplength, c->prot,
                           MAP_PRIVATE | MAP_FILE, fd, c->mapoff);
 
-    if (IS_ERR(base)) {
+    if (IS_ERR_P(base)) {
         ret = -ERRNO_P(base);
         goto out;
     }


### PR DESCRIPTION
The Macro IS_ERR should not be used to test the result value of address type.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/260)
<!-- Reviewable:end -->
