### PR TITLE
Rewriting the code which potentially generates incorrect assembly for signal handler returns

### DIFF
--- a/Pal/src/host/Linux-SGX/sgx_exception.c
+++ b/Pal/src/host/Linux-SGX/sgx_exception.c
@@ -57,8 +57,6 @@
  *     }
  */
 
-void restore_rt (void) __asm__ ("__restore_rt");
-
 #ifndef SA_RESTORER
 #define SA_RESTORER  0x04000000
 #endif
@@ -75,6 +73,11 @@ void restore_rt (void) __asm__ ("__restore_rt");
          "    syscall\n");
 
 DEFINE_RESTORE_RT(__NR_rt_sigreturn)
+
+/* Workaround for fixing an old GAS (2.27) bug that incorrectly
+ * omits relocations when referencing this symbol */
+__attribute__((visibility("hidden"))) void __restore_rt(void);
+
 #endif
 
 int set_sighandler (int * sigs, int nsig, void * handler)
@@ -85,7 +88,7 @@ int set_sighandler (int * sigs, int nsig, void * handler)
 
 #if !defined(__i386__)
     action.sa_flags |= SA_RESTORER;
-    action.sa_restorer = restore_rt;
+    action.sa_restorer = __restore_rt;
 #endif
 
     __sigemptyset((__sigset_t *) &action.sa_mask);

--- a/Pal/src/host/Linux/db_exception.c
+++ b/Pal/src/host/Linux/db_exception.c
@@ -54,8 +54,6 @@
  *     }
  */
 
-void restore_rt (void) __asm__ ("__restore_rt");
-
 #ifndef SA_RESTORER
 #define SA_RESTORER  0x04000000
 #endif
@@ -72,6 +70,11 @@ void restore_rt (void) __asm__ ("__restore_rt");
          "    syscall\n");
 
 DEFINE_RESTORE_RT(__NR_rt_sigreturn)
+
+/* Workaround for an old GAS (2.27) bug that incorrectly
+ * omits relocations when referencing this symbol */
+__attribute__((visibility("hidden"))) void __restore_rt(void);
+
 #endif
 
 int set_sighandler (int * sigs, int nsig, void * handler)
@@ -83,7 +86,7 @@ int set_sighandler (int * sigs, int nsig, void * handler)
         action.sa_flags = SA_SIGINFO;
 #if !defined(__i386__)
         action.sa_flags |= SA_RESTORER;
-        action.sa_restorer = restore_rt;
+        action.sa_restorer = __restore_rt;
 #endif
     } else {
         action.sa_flags = 0x0u;


### PR DESCRIPTION
In file Pal/src/host/Linux-SGX/sgx_main.c:88:
` action.sa_restorer = restore_rt; `

restore_rt is a function written in assembly which is assigned as the location after signal handler returns. Ideally, this code will be compiled into assembly like this:

`lea    -0x165(%rip),%rax        # 0x5577c22000e0 <restore_rt>`

However, on centos, the compiler for some reason, generated code like this:

`mov    -0x165(%rip),%rax        # 0x5577c22000e0 <restore_rt>`

This leads the semantic fundamentally different, causing segmentation fault at runtime. The potential reason could be the compiler with different configuration has different understanding about assigning "assembly function" to C-based structures.

The PR fixes this issue by explicitly wrapping the assembly with a C-based function.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/280)
<!-- Reviewable:end -->
