### PR TITLE
glibc: optimize SYSCALLDB

### DIFF
--- a/LibOS/glibc-2.19/syscalldb.h
+++ b/LibOS/glibc-2.19/syscalldb.h
@@ -19,10 +19,8 @@ asm (
 
 #define SYSCALLDB							      \
 	"subq $128, %%rsp\n\t"						      \
-	"pushq %%rbx\n\t"						      \
-	"movq syscalldb@GOTPCREL(%%rip), %%rbx\n\t"			      \
-	"callq *%%rbx\n\t"						      \
-	"popq %%rbx\n\t"						      \
+	"movq syscalldb@GOTPCREL(%%rip), %%rcx\n\t"			      \
+	"callq *%%rcx\n\t"						      \
 	"addq $128, %%rsp\n\t"
 
 #define SYSCALLDB_ASM							      \


### PR DESCRIPTION
Linux x86 syscall convention clobbers %rcx and %r11.
%rcx can be used instead of %rbx without save/restore.

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/337)
<!-- Reviewable:end -->
