### PR TITLE
Take out futex_wait03, again

### DIFF
--- a/LibOS/shim/test/apps/ltp/PASSED
+++ b/LibOS/shim/test/apps/ltp/PASSED
@@ -239,7 +239,6 @@ futex_wait01,1
 futex_wait01,2
 futex_wait01,3
 futex_wait01,4
-futex_wait03,1
 futex_wait04,1
 futex_wait05,1
 futex_wait_bitset01,1


### PR DESCRIPTION
This LTP has been on the FLAKY list for some time.  It was erroneously added back to the PASSED list because it was believed to have been fixed by some unrelated changes.  It did not.

This test should only be reenabled after a credible bugfix and running in a loop to trigger whatever underlying heisenbug there is here.

This is causing #258 not to pass CI.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/266)
<!-- Reviewable:end -->
