### PR TITLE
Vdso support

### DIFF
--- a/LibOS/01-glibc-gettimeofday.patch
+++ b/LibOS/01-glibc-gettimeofday.patch
@@ -1,0 +1,48 @@
+--- glibc-2.19-nopatch/sysdeps/unix/sysv/linux/x86_64/gettimeofday.c	2018-11-02 15:22:03.453512619 -0700
++++ glibc-2.19/sysdeps/unix/sysv/linux/x86_64/gettimeofday.c	2018-11-06 20:52:21.003309448 -0800
+@@ -17,12 +17,17 @@
+ 
+ #include <sys/time.h>
+ 
+-#if 0 /* In graphene, do not use vsyscall or VDSO call */
+ #ifdef SHARED
+ 
++# include <sysdep.h>
++# include <errno.h>
+ # include <dl-vdso.h>
+ 
+-# define VSYSCALL_ADDR_vgettimeofday	0xffffffffff600000ul
++static int
++__inline_gettimeofday (struct timeval *tv, struct timezone *tz)
++{
++  return INLINE_SYSCALL (gettimeofday, 2, tv, tz);
++}
+ 
+ void *gettimeofday_ifunc (void) __asm__ ("__gettimeofday");
+ 
+@@ -33,7 +38,7 @@ gettimeofday_ifunc (void)
+ 
+   /* If the vDSO is not available we fall back on the old vsyscall.  */
+   return (_dl_vdso_vsym ("__vdso_gettimeofday", &linux26)
+-	  ?: (void *) VSYSCALL_ADDR_vgettimeofday);
++	  ?: &__inline_gettimeofday);
+ }
+ asm (".type __gettimeofday, %gnu_indirect_function");
+ 
+@@ -43,8 +48,7 @@ asm (".type __gettimeofday, %gnu_indirec
+ asm (".globl __GI___gettimeofday\n"
+      "__GI___gettimeofday = __gettimeofday");
+ 
+-#endif
+-#endif
++#else
+ 
+ # include <sysdep.h>
+ # include <errno.h>
+@@ -56,5 +60,6 @@ __gettimeofday (struct timeval *tv, stru
+ }
+ libc_hidden_def (__gettimeofday)
+ 
++#endif
+ weak_alias (__gettimeofday, gettimeofday)
+ libc_hidden_weak (gettimeofday)

--- a/LibOS/02-glibc-sched-getscpu-S.patch
+++ b/LibOS/02-glibc-sched-getscpu-S.patch
@@ -1,0 +1,13 @@
+--- a/sysdeps/unix/sysv/linux/x86_64/sched_getcpu.S	2014-02-07 01:04:38.000000000 -0800
++++ b/sysdeps/unix/sysv/linux/x86_64/sched_getcpu.S	2018-11-06 01:30:35.894970038 -0800
+@@ -21,9 +21,7 @@
+ #include <bits/errno.h>
+ #include <kernel-features.h>
+ 
+-/* For the calculation see asm/vsyscall.h.  */
+-#define VSYSCALL_ADDR_vgetcpu	0xffffffffff600800
+-
++#define __ASSUME_GETCPU_SYSCALL
+ 
+ ENTRY (sched_getcpu)
+ 	/* Align stack and create local variable for result.  */

--- a/LibOS/03-glibc-time-c.patch
+++ b/LibOS/03-glibc-time-c.patch
@@ -1,0 +1,27 @@
+--- a/sysdeps/unix/sysv/linux/x86_64/time.c	2014-02-07 01:04:38.000000000 -0800
++++ b/sysdeps/unix/sysv/linux/x86_64/time.c	2018-11-06 01:42:24.778973490 -0800
+@@ -24,7 +24,14 @@
+ 
+ #include <dl-vdso.h>
+ 
+-#define VSYSCALL_ADDR_vtime	0xffffffffff600400
++# include <sysdep.h>
++
++time_t
++__inline_time (time_t *t)
++{
++  INTERNAL_SYSCALL_DECL (err);
++  return INTERNAL_SYSCALL (time, err, 1, t);
++}
+ 
+ /* Avoid DWARF definition DIE on ifunc symbol so that GDB can handle
+    ifunc symbol properly.  */
+@@ -37,7 +44,7 @@ time_ifunc (void)
+   PREPARE_VERSION (linux26, "LINUX_2.6", 61765110);
+ 
+   /* If the vDSO is not available we fall back on the old vsyscall.  */
+-  return _dl_vdso_vsym ("__vdso_time", &linux26) ?: (void *) VSYSCALL_ADDR_vtime;
++  return _dl_vdso_vsym ("__vdso_time", &linux26) ?: &__inline_time;
+ }
+ __asm (".type __libc_time, %gnu_indirect_function");
+ 

