### PR TITLE
Linux-SGX: sgx_framework.c doesn't compile

### DIFF
--- a/Pal/src/host/Linux-SGX/sgx_framework.c
+++ b/Pal/src/host/Linux-SGX/sgx_framework.c
@@ -10,6 +10,15 @@
 
 #include <asm/errno.h>
 
+/* SGX_INVALID_LICENSE is renamed to SGX_INVALID_EINITTOKEN */
+#ifndef SGX_INVALID_EINITTOKEN
+# ifndef SGX_INVALID_LICENSE
+#  error "sgx.h version mismatch? Please verify linux sgx driver version."
+# else
+#  define SGX_INVALID_EINITTOKEN SGX_INVALID_LICENSE
+# endif
+#endif
+
 int gsgx_device = -1;
 int isgx_device = -1;
 #define ISGX_FILE "/dev/isgx"
@@ -345,7 +354,7 @@ int init_enclave(sgx_arch_secs_t * secs,
             error = "Invalid measurement";        break;
         case SGX_INVALID_SIGNATURE:
             error = "Invalid signature";          break;
-        case SGX_INVALID_LICENSE:
+        case SGX_INVALID_EINITTOKEN:
             error = "Invalid EINIT token";        break;
         case SGX_INVALID_CPUSVN:
             error = "Invalid CPU SVN";            break;

--- a/Pal/src/host/Linux-SGX/sgx_framework.c
+++ b/Pal/src/host/Linux-SGX/sgx_framework.c
@@ -10,10 +10,12 @@
 
 #include <asm/errno.h>
 
-/* SGX_INVALID_LICENSE is renamed to SGX_INVALID_EINITTOKEN */
+/* SGX_INVALID_LICENSE is renamed to SGX_INVALID_EINITTOKEN from SGX driver
+ * version 2.1
+ */
 #ifndef SGX_INVALID_EINITTOKEN
 # ifndef SGX_INVALID_LICENSE
-#  error "sgx.h version mismatch? Please verify linux sgx driver version."
+#  error "sgx_user.h version mismatch? Please verify linux sgx driver version."
 # else
 #  define SGX_INVALID_EINITTOKEN SGX_INVALID_LICENSE
 # endif


### PR DESCRIPTION
sgx_framework.c doesn't compile because SGX_INVALID_LICENSE is
renamed to SGX_INVALID_EINITTOKEN.

> sgx_framework.c: In function 'init_enclave':
> sgx_framework.c:348:14: error: 'SGX_INVALID_LICENSE' undeclared (first use in this function); did you mean 'SGX_INVALID_KEYNAME'?
>          case SGX_INVALID_LICENSE:
>          ^~~~~~~~~~~~~~~~~~~
>          SGX_INVALID_KEYNAME

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/316)
<!-- Reviewable:end -->
