### PR TITLE
shim/Makefile: don't build glibc unnecessarily

### DIFF
--- a/LibOS/Makefile
+++ b/LibOS/Makefile
@@ -19,11 +19,11 @@ format:
 
 ifeq ($(findstring x86_64,$(SYS))$(findstring linux,$(SYS)),x86_64linux)
 
-.INTERMEDIATE: $(BUILD_DIR)/Build.success
+.SECONDARY: $(BUILD_DIR)/Build.success
 
 $(BUILD_DIR)/Build.success: $(BUILD_DIR)/Makefile
 	@echo "Building glibc, may take a while to finish. Warning messages may show up. If this process terminates with failures, see \"$(BUILD_DIR)/build.log\" for more information."
-	cd $(BUILD_DIR) && ($(MAKE) 2>&1 >> build.log)
+	($(MAKE) -C $(BUILD_DIR) 2>&1 >> build.log) && touch $@
 #  2>&1 | tee -a build.log)
 
 $(GLIBC_TARGET): $(BUILD_DIR)/Build.success


### PR DESCRIPTION
Keep Success.build file by .SECONDARY instead of .INTERMEDIATE.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/341)
<!-- Reviewable:end -->