--- a/LibOS/04-pthread-cond-timedwait-S.patch
+++ b/LibOS/04-pthread-cond-timedwait-S.patch
@@ -1,0 +1,65 @@
+--- a/nptl/sysdeps/unix/sysv/linux/x86_64/pthread_cond_timedwait.S	2014-02-07 01:04:38.000000000 -0800
++++ b/nptl/sysdeps/unix/sysv/linux/x86_64/pthread_cond_timedwait.S	2018-11-06 02:00:42.586978836 -0800
+@@ -188,7 +188,7 @@ __pthread_cond_timedwait:
+ 	movq	%r12, %rdx
+ 	addq	$cond_futex, %rdi
+ 	movl	$SYS_futex, %eax
+-	syscall
++	SYSCALLDB
+ 
+ 	cmpl	$0, %eax
+ 	sete	%r15b
+@@ -234,7 +234,7 @@ __pthread_cond_timedwait:
+ 	movq	%r12, %rdx
+ 	addq	$cond_futex, %rdi
+ 	movl	$SYS_futex, %eax
+-	syscall
++	SYSCALLDB
+ 62:	movq	%rax, %r14
+ 
+ 	movl	(%rsp), %edi
+@@ -321,7 +321,7 @@ __pthread_cond_timedwait:
+ 	orl	$FUTEX_WAKE, %esi
+ #endif
+ 	movl	$SYS_futex, %eax
+-	syscall
++	SYSCALLDB
+ 	subq	$cond_nwaiters, %rdi
+ 
+ 55:	LOCK
+@@ -492,7 +492,7 @@ __pthread_cond_timedwait:
+ 	call	*%rax
+ #  else
+ 	movl	$__NR_clock_gettime, %eax
+-	syscall
++	SYSCALLDB
+ #  endif
+ 
+ 	/* Compute relative timeout.  */
+@@ -560,7 +560,7 @@ __pthread_cond_timedwait:
+ # endif
+ 	addq	$cond_futex, %rdi
+ 	movl	$SYS_futex, %eax
+-	syscall
++	SYSCALLDB
+ 	movq	%rax, %r14
+ 
+ 	movl	(%rsp), %edi
+@@ -732,7 +732,7 @@ __condvar_cleanup2:
+ 	orl	$FUTEX_WAKE, %esi
+ #endif
+ 	movl	$SYS_futex, %eax
+-	syscall
++	SYSCALLDB
+ 	subq	$cond_nwaiters, %rdi
+ 	movl	$1, %r12d
+ 
+@@ -769,7 +769,7 @@ __condvar_cleanup2:
+ 	orl	$FUTEX_WAKE, %esi
+ #endif
+ 	movl	$SYS_futex, %eax
+-	syscall
++	SYSCALLDB
+ 
+ 	/* Lock the mutex only if we don't own it already.  This only happens
+ 	   in case of PI mutexes, if we got cancelled after a successful

--- a/LibOS/Makefile
+++ b/LibOS/Makefile
@@ -31,13 +31,24 @@ else
 endif
 
 ifeq ($(shell git ls-files $(GLIBC_SRC)/configure),)
-$(GLIBC_SRC)/configure: $(GLIBC_SRC).patch
+GLIBC_PATCHES = \
+	$(GLIBC_SRC).patch \
+	glibc-fix-warning.patch \
+	glibc-no-pie.patch \
+	01-glibc-gettimeofday.patch \
+	02-glibc-sched-getscpu-S.patch \
+	03-glibc-time-c.patch \
+	04-pthread-cond-timedwait-S.patch
+
+$(GLIBC_SRC)/configure: $(GLIBC_PATCHES) Makefile
 	[ -f $(GLIBC_SRC).tar.gz ] || \
 	wget http://ftp.gnu.org/gnu/glibc/$(GLIBC_SRC).tar.gz
 	tar -xzf $(GLIBC_SRC).tar.gz
-	cd $(GLIBC_SRC) && patch -p1 < ../$(GLIBC_SRC).patch
-	cd $(GLIBC_SRC) && patch -p1 < ../glibc-fix-warning.patch
-	cd $(GLIBC_SRC) && patch -p1 < ../glibc-no-pie.patch
+	cd $(GLIBC_SRC) && \
+	for p in $(GLIBC_PATCHES); do \
+		echo applying $$p; \
+		patch -p1 < ../$$p; \
+	done
 endif
 
 .PHONY: clean

--- a/LibOS/glibc-2.19.patch
+++ b/LibOS/glibc-2.19.patch
@@ -1172,81 +1172,6 @@ index 53d65b6..16df581 100644
  
  	/* Unlock.  */
  4:	LOCK
