### PR TITLE
Turn on -Wsign-compare flag and fix the produced warnings

### DIFF
--- a/Pal/lib/crypto/adapters/mbedtls_adapter.c
+++ b/Pal/lib/crypto/adapters/mbedtls_adapter.c
@@ -31,7 +31,7 @@
 #define BITS_PER_BYTE 8
 
 /* This is declared in pal_internal.h, but that can't be included here. */
-int _DkRandomBitsRead(void *buffer, int size);
+size_t _DkRandomBitsRead(void *buffer, size_t size);
 
 /* Wrapper to provide mbedtls the RNG interface it expects. It passes an
  * extra context parameter, and expects a return value of 0 for success

--- a/Pal/lib/crypto/adapters/mbedtls_dh.c
+++ b/Pal/lib/crypto/adapters/mbedtls_dh.c
@@ -27,7 +27,7 @@
 #define BITS_PER_BYTE 8
 
 /* This is declared in pal_internal.h, but that can't be included here. */
-int _DkRandomBitsRead(void *buffer, int size);
+size_t _DkRandomBitsRead(void *buffer, size_t size);
 
 /* Wrapper to provide mbedtls the RNG interface it expects. It passes an
  * extra context parameter, and expects a return value of 0 for success

--- a/Pal/lib/graphene/config.c
+++ b/Pal/lib/graphene/config.c
@@ -42,8 +42,8 @@ struct config {
 };
 
 static int __add_config (struct config_store * store,
-                         const char * key, int klen,
-                         const char * val, int vlen,
+                         const char * key, size_t klen,
+                         const char * val, size_t vlen,
                          struct config ** entry)
 {
     LISTP_TYPE(config) * list = &store->root;
@@ -110,7 +110,7 @@ static struct config * __get_config (struct config_store * store,
 
     while (*key) {
         const char * token = key;
-        int len = 0;
+        size_t len = 0;
         for ( ; token[len] ; len++)
             if (token[len] == '.')
                 break;
@@ -187,7 +187,7 @@ static int __del_config (struct config_store * store,
                          struct config * p, const char * key)
 {
     struct config * e, * found = NULL;
-    int len = 0;
+    size_t len = 0;
     for ( ; key[len] ; len++)
         if (key[len] == '.')
             break;
@@ -394,7 +394,7 @@ static int __dup_config (const struct config_store * ss,
                          const LISTP_TYPE(config) * sr,
                          struct config_store * ts,
                          LISTP_TYPE(config) * tr,
-                         void ** data, int * size)
+                         void ** data, size_t * size)
 {
     struct config * e, * new;
 
@@ -470,7 +470,7 @@ int copy_config (struct config_store * store, struct config_store * new_store)
     INIT_LISTP(&new_store->entries);
 
     struct config * e;
-    int size = 0;
+    size_t size = 0;
 
     LISTP_FOR_EACH_ENTRY(e, &store->entries, list) {
         if (e->key)
@@ -485,7 +485,7 @@ int copy_config (struct config_store * store, struct config_store * new_store)
         return -PAL_ERROR_NOMEM;
 
     void * dataptr = data;
-    int datasz = size;
+    size_t datasz = size;
 
     new_store->raw_data = data;
     new_store->raw_size = size;

--- a/Pal/src/db_main.c
+++ b/Pal/src/db_main.c
@@ -289,7 +289,7 @@ void pal_main (
     /* try open "<execname>.manifest" */
     ret = get_base_name(exec_uri, uri_buf, URI_MAX);
 
-    strcpy_static(uri_buf + ret, ".manifest", URI_MAX - ret);
+    strcpy_static(uri_buf + ret, ".manifest", URI_MAX - (size_t)ret);
     ret = _DkStreamOpen(&manifest_handle, uri_buf, PAL_ACCESS_RDONLY, 0, 0, 0);
     if (!ret)
         goto has_manifest;

--- a/Pal/src/db_misc.c
+++ b/Pal/src/db_misc.c
@@ -39,10 +39,10 @@ PAL_NUM DkSystemTimeQuery (void)
 static PAL_LOCK lock = LOCK_INIT;
 static unsigned long seed;
 
-int _DkFastRandomBitsRead (void * buffer, int size)
+size_t _DkFastRandomBitsRead (void * buffer, size_t size)
 {
     unsigned long rand;
-    int bytes = 0;
+    size_t bytes = 0;
 
     _DkInternalLock(&lock);
     rand = seed;
@@ -51,7 +51,6 @@ int _DkFastRandomBitsRead (void * buffer, int size)
         int ret = _DkRandomBitsRead(&rand, sizeof(rand));
         if (ret < 0)
             return ret;
-
         _DkInternalLock(&lock);
         seed = rand;
     }
@@ -61,7 +60,7 @@ int _DkFastRandomBitsRead (void * buffer, int size)
             *(unsigned long *) ((char *) buffer + bytes) = rand;
             bytes += sizeof(rand);
         } else {
-            for (int i = 0 ; i < size - bytes ; i++)
+            for (size_t i = 0 ; i < size - bytes ; i++)
                 *(unsigned char *) ((char *) buffer + bytes + i) = ((unsigned char *) &rand)[i];
             bytes = size;
         }

--- a/Pal/src/db_object.c
+++ b/Pal/src/db_object.c
@@ -87,16 +87,14 @@ DkObjectsWaitAny (PAL_NUM count, PAL_HANDLE * handleArray, PAL_NUM timeout)
         LEAVE_PAL_CALL_RETURN(NULL);
     }
 
-    for (int i = 0 ; i < count ; i++)
+    for (uint32_t i = 0 ; i < count ; i++)
         // We modify the caller's handleArray?
         if (handleArray[i] && UNKNOWN_HANDLE(handleArray[i]))
             handleArray[i] = NULL;
 
     PAL_HANDLE polled = NULL;
 
-    int ret = _DkObjectsWaitAny (count, handleArray,
-                                 timeout == NO_TIMEOUT ? -1 : timeout,
-                                 &polled);
+    int ret = _DkObjectsWaitAny (count, handleArray, timeout, &polled);
 
     if (ret < 0) {
         _DkRaiseFailure(-ret);

--- a/Pal/src/db_streams.c
+++ b/Pal/src/db_streams.c
@@ -664,7 +664,7 @@ DkStreamSetLength (PAL_HANDLE handle, PAL_NUM length)
     }
 
     // At this point, ret should equal length
-    assert(ret == length);
+    assert((uint64_t)ret == length);
 
     LEAVE_PAL_CALL_RETURN(rv);
 }

