### PR TITLE
glibc: optimize syscalldb for normal path

### DIFF
--- a/LibOS/shim/src/syscallas.S
+++ b/LibOS/shim/src/syscallas.S
@@ -92,7 +92,10 @@ isdef:
         popq %rsi
         popq %rdi
 
-        jmp ret
+ret:
+        popq %rbx
+        popq %rbp
+        retq
 
 isundef:
 #ifdef DEBUG
@@ -100,11 +103,7 @@ isundef:
         call debug_unsupp
 #endif
         movq $-38, %rax
-
-ret:
-        popq %rbx
-        popq %rbp
-        retq
+        jmp ret
 
         .cfi_endproc
         .size syscalldb, .-syscalldb


### PR DESCRIPTION
Now syscalldb in normal path on return include jmp.
jmp can be eliminated and penalize error path.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/338)
<!-- Reviewable:end -->