-diff --git a/nptl/sysdeps/unix/sysv/linux/x86_64/pthread_cond_timedwait.S b/nptl/sysdeps/unix/sysv/linux/x86_64/pthread_cond_timedwait.S
-index 0dc2340..8aff242 100644
---- a/nptl/sysdeps/unix/sysv/linux/x86_64/pthread_cond_timedwait.S
-+++ b/nptl/sysdeps/unix/sysv/linux/x86_64/pthread_cond_timedwait.S
-@@ -188,7 +188,7 @@ __pthread_cond_timedwait:
- 	movq	%r12, %rdx
- 	addq	$cond_futex, %rdi
- 	movl	$SYS_futex, %eax
--	syscall
-+	SYSCALLDB
- 
- 	cmpl	$0, %eax
- 	sete	%r15b
-@@ -234,7 +234,7 @@ __pthread_cond_timedwait:
- 	movq	%r12, %rdx
- 	addq	$cond_futex, %rdi
- 	movl	$SYS_futex, %eax
--	syscall
-+	SYSCALLDB
- 62:	movq	%rax, %r14
- 
- 	movl	(%rsp), %edi
-@@ -321,7 +321,7 @@ __pthread_cond_timedwait:
- 	orl	$FUTEX_WAKE, %esi
- #endif
- 	movl	$SYS_futex, %eax
--	syscall
-+	SYSCALLDB
- 	subq	$cond_nwaiters, %rdi
- 
- 55:	LOCK
-@@ -485,15 +485,8 @@ __pthread_cond_timedwait:
- 	/* Only clocks 0 and 1 are allowed so far.  Both are handled in the
- 	   kernel.  */
- 	leaq	32(%rsp), %rsi
--#  ifdef SHARED
--	mov	__vdso_clock_gettime@GOTPCREL(%rip), %RAX_LP
--	mov	(%rax), %RAX_LP
--	PTR_DEMANGLE (%RAX_LP)
--	call	*%rax
--#  else
- 	movl	$__NR_clock_gettime, %eax
--	syscall
--#  endif
-+	SYSCALLDB
- 
- 	/* Compute relative timeout.  */
- 	movq	(%r13), %rcx
-@@ -560,7 +553,7 @@ __pthread_cond_timedwait:
- # endif
- 	addq	$cond_futex, %rdi
- 	movl	$SYS_futex, %eax
--	syscall
-+	SYSCALLDB
- 	movq	%rax, %r14
- 
- 	movl	(%rsp), %edi
-@@ -732,7 +725,7 @@ __condvar_cleanup2:
- 	orl	$FUTEX_WAKE, %esi
- #endif
- 	movl	$SYS_futex, %eax
--	syscall
-+	SYSCALLDB
- 	subq	$cond_nwaiters, %rdi
- 	movl	$1, %r12d
- 
-@@ -769,7 +762,7 @@ __condvar_cleanup2:
- 	orl	$FUTEX_WAKE, %esi
- #endif
- 	movl	$SYS_futex, %eax
--	syscall
-+	SYSCALLDB
- 
- 	/* Lock the mutex only if we don't own it already.  This only happens
- 	   in case of PI mutexes, if we got cancelled after a successful
 diff --git a/nptl/sysdeps/unix/sysv/linux/x86_64/pthread_cond_wait.S b/nptl/sysdeps/unix/sysv/linux/x86_64/pthread_cond_wait.S
 index 0e61d0a..b4bcc15 100644
 --- a/nptl/sysdeps/unix/sysv/linux/x86_64/pthread_cond_wait.S
@@ -1561,24 +1486,6 @@ index 49f0384..6b1a975 100644
  	/* Without working sigaltstack we cannot perform the test.  */
  	testl	%eax, %eax
  	jne	.Lok2
-diff --git a/sysdeps/unix/sysv/linux/x86_64/clock_gettime.c b/sysdeps/unix/sysv/linux/x86_64/clock_gettime.c
-index f712110..f6bad14 100644
---- a/sysdeps/unix/sysv/linux/x86_64/clock_gettime.c
-+++ b/sysdeps/unix/sysv/linux/x86_64/clock_gettime.c
-@@ -1,5 +1,6 @@
- #include "bits/libc-vdso.h"
- 
-+#if 0 /* in Graphene, disallow VDSO calls */
- #ifdef SHARED
- # define SYSCALL_GETTIME(id, tp) \
-   ({ long int (*f) (clockid_t, struct timespec *) = __vdso_clock_gettime; \
-@@ -16,5 +17,6 @@
-   PTR_DEMANGLE (f);							  \
-   f (id, tp); })
- #endif
-+#endif
- 
- #include "../clock_gettime.c"
 diff --git a/sysdeps/unix/sysv/linux/x86_64/clone.S b/sysdeps/unix/sysv/linux/x86_64/clone.S
 index 0508730..e1b35ec 100644
 --- a/sysdeps/unix/sysv/linux/x86_64/clone.S
@@ -1670,45 +1577,6 @@ index 440ca7f..571125d 100644
 -#endif
  weak_alias (__gettimeofday, gettimeofday)
  libc_hidden_weak (gettimeofday)
