### PR TITLE
Clean up and optimize the integration of docker container and graphene-SGX

### DIFF
--- a/Tools/gsce
+++ b/Tools/gsce
@@ -22,23 +22,22 @@ def gen_dockerfile( image_name, app_name, bin_name, proj_dir) :
  
   # DOWNLOAD dependencies
   df.write('# Download dependencies\n')
-  df.write('RUN apt-get update && \ \n')
-  df.write('    apt-get install -y openssl libjemalloc-dev python python-pip python-dev \n')
-  df.write('RUN pip install protobuf && \ \n')
-  df.write('    pip install pycrypto\n')
+  df.write('RUN apt-get update \\\n')
+  df.write('    && apt-get install -y openssl libjemalloc-dev python python-pip python-dev \\\n')
+  df.write('    && pip install protobuf \\\n')
+  df.write('    && pip install pycrypto \n')
 
   df.write('# Temporal fixes for Dependencies Issue #1: libcrypto.so.1.0.0 and libssl.so.1.0.0 have different locations \n')
-  df.write('RUN ln -s /usr/lib/x86_64-linux-gnu/libcrypto.so.1.0.0 /lib/x86_64-linux-gnu/libcrypto.so.1.0.0 && \ \n')
-  df.write('    ln -s /usr/lib/x86_64-linux-gnu/libssl.so.1.0.0 /lib/x86_64-linux-gnu/libssl.so.1.0.0 \n')
-  
+  df.write('RUN ln -s /usr/lib/x86_64-linux-gnu/libcrypto.so.1.0.0 /lib/x86_64-linux-gnu/libcrypto.so.1.0.0 \\\n')
+  df.write('    && ln -s /usr/lib/x86_64-linux-gnu/libssl.so.1.0.0 /lib/x86_64-linux-gnu/libssl.so.1.0.0 \n')
+
   # SETUP Directory Structure
   print "cwd: "+ proj_dir
   df.write('# Setup Directory Structure \n')
- # df.write('RUN mkdir -p ' + proj_dir + '\n')
-  df.write('RUN mkdir -p ' + proj_dir + '/LibOS/shim/test/apps/' + app_name + '\n')
-  df.write('RUN mkdir -p ' + proj_dir + '/Pal/src/host/Linux-SGX/signer \n')
-  df.write('RUN mkdir -p ' + proj_dir + '/Runtime \n')
-  df.write('RUN mkdir /gbin \n')
+  df.write('RUN mkdir -p ' + proj_dir + '/LibOS/shim/test/apps/' + app_name + ' \\\n')
+  df.write('    && mkdir -p ' + proj_dir + '/Pal/src/host/Linux-SGX/signer \\\n')
+  df.write('    && mkdir -p ' + proj_dir + '/Runtime \\\n')
+  df.write('    && mkdir /gbin \n')
 
   # COPY system files
   df.write('# Copy system files \n')


### PR DESCRIPTION
    The dockerfile instruction RUN will create new layers
    when it is executed, original codes will increase the size of
    the final image and causes potential cache issues.
    So we need to employ shell tricks to keep the layers as small as possible.
    
    The detail:
    https://docs.docker.com/v17.09/engine/userguide/eng-image/dockerfile_best-practices

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/307)
<!-- Reviewable:end -->
