### PR TITLE
Linux-SGX/Makefile.Test: define SGX_SIGNER_KEY only when not defined

### DIFF
--- a/Pal/src/host/Linux-SGX/Makefile.Test
+++ b/Pal/src/host/Linux-SGX/Makefile.Test
@@ -2,7 +2,7 @@ SGX_DIR = $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
 RUNTIME_DIR = $(SGX_DIR)/../../../../Runtime
 
 LIBPAL = $(RUNTIME_DIR)/libpal-Linux-SGX.so
-SGX_SIGNER_KEY = $(SGX_DIR)/signer/enclave-key.pem
+SGX_SIGNER_KEY ?= $(SGX_DIR)/signer/enclave-key.pem
 SGX_SIGN = $(SGX_DIR)/signer/pal-sgx-sign -libpal $(LIBPAL) -key $(SGX_SIGNER_KEY)
 SGX_GET_TOKEN = $(SGX_DIR)/signer/pal-sgx-get-token
 


### PR DESCRIPTION
define SGX_SIGNER_KEY only when not defined so that user can define
SGX_SIGNER_KEY as error message.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/327)
<!-- Reviewable:end -->