-diff --git a/sysdeps/unix/sysv/linux/x86_64/sched_getcpu.S b/sysdeps/unix/sysv/linux/x86_64/sched_getcpu.S
-index 0fd47f2..7a82975 100644
---- a/sysdeps/unix/sysv/linux/x86_64/sched_getcpu.S
-+++ b/sysdeps/unix/sysv/linux/x86_64/sched_getcpu.S
-@@ -30,6 +30,7 @@ ENTRY (sched_getcpu)
- 	sub	$0x8, %rsp
- 	cfi_adjust_cfa_offset(8)
- 
-+#if 0 /* for Graphene, never do VDSO calls */
- 	movq	%rsp, %rdi
- 	xorl	%esi, %esi
- 	movl	$VGETCPU_CACHE_OFFSET, %edx
-@@ -39,16 +40,19 @@ ENTRY (sched_getcpu)
- 	movq	__vdso_getcpu(%rip), %rax
- 	PTR_DEMANGLE (%rax)
- 	callq	*%rax
--#else
--# ifdef __NR_getcpu
-+#endif
-+#endif
-+
-+#ifdef __NR_getcpu
- 	movl	$__NR_getcpu, %eax
--	syscall
--#  ifndef __ASSUME_GETCPU_SYSCALL
-+	SYSCALLDB
-+#endif
-+
-+#if 0 /* for Graphene, never do vsyscall */
-+# ifndef __ASSUME_GETCPU_SYSCALL
- 	cmpq	$-ENOSYS, %rax
- 	jne	1f
--#  endif
--# endif
--# ifndef __ASSUME_GETCPU_SYSCALL
-+
- 	movq	$VSYSCALL_ADDR_vgetcpu, %rax
- 	callq	*%rax
- 1:
 diff --git a/sysdeps/unix/sysv/linux/x86_64/setcontext.S b/sysdeps/unix/sysv/linux/x86_64/setcontext.S
 index b726fa0..bb3ae34 100644
 --- a/sysdeps/unix/sysv/linux/x86_64/setcontext.S
@@ -1881,72 +1749,6 @@ index 4a9a9d9..dc452ed 100644
  
  # define LOAD_ARGS_0()
  # define LOAD_REGS_0
-diff --git a/sysdeps/unix/sysv/linux/x86_64/time.c b/sysdeps/unix/sysv/linux/x86_64/time.c
-deleted file mode 100644
-index 79f1fab..0000000
---- a/sysdeps/unix/sysv/linux/x86_64/time.c
-+++ /dev/null
-@@ -1,60 +0,0 @@
--/* Copyright (C) 2001-2014 Free Software Foundation, Inc.
--   This file is part of the GNU C Library.
--
--   The GNU C Library is free software; you can redistribute it and/or
--   modify it under the terms of the GNU Lesser General Public
--   License as published by the Free Software Foundation; either
--   version 2.1 of the License, or (at your option) any later version.
--
--   The GNU C Library is distributed in the hope that it will be useful,
--   but WITHOUT ANY WARRANTY; without even the implied warranty of
--   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
--   Lesser General Public License for more details.
--
--   You should have received a copy of the GNU Lesser General Public
--   License along with the GNU C Library; if not, see
--   <http://www.gnu.org/licenses/>.  */
--
--#ifdef SHARED
--/* Redefine time so that the compiler won't complain about the type
--   mismatch with the IFUNC selector in strong_alias, below.  */
--#undef time
--#define time __redirect_time
--#include <time.h>
--
--#include <dl-vdso.h>
--
--#define VSYSCALL_ADDR_vtime	0xffffffffff600400
--
--/* Avoid DWARF definition DIE on ifunc symbol so that GDB can handle
--   ifunc symbol properly.  */
--extern __typeof (__redirect_time) __libc_time;
--void *time_ifunc (void) __asm__ ("__libc_time");
--
--void *
--time_ifunc (void)
--{
--  PREPARE_VERSION (linux26, "LINUX_2.6", 61765110);
--
--  /* If the vDSO is not available we fall back on the old vsyscall.  */
--  return _dl_vdso_vsym ("__vdso_time", &linux26) ?: (void *) VSYSCALL_ADDR_vtime;
--}
--__asm (".type __libc_time, %gnu_indirect_function");
--
--#undef time
--strong_alias (__libc_time, time)
--libc_hidden_ver (__libc_time, time)
--
--#else
--
--# include <time.h>
--# include <sysdep.h>
--
--time_t
--time (time_t *t)
--{
--  INTERNAL_SYSCALL_DECL (err);
--  return INTERNAL_SYSCALL (time, err, 1, t);
--}
--
--#endif
 diff --git a/sysdeps/unix/sysv/linux/x86_64/vfork.S b/sysdeps/unix/sysv/linux/x86_64/vfork.S
 index d3b450a..75a63e1 100644
 --- a/sysdeps/unix/sysv/linux/x86_64/vfork.S

--- a/LibOS/shim/include/shim_vdso.h
+++ b/LibOS/shim/include/shim_vdso.h
@@ -1,0 +1,31 @@
+/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
+/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
+/*
+ * Copyright 2018 Intel Corporation.
+ * Copyright 2018 Isaku Yamahata <isaku.yamahata at intel.com>
+ *                               <isaku.yamahata at gmail.com>
+ * All Rights Reserved.
+ *
+ * This file is part of Graphene Library OS.
+ *
+ * Graphene Library OS is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Graphene Library OS is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef _SHIM_VDSO_H_
+#define _SHIM_VDSO_H_
+
+/* TODO: remove PAGE SIZE alignment for runtime value, allocsz? */
+extern unsigned char vdso_so[4096] __attribute((aligned(4096)));
+
+#endif /* _SHIM_VDSO_H_ */

