### PR TITLE
Improving the warning messages in SGX PAL

### DIFF
--- a/Pal/src/host/Linux-SGX/sgx_framework.c
+++ b/Pal/src/host/Linux-SGX/sgx_framework.c
@@ -107,7 +107,7 @@ static size_t get_ssaframesize (uint64_t xfrm)
     return ALLOC_ALIGNUP(xsave_size + sizeof(sgx_arch_gpr_t) + 1);
 }
 
-int check_wrfsbase_support (void)
+bool is_wrfsbase_supported (void)
 {
     uint32_t cpuinfo[4];
     cpuid(7, 0, cpuinfo);
@@ -116,10 +116,10 @@ int check_wrfsbase_support (void)
         SGX_DBG(DBG_E, "The WRFSBASE instruction is not permitted on this"
                 " platform. Please make sure the \'graphene_sgx\' kernel module"
                 " is loaded properly.\n");
-        return 0;
+        return false;
     }
 
-    return 1;
+    return true;
 }
 
 int create_enclave(sgx_arch_secs_t * secs,

--- a/Pal/src/host/Linux-SGX/sgx_framework.c
+++ b/Pal/src/host/Linux-SGX/sgx_framework.c
@@ -19,11 +19,19 @@ void * zero_page;
 int open_gsgx(void)
 {
     gsgx_device = INLINE_SYSCALL(open, 3, GSGX_FILE, O_RDWR, 0);
-    if (IS_ERR(gsgx_device))
+    if (IS_ERR(gsgx_device)) {
+        SGX_DBG(DBG_E, "Cannot open device " GSGX_FILE ". Please make sure the"
+                " \'graphene_sgx\' kernel module is loaded.\n");
         return -ERRNO(gsgx_device);
+    }
+
     isgx_device = INLINE_SYSCALL(open, 3, ISGX_FILE, O_RDWR, 0);
-    if (IS_ERR(isgx_device))
+    if (IS_ERR(isgx_device)) {
+        SGX_DBG(DBG_E, "Cannot open device " ISGX_FILE ". Please make sure the"
+                " Intel SGX kernel module is loaded.\n");
         return -ERRNO(isgx_device);
+    }
+
     return 0;
 }
 
@@ -101,14 +109,15 @@ static size_t get_ssaframesize (uint64_t xfrm)
 
 int check_wrfsbase_support (void)
 {
-    if (gsgx_device == -1)
-        return -EACCES;
-
     uint32_t cpuinfo[4];
     cpuid(7, 0, cpuinfo);
 
-    if (!(cpuinfo[1] & 0x1))
+    if (!(cpuinfo[1] & 0x1)) {
+        SGX_DBG(DBG_E, "The WRFSBASE instruction is not permitted on this"
+                " platform. Please make sure the \'graphene_sgx\' kernel module"
+                " is loaded properly.\n");
         return 0;
+    }
 
     return 1;
 }

--- a/Pal/src/host/Linux-SGX/sgx_internal.h
+++ b/Pal/src/host/Linux-SGX/sgx_internal.h
@@ -83,7 +83,7 @@ struct pal_enclave {
 };
 
 int open_gsgx (void);
-int check_wrfsbase_support (void);
+bool is_wrfsbase_supported (void);
 
 int read_enclave_token (int token_file, sgx_arch_token_t * token);
 int read_enclave_sigstruct (int sigfile, sgx_arch_sigstruct_t * sig);

--- a/Pal/src/host/Linux-SGX/sgx_main.c
+++ b/Pal/src/host/Linux-SGX/sgx_main.c
@@ -684,10 +684,7 @@ static int load_enclave (struct pal_enclave * enclave,
     if (ret < 0)
         return ret;
 
-    ret = check_wrfsbase_support();
-    if (ret < 0)
-        return ret;
-    if (!ret)
+    if (!is_wrfsbase_supported())
         return -EPERM;
 
     INLINE_SYSCALL(gettimeofday, 2, &tv, NULL);

--- a/Pal/src/host/Linux-SGX/sgx_main.c
+++ b/Pal/src/host/Linux-SGX/sgx_main.c
@@ -681,11 +681,8 @@ static int load_enclave (struct pal_enclave * enclave,
 #endif
 
     ret = open_gsgx();
-    if (ret < 0) {
-        SGX_DBG(DBG_E, "cannot open device /dev/gsgx, possibly the kernel "
-                "module is not loaded.\n");
+    if (ret < 0)
         return ret;
-    }
 
     ret = check_wrfsbase_support();
     if (ret < 0)


### PR DESCRIPTION
When the Intel SGX driver is not loaded, the SGX PAL shows the following warning message:

```
cannot open device /dev/gsgx, possibly the kernel module is not loaded.
```

This warning message is confusing because the Graphene-SGX driver is actually loaded. This PR fixes the code to show the proper warning messages. In addition, the PR also adds a warning message for the check for WRFSBASE instruction availability.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/272)
<!-- Reviewable:end -->
