### PR TITLE
LibOS/shim/src/fs/shim_namei.c: comparison pointer with char

### DIFF
--- a/LibOS/shim/src/fs/shim_namei.c
+++ b/LibOS/shim/src/fs/shim_namei.c
@@ -300,7 +300,7 @@ int __path_lookupat (struct shim_dentry * start, const char * path, int flags,
     path = eat_slashes(path);
 
     // Check that we didn't hit the base case 
-    if (path == '\0') {
+    if (*path == '\0') {
         my_dent = start;
         base_case = 1;
     } else {


### PR DESCRIPTION
> fs/shim_namei.c: In function '__path_lookupat':
> fs/shim_namei.c:303:14: warning: comparison between pointer and zero character constant [-Wpointer-compare]
>      if (path == '\0') {
>               ^~
> fs/shim_namei.c:303:9: note: did you mean to dereference the pointer?
>      if (path == '\0') {
>          ^

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/310)
<!-- Reviewable:end -->