--- a/LibOS/shim/src/Makefile
+++ b/LibOS/shim/src/Makefile
@@ -43,7 +43,8 @@ objs	= $(addprefix bookkeep/shim_,handle vma thread signal) \
 	  elf/shim_rtld \
 	  $(addprefix shim_,init table syscalls checkpoint random malloc \
 	  async parser debug) syscallas start \
-	  $(patsubst %.c,%,$(wildcard sys/*.c))
+	  $(patsubst %.c,%,$(wildcard sys/*.c)) \
+	  vdso/vdso-data
 graphene_lib = .lib/graphene-lib.a
 pal_lib = $(RUNTIME_DIR)/libpal-$(PAL_HOST).so
 headers = ../include/*.h ../../../Pal/lib/*.h ../../../Pal/include/pal/*.h
@@ -119,6 +120,23 @@ elf/shim_rtld.o: $(wildcard elf/*.h)
 %.e: %.S $(headers)
 	@echo [ $@ ]
 	@$(AS) $(ASFLAGS) $(defs) -E $< -o $@
+
+LDFLAGS_vdso = -nostdlib -shared  \
+               --hash-style=both --build-id -Bsymbolic \
+               -m elf_x86_64 -soname linux-vdso.so.1 \
+               --no-undefined \
+               -z max-page-size=4096 -z common-page-size=4096
+vdso/vdso.so.dbg: vdso/vdso.lds vdso/vdso.o
+	@echo [ $@ ]
+	$(LD) -o $@ -T $(filter %.lds, $^) $(LDFLAGS_vdso) $(filter %.o, $^)
+
+vdso/vdso.so: vdso/vdso.so.dbg
+	@echo [ $@ ]
+	objcopy -S $^ $@
+
+vdso/vdso-data.c: vdso/vdso.so
+	@echo [ $@ ]
+	xxd -i $^ | sed -e 's/vdso_vdso_/vdso_/' -e 's/\[\]/[4096]/' -e 's/= {/__attribute__((aligned(4096))) = {/' > $@
 
 clean:
 	rm -rf $(addsuffix .o,$(objs)) $(shim_target) .lib

--- a/LibOS/shim/src/elf/shim_rtld.c
+++ b/LibOS/shim/src/elf/shim_rtld.c
@@ -35,6 +35,7 @@
 #include <shim_vma.h>
 #include <shim_checkpoint.h>
 #include <shim_profile.h>
+#include <shim_vdso.h>
 
 #include <errno.h>
 
@@ -58,6 +59,7 @@ enum object_type {
     OBJECT_MAPPED       = 2,
     OBJECT_REMAP        = 3,
     OBJECT_USER         = 4,
+    OBJECT_VDSO         = 5,
 };
 
 /* Structure describing a loaded shared object.  The `l_next' and `l_prev'
@@ -150,6 +152,7 @@ struct link_map * lookup_symbol (const char * undef_name, ElfW(Sym) ** ref);
 
 static struct link_map * loaded_libraries = NULL;
 static struct link_map * internal_map = NULL, * interp_map = NULL;
+static struct link_map * vdso_map = NULL;
 
 /* This macro is used as a callback from the ELF_DYNAMIC_RELOCATE code.  */
 static ElfW(Addr) resolve_map (const char ** strtab, ElfW(Sym) ** ref)
@@ -375,7 +378,7 @@ __map_elf_object (struct shim_handle * file,
     int errval = 0;
     int ret;
 
-    if (type != OBJECT_INTERNAL && !file) {
+    if (type != OBJECT_INTERNAL && type != OBJECT_VDSO && !file) {
         errstring = "shared object has to be backed by file";
         errval = -EINVAL;
 call_lose:
@@ -591,9 +594,9 @@ do_remap:
             }
 
 #if BOOKKEEP_INTERNAL_OBJ == 0
-                if (type != OBJECT_INTERNAL && type != OBJECT_USER)
+                if (type != OBJECT_INTERNAL && type != OBJECT_USER && type != OBJECT_VDSO)
 #else
-                if (type != OBJECT_USER)
+                if (type != OBJECT_USER && type != OBJECT_VDSO)
 #endif
                     bkeep_mmap(mapaddr, c->mapend - c->mapstart, c->prot,
                                c->flags|MAP_FIXED|MAP_PRIVATE|
@@ -625,7 +628,9 @@ postmap:
 
             if (type != OBJECT_MAPPED &&
                 type != OBJECT_INTERNAL &&
-                type != OBJECT_USER && zeropage > zero) {
+                type != OBJECT_USER &&
+                type != OBJECT_VDSO &&
+                zeropage > zero) {
                 /* Zero the final part of the last page of the segment.  */
                 if (__builtin_expect ((c->prot & PROT_WRITE) == 0, 0)) {
                     /* Dag nab it.  */
@@ -649,7 +654,8 @@ postmap:
             if (zeroend > zeropage) {
                 if (type != OBJECT_MAPPED &&
                     type != OBJECT_INTERNAL &&
-                    type != OBJECT_USER) {
+                    type != OBJECT_USER &&
+                    type != OBJECT_VDSO) {
                     caddr_t mapat = (caddr_t)
                         DkVirtualMemoryAlloc((caddr_t) zeropage,
                                              zeroend - zeropage,
@@ -661,9 +667,9 @@ postmap:
                 }
 
 #if BOOKKEEP_INTERNAL_OBJ == 0
-                if (type != OBJECT_INTERNAL && type != OBJECT_USER)
+                if (type != OBJECT_INTERNAL && type != OBJECT_USER && type != OBJECT_VDSO)
 #else
-                if (type != OBJECT_USER)
+                if (type != OBJECT_USER && type != OBJECT_VDSO)
 #endif
                     bkeep_mmap((void *) zeropage, zeroend - zeropage, c->prot,
                                MAP_ANONYMOUS|MAP_PRIVATE|MAP_FIXED|
@@ -1050,7 +1056,7 @@ static int __load_elf_object (struct shim_handle * file, void * addr,
         goto out;
     }
 
-    if (type != OBJECT_INTERNAL)
+    if (type != OBJECT_INTERNAL && type != OBJECT_VDSO)
         do_relocate_object(map);
 
     if (internal_map) {
@@ -1060,6 +1066,8 @@ static int __load_elf_object (struct shim_handle * file, void * addr,
 
     if (type == OBJECT_INTERNAL)
         internal_map = map;
+    if (type == OBJECT_VDSO)
+        vdso_map = map;
 
     if (type != OBJECT_REMAP) {
         if (file) {
@@ -1254,14 +1262,21 @@ do_lookup_map (ElfW(Sym) * ref, const char * undef_name,
 /* Inner part of the lookup functions.  We return a value > 0 if we
    found the symbol, the value 0 if nothing is found and < 0 if
    something bad happened.  */
-static int do_lookup (const char * undef_name, ElfW(Sym) * ref,
-                      struct sym_val * result)
+static ElfW(Sym) *
+__do_lookup (const char * undef_name, ElfW(Sym) * ref,
+             struct link_map * map)
 {
     const uint_fast32_t fast_hash = elf_fast_hash(undef_name);
     const long int hash = elf_hash(undef_name);
+    return do_lookup_map(ref, undef_name, fast_hash, hash, map);
+}
+
+static int do_lookup (const char * undef_name, ElfW(Sym) * ref,
+                      struct sym_val * result)
+{
     ElfW(Sym) *sym = NULL;
 
-    sym = do_lookup_map(ref, undef_name, fast_hash, hash, internal_map);
+    sym = __do_lookup(undef_name, ref, internal_map);
 
     if (!sym)
         return 0;;
@@ -1292,7 +1307,6 @@ static int do_lookup (const char * undef_name, ElfW(Sym) * ref,
     /* We have not found anything until now.  */
     return 0;
 }
-
 
 /* Search loaded objects' symbol tables for a definition of the symbol
    UNDEF_NAME, perhaps with a requested version for the symbol.
@@ -1469,11 +1483,59 @@ int remove_loaded_libraries (void)
 void * __load_address;
 void * migrated_shim_addr __attribute_migratable = &__load_address;
 
+static int init_vdso_map(void)
+{
+    __load_elf_object(NULL, vdso_so, OBJECT_VDSO, NULL);
+    vdso_map->l_name = "vDSO";
+
+    if (!DkVirtualMemoryProtect(ALIGN_DOWN((void*)vdso_so),
+                                ALIGN_UP(sizeof(vdso_so)),
+                                PAL_PROT_READ | PAL_PROT_WRITE)) {
+            return -PAL_ERRNO;
+    }
+
+    struct {
+        const char *name;
+        uintptr_t value;
+    } vsyms[] = {
+        {
+            .name = "__vdso_clock_gettime",
+            .value = (uintptr_t)&__shim_clock_gettime,
+        },
+        {
+            .name = "__vdso_gettimeofday",
+            .value = (uintptr_t)&__shim_gettimeofday,
+        },
+        {
+            .name = "__vdso_time",
+            .value = (uintptr_t)&__shim_time,
+        },
+        {
+            .name = "__vdso_getcpu",
+            .value = (uintptr_t)&__shim_getcpu,
+        }
+    };
+    for (int i = 0; i < sizeof(vsyms)/sizeof(vsyms[0]); i++) {
+        ElfW(Sym) *sym = __do_lookup(vsyms[i].name, NULL, vdso_map);
+        if (sym == NULL) {
+            debug("vDSO: unfound symbol value for %s\n", vsyms[i].name);
+        }
+        sym->st_value = vsyms[i].value - vdso_map->l_addr;
+    }
+
+    if (!DkVirtualMemoryProtect(ALIGN_DOWN((void*)vdso_so),
+                                ALIGN_UP(sizeof(vdso_so)),
+                                PAL_PROT_READ | PAL_PROT_EXEC)) {
+            return -PAL_ERRNO;
+    }
+    return 0;
+}
+
 int init_internal_map (void)
 {
     __load_elf_object(NULL, &__load_address, OBJECT_INTERNAL, NULL);
     internal_map->l_name = "libsysdb.so";
-    return 0;
+    return init_vdso_map();
 }
 
 int init_brk_from_executable (struct shim_handle * exec);
@@ -1569,7 +1631,9 @@ int execute_elf_object (struct shim_handle * exec, int argc, const char ** argp,
     auxp[3].a_un.a_val = exec_map->l_entry;
     auxp[4].a_type = AT_BASE;
     auxp[4].a_un.a_val = interp_map ? interp_map->l_addr : 0;
-    auxp[5].a_type = AT_NULL;
+    auxp[5].a_type = AT_SYSINFO_EHDR;
+    auxp[5].a_un.a_val = (uint64_t)vdso_so;
+    auxp[6].a_type = AT_NULL;
 
     ElfW(Addr) entry = interp_map ? interp_map->l_entry : exec_map->l_entry;
 

--- a/LibOS/shim/src/shim_init.c
+++ b/LibOS/shim/src/shim_init.c
@@ -287,6 +287,7 @@ int populate_user_stack (void * stack, size_t stack_size,
 {
     const char ** argv = *argvp, ** envp = *envpp;
     const char ** new_argv = NULL, ** new_envp = NULL;
+    elf_auxv_t *new_auxp = NULL;
     void * stack_bottom = stack;
     void * stack_top = stack + stack_size;
 
@@ -325,21 +326,30 @@ copy_envp:
     if (!new_envp)
         *(const char **) ALLOCATE_BOTTOM(sizeof(const char *)) = NULL;
 
-    stack_bottom = (void *) ((unsigned long) stack_bottom & ~7UL);
-    *((unsigned long *) ALLOCATE_TOP(sizeof(unsigned long))) = 0;
-
     if (nauxv) {
-        elf_auxv_t * old_auxp = *auxpp;
-        *auxpp = ALLOCATE_TOP(sizeof(elf_auxv_t) * nauxv);
-        if (old_auxp)
-            memcpy(*auxpp, old_auxp, nauxv * sizeof(elf_auxv_t));
+        /* 32 for other usage */
+        new_auxp = ALLOCATE_BOTTOM(sizeof(elf_auxv_t) * (nauxv + 32));
+        if (*auxpp)
+            memcpy(new_auxp, *auxpp, nauxv * sizeof(elf_auxv_t));
     }
 
-    memmove(stack_top - (stack_bottom - stack), stack, stack_bottom - stack);
+    *((unsigned long *) ALLOCATE_TOP(sizeof(unsigned long))) = 0;
+
+    /* x86_64 ABI requires 16 bytes alignment on stack
+     * on entering _start.
+     * 8 bytes for pushq %%rdi by execute_elf_object before jmp.
+     */
+#define ALIGN_DOWN_PTR(ptr, size)   (((uintptr_t)ptr) & -(size))
+#define ALIGN_UP_PTR(ptr, size)     ALIGN_DOWN_PTR(((uintptr_t)ptr) + (size - 1), (size))
+    stack_top = (void*)(ALIGN_DOWN_PTR(stack_top, 16UL));
+    stack_bottom = (void*)(ALIGN_UP_PTR(stack_bottom, 16UL));
+    memmove(stack_top - (stack_bottom - stack) - 8, stack, stack_bottom - stack);
     if (new_argv)
-        *argvp = (void *) new_argv + (stack_top - stack_bottom);
+        *argvp = (void *) new_argv + (stack_top - stack_bottom) - 8;
     if (new_envp)
-        *envpp = (void *) new_envp + (stack_top - stack_bottom);
+        *envpp = (void *) new_envp + (stack_top - stack_bottom) - 8;
+    if (new_auxp)
+        *auxpp = (void *) new_auxp + (stack_top - stack_bottom) - 8;
     return 0;
 }
 

--- a/LibOS/shim/src/vdso/.gitignore
+++ b/LibOS/shim/src/vdso/.gitignore
@@ -1,0 +1,2 @@
+vdso-data.c
+vdso.so.dbg

--- a/LibOS/shim/src/vdso/vdso.c
+++ b/LibOS/shim/src/vdso/vdso.c
@@ -1,0 +1,81 @@
+/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
+/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
+
+/* Copyright (C) 2018 Intel Corporation
+                      Isaku Yamahata <isaku.yamahata at gmail.com>
+                                     <isaku.yamahata at intel.com>
+   All Rights Reserved.
+
+   This file is part of Graphene Library OS.
+
+   Graphene Library OS is free software: you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public License
+   as published by the Free Software Foundation, either version 3 of the
+   License, or (at your option) any later version.
+
+   Graphene Library OS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <shim_types.h>
+
+int __vdso_clock_gettime(clockid_t clock, struct timespec *t)
+{
+    return 0;
+}
+int clock_gettime(clockid_t clock, struct timespec *t)
+    __attribute__((weak, alias("__vdso_clock_gettime")));
+
+int __vdso_gettimeofday(struct timeval *tv, struct timezone *tz)
+{
+    return 0;
+}
+int gettimeofday(struct timeval *tv, struct timezone *tz)
+    __attribute__((weak, alias("__vdso_gettimeofday")));
+
+time_t __vdso_time(time_t *t)
+{
+    return 0;
+}
+time_t time(time_t *t) __attribute__((weak, alias("__vdso_time")));
+
+long __vdso_getcpu(unsigned *cpu, struct getcpu_cache *unused)
+{
+    return 0;
+}
+long getcpu(unsigned *cpu, struct getcpu_cache *unused)
+    __attribute__((weak, alias("__vdso_getcpu")));
+
+
+/* notes section: .note.Linux */
+asm(".pushsection .note.Linux, \"a\", @note\n");
+struct __Elf64_Nhdr {
+    Elf64_Nhdr nhdr;
+    /* 6 = length of "Linux" (including tailing '\0')*/
+    unsigned char name[6] __attribute__((aligned(sizeof(Elf64_Word))));
+    // unsigned char desc[0] __attribute__((aligned(sizeof(Elf64_Word))));
+    unsigned int desc __attribute__((aligned(sizeof(Elf64_Word))));
+};
+
+struct __Elf64_Nhdr __vdso_note_Linux
+__attribute__((aligned(sizeof(Elf64_Word)), unused)) = {
+    .nhdr.n_namesz = 6,
+    .nhdr.n_descsz = sizeof(int),
+    .nhdr.n_type = 0,
+    .name = "Linux",
+    .desc = 267008,  /* LINUX_VERSION_CODE */
+};
+struct __Elf64_Nhdr __vdso_note_Linux_salt
+__attribute__((aligned(sizeof(Elf64_Word)), unused)) = {
+    .nhdr.n_namesz = 6,
+    .nhdr.n_descsz = sizeof(int),
+    .nhdr.n_type = 0x100,
+    .name = "Linux",
+    .desc = 0,  /* CONFIG_BUILD_SALT TODO */
+};
+asm(".popsection\n");

--- a/LibOS/shim/src/vdso/vdso.lds
+++ b/LibOS/shim/src/vdso/vdso.lds
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2018 Intel Corporation
+ *                    Isaku Yamahata <isaku.yamahata at gmail.com>
+ *                                   <isaku.yamahata at intel.com>
+ * All Rights Reserved.*
+ * This file is part of*Graphene Library OS.
+ *
+ * Graphene Library OS is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Graphene Library OS is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Linker script for graphene vDSO simulation
+ */
+
+PHDRS
+{
+        text            PT_LOAD         FLAGS(5) FILEHDR PHDRS;
+        dynamic         PT_DYNAMIC      FLAGS(4);
+        note            PT_NOTE         FLAGS(4);
+        eh_frame_header PT_GNU_EH_FRAME;
+}
+
+SECTIONS
+{
+        . = SIZEOF_HEADERS;
+        .hash : { *(.hash) } :text
+        .gnu.hash : { *(.gnu.hash) }
+        .dynsym : { *(.dynsym) }
+        .dynstr : { *(.dynstr) }
+        .gnu.version : { *(.gnu.version) }
+        .gnu.version_d : { *(.gnu.version_d) }
+        .gnu.version_r : { *(.gnu.version_r) }
+        .dynamic : { *(.dynamic) } :text :dynamic
+        .rodata : {
+                *(.rodata*)
+                *(.data*)
+                *(.sdata*)
+                *(.got.plt) *(.got)
+                *(.gnu.linkonce.d.*)
+                *(.bss*)
+                *(.dynbss*)
+                *(.gnu.linkonce.b.*)
+        } : text
+        .note : { *(.note.*) } :text :note
+        .eh_frame_hdr : { *(.eh_frame_hdr) } :text :eh_frame_hdr
+        .eh_frame : { KEEP (*(.eh_frame)) } :text
+        .text   : { *(.text*) } : text = 0x909090
+
+        /DISCARD/ : {
+                *(.discard)
+                *(.discard.*)
+        }
+}
+
+VERSION {
+        LINUX_2.6 {
+        global:
+                clock_gettime;
+                __vdso_clock_gettime;
+                gettimeofday;
+                __vdso_gettimeofday;
+                getcpu;
+                __vdso_getcpu;
+                time;
+                __vdso_time;
+        local: *;
+        };
+}


### PR DESCRIPTION
LibOS: vDSO support

This patch series adds vDSO support to LibOS.
the first patch adds vDSO support to LibOS. It create dedicated page which contains necessary symbols in ELF format. plus fix of stack initialization to align 16bytes of stack
which is required by x86_64 ABI.

the second patch removes modification to glibc to avoid vDSO usage.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/290)
<!-- Reviewable:end -->
