### PR TITLE
Linux-SGX: Makefile to use $(MAKE), not "make" command directly

### DIFF
--- a/Pal/src/host/Linux-SGX/Makefile
+++ b/Pal/src/host/Linux-SGX/Makefile
@@ -67,7 +67,7 @@ debugger/sgx_gdb.so: debugger/sgx_gdb.c debugger/sgx_gdb.h sgx_arch.h
 	$(LD) -shared debugger/sgx_gdb.o -o debugger/sgx_gdb.so -lc
 
 sgx-driver/isgx_version.h:
-	cd sgx-driver && make isgx_version.h
+	$(MAKE) -C sgx-driver $(notdir $<)
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
This is for consistency and more robust make.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/328)
<!-- Reviewable:end -->
