### PR TITLE
fork optimization by cross memory attach

### DIFF
--- a/LibOS/shim/include/shim_checkpoint.h
+++ b/LibOS/shim/include/shim_checkpoint.h
@@ -105,6 +105,10 @@ struct shim_gipc_entry {
 #endif
 };
 
+struct shim_cma_entry {
+    struct shim_mem_entry mem;
+};
+
 struct shim_palhdl_entry {
     struct shim_palhdl_entry * prev;
     PAL_HANDLE handle;
@@ -127,6 +131,11 @@ struct shim_cp_store {
     bool use_gipc;
     struct shim_gipc_entry * last_gipc_entry;
     int gipc_nentries;
+
+    /* entries of cma records */
+    bool use_cma;
+    struct shim_cma_entry * last_cma_entry;
+    int cma_nentries;
 
     /* entries of out-of-band data */
     struct shim_mem_entry * last_mem_entry;
@@ -424,6 +433,10 @@ struct newproc_cp_header {
         unsigned long entoffset;
         int nentries;
     } gipc;
+    struct cma_header {
+        unsigned long entoffset;
+        int nentries;
+    } cma;
 };
 
 struct newproc_header {
@@ -443,8 +456,7 @@ struct newproc_response {
 
 int do_migration (struct newproc_cp_header * hdr, void ** cpptr);
 
-int restore_checkpoint (struct cp_header * cphdr, struct mem_header * memhdr,
-                        ptr_t base, int type);
+int restore_checkpoint (struct newproc_header *hdr, ptr_t base, int type);
 
 int do_migrate_process (int (*migrate) (struct shim_cp_store *,
                                         struct shim_thread *,

--- a/LibOS/shim/src/bookkeep/shim_vma.c
+++ b/LibOS/shim/src/bookkeep/shim_vma.c
@@ -1087,6 +1087,10 @@ BEGIN_CP_FUNC(vma)
             struct shim_gipc_entry * gipc;
             DO_CP_SIZE(gipc, send_addr, send_size, &gipc);
             gipc->mem.prot = pal_prot;
+        } else if (store->use_cma) {
+            struct shim_cma_entry * cma;
+            DO_CP_SIZE(cma, send_addr, send_size, &cma);
+            cma->mem.prot = pal_prot;
         } else {
             struct shim_mem_entry * mem;
             DO_CP_SIZE(memory, send_addr, send_size, &mem);

--- a/LibOS/shim/src/shim_init.c
+++ b/LibOS/shim/src/shim_init.c
@@ -747,9 +747,7 @@ int shim_init (int argc, void * args, void ** return_stack)
     if (cpaddr) {
 restore:
         thread_start_event = DkNotificationEventCreate(PAL_FALSE);
-        RUN_INIT(restore_checkpoint,
-                 &hdr.checkpoint.hdr, &hdr.checkpoint.mem,
-                 (ptr_t) cpaddr, 0);
+        RUN_INIT(restore_checkpoint, &hdr, (ptr_t) cpaddr, 0);
     }
 
     if (PAL_CB(manifest_handle))

--- a/Pal/src/db_ipc.c
+++ b/Pal/src/db_ipc.c
@@ -73,8 +73,8 @@ DkPhysicalMemoryMap (PAL_HANDLE channel, PAL_NUM entries, PAL_PTR * addrs,
 {
     ENTER_PAL_CALL(DkPhysicalMemoryMap);
 
-    if (!sizes || !channel || !IS_HANDLE_TYPE(channel, gipc) ||
-        !IS_HANDLE_TYPE(channel, process)) {
+    if (!sizes || !channel ||
+        (!IS_HANDLE_TYPE(channel, gipc) && !IS_HANDLE_TYPE(channel, process))) {
         _DkRaiseFailure(PAL_ERROR_INVAL);
         LEAVE_PAL_CALL_RETURN(0);
     }

--- a/Pal/src/db_ipc.c
+++ b/Pal/src/db_ipc.c
@@ -52,7 +52,8 @@ DkPhysicalMemoryCommit (PAL_HANDLE channel, PAL_NUM entries, PAL_PTR * addrs,
 {
     ENTER_PAL_CALL(DkPhysicalMemoryCommit);
 
-    if (!addrs || !sizes || !channel || !IS_HANDLE_TYPE(channel, gipc)) {
+    if (!addrs || !sizes || !channel ||
+        (!IS_HANDLE_TYPE(channel, gipc) && !IS_HANDLE_TYPE(channel, process))) {
         _DkRaiseFailure(PAL_ERROR_INVAL);
         LEAVE_PAL_CALL_RETURN(0);
     }

--- a/Pal/src/db_ipc.c
+++ b/Pal/src/db_ipc.c
@@ -73,7 +73,8 @@ DkPhysicalMemoryMap (PAL_HANDLE channel, PAL_NUM entries, PAL_PTR * addrs,
 {
     ENTER_PAL_CALL(DkPhysicalMemoryMap);
 
-    if (!sizes || !channel || !IS_HANDLE_TYPE(channel, gipc)) {
+    if (!sizes || !channel || !IS_HANDLE_TYPE(channel, gipc) ||
+        !IS_HANDLE_TYPE(channel, process)) {
         _DkRaiseFailure(PAL_ERROR_INVAL);
         LEAVE_PAL_CALL_RETURN(0);
     }

--- a/Pal/src/host/Linux/db_process.c
+++ b/Pal/src/host/Linux/db_process.c
@@ -516,8 +516,18 @@ static int64_t proc_read (PAL_HANDLE handle, uint64_t offset, uint64_t count,
 static int64_t proc_write (PAL_HANDLE handle, uint64_t offset, uint64_t count,
                        const void * buffer)
 {
-    int64_t bytes = INLINE_SYSCALL(write, 3, handle->process.stream_out, buffer,
-                                   count);
+    int64_t bytes;
+    if (offset & PAL_OPTION_SPLICE_GIFT) {
+        struct iovec iov = {
+            .iov_base = (void*)buffer,
+            .iov_len = count
+        };
+        bytes = INLINE_SYSCALL(vmsplice, 4, handle->process.stream_out,
+                               &iov, 1, offset & PAL_OPTION_SPLICE_GIFT);
+    } else {
+        bytes = INLINE_SYSCALL(write, 3, handle->process.stream_out, buffer,
+                               count);
+    }
 
     if (IS_ERR(bytes))
         switch(ERRNO(bytes)) {

--- a/Pal/src/pal.h
+++ b/Pal/src/pal.h
@@ -296,6 +296,7 @@ DkProcessSandboxCreate (PAL_STR manifest, PAL_FLG flags);
 /* Stream Option Flags */
 #define PAL_OPTION_NONBLOCK     04000
 #define PAL_OPTION_MASK         04000
+#define PAL_OPTION_SPLICE_GIFT  0x08    /* = SPLICE_F_GIFT */
 
 PAL_HANDLE
 DkStreamOpen (PAL_STR uri, PAL_FLG access, PAL_FLG share_flags,

--- a/Pal/src/security/Linux/filter.c
+++ b/Pal/src/security/Linux/filter.c
@@ -78,6 +78,7 @@ typedef __builtin_va_list __gnuc_va_list;
     SYSCALL(__NR_vfork,         ALLOW),                  \
     SYSCALL(__NR_wait4,         ALLOW),                  \
     SYSCALL(__NR_write,         ALLOW),                  \
+    SYSCALL(__NR_process_vm_readv, ALLOW),               \
                                                          \
     SYSCALL_ARCH_FILTERS
 

--- a/Pal/src/security/Linux/filter.c
+++ b/Pal/src/security/Linux/filter.c
@@ -80,6 +80,7 @@ typedef __builtin_va_list __gnuc_va_list;
     SYSCALL(__NR_write,         ALLOW),                  \
     SYSCALL(__NR_process_vm_readv, ALLOW),               \
     SYSCALL(__NR_prctl, ALLOW),                          \
+    SYSCALL(__NR_vmsplice, ALLOW),                       \
                                                          \
     SYSCALL_ARCH_FILTERS
 

--- a/Pal/src/security/Linux/filter.c
+++ b/Pal/src/security/Linux/filter.c
@@ -79,6 +79,7 @@ typedef __builtin_va_list __gnuc_va_list;
     SYSCALL(__NR_wait4,         ALLOW),                  \
     SYSCALL(__NR_write,         ALLOW),                  \
     SYSCALL(__NR_process_vm_readv, ALLOW),               \
+    SYSCALL(__NR_prctl, ALLOW),                          \
                                                          \
     SYSCALL_ARCH_FILTERS
 


### PR DESCRIPTION
This pull request is to get comments/feedback before going further.
The current graphene ipc device driver isn't stable and unlikely for upstreaming.
so it's desirable to optimize fork with the existing linux kernel feature.

This is the first try to optimize fork. The patch series uses cross memory attach, process_vm_readv() system call so that one memory copy is done instead of two memory copy by unix pipe.
I implemented it only for Linux Pal for now and the code quality is not for merge yet.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/291)
<!-- Reviewable:end -->
