### PR TITLE
Using leaf 0xb and subleaf 1 to get the correct cpu (logic core) number

### DIFF
--- a/Pal/src/host/FreeBSD/db_main.c
+++ b/Pal/src/host/FreeBSD/db_main.c
@@ -358,10 +358,18 @@ void _DkGetCPUInfo (PAL_CPU_INFO * ci)
     ci->cpu_brand = brand;
 
     cpuid(2, 1, words, 0);
-    ci->cpu_num      = BIT_EXTRACT_LE(words[WORD_EBX], 16, 24);
     ci->cpu_family   = BIT_EXTRACT_LE(words[WORD_EAX],  8, 12) + 1;
     ci->cpu_model    = BIT_EXTRACT_LE(words[WORD_EAX],  4,  8);
     ci->cpu_stepping = BIT_EXTRACT_LE(words[WORD_EAX],  0,  4);
+
+    /* According to SDM: EBX[15:0] is to enumerate processor topology 
+     * of the system. However this value is intended for display/diagnostic
+     * purposes. The actual number of logical processors available to
+     * BIOS/OS/App may be different. We use this leaf for now as it's the 
+     * best option we have so far to get the cpu number  */
+
+    cpuid(0xb, 1, words, 0);
+    ci->cpu_num      = BIT_EXTRACT_LE(words[WORD_EBX],  0, 16);
 
     int flen = 0, fmax = 80;
     char * flags = malloc(fmax);

--- a/Pal/src/host/Linux-SGX/db_main.c
+++ b/Pal/src/host/Linux-SGX/db_main.c
@@ -311,8 +311,14 @@ void _DkGetCPUInfo (PAL_CPU_INFO * ci)
     memcpy(&brand[32], words, sizeof(unsigned int) * WORD_NUM);
     ci->cpu_brand = brand;
 
-    cpuid(4, 0, words);
-    ci->cpu_num      = BIT_EXTRACT_LE(words[WORD_EAX], 26, 32) + 1;
+    /* According to SDM: EBX[15:0] is to enumerate processor topology 
+     * of the system. However this value is intended for display/diagnostic
+     * purposes. The actual number of logical processors available to
+     * BIOS/OS/App may be different. We use this leaf for now as it's the 
+     * best option we have so far to get the cpu number  */
+
+    cpuid(0xb, 1, words);
+    ci->cpu_num      = BIT_EXTRACT_LE(words[WORD_EBX], 0, 16);
 
     cpuid(1, 0, words);
     ci->cpu_family   = BIT_EXTRACT_LE(words[WORD_EAX],  8, 12) +

--- a/Pal/src/host/Linux/db_main.c
+++ b/Pal/src/host/Linux/db_main.c
@@ -407,8 +407,15 @@ void _DkGetCPUInfo (PAL_CPU_INFO * ci)
     ci->cpu_brand = brand;
 
     if (!memcmp(vendor_id, "GenuineIntel", 12)) {
-        cpuid(4, 0, words);
-        ci->cpu_num  = BIT_EXTRACT_LE(words[WORD_EAX], 26, 32) + 1;
+
+       /* According to SDM: EBX[15:0] is to enumerate processor topology
+        * of the system. However this value is intended for display/diagnostic
+        * purposes. The actual number of logical processors available to
+        * BIOS/OS/App may be different. We use this leaf for now as it's the
+        * best option we have so far to get the cpu number  */
+
+        cpuid(0xb, 1, words);
+        ci->cpu_num  = BIT_EXTRACT_LE(words[WORD_EBX], 0, 16);
     } else if (!memcmp(vendor_id, "AuthenticAMD", 12)) {
         cpuid(0x8000008, 0, words);
         ci->cpu_num  = BIT_EXTRACT_LE(words[WORD_EAX], 0, 8) + 1;


### PR DESCRIPTION
Currently to get the number of cpus (logic cores), graphene uses cpuid with leaf 4 and extracts the values from EAX[26:31]. However, the number is not the correct value of cpu logic cores.  
According to SDM, "Bits 31 - 26: **Maximum number of addressable IDs for processor cores** in the physical package". The maximum number of addressable IDs for processor cores (not logic cores) is not necessarily equal to the number of logic cores the machine has. In practice, it often returns 8 on the platforms with 4 cores or 12 cores. So far at least causing the regression tests failed. 

To fix, we should use cpuid with leaf 0xb and subleaf 1, and extract the values from EBX[0:15] In SDM, this means "Bits 15 - 00: **Number of logical processors** at this level type." Subleaf 1 represents the number of logic cores across different physical cores.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/278)
<!-- Reviewable:end -->