--- a/Pal/src/dynamic_link.h
+++ b/Pal/src/dynamic_link.h
@@ -76,6 +76,8 @@ elf_get_dynamic_info (ElfW(Dyn) *dyn, ElfW(Dyn) **l_info, ElfW(Addr) l_addr)
 #endif
 
     while (dyn->d_tag != DT_NULL) {
+        d_tag_utype dt_extranum = DT_EXTRANUM;
+
         if ((d_tag_utype) dyn->d_tag < DT_NUM)
             l_info[dyn->d_tag] = dyn;
 
@@ -86,7 +88,7 @@ elf_get_dynamic_info (ElfW(Dyn) *dyn, ElfW(Dyn) **l_info, ElfW(Addr) l_addr)
         else if ((d_tag_utype) DT_VERSIONTAGIDX (dyn->d_tag) < DT_VERSIONTAGNUM)
             l_info[VERSYMIDX (dyn->d_tag)] = dyn;
 
-        else if ((d_tag_utype) DT_EXTRATAGIDX (dyn->d_tag) < DT_EXTRANUM)
+        else if ((d_tag_utype) DT_EXTRATAGIDX (dyn->d_tag) < dt_extranum)
             l_info[DT_EXTRATAGIDX (dyn->d_tag) + DT_NUM + DT_THISPROCNUM
                    + DT_VERSIONTAGNUM] = dyn;
 
@@ -207,7 +209,7 @@ _elf_dynamic_do_reloc(struct link_map *l, int dt_reloc, int dt_reloc_sz,
 /* Now this part is for our x86s machines */
 
 static void __attribute_unused
-_elf_dynamic_do_reloc(struct link_map * l, int dt_reloc, int dt_reloc_sz,
+_elf_dynamic_do_reloc(struct link_map * l, uint64_t dt_reloc, int dt_reloc_sz,
                       void (*do_reloc) (struct link_map *, ElfW(Addr), int))
 {
     struct { ElfW(Addr) start, size; } ranges[2];

--- a/Pal/src/host/Linux-SGX/Makefile.am
+++ b/Pal/src/host/Linux-SGX/Makefile.am
@@ -10,7 +10,7 @@ CFLAGS	= -Wall -fPIC -O2 -maes -std=c11 -U_FORTIFY_SOURCE \
 	  -fno-omit-frame-pointer \
 	  -fno-stack-protector -fno-builtin -DIN_ENCLAVE
 
-EXTRAFLAGS = -Wextra -Wno-sign-compare
+EXTRAFLAGS = -Wextra
 
 CFLAGS += $(EXTRAFLAGS)
 

--- a/Pal/src/host/Linux-SGX/db_devices.c
+++ b/Pal/src/host/Linux-SGX/db_devices.c
@@ -206,7 +206,7 @@ static int64_t char_read (PAL_HANDLE handle, uint64_t offset, uint64_t size,
     if (offset)
         return -PAL_ERROR_INVAL;
 
-    int fd = handle->dev.fd_in;
+    PAL_IDX fd = handle->dev.fd_in;
 
     if (fd == PAL_IDX_POISON)
         return -PAL_ERROR_DENIED;
@@ -225,7 +225,7 @@ static int64_t char_write (PAL_HANDLE handle, uint64_t offset, uint64_t size,
     if (offset)
         return -PAL_ERROR_INVAL;
 
-    int fd = handle->dev.fd_out;
+    PAL_IDX fd = handle->dev.fd_out;
 
     if (fd == PAL_IDX_POISON)
         return -PAL_ERROR_DENIED;

--- a/Pal/src/host/Linux-SGX/db_files.c
+++ b/Pal/src/host/Linux-SGX/db_files.c
@@ -378,7 +378,7 @@ static int file_rename (PAL_HANDLE handle, const char * type,
     return 0;
 }
 
-static int file_getname (PAL_HANDLE handle, char * buffer, int count)
+static int file_getname (PAL_HANDLE handle, char * buffer, size_t count)
 {
     if (!handle->file.realpath)
         return 0;
@@ -459,7 +459,7 @@ static int dir_open (PAL_HANDLE * handle, const char * type, const char * uri,
 
 /* 'read' operation for directory stream. Directory stream will not
    need a 'write' operat4on. */
-static int64_t dir_read (PAL_HANDLE handle, uint64_t offset, uint64_t count,
+static int64_t dir_read (PAL_HANDLE handle, uint64_t offset, size_t count,
                          void * buf)
 {
     if (offset)
@@ -499,7 +499,7 @@ output:
                 goto next;
 
             bool isdir = (d->d_type == DT_DIR);
-            int len = strlen(d->d_name);
+            size_t len = strlen(d->d_name);
             if (len + (isdir ? 2 : 1) > count)
                 break;
 
@@ -593,12 +593,12 @@ static int dir_rename (PAL_HANDLE handle, const char * type,
     return 0;
 }
 
-static int dir_getname (PAL_HANDLE handle, char * buffer, int count)
+static int dir_getname (PAL_HANDLE handle, char * buffer, size_t count)
 {
     if (!handle->dir.realpath)
         return 0;
 
-    int len = strlen(handle->dir.realpath);
+    size_t len = strlen(handle->dir.realpath);
     char * tmp = strcpy_static(buffer, "dir:", count);
 
     if (!tmp || buffer + count < tmp + len + 1)

--- a/Pal/src/host/Linux-SGX/db_memory.c
+++ b/Pal/src/host/Linux-SGX/db_memory.c
@@ -43,7 +43,7 @@ static struct pal_vma {
     void * top, * bottom;
 } pal_vmas[PAL_VMA_MAX];
 
-static unsigned int pal_nvmas = 0;
+static uint32_t pal_nvmas = 0;
 static struct spinlock pal_vma_lock;
 
 bool _DkCheckMemoryMappable (const void * addr, size_t size)
@@ -55,7 +55,7 @@ bool _DkCheckMemoryMappable (const void * addr, size_t size)
 
     _DkSpinLock(&pal_vma_lock);
 
-    for (int i = 0 ; i < pal_nvmas ; i++)
+    for (uint32_t i = 0 ; i < pal_nvmas ; i++)
         if (addr < pal_vmas[i].top && addr + size > pal_vmas[i].bottom) {
             printf("address %p-%p is not mappable\n", addr, addr + size);
             _DkSpinUnlock(&pal_vma_lock);

--- a/Pal/src/host/Linux-SGX/db_misc.c
+++ b/Pal/src/host/Linux-SGX/db_misc.c
@@ -44,10 +44,10 @@ unsigned long _DkSystemTimeQuery (void)
     return microsec;
 }
 
-int _DkRandomBitsRead (void * buffer, int size)
+size_t _DkRandomBitsRead (void * buffer, size_t size)
 {
     uint32_t rand;
-    for (int i = 0; i < size; i += sizeof(rand)) {
+    for (size_t i = 0; i < size; i += sizeof(rand)) {
         rand = rdrand();
         memcpy(buffer + i, &rand, MIN(sizeof(rand), size - i));
     }

--- a/Pal/src/host/Linux-SGX/db_mutex.c
+++ b/Pal/src/host/Linux-SGX/db_mutex.c
@@ -63,7 +63,7 @@ _DkMutexCreate (PAL_HANDLE * handle, int initialCount)
     return 0;
 }
 
-int _DkMutexLockTimeout (struct mutex_handle * m, uint64_t timeout)
+int _DkMutexLockTimeout (struct mutex_handle * m, PAL_NUM timeout)
 {
     int ret = 0;
 
@@ -84,7 +84,8 @@ int _DkMutexLockTimeout (struct mutex_handle * m, uint64_t timeout)
          * can be used for futex. Potentially this design may allow
          * attackers to change the mutex value and cause DoS.
          */
-        ret = ocall_futex((int *) m->locked, FUTEX_WAIT, MUTEX_LOCKED, timeout == -1 ? NULL : &timeout);
+        int64_t waittime = timeout;
+        ret = ocall_futex((int *) m->locked, FUTEX_WAIT, MUTEX_LOCKED, timeout == NO_TIMEOUT ? NULL : &waittime);
 
         if (IS_ERR(ret)) {
             if (ERRNO(ret) == EWOULDBLOCK) {
@@ -111,7 +112,7 @@ int _DkMutexLock (struct mutex_handle * m)
     return _DkMutexLockTimeout(m, -1);
 }
 
-int _DkMutexAcquireTimeout (PAL_HANDLE handle, int _timeout)
+int _DkMutexAcquireTimeout (PAL_HANDLE handle, PAL_NUM _timeout)
 {
     struct mutex_handle * mut = &handle->mutex.mut;
     return _DkMutexLockTimeout(mut, _timeout);
@@ -146,7 +147,7 @@ void _DkMutexRelease (PAL_HANDLE handle)
     return;
 }
 
-static int mutex_wait (PAL_HANDLE handle, uint64_t timeout)
+static int mutex_wait (PAL_HANDLE handle, PAL_NUM timeout)
 {
     return _DkMutexAcquireTimeout(handle, timeout);
 }

--- a/Pal/src/host/Linux-SGX/db_pipes.c
+++ b/Pal/src/host/Linux-SGX/db_pipes.c
@@ -250,7 +250,7 @@ static int64_t pipe_write (PAL_HANDLE handle, uint64_t offset, uint64_t len,
         return bytes;
     }
 
-    if (bytes == len)
+    if ((uint64_t)bytes == len)
         HANDLE_HDR(handle)->flags |= writeable;
     else
         HANDLE_HDR(handle)->flags &= ~writeable;
@@ -366,7 +366,7 @@ static int pipe_attrquerybyhdl (PAL_HANDLE handle, PAL_STREAM_ATTR * attr)
     }
 
     struct pollfd pfd = { .fd = read_fd, .events = POLLIN, .revents = 0 };
-    unsigned long waittime = 0;
+    int64_t waittime = 0;
     int ret = ocall_poll(&pfd, 1, &waittime);
     if (IS_ERR(ret))
         return unix_to_pal_error(ERRNO(ret));
@@ -400,13 +400,13 @@ static int pipe_attrsetbyhdl (PAL_HANDLE handle, PAL_STREAM_ATTR * attr)
     return 0;
 }
 
-static int pipe_getname (PAL_HANDLE handle, char * buffer, int count)
+static int pipe_getname (PAL_HANDLE handle, char * buffer, size_t count)
 {
     int old_count = count;
     int ret;
 
     const char * prefix = NULL;
-    int prefix_len = 0;
+    size_t prefix_len = 0;
 
     switch (HANDLE_TYPE(handle)) {
         case pal_type_pipesrv:

--- a/Pal/src/host/Linux-SGX/db_process.c
+++ b/Pal/src/host/Linux-SGX/db_process.c
@@ -80,7 +80,7 @@ int register_trusted_child(const char * uri, const char * mrenclave_str)
     memcpy(new->uri, uri, uri_len + 1);
 
     char mrenclave_text[sizeof(sgx_arch_hash_t) * 2 + 1] = "\0";
-    int nbytes = 0;
+    size_t nbytes = 0;
     for (; nbytes < sizeof(sgx_arch_hash_t) ; nbytes++) {
         char byte1 = mrenclave_str[nbytes * 2];
         char byte2 = mrenclave_str[nbytes * 2 + 1];
@@ -372,7 +372,7 @@ static int64_t proc_write (PAL_HANDLE handle, uint64_t offset, uint64_t count,
         return bytes;
     }
 
-    if (bytes == count)
+    if ((uint64_t)bytes == count)
         HANDLE_HDR(handle)->flags |= WRITEABLE(1);
     else
         HANDLE_HDR(handle)->flags &= ~WRITEABLE(1);

--- a/Pal/src/host/Linux-SGX/db_rtld.c
+++ b/Pal/src/host/Linux-SGX/db_rtld.c
@@ -74,7 +74,7 @@ void _DkDebugAddMap (struct link_map * map)
     }
 
     ElfW(Shdr) * shdrend = (void *) shdr + shdrsz;
-    int shstroff = shdr[ehdr->e_shstrndx].sh_offset;
+    size_t shstroff = shdr[ehdr->e_shstrndx].sh_offset;
     size_t shstrsz = shdr[ehdr->e_shstrndx].sh_size;
     const char * shstrtab = NULL;
 

--- a/Pal/src/host/Linux-SGX/db_sockets.c
+++ b/Pal/src/host/Linux-SGX/db_sockets.c
@@ -535,7 +535,7 @@ static int64_t tcp_write (PAL_HANDLE handle, uint64_t offset, uint64_t len,
         return bytes;
     }
 
-    if (bytes == len)
+    if ((uint64_t)bytes == len)
         HANDLE_HDR(handle)->flags |= WRITEABLE(0);
     else
         HANDLE_HDR(handle)->flags &= ~WRITEABLE(0);
@@ -671,7 +671,7 @@ static int64_t udp_receive (PAL_HANDLE handle, uint64_t offset, uint64_t len,
 }
 
 static int64_t udp_receivebyaddr (PAL_HANDLE handle, uint64_t offset, uint64_t len,
-                                  void * buf, char * addr, int addrlen)
+                                  void * buf, char * addr, size_t addrlen)
 {
     if (offset)
         return -PAL_ERROR_INVAL;
@@ -730,7 +730,7 @@ static int64_t udp_send (PAL_HANDLE handle, uint64_t offset, uint64_t len,
         return bytes;
     }
 
-    if (bytes == len)
+    if ((uint64_t)bytes == len)
         HANDLE_HDR(handle)->flags |= WRITEABLE(0);
     else
         HANDLE_HDR(handle)->flags &= ~WRITEABLE(0);
@@ -739,7 +739,7 @@ static int64_t udp_send (PAL_HANDLE handle, uint64_t offset, uint64_t len,
 }
 
 static int64_t udp_sendbyaddr (PAL_HANDLE handle, uint64_t offset, uint64_t len,
-                               const void * buf, const char * addr, int addrlen)
+                               const void * buf, const char * addr, size_t addrlen)
 {
     if (offset)
         return -PAL_ERROR_INVAL;
@@ -779,7 +779,7 @@ static int64_t udp_sendbyaddr (PAL_HANDLE handle, uint64_t offset, uint64_t len,
         return bytes;
     }
 
-    if (bytes == len)
+    if ((uint64_t)bytes == len)
         HANDLE_HDR(handle)->flags |= WRITEABLE(0);
     else
         HANDLE_HDR(handle)->flags &= ~WRITEABLE(0);
@@ -863,7 +863,7 @@ static int socket_attrquerybyhdl (PAL_HANDLE handle, PAL_STREAM_ATTR  * attr)
     }
 
     struct pollfd pfd = { .fd = fd, .events = POLLIN, .revents = 0 };
-    unsigned long waittime = 0;
+    int64_t waittime = 0;
     ret = ocall_poll(&pfd, 1, &waittime);
     if (IS_ERR(ret))
         return unix_to_pal_error(ERRNO(ret));
@@ -984,13 +984,13 @@ static int socket_attrsetbyhdl (PAL_HANDLE handle, PAL_STREAM_ATTR  * attr)
     return 0;
 }
 
-static int socket_getname (PAL_HANDLE handle, char * buffer, int count)
+static int socket_getname (PAL_HANDLE handle, char * buffer, size_t count)
 {
     int old_count = count;
     int ret;
 
     const char * prefix = NULL;
-    int prefix_len = 0;
+    size_t prefix_len = 0;
     struct sockaddr * bind_addr = NULL, * dest_addr = NULL;
 
     switch (HANDLE_TYPE(handle)) {
@@ -1117,7 +1117,7 @@ static int64_t mcast_send (PAL_HANDLE handle, uint64_t offset, uint64_t size,
         return bytes;
     }
 
-    if (bytes == size)
+    if ((uint64_t)bytes == size)
         HANDLE_HDR(handle)->flags |= WRITEABLE(1);
     else
         HANDLE_HDR(handle)->flags &= ~WRITEABLE(1);

--- a/Pal/src/host/Linux-SGX/db_streams.c
+++ b/Pal/src/host/Linux-SGX/db_streams.c
@@ -319,7 +319,7 @@ int _DkReceiveHandle(PAL_HANDLE hdl, PAL_HANDLE * cargo)
 
     if (IS_ERR(ret))
         return unix_to_pal_error(ERRNO(ret));
-    if (ret < sizeof(struct hdl_header)) {
+    if ((size_t)ret < sizeof(struct hdl_header)) {
         /*
          * This code block is just in case to cover all the possibilities
          * to shield Iago attack.
@@ -343,13 +343,13 @@ int _DkReceiveHandle(PAL_HANDLE hdl, PAL_HANDLE * cargo)
 
     // initialize variables to get body
     void * buffer = __alloca(hdl_hdr.data_size);
-    unsigned int nfds = 0;
+    uint32_t nfds = 0;
 
     for (int i = 0 ; i < MAX_FDS ; i++)
         if (hdl_hdr.fds & (1U << i))
             nfds++;
 
-    unsigned int * fds = __alloca(sizeof(unsigned int) * nfds);
+    uint32_t * fds = __alloca(sizeof(unsigned int) * nfds);
 
     ret = ocall_sock_recv_fd(ch, buffer, hdl_hdr.data_size,
                              fds, &nfds);
@@ -362,8 +362,8 @@ int _DkReceiveHandle(PAL_HANDLE hdl, PAL_HANDLE * cargo)
     if (ret < 0)
         return ret;
 
-    int n = 0;
-    for (int i = 0 ; i < MAX_FDS ; i++)
+    uint32_t n = 0;
+    for (uint32_t i = 0 ; i < MAX_FDS ; i++)
         if (hdl_hdr.fds & (1U << i)) {
             if (n < nfds) {
                 handle->generic.fds[i] = fds[n++];

--- a/Pal/src/host/Linux-SGX/enclave_framework.c
+++ b/Pal/src/host/Linux-SGX/enclave_framework.c
@@ -338,7 +338,7 @@ int load_trusted_file (PAL_HANDLE file, sgx_stub_t ** stubptr,
 #define FILE_CHUNK_SIZE 1024
 
         uint8_t small_chunk[FILE_CHUNK_SIZE]; /* Buffer for hashing */
-        int chunk_offset = 0;
+        size_t chunk_offset = 0;
 
         for (; chunk_offset < mapping_size; chunk_offset += FILE_CHUNK_SIZE) {
             uint64_t chunk_size = MIN(mapping_size - chunk_offset, FILE_CHUNK_SIZE);
@@ -589,7 +589,7 @@ static int register_trusted_file (const char * uri, const char * checksum_str)
             new->size = attr.pending_size;
 
         char checksum_text[sizeof(sgx_checksum_t) * 2 + 1] = "\0";
-        int nbytes = 0;
+        size_t nbytes = 0;
         for (; nbytes < sizeof(sgx_checksum_t) ; nbytes++) {
             char byte1 = checksum_str[nbytes * 2];
             char byte2 = checksum_str[nbytes * 2 + 1];
@@ -1010,7 +1010,7 @@ int _DkStreamKeyExchange (PAL_HANDLE stream, PAL_SESSION_KEY * keyptr)
     assert(agreesz > 0 && agreesz <= sizeof agree);
     // TODO(security): use a real KDF
     memset(session_key, 0, sizeof(session_key));
-    for (int i = 0 ; i < agreesz ; i++)
+    for (uint32_t i = 0 ; i < agreesz ; i++)
         session_key[i % sizeof(session_key)] ^= agree[i];
 
     SGX_DBG(DBG_S, "key exchange: (%p) %s\n", session_key,
@@ -1044,7 +1044,8 @@ int _DkStreamAttestationRequest (PAL_HANDLE stream, void * data,
 {
     struct attestation_request req;
     struct attestation att;
-    int bytes, ret;
+    size_t bytes;
+    int ret;
 
     memcpy(req.mrenclave, pal_sec.mrenclave, sizeof(sgx_arch_hash_t));
     memcpy(&req.attributes, &pal_sec.enclave_attributes,
@@ -1138,7 +1139,8 @@ int _DkStreamAttestationRespond (PAL_HANDLE stream, void * data,
 {
     struct attestation_request req;
     struct attestation att;
-    int bytes, ret;
+    size_t bytes;
+    int ret;
 
     for (bytes = 0, ret = 0 ; bytes < sizeof(req) ; bytes += ret) {
         ret = _DkStreamRead(stream, 0, sizeof(req) - bytes,

--- a/Pal/src/host/Linux-SGX/enclave_ocalls.c
+++ b/Pal/src/host/Linux-SGX/enclave_ocalls.c
@@ -532,7 +532,7 @@ int ocall_create_process (const char * uri,
 }
 
 int ocall_futex (int * futex, int op, int val,
-                 const uint64_t * timeout)
+                 const int64_t * timeout)
 {
     int retval = 0;
     ms_ocall_futex_t * ms;
@@ -1004,7 +1004,7 @@ int ocall_sleep (unsigned long * microsec)
     return retval;
 }
 
-int ocall_poll (struct pollfd * fds, int nfds, uint64_t * timeout)
+int ocall_poll (struct pollfd * fds, int nfds, int64_t * timeout)
 {
     int retval = 0;
     unsigned int nfds_bytes = nfds * sizeof(struct pollfd);

--- a/Pal/src/host/Linux-SGX/enclave_ocalls.h
+++ b/Pal/src/host/Linux-SGX/enclave_ocalls.h
@@ -88,7 +88,7 @@ int ocall_create_process (const char * uri,
                           int procfds[3],
                           unsigned int * pid);
 
-int ocall_futex (int * uaddr, int op, int val, const uint64_t * timeout);
+int ocall_futex (int * uaddr, int op, int val, const int64_t * timeout);
 
 int ocall_gettime (unsigned long * microsec);
 
@@ -96,7 +96,7 @@ int ocall_sleep (unsigned long * microsec);
 
 int ocall_socketpair (int domain, int type, int protocol, int sockfds[2]);
 
-int ocall_poll (struct pollfd * fds, int nfds, uint64_t * timeout);
+int ocall_poll (struct pollfd * fds, int nfds, int64_t * timeout);
 
 int ocall_rename (const char * oldpath, const char * newpath);
 

--- a/Pal/src/host/Linux-SGX/enclave_pages.c
+++ b/Pal/src/host/Linux-SGX/enclave_pages.c
@@ -72,7 +72,7 @@ static void assert_vma_list (void)
 
 // TODO: This function should be fixed to always either return exactly `addr` or
 // fail.
-void * get_reserved_pages(void * addr, uint64_t size)
+void * get_reserved_pages(void * addr, size_t size)
 {
     if (!size)
         return NULL;
@@ -120,7 +120,7 @@ void * get_reserved_pages(void * addr, uint64_t size)
     void * avail_top = heap_base + heap_size;
 
     LISTP_FOR_EACH_ENTRY(vma, &heap_vma_list, list) {
-        if (avail_top - vma->top > size) {
+        if ((size_t)(avail_top - vma->top) > size) {
             addr = avail_top - size;
             goto allocated;
         }
@@ -252,7 +252,7 @@ allocated:
     return addr;
 }
 
-void free_pages(void * addr, uint64_t size)
+void free_pages(void * addr, size_t size)
 {
     void * addr_top = addr + size;
 

--- a/Pal/src/host/Linux-SGX/enclave_pages.h
+++ b/Pal/src/host/Linux-SGX/enclave_pages.h
@@ -3,5 +3,5 @@
 
 extern void * heap_base;
 void init_pages (void);
-void * get_reserved_pages (void * addr, uint64_t size);
-void free_pages (void * addr, uint64_t size);
+void * get_reserved_pages (void * addr, size_t size);
+void free_pages (void * addr, size_t size);

--- a/Pal/src/host/Linux-SGX/ocall_types.h
+++ b/Pal/src/host/Linux-SGX/ocall_types.h
@@ -6,6 +6,7 @@
  */
 
 #include "linux_types.h"
+#include "pal.h"
 
 /*
  * GCC's structure padding may cause leaking from uninialized
@@ -58,7 +59,7 @@ enum {
     OCALL_NR,
 };
 
-#define OCALL_NO_TIMEOUT   ((uint64_t)-1)
+#define OCALL_NO_TIMEOUT   ((int64_t)-1)
 
 typedef struct {
     const char * ms_str;
@@ -161,7 +162,7 @@ typedef struct {
 typedef struct {
     int * ms_futex;
     int ms_op, ms_val;
-    uint64_t ms_timeout;
+    int64_t ms_timeout;
 } ms_ocall_futex_t;
 
 typedef struct {
@@ -193,7 +194,7 @@ typedef struct {
 } ms_ocall_sock_connect_t;
 
 typedef struct {
-    int ms_sockfd;
+    PAL_IDX ms_sockfd;
     void * ms_buf;
     unsigned int ms_count;
     struct sockaddr * ms_addr;
@@ -201,7 +202,7 @@ typedef struct {
 } ms_ocall_sock_recv_t;
 
 typedef struct {
-    int ms_sockfd;
+    PAL_IDX ms_sockfd;
     const void * ms_buf;
     unsigned int ms_count;
     const struct sockaddr * ms_addr;
@@ -248,7 +249,7 @@ typedef struct {
 typedef struct {
     struct pollfd * ms_fds;
     int ms_nfds;
-    uint64_t ms_timeout;
+    int64_t ms_timeout;
 } ms_ocall_poll_t;
 
 typedef struct {

--- a/Pal/src/host/Linux-SGX/pal_linux.h
+++ b/Pal/src/host/Linux-SGX/pal_linux.h
@@ -90,7 +90,7 @@ int __DkMutexCreate (struct mutex_handle * mut);
 int _DkMutexAtomicCreate (struct mutex_handle * mut);
 int __DkMutexDestroy (struct mutex_handle * mut);
 int _DkMutexLock (struct mutex_handle * mut);
-int _DkMutexLockTimeout (struct mutex_handle * mut, uint64_t timeout);
+int _DkMutexLockTimeout (struct mutex_handle * mut, PAL_NUM timeout);
 int _DkMutexUnlock (struct mutex_handle * mut);
 
 int * get_futex (void);

--- a/Pal/src/host/Linux-SGX/sgx_enclave.c
+++ b/Pal/src/host/Linux-SGX/sgx_enclave.c
@@ -596,7 +596,7 @@ static int sgx_ocall_sleep(void * pms)
     }
     struct timespec req, rem;
     unsigned long microsec = ms->ms_microsec;
-    const long VERY_LONG_TIME_IN_US = 1000000L * 60 * 60 * 24 * 365 * 128;
+    const unsigned long VERY_LONG_TIME_IN_US = 1000000L * 60 * 60 * 24 * 365 * 128;
     if (ms->ms_microsec > VERY_LONG_TIME_IN_US) {
         /* avoid overflow with time_t */
         req.tv_sec  = VERY_LONG_TIME_IN_US / 1000000;

--- a/Pal/src/host/Linux-SGX/sgx_framework.c
+++ b/Pal/src/host/Linux-SGX/sgx_framework.c
@@ -71,7 +71,7 @@ int read_enclave_sigstruct(int sigfile, sgx_arch_sigstruct_t * sig)
     if (IS_ERR(ret))
         return -ERRNO(ret);
 
-    if (stat.st_size < sizeof(sgx_arch_sigstruct_t)) {
+    if ((size_t)stat.st_size < sizeof(sgx_arch_sigstruct_t)) {
         SGX_DBG(DBG_I, "size of sigstruct size does not match\n");
         return -EINVAL;
     }
@@ -100,7 +100,7 @@ static size_t get_ssaframesize (uint64_t xfrm)
 {
     uint32_t cpuinfo[4];
     uint64_t xfrm_ex;
-    int xsave_size = 0;
+    size_t xsave_size = 0;
 
     cpuid(SE_LEAF, 1, cpuinfo);
     xfrm_ex = ((uint64_t) cpuinfo[3] << 32) + cpuinfo[2];
@@ -328,7 +328,7 @@ int init_enclave(sgx_arch_secs_t * secs,
     SGX_DBG(DBG_I, "enclave initializing:\n");
     SGX_DBG(DBG_I, "    enclave id:   0x%016lx\n", enclave_valid_addr);
     SGX_DBG(DBG_I, "    enclave hash:");
-    for (int i = 0 ; i < sizeof(sgx_arch_hash_t) ; i++)
+    for (size_t i = 0 ; i < sizeof(sgx_arch_hash_t) ; i++)
         SGX_DBG(DBG_I, " %02x", sigstruct->enclave_hash[i]);
     SGX_DBG(DBG_I, "\n");
 

--- a/Pal/src/host/Linux-SGX/sgx_main.c
+++ b/Pal/src/host/Linux-SGX/sgx_main.c
@@ -23,11 +23,11 @@ unsigned long pagemask  = ~(PRESET_PAGESIZE - 1);
 unsigned long pageshift = PRESET_PAGESIZE - 1;
 
 static inline
-char * alloc_concat(const char * p, int plen,
-                    const char * s, int slen)
+char * alloc_concat(const char * p, size_t plen,
+                    const char * s, size_t slen)
 {
-    plen = (plen != -1) ? plen : (p ? strlen(p) : 0);
-    slen = (slen != -1) ? slen : (s ? strlen(s) : 0);
+    plen = (plen != (size_t)-1) ? plen : (p ? strlen(p) : 0);
+    slen = (slen != (size_t)-1) ? slen : (s ? strlen(s) : 0);
 
     char * buf = malloc(plen + slen + 1);
     if (plen)
@@ -350,7 +350,7 @@ int initialize_enclave (struct pal_enclave * enclave)
                  PROT_READ|PROT_WRITE, SGX_PAGE_REG);
 
     struct mem_area * stack_areas = &areas[area_num];
-    for (int t = 0 ; t < enclave->thread_num ; t++)
+    for (uint32_t t = 0 ; t < enclave->thread_num ; t++)
         SET_AREA("stack", false, false, -1, 0, ENCLAVE_STACK_SIZE,
                  PROT_READ|PROT_WRITE, SGX_PAGE_REG);
 
@@ -416,7 +416,7 @@ int initialize_enclave (struct pal_enclave * enclave)
                                            PROT_READ|PROT_WRITE,
                                            MAP_ANONYMOUS|MAP_PRIVATE, -1, 0);
 
-            for (int t = 0 ; t < enclave->thread_num ; t++) {
+            for (uint32_t t = 0 ; t < enclave->thread_num ; t++) {
                 struct enclave_tls * gs = data + pagesize * t;
                 gs->enclave_size = enclave->size;
                 gs->tcs_offset = tcs_area->addr + pagesize * t;
@@ -440,7 +440,7 @@ int initialize_enclave (struct pal_enclave * enclave)
                                            PROT_READ|PROT_WRITE,
                                            MAP_ANONYMOUS|MAP_PRIVATE, -1, 0);
 
-            for (int t = 0 ; t < enclave->thread_num ; t++) {
+            for (uint32_t t = 0 ; t < enclave->thread_num ; t++) {
                 sgx_arch_tcs_t * tcs = data + pagesize * t;
                 memset(tcs, 0, pagesize);
                 tcs->ossa = ssa_area->addr +
@@ -887,10 +887,10 @@ int main (int argc, char ** argv, char ** envp)
     }
 
     if (strcmp_static(sgx_manifest + len - strlen(".manifest"), ".manifest")) {
-        strcpy_static(sgx_manifest + len, ".sgx", URI_MAX - len);
+        strcpy_static(sgx_manifest + len, ".sgx", URI_MAX - (size_t)len);
     } else if (!strcmp_static(sgx_manifest + len - strlen(".manifest.sgx"),
                               ".manifest.sgx")) {
-        strcpy_static(sgx_manifest + len, ".manifest.sgx", URI_MAX - len);
+        strcpy_static(sgx_manifest + len, ".manifest.sgx", URI_MAX - (size_t)len);
     }
 
     if (memcmp(filebuf, "\177ELF", 4)) {

--- a/Pal/src/host/Linux-SGX/sgx_process.c
+++ b/Pal/src/host/Linux-SGX/sgx_process.c
@@ -116,14 +116,14 @@ int sgx_create_process (const char * uri, int nargs, const char ** args,
     ret = INLINE_SYSCALL(write, 3, pipe_out, &proc_args,
                          sizeof(struct proc_args));
 
-    if (IS_ERR(ret) || ret < sizeof(struct proc_args)) {
+    if (IS_ERR(ret) || (size_t)ret < sizeof(struct proc_args)) {
         ret = -EPERM;
         goto out;
     }
 
     ret = INLINE_SYSCALL(read, 3, pipe_in, &rete, sizeof(int));
 
-    if (IS_ERR(ret) || ret < sizeof(int)) {
+    if (IS_ERR(ret) || (size_t)ret < sizeof(int)) {
         ret = -EPERM;
         goto out;
     }

--- a/Pal/src/host/Linux-SGX/sgx_thread.c
+++ b/Pal/src/host/Linux-SGX/sgx_thread.c
@@ -31,7 +31,7 @@ void create_tcs_mapper (void * tcs_base, unsigned int thread_num)
     enclave_thread_map = malloc(sizeof(struct thread_map) * thread_num);
     enclave_thread_num = thread_num;
 
-    for (int i = 0 ; i < thread_num ; i++) {
+    for (uint32_t i = 0 ; i < thread_num ; i++) {
         enclave_thread_map[i].tid = 0;
         enclave_thread_map[i].tcs = &enclave_tcs[i];
     }

--- a/Pal/src/host/Linux-SGX/sysdep-x86_64.h
+++ b/Pal/src/host/Linux-SGX/sysdep-x86_64.h
@@ -160,7 +160,7 @@
 
 #undef INTERNAL_SYSCALL_ERROR_P
 #define INTERNAL_SYSCALL_ERROR_P(val) \
-  ((unsigned long) (val) >= -4095L)
+  ((unsigned long) (val) >= (unsigned long)-4095L)
 
 #undef INTERNAL_SYSCALL_ERRNO
 #define INTERNAL_SYSCALL_ERRNO(val) (-(val))

--- a/Pal/src/host/Linux/db_events.c
+++ b/Pal/src/host/Linux/db_events.c
@@ -75,7 +75,7 @@ int _DkEventSet (PAL_HANDLE event, int wakeup)
     return IS_ERR(ret) ? -PAL_ERROR_TRYAGAIN : ret;
 }
 
-int _DkEventWaitTimeout (PAL_HANDLE event, uint64_t timeout)
+int _DkEventWaitTimeout (PAL_HANDLE event, PAL_NUM timeout)
 {
     int ret = 0;
 
@@ -149,7 +149,7 @@ static int event_close (PAL_HANDLE handle)
     return 0;
 }
 
-static int event_wait (PAL_HANDLE handle, uint64_t timeout)
+static int event_wait (PAL_HANDLE handle, PAL_NUM timeout)
 {
     return timeout == NO_TIMEOUT ? _DkEventWait(handle) :
            _DkEventWaitTimeout(handle, timeout);

--- a/Pal/src/host/Linux/db_files.c
+++ b/Pal/src/host/Linux/db_files.c
@@ -310,7 +310,7 @@ static int file_rename (PAL_HANDLE handle, const char * type,
     return 0;
 }
 
-static int file_getname (PAL_HANDLE handle, char * buffer, int count)
+static int file_getname (PAL_HANDLE handle, char * buffer, size_t count)
 {
     if (!handle->file.realpath)
         return 0;
@@ -552,7 +552,7 @@ static int dir_rename (PAL_HANDLE handle, const char * type,
     return 0;
 }
 
-static int dir_getname (PAL_HANDLE handle, char * buffer, int count)
+static int dir_getname (PAL_HANDLE handle, char * buffer, size_t count)
 {
     if (!handle->dir.realpath)
         return 0;

--- a/Pal/src/host/Linux/db_misc.c
+++ b/Pal/src/host/Linux/db_misc.c
@@ -136,7 +136,7 @@ int _DkRandomBitsRead (void * buffer, int size)
     return 0;
 }
 #else
-int _DkRandomBitsRead (void * buffer, int size)
+size_t _DkRandomBitsRead (void * buffer, size_t size)
 {
     if (!pal_sec.random_device) {
         int fd = INLINE_SYSCALL(open, 3, RANDGEN_DEVICE, O_RDONLY, 0);

--- a/Pal/src/host/Linux/db_mutex.c
+++ b/Pal/src/host/Linux/db_mutex.c
@@ -86,7 +86,7 @@ _DkMutexCreate (PAL_HANDLE * handle, int initialCount)
     return 0;
 }
 
-int _DkMutexLockTimeout (struct mutex_handle * m, uint64_t timeout)
+int _DkMutexLockTimeout (struct mutex_handle * m, PAL_NUM timeout)
 {
     int i, ret = 0;
 #ifdef DEBUG_MUTEX
@@ -162,7 +162,7 @@ int _DkMutexLock (struct mutex_handle * m)
     return _DkMutexLockTimeout(m, -1);
 }
 
-int _DkMutexAcquireTimeout (PAL_HANDLE handle, int timeout)
+int _DkMutexAcquireTimeout (PAL_HANDLE handle, PAL_NUM timeout)
 {
     return _DkMutexLockTimeout(&handle->mutex.mut, timeout);
 }
@@ -207,7 +207,7 @@ int _DkInternalUnlock (PAL_LOCK* lock) {
     return 0;
 }
 
-static int mutex_wait (PAL_HANDLE handle, uint64_t timeout)
+static int mutex_wait (PAL_HANDLE handle, PAL_NUM timeout)
 {
     return _DkMutexAcquireTimeout(handle, timeout);
 }

--- a/Pal/src/host/Linux/db_object.c
+++ b/Pal/src/host/Linux/db_object.c
@@ -45,14 +45,14 @@
  *
  *  Returns 0 on success, negative value on failure (e.g., -PAL_ERROR_TRYAGAIN)
  */
-static int _DkObjectWaitOne (PAL_HANDLE handle, int64_t timeout)
+static int _DkObjectWaitOne (PAL_HANDLE handle, PAL_NUM timeout)
 {
     /* only for all these handle which has a file descriptor, or
        a eventfd. events and semaphores will skip this part */
     if (HANDLE_HDR(handle)->flags & HAS_FDS) {
         struct timespec timeout_ts;
 
-        if (timeout >= 0) {
+        if (timeout != NO_TIMEOUT) {
             long sec = (unsigned long) timeout / 1000000;
             long microsec = (unsigned long) timeout - (sec * 1000000);
 
@@ -88,7 +88,7 @@ static int _DkObjectWaitOne (PAL_HANDLE handle, int64_t timeout)
             return -PAL_ERROR_TRYAGAIN;
 
         int ret = INLINE_SYSCALL(ppoll, 5, &fds, nfds,
-                                 timeout >= 0 ? &timeout_ts : NULL,
+                                 timeout != NO_TIMEOUT ? &timeout_ts : NULL,
                                  NULL, 0);
 
         if (IS_ERR(ret))
@@ -125,7 +125,7 @@ static int _DkObjectWaitOne (PAL_HANDLE handle, int64_t timeout)
 
 /* _DkObjectsWaitAny for internal use. The function wait for any of the handle
    in the handle array. timeout can be set for the wait. */
-int _DkObjectsWaitAny (int count, PAL_HANDLE * handleArray, int64_t timeout,
+int _DkObjectsWaitAny (int count, PAL_HANDLE * handleArray, PAL_NUM timeout,
                        PAL_HANDLE * polled)
 {
     if (count <= 0)
@@ -210,7 +210,7 @@ int _DkObjectsWaitAny (int count, PAL_HANDLE * handleArray, int64_t timeout,
 
     struct timespec timeout_ts;
 
-    if (timeout >= 0) {
+    if (timeout != NO_TIMEOUT) {
         long sec = (unsigned long) timeout / 1000000;
         long microsec = (unsigned long) timeout - (sec * 1000000);
         timeout_ts.tv_sec = sec;
@@ -218,7 +218,7 @@ int _DkObjectsWaitAny (int count, PAL_HANDLE * handleArray, int64_t timeout,
     }
 
     ret = INLINE_SYSCALL(ppoll, 5, fds, nfds,
-                         timeout >= 0 ? &timeout_ts : NULL,
+                         timeout != NO_TIMEOUT ? &timeout_ts : NULL,
                          NULL, 0);
 
     if (IS_ERR(ret))

--- a/Pal/src/host/Linux/db_pipes.c
+++ b/Pal/src/host/Linux/db_pipes.c
@@ -577,7 +577,7 @@ static int pipe_attrsetbyhdl (PAL_HANDLE handle, PAL_STREAM_ATTR * attr)
     return 0;
 }
 
-static int pipe_getname (PAL_HANDLE handle, char * buffer, int count)
+static int pipe_getname (PAL_HANDLE handle, char * buffer, size_t count)
 {
     int old_count = count;
     int ret;

--- a/Pal/src/host/Linux/db_sockets.c
+++ b/Pal/src/host/Linux/db_sockets.c
@@ -846,7 +846,7 @@ static int64_t udp_receive (PAL_HANDLE handle, uint64_t offset, uint64_t len,
 }
 
 static int64_t udp_receivebyaddr (PAL_HANDLE handle, uint64_t offset, uint64_t len,
-                                  void * buf, char * addr, int addrlen)
+                                  void * buf, char * addr, size_t addrlen)
 {
     if (offset)
         return -PAL_ERROR_INVAL;
@@ -927,7 +927,7 @@ static int64_t udp_send (PAL_HANDLE handle, uint64_t offset, uint64_t len,
 }
 
 static int64_t udp_sendbyaddr (PAL_HANDLE handle, uint64_t offset, uint64_t len,
-                               const void * buf, const char * addr, int addrlen)
+                               const void * buf, const char * addr, size_t addrlen)
 {
     if (offset)
         return -PAL_ERROR_INVAL;
@@ -1191,7 +1191,7 @@ static int socket_attrsetbyhdl (PAL_HANDLE handle, PAL_STREAM_ATTR  * attr)
     return 0;
 }
 
-static int socket_getname (PAL_HANDLE handle, char * buffer, int count)
+static int socket_getname (PAL_HANDLE handle, char * buffer, size_t count)
 {
     int old_count = count;
     int ret;

--- a/Pal/src/host/Linux/pal_host.h
+++ b/Pal/src/host/Linux/pal_host.h
@@ -55,7 +55,7 @@ typedef struct mutex_handle {
 
 /* Locking and unlocking of Mutexes */
 int _DkMutexLock (struct mutex_handle * mut);
-int _DkMutexLockTimeout (struct mutex_handle * mut, uint64_t timeout);
+int _DkMutexLockTimeout (struct mutex_handle * mut, PAL_NUM timeout);
 int _DkMutexUnlock (struct mutex_handle * mut);
 
 typedef struct {

--- a/Pal/src/host/Linux/pal_linux.h
+++ b/Pal/src/host/Linux/pal_linux.h
@@ -157,7 +157,7 @@ bool stataccess (struct stat * stats, int acc);
 
 /* Locking and unlocking of Mutexes */
 int _DkMutexLock (struct mutex_handle * mut);
-int _DkMutexLockTimeout (struct mutex_handle * mut, uint64_t timeout);
+int _DkMutexLockTimeout (struct mutex_handle * mut, PAL_NUM timeout);
 int _DkMutexUnlock (struct mutex_handle * mut);
 
 void init_child_process (PAL_HANDLE * parent, PAL_HANDLE * exec,

--- a/Pal/src/pal_internal.h
+++ b/Pal/src/pal_internal.h
@@ -47,7 +47,7 @@ struct handle_ops {
 
     /* 'getname' is used by DkStreamGetName. It's different from
        'getrealpath' */
-    int (*getname) (PAL_HANDLE handle, char * buffer, int count);
+    int (*getname) (PAL_HANDLE handle, char * buffer, size_t count);
 
     /* 'open' is used by DkStreamOpen. 'handle' is a preallocated handle,
        'type' will be a normalized prefix, 'uri' is the remaining string
@@ -68,9 +68,9 @@ struct handle_ops {
     /* 'readbyaddr' and 'writebyaddr' are the same as read and write,
        but with extra field to specify address */
     int64_t (*readbyaddr) (PAL_HANDLE handle, uint64_t offset, uint64_t count,
-                           void * buffer, char * addr, int addrlen);
+                           void * buffer, char * addr, size_t addrlen);
     int64_t (*writebyaddr) (PAL_HANDLE handle, uint64_t offset, uint64_t count,
-                            const void * buffer, const char * addr, int addrlen);
+                            const void * buffer, const char * addr, size_t addrlen);
 
     /* 'close' and 'delete' is used by DkObjectClose and DkStreamDelete,
        'close' will close the stream, while 'delete' actually destroy
@@ -118,7 +118,7 @@ struct handle_ops {
      * Timeout: -PAL_ERROR_TRYAGAIN
      * Positive return values are undefined.
      */
-    int (*wait) (PAL_HANDLE handle, uint64_t time);
+    int (*wait) (PAL_HANDLE handle, PAL_NUM time);
 
     /* 'rename' is used to change name of a stream, or reset its share
        option */
@@ -311,7 +311,7 @@ int _DkProcessSandboxCreate (const char * manifest, int flags);
 /* DkMutex calls */
 int _DkMutexCreate (PAL_HANDLE * handle, int initialCount);
 int _DkMutexAcquire (PAL_HANDLE sem);
-int _DkMutexAcquireTimeout (PAL_HANDLE sem, int timeout);
+int _DkMutexAcquireTimeout (PAL_HANDLE sem, PAL_NUM timeout);
 void _DkMutexRelease (PAL_HANDLE sem);
 int _DkMutexGetCurrentCount (PAL_HANDLE sem);
 
@@ -319,7 +319,7 @@ int _DkMutexGetCurrentCount (PAL_HANDLE sem);
 int _DkEventCreate (PAL_HANDLE * event, bool initialState,
                     bool isnotification);
 int _DkEventSet (PAL_HANDLE event, int wakeup);
-int _DkEventWaitTimeout (PAL_HANDLE event, uint64_t timeout);
+int _DkEventWaitTimeout (PAL_HANDLE event, PAL_NUM timeout);
 int _DkEventWait (PAL_HANDLE event);
 int _DkEventClear (PAL_HANDLE event);
 
@@ -331,7 +331,7 @@ int _DkVirtualMemoryProtect (void * addr, uint64_t size, int prot);
 /* DkObject calls */
 int _DkObjectReference (PAL_HANDLE objectHandle);
 int _DkObjectClose (PAL_HANDLE objectHandle);
-int _DkObjectsWaitAny (int count, PAL_HANDLE * handleArray, int64_t timeout,
+int _DkObjectsWaitAny (int count, PAL_HANDLE * handleArray, PAL_NUM timeout,
                        PAL_HANDLE * polled);
 
 /* DkException calls & structures */
@@ -343,14 +343,13 @@ void _DkExceptionReturn (void * event);
 int _DkInternalLock (PAL_LOCK * mut);
 int _DkInternalUnlock (PAL_LOCK * mut);
 unsigned long _DkSystemTimeQuery (void);
-int _DkFastRandomBitsRead (void * buffer, int size);
+size_t _DkFastRandomBitsRead (void * buffer, size_t size);
 
 /*
  * Cryptographically secure random.
  * 0 on success, negative on failure.
  */
-int _DkRandomBitsRead (void * buffer, int size);
-
+size_t _DkRandomBitsRead (void * buffer, size_t size);
 int _DkSegmentRegisterSet (int reg, const void * addr);
 int _DkSegmentRegisterGet (int reg, void ** addr);
 int _DkInstructionCacheFlush (const void * addr, int size);


### PR DESCRIPTION
This is a part of the efforts for including -Wextra in the build. The PR turned on Wsign-compare (a major flag in Wextra) for building SGX-specific files. Eventually we will move to use Wextra by adding major flags one by one and fixing produced warnings.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/261)
<!-- Reviewable:end -->
