### PR TITLE
LibOS: sched_getaffinity return byte size, not bit size

### DIFF
--- a/LibOS/shim/src/sys/shim_sched.c
+++ b/LibOS/shim/src/sys/shim_sched.c
@@ -41,7 +41,12 @@ int shim_do_sched_getaffinity (pid_t pid, size_t len,
 {
     int ncpus = PAL_CB(cpu_info.cpu_num);
     memset(user_mask_ptr, 0, len);
-    for (int i = 0 ; i < ncpus ; i++)
+    for (int i = 0 ; i < MIN(ncpus, len * 8) ; i++)
         ((uint8_t *) user_mask_ptr)[i / 8] |= 1 << (i % 8);
-    return ncpus;
+    return MIN(
+        /* Linux kernel bitmap is based on long. So follow it to round up to
+         * sizeof long)
+         */
+        (ncpus + sizeof(long) * 8 - 1) / (sizeof(long) * 8) * sizeof(long),
+        len);
 }


### PR DESCRIPTION
sched_getaffinity(2) returns the # of bytes, not bits.
So calculate the # of bytes. Also it should honer input argument, len.
Actually Linux sched_getaffinity() returns in bytes with long aligned.
So this patch tries to follow it.

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>