### PR TITLE
LibOS/glibc: syscall-template.S ignores redzone

### DIFF
--- a/LibOS/glibc-2.19/syscalldb.h
+++ b/LibOS/glibc-2.19/syscalldb.h
@@ -5,12 +5,17 @@
 .weak syscalldb
 .type syscalldb, @function
 
-# define SYSCALLDB				\
-    pushq %rbx;					\
-    movq syscalldb@GOTPCREL(%rip), %rbx;	\
-    call *%rbx;					\
-    popq %rbx;
-
+# if defined(PSEUDO) && defined(SYSCALL_NAME) && defined(SYSCALL_SYMBOL)
+#  define SYSCALLDB				\
+    subq $128, %rsp;            \
+    movq syscalldb@GOTPCREL(%rip), %rcx;	\
+    call *%rcx;					\
+    addq $128, %rsp
+# else
+#  define SYSCALLDB				\
+    movq syscalldb@GOTPCREL(%rip), %rcx;	\
+    call *%rcx
+# endif
 
 #else /* !__ASSEMBLER__ */
 asm (


### PR DESCRIPTION
For trivial system call, sysdeps/unix/syscall-template.S is used to generate
system call stub functions. which ignores redzone.
Teach it redzone.
Also use %rcx instead of %rbx without pushq/popq as %rcx is clobbered
register as system call abi.

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/342)
<!-- Reviewable:end -->
