### PR TITLE
Pal: make _dl_debug_status versioned to PAL_PRIVATE not  GLIBC

### DIFF
--- a/Pal/src/host/FreeBSD/pal.map
+++ b/Pal/src/host/FreeBSD/pal.map
@@ -1,7 +1,3 @@
-GLIBC {
-    global:
-        r_debug_state;
-};
 PAL {
     global:
         # Drawbridge ABIs
@@ -53,4 +49,8 @@ PAL {
         r_debug;
 
     local: *;
+};
+PAL_PRIVATE {
+    global:
+        r_debug_state;
 };

--- a/Pal/src/host/Linux/pal.map
+++ b/Pal/src/host/Linux/pal.map
@@ -1,7 +1,3 @@
-GLIBC {
-    global:
-        _dl_debug_state;
-};
 PAL {
     global:
         # Drawbridge ABIs
@@ -54,4 +50,8 @@ PAL {
         _r_debug;
 
     local: *;
+};
+PAL_PRIVATE {
+    global:
+        _dl_debug_state;
 };

--- a/Pal/src/host/Skeleton/pal.map
+++ b/Pal/src/host/Skeleton/pal.map
@@ -1,7 +1,3 @@
-GLIBC {
-    global:
-        _dl_debug_state;
-};
 PAL {
     global:
         # Drawbridge ABIs
@@ -53,4 +49,8 @@ PAL {
         _r_debug;
 
     local: *;
+};
+PAL_PRIVATE {
+    global:
+        _dl_debug_state;
 };

--- a/Pal/src/security/Linux/pal-sec.map
+++ b/Pal/src/security/Linux/pal-sec.map
@@ -1,9 +1,9 @@
-GLIBC {
-    global:
-        _dl_debug_state;
-};
 PAL {
     global:
         _r_debug;
     local: *;
+};
+PAL_PRIVATE {
+    global:
+        _dl_debug_state;
 };


### PR DESCRIPTION
dynamic symbol of _dl_debug_state is interface for debugger. Not
for depdent library or executable. So there is no point to put in
GLIBC version. this patch put _dl_debug_status symbol to PAL_PRIVATE.
So that the next patch eliminates rename in glibc. _dl_debug_status
-> __libc_dl_debug_status.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/295)
<!-- Reviewable:end -->
