### PR TITLE
LibOS: asm offset generation

### DIFF
--- a/LibOS/shim/include/shim_tls.h
+++ b/LibOS/shim/include/shim_tls.h
@@ -8,12 +8,6 @@
 
 #define SHIM_TLS_CANARY $xdeadbeef
 
-#if defined(__x86_64__)
-# define SHIM_TCB_OFFSET    80
-#else
-# define SHIM_TCB_OFFSET    44
-#endif
-
 #else /* !__ASSEMBLER__ */
 
 #define SHIM_TLS_CANARY 0xdeadbeef

--- a/LibOS/shim/src/.gitignore
+++ b/LibOS/shim/src/.gitignore
@@ -1,1 +1,3 @@
 libsysdb.so.cached
+asm-offsets.h
+asm-offsets.s

--- a/LibOS/shim/src/Makefile
+++ b/LibOS/shim/src/Makefile
@@ -129,5 +129,9 @@ elf/shim_rtld.o: $(wildcard elf/*.h)
 	@echo [ $@ ]
 	@$(AS) $(ASFLAGS) $(defs) -E $< -o $@
 
+syscallas.S: asm-offsets.h
+
+include ../../../Makefile.rules
+
 clean:
-	rm -rf $(addsuffix .o,$(objs)) $(shim_target) $(files_to_build) .lib
+	rm -rf $(addsuffix .o,$(objs)) $(shim_target) $(files_to_build) .lib $(CLEAN_FILES)

--- a/LibOS/shim/src/asm-offsets.c
+++ b/LibOS/shim/src/asm-offsets.c
@@ -1,0 +1,18 @@
+#include <stddef.h>
+
+#include <shim_internal.h>
+#include <shim_tls.h>
+
+#define OFFSET_T(name, str_t, member)                       \
+    asm volatile(".ascii \" #define " #name " %0 \"\n"::    \
+                 "i"(offsetof(str_t, member)))
+
+void dummy(void)
+{
+    OFFSET_T(SHIM_TCB_OFFSET, __libc_tcb_t, shim_tcb);
+    OFFSET_T(TCB_SYSCALL_NR, shim_tcb_t, context.syscall_nr);
+    OFFSET_T(TCB_SP, shim_tcb_t, context.sp);
+    OFFSET_T(TCB_RET_IP, shim_tcb_t, context.ret_ip);
+    OFFSET_T(TCB_REGS, shim_tcb_t, context.regs);
+}
+

--- a/LibOS/shim/src/syscallas.S
+++ b/LibOS/shim/src/syscallas.S
@@ -23,6 +23,8 @@
 #include <shim_tls.h>
 #include <shim_unistd_defs.h>
 
+#include "asm-offsets.h"
+
         .global syscalldb
         .type syscalldb, @function
         .extern shim_table, debug_unsupp
@@ -62,22 +64,22 @@ isdef:
         pushq %r14
         pushq %r15
 
-        movq %rax, %fs:(SHIM_TCB_OFFSET + 24)
+        movq %rax, %fs:(SHIM_TCB_OFFSET + TCB_SYSCALL_NR)
         leaq 16(%rbp), %rax
-        movq %rax, %fs:(SHIM_TCB_OFFSET + 32)
+        movq %rax, %fs:(SHIM_TCB_OFFSET + TCB_SP)
         movq 8(%rbp), %rax
-        movq %rax, %fs:(SHIM_TCB_OFFSET + 40)
-        movq %rsp, %fs:(SHIM_TCB_OFFSET + 48)
+        movq %rax, %fs:(SHIM_TCB_OFFSET + TCB_RET_IP)
+        movq %rsp, %fs:(SHIM_TCB_OFFSET + TCB_REGS)
 
         /* Translating x86_64 kernel calling convention to user-space
          * calling convention */
         movq %r10, %rcx
         call *%rbx
 
-        movq $0, %fs:(SHIM_TCB_OFFSET + 24)
-        movq $0, %fs:(SHIM_TCB_OFFSET + 32)
-        movq $0, %fs:(SHIM_TCB_OFFSET + 40)
-        movq $0, %fs:(SHIM_TCB_OFFSET + 48)
+        movq $0, %fs:(SHIM_TCB_OFFSET + TCB_SYSCALL_NR)
+        movq $0, %fs:(SHIM_TCB_OFFSET + TCB_SP)
+        movq $0, %fs:(SHIM_TCB_OFFSET + TCB_RET_IP)
+        movq $0, %fs:(SHIM_TCB_OFFSET + TCB_REGS)
 
         popq %r15
         popq %r14

--- a/Makefile.rules
+++ b/Makefile.rules
@@ -1,0 +1,46 @@
+ifeq ("$(origin V)", "command line")
+  BUILD_VERBOSE = $(V)
+endif
+ifndef BUILD_VERBOSE
+  BUILD_VERBOSE = 0
+endif
+
+ifeq ($(BUILD_VERBOSE),1)
+  quiet =
+  Q =
+else
+  quiet = quiet_
+  Q = @
+endif
+
+export Q quiet BUILD_VERBOSE
+
+squote  := '
+escsq = $(subst $(squote),'\$(squote)',$1)
+
+echo-cmd = $(if $($(quiet)cmd_$(1)), echo '  $(call escsq,$($(quiet)cmd_$(1)))';)
+cmd = @$(echo-cmd) $(cmd_$(1))
+
+
+quiet_cmd_asm_offsets_s = [ $@ ]
+      cmd_asm_offsets_s = $(CC) $(CFLAGS) $(defs) -S $< -o $@
+
+asm-offsets.s: asm-offsets.c $(headers)
+	$(call cmd,asm_offsets_s)
+CLEAN_FILES += asm-offsets.s
+
+
+quiet_cmd_asm_offsets_h = [ $@ ]
+      cmd_asm_offsets_h = \
+	(set -e; \
+	 echo "/* DO NOT MODIFY. THIS FILE WAS AUTO-GENERATED. */"; \
+	 echo "\#ifndef _ASM_OFFSETS_H_"; \
+	 echo "\#define _ASM_OFFSETS_H_"; \
+	 echo ""; \
+	 awk '/\.ascii \" \#define/{val=$$5; gsub("\\$$", "", val); print $$3" "$$4" "val}' $^; \
+	 echo ""; \
+	 echo "\#endif") > $@
+
+asm-offsets.h: asm-offsets.s
+	$(call cmd,asm_offsets_h)
+CLEAN_FILES += asm-offests.h


### PR DESCRIPTION
Auto generate offset constants for assembly.
replace magic number with symbolic constants in
LibOS/shim/src/syscallas.S.

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/344)
<!-- Reviewable:end -->
