### PR TITLE
LibOS/shim/src/shim_checkpoint.c: retry DkStreamRead/DkStreamWrite

### DIFF
--- a/LibOS/shim/src/shim_checkpoint.c
+++ b/LibOS/shim/src/shim_checkpoint.c
@@ -475,8 +475,12 @@ static int send_checkpoint_on_stream (PAL_HANDLE stream,
         size_t ret = DkStreamWrite(stream, 0, total_bytes - bytes,
                                    (void *) store->base + bytes, NULL);
 
-        if (!ret)
+        if (!ret) {
+            if (PAL_ERRNO == EINTR || PAL_ERRNO == EAGAIN ||
+                PAL_ERRNO == EWOULDBLOCK)
+                continue;
             return -PAL_ERRNO;
+        }
 
         bytes += ret;
     } while (bytes < total_bytes);
@@ -490,8 +494,12 @@ static int send_checkpoint_on_stream (PAL_HANDLE stream,
         do {
             size_t ret = DkStreamWrite(stream, 0, mem_size - bytes,
                                        mem_addr + bytes, NULL);
-            if (!ret)
+            if (!ret) {
+                if (PAL_ERRNO == EINTR || PAL_ERRNO == EAGAIN ||
+                    PAL_ERRNO == EWOULDBLOCK)
+                    continue;
                 return -PAL_ERRNO;
+            }
 
             bytes += ret;
         } while (bytes < mem_entries[i]->size);
@@ -1215,8 +1223,12 @@ int do_migration (struct newproc_cp_header * hdr, void ** cpptr)
                                      size - total_bytes,
                                      (void *) base + total_bytes, NULL, 0);
 
-            if (!bytes)
+            if (!bytes) {
+                if (PAL_ERRNO == EINTR || PAL_ERRNO == EAGAIN ||
+                    PAL_ERRNO == EWOULDBLOCK)
+                    continue;
                 return -PAL_ERRNO;
+            }
 
             total_bytes += bytes;
         }


### PR DESCRIPTION
On EINTR/EAGAIN of DkStreaRead/DkStreamWrite, retry the PAL call
instead of error out.
Especially when it runs under debugger, EINTR often happens.
This patch makes debug easier.

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/314)
<!-- Reviewable:end -->
