### PR TITLE
Enabling --std=c11 as compiler option

### DIFF
--- a/LibOS/shim/include/shim_internal.h
+++ b/LibOS/shim/include/shim_internal.h
@@ -150,7 +150,7 @@ static inline void do_pause (void);
 #if USE_PAUSE == 1
 # define pause() do { do_pause(); } while (0)
 #else
-# define pause() do { asm volatile ("int $3"); } while (0)
+# define pause() do { __asm__ volatile ("int $3"); } while (0)
 #endif
 
 #define bug()                                                               \
@@ -394,7 +394,7 @@ void parse_syscall_after (int sysno, const char * name, int nr, ...);
  *
  */
 #define container_of(ptr, type, member) ({			\
-	const typeof( ((type *)0)->member ) *__mptr = (ptr);	\
+	const __typeof( ((type *) 0)->member ) *__mptr = (ptr);	\
 	(type *)( (char *)__mptr - offsetof(type,member) );})
 #endif
 
@@ -725,28 +725,28 @@ extern const char ** initial_envp;
 
 #define ALIGNED(addr)   (!(((unsigned long) addr) & allocshift))
 #define ALIGN_UP(addr)      \
-    ((typeof(addr)) ((((unsigned long) addr) + allocshift) & allocmask))
+    ((__typeof(addr)) ((((unsigned long) addr) + allocshift) & allocmask))
 #define ALIGN_DOWN(addr)    \
-    ((typeof(addr)) (((unsigned long) addr) & allocmask))
+    ((__typeof(addr)) (((unsigned long) addr) & allocmask))
 
 #define switch_stack(stack_top)                                     \
     ({                                                              \
         void * _rsp, * _rbp;                                        \
         void * _stack = (stack_top);                                \
-        asm volatile ("movq %%rsp, %0" : "=r"(_rsp) :: "memory");   \
-        asm volatile ("movq %%rbp, %0" : "=r"(_rbp) :: "memory");   \
+        __asm__ volatile ("movq %%rsp, %0" : "=r"(_rsp) :: "memory");   \
+        __asm__ volatile ("movq %%rbp, %0" : "=r"(_rbp) :: "memory");   \
         _rsp = _stack - (_rbp - _rsp);                              \
         _rbp = _stack;                                              \
-        asm volatile ("movq %0, %%rsp" :: "r"(_rsp) : "memory");    \
-        asm volatile ("movq %0, %%rbp" :: "r"(_rbp) : "memory");    \
-        asm volatile ("movq %%rbp, %0" : "=r"(_stack) :: "memory"); \
+        __asm__ volatile ("movq %0, %%rsp" :: "r"(_rsp) : "memory");    \
+        __asm__ volatile ("movq %0, %%rbp" :: "r"(_rbp) : "memory");    \
+        __asm__ volatile ("movq %%rbp, %0" : "=r"(_stack) :: "memory"); \
         _stack;                                                     \
     })
 
 #define current_stack()                                             \
     ({                                                              \
         void * _rsp;                                                \
-        asm volatile ("movq %%rsp, %0" : "=r"(_rsp) :: "memory");   \
+        __asm__ volatile ("movq %%rsp, %0" : "=r"(_rsp) :: "memory");   \
         _rsp;                                                       \
     })
 

