### PR TITLE
Enable -Werror in PALs and LibOS

### DIFF
--- a/Jenkinsfiles/Linux
+++ b/Jenkinsfiles/Linux
@@ -6,7 +6,7 @@ pipeline {
                 stage('Build') {
                     steps {
                         sh '''
-                            make
+                            make WERROR=1
                            '''
                     }
                 }

--- a/Jenkinsfiles/Linux-Debug
+++ b/Jenkinsfiles/Linux-Debug
@@ -6,7 +6,7 @@ pipeline {
                 stage('Build') {
                     steps {
                         sh '''
-                            make DEBUG=1
+                            make DEBUG=1 WERROR=1
                            '''
                     }
                 }

--- a/Jenkinsfiles/Linux-SGX
+++ b/Jenkinsfiles/Linux-SGX
@@ -23,7 +23,7 @@ pipeline {
                             ISGX_DRIVER_PATH=/opt/intel/linux-sgx-driver ISGX_DRIVER_VERSION=1.9 make
                         '''
                         sh '''
-                            make SGX=1
+                            make SGX=1 WERROR=1
                         '''
                         sh '''
                             make SGX_RUN=1

--- a/LibOS/shim/include/shim_internal.h
+++ b/LibOS/shim/include/shim_internal.h
@@ -393,18 +393,6 @@ void parse_syscall_after (int sysno, const char * name, int nr, ...);
     END_SHIM(name)                                                  \
     EXPORT_SHIM_SYSCALL(name, n, __VA_ARGS__)
 
-#ifndef container_of
-/**
- * container_of - cast a member of a structure out to the containing structure
- * @ptr:	the pointer to the member.
- * @type:	the type of the container struct this is embedded in.
- * @field:	the name of the field within the struct.
- *
- */
-#define container_of(ptr, type, field) ((type *)((char *)(ptr) - offsetof(type, field)))
-#endif
-
-
 #define CONCAT2(t1, t2) __CONCAT2(t1, t2)
 #define __CONCAT2(t1, t2) t1##_##t2
 

--- a/LibOS/shim/src/Makefile
+++ b/LibOS/shim/src/Makefile
@@ -33,6 +33,10 @@ LDFLAGS	= -shared -nostdlib --version-script shim.map -T shim.lds \
 LDFLAGS-debug = $(patsubst shim.map,shim-debug.map,$(LDFLAGS))
 ARFLAGS	=
 
+ifeq ($(WERROR),1)
+CFLAGS += -Werror
+endif
+
 files_to_build = libsysdb.a libsysdb.so libsysdb_debug.so
 files_to_install = $(addprefix $(RUNTIME_DIR)/,$(files_to_build))
 

--- a/LibOS/shim/src/ipc/shim_ipc_nsimpl.h
+++ b/LibOS/shim/src/ipc/shim_ipc_nsimpl.h
@@ -31,6 +31,15 @@
 
 #include <errno.h>
 
+#ifndef INCLUDE_IPC_NSIMPL
+# warning "Be sure before including \"shim_ipc_nsimpl.h\"."
+#endif
+
+#ifdef __SHIM_IPC_NSIMPL__
+# error "Include \"shim_ipc_nsimpl.h\" only once."
+#endif
+#define __SHIM_IPC_NSIMPL__
+
 #if !defined(NS) || !defined(NS_CAP)
 # error "NS or NS_CAP is not defined"
 #endif
@@ -827,7 +836,7 @@ out:
 
 static int connect_ns (IDTYPE * vmid, struct shim_ipc_port ** portptr)
 {
-    __discover_ns(true, false); // Should not hold cur_process.lock
+    __discover_ns(true, false); // This function cannot be called with cur_process.lock held
     lock(cur_process.lock);
 
     if (!NS_LEADER) {
@@ -896,7 +905,7 @@ int CONCAT3(prepare, NS, leader) (void)
     unlock(cur_process.lock);
 
     if (need_discover)
-        __discover_ns(true, true); // Should not hold cur_process.lock
+        __discover_ns(true, true); // This function cannot be called with cur_process.lock held
     return 0;
 }
 
@@ -1014,7 +1023,7 @@ int NS_CALLBACK(findns) (IPC_CALLBACK_ARGS)
           msg->src);
 
     int ret = 0;
-    __discover_ns(false, true); // Non-blocking discovery; should not hold cur_process.lock
+    __discover_ns(false, true); // This function cannot be called with cur_process.lock held
     lock(cur_process.lock);
 
     if (NS_LEADER && !qstrempty(&NS_LEADER->uri)) {

--- a/LibOS/shim/src/ipc/shim_ipc_pid.c
+++ b/LibOS/shim/src/ipc/shim_ipc_pid.c
@@ -40,6 +40,7 @@
 #define NS      pid
 #define NS_CAP  PID
 
+#define INCLUDE_IPC_NSIMPL
 #include "shim_ipc_nsimpl.h"
 
 static int thread_add_subrange (struct shim_thread * thread, void * arg,

--- a/LibOS/shim/src/ipc/shim_ipc_sysv.c
+++ b/LibOS/shim/src/ipc/shim_ipc_sysv.c
@@ -47,6 +47,7 @@
 #define NS_CAP SYSV
 #define NS_KEY struct sysv_key
 
+#define INCLUDE_IPC_NSIMPL
 #include "shim_ipc_nsimpl.h"
 
 int init_ns_sysv (void)

--- a/LibOS/shim/src/sys/shim_epoll.c
+++ b/LibOS/shim/src/sys/shim_epoll.c
@@ -321,11 +321,8 @@ retry:
 
     unlock(epoll_hdl->lock);
 
-    if (timeout < 0)
-        timeout = NO_TIMEOUT;
-
     PAL_HANDLE polled = DkObjectsWaitAny(nread ? npals + 1 : npals, pal_handles,
-                                         nread ? timeout : 0);
+                                         nread ? (timeout == -1 ? NO_TIMEOUT : (PAL_NUM) timeout) : 0);
 
     lock(epoll_hdl->lock);
 

--- a/LibOS/shim/test/Makefile
+++ b/LibOS/shim/test/Makefile
@@ -15,7 +15,7 @@ endif
 
 CC = gcc
 CXX = g++
-CFLAGS 	= -std=gnu99
+CFLAGS 	= -Wall -std=gnu99
 CFLAGS-debug = $(CFLAGS) -I$(SHIMDIR)/../include -I$(PALDIR)/../include/pal -I$(PALDIR)/../lib
 LDFLAGS	=
 LDFLAGS-debug = $(LDFLAGS) -L$(SHIMDIR) -L$(PALDIR) -Wl,-rpath-link=$(abspath $(RUNTIME))
@@ -35,6 +35,10 @@ CC += -g
 CXX += -g
 endif
 export DEBUG
+
+ifeq ($(WERROR),1)
+CFLAGS += -Werror
+endif
 
 ifeq ($(ABSPATH_IN_MANIFEST),yes)
 manifest_rules = \

--- a/LibOS/shim/test/benchmark/Makefile
+++ b/LibOS/shim/test/benchmark/Makefile
@@ -7,6 +7,8 @@ target = $(c_executables) $(cxx_executables) \
 level = ../
 include ../Makefile
 
+CFLAGS-libos = -L../../../glibc-build/libos -I../../include
+
 %.manifest: %.manifest.template
 	rm -rf $@
 	cp $@.template $@

--- a/LibOS/shim/test/benchmark/fork_latency.c
+++ b/LibOS/shim/test/benchmark/fork_latency.c
@@ -59,7 +59,6 @@ int main(int argc, char ** argv)
                     waitpid(child, NULL, 0);
             }
 
-            struct timeval finish_time;
             gettimeofday(&timevals[1], NULL);
 
             close(pipes[0]);

--- a/LibOS/shim/test/benchmark/rpc_latency.libos.c
+++ b/LibOS/shim/test/benchmark/rpc_latency.libos.c
@@ -68,7 +68,6 @@ int main(int argc, char ** argv)
 
             benchmark_rpc(pids[i][0], NTRIES, &byte, 1);
 
-            struct timeval finish_time;
             gettimeofday(&timevals[1], NULL);
 
             close(pipes[0]);

--- a/LibOS/shim/test/benchmark/sig_latency.c
+++ b/LibOS/shim/test/benchmark/sig_latency.c
@@ -140,7 +140,6 @@ int main(int argc, char ** argv)
             while (count < NTRIES - 1)
                 sched_yield();
 
-            struct timeval finish_time;
             gettimeofday(&timevals[1], NULL);
 
             close(pipes[0]);

--- a/LibOS/shim/test/inline/fork.c
+++ b/LibOS/shim/test/inline/fork.c
@@ -4,7 +4,7 @@
 #include <shim_table.h>
 #include <errno.h>
 
-void main (int argc, char ** argv)
+int main (int argc, char ** argv)
 {
     pid_t pid = shim_fork();
 
@@ -21,4 +21,5 @@ void main (int argc, char ** argv)
     }
 
     shim_exit_group(0);
+    return 0; // should not reach here.
 }

--- a/LibOS/shim/test/inline/helloworld.c
+++ b/LibOS/shim/test/inline/helloworld.c
@@ -3,8 +3,9 @@
 
 #include <shim_table.h>
 
-void main (int argc, char ** argv)
+int main (int argc, char ** argv)
 {
     shim_write(1, "Hello world\n", 12);
     shim_exit_group(0);
+    return 0; // should not reach here.
 }

--- a/LibOS/shim/test/inline/vfork.c
+++ b/LibOS/shim/test/inline/vfork.c
@@ -4,7 +4,7 @@
 #include <shim_table.h>
 #include <errno.h>
 
-void main (int argc, char ** argv)
+int main (int argc, char ** argv)
 {
     pid_t pid = shim_vfork();
 
@@ -21,4 +21,5 @@ void main (int argc, char ** argv)
     }
 
     shim_exit_group(0);
+    return 0; // should not reach here.
 }

--- a/LibOS/shim/test/native/epoll.c
+++ b/LibOS/shim/test/native/epoll.c
@@ -11,13 +11,13 @@
 
 #define TEST_TIMES    4
 
-int main (int argc, const char * argv)
+int main (int argc, char ** argv)
 {
     int ret = 0;
     int fds[TEST_TIMES][2];
 
     int efd = epoll_create(TEST_TIMES);
-    if (!efd < 0) {
+    if (efd < 0) {
         perror("epoll_create");
         exit(1);
     }

--- a/LibOS/shim/test/native/futextest.pthread.c
+++ b/LibOS/shim/test/native/futextest.pthread.c
@@ -27,6 +27,7 @@ void * func(void * arg )
 {
     int * ptr = (int *) arg;
     printf("Parent gave %d\n",*ptr);
+    return NULL;
 }
 
 int main(int argc, char ** argv)

--- a/LibOS/shim/test/native/get_time.m.c
+++ b/LibOS/shim/test/native/get_time.m.c
@@ -82,15 +82,6 @@ int main (int argc, char ** argv, char ** envp)
         gettimeofday(&tv, NULL);
         unsigned long long msec = tv.tv_sec * 1000000ULL + tv.tv_usec;
 
-        struct timeval tv1, tv2;
-        gettimeofday(&tv1, NULL);
-        for (int j = 0 ; j < OVERHEAD_TIMES ; j++)
-            gettimeofday(&tv, NULL);
-        gettimeofday(&tv2, NULL);
-        unsigned long long msec3 = tv1.tv_sec * 1000000ULL + tv1.tv_usec;
-        unsigned long long msec4 = tv2.tv_sec * 1000000ULL + tv2.tv_usec;
-        unsigned long long overhead = (msec4 - msec3) / OVERHEAD_TIMES;
-
         if (read(pipes[0], time_arg, 30) < 0)
             break;
 

--- a/LibOS/shim/test/native/msg_create.c
+++ b/LibOS/shim/test/native/msg_create.c
@@ -67,7 +67,7 @@ int pipefds[4];
 int keys[TEST_TIMES];
 
 /* server always creates queues */
-int server (void)
+void server (void)
 {
     struct timeval tv1, tv2;
     int i;
@@ -101,7 +101,7 @@ int server (void)
 }
 
 /* client always connects queues */
-int client (void)
+void client (void)
 {
     struct timeval tv1, tv2;
     int i;

--- a/LibOS/shim/test/native/msg_create.libos.c
+++ b/LibOS/shim/test/native/msg_create.libos.c
@@ -67,7 +67,7 @@ int keys[TEST_TIMES];
 int ids[TEST_TIMES];
 
 /* server always creates queues */
-int server (void)
+void server (void)
 {
     struct timeval tv1, tv2;
     int i;
@@ -89,7 +89,7 @@ int server (void)
 }
 
 /* client always connects queues */
-int client (void)
+void client (void)
 {
     struct timeval tv1, tv2;
     int i;

--- a/LibOS/shim/test/native/msg_send.c
+++ b/LibOS/shim/test/native/msg_send.c
@@ -26,13 +26,11 @@ enum { PARALLEL, SERIAL, IN_PROCESS } mode = PARALLEL;
 int pipefds[4], key;
 
 /* server always sends messages */
-int server (void)
+void server (void)
 {
     struct timeval tv1, tv2;
     int msqid;
     struct msgbuf buf;
-    size_t len;
-    int i;
 
     if ((msqid = msgget(key, mode == SERIAL ? 0600|IPC_CREAT : 0)) < 0) {
         perror("msgget");
@@ -41,7 +39,7 @@ int server (void)
 
     gettimeofday(&tv1, NULL);
 
-    for (i = 0 ; i < TEST_TIMES ; i++) {
+    for (int i = 0 ; i < TEST_TIMES ; i++) {
         buf.mtype = (i % TEST_TYPES) + 1;
         if (msgsnd(msqid, &buf, PAYLOAD_SIZE, 0) < 0) {
             perror("msgsnd");
@@ -75,12 +73,12 @@ int server (void)
 }
 
 /* client always sends messages */
-int client (void)
+void client (void)
 {
     struct timeval tv1, tv2;
     int msqid;
     struct msgbuf buf;
-    int i, ret;
+    int ret;
 
     if (mode == PARALLEL) {
         char byte = 0;
@@ -144,7 +142,6 @@ int main (int argc, char ** argv)
         if (fork() == 0)
             client();
         wait(NULL);
-        msgctl(msqid, IPC_RMID, NULL);
         return 0;
     }
 

--- a/LibOS/shim/test/native/msg_send.libos.c
+++ b/LibOS/shim/test/native/msg_send.libos.c
@@ -25,7 +25,7 @@ struct msgbuf {
 int msqid;
 
 /* server always sends messages */
-int server (void)
+void server (void)
 {
     struct timeval tv1, tv2;
     struct msgbuf buf;
@@ -57,11 +57,11 @@ int server (void)
 }
 
 /* client always sends messages */
-int client (void)
+void client (void)
 {
     struct timeval tv1, tv2;
     struct msgbuf buf;
-    int i, ret;
+    int ret;
 
     gettimeofday(&tv1, NULL);
 

--- a/LibOS/shim/test/native/script.c
+++ b/LibOS/shim/test/native/script.c
@@ -8,7 +8,7 @@
 
 int main (int argc, const char ** argv, const char ** envp)
 {
-    int newfd = dup(1), outfd = dup(1);
+    int newfd = dup(1);
     char fd_argv[4];
     snprintf(fd_argv, 4, "%d", newfd);
     char * const new_argv[] = { "./script1.sh", fd_argv, NULL };

--- a/LibOS/shim/test/native/sem.c
+++ b/LibOS/shim/test/native/sem.c
@@ -18,13 +18,11 @@ enum { PARALLEL, SERIAL, IN_PROCESS } mode = PARALLEL;
 int pipefds[2], key;
 
 /* server always sends messages */
-int server (void)
+void server (void)
 {
     struct timeval tv1, tv2;
     int semid;
     struct sembuf buf;
-    size_t len;
-    int i;
 
     if ((semid = semget(key, 2, mode == SERIAL ? 0600|IPC_CREAT : 0)) < 0) {
         perror("semget");
@@ -33,7 +31,7 @@ int server (void)
 
     gettimeofday(&tv1, NULL);
 
-    for (i = 0 ; i < TEST_TIMES ; i++) {
+    for (int i = 0 ; i < TEST_TIMES ; i++) {
         buf.sem_num = 0;
         buf.sem_op  = 1;
         buf.sem_flg = 0;
@@ -75,12 +73,11 @@ int server (void)
 }
 
 /* client always sends messages */
-int client (void)
+void client (void)
 {
     struct timeval tv1, tv2;
     int semid;
     struct sembuf buf;
-    int i, ret;
 
     if (mode == PARALLEL) {
         close(pipefds[1]);

--- a/LibOS/shim/test/native/sync.pthread.c
+++ b/LibOS/shim/test/native/sync.pthread.c
@@ -55,7 +55,7 @@ int main(int argc, char **argv)
         pthread_mutex_unlock(&mutex);
     }
 
-    if(rv = pthread_join(other, NULL))
+    if((rv = pthread_join(other, NULL)) < 0)
     {
         printf("Could not join thread - %d\n", rv);
         return -1;

--- a/LibOS/shim/test/native/tcp.c
+++ b/LibOS/shim/test/native/tcp.c
@@ -30,7 +30,8 @@ int pipefds[2];
 
 int server(void)
 {
-    int conn, create_socket, new_socket, addrlen, fd;
+    int conn, create_socket, new_socket, fd;
+    socklen_t addrlen;
     int bufsize = 1024;
     char * buffer = malloc(bufsize);
     struct sockaddr_in address;

--- a/LibOS/shim/test/native/udp.c
+++ b/LibOS/shim/test/native/udp.c
@@ -24,7 +24,8 @@ int pipefds[2];
 int server(void)
 {
     struct sockaddr_in si_me, si_other;
-    int s, i, slen=sizeof(si_other);
+    int s, i;
+    socklen_t slen = sizeof(si_other);
     char buf[BUFLEN];
 
     if ((s=socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP))==-1) {
@@ -76,7 +77,8 @@ int server(void)
 int client(void)
 {
     struct sockaddr_in si_other;
-    int s, i, slen=sizeof(si_other);
+    int s, i;
+    socklen_t slen = sizeof(si_other);
     char buf[BUFLEN]= "hi";
     int res;
 

--- a/LibOS/shim/test/native/unix.c
+++ b/LibOS/shim/test/native/unix.c
@@ -28,7 +28,8 @@ int pipefds[2];
 
 int server(void)
 {
-    int conn,create_socket,new_socket,addrlen,fd;
+    int conn,create_socket,new_socket,fd;
+    socklen_t addrlen;
     int bufsize = 1024;
     char *buffer = malloc(bufsize);
     struct sockaddr_un address;

--- a/LibOS/shim/test/regression/Makefile
+++ b/LibOS/shim/test/regression/Makefile
@@ -14,6 +14,8 @@ default: all
 level = ../
 include ../Makefile
 
+CFLAGS-libos = -L../../../build/libos -I../../include
+
 ifeq ($(findstring x86_64,$(SYS))$(findstring linux,$(SYS)),x86_64linux)
 $(c_executables): %: %.c
 	@echo [ $@ ]

--- a/LibOS/shim/test/regression/exec.c
+++ b/LibOS/shim/test/regression/exec.c
@@ -8,7 +8,7 @@
 
 int main (int argc, const char ** argv, const char ** envp)
 {
-    int newfd = dup(1), outfd = dup(1);
+    int newfd = dup(1);
     char fd_argv[4];
     snprintf(fd_argv, 4, "%d", newfd);
     char * const new_argv[] = { "./exec_victim", fd_argv, NULL };

--- a/Pal/lib/api.h
+++ b/Pal/lib/api.h
@@ -50,6 +50,17 @@ typedef ptrdiff_t ssize_t;
 #define ALIGN_UP_PTR(ptr, size) \
     ((__typeof__(ptr)) ALIGN_DOWN_PTR((uintptr_t)(ptr) + ((size) - 1), (size)))
 
+#ifndef container_of
+/**
+ * container_of - cast a member of a structure out to the containing structure
+ * @ptr:    the pointer to the member.
+ * @type:   the type of the container struct this is embedded in.
+ * @member: the name of the member within the struct.
+ *
+ */
+# define container_of(ptr, type, member) ((type *)((char *)(ptr) - offsetof(type, member)))
+#endif
+
 #define __alloca __builtin_alloca
 
 #define XSTRINGIFY(x) STRINGIFY(x)

--- a/Pal/lib/slabmgr.h
+++ b/Pal/lib/slabmgr.h
@@ -27,6 +27,7 @@
 #define SLABMGR_H
 
 #include "list.h"
+#include "api.h"
 #include <pal_debug.h>
 #include <assert.h>
 #include <errno.h>
@@ -167,10 +168,6 @@ typedef struct __attribute__((packed)) large_mem_obj {
 
 #define OBJ_LEVEL(obj) ((obj)->level)
 #define OBJ_RAW(obj) (&(obj)->raw)
-
-#ifndef container_of
-#define container_of(ptr, type, field) ((type *)((char *)(ptr) - offsetof(type, field)))
-#endif
 
 #define RAW_TO_LEVEL(raw_ptr) \
             (*((const unsigned char *) (raw_ptr) - OBJ_PADDING - 1))

--- a/Pal/regression/Makefile
+++ b/Pal/regression/Makefile
@@ -31,6 +31,10 @@ CC += -g
 endif
 export DEBUG
 
+ifeq ($(WERROR),1)
+CFLAGS += -Werror
+endif
+
 manifest_rules = \
 	-e 's:\$$(PAL):$(abspath ../../Runtime/pal_loader):g' \
 	-e 's:\$$(PWD):$(shell pwd)/:g' \

--- a/Pal/src/Makefile.Test
+++ b/Pal/src/Makefile.Test
@@ -1,5 +1,8 @@
 DIR = $(dir $(lastword $(MAKEFILE_LIST)))
 expand_target = $(1)
 
+ifeq ($(PAL_HOST),)
 include $(DIR)/Makefile.Host
+endif
+
 -include $(DIR)/host/$(PAL_HOST)/Makefile.Test

--- a/Pal/src/host/FreeBSD/Makefile
+++ b/Pal/src/host/FreeBSD/Makefile
@@ -1,16 +1,8 @@
-CC	= gcc
-AS	= gcc
-AR	= ar rcs
+include Makefile.am
 
-CFLAGS	= -Wall -fPIC -O2 -std=gnu99 -fgnu89-inline -Wall -U_FORTIFY_SOURCE \
-	  -fno-omit-frame-pointer\
-	  -fno-stack-protector -fno-builtin \
-	  -I. -Iinclude -I../.. -I../../../include -I../../../lib -I../../../ipc/linux \
-	  -I../../../linux-3.5/graphene 
-ASFLAGS = -DPIC -DSHARED -fPIC -DASSEMBLER -Wa,--noexecstack \
-	  -x assembler-with-cpp \
-	  -I. -Iinclude -I../.. -I../../../include
-ARFLAGS	=
+CFLAGS	+= -I. -Iinclude -I../.. -I../../../include -I../../../lib -I../../../ipc/linux \
+	   -I../../../linux-kernel/graphene
+ASFLAGS += -I. -Iinclude -I../.. -I../../../include
 
 host_target = libpal-FreeBSD.a ../../pal-gdb
 

--- a/Pal/src/host/FreeBSD/Makefile.am
+++ b/Pal/src/host/FreeBSD/Makefile.am
@@ -15,6 +15,10 @@ LDFLAGS	= -shared -nostdlib -z combreloc -z defs \
 	  --version-script $(HOST_DIR)/pal.map -T $(HOST_DIR)/pal.lds
 ARFLAGS	=
 
+ifeq ($(WERROR),1)
+CFLAGS += -Werror
+endif
+
 pal_loader = $(HOST_DIR)/libpal.so
 pal_sec =
 pal_lib = $(HOST_DIR)/libpal.so

--- a/Pal/src/host/Linux-SGX/Makefile.am
+++ b/Pal/src/host/Linux-SGX/Makefile.am
@@ -24,6 +24,10 @@ ARFLAGS	=
 CRYPTO_PROVIDER = mbedtls
 CFLAGS += -DCRYPTO_USE_MBEDTLS
 
+ifeq ($(WERROR),1)
+CFLAGS += -Werror
+endif
+
 pal_loader = $(HOST_DIR)/pal-sgx
 pal_sec =
 pal_lib = $(HOST_DIR)/libpal.so

--- a/Pal/src/host/Linux/Makefile.am
+++ b/Pal/src/host/Linux/Makefile.am
@@ -20,6 +20,10 @@ LDFLAGS	= -shared -nostdlib -z combreloc -z defs \
 	  --version-script $(HOST_DIR)/pal.map -T $(HOST_DIR)/pal.lds
 ARFLAGS	=
 
+ifeq ($(WERROR),1)
+CFLAGS += -Werror
+endif
+
 pal_loader = $(HOST_DIR)/libpal.so
 pal_sec = $(SEC_DIR)/libpal_sec.so
 pal_lib = $(HOST_DIR)/libpal.so

--- a/Pal/src/host/Skeleton/Makefile
+++ b/Pal/src/host/Skeleton/Makefile
@@ -1,13 +1,7 @@
-CC	= gcc
-AS	= gcc
-AR	= ar rcs
+include Makefile.am
 
-CFLAGS	= -Wall -fPIC -O2 -std=gnu99 -fgnu89-inline -Wall -U_FORTIFY_SOURCE \
-	  -fno-builtin -I. -I../.. -I../../../include -I../../../lib
-ASFLAGS = -DPIC -DSHARED -fPIC -DASSEMBLER -Wa,--noexecstack \
-	  -x assembler-with-cpp \
-	  -I. -I../.. -I../../../include
-ARFLAGS	=
+CFLAGS  += -I. -I../.. -I../../../include -I../../../lib
+ASFLAGS += -I. -I../.. -I../../../include
 
 host_target = libpal-Skeleton.a
 

--- a/Pal/src/host/Skeleton/Makefile.am
+++ b/Pal/src/host/Skeleton/Makefile.am
@@ -1,1 +1,13 @@
 # Add host-specific compilation rules here
+
+CC	= gcc
+AS	= gcc
+AR	= ar rcs
+
+CFLAGS  = -Wall -fPIC -O2 -std=gnu99 -fgnu89-inline -Wall -U_FORTIFY_SOURCE -fno-builtin
+ASFLAGS = -DPIC -DSHARED -fPIC -DASSEMBLER -Wa,--noexecstack -x assembler-with-cpp
+ARFLAGS =
+
+ifeq ($(WERROR),1)
+CFLAGS += -Werror
+endif

--- a/Pal/test/Makefile
+++ b/Pal/test/Makefile
@@ -27,6 +27,10 @@ CC += -g
 endif
 export DEBUG
 
+ifeq ($(WERROR),1)
+CFLAGS += -Werror
+endif
+
 pal_loader:
 	ln -sf ../../Runtime/pal_loader
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ To build Graphene library OS with debug symbols, run "make DEBUG=1" instead of
 "make". To specify custom mirrors for downloading the GLIBC source, use
 "GLIBC_MIRRORS=..." when running "make".
 
+To build with "-Werror", run "make WERROR=1".
+
 ### 2.1. BUILD WITH KERNEL-LEVEL SANDBOXING (OPTIONAL)
 
 __** Note: this step is optional. **__


### PR DESCRIPTION
This PR adds "-Wall -Werror" as the default compilation setting in PALs, LibOS, and all the test directories. Minor changes are made to a few source files to resolve the remaining warnings.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/286)
<!-- Reviewable:end -->
