### PR TITLE
atomic.h: add atomic_inc_return, atomic_add_return

### DIFF
--- a/LibOS/shim/include/shim_profile.h
+++ b/LibOS/shim/include/shim_profile.h
@@ -117,22 +117,16 @@ extern struct shim_profile __profile_end;
 #define _INC_PROFILE_OCCURENCE(prof)                        \
     ({                                                      \
         extern struct shim_profile profile_##prof;          \
-        profile_##prof.disabled ? 0 : ({                    \
-        unsigned long _c;                                   \
-        _c = atomic_read(&profile_##prof.val.occurence.count); \
-        atomic_inc(&profile_##prof.val.occurence.count);    \
-        _c + 1; });                                         \
+        profile_##prof.disabled ? 0 :                       \
+        atomic_inc_return(&profile_##prof.val.occurence.count); \
     })
 
 #define ADD_PROFILE_OCCURENCE(prof, num) _ADD_PROFILE_OCCURENCE(prof, num)
 #define _ADD_PROFILE_OCCURENCE(prof, num)                   \
     ({                                                      \
         extern struct shim_profile profile_##prof;          \
-        profile_##prof.disabled ? 0 : ({                    \
-        unsigned long _c, _num = (num);                     \
-        _c = atomic_read(&profile_##prof.val.occurence.count); \
-        atomic_add(_num, &profile_##prof.val.occurence.count); \
-        _c + _num; });                                      \
+        profile_##prof.disabled ? 0 :                       \
+        atomic_add_return(num, &profile_##prof.val.occurence.count); \
     })
 
 #define BEGIN_PROFILE_INTERVAL()                            \

--- a/LibOS/shim/src/ipc/shim_ipc.c
+++ b/LibOS/shim/src/ipc/shim_ipc.c
@@ -405,8 +405,7 @@ int send_ipc_message_duplex (struct shim_ipc_msg_obj * msg,
                              struct shim_ipc_port * port, bool save,
                              void * private_data)
 {
-    atomic_inc(&ipc_seq_counter);
-    msg->msg.seq = atomic_read(&ipc_seq_counter);
+    msg->msg.seq = atomic_inc_return(&ipc_seq_counter);
 
     if (save) {
         lock(&port->msgs_lock);

--- a/LibOS/shim/src/shim_init.c
+++ b/LibOS/shim/src/shim_init.c
@@ -1113,8 +1113,7 @@ int shim_clean (int err)
 {
     /* preventing multiple cleanup, this is mostly caused by
        assertion in shim_clean */
-    atomic_inc(&in_terminate);
-    if (atomic_read(&in_terminate) > 1)
+    if (atomic_inc_return(&in_terminate) > 1)
         return 0;
 
     if (err != 0)

--- a/Pal/lib/atomic.h
+++ b/Pal/lib/atomic.h
@@ -165,6 +165,9 @@ static inline int64_t cmpxchg(volatile int64_t *p, int64_t t, int64_t s)
     return t;
 }
 
+#define atomic_add_return(i, v)  _atomic_add(i, v)
+#define atomic_inc_return(v)     _atomic_add(1, v)
+
 /* Helper function to atomically compare-and-swap the value in v.
  * If v == old, it sets v = new.
  * Returns the value originally in v. */


### PR DESCRIPTION
atomic_inc + atomic_read isn't atomic.
atomic_add/inc_return is needed for atomicity.
Introduce atomic_add/inc_return and use it.

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/311)
<!-- Reviewable:end -->