--- a/LibOS/shim/include/shim_thread.h
+++ b/LibOS/shim/include/shim_thread.h
@@ -123,12 +123,12 @@ int init_thread (void);
 
 #define SHIM_THREAD_SELF()                                     \
     ({ struct shim_thread * __self;                            \
-        asm ("movq %%fs:%c1,%q0" : "=r" (__self)               \
+        __asm__ ("movq %%fs:%c1,%q0" : "=r" (__self)               \
            : "i" (offsetof(__libc_tcb_t, shim_tcb.tp)));       \
       __self; })
 
 #define SAVE_SHIM_THREAD_SELF(__self)                         \
-  ({ asm ("movq %q0,%%fs:%c1" : : "r" (__self),               \
+  ({ __asm__ ("movq %q0,%%fs:%c1" : : "r" (__self),               \
           "i" (offsetof(__libc_tcb_t, shim_tcb.tp)));         \
      __self; })
 
@@ -318,7 +318,7 @@ bool check_stack_size (struct shim_thread * cur_thread, int size)
         cur_thread = get_cur_thread();
 
     void * rsp;
-    asm volatile ("movq %%rsp, %0" : "=r"(rsp) :: "memory");
+    __asm__ volatile ("movq %%rsp, %0" : "=r"(rsp) :: "memory");
 
     if (rsp <= cur_thread->stack_top && rsp > cur_thread->stack)
         return size < rsp - cur_thread->stack;

--- a/LibOS/shim/include/shim_tls.h
+++ b/LibOS/shim/include/shim_tls.h
@@ -99,19 +99,19 @@ typedef struct
 
 #define SHIM_TLS_CHECK_CANARY()                                \
     ({ uint64_t __canary;                                      \
-        asm ("movq %%fs:%c1,%q0" : "=r" (__canary)             \
+        __asm__ ("movq %%fs:%c1,%q0" : "=r" (__canary)         \
            : "i" (offsetof(__libc_tcb_t, shim_tcb.canary)));   \
       __canary == SHIM_TLS_CANARY; })
 
 #define SHIM_GET_TLS()                                         \
     ({ shim_tcb_t *__self;                                     \
-        asm ("movq %%fs:%c1,%q0" : "=r" (__self)               \
+        __asm__ ("movq %%fs:%c1,%q0" : "=r" (__self)           \
            : "i" (offsetof(__libc_tcb_t, shim_tcb.self)));     \
       __self; })
 
 #define GET_LIBC_TCB()                                         \
     ({ void *__self;                                           \
-        asm ("movq %%fs:%c1,%q0" : "=r" (__self)               \
+        __asm__ ("movq %%fs:%c1,%q0" : "=r" (__self)           \
            : "i" (offsetof(__libc_tcb_t, tcb)));               \
       __self; })
 

--- a/LibOS/shim/include/shim_types.h
+++ b/LibOS/shim/include/shim_types.h
@@ -36,6 +36,22 @@ typedef unsigned int        __u32;
 typedef unsigned long int   nfds_t;
 typedef unsigned long int   nlink_t;
 
+#ifndef pid_t
+typedef __kernel_pid_t      pid_t;
+#endif
+
+#ifndef uid_t
+typedef __kernel_uid_t      uid_t;
+#endif
+
+#ifndef gid_t
+typedef __kernel_gid_t      gid_t;
+#endif
+
+#ifndef off_t
+typedef __kernel_off_t      off_t;
+#endif
+
 typedef __kernel_caddr_t    caddr_t;
 typedef __kernel_mode_t     mode_t;
 typedef __kernel_loff_t     loff_t;
@@ -46,6 +62,10 @@ typedef __kernel_clockid_t  clockid_t;
 typedef __kernel_key_t      key_t;
 typedef __kernel_timer_t    timer_t;
 typedef __kernel_fd_set     fd_set;
+
+#ifndef socklen_t
+typedef int                 socklen_t;
+#endif
 
 /* linux/time.h */
 struct __kernel_timespec {

--- a/LibOS/shim/src/Makefile
+++ b/LibOS/shim/src/Makefile
@@ -9,7 +9,7 @@ LD	= ld
 
 OMIT_FRAME_POINTER = no
 
-CFLAGS	= -Wall -fPIC -std=gnu99 -fgnu89-inline -Winline -Wwrite-strings \
+CFLAGS	= -Wall -fPIC -std=c11 -Winline -Wwrite-strings \
 	  -fmerge-all-constants -Wstrict-prototypes \
 	  -Werror=implicit-function-declaration \
 	  -fno-stack-protector -fno-builtin -Wno-inline \

--- a/LibOS/shim/src/bookkeep/shim_thread.c
+++ b/LibOS/shim/src/bookkeep/shim_thread.c
@@ -587,7 +587,7 @@ void switch_dummy_thread (struct shim_thread * thread)
 
     /* jump onto old stack
        we actually pop rbp as rsp, and later we will call 'ret' */
-    asm volatile("movq %0, %%rbp\r\n"
+    __asm__ volatile("movq %0, %%rbp\r\n"
                  "leaveq\r\n"
                  "retq\r\n" :
                  : "g"(real_thread->frameptr),

--- a/LibOS/shim/src/elf/rel.h
+++ b/LibOS/shim/src/elf/rel.h
@@ -15,7 +15,7 @@
         ((ElfW(Addr)) (addr) >= (l)->l_map_start && (ElfW(Addr)) (addr) < (l)->l_map_end)
 
 #define RELOCATE(l, addr)   \
-        ((typeof(addr)) (IN_RANGE((l), (addr)) ? (ElfW(Addr)) (addr) :    \
+        ((__typeof(addr)) (IN_RANGE((l), (addr)) ? (ElfW(Addr)) (addr) :    \
             (ElfW(Addr)) (addr) + (ElfW(Addr)) ((l)->l_addr)))
 
 #ifdef __x86_64__

--- a/LibOS/shim/src/elf/shim_rtld.c
+++ b/LibOS/shim/src/elf/shim_rtld.c
@@ -875,7 +875,7 @@ static int __check_elf_header (void * fbp, int len)
 
     /* Check whether the ELF header use the right endian */
     if (ehdr->e_ident[EI_DATA] != byteorder) {
-        if (BYTE_ORDER == BIG_ENDIAN) {
+        if (__BYTE_ORDER == __BIG_ENDIAN) {
             errstring = "ELF file data encoding not big-endian";
             goto verify_failed;
         } else {
@@ -1574,7 +1574,7 @@ int execute_elf_object (struct shim_handle * exec, int argc, const char ** argp,
     ElfW(Addr) entry = interp_map ? interp_map->l_entry : exec_map->l_entry;
 
 #if defined(__x86_64__)
-    asm volatile (
+    __asm__ volatile (
                     "movq %%rbx, %%rsp\r\n"
                     "pushq %%rdi\r\n"
                     "jmp *%%rax\r\n"

--- a/LibOS/shim/src/shim_checkpoint.c
+++ b/LibOS/shim/src/shim_checkpoint.c
@@ -1258,7 +1258,7 @@ void restore_context (struct shim_context * context)
 
     memset(context, 0, sizeof(struct shim_context));
 
-    asm volatile("movq %0, %%rsp\r\n"
+    __asm__ volatile("movq %0, %%rsp\r\n"
                  "popq %%r15\r\n"
                  "popq %%r14\r\n"
                  "popq %%r13\r\n"

--- a/LibOS/shim/src/shim_init.c
+++ b/LibOS/shim/src/shim_init.c
@@ -1036,7 +1036,7 @@ void check_stack_hook (void)
     struct shim_thread * cur_thread = get_cur_thread();
 
     void * rsp;
-    asm volatile ("movq %%rsp, %0" : "=r"(rsp) :: "memory");
+    __asm__ volatile ("movq %%rsp, %0" : "=r"(rsp) :: "memory");
 
     if (rsp <= cur_thread->stack_top && rsp > cur_thread->stack) {
         if (rsp - cur_thread->stack < PAL_CB(pagesize))

--- a/LibOS/shim/src/sys/shim_vfork.c
+++ b/LibOS/shim/src/sys/shim_vfork.c
@@ -58,7 +58,7 @@ int shim_do_vfork (void)
     struct shim_thread * new_thread = get_new_thread(0);
     /* put the new thread in a new process (thread group) */
 
-    asm volatile ("movq %%rbp, %0\r\n"
+    __asm__ volatile ("movq %%rbp, %0\r\n"
                   : "=r"(new_thread->frameptr));
 
     size_t stack_size = 4096;

--- a/Pal/include/sysdeps/generic/memcopy.h
+++ b/Pal/include/sysdeps/generic/memcopy.h
@@ -50,10 +50,10 @@ typedef unsigned char byte;
 /* Optimal type for storing bytes in registers.  */
 #define	reg_char	char
 
-#if BYTE_ORDER == LITTLE_ENDIAN
+#if __BYTE_ORDER == __LITTLE_ENDIAN
 #define MERGE(w0, sh_1, w1, sh_2) (((w0) >> (sh_1)) | ((w1) << (sh_2)))
 #endif
-#if BYTE_ORDER == BIG_ENDIAN
+#if __BYTE_ORDER == __BIG_ENDIAN
 #define MERGE(w0, sh_1, w1, sh_2) (((w0) << (sh_1)) | ((w1) >> (sh_2)))
 #endif
 

--- a/Pal/lib/list.h
+++ b/Pal/lib/list.h
@@ -172,8 +172,8 @@
 /* This helper takes 3 arguments - all should be containing structures,
  * and the field to use for the offset to the list node */
 #define __list_add(NEW, NEXT, PREV, FIELD) do {       \
-        typeof(NEW) __tmp_next = (NEXT);              \
-        typeof(NEW) __tmp_prev = (PREV);              \
+        __typeof__(NEW) __tmp_next = (NEXT);          \
+        __typeof__(NEW) __tmp_prev = (PREV);          \
         __tmp_prev->FIELD.next = (NEW);               \
         __tmp_next->FIELD.prev = (NEW);               \
         (NEW)->FIELD.next = __tmp_next;               \

--- a/Pal/lib/network/inet_pton.c
+++ b/Pal/lib/network/inet_pton.c
@@ -43,7 +43,7 @@ int inet_pton4 (const char *src, int len, void *dstp)
     while (src < end && (ch = *src++) != '\0') {
 
         if (ch >= '0' && ch <= '9') {
-            u_int new = *tp * 10 + (ch - '0');
+            unsigned new = *tp * 10 + (ch - '0');
 
             if (saw_digit && *tp == 0)
                 return (0);

--- a/Pal/regression/Exception.c
+++ b/Pal/regression/Exception.c
@@ -46,16 +46,16 @@ int main (void)
     DkSetExceptionHandler(handler1, PAL_EVENT_DIVZERO, 0);
     i = 0;
     i = 1 / i;
-    asm volatile("nop");
+    __asm__ volatile("nop");
 
     DkSetExceptionHandler(handler2, PAL_EVENT_DIVZERO, 0);
     i = 0;
     i = 1 / i;
-    asm volatile("nop");
+    __asm__ volatile("nop");
 
     DkSetExceptionHandler(handler3, PAL_EVENT_MEMFAULT, 0);
     *(volatile long *) 0x1000 = 0;
-    asm volatile("nop");
+    __asm__ volatile("nop");
 
     return 0;
 }

--- a/Pal/regression/Ipc.c
+++ b/Pal/regression/Ipc.c
@@ -150,7 +150,7 @@ int main (int argc, char ** argv, char ** envp)
                 if (ret > 0) {
                     message = "[Test 4] Physical Memory Map   : Memory Fault\n";
                     *(volatile int *) mem_addr;
-                    asm volatile("nop");
+                    __asm__ volatile("nop");
                     message = NULL;
                 }
 

--- a/Pal/regression/Makefile
+++ b/Pal/regression/Makefile
@@ -1,7 +1,7 @@
 include ../src/Makefile.Host
 
 CC	= gcc
-CFLAGS	= -Wall -O2 -std=gnu99 -fgnu89-inline -fno-builtin -nostdlib \
+CFLAGS	= -Wall -O2 -std=c11 -fno-builtin -nostdlib \
 	  -I../include/pal -I../lib
 
 preloads    = $(patsubst %.c,%,$(wildcard *.so.c))

--- a/Pal/regression/Memory.c
+++ b/Pal/regression/Memory.c
@@ -44,14 +44,14 @@ int main (int argc, char ** argv, char ** envp)
         DkVirtualMemoryProtect(mem2, UNIT, PAL_PROT_READ);
         c = count;
         *(volatile int *) mem2 = 0;
-        asm volatile("nop");
+        __asm__ volatile("nop");
         if (c == count - 1)
             pal_printf("Memory Protection (R) OK\n");
 
         DkVirtualMemoryFree(mem2, UNIT);
         c = count;
         *(volatile int *) mem2 = 0;
-        asm volatile("nop");
+        __asm__ volatile("nop");
         if (c == count - 1)
             pal_printf("Memory Deallocation OK\n");
     }

--- a/Pal/regression/Symbols.c
+++ b/Pal/regression/Symbols.c
@@ -6,7 +6,7 @@
 
 #define symbol_addr(sym)                                        \
     ({  void * _sym;                                            \
-        asm volatile ("movq " #sym "@GOTPCREL(%%rip), %0"       \
+        __asm__ volatile ("movq " #sym "@GOTPCREL(%%rip), %0"   \
                       : "=r"(_sym));                            \
         _sym; })
 

--- a/Pal/regression/Thread.c
+++ b/Pal/regression/Thread.c
@@ -18,21 +18,21 @@ int callback1 (void * args)
         while (!(count1 % 2))
             DkThreadYieldExecution();
         count1++;
-        asm volatile("nop" ::: "memory");
+        __asm__ volatile("nop" ::: "memory");
     }
 
     pal_printf("Threads Run in Parallel OK\n");
 
     DkSegmentRegister(PAL_SEGMENT_FS, &private2);
     const char * ptr2;
-    asm volatile("mov %%fs:0, %0" : "=r"(ptr2) :: "memory");
+    __asm__ volatile("mov %%fs:0, %0" : "=r"(ptr2) :: "memory");
     pal_printf("Private Message (FS Segment) 2: %s\n", ptr2);
 
     count1 = 100;
-    asm volatile("nop" ::: "memory");
+    __asm__ volatile("nop" ::: "memory");
     DkThreadExit();
     count1 = 101;
-    asm volatile("nop" ::: "memory");
+    __asm__ volatile("nop" ::: "memory");
 
     return 0;
 }
@@ -41,7 +41,7 @@ int main (int argc, const char ** argv, const char ** envp)
 {
     DkSegmentRegister(PAL_SEGMENT_FS, &private1);
     const char * ptr1;
-    asm volatile("mov %%fs:0, %0" : "=r"(ptr1) :: "memory");
+    __asm__ volatile("mov %%fs:0, %0" : "=r"(ptr1) :: "memory");
     pal_printf("Private Message (FS Segment) 1: %s\n", ptr1);
 
     PAL_HANDLE thread1 = DkThreadCreate(callback1, "Hello World", 0);
@@ -53,7 +53,7 @@ int main (int argc, const char ** argv, const char ** envp)
             while (!!(count1 % 2))
                 DkThreadYieldExecution();
             count1++;
-            asm volatile("nop" ::: "memory");
+            __asm__ volatile("nop" ::: "memory");
         }
 
         while (count1 < 100)

--- a/Pal/src/db_rtld.c
+++ b/Pal/src/db_rtld.c
@@ -1286,7 +1286,7 @@ void * stack_before_call __attribute_unused = NULL;
 
 #define CALL_ENTRY(l, cookies)                                          \
     ({  long ret;                                                       \
-        asm volatile("movq %%rsp, stack_before_call(%%rip)\r\n"         \
+        __asm__ volatile("movq %%rsp, stack_before_call(%%rip)\r\n"     \
                      "leaq 1f(%%rip), %%rdx\r\n"                        \
                      "movq %2, %%rsp\r\n"                               \
                      "jmp *%1\r\n"                                      \

--- a/Pal/src/host/Linux-SGX/Makefile
+++ b/Pal/src/host/Linux-SGX/Makefile
@@ -63,7 +63,7 @@ pal-sgx: $(addsuffix .o,$(urts-objs) $(urts-asm-objs)) $(graphene_lib)
 
 debugger/sgx_gdb.so: debugger/sgx_gdb.c debugger/sgx_gdb.h sgx_arch.h
 	@echo [ host/Linux-SGX/$@ ]
-	$(CC) -Wall -fPIC -O2 -std=gnu99 -fgnu89-inline -c debugger/sgx_gdb.c -o debugger/sgx_gdb.o
+	$(CC) -Wall -fPIC -O2 -std=c11 -c debugger/sgx_gdb.c -o debugger/sgx_gdb.o
 	$(LD) -shared debugger/sgx_gdb.o -o debugger/sgx_gdb.so -lc
 
 sgx-driver/isgx_version.h:

--- a/Pal/src/host/Linux-SGX/Makefile.am
+++ b/Pal/src/host/Linux-SGX/Makefile.am
@@ -6,7 +6,7 @@ AS	= gcc
 AR	= ar rcs
 LD	= ld
 
-CFLAGS	= -Wall -fPIC -O2 -maes -std=gnu99 -fgnu89-inline -U_FORTIFY_SOURCE \
+CFLAGS	= -Wall -fPIC -O2 -maes -std=c11 -U_FORTIFY_SOURCE \
 	  -fno-omit-frame-pointer \
 	  -fno-stack-protector -fno-builtin -DIN_ENCLAVE
 ASFLAGS = -DPIC -DSHARED -fPIC -DASSEMBLER -Wa,--noexecstack \

--- a/Pal/src/host/Linux-SGX/db_exception.c
+++ b/Pal/src/host/Linux-SGX/db_exception.c
@@ -93,7 +93,7 @@ static struct pal_frame * get_frame (sgx_context_t * uc)
         if (!ADDR_IN_PAL(rip))
             return NULL;
     } else {
-        asm volatile ("movq %%rbp, %0" : "=r"(rbp) :: "memory");
+        __asm__ volatile ("movq %%rbp, %0" : "=r"(rbp) :: "memory");
     }
 
     while (ADDR_IN_PAL(((unsigned long *) rbp)[1]))
@@ -111,7 +111,7 @@ static struct pal_frame * get_frame (sgx_context_t * uc)
     return NULL;
 }
 
-asm (".type arch_exception_return_asm, @function;"
+__asm__ (".type arch_exception_return_asm, @function;"
      "arch_exception_return_asm:"
      "  pop %rax;"
      "  pop %rbx;"
@@ -129,7 +129,7 @@ asm (".type arch_exception_return_asm, @function;"
      "  pop %r15;"
      "  retq;");
 
-extern void arch_exception_return (void) asm ("arch_exception_return_asm");
+extern void arch_exception_return (void) __asm__ ("arch_exception_return_asm");
 
 void _DkExceptionRealHandler (int event, PAL_NUM arg, struct pal_frame * frame,
                               PAL_CONTEXT * context)
@@ -171,7 +171,8 @@ void restore_sgx_context (sgx_context_t * uc)
     *(uint64_t *) uc->rsp = uc->rip;
 
     /* now pop the stack */
-    asm volatile ("mov %0, %%rsp\n"
+    __asm__ volatile (
+                  "mov %0, %%rsp\n"
                   "pop %%rax\n"
                   "pop %%rcx\n"
                   "pop %%rdx\n"
@@ -315,7 +316,8 @@ void _DkExceptionReturn (void * event)
         __clear_frame(frame);
         arch_restore_frame(&frame->arch);
 
-        asm volatile ("xor %%rax, %%rax\r\n"
+        __asm__ volatile (
+                      "xor %%rax, %%rax\r\n"
                       "leaveq\r\n"
                       "retq\r\n" ::: "memory");
     }

--- a/Pal/src/host/Linux-SGX/db_memory.c
+++ b/Pal/src/host/Linux-SGX/db_memory.c
@@ -80,7 +80,7 @@ int _DkVirtualMemoryAlloc (void ** paddr, uint64_t size, int alloc_type, int pro
         return -PAL_ERROR_INVAL;
 
     if (size == 0)
-        asm volatile ("int $3");
+        __asm__ volatile ("int $3");
 
     mem = get_reserved_pages(addr, size);
     if (!mem)

--- a/Pal/src/host/Linux-SGX/elf-x86_64.h
+++ b/Pal/src/host/Linux-SGX/elf-x86_64.h
@@ -63,7 +63,7 @@ elf_machine_load_address (void)
        load offset which is zero if the binary was loaded at the address
        it is prelinked for.  */
 
-    asm ("leaq " XSTRINGIFY(_ENTRY) "(%%rip), %0\n\t"
+    __asm__ ("leaq " XSTRINGIFY(_ENTRY) "(%%rip), %0\n\t"
          "subq 1f(%%rip), %0\n\t"
          ".section\t.data.rel.ro\n"
          "1:\t.quad " XSTRINGIFY(_ENTRY) "\n\t"

--- a/Pal/src/host/Linux-SGX/enclave_ocalls.c
+++ b/Pal/src/host/Linux-SGX/enclave_ocalls.c
@@ -35,17 +35,17 @@ int printf(const char * fmt, ...);
 
 #define ALLOC_IN_USER(ptr, size)                    \
     ({                                              \
-        typeof(ptr) tmp = ptr;                      \
+        __typeof(ptr) tmp = ptr;                    \
         if (sgx_is_within_enclave(ptr, size)) {     \
-            OCALLOC(tmp, typeof(tmp), size);        \
+            OCALLOC(tmp, __typeof(tmp), size);      \
         }; tmp;                                     \
     })
 
 #define COPY_TO_USER(ptr, size)                     \
     ({                                              \
-        typeof(ptr) tmp = ptr;                      \
+        __typeof(ptr) tmp = ptr;                    \
         if (sgx_is_within_enclave(ptr, size)) {     \
-            OCALLOC(tmp, typeof(tmp), size);        \
+            OCALLOC(tmp, __typeof(tmp), size);      \
             memcpy((void *) tmp, ptr, size);        \
         }; tmp;                                     \
     })

--- a/Pal/src/host/Linux-SGX/enclave_pages.c
+++ b/Pal/src/host/Linux-SGX/enclave_pages.c
@@ -61,7 +61,7 @@ static void assert_vma_list (void)
             SGX_DBG(DBG_E, "*** [%d] corrupted heap vma: %p - %p (last = %p) ***\n", pal_sec.pid, vma->bottom, vma->top, last_addr);
 #ifdef DEBUG
             if (pal_sec.in_gdb)
-                asm volatile ("int $3" ::: "memory");
+                __asm__ volatile ("int $3" ::: "memory");
 #endif
             ocall_exit();
         }
@@ -136,7 +136,7 @@ void * get_reserved_pages(void * addr, uint64_t size)
     _DkInternalUnlock(&heap_vma_lock);
 
     SGX_DBG(DBG_E, "*** Not enough space on the heap (requested = %llu) ***\n", size);
-    asm volatile("int $3");
+    __asm__ volatile("int $3");
     return NULL;
 
 allocated:
@@ -241,7 +241,7 @@ allocated:
                 vma->bottom, vma->top);
 #ifdef DEBUG
         if (pal_sec.in_gdb)
-            asm volatile ("int $3" ::: "memory");
+            __asm__ volatile ("int $3" ::: "memory");
 #endif
     }
     assert_vma_list();

--- a/Pal/src/host/Linux-SGX/pal_host.h
+++ b/Pal/src/host/Linux-SGX/pal_host.h
@@ -197,7 +197,7 @@ struct arch_frame {
 
 #ifdef __x86_64__
 # define store_register(reg, var)     \
-    asm volatile ("movq %%" #reg ", %0" : "=g" (var) :: "memory");
+    __asm__ volatile ("movq %%" #reg ", %0" : "=g" (var) :: "memory");
 
 # define store_register_in_frame(reg, f)     store_register(reg, (f)->reg)
 
@@ -213,7 +213,7 @@ struct arch_frame {
     store_register_in_frame(r15, f)
 
 # define restore_register(reg, var, clobber...)  \
-    asm volatile ("movq %0, %%" #reg :: "g" (var) : "memory", ##clobber);
+    __asm__ volatile ("movq %0, %%" #reg :: "g" (var) : "memory", ##clobber);
 
 # define restore_register_in_frame(reg, f)       \
     restore_register(reg, (f)->reg,              \
@@ -255,7 +255,7 @@ void __store_frame (volatile struct pal_frame * frame,
     arch_store_frame(&frame->arch)
     frame->func = func;
     frame->funcname = funcname;
-    asm volatile ("nop" ::: "memory");
+    __asm__ volatile ("nop" ::: "memory");
     frame->identifier = PAL_FRAME_IDENTIFIER;
 }
 
@@ -268,7 +268,7 @@ static inline
 void __clear_frame (volatile struct pal_frame * frame)
 {
     if (frame->identifier == PAL_FRAME_IDENTIFIER) {
-        asm volatile ("nop" ::: "memory");
+        __asm__ volatile ("nop" ::: "memory");
         frame->identifier = 0;
     }
 }

--- a/Pal/src/host/Linux-SGX/sgx_enclave.c
+++ b/Pal/src/host/Linux-SGX/sgx_enclave.c
@@ -81,7 +81,7 @@ static int sgx_ocall_cpuid(void * pms)
 {
     ms_ocall_cpuid_t * ms = (ms_ocall_cpuid_t *) pms;
     ODEBUG(OCALL_CPUID, ms);
-    asm volatile ("cpuid"
+    __asm__ volatile ("cpuid"
                   : "=a"(ms->ms_values[0]),
                     "=b"(ms->ms_values[1]),
                     "=c"(ms->ms_values[2]),

--- a/Pal/src/host/Linux-SGX/sgx_exception.c
+++ b/Pal/src/host/Linux-SGX/sgx_exception.c
@@ -57,7 +57,7 @@
  *     }
  */
 
-void restore_rt (void) asm ("__restore_rt");
+void restore_rt (void) __asm__ ("__restore_rt");
 
 #ifndef SA_RESTORER
 #define SA_RESTORER  0x04000000
@@ -65,7 +65,7 @@ void restore_rt (void) asm ("__restore_rt");
 
 #define DEFINE_RESTORE_RT(syscall) DEFINE_RESTORE_RT2(syscall)
 # define DEFINE_RESTORE_RT2(syscall)                \
-    asm (                                           \
+    __asm__ (                                       \
          "    nop\n"                                \
          ".align 16\n"                              \
          ".LSTART_restore_rt:\n"                    \

--- a/Pal/src/host/Linux-SGX/sgx_framework.c
+++ b/Pal/src/host/Linux-SGX/sgx_framework.c
@@ -71,7 +71,7 @@ int read_enclave_sigstruct(int sigfile, sgx_arch_sigstruct_t * sig)
 
 static inline void cpuid(uint32_t leaf, uint32_t subleaf, uint32_t info[4])
 {
-    asm volatile("cpuid"
+    __asm__ volatile("cpuid"
                  : "=a"(info[0]),
                    "=b"(info[1]),
                    "=c"(info[2]),

--- a/Pal/src/host/Linux-SGX/sgx_main.c
+++ b/Pal/src/host/Linux-SGX/sgx_main.c
@@ -417,7 +417,7 @@ int initialize_enclave (struct pal_enclave * enclave)
         if (strcmp_static(areas[i].desc, "tls")) {
             data = (void *) INLINE_SYSCALL(mmap, 6, NULL, areas[i].size,
                                            PROT_READ|PROT_WRITE,
-                                           MAP_ANON|MAP_PRIVATE, -1, 0);
+                                           MAP_ANONYMOUS|MAP_PRIVATE, -1, 0);
 
             for (int t = 0 ; t < enclave->thread_num ; t++) {
                 struct enclave_tls * gs = data + pagesize * t;
@@ -438,7 +438,7 @@ int initialize_enclave (struct pal_enclave * enclave)
         if (strcmp_static(areas[i].desc, "tcs")) {
             data = (void *) INLINE_SYSCALL(mmap, 6, NULL, areas[i].size,
                                            PROT_READ|PROT_WRITE,
-                                           MAP_ANON|MAP_PRIVATE, -1, 0);
+                                           MAP_ANONYMOUS|MAP_PRIVATE, -1, 0);
 
             for (int t = 0 ; t < enclave->thread_num ; t++) {
                 sgx_arch_tcs_t * tcs = data + pagesize * t;

--- a/Pal/src/host/Linux-SGX/sgx_process.c
+++ b/Pal/src/host/Linux-SGX/sgx_process.c
@@ -97,7 +97,7 @@ int sgx_create_process (const char * uri, int nargs, const char ** args,
         /* shouldn't get to here */
         SGX_DBG(DBG_E, "unexpected failure of new process\n");
 out_child:
-        asm("hlt");
+        __asm__ volatile ("hlt");
         return 0;
     }
 

--- a/Pal/src/host/Linux-SGX/sgx_rtld.c
+++ b/Pal/src/host/Linux-SGX/sgx_rtld.c
@@ -29,7 +29,7 @@
 #include <pal_internal.h>
 #include <api.h>
 
-asm (".pushsection \".debug_gdb_scripts\", \"MS\",@progbits,1\r\n"
+__asm__ (".pushsection \".debug_gdb_scripts\", \"MS\",@progbits,1\r\n"
      ".byte 1\r\n"
      ".asciz \"" PAL_FILE("host/Linux-SGX/debugger/pal-gdb.py") "\"\r\n"
      ".popsection\r\n");

--- a/Pal/src/host/Linux-SGX/sgx_tls.h
+++ b/Pal/src/host/Linux-SGX/sgx_tls.h
@@ -30,13 +30,13 @@ extern uint64_t dummy_debug_variable;
     ({                                                              \
         struct enclave_tls * tmp;                                   \
         uint64_t val;                                               \
-        asm ("movq %%gs:%c1, %q0": "=r" (val)                       \
+        __asm__ ("movq %%gs:%c1, %q0": "=r" (val)                   \
              : "i" (offsetof(struct enclave_tls, member)));         \
-        (typeof(tmp->member)) val;                                  \
+        (__typeof(tmp->member)) val;                                \
     })
 #  define SET_ENCLAVE_TLS(member, value)                            \
     do {                                                            \
-        asm ("movq %q0, %%gs:%c1":: "r" (value),                    \
+        __asm__ ("movq %q0, %%gs:%c1":: "r" (value),                \
              "i" (offsetof(struct enclave_tls, member)));           \
     } while (0)
 # endif

--- a/Pal/src/host/Linux-SGX/sysdep-x86_64.h
+++ b/Pal/src/host/Linux-SGX/sysdep-x86_64.h
@@ -145,7 +145,7 @@
     unsigned long resultvar;                                \
     LOAD_ARGS_##nr (args)                                   \
     LOAD_REGS_##nr                                          \
-    asm volatile (                                          \
+    __asm__ volatile (                                          \
     DO_SYSCALL                                              \
     : "=a" (resultvar)                                      \
     : "0" (name) ASM_ARGS_##nr : "memory", "cc", "r11", "cx");  \
@@ -176,7 +176,7 @@
   long int __arg1 = (long) (a1);                        \
   LOAD_ARGS_0 ()
 #define LOAD_REGS_1                                     \
-  register long int _a1 asm ("rdi") = __arg1;           \
+  register long int _a1 __asm__ ("rdi") = __arg1;       \
   LOAD_REGS_0
 #define ASM_ARGS_1    ASM_ARGS_0, "r" (_a1)
 
@@ -184,7 +184,7 @@
   long int __arg2 = (long) (a2);                        \
   LOAD_ARGS_1 (a1)
 #define LOAD_REGS_2                                     \
-  register long int _a2 asm ("rsi") = __arg2;           \
+  register long int _a2 __asm__ ("rsi") = __arg2;       \
   LOAD_REGS_1
 #define ASM_ARGS_2    ASM_ARGS_1, "r" (_a2)
 
@@ -192,7 +192,7 @@
   long int __arg3 = (long) (a3);                        \
   LOAD_ARGS_2 (a1, a2)
 #define LOAD_REGS_3                                     \
-  register long int _a3 asm ("rdx") = __arg3;           \
+  register long int _a3 __asm__ ("rdx") = __arg3;       \
   LOAD_REGS_2
 #define ASM_ARGS_3    ASM_ARGS_2, "r" (_a3)
 
@@ -200,7 +200,7 @@
   long int __arg4 = (long) (a4);                        \
   LOAD_ARGS_3 (a1, a2, a3)
 #define LOAD_REGS_4                                     \
-  register long int _a4 asm ("r10") = __arg4;           \
+  register long int _a4 __asm__ ("r10") = __arg4;       \
   LOAD_REGS_3
 #define ASM_ARGS_4    ASM_ARGS_3, "r" (_a4)
 
@@ -208,7 +208,7 @@
   long int __arg5 = (long) (a5);                        \
   LOAD_ARGS_4 (a1, a2, a3, a4)
 #define LOAD_REGS_5                                     \
-  register long int _a5 asm ("r8") = __arg5;            \
+  register long int _a5 __asm__ ("r8") = __arg5;        \
   LOAD_REGS_4
 #define ASM_ARGS_5    ASM_ARGS_4, "r" (_a5)
 
@@ -216,7 +216,7 @@
   long int __arg6 = (long) (a6);                        \
   LOAD_ARGS_5 (a1, a2, a3, a4, a5)
 #define LOAD_REGS_6                                     \
-  register long int _a6 asm ("r9") = __arg6;            \
+  register long int _a6 __asm__ ("r9") = __arg6;        \
   LOAD_REGS_5
 #define ASM_ARGS_6    ASM_ARGS_5, "r" (_a6)
 

--- a/Pal/src/host/Linux/Makefile.am
+++ b/Pal/src/host/Linux/Makefile.am
@@ -7,7 +7,7 @@ AS	= gcc
 AR	= ar rcs
 LD	= ld
 
-CFLAGS	= -Wall -fPIC -O2 -std=gnu99 -fgnu89-inline -U_FORTIFY_SOURCE \
+CFLAGS	= -Wall -fPIC -O2 -std=c11 -U_FORTIFY_SOURCE \
 	  -fno-omit-frame-pointer \
 	  -fno-stack-protector -fno-builtin
 ASFLAGS = -DPIC -DSHARED -fPIC -DASSEMBLER -Wa,--noexecstack \

--- a/Pal/src/host/Linux/db_exception.c
+++ b/Pal/src/host/Linux/db_exception.c
@@ -53,7 +53,7 @@
  *     }
  */
 
-void restore_rt (void) asm ("__restore_rt");
+void restore_rt (void) __asm__ ("__restore_rt");
 
 #ifndef SA_RESTORER
 #define SA_RESTORER  0x04000000
@@ -61,7 +61,7 @@ void restore_rt (void) asm ("__restore_rt");
 
 #define DEFINE_RESTORE_RT(syscall) DEFINE_RESTORE_RT2(syscall)
 # define DEFINE_RESTORE_RT2(syscall)                \
-    asm (                                           \
+    __asm__ (                                       \
          "    nop\n"                                \
          ".align 16\n"                              \
          ".LSTART_restore_rt:\n"                    \
@@ -120,7 +120,7 @@ typedef struct {
 #define SIGNAL_MASK_TIME 1000
 
 #define save_return_point(ptr)                      \
-    asm volatile ("leaq 0(%%rip), %%rax\r\n"        \
+    __asm__ volatile ("leaq 0(%%rip), %%rax\r\n"        \
                   "movq %%rax, %0\r\n"              \
                   : "=b"(ptr) :: "memory", "rax")
 
@@ -238,7 +238,7 @@ static void return_frame (struct pal_frame * frame, int err)
     __clear_frame(frame);
     arch_restore_frame(&frame->arch);
 
-    asm volatile ("xor %rax, %rax\r\n"
+    __asm__ volatile ("xor %rax, %rax\r\n"
                   "leaveq\r\n"
                   "retq\r\n");
 }
@@ -271,7 +271,7 @@ static void _DkGenericSighandler (int signum, siginfo_t * info,
     if (signum == SIGCONT && frame && frame->func == DkObjectsWaitAny)
         return;
 
-    asm volatile ("movq %%rbp, %0" : "=r"(eframe));
+    __asm__ volatile ("movq %%rbp, %0" : "=r"(eframe));
 
     if (frame && frame->func != &_DkGenericSighandler &&
         signum != SIGCONT &&
@@ -294,7 +294,7 @@ static void _DkTerminateSighandler (int signum, siginfo_t * info,
     struct pal_frame * frame = get_frame(uc);
     void * eframe;
 
-    asm volatile ("movq %%rbp, %0" : "=r"(eframe));
+    __asm__ volatile ("movq %%rbp, %0" : "=r" (eframe));
 
     int event_num = get_event_num(signum);
     if (event_num == -1)

--- a/Pal/src/host/Linux/db_main.c
+++ b/Pal/src/host/Linux/db_main.c
@@ -43,7 +43,7 @@
 /* At the begining of entry point, rsp starts at argc, then argvs,
    envps and auxvs. Here we store rsp to rdi, so it will not be
    messed up by function calls */
-asm (".global pal_start \n"
+__asm__ (".global pal_start \n"
      "  .type pal_start,@function \n"
      "pal_start: \n"
      "  movq %rsp, %rdi \n"
@@ -56,7 +56,7 @@ asm (".global pal_start \n"
 
 /* use objfile-gdb convention instead of .debug_gdb_scripts */
 #ifdef DEBUG
-asm (".pushsection \".debug_gdb_scripts\", \"MS\",@progbits,1\r\n"
+__asm__ (".pushsection \".debug_gdb_scripts\", \"MS\",@progbits,1\r\n"
      ".byte 1\r\n"
      ".asciz \"" PAL_FILE("host/Linux/pal-gdb.py") "\"\r\n"
      ".popsection\r\n");
@@ -308,7 +308,7 @@ done_init:
 static void cpuid (unsigned int leaf, unsigned int subleaf,
                    unsigned int words[])
 {
-  asm("cpuid"
+  __asm__ ("cpuid"
       : "=a" (words[WORD_EAX]),
         "=b" (words[WORD_EBX]),
         "=c" (words[WORD_ECX]),

--- a/Pal/src/host/Linux/db_pipes.c
+++ b/Pal/src/host/Linux/db_pipes.c
@@ -40,6 +40,7 @@ typedef __kernel_pid_t pid_t;
 #include <asm/fcntl.h>
 #include <asm/poll.h>
 #include <sys/socket.h>
+#include <linux/time.h>
 #include <linux/un.h>
 #include <asm/errno.h>
 

--- a/Pal/src/host/Linux/db_sockets.c
+++ b/Pal/src/host/Linux/db_sockets.c
@@ -42,6 +42,7 @@ typedef __kernel_pid_t pid_t;
 #include <sys/socket.h>
 #include <linux/in.h>
 #include <linux/in6.h>
+#include <linux/time.h>
 #include <netinet/tcp.h>
 #include <asm/errno.h>
 

--- a/Pal/src/host/Linux/elf-x86_64.h
+++ b/Pal/src/host/Linux/elf-x86_64.h
@@ -67,7 +67,7 @@ elf_machine_load_address (void)
        load offset which is zero if the binary was loaded at the address
        it is prelinked for.  */
 
-    asm ("leaq " XSTRINGIFY(_ENTRY) "(%%rip), %0\n\t"
+    __asm__ ("leaq " XSTRINGIFY(_ENTRY) "(%%rip), %0\n\t"
          "subq 1f(%%rip), %0\n\t"
          ".section\t.data.rel.ro\n"
          "1:\t.quad " XSTRINGIFY(_ENTRY) "\n\t"

--- a/Pal/src/host/Linux/pal_host.h
+++ b/Pal/src/host/Linux/pal_host.h
@@ -193,7 +193,7 @@ struct arch_frame {
 
 #ifdef __x86_64__
 # define store_register(reg, var)     \
-    asm volatile ("movq %%" #reg ", %0" : "=a" (var) :: "memory");
+    __asm__ volatile ("movq %%" #reg ", %0" : "=a" (var) :: "memory");
 
 # define store_register_in_frame(reg, f)     store_register(reg, (f)->reg)
 
@@ -209,7 +209,7 @@ struct arch_frame {
     store_register_in_frame(r15, f)
 
 # define restore_register(reg, var, clobber...)  \
-    asm volatile ("movq %0, %%" #reg :: "g" (var) : "memory", ##clobber);
+    __asm__ volatile ("movq %0, %%" #reg :: "g" (var) : "memory", ##clobber);
 
 # define restore_register_in_frame(reg, f)       \
     restore_register(reg, (f)->reg,              \
@@ -264,7 +264,7 @@ void __store_frame (volatile struct pal_frame * frame,
     arch_store_frame(&frame->arch)
     frame->func = func;
     frame->funcname = funcname;
-    asm volatile ("nop" ::: "memory");
+    __asm__ volatile ("nop" ::: "memory");
     frame->identifier = PAL_FRAME_IDENTIFIER;
 }
 
@@ -277,7 +277,7 @@ static inline
 void __clear_frame (volatile struct pal_frame * frame)
 {
     if (frame->identifier == PAL_FRAME_IDENTIFIER) {
-        asm volatile ("nop" ::: "memory");
+        __asm__ volatile ("nop" ::: "memory");
         frame->identifier = 0;
     }
 }

--- a/Pal/src/host/Linux/sysdep-x86_64.h
+++ b/Pal/src/host/Linux/sysdep-x86_64.h
@@ -145,7 +145,7 @@
     unsigned long resultvar;                                \
     LOAD_ARGS_##nr (args)                                   \
     LOAD_REGS_##nr                                          \
-    asm volatile (                                          \
+    __asm__ volatile (                                      \
     DO_SYSCALL                                              \
     : "=a" (resultvar)                                      \
     : "0" (name) ASM_ARGS_##nr : "memory", "cc", "r11", "cx");  \
@@ -176,7 +176,7 @@
   long int __arg1 = (long) (a1);                        \
   LOAD_ARGS_0 ()
 #define LOAD_REGS_1                                     \
-  register long int _a1 asm ("rdi") = __arg1;           \
+  register long int _a1 __asm__ ("rdi") = __arg1;       \
   LOAD_REGS_0
 #define ASM_ARGS_1    ASM_ARGS_0, "r" (_a1)
 
@@ -184,7 +184,7 @@
   long int __arg2 = (long) (a2);                        \
   LOAD_ARGS_1 (a1)
 #define LOAD_REGS_2                                     \
-  register long int _a2 asm ("rsi") = __arg2;           \
+  register long int _a2 __asm__ ("rsi") = __arg2;       \
   LOAD_REGS_1
 #define ASM_ARGS_2    ASM_ARGS_1, "r" (_a2)
 
@@ -192,7 +192,7 @@
   long int __arg3 = (long) (a3);                        \
   LOAD_ARGS_2 (a1, a2)
 #define LOAD_REGS_3                                     \
-  register long int _a3 asm ("rdx") = __arg3;           \
+  register long int _a3 __asm__ ("rdx") = __arg3;       \
   LOAD_REGS_2
 #define ASM_ARGS_3    ASM_ARGS_2, "r" (_a3)
 
@@ -200,7 +200,7 @@
   long int __arg4 = (long) (a4);                        \
   LOAD_ARGS_3 (a1, a2, a3)
 #define LOAD_REGS_4                                     \
-  register long int _a4 asm ("r10") = __arg4;           \
+  register long int _a4 __asm__ ("r10") = __arg4;       \
   LOAD_REGS_3
 #define ASM_ARGS_4    ASM_ARGS_3, "r" (_a4)
 
@@ -208,7 +208,7 @@
   long int __arg5 = (long) (a5);                        \
   LOAD_ARGS_4 (a1, a2, a3, a4)
 #define LOAD_REGS_5                                     \
-  register long int _a5 asm ("r8") = __arg5;            \
+  register long int _a5 __asm__ ("r8") = __arg5;        \
   LOAD_REGS_4
 #define ASM_ARGS_5    ASM_ARGS_4, "r" (_a5)
 
@@ -216,7 +216,7 @@
   long int __arg6 = (long) (a6);                        \
   LOAD_ARGS_5 (a1, a2, a3, a4, a5)
 #define LOAD_REGS_6                                     \
-  register long int _a6 asm ("r9") = __arg6;            \
+  register long int _a6 __asm__ ("r9") = __arg6;        \
   LOAD_REGS_5
 #define ASM_ARGS_6    ASM_ARGS_5, "r" (_a6)
 

--- a/Pal/src/pal_internal.h
+++ b/Pal/src/pal_internal.h
@@ -231,7 +231,7 @@ extern struct pal_internal_state {
 #ifdef __GNUC__
 #define BREAK()                         \
     do {                                \
-        asm volatile ("int $3");        \
+        __asm__ volatile ("int $3");    \
     } while (0)
 #else
 #define BREAK()

--- a/Pal/src/security/Linux/Makefile
+++ b/Pal/src/security/Linux/Makefile
@@ -1,7 +1,7 @@
 CC	= gcc
 LD	= ld
 
-CFLAGS	= -Wall -fPIC -O2 -std=gnu99 -fgnu89-inline -Wall -U_FORTIFY_SOURCE \
+CFLAGS	= -Wall -fPIC -O2 -std=c11 -Wall -U_FORTIFY_SOURCE \
 	  -fno-stack-protector -fno-builtin \
 	  -DPAL_LOADER_PATH="$(abspath ../../libpal.so)" \
 	  -I. -I../../host/Linux/include -I../.. -I../../../include -I../../host/Linux \

--- a/Pal/src/security/Linux/main.c
+++ b/Pal/src/security/Linux/main.c
@@ -86,7 +86,7 @@ static void do_bootstrap (void * args, int * pargc, const char *** pargv,
         }
 
     if (!base) {
-        asm ("leaq start(%%rip), %0\r\n"
+        __asm__ ("leaq start(%%rip), %0\r\n"
              "subq 1f(%%rip), %0\r\n"
              ".section\t.data.rel.ro\r\n"
              "1:\t.quad start\r\n"
@@ -417,7 +417,7 @@ int install_syscall_filter (void * code_start, void * code_end);
 
 void start(void);
 
-asm (".global start\r\n"
+__asm__ (".global start\r\n"
      "  .type start,@function\r\n"
      ".global main\r\n"
      "  .type do_main,@function\r\n");
@@ -425,7 +425,7 @@ asm (".global start\r\n"
 /* At the begining of entry point, rsp starts at argc, then argvs,
    envps and auxvs. Here we store rsp to rdi, so it will not be
    messed up by function calls */
-asm ("start:\r\n"
+__asm__ ("start:\r\n"
      "  movq %rsp, %rdi\r\n"
      "  call do_main\r\n");
 
@@ -577,7 +577,7 @@ void do_main (void * args)
                 break;
         }
 
-    asm volatile ("xorq %%rsp, %%rsp\r\n"
+    __asm__ volatile ("xorq %%rsp, %%rsp\r\n"
                   "movq %0, %%rsp\r\n"
                   "jmpq *%1\r\n"
                   :: "r"(stack), "r"(pal_entry) : "memory");

--- a/Pal/test/Cpuid.c
+++ b/Pal/test/Cpuid.c
@@ -9,7 +9,7 @@
 int main (int argc, char ** argv, char ** envp)
 {
     PAL_NUM values[4];
-    asm volatile("mov $0, %%rax\n"
+    __asm__ volatile("mov $0, %%rax\n"
                  "cpuid\n"
                  : "=a"(values[0]),
                    "=b"(values[1]),

--- a/Pal/test/Fork.c
+++ b/Pal/test/Fork.c
@@ -13,7 +13,7 @@ struct stack_frame {
 
 PAL_HANDLE _fork (void * args)
 {
-    register struct stack_frame * fp asm("ebp");
+    register struct stack_frame * fp __asm__ ("ebp");
     struct stack_frame * frame = fp;
 
     if (args == NULL) {

--- a/Pal/test/Makefile
+++ b/Pal/test/Makefile
@@ -1,7 +1,7 @@
 include ../src/Makefile.Host
 
 CC	= gcc
-CFLAGS	= -Wall -O2 -std=gnu99 -fgnu89-inline -fno-builtin -nostdlib \
+CFLAGS	= -Wall -O2 -std=c11 -fno-builtin -nostdlib \
 	  -I../include/pal -I../lib
 
 .PHONY: default

--- a/Pal/test/Segment.c
+++ b/Pal/test/Segment.c
@@ -12,7 +12,7 @@ int main (int argc, char ** argv, char ** envp)
 {
     DkSegmentRegister(PAL_SEGMENT_FS, private);
     void * ptr;
-    asm volatile("mov %%fs:0, %0" : "=r"(ptr) :: "memory");
+    __asm__ volatile("mov %%fs:0, %0" : "=r"(ptr) :: "memory");
     pal_printf("TLS = %p\n", ptr);
     return 0;
 }


### PR DESCRIPTION
This PR replaces the `--std=gnu99 -fgnu89-inline` options with `--std=c11` in Linux/SGX PALs, all PAL tests, and LibOS. Code changes are included to make these components C11-compliant.

Note that native tests (in `LibOS/shim/test/native`) are still compiled with GNU standard. Significant efforts are required to make them C11-compliant, so I leave them for future work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/288)
<!-- Reviewable:end -->
