### PR TITLE
Makefile: add targets for .i and .s

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 /Jenkinsfiles/JenkinsfileSGX-*
 
 .lib
+*.i
+*.s
+*.e

--- a/LibOS/shim/src/Makefile
+++ b/LibOS/shim/src/Makefile
@@ -117,15 +117,19 @@ elf/shim_rtld.o: $(wildcard elf/*.h)
 	@echo [ $@ ]
 	@$(CC) $(CFLAGS) $(defs) -c $< -o $@
 
-%.e: %.c $(headers)
+%.e %.i: %.c $(headers)
 	@echo [ $@ ]
 	@$(CC) $(CFLAGS) $(defs) -E $< -o $@
+
+%.s: %.c $(headers)
+	@echo [ $@ ]
+	@$(CC) $(CFLAGS) $(defs) -S $< -o $@
 
 %.o: %.S $(headers)
 	@echo [ $@ ]
 	@$(AS) $(ASFLAGS) $(defs) -c $< -o $@
 
-%.e: %.S $(headers)
+%.e %.s: %.S $(headers)
 	@echo [ $@ ]
 	@$(AS) $(ASFLAGS) $(defs) -E $< -o $@
 

--- a/Pal/src/Makefile
+++ b/Pal/src/Makefile
@@ -157,10 +157,15 @@ $(OBJ_DIR)/%.o: %.c $(headers)
 	@echo [ $@ ]
 	@$(CC) $(CFLAGS) $(defs) -c $< -o $@ $(CFLAGS-suffix)
 
-$(OBJ_DIR)/%.e: %.c $(headers)
+$(OBJ_DIR)/%.e $(OBJ_DIR)/%.i: %.c $(headers)
 	@mkdir -p $(OBJ_DIR)
 	@echo [ $@ ]
 	@$(CC) $(CFLAGS) $(defs) -E $< -o $@ $(CFLAGS-suffix)
+
+$(OBJ_DIR)/%.s: %.c $(headers)
+	@mkdir -p $(OBJ_DIR)
+	@echo [ $@ ]
+	@$(CC) $(CFLAGS) $(defs) -S $< -o $@ $(CFLAGS-suffix)
 
 .PHONY: clean
 clean:

--- a/Pal/src/host/FreeBSD/Makefile
+++ b/Pal/src/host/FreeBSD/Makefile
@@ -39,15 +39,19 @@ libpal-FreeBSD.a: $(addsuffix .o,$(objs)) $(graphene_lib)
 	@echo [ host/FreeBSD/$@ ]
 	@$(CC) $(CFLAGS) $(defs) -c $< -o $@
 
-%.e: %.c $(headers)
+%.e %.i: %.c $(headers)
 	@echo [ host/FreeBSD/$@ ]
 	@$(CC) $(CFLAGS) $(defs) -E $< -o $@
+
+%.s: %.c $(headers)
+	@echo [ host/FreeBSD/$@ ]
+	@$(CC) $(CFLAGS) $(defs) -S $< -o $@
 
 %.o: %.S $(headers)
 	@echo [ host/FreeBSD/$@ ]
 	@$(AS) $(ASFLAGS) $(defs) -c $< -o $@
 
-%.e: %.S $(headers)
+%.e %.s: %.S $(headers)
 	@echo [ host/FreeBSD/$@ ]
 	@$(AS) $(ASFLAGS) $(defs) -E $< -o $@
 

--- a/Pal/src/host/Linux-SGX/Makefile
+++ b/Pal/src/host/Linux-SGX/Makefile
@@ -41,9 +41,21 @@ $(addsuffix .e,$(enclave-objs)): %.e: %.c $(headers)
 	@echo [ host/Linux-SGX/$@ ]
 	@$(CC) $(CFLAGS) $(defs) -DIN_ENCLAVE -E $< -o $@
 
+$(addsuffix .i,$(enclave-objs)): %.i: %.c $(headers)
+	@echo [ host/Linux-SGX/$@ ]
+	@$(CC) $(CFLAGS) $(defs) -DIN_ENCLAVE -E $< -o $@
+
+$(addsuffix .s,$(enclave-objs)): %.s: %.c $(headers)
+	@echo [ host/Linux-SGX/$@ ]
+	@$(CC) $(CFLAGS) $(defs) -DIN_ENCLAVE -S $< -o $@
+
 $(addsuffix .o,$(enclave-asm-objs)): %.o: %.S $(headers)
 	@echo [ host/Linux-SGX/$@ ]
 	@$(AS) $(ASFLAGS) $(defs) -DIN_ENCLAVE -c $< -o $@
+
+$(addsuffix .s,$(enclave-asm-objs)): %.s: %.S $(headers)
+	@echo [ host/Linux-SGX/$@ ]
+	@$(AS) $(ASFLAGS) $(defs) -DIN_ENCLAVE -E $< -o $@
 
 $(addsuffix .o,$(urts-objs)): %.o: %.c $(headers)
 	@echo [ host/Linux-SGX/$@ ]
@@ -52,6 +64,18 @@ $(addsuffix .o,$(urts-objs)): %.o: %.c $(headers)
 $(addsuffix .e,$(urts-objs)): %.e: %.c $(headers)
 	@echo [ host/Linux-SGX/$@ ]
 	@$(CC) $(filter-out -DIN_ENCLAVE,$(CFLAGS)) $(defs) -E $< -o $@
+
+$(addsuffix .i,$(urts-objs)): %.i: %.c $(headers)
+	@echo [ host/Linux-SGX/$@ ]
+	@$(CC) $(filter-out -DIN_ENCLAVE,$(CFLAGS)) $(defs) -E $< -o $@
+
+$(addsuffix .s,$(urts-objs)): %.s: %.c $(headers)
+	@echo [ host/Linux-SGX/$@ ]
+	@$(CC) $(filter-out -DIN_ENCLAVE,$(CFLAGS)) $(defs) -S $< -o $@
+
+$(addsuffix .s,$(urts-asm-objs)): %.s: %.S $(headers)
+	@echo [ host/Linux-SGX/$@ ]
+	@$(AS) $(filter-out -DIN_ENCLAVE,$(ASFLAGS)) $(defs) -E $< -o $@
 
 $(addsuffix .o,$(urts-asm-objs)): %.o: %.S $(headers)
 	@echo [ host/Linux-SGX/$@ ]
@@ -74,4 +98,4 @@ CLEAN_FILES += debugger/sgx_gdb.o
 
 .PHONY: clean
 clean:
-	rm -f *.o *.e $(host_files) $(CLEAN_FILES)
+	rm -f *.o *.e *.i *.s $(host_files) $(CLEAN_FILES)

--- a/Pal/src/host/Linux/Makefile
+++ b/Pal/src/host/Linux/Makefile
@@ -40,15 +40,19 @@ libpal-Linux.a: $(addsuffix .o,$(objs)) $(graphene_lib)
 	@echo [ host/Linux/$@ ]
 	@$(CC) $(CFLAGS) $(defs) -c $< -o $@
 
-%.e: %.c $(headers)
+%.e %.i: %.c $(headers)
 	@echo [ host/Linux/$@ ]
 	@$(CC) $(CFLAGS) $(defs) -E $< -o $@
+
+%.s: %.c $(headers)
+	@echo [ host/Linux/$@ ]
+	@$(CC) $(CFLAGS) $(defs) -S $< -o $@
 
 %.o: %.S $(headers)
 	@echo [ host/Linux/$@ ]
 	@$(AS) $(ASFLAGS) $(defs) -c $< -o $@
 
-%.e: %.S $(headers)
+%.e %.s: %.S $(headers)
 	@echo [ host/Linux/$@ ]
 	@$(AS) $(ASFLAGS) $(defs) -E $< -o $@
 

--- a/Pal/src/security/Linux/Makefile
+++ b/Pal/src/security/Linux/Makefile
@@ -27,9 +27,13 @@ libpal_sec.so: $(addsuffix .o,$(objs)) $(graphene_lib)
 	@echo [ security/Linux/$@ ]
 	@$(CC) $(CFLAGS) -c $< -o $@
 
-%.e: %.c
+%.e %.i: %.c
 	@echo [ security/Linux/$@ ]
 	@$(CC) $(CFLAGS) -E $< -o $@
+
+%.s: %.c
+	@echo [ security/Linux/$@ ]
+	@$(CC) $(CFLAGS) -S $< -o $@
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
For prepossessed file, .i for .c and .s for .S are commonly used.
not .e.
This patch adds rules to produce .i/.s file in addition to .e.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/329)
<!-- Reviewable:end -->
