### PR TITLE
Makefile: prevent gcc from fp code

### DIFF
--- a/LibOS/shim/src/Makefile
+++ b/LibOS/shim/src/Makefile
@@ -13,6 +13,7 @@ CFLAGS	= -Wall -fPIC -std=gnu99 -fgnu89-inline -Winline -Wwrite-strings \
 	  -fmerge-all-constants -Wstrict-prototypes \
 	  -Werror=implicit-function-declaration \
 	  -fno-stack-protector -fno-builtin -Wno-inline \
+	  -mno-sse -mno-mmx -mno-sse2 -mno-3dnow -mno-avx \
 	  -I../include -I../../../Pal/lib -I../../../Pal/include/pal
 ifeq ($(OMIT_FRAME_POINTER),yes)
 CFLAGS += -DOMIT_FRAME_POINTER=1

--- a/Pal/lib/Makefile
+++ b/Pal/lib/Makefile
@@ -38,7 +38,7 @@ ifeq ($(CRYPTO_PROVIDER),mbedtls)
 subdirs += crypto/mbedtls
 headers += $(wildcard crypto/mbedtls/mbedtls/*.h)
 # XXX: For now, allow aesni.c to compile.
-$(target)crypto/mbedtls/aesni.o : CFLAGS ::= $(filter-out -mno-sse -mno-mmx -mno-sse2 -mno-3dnow -mno-avx, $(CFLAGS))
+$(target)crypto/mbedtls/aesni.o : CFLAGS := $(filter-out -mno-sse -mno-mmx -mno-sse2 -mno-3dnow -mno-avx, $(CFLAGS))
 endif
 ifeq ($(CRYPTO_PROVIDER),wolfssl)
 subdirs += crypto/wolfssl

--- a/Pal/lib/Makefile
+++ b/Pal/lib/Makefile
@@ -37,6 +37,8 @@ CRYPTO_PROVIDER ?= mbedtls
 ifeq ($(CRYPTO_PROVIDER),mbedtls)
 subdirs += crypto/mbedtls
 headers += $(wildcard crypto/mbedtls/mbedtls/*.h)
+# XXX: For now, allow aesni.c to compile.
+$(target)crypto/mbedtls/aesni.o : CFLAGS ::= $(filter-out -mno-sse -mno-mmx -mno-sse2 -mno-3dnow -mno-avx, $(CFLAGS))
 endif
 ifeq ($(CRYPTO_PROVIDER),wolfssl)
 subdirs += crypto/wolfssl

--- a/Pal/src/host/FreeBSD/Makefile.am
+++ b/Pal/src/host/FreeBSD/Makefile.am
@@ -8,7 +8,8 @@ LD	= ld
 
 CFLAGS	= -Wall -fPIC -O2 -std=gnu99 -fgnu89-inline -U_FORTIFY_SOURCE \
 	  -fno-omit-frame-pointer \
-	  -fno-stack-protector -fno-builtin
+	  -fno-stack-protector -fno-builtin \
+	  -mno-sse -mno-mmx -mno-sse2 -mno-3dnow -mno-avx
 ASFLAGS = -DPIC -DSHARED -fPIC -DASSEMBLER -Wa,--noexecstack \
 	  -x assembler-with-cpp
 LDFLAGS	= -shared -nostdlib -z combreloc -z defs \

--- a/Pal/src/host/Linux-SGX/Makefile.am
+++ b/Pal/src/host/Linux-SGX/Makefile.am
@@ -8,7 +8,8 @@ LD	= ld
 
 CFLAGS	= -Wall -fPIC -O2 -maes -std=gnu99 -fgnu89-inline -U_FORTIFY_SOURCE \
 	  -fno-omit-frame-pointer \
-	  -fno-stack-protector -fno-builtin -DIN_ENCLAVE
+	  -fno-stack-protector -fno-builtin -DIN_ENCLAVE \
+	  -mno-sse -mno-mmx -mno-sse2 -mno-3dnow -mno-avx
 ASFLAGS = -DPIC -DSHARED -fPIC -DASSEMBLER -Wa,--noexecstack \
 	  -x assembler-with-cpp -DIN_ENCLAVE
 LDFLAGS	= -shared -nostdlib -z combreloc -z defs \

--- a/Pal/src/host/Linux-SGX/sgx_enclave.c
+++ b/Pal/src/host/Linux-SGX/sgx_enclave.c
@@ -13,7 +13,6 @@
 #include <linux/fs.h>
 #include <linux/in.h>
 #include <linux/in6.h>
-#include <math.h>
 #include <asm/errno.h>
 
 #ifndef SOL_IPV6

--- a/Pal/src/host/Linux/Makefile.am
+++ b/Pal/src/host/Linux/Makefile.am
@@ -9,7 +9,8 @@ LD	= ld
 
 CFLAGS	= -Wall -fPIC -O2 -std=gnu99 -fgnu89-inline -U_FORTIFY_SOURCE \
 	  -fno-omit-frame-pointer \
-	  -fno-stack-protector -fno-builtin
+	  -fno-stack-protector -fno-builtin \
+	  -mno-sse -mno-mmx -mno-sse2 -mno-3dnow -mno-avx
 ASFLAGS = -DPIC -DSHARED -fPIC -DASSEMBLER -Wa,--noexecstack \
 	  -x assembler-with-cpp
 LDFLAGS	= -shared -nostdlib -z combreloc -z defs \


### PR DESCRIPTION
Pal and LibOS shouldn't clobber FP registers in most cases.
i.e. system call emulation.
Update CFLAGS to prevent gcc from generating FP code
accidentally for safety for now.

It's exceptional FP is allowed. i.e. signal handlers for host,
internal thread(ipc and migration), code before entering user program.
Anyway those codes need to be checked carefully before allowing FP
code. For now, disable FP code at the moment.

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/301)
<!-- Reviewable:end -->
