### PR TITLE
shim/Makefile: don't use -e for ld, but use ENTRY in linker script

### DIFF
--- a/LibOS/shim/src/Makefile
+++ b/LibOS/shim/src/Makefile
@@ -77,15 +77,13 @@ ifeq ($(findstring x86_64,$(SYS))$(findstring linux,$(SYS)),x86_64linux)
 libsysdb.so: $(addsuffix .o,$(objs)) $(filter %.map %.lds,$(LDFLAGS)) \
 	     $(graphene_lib) $(pal_lib)
 	@echo [ $@ ]
-	$(LD) $(LDFLAGS) -o $@ $(filter-out %.map %.lds,$^) -soname $@ \
-		-e shim_start
+	$(LD) $(LDFLAGS) -o $@ $(filter-out %.map %.lds,$^) -soname $@
 
 libsysdb_debug.so: $(addsuffix .o,$(filter-out syscallas,$(objs))) \
 		   $(filter %.map %.lds,$($LDFLAGS-debug)) \
 		   $(graphene_lib) $(pal_lib)
 	@echo [ $@ ]
-	$(LD) $(LDFLAGS-debug) -o $@ $(filter-out %.map %.lds,$^) -soname $@ \
-		-e shim_start
+	$(LD) $(LDFLAGS-debug) -o $@ $(filter-out %.map %.lds,$^) -soname $@
 
 .lib/host_endian.h: ../../../Pal/src/host/$(PAL_HOST)/host_endian.h
 	@mkdir -p .lib

--- a/LibOS/shim/src/shim.lds
+++ b/LibOS/shim/src/shim.lds
@@ -1,5 +1,6 @@
 OUTPUT_FORMAT("elf64-x86-64", "elf64-x86-64", "elf64-x86-64")
 OUTPUT_ARCH(i386:x86-64)
+ENTRY(shim_start)
 
 SECTIONS
 {

--- a/Pal/src/host/Linux-SGX/Makefile.am
+++ b/Pal/src/host/Linux-SGX/Makefile.am
@@ -18,7 +18,7 @@ ASFLAGS = -DPIC -DSHARED -fPIC -DASSEMBLER -Wa,--noexecstack \
 	  -x assembler-with-cpp -DIN_ENCLAVE
 LDFLAGS	= -shared -nostdlib -z combreloc -z defs \
 	  --version-script $(HOST_DIR)/pal.map -T $(HOST_DIR)/enclave.lds \
-	  --hash-style=gnu -e enclave_entry
+	  --hash-style=gnu
 ARFLAGS	=
 
 CRYPTO_PROVIDER = mbedtls

--- a/Pal/src/host/Linux-SGX/enclave.lds
+++ b/Pal/src/host/Linux-SGX/enclave.lds
@@ -1,5 +1,6 @@
 OUTPUT_FORMAT("elf64-x86-64", "elf64-x86-64", "elf64-x86-64")
 OUTPUT_ARCH(i386:x86-64)
+ENTRY(enclave_entry)
 
 PHDRS
 {


### PR DESCRIPTION
For consistency use ENTRY(shim_start) in linker script, not command
line option of -e shim_start.
This also helps to understand how link is done. only shim.lds needs
to be read. don't have to dig into Makefile for command line.

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/339)
<!-- Reviewable:end -->
