### PR TITLE
LibOS: sched_getaffinity return 0, not # of cpu

### DIFF
--- a/LibOS/shim/src/sys/shim_sched.c
+++ b/LibOS/shim/src/sys/shim_sched.c
@@ -43,5 +43,5 @@ int shim_do_sched_getaffinity (pid_t pid, size_t len,
     memset(user_mask_ptr, 0, len);
     for (int i = 0 ; i < ncpus ; i++)
         ((uint8_t *) user_mask_ptr)[i / 8] |= 1 << (i % 8);
-    return ncpus;
+    return 0;
 }


### PR DESCRIPTION
sched_getaffinity(2) return 0 on success, not # of cpu.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/306)
<!-- Reviewable:end -->
