### PR TITLE
Enable Wextra (-Wunused-parameter and -Wsign-compare excluded) for Li…

### DIFF
--- a/LibOS/shim/include/shim_handle.h
+++ b/LibOS/shim/include/shim_handle.h
@@ -431,7 +431,7 @@ int walk_handle_map (int (*callback) (struct shim_fd_handle *,
 int init_handle (void);
 int init_important_handles (void);
 
-size_t get_file_size (struct shim_handle * file);
+ssize_t get_file_size (struct shim_handle * file);
 
 int do_handle_read (struct shim_handle * hdl, void * buf, int count);
 int do_handle_write (struct shim_handle * hdl, const void * buf, int count);

--- a/LibOS/shim/include/shim_table.h
+++ b/LibOS/shim/include/shim_table.h
@@ -347,8 +347,8 @@ int shim_do_sigaction (int signum, const struct __kernel_sigaction * act,
 int shim_do_sigprocmask (int how, const __sigset_t * set, __sigset_t * oldset);
 int shim_do_sigreturn (int __unused);
 int shim_do_ioctl (int fd, int cmd, unsigned long arg);
-size_t shim_do_pread64 (int fd, char * buf, size_t count, loff_t pos);
-size_t shim_do_pwrite64 (int fd, char * buf,  size_t count, loff_t pos);
+ssize_t shim_do_pread64 (int fd, char * buf, size_t count, loff_t pos);
+ssize_t shim_do_pwrite64 (int fd, char * buf,  size_t count, loff_t pos);
 ssize_t shim_do_readv (int fd, const struct iovec * vec, int vlen);
 ssize_t shim_do_writev (int fd, const struct iovec * vec, int vlen);
 int shim_do_access (const char * file, mode_t mode);

--- a/LibOS/shim/include/shim_utils.h
+++ b/LibOS/shim/include/shim_utils.h
@@ -239,7 +239,7 @@ int create_handle (const char * prefix, char * path, size_t size,
 
 /* Asynchronous event support */
 int init_async (void);
-uint64_t install_async_event (PAL_HANDLE object, unsigned long time,
+int64_t install_async_event (PAL_HANDLE object, unsigned long time,
                               void (*callback) (IDTYPE caller, void * arg),
                               void * arg);
 int create_async_helper (void);

--- a/LibOS/shim/src/Makefile
+++ b/LibOS/shim/src/Makefile
@@ -14,6 +14,11 @@ CFLAGS	= -Wall -fPIC -std=gnu99 -fgnu89-inline -Winline -Wwrite-strings \
 	  -Werror=implicit-function-declaration \
 	  -fno-stack-protector -fno-builtin -Wno-inline \
 	  -I../include -I../../../Pal/lib -I../../../Pal/include/pal
+
+EXTRAFLAGS = -Wextra -Wno-unused-parameter -Wno-sign-compare
+
+CFLAGS += $(EXTRAFLAGS)
+
 ifeq ($(OMIT_FRAME_POINTER),yes)
 CFLAGS += -DOMIT_FRAME_POINTER=1
 else

--- a/LibOS/shim/src/bookkeep/shim_handle.c
+++ b/LibOS/shim/src/bookkeep/shim_handle.c
@@ -561,7 +561,7 @@ void put_handle (struct shim_handle * hdl)
     }
 }
 
-size_t get_file_size (struct shim_handle * hdl)
+ssize_t get_file_size (struct shim_handle * hdl)
 {
     if (!hdl->fs || !hdl->fs->fs_ops)
         return -EINVAL;

--- a/LibOS/shim/src/bookkeep/shim_vma.c
+++ b/LibOS/shim/src/bookkeep/shim_vma.c
@@ -1061,7 +1061,7 @@ BEGIN_CP_FUNC(vma)
              * (3) Data in the last file-backed page is valid before or after
              *     forking. Has to be included in process migration.
              */
-            uint64_t file_len = get_file_size(vma->file);
+            int64_t file_len = get_file_size(vma->file);
             if (file_len >= 0 &&
                 vma->offset + vma->length > file_len) {
                 send_size = file_len > vma->offset ?

--- a/LibOS/shim/src/elf/shim_rtld.c
+++ b/LibOS/shim/src/elf/shim_rtld.c
@@ -650,8 +650,8 @@ postmap:
                 if (type != OBJECT_MAPPED &&
                     type != OBJECT_INTERNAL &&
                     type != OBJECT_USER) {
-                    caddr_t mapat = (caddr_t)
-                        DkVirtualMemoryAlloc((caddr_t) zeropage,
+                    int64_t mapat = (int64_t)
+                        DkVirtualMemoryAlloc((void *)zeropage,
                                              zeroend - zeropage,
                                              0, c->prot);
                     if (__builtin_expect (mapat < 0, 0)) {

--- a/LibOS/shim/src/fs/chroot/fs.c
+++ b/LibOS/shim/src/fs/chroot/fs.c
@@ -395,7 +395,6 @@ static int __chroot_open (struct shim_dentry * dent,
 
     if (!uri) {
         uri = qstrgetstr(&data->host_uri);
-        len = data->host_uri.len;
     }
 
     int version = atomic_read(&data->version);
@@ -929,7 +928,7 @@ out:
 
 static int chroot_truncate (struct shim_handle * hdl, uint64_t len)
 {
-    uint64_t ret = 0;
+    int ret = 0;
 
     if (NEED_RECREATE(hdl) && (ret = chroot_recreate(hdl)) < 0)
         return ret;

--- a/LibOS/shim/src/shim_async.c
+++ b/LibOS/shim/src/shim_async.c
@@ -54,7 +54,7 @@ static AEVENTTYPE           async_helper_event;
 static LOCKTYPE async_helper_lock;
 
 /* Returns remaining usecs */
-uint64_t install_async_event (PAL_HANDLE object, unsigned long time,
+int64_t install_async_event (PAL_HANDLE object, unsigned long time,
                               void (*callback) (IDTYPE caller, void * arg),
                               void * arg)
 {
@@ -62,7 +62,7 @@ uint64_t install_async_event (PAL_HANDLE object, unsigned long time,
                     malloc(sizeof(struct async_event));
 
     unsigned long install_time = DkSystemTimeQuery();
-    uint64_t rv = 0;
+    int64_t rv = 0;
     
     debug("install async event at %llu\n", install_time);
 

--- a/LibOS/shim/src/shim_parser.c
+++ b/LibOS/shim/src/shim_parser.c
@@ -813,7 +813,7 @@ const char *const siglist[NUM_KNOWN_SIGS + 1] =
 
 static void parse_signum (const char * type, va_list * ap)
 {
-    unsigned int signum = va_arg(*ap, unsigned int);
+    int signum = va_arg(*ap, int);
 
     if (signum >= 0 && signum <= NUM_KNOWN_SIGS)
         PUTS(signal_name(signum));

--- a/LibOS/shim/src/sys/shim_alarm.c
+++ b/LibOS/shim/src/sys/shim_alarm.c
@@ -99,7 +99,7 @@ int shim_do_setitimer (int which, struct __kernel_itimerval * value,
                                     real_itimer.timeout - setup_time : 0;
     unsigned long current_reset = real_itimer.reset;
 
-    uint64_t ret = install_async_event(NULL, next_value, &signal_itimer,
+    int64_t ret = install_async_event(NULL, next_value, &signal_itimer,
                                        (void *) (setup_time + next_value));
 
     if (ret < 0) {

--- a/LibOS/shim/src/sys/shim_msgget.c
+++ b/LibOS/shim/src/sys/shim_msgget.c
@@ -376,7 +376,7 @@ int shim_do_msgsnd (int msqid, const void * msgp, size_t msgsz, int msgflg)
     INC_PROFILE_OCCURENCE(syscall_use_ipc);
     int ret;
 
-    if ((msgsz < 0) || (msgsz > MSGMAX))
+    if (msgsz > MSGMAX)
         return -EINVAL;
 
     if (!msgp)
@@ -404,7 +404,7 @@ int shim_do_msgrcv (int msqid, void * msgp, size_t msgsz, long msgtype,
     INC_PROFILE_OCCURENCE(syscall_use_ipc);
     int ret;
 
-    if (msgsz < 0)
+    if (msgsz > MSGMAX)
         return -EINVAL;
     if (!msgp)
         return -EFAULT;

--- a/LibOS/shim/src/sys/shim_open.c
+++ b/LibOS/shim/src/sys/shim_open.c
@@ -206,7 +206,7 @@ out:
     return ret;
 }
 
-size_t shim_do_pread64 (int fd, char * buf, size_t count, loff_t pos)
+ssize_t shim_do_pread64 (int fd, char * buf, size_t count, loff_t pos)
 {
     if (!buf || test_user_memory(buf, count, true))
         return -EFAULT;
@@ -219,7 +219,7 @@ size_t shim_do_pread64 (int fd, char * buf, size_t count, loff_t pos)
         return -EBADF;
 
     struct shim_mount * fs = hdl->fs;
-    size_t ret = -EACCES;
+    ssize_t ret = -EACCES;
 
     if (!fs || !fs->fs_ops)
         goto out;
@@ -257,7 +257,7 @@ out:
     return ret;
 }
 
-size_t shim_do_pwrite64 (int fd, char * buf, size_t count, loff_t pos)
+ssize_t shim_do_pwrite64 (int fd, char * buf, size_t count, loff_t pos)
 {
     if (!buf || test_user_memory(buf, count, false))
         return -EFAULT;
@@ -270,7 +270,7 @@ size_t shim_do_pwrite64 (int fd, char * buf, size_t count, loff_t pos)
         return -EBADF;
 
     struct shim_mount * fs = hdl->fs;
-    size_t ret = -EACCES;
+    ssize_t ret = -EACCES;
 
     if (!fs || !fs->fs_ops)
         goto out;

--- a/LibOS/shim/src/sys/shim_semget.c
+++ b/LibOS/shim/src/sys/shim_semget.c
@@ -705,9 +705,9 @@ int submit_sysv_sem (struct shim_sem_handle * sem, struct sembuf * sops,
     for (int i = 0 ; i < nsops ; i++) {
         struct sembuf * op = &sops[i];
 
-        if (op->sem_num > 0) {
+        if (op->sem_op > 0) {
             score += SEM_POSITIVE_SCORE(op->sem_num);
-        } else if (op->sem_num < 0) {
+        } else if (op->sem_op < 0) {
             score += SEM_NEGATIVE_SCORE(-op->sem_num);
             sendreply = true;
         } else {

--- a/Pal/src/host/Linux-SGX/Makefile.am
+++ b/Pal/src/host/Linux-SGX/Makefile.am
@@ -9,6 +9,11 @@ LD	= ld
 CFLAGS	= -Wall -fPIC -O2 -maes -std=gnu99 -fgnu89-inline -U_FORTIFY_SOURCE \
 	  -fno-omit-frame-pointer \
 	  -fno-stack-protector -fno-builtin -DIN_ENCLAVE
+
+EXTRAFLAGS = -Wextra -Wno-unused-parameter -Wno-sign-compare
+
+CFLAGS += $(EXTRAFLAGS)
+
 ASFLAGS = -DPIC -DSHARED -fPIC -DASSEMBLER -Wa,--noexecstack \
 	  -x assembler-with-cpp -DIN_ENCLAVE
 LDFLAGS	= -shared -nostdlib -z combreloc -z defs \

--- a/Pal/src/host/Linux-SGX/db_object.c
+++ b/Pal/src/host/Linux-SGX/db_object.c
@@ -41,7 +41,7 @@
 
 /* internally to wait for one object. Also used as a shortcut to wait
    on events and semaphores */
-static int _DkObjectWaitOne (PAL_HANDLE handle, uint64_t timeout)
+static int _DkObjectWaitOne (PAL_HANDLE handle, int64_t timeout)
 {
     /* only for all these handle which has a file descriptor, or
        a eventfd. events and semaphores will skip this part */
@@ -103,7 +103,7 @@ static int _DkObjectWaitOne (PAL_HANDLE handle, uint64_t timeout)
 
 /* _DkObjectsWaitAny for internal use. The function wait for any of the handle
    in the handle array. timeout can be set for the wait. */
-int _DkObjectsWaitAny (int count, PAL_HANDLE * handleArray, uint64_t timeout,
+int _DkObjectsWaitAny (int count, PAL_HANDLE * handleArray, int64_t timeout,
                        PAL_HANDLE * polled)
 {
     if (count <= 0)

--- a/Pal/src/host/Linux/Makefile.am
+++ b/Pal/src/host/Linux/Makefile.am
@@ -9,6 +9,11 @@ LD	= ld
 
 CFLAGS	= -Wall -fPIC -O2 -std=gnu99 -fgnu89-inline -U_FORTIFY_SOURCE \
 	  -fno-stack-protector -fno-builtin
+
+EXTRAFLAGS = -Wextra -Wno-unused-parameter -Wno-sign-compare
+
+CFLAGS += $(EXTRAFLAGS)
+
 ASFLAGS = -DPIC -DSHARED -fPIC -DASSEMBLER -Wa,--noexecstack \
 	  -x assembler-with-cpp
 LDFLAGS	= -shared -nostdlib -z combreloc -z defs \

--- a/Pal/src/host/Linux/db_ipc.c
+++ b/Pal/src/host/Linux/db_ipc.c
@@ -82,7 +82,7 @@ struct handle_ops gipc_ops = {
 
 int _DkCreatePhysicalMemoryChannel (PAL_HANDLE * handle, uint64_t * key)
 {
-    unsigned long token = 0;
+    int token = 0;
     int fd = INLINE_SYSCALL(open, 3, GIPC_FILE, O_RDONLY|O_CLOEXEC, 0);
 
     if (IS_ERR(fd))

--- a/Pal/src/host/Linux/db_object.c
+++ b/Pal/src/host/Linux/db_object.c
@@ -45,7 +45,7 @@
  *
  *  Returns 0 on success, negative value on failure (e.g., -PAL_ERROR_TRYAGAIN)
  */
-static int _DkObjectWaitOne (PAL_HANDLE handle, uint64_t timeout)
+static int _DkObjectWaitOne (PAL_HANDLE handle, int64_t timeout)
 {
     /* only for all these handle which has a file descriptor, or
        a eventfd. events and semaphores will skip this part */
@@ -125,7 +125,7 @@ static int _DkObjectWaitOne (PAL_HANDLE handle, uint64_t timeout)
 
 /* _DkObjectsWaitAny for internal use. The function wait for any of the handle
    in the handle array. timeout can be set for the wait. */
-int _DkObjectsWaitAny (int count, PAL_HANDLE * handleArray, uint64_t timeout,
+int _DkObjectsWaitAny (int count, PAL_HANDLE * handleArray, int64_t timeout,
                        PAL_HANDLE * polled)
 {
     if (count <= 0)

--- a/Pal/src/pal_internal.h
+++ b/Pal/src/pal_internal.h
@@ -327,7 +327,7 @@ int _DkVirtualMemoryProtect (void * addr, uint64_t size, int prot);
 /* DkObject calls */
 int _DkObjectReference (PAL_HANDLE objectHandle);
 int _DkObjectClose (PAL_HANDLE objectHandle);
-int _DkObjectsWaitAny (int count, PAL_HANDLE * handleArray, uint64_t timeout,
+int _DkObjectsWaitAny (int count, PAL_HANDLE * handleArray, int64_t timeout,
                        PAL_HANDLE * polled);
 
 /* DkException calls & structures */


### PR DESCRIPTION
This PR turns on Wextra flags for building shim and PAL. The two major sub-flags, Wunused-parameter and Wsign-compare are disabled. These two requires big source code changes. Will submit separated PRs for them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/298)
<!-- Reviewable:end -->
