### PR TITLE
Normalize this function's definition.

### DIFF
--- a/Pal/src/host/FreeBSD/db_ipc.c
+++ b/Pal/src/host/FreeBSD/db_ipc.c
@@ -57,7 +57,7 @@ struct handle_ops gipc_ops = {
         .close              = &gipc_close,
     };
 
-int _DkCreatePhysicalMemoryChannel (PAL_HANDLE * handle, unsigned long * key)
+int _DkCreatePhysicalMemoryChannel (PAL_HANDLE * handle, uint64_t * key)
 {
     return -PAL_ERROR_NOTIMPLEMENTED;
 }

--- a/Pal/src/host/Linux-SGX/db_ipc.c
+++ b/Pal/src/host/Linux-SGX/db_ipc.c
@@ -52,7 +52,7 @@ struct handle_ops gipc_ops = {
         .close              = &gipc_close,
     };
 
-int _DkCreatePhysicalMemoryChannel (PAL_HANDLE * handle, unsigned long * key)
+int _DkCreatePhysicalMemoryChannel (PAL_HANDLE * handle, uint64_t * key)
 {
     return -PAL_ERROR_NOTIMPLEMENTED;
 }

--- a/Pal/src/host/Linux/db_ipc.c
+++ b/Pal/src/host/Linux/db_ipc.c
@@ -80,7 +80,7 @@ struct handle_ops gipc_ops = {
         .close              = &gipc_close,
     };
 
-int _DkCreatePhysicalMemoryChannel (PAL_HANDLE * handle, unsigned long * key)
+int _DkCreatePhysicalMemoryChannel (PAL_HANDLE * handle, uint64_t * key)
 {
     unsigned long token = 0;
     int fd = INLINE_SYSCALL(open, 3, GIPC_FILE, O_RDONLY|O_CLOEXEC, 0);

--- a/Pal/src/host/Skeleton/db_ipc.c
+++ b/Pal/src/host/Skeleton/db_ipc.c
@@ -51,7 +51,7 @@ struct handle_ops gipc_ops = {
         .close              = &gipc_close,
     };
 
-int _DkCreatePhysicalMemoryChannel (PAL_HANDLE * handle, PAL_NUM * key)
+int _DkCreatePhysicalMemoryChannel (PAL_HANDLE * handle, uint64_t * key)
 {
     return -PAL_ERROR_NOTIMPLEMENTED;
 }

--- a/Pal/src/pal_internal.h
+++ b/Pal/src/pal_internal.h
@@ -344,7 +344,7 @@ int _DkRandomBitsRead (void * buffer, int size);
 int _DkSegmentRegisterSet (int reg, const void * addr);
 int _DkSegmentRegisterGet (int reg, void ** addr);
 int _DkInstructionCacheFlush (const void * addr, int size);
-int _DkCreatePhysicalMemoryChannel (PAL_HANDLE * handle, unsigned long * key);
+int _DkCreatePhysicalMemoryChannel (PAL_HANDLE * handle, uint64_t * key);
 int _DkPhysicalMemoryCommit (PAL_HANDLE channel, int entries,
                              PAL_PTR * addrs, PAL_NUM * sizes, int flags);
 int _DkPhysicalMemoryMap (PAL_HANDLE channel, int entries,


### PR DESCRIPTION
In reviewing #257, it became clear that this function's definition is not consistent between headers and implementation.  Changing to a uint64_t.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/268)
<!-- Reviewable:end -->
