### PR TITLE
Pal/Linux, FreeBSD: ~15 instead of ~16 for child stack alignment

### DIFF
--- a/Pal/lib/api.h
+++ b/Pal/lib/api.h
@@ -45,6 +45,11 @@ typedef ptrdiff_t ssize_t;
 # define MAX(a, b) ((a) > (b) ? (a) : (b))
 #endif
 
+#define ALIGN_DOWN_PTR(ptr, size) \
+    ((typeof(ptr))(((uintptr_t)(ptr)) & -(size)))
+#define ALIGN_UP_PTR(ptr, size) \
+    ((typeof(ptr))ALIGN_DOWN_PTR((uintptr_t)(ptr) + ((size) - 1), (size)))
+
 #define __alloca __builtin_alloca
 
 #define XSTRINGIFY(x) STRINGIFY(x)

--- a/Pal/src/host/FreeBSD/db_threading.c
+++ b/Pal/src/host/FreeBSD/db_threading.c
@@ -58,7 +58,7 @@ int _DkThreadCreate (PAL_HANDLE * handle, int (*callback) (void *),
     child_stack += THREAD_STACK_SIZE;
 
     // align child_stack to 16 
-    child_stack = (void *) ((uintptr_t) child_stack & ~16);
+    child_stack = ALIGN_DOWN_PTR(child_stack, 16);
 
     flags &= PAL_THREAD_MASK;
 

--- a/Pal/src/host/Linux/db_threading.c
+++ b/Pal/src/host/Linux/db_threading.c
@@ -110,7 +110,7 @@ int _DkThreadCreate (PAL_HANDLE * handle, int (*callback) (void *),
     tcb->param     = (void *) param;
 
     /* align child_stack to 16 */
-    child_stack = (void *) ((uintptr_t) child_stack & ~15);
+    child_stack = ALIGN_DOWN_PTR(child_stack, 16);
 
     ret = clone(pal_thread_init, child_stack,
                     CLONE_VM|CLONE_FS|CLONE_FILES|CLONE_SYSVSEM|


### PR DESCRIPTION
It should be "& ~15", not "& ~16" to align to 16 bytes.
It seems typo.

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/320)
<!-- Reviewable:end -->
