### PR TITLE
LibOS: race condition on thread exiting

### DIFF
--- a/LibOS/shim/include/shim_thread.h
+++ b/LibOS/shim/include/shim_thread.h
@@ -91,6 +91,10 @@ struct shim_thread {
 #ifdef PROFILE
     unsigned long exit_time;
 #endif
+
+    __libc_tcb_t exit_tcb;
+#define SHIM_THREAD_EXIT_STACK_SIZE (4096)
+    uint8_t exit_stack[SHIM_THREAD_EXIT_STACK_SIZE];
 };
 
 DEFINE_LIST(shim_simple_thread);

--- a/LibOS/shim/src/ipc/shim_ipc_helper.c
+++ b/LibOS/shim/src/ipc/shim_ipc_helper.c
@@ -780,6 +780,7 @@ noreturn static void shim_ipc_helper(void* dummy) {
     free(object_list);
     free(palhandle_list);
 
+    __disable_preempt(&self->tcb->shim_tcb);
     put_thread(self);
     debug("IPC helper thread terminated\n");
 

--- a/LibOS/shim/src/shim_async.c
+++ b/LibOS/shim/src/shim_async.c
@@ -268,6 +268,7 @@ static void shim_async_helper(void * arg) {
         polled = DkObjectsWaitAny(object_num + 1, object_list, sleep_time);
     }
 
+    __disable_preempt(&self->tcb->shim_tcb);
     put_thread(self);
     debug("Async helper thread terminated\n");
     free(object_list);


### PR DESCRIPTION
Once exiting thread notifies at shim LibOS level, other threads can
release stack memory and tls. But the existing thread can be still
executing resulting in SEGV. Switch stack and tls to private area to
avoid race condition.

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/322)
<!-- Reviewable:end -->
