### PR TITLE
Pal: re-version _r_debug from GLIBC to PAL to reduce glibc patch

### DIFF
--- a/Pal/src/host/FreeBSD/db_rtld.c
+++ b/Pal/src/host/FreeBSD/db_rtld.c
@@ -50,9 +50,6 @@
 struct r_debug pal_r_debug =
         { 1, NULL, &pal_r_debug_state, RT_CONSISTENT, };
 
-extern __typeof(pal_r_debug) r_debug
-    __attribute ((alias ("pal_r_debug")));
-
 /* This function exists solely to have a breakpoint set on it by the
    debugger.  The debugger is supposed to find this function's address by
    examining the r_brk member of struct r_debug, but GDB 4.15 in fact looks

--- a/Pal/src/host/FreeBSD/pal.map
+++ b/Pal/src/host/FreeBSD/pal.map
@@ -1,6 +1,6 @@
 GLIBC {
     global:
-        r_debug; r_debug_state;
+        r_debug_state;
 };
 PAL {
     global:
@@ -48,6 +48,9 @@ PAL {
 
         # Control block
         pal_control_addr; pal_sec;
+
+        # debugger interface
+        r_debug;
 
     local: *;
 };

--- a/Pal/src/host/FreeBSD/pal_security.h
+++ b/Pal/src/host/FreeBSD/pal_security.h
@@ -58,6 +58,7 @@ void pal_r_debug_state (struct r_debug *, struct link_gdb_map *);
    a statically-linked program there is no dynamic section for the debugger
    to examine and it looks for this particular symbol name.  */
 extern struct r_debug pal_r_debug;
+symbol_version_default(pal_r_debug, r_debug, PAL);
 
 extern struct pal_sec {
     unsigned int        domain_id;

--- a/Pal/src/host/Linux/db_rtld.c
+++ b/Pal/src/host/Linux/db_rtld.c
@@ -49,9 +49,6 @@
 struct r_debug pal_r_debug =
         { 1, NULL, (ElfW(Addr)) &pal_dl_debug_state, RT_CONSISTENT, 0 };
 
-extern __typeof(pal_r_debug) _r_debug
-    __attribute ((alias ("pal_r_debug")));
-
 /* This function exists solely to have a breakpoint set on it by the
    debugger.  The debugger is supposed to find this function's address by
    examining the r_brk member of struct r_debug, but GDB 4.15 in fact looks

--- a/Pal/src/host/Linux/pal.map
+++ b/Pal/src/host/Linux/pal.map
@@ -1,6 +1,6 @@
 GLIBC {
     global:
-        _r_debug; _dl_debug_state;
+        _dl_debug_state;
 };
 PAL {
     global:
@@ -48,6 +48,9 @@ PAL {
 
         # Control block
         pal_control_addr; pal_sec;
+
+        # debugger
+        _r_debug;
 
     local: *;
 };

--- a/Pal/src/host/Linux/pal_security.h
+++ b/Pal/src/host/Linux/pal_security.h
@@ -58,6 +58,7 @@ void pal_dl_debug_state (void);
    a statically-linked program there is no dynamic section for the debugger
    to examine and it looks for this particular symbol name.  */
 extern struct r_debug pal_r_debug;
+symbol_version_default(pal_r_debug, _r_debug, PAL);
 
 extern struct pal_sec {
     /* system variables */

--- a/Pal/src/host/Skeleton/pal.map
+++ b/Pal/src/host/Skeleton/pal.map
@@ -1,6 +1,6 @@
 GLIBC {
     global:
-        _r_debug; _dl_debug_state;
+        _dl_debug_state;
 };
 PAL {
     global:
@@ -48,6 +48,9 @@ PAL {
 
         # Control block
         pal_control_addr; pal_sec;
+
+        # debugger interface
+        _r_debug;
 
     local: *;
 };

--- a/Pal/src/pal.h
+++ b/Pal/src/pal.h
@@ -509,4 +509,11 @@ PAL_NUM DkMemoryAvailableQuota (void);
 PAL_BOL
 DkCpuIdRetrieve (PAL_IDX leaf, PAL_IDX subleaf, PAL_IDX values[4]);
 
+#ifdef __GNUC__
+# define symbol_version_default(real, name, version) \
+    __asm__ (".symver " #real "," #name "@@" #version "\n")
+#else
+# define symbol_version_default(real, name, version)
+#endif
+
 #endif /* PAL_H */

--- a/Pal/src/security/Linux/pal-sec.map
+++ b/Pal/src/security/Linux/pal-sec.map
@@ -1,7 +1,9 @@
 GLIBC {
     global:
-        _r_debug; _dl_debug_state;
+        _dl_debug_state;
 };
 PAL {
+    global:
+        _r_debug;
     local: *;
 };


### PR DESCRIPTION
_r_debug symbol is interface for for debugger, like gdb, to understand
how dynamic loading is happening. So it's not used by dependent
library or executable. So there is no point to put _r_debug into GLIBC
version space for export. Put it into its own version (PAL_PRIVATE).
Then, the next patch will reduce glibc modification.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/293)
<!-- Reviewable:end -->
