### PR TITLE
Pal/host: static'fy _DkGenericEventTrigger

### DIFF
--- a/Pal/src/host/FreeBSD/db_exception.c
+++ b/Pal/src/host/FreeBSD/db_exception.c
@@ -219,9 +219,10 @@ static int get_event_num (int signum)
     }
 }
 
-void _DkGenericEventTrigger (int event_num, PAL_UPCALL upcall,
-                             int flags, PAL_NUM arg, struct pal_frame * frame,
-                             ucontext_t * uc, void * eframe)
+static void _DkGenericEventTrigger (int event_num, PAL_UPCALL upcall,
+                                    int flags, PAL_NUM arg,
+                                    struct pal_frame * frame,
+                                    ucontext_t * uc, void * eframe)
 {
     struct exception_event event;
 

--- a/Pal/src/host/FreeBSD/db_exception2.c
+++ b/Pal/src/host/FreeBSD/db_exception2.c
@@ -130,9 +130,9 @@ static int get_event_num (int signum)
     }
 }
 
-void _DkGenericEventTrigger (PAL_IDX event_num, PAL_EVENT_HANDLER upcall,
-                             PAL_NUM arg, struct pal_frame * frame,
-                             ucontext_t * uc, void * eframe)
+static void _DkGenericEventTrigger (PAL_IDX event_num, PAL_EVENT_HANDLER upcall,
+                                    PAL_NUM arg, struct pal_frame * frame,
+                                    ucontext_t * uc, void * eframe)
 {
     PAL_EVENT event;
     event.event_num = event_num;

--- a/Pal/src/host/Linux-SGX/db_exception.c
+++ b/Pal/src/host/Linux-SGX/db_exception.c
@@ -45,9 +45,9 @@ typedef struct exception_event {
     struct pal_frame *  frame;
 } PAL_EVENT;
 
-void _DkGenericEventTrigger (PAL_IDX event_num, PAL_EVENT_HANDLER upcall,
-                             PAL_NUM arg, struct pal_frame * frame,
-                             PAL_CONTEXT * context)
+static void _DkGenericEventTrigger (PAL_IDX event_num, PAL_EVENT_HANDLER upcall,
+                                    PAL_NUM arg, struct pal_frame * frame,
+                                    PAL_CONTEXT * context)
 {
     struct exception_event event;
 

--- a/Pal/src/host/Linux/db_exception.c
+++ b/Pal/src/host/Linux/db_exception.c
@@ -130,8 +130,8 @@ static int get_event_num (int signum)
     }
 }
 
-void _DkGenericEventTrigger (PAL_IDX event_num, PAL_EVENT_HANDLER upcall,
-                             PAL_NUM arg, ucontext_t * uc)
+static void _DkGenericEventTrigger (PAL_IDX event_num, PAL_EVENT_HANDLER upcall,
+                                    PAL_NUM arg, ucontext_t * uc)
 {
     PAL_EVENT event;
     event.event_num = event_num;


### PR DESCRIPTION
_DkGenericEventTrigger isn't used by other .o files.
So make it static.

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/340)
<!-- Reviewable:end -->
