### PR TITLE
RFC: Signal delivery in user program via signal stack frame

### DIFF
--- a/LibOS/shim/include/shim_internal.h
+++ b/LibOS/shim/include/shim_internal.h
@@ -170,8 +170,12 @@ static inline void do_pause (void);
     do { debug("%s (" __FILE__ ":%d)\n", __func__, __LINE__); } while (0)
 
 /* definition for syscall table */
+extern unsigned long fpu_xstate_size;
+void handle_sysret_signal(void);
 void handle_signal (bool delayed_only);
+int handle_next_signal(ucontext_t * user_uc);
 long convert_pal_errno (long err);
+void __sigreturn(mcontext_t * user_uc);
 
 #define PAL_ERRNO  convert_pal_errno(PAL_NATIVE_ERRNO)
 
@@ -211,8 +215,9 @@ static inline uint64_t get_cur_preempt (void) {
 
 #define END_SHIM(name)                                      \
         END_SYSCALL_PROFILE(name);                          \
-        handle_signal(false);                               \
+        /* handle_signal(false); */                         \
         assert(preempt == get_cur_preempt());               \
+        handle_sysret_signal();                             \
         return ret;                                         \
     }
 
@@ -461,7 +466,12 @@ static inline void __enable_preempt (shim_tcb_t * tcb)
     //debug("enable preempt: %d\n", tcb->context.preempt & ~SIGNAL_DELAYED);
 }
 
-void __handle_signal (shim_tcb_t * tcb, int sig, ucontext_t * uc);
+typedef struct {
+    PAL_IDX         event_num;
+    PAL_CONTEXT     context;
+    ucontext_t *    uc;
+} PAL_EVENT;
+int __handle_signal (shim_tcb_t * tcb, int sig, ucontext_t * uc, PAL_EVENT * event);
 
 static inline void enable_preempt (shim_tcb_t * tcb)
 {
@@ -472,7 +482,7 @@ static inline void enable_preempt (shim_tcb_t * tcb)
         return;
 
     if ((tcb->context.preempt & ~SIGNAL_DELAYED) == 1)
-        __handle_signal(tcb, 0, NULL);
+        __handle_signal(tcb, 0, NULL, NULL);
 
     __enable_preempt(tcb);
 }
@@ -726,6 +736,13 @@ extern void * migrated_memory_end;
 
 extern void * __load_address, * __load_address_end;
 extern void * __code_address, * __code_address_end;
+extern void * __syscallas_signal_allowed_0_begin;
+extern void * __syscallas_signal_allowed_0_end;
+extern void * __syscallas_signal_allowed_1_begin;
+extern void * __syscallas_signal_allowed_1_end;
+extern void * __syscallas_signal_allowed_2_begin;
+extern void * __syscallas_signal_allowed_2_end;
+extern void * __syscallas_need_emulate_jmp;
 
 int shim_clean (void);
 
@@ -739,6 +756,9 @@ extern const char ** initial_envp;
     ((typeof(addr)) ((((unsigned long) addr) + allocshift) & allocmask))
 #define ALIGN_DOWN(addr)    \
     ((typeof(addr)) (((unsigned long) addr) & allocmask))
+
+#define ALIGN_DOWN_PTR(ptr, size)   ((typeof(ptr))(((uintptr_t)ptr) & -(size)))
+#define ALIGN_UP_PTR(ptr, size)     ((typeof(ptr))ALIGN_DOWN_PTR((uintptr_t)ptr + ((size) - 1), (size)))
 
 #define switch_stack(stack_top)                                     \
     ({                                                              \

--- a/LibOS/shim/include/shim_signal.h
+++ b/LibOS/shim/include/shim_signal.h
@@ -141,7 +141,7 @@ void __store_context (shim_tcb_t * tcb, PAL_CONTEXT * pal_context,
 
 void append_signal (struct shim_thread * thread, int sig, siginfo_t * info,
                     bool wakeup);
-void deliver_signal (siginfo_t * info, PAL_CONTEXT * context);
+void deliver_signal (PAL_PTR event, siginfo_t * info, PAL_CONTEXT * context);
 
 __sigset_t * get_sig_mask (struct shim_thread * thread);
 __sigset_t * set_sig_mask (struct shim_thread * thread,

--- a/LibOS/shim/include/shim_tls.h
+++ b/LibOS/shim/include/shim_tls.h
@@ -8,6 +8,8 @@
 
 #define SHIM_TLS_CANARY $xdeadbeef
 
+#define SHIM_FLAG_SIGPENDING        0
+
 #else /* !__ASSEMBLER__ */
 
 #define SHIM_TLS_CANARY 0xdeadbeef
@@ -65,6 +67,8 @@ typedef struct {
     unsigned int            tid;
     int                     pal_errno;
     void *                  debug_buf;
+#define SHIM_FLAG_SIGPENDING   0
+    unsigned long           flags;
 
     /* This record is for testing the memory of user inputs.
      * If a segfault occurs with the range [start, end],

--- a/LibOS/shim/include/shim_tls.h
+++ b/LibOS/shim/include/shim_tls.h
@@ -8,12 +8,6 @@
 
 #define SHIM_TLS_CANARY $xdeadbeef
 
-#if defined(__x86_64__)
-# define SHIM_TCB_OFFSET    80
-#else
-# define SHIM_TCB_OFFSET    44
-#endif
-
 #else /* !__ASSEMBLER__ */
 
 #define SHIM_TLS_CANARY 0xdeadbeef

--- a/LibOS/shim/src/.gitignore
+++ b/LibOS/shim/src/.gitignore
@@ -1,1 +1,3 @@
 libsysdb.so.cached
+asm-offsets.h
+asm-offsets.s

--- a/LibOS/shim/src/Makefile
+++ b/LibOS/shim/src/Makefile
@@ -104,7 +104,7 @@ $(addsuffix .o,$(addprefix ipc/shim_ipc_,$(ipcns))): $(wildcard ipc/*.h)
 elf/shim_rtld.o: $(wildcard elf/*.h)
 
 
-%.o: %.c $(headers)
+%.o %.s: %.c $(headers)
 	@echo [ $@ ]
 	@$(CC) $(CFLAGS) $(defs) -c $< -o $@
 
@@ -119,6 +119,18 @@ elf/shim_rtld.o: $(wildcard elf/*.h)
 %.e: %.S $(headers)
 	@echo [ $@ ]
 	@$(AS) $(ASFLAGS) $(defs) -E $< -o $@
+
+
+syscallas.S: asm-offsets.h
+asm-offsets.h: asm-offsets.s
+	@echo [ $@ ]
+	@(echo "/* DO NOT MODIFY. this file is auto generated file. */"; \
+	echo "#ifndef _ASM_OFFSETS_H_"; \
+	echo "#define _ASM_OFFSETS_H_"; \
+	echo ""; \
+	awk '/\.ascii \" #define/{val=$$5;gsub("\\$$", "", val);print $$3" "$$4" "val}' $^; \
+	echo ""; \
+	echo "#endif") > $@
 
 clean:
 	rm -rf $(addsuffix .o,$(objs)) $(shim_target) .lib

--- a/LibOS/shim/src/asm-offsets.c
+++ b/LibOS/shim/src/asm-offsets.c
@@ -2,17 +2,33 @@
 
 #include <shim_internal.h>
 #include <shim_tls.h>
+#include <shim_thread.h>
+#include <shim_types.h>
 
-#define OFFSET_T(name, str_t, member)                       \
-    asm volatile(".ascii \" #define " #name " %0 \"\n"::    \
-                 "i"(offsetof(str_t, member)))
+#define DEFINE(name, value)     \
+    asm volatile(".ascii \" #define " #name " %0 \"\n":: "i"(value))
+
+#define OFFSET(name, str, member)   DEFINE(name, offsetof(struct str, member))
+#define OFFSET_T(name, str_t, member) DEFINE(name, offsetof(str_t, member))
 
 void dummy(void)
 {
+    /* shim_tcb_t */
     OFFSET_T(SHIM_TCB_OFFSET, __libc_tcb_t, shim_tcb);
+    OFFSET_T(TCB_SELF, shim_tcb_t, self);
+    OFFSET_T(TCB_TP, shim_tcb_t, tp);
     OFFSET_T(TCB_SYSCALL_NR, shim_tcb_t, context.syscall_nr);
     OFFSET_T(TCB_SP, shim_tcb_t, context.sp);
     OFFSET_T(TCB_RET_IP, shim_tcb_t, context.ret_ip);
     OFFSET_T(TCB_REGS, shim_tcb_t, context.regs);
+    OFFSET_T(TCB_FLAGS, shim_tcb_t, flags);
+
+    /* struct shim_thread */
+    OFFSET(THREAD_HAS_SIGNAL, shim_thread, has_signal);
+
+    /* definitions */
+    DEFINE(SIGFRAME_SIZE, sizeof(struct sigframe));
+    DEFINE(FP_XSTATE_SIZE, sizeof(struct _libc_fpstate));
+    DEFINE(FP_XSTATE_MAGIC2_SIZE, FP_XSTATE_MAGIC2_SIZE);
 }
 

--- a/LibOS/shim/src/asm-offsets.c
+++ b/LibOS/shim/src/asm-offsets.c
@@ -1,0 +1,18 @@
+#include <stddef.h>
+
+#include <shim_internal.h>
+#include <shim_tls.h>
+
+#define OFFSET_T(name, str_t, member)                       \
+    asm volatile(".ascii \" #define " #name " %0 \"\n"::    \
+                 "i"(offsetof(str_t, member)))
+
+void dummy(void)
+{
+    OFFSET_T(SHIM_TCB_OFFSET, __libc_tcb_t, shim_tcb);
+    OFFSET_T(TCB_SYSCALL_NR, shim_tcb_t, context.syscall_nr);
+    OFFSET_T(TCB_SP, shim_tcb_t, context.sp);
+    OFFSET_T(TCB_RET_IP, shim_tcb_t, context.ret_ip);
+    OFFSET_T(TCB_REGS, shim_tcb_t, context.regs);
+}
+

--- a/LibOS/shim/src/bookkeep/shim_signal.c
+++ b/LibOS/shim/src/bookkeep/shim_signal.c
@@ -59,6 +59,18 @@ allocate_signal_log (struct shim_thread * thread, int sig)
 
     atomic_inc(&thread->has_signal);
 
+#if 0
+    // TODO: XXX ??? why thread->tcb seems stale?
+    if (thread->tcb)
+        set_bit(SHIM_FLAG_SIGPENDING, &(((shim_tcb_t*)thread->tcb)->flags));
+#endif
+
+    debug("signal set_bit thread: %p tcb: %p &tcb->flags: %p tcb->flags 0x%x "
+          "tcb->tid %d counter = %d\n",
+          thread, thread->tcb, &(((shim_tcb_t*)thread->tcb)->flags),
+          ((shim_tcb_t*)thread->tcb)->flags, ((shim_tcb_t*)thread->tcb)->tid,
+        thread->has_signal.counter);
+
     return &log->logs[old_tail];
 }
 
@@ -96,7 +108,8 @@ fetch_signal_log (shim_tcb_t * tcb, struct shim_thread * thread, int sig)
 }
 
 static void
-__handle_one_signal (shim_tcb_t * tcb, int sig, struct shim_signal * signal);
+__handle_one_signal (shim_tcb_t * tcb, int sig, struct shim_signal * signal,
+                     PAL_EVENT * event);
 
 static void __store_info (siginfo_t * info, struct shim_signal * signal)
 {
@@ -143,7 +156,7 @@ void __store_context (shim_tcb_t * tcb, PAL_CONTEXT * pal_context,
     }
 }
 
-void deliver_signal (siginfo_t * info, PAL_CONTEXT * context)
+void deliver_signal (PAL_PTR event, siginfo_t * info, PAL_CONTEXT * context)
 {
     shim_tcb_t * tcb = SHIM_GET_TLS();
     assert(tcb);
@@ -166,7 +179,8 @@ void deliver_signal (siginfo_t * info, PAL_CONTEXT * context)
     signal->pal_context = context;
 
     if ((tcb->context.preempt & ~SIGNAL_DELAYED) > 1 ||
-        __sigismember(&cur_thread->signal_mask, sig)) {
+        __sigismember(&cur_thread->signal_mask, sig) ||
+        event == NULL /* send to self */) {
         struct shim_signal ** signal_log = NULL;
         if ((signal = malloc_copy(signal,sizeof(struct shim_signal))) &&
             (signal_log = allocate_signal_log(cur_thread, sig))) {
@@ -178,8 +192,8 @@ void deliver_signal (siginfo_t * info, PAL_CONTEXT * context)
             free(signal);
         }
     } else {
-        __handle_signal(tcb, sig, &signal->context);
-        __handle_one_signal(tcb, sig, signal);
+        if (!__handle_signal(tcb, sig, &signal->context, event))
+            __handle_one_signal(tcb, sig, signal, event);
     }
 
     __enable_preempt(tcb);
@@ -208,6 +222,26 @@ static inline bool is_internal(PAL_CONTEXT * context)
         (void *) context->IP < (void *) &__code_address_end;
 }
 
+static inline bool is_signal_allowed(const PAL_CONTEXT * context)
+{
+    if (context == NULL)
+        return false;
+
+    const void * ip = (const void *)context->IP;
+    return (((void *) &__syscallas_signal_allowed_0_begin <= ip &&
+             ip < (void *) &__syscallas_signal_allowed_0_end) ||
+            ((void *) &__syscallas_signal_allowed_1_begin <= ip &&
+             ip < (void *) &__syscallas_signal_allowed_1_end) ||
+            ((void *) &__syscallas_signal_allowed_2_begin <= ip &&
+             ip < (void *) &__syscallas_signal_allowed_2_end));
+}
+
+static inline bool is_sigreturn_jmp_emulation(const PAL_CONTEXT * context)
+{
+    return context != NULL &&
+        (void *)context->IP == (void *)&__syscallas_need_emulate_jmp;
+}
+
 static inline void internal_fault(const char* errstr,
                                   PAL_NUM addr, PAL_CONTEXT * context)
 {
@@ -232,8 +266,8 @@ static void divzero_upcall (PAL_PTR event, PAL_NUM arg, PAL_CONTEXT * context)
         if (context)
             debug("arithmetic fault at %p\n", context->IP);
 
-        deliver_signal(ALLOC_SIGINFO(SIGFPE, FPE_INTDIV,
-                                     si_addr, (void *) arg), context);
+        deliver_signal(event, ALLOC_SIGINFO(SIGFPE, FPE_INTDIV,
+                                            si_addr, (void *) arg), context);
     }
     DkExceptionReturn(event);
 }
@@ -293,7 +327,8 @@ static void memfault_upcall (PAL_PTR event, PAL_NUM arg, PAL_CONTEXT * context)
         code = SEGV_MAPERR;
     }
 
-    deliver_signal(ALLOC_SIGINFO(signo, code, si_addr, (void *) arg), context);
+    deliver_signal(event, ALLOC_SIGINFO(signo, code, si_addr, (void *) arg),
+                   context);
 
 ret_exception:
     DkExceptionReturn(event);
@@ -407,8 +442,8 @@ static void illegal_upcall (PAL_PTR event, PAL_NUM arg, PAL_CONTEXT * context)
         if (context)
             debug("illegal instruction at %p\n", context->IP);
 
-        deliver_signal(ALLOC_SIGINFO(SIGILL, ILL_ILLOPC,
-                                     si_addr, (void *) arg), context);
+        deliver_signal(event, ALLOC_SIGINFO(SIGILL, ILL_ILLOPC,
+                                            si_addr, (void *) arg), context);
     } else {
         internal_fault("Internal illegal fault", arg, context);
     }
@@ -418,7 +453,7 @@ static void illegal_upcall (PAL_PTR event, PAL_NUM arg, PAL_CONTEXT * context)
 static void quit_upcall (PAL_PTR event, PAL_NUM arg, PAL_CONTEXT * context)
 {
     if (!IS_INTERNAL_TID(get_cur_tid())) {
-        deliver_signal(ALLOC_SIGINFO(SIGTERM, SI_USER, si_pid, 0), NULL);
+        deliver_signal(event, ALLOC_SIGINFO(SIGTERM, SI_USER, si_pid, 0), NULL);
     }
     DkExceptionReturn(event);
 }
@@ -426,12 +461,12 @@ static void quit_upcall (PAL_PTR event, PAL_NUM arg, PAL_CONTEXT * context)
 static void suspend_upcall (PAL_PTR event, PAL_NUM arg, PAL_CONTEXT * context)
 {
     if (!IS_INTERNAL_TID(get_cur_tid())) {
-        deliver_signal(ALLOC_SIGINFO(SIGINT, SI_USER, si_pid, 0), NULL);
+        deliver_signal(event, ALLOC_SIGINFO(SIGINT, SI_USER, si_pid, 0), NULL);
     }
     DkExceptionReturn(event);
 }
 
-static void resume_upcall (PAL_PTR event, PAL_NUM arg, PAL_CONTEXT * context)
+static void resume_upcall (PAL_PTR eventp, PAL_NUM arg, PAL_CONTEXT * context)
 {
     shim_tcb_t * tcb = SHIM_GET_TLS();
 
@@ -442,13 +477,17 @@ static void resume_upcall (PAL_PTR event, PAL_NUM arg, PAL_CONTEXT * context)
         if ((tcb->context.preempt & ~SIGNAL_DELAYED) > 1) {
             tcb->context.preempt |= SIGNAL_DELAYED;
         } else {
-            __handle_signal(tcb, 0, NULL);
+            PAL_EVENT * event = (PAL_EVENT *) eventp;
+            debug("resume_upcall rsp: %p rip %p tid: %d\n",
+                  context->rsp, context->rip, get_cur_tid());
+
+            __handle_signal(tcb, 0, event->uc, event);
         }
 
         __enable_preempt(tcb);
     }
 
-    DkExceptionReturn(event);
+    DkExceptionReturn(eventp);
 }
 
 int init_signal (void)
@@ -488,19 +527,91 @@ __sigset_t * set_sig_mask (struct shim_thread * thread,
 
 static void (*default_sighandler[NUM_SIGS]) (int, siginfo_t *, void *);
 
-static void
-__handle_one_signal (shim_tcb_t * tcb, int sig, struct shim_signal * signal)
+static unsigned int fpstate_size_get(const struct _libc_fpstate * fpstate)
 {
-    struct shim_thread * thread = (struct shim_thread *) tcb->tp;
-    struct shim_signal_handle * sighdl = &thread->signal_handles[sig - 1];
-    void (*handler) (int, siginfo_t *, void *) = NULL;
+    if (fpstate == NULL)
+        return 0;
 
-    if (signal->info.si_signo == SIGCP) {
-        join_checkpoint(thread, &signal->context, si_cp_session(&signal->info));
-        return;
+    const struct _fpx_sw_bytes * sw = &fpstate->sw_reserved;
+    if (sw->magic1 == FP_XSTATE_MAGIC1 &&
+        sw->xstate_size < sw->extended_size &&
+        *((typeof(FP_XSTATE_MAGIC2)*)((void*)fpstate + sw->xstate_size)) ==
+        FP_XSTATE_MAGIC2)
+        return sw->extended_size;
+
+    return sizeof(struct swregs_state);
+}
+
+static void __setup_sig_frame(
+    shim_tcb_t * tcb, int sig, struct shim_signal * signal,
+    PAL_PTR eventp,
+    void (*handler) (int, siginfo_t *, void *), void (*restorer) (void))
+{
+    PAL_EVENT * event = (PAL_EVENT *) eventp;
+    //struct shim_thread * thread = (struct shim_thread *) tcb->tp;
+
+    ucontext_t * uc = event->uc;
+    struct _libc_fpstate * fpstate = uc->uc_mcontext.fpregs;
+    unsigned int fpstate_size = fpstate_size_get(fpstate);
+
+    long sp = uc->uc_mcontext.gregs[REG_RSP];
+    sp -= 128;  /* redzone */
+    fpregset_t user_fp = (fpregset_t)ALIGN_DOWN_PTR(sp - fpstate_size, 64UL);
+    struct sigframe * user_sigframe = (struct sigframe *)ALIGN_DOWN_PTR(user_fp - sizeof(struct sigframe), 16UL) - 8;
+    user_sigframe->restorer = restorer;
+    memcpy(&user_sigframe->uc, uc, sizeof(*uc));
+    /* For now sigaltstack isn't supported */
+    stack_t * stack = &user_sigframe->uc.uc_stack;
+    stack->ss_sp = 0;
+    stack->ss_flags = SS_DISABLE;
+    stack->ss_size = 0;
+    memcpy(&user_sigframe->info, &signal->info, sizeof(signal->info));
+    if (fpstate_size > 0) {
+        memcpy(user_fp, fpstate, fpstate_size);
+        user_sigframe->uc.uc_mcontext.fpregs = user_fp;
+    } else {
+        user_sigframe->uc.uc_mcontext.fpregs = NULL;
+    }
+    memcpy(&user_sigframe->uc.uc_sigmask, &uc->uc_sigmask,
+           sizeof(user_sigframe->uc.uc_sigmask));
+
+    PAL_CONTEXT * pal_context = signal->pal_context;
+    if (pal_context) {
+        pal_context->rsp = (long)user_sigframe;
+        pal_context->rip = (long)handler;
+        pal_context->rdi = signal->info.si_signo;
+        pal_context->rsi = (long)&user_sigframe->info;
+        pal_context->rdx = (long)&user_sigframe->uc;
+        pal_context->rax = 0;
     }
 
-    debug("%s handled\n", signal_name(sig));
+    gregset_t * gregs = &uc->uc_mcontext.gregs;
+    (*gregs)[REG_RSP] = (long)user_sigframe;
+    (*gregs)[REG_RIP] = (long)handler;
+    (*gregs)[REG_RDI] = (long)signal->info.si_signo;
+    (*gregs)[REG_RSI] = (long)&user_sigframe->info;
+    (*gregs)[REG_RDX] = (long)&user_sigframe->uc;
+    (*gregs)[REG_RAX] = 0;
+
+    // _DkExceptionReturn overwrite uc.uc_mcontext.gregs
+    // PAL_CONTEXT == greg_t
+    memcpy(&event->context, gregs, sizeof(PAL_CONTEXT));
+
+    // keep fpu state to user signal handler
+    uc->uc_mcontext.fpregs = NULL;
+    uc->uc_flags &= ~UC_FP_XSTATE;
+
+    debug("deliver signal handler to user stack %p (%d, %p, %p)\n",
+          handler, sig, &signal->info, &signal->context);
+}
+
+static void get_signal_handler(struct shim_thread * thread, int sig,
+                               void (**handler) (int, siginfo_t *, void *),
+                               void (**restorer) (void))
+{
+    struct shim_signal_handle * sighdl = &thread->signal_handles[sig - 1];
+    *handler = NULL;
+    *restorer = NULL;
 
     lock(thread->lock);
 
@@ -510,12 +621,13 @@ __handle_one_signal (shim_tcb_t * tcb, int sig, struct shim_signal * signal)
            use sa_handler as sa_sigaction, because sa_sigaction is
            not supported in amd64 */
 #ifdef __i386__
-        handler = (void (*) (int, siginfo_t *, void *)) act->_u._sa_handler;
+        *handler = (void (*) (int, siginfo_t *, void *)) act->_u._sa_handler;
         if (act->sa_flags & SA_SIGINFO)
             sa_handler = act->_u._sa_sigaction;
 #else
-        handler = (void (*) (int, siginfo_t *, void *)) act->k_sa_handler;
+        *handler = (void (*) (int, siginfo_t *, void *)) act->k_sa_handler;
 #endif
+        *restorer = act->sa_restorer;
         if (act->sa_flags & SA_RESETHAND) {
             sighdl->action = NULL;
             free(act);
@@ -523,7 +635,25 @@ __handle_one_signal (shim_tcb_t * tcb, int sig, struct shim_signal * signal)
     }
 
     unlock(thread->lock);
+}
 
+
+static void
+__handle_one_signal (shim_tcb_t * tcb, int sig, struct shim_signal * signal,
+                     PAL_EVENT * event)
+{
+    struct shim_thread * thread = (struct shim_thread *) tcb->tp;
+    void (*handler) (int, siginfo_t *, void *) = NULL;
+    void (*restorer) (void) = NULL;
+
+    if (signal->info.si_signo == SIGCP) {
+        join_checkpoint(thread, &signal->context, si_cp_session(&signal->info));
+        return;
+    }
+
+    debug("%s handled\n", signal_name(sig));
+
+    get_signal_handler(thread, sig, &handler, &restorer);
     if ((void *) handler == (void *) 1) /* SIG_IGN */
         return;
 
@@ -536,30 +666,47 @@ __handle_one_signal (shim_tcb_t * tcb, int sig, struct shim_signal * signal)
     if (!signal->context_stored)
         __store_context(tcb, NULL, signal);
 
-    struct shim_context * context = NULL;
+    if (event != NULL &&
+        (!is_internal(&event->context) || is_signal_allowed(&event->context)) &&
+        !DkInPal(&event->context)) {
+        if (is_sigreturn_jmp_emulation(&event->context)) {
+            /* see syscallas.S */
+            PAL_CONTEXT * context = &event->context;
+            context->rip = *(long*)((void*)context->rsp - 128 - 8);
 
-    if (tcb->context.syscall_nr) {
-        context = __alloca(sizeof(struct shim_context));
-        memcpy(context, &tcb->context, sizeof(struct shim_context));
-        tcb->context.syscall_nr = 0;
-        tcb->context.next = context;
+            gregset_t *gregset = &event->uc->uc_mcontext.gregs;
+            (*gregset)[REG_RIP] = *(long*)((*gregset)[REG_RSP] - 128 - 8);
+        }
+        __setup_sig_frame(tcb, sig, signal, event, handler, restorer);
+    } else {
+        /*
+         * host signal handler is called during PAL or LibOS.
+         * It means thread is in systeam call emulation. actual signal
+         * delivery is done by deliver_signal_on_sysret()
+         */
+        debug("appending signal for trigger syscall return  "
+              "%p (%d, %p, %p)\n", handler, sig, &signal->info,
+              &signal->context);
+        debug("waking up for signal "
+              "thread: %p tcb: %p, tcb->flags: %p 0x%x tid: %d\n",
+              thread, tcb, &tcb->flags, tcb->flags, tcb->tid);
+        set_bit(SHIM_FLAG_SIGPENDING, &(((shim_tcb_t*)thread->tcb)->flags));
     }
-
-    debug("run signal handler %p (%d, %p, %p)\n", handler, sig, &signal->info,
-          &signal->context);
-
-    (*handler) (sig, &signal->info, &signal->context);
-
-    if (context)
-        memcpy(&tcb->context, context, sizeof(struct shim_context));
-
-    if (signal->pal_context)
-        memcpy(signal->pal_context, signal->context.uc_mcontext.gregs,
-               sizeof(PAL_CONTEXT));
 }
 
-void __handle_signal (shim_tcb_t * tcb, int sig, ucontext_t * uc)
+int __handle_signal (shim_tcb_t * tcb, int sig, ucontext_t * uc, PAL_EVENT * event)
 {
+    if (uc == NULL || event == NULL)
+        return 0;
+
+    if (event != NULL &&
+        (is_internal(&event->context) &&
+         !is_signal_allowed(&event->context) &&
+         DkInPal(&event->context))) {
+        debug("__handle_signal: in libos or pal. just returning\n");
+        return 0;
+    }
+
     struct shim_thread * thread = (struct shim_thread *) tcb->tp;
     int begin_sig = 1, end_sig = NUM_KNOWN_SIGS;
 
@@ -582,11 +729,32 @@ void __handle_signal (shim_tcb_t * tcb, int sig, ucontext_t * uc)
         if (!signal->context_stored)
             __store_context(tcb, NULL, signal);
 
-        __handle_one_signal(tcb, sig, signal);
+        __handle_one_signal(tcb, sig, signal, event);
         free(signal);
         DkThreadYieldExecution();
         tcb->context.preempt &= ~SIGNAL_DELAYED;
+        if (uc != NULL && event != NULL)
+            return 1;
     }
+
+    return 0;
+}
+
+void handle_sysret_signal(void)
+{
+    shim_tcb_t * tcb = SHIM_GET_TLS();
+    struct shim_thread * thread = (struct shim_thread *) tcb->tp;
+    debug("sysret signal: regs %p stack: %p "
+          "thread: %p tcb: %p &flags: %p flags: 0x%x (counter = %d) stack: %p\n",
+          tcb->context.regs, tcb->context.sp,
+          thread, tcb, &tcb->flags, tcb->flags, thread->has_signal.counter,
+          &tcb);
+
+    clear_bit(SHIM_FLAG_SIGPENDING, &tcb->flags);
+    /* This doesn't take user signal mask into account.
+       peek_signal_log would be needed. not fetch_signal_log */
+    if (atomic_read(&thread->has_signal))
+        set_bit(SHIM_FLAG_SIGPENDING, &tcb->flags);
 }
 
 void handle_signal (bool delayed_only)
@@ -597,22 +765,218 @@ void handle_signal (bool delayed_only)
     struct shim_thread * thread = (struct shim_thread *) tcb->tp;
 
     /* Fast path */
-    if (!thread || !thread->has_signal.counter)
+    if (!thread || !atomic_read(&thread->has_signal))
         return;
+
+    debug("handle signal (counter = %d)\n", atomic_read(&thread->has_signal));
 
     __disable_preempt(tcb);
 
     if ((tcb->context.preempt & ~SIGNAL_DELAYED) > 1) {
         debug("signal delayed (%d)\n", tcb->context.preempt & ~SIGNAL_DELAYED);
         tcb->context.preempt |= SIGNAL_DELAYED;
+        set_bit(SHIM_FLAG_SIGPENDING, &tcb->flags);
     } else {
         if (!(delayed_only && !(tcb->context.preempt & SIGNAL_DELAYED))) {
-            __handle_signal(tcb, 0, NULL);
+            __handle_signal(tcb, 0, NULL, NULL);
         }
     }
 
     __enable_preempt(tcb);
     debug("__enable_preempt: %s:%d\n", __FILE__, __LINE__);
+}
+
+static void __setup_next_sig_frame(
+    shim_tcb_t * tcb, int sig, struct shim_signal * signal,
+    ucontext_t * user_uc,
+    void (*handler) (int, siginfo_t *, void *), void (*restorer) (void))
+{
+    struct sigframe * user_sigframe = (struct sigframe*)(((void *)user_uc) - 8);
+
+    user_sigframe->restorer = restorer;
+    struct shim_regs * regs = tcb->context.regs;
+    tcb->context.sp = (void *)user_sigframe;
+    tcb->context.ret_ip = (void *)handler;
+    regs->rdi = (unsigned long)sig;
+    regs->rsi = (unsigned long)&user_sigframe->info;
+    regs->rdx = (unsigned long)&user_sigframe->uc;
+    tcb->context.syscall_nr = 0; // rax
+
+    // TODO signal mask
+
+    // TODO initialize more fp registers.
+    __asm__ __volatile__("fninit\n");
+}
+
+struct sig_deliver
+{
+    int sig;
+    struct shim_signal * signal;
+    void (*handler) (int, siginfo_t *, void *);
+    void (*restorer) (void);
+};
+
+static bool __get_signal_to_deliver(struct sig_deliver * deliver)
+{
+    deliver->signal = NULL;
+    shim_tcb_t * tcb = SHIM_GET_TLS();
+    struct shim_thread * thread = get_cur_thread();
+
+    while (atomic_read(&thread->has_signal)) {
+        struct shim_signal * signal = NULL;
+        /* signul number starts from 1 */
+        int sig;
+        for (sig = 1 ; sig < NUM_KNOWN_SIGS ; sig++)
+            if (!__sigismember(&thread->signal_mask, sig) &&
+                (signal = fetch_signal_log(tcb, thread, sig)))
+                break;
+
+        if (!signal)
+            continue;
+
+        void (*handler) (int, siginfo_t *, void *);
+        void (*restorer) (void);
+        get_signal_handler(thread, sig, &handler, &restorer);
+        if ((void *) handler == (void *) 1) /* SIG_IGN */
+            continue;
+
+        if (!handler && !(handler = default_sighandler[sig - 1]))
+            continue;
+
+        deliver->sig = sig;
+        deliver->signal = signal;
+        deliver->handler = handler;
+        deliver->restorer = restorer;
+        return true;
+    }
+    return false;
+}
+
+
+int handle_next_signal(ucontext_t * user_uc)
+{
+    struct sig_deliver deliver;
+    if (__get_signal_to_deliver(&deliver)) {
+        __setup_next_sig_frame(SHIM_GET_TLS(), deliver.sig, deliver.signal,
+                               user_uc, deliver.handler, deliver.restorer);
+        return 1;
+    }
+    return 0;
+}
+
+bool deliver_signal_on_sysret(void * stack,
+                              uint64_t rflags, uint64_t syscall_ret)
+{
+    shim_tcb_t * tcb = SHIM_GET_TLS();
+
+    struct sig_deliver deliver;
+    debug("regs: %p sp: %p ip: %p stack: %p &tcb %p tcb %p\n",
+          tcb->context.regs, tcb->context.sp, tcb->context.ret_ip,
+          stack, &tcb, tcb);
+
+    clear_bit(SHIM_FLAG_SIGPENDING, &tcb->flags);
+    if (!__get_signal_to_deliver(&deliver)) {
+        /* syscallas.S restore %rax as return value for system call */
+        tcb->context.syscall_nr = syscall_ret;
+        return false;
+    }
+
+    int sig = deliver.sig;
+    struct shim_signal * signal = deliver.signal;
+    void (*handler) (int, siginfo_t *, void *) = deliver.handler;
+    void (*restorer) (void) = deliver.restorer;
+
+    struct shim_regs * regs = stack;
+    stack += sizeof(*regs);
+    long * rip = stack;
+    stack += sizeof(*rip);
+    struct sigframe * user_sigframe = stack;
+    assert(user_sigframe == ALIGN_UP_PTR(user_sigframe, 16UL));
+    stack += sizeof(*user_sigframe);
+    stack = ALIGN_UP_PTR(stack, 64UL);
+    struct _libc_fpstate * user_fpstate = stack;
+
+    debug("regs: %p rip: %p sigframe: %p uc: %p fpstate: %p\n",
+          regs, rip, user_sigframe, &user_sigframe->uc, user_fpstate);
+
+    /* move up context.regs on stack*/
+    memcpy(regs, tcb->context.regs, sizeof(*regs));
+    tcb->context.regs = regs;
+
+    /* setup sigframe */
+    user_sigframe->restorer = restorer;
+
+    ucontext_t * user_uc = &user_sigframe->uc;
+    user_uc->uc_flags = UC_FP_XSTATE;
+    user_uc->uc_link = NULL;
+    user_uc->uc_stack.ss_sp = 0;
+    user_uc->uc_stack.ss_size = 0;
+    user_uc->uc_stack.ss_flags = 0;
+
+    gregset_t * gregs = &user_uc->uc_mcontext.gregs;
+    (*gregs)[REG_R8] = regs->r8;
+    (*gregs)[REG_R9] = regs->r9;
+    (*gregs)[REG_R10] = regs->r10;
+    (*gregs)[REG_R11] = regs->r11;
+    (*gregs)[REG_R12] = regs->r12;
+    (*gregs)[REG_R13] = regs->r13;
+    (*gregs)[REG_R14] = regs->r14;
+    (*gregs)[REG_R15] = regs->r15;
+    (*gregs)[REG_RDI] = regs->rdi;
+    (*gregs)[REG_RSI] = regs->rsi;
+    (*gregs)[REG_RBP] = regs->rbp;
+    (*gregs)[REG_RBX] = regs->rbx;
+    (*gregs)[REG_RDX] = regs->rdx;
+    (*gregs)[REG_RAX] = syscall_ret;
+    (*gregs)[REG_RCX] = regs->rcx;
+    (*gregs)[REG_RSP] = (long)tcb->context.sp;
+    (*gregs)[REG_RIP] = (long)tcb->context.ret_ip;
+    (*gregs)[REG_EFL] = rflags;
+    union csgsfs sr = {
+        .cs = 0x33, // __USER_CS(5) | 0(GDT) | 3(RPL)
+        .fs = 0,
+        .gs = 0,
+        .ss = 0x2b, // __USER_DS(6) | 0(GDT) | 3(RPL)
+    };
+    (*gregs)[REG_CSGSFS] = sr.csgsfs;
+
+    (*gregs)[REG_ERR] = signal->info.si_errno;
+    (*gregs)[REG_TRAPNO] = signal->info.si_code;
+    (*gregs)[REG_OLDMASK] = 0;
+    (*gregs)[REG_CR2] = (long)signal->info.si_addr;
+
+    user_uc->uc_mcontext.fpregs = user_fpstate;
+    memset(user_fpstate, 0, fpu_xstate_size);
+
+    long lmask = -1;
+    long hmask = -1;
+    asm volatile("xsave64 (%0)"
+                 :: "r"(user_fpstate), "m"(*user_fpstate),
+                  "a"(lmask), "d"(hmask)
+                 : "memory");
+    struct _fpx_sw_bytes * user_sw = &user_fpstate->sw_reserved;
+    user_sw->magic1 = FP_XSTATE_MAGIC1;
+    user_sw->extended_size = fpu_xstate_size + FP_XSTATE_MAGIC2_SIZE;
+    user_sw->xstate_size = fpu_xstate_size;
+    *((typeof(FP_XSTATE_MAGIC2)*)((void*)user_fpstate + user_sw->xstate_size))
+        = FP_XSTATE_MAGIC2;
+
+    // TODO initialize by XRESTORE64
+    asm volatile("fninit");
+
+    // TODO. get current sigmask and mask signal
+    // XXX sigaction();
+    __sigemptyset(&user_uc->uc_sigmask);
+
+    // setup to return to signal handler
+    // tcb->context.sp = (void *)user_sigframe;
+    // tcb->context.ret_ip = (void *)handler;
+    *rip = (long)handler;
+    regs->rdi = (long)sig;
+    regs->rsi = (unsigned long)&user_sigframe->info;
+    regs->rdx = (unsigned long)&user_sigframe->uc;
+
+    return true;
 }
 
 void append_signal (struct shim_thread * thread, int sig, siginfo_t * info,

--- a/LibOS/shim/src/bookkeep/shim_signal.c
+++ b/LibOS/shim/src/bookkeep/shim_signal.c
@@ -165,34 +165,23 @@ void deliver_signal (siginfo_t * info, PAL_CONTEXT * context)
     __store_context(tcb, context, signal);
     signal->pal_context = context;
 
-    if ((tcb->context.preempt & ~SIGNAL_DELAYED) > 1)
-        goto delay;
-
-    if (__sigismember(&cur_thread->signal_mask, sig))
-        goto delay;
-
-    __handle_signal(tcb, sig, &signal->context);
-    __handle_one_signal(tcb, sig, signal);
-    goto out;
-
-delay:
-    {
-        if (!(signal = malloc_copy(signal,sizeof(struct shim_signal))))
-            goto out;
-
-        struct shim_signal ** signal_log = allocate_signal_log(cur_thread, sig);
-
-        if (!signal_log) {
+    if ((tcb->context.preempt & ~SIGNAL_DELAYED) > 1 ||
+        __sigismember(&cur_thread->signal_mask, sig)) {
+        struct shim_signal ** signal_log = NULL;
+        if ((signal = malloc_copy(signal,sizeof(struct shim_signal))) &&
+            (signal_log = allocate_signal_log(cur_thread, sig))) {
+            *signal_log = signal;
+        }
+        if (signal && !signal_log) {
             sys_printf("signal queue is full (TID = %u, SIG = %d)\n",
                        tcb->tid, sig);
             free(signal);
-            goto out;
         }
-
-        *signal_log = signal;
+    } else {
+        __handle_signal(tcb, sig, &signal->context);
+        __handle_one_signal(tcb, sig, signal);
     }
 
-out:
     __enable_preempt(tcb);
 }
 
@@ -212,39 +201,40 @@ out:
 #define IP eip
 #endif
 
-#define is_internal(context)                                                \
-    ((context) &&                                                           \
-     (void *) (context)->IP >= (void *) &__code_address &&                  \
-     (void *) (context)->IP < (void *) &__code_address_end)
+static inline bool is_internal(PAL_CONTEXT * context)
+{
+    return context &&
+        (void *) context->IP >= (void *) &__code_address &&
+        (void *) context->IP < (void *) &__code_address_end;
+}
 
-#define internal_fault(errstr, addr, context)                               \
-    do {                                                                    \
-        IDTYPE tid = get_cur_tid();                                         \
-        if (is_internal((context)))                                         \
-            sys_printf(errstr " at %p (IP = +0x%lx, VMID = %u, TID = %u)\n",\
-                       arg,                                                 \
-                       (void *) context->IP - (void *) &__load_address,     \
-                       cur_process.vmid, IS_INTERNAL_TID(tid) ? 0 : tid);   \
-        else                                                                \
-            sys_printf(errstr " at %p (IP = %p, VMID = %u, TID = %u)\n",    \
-                       arg, context ? context->IP : 0,                      \
-                       cur_process.vmid, IS_INTERNAL_TID(tid) ? 0 : tid);   \
-    } while (0)
+static inline void internal_fault(const char* errstr,
+                                  PAL_NUM addr, PAL_CONTEXT * context)
+{
+    IDTYPE tid = get_cur_tid();
+    if (is_internal(context))
+        sys_printf("%s at %p (IP = +0x%lx, VMID = %u, TID = %u)\n", errstr,
+                   addr, (void *) context->IP - (void *) &__load_address,
+                   cur_process.vmid, IS_INTERNAL_TID(tid) ? 0 : tid);
+    else
+        sys_printf("%s at %p (IP = %p, VMID = %u, TID = %u)\n", errstr,
+                   addr, context ? context->IP : 0,
+                   cur_process.vmid, IS_INTERNAL_TID(tid) ? 0 : tid);
+
+    pause();
+}
 
 static void divzero_upcall (PAL_PTR event, PAL_NUM arg, PAL_CONTEXT * context)
 {
     if (IS_INTERNAL_TID(get_cur_tid()) || is_internal(context)) {
         internal_fault("Internal arithmetic fault", arg, context);
-        pause();
-        goto ret_exception;
+    } else {
+        if (context)
+            debug("arithmetic fault at %p\n", context->IP);
+
+        deliver_signal(ALLOC_SIGINFO(SIGFPE, FPE_INTDIV,
+                                     si_addr, (void *) arg), context);
     }
-
-    if (context)
-        debug("arithmetic fault at %p\n", context->IP);
-
-    deliver_signal(ALLOC_SIGINFO(SIGFPE, FPE_INTDIV, si_addr, (void *) arg), context);
-
-ret_exception:
     DkExceptionReturn(event);
 }
 
@@ -262,9 +252,7 @@ static void memfault_upcall (PAL_PTR event, PAL_NUM arg, PAL_CONTEXT * context)
     }
 
     if (IS_INTERNAL_TID(get_cur_tid()) || is_internal(context)) {
-internal:
         internal_fault("Internal memory fault", arg, context);
-        pause();
         goto ret_exception;
     }
 
@@ -278,7 +266,8 @@ internal:
         code = SEGV_MAPERR;
     } else if (!lookup_vma((void *) arg, &vma)) {
         if (vma.flags & VMA_INTERNAL) {
-            goto internal;
+            internal_fault("Internal memory fault with VMA", arg, context);
+            goto ret_exception;
         }
         if (vma.file && vma.file->type == TYPE_FILE) {
             /* DEP 3/3/17: If the mapping exceeds end of a file (but is in the VMA)
@@ -308,6 +297,7 @@ internal:
 
 ret_exception:
     DkExceptionReturn(event);
+    return;
 }
 
 /*
@@ -408,70 +398,56 @@ ret_fault:
 
 static void illegal_upcall (PAL_PTR event, PAL_NUM arg, PAL_CONTEXT * context)
 {
-    if (IS_INTERNAL_TID(get_cur_tid()) || is_internal(context)) {
-internal:
-        internal_fault("Internal illegal fault", arg, context);
-        pause();
-        goto ret_exception;
-    }
-
     struct shim_vma_val vma;
 
-    if (!(lookup_vma((void *) arg, &vma)) &&
+    if (!IS_INTERNAL_TID(get_cur_tid()) &&
+        !is_internal(context) &&
+        !(lookup_vma((void *) arg, &vma)) &&
         !(vma.flags & VMA_INTERNAL)) {
         if (context)
             debug("illegal instruction at %p\n", context->IP);
 
-        deliver_signal(ALLOC_SIGINFO(SIGILL, ILL_ILLOPC, si_addr, (void *) arg), context);
+        deliver_signal(ALLOC_SIGINFO(SIGILL, ILL_ILLOPC,
+                                     si_addr, (void *) arg), context);
     } else {
-        goto internal;
+        internal_fault("Internal illegal fault", arg, context);
     }
-
-ret_exception:
     DkExceptionReturn(event);
 }
 
 static void quit_upcall (PAL_PTR event, PAL_NUM arg, PAL_CONTEXT * context)
 {
-    if (IS_INTERNAL_TID(get_cur_tid()))
-        goto ret_exception;
-
-    deliver_signal(ALLOC_SIGINFO(SIGTERM, SI_USER, si_pid, 0), NULL);
-
-ret_exception:
+    if (!IS_INTERNAL_TID(get_cur_tid())) {
+        deliver_signal(ALLOC_SIGINFO(SIGTERM, SI_USER, si_pid, 0), NULL);
+    }
     DkExceptionReturn(event);
 }
 
 static void suspend_upcall (PAL_PTR event, PAL_NUM arg, PAL_CONTEXT * context)
 {
-    if (IS_INTERNAL_TID(get_cur_tid()))
-        goto ret_exception;
-
-    deliver_signal(ALLOC_SIGINFO(SIGINT, SI_USER, si_pid, 0), NULL);
-
-ret_exception:
+    if (!IS_INTERNAL_TID(get_cur_tid())) {
+        deliver_signal(ALLOC_SIGINFO(SIGINT, SI_USER, si_pid, 0), NULL);
+    }
     DkExceptionReturn(event);
 }
 
 static void resume_upcall (PAL_PTR event, PAL_NUM arg, PAL_CONTEXT * context)
 {
-    if (IS_INTERNAL_TID(get_cur_tid()))
-        goto ret_exception;
-
     shim_tcb_t * tcb = SHIM_GET_TLS();
-    assert(tcb);
-    __disable_preempt(tcb);
 
-    if ((tcb->context.preempt & ~SIGNAL_DELAYED) > 1) {
-        tcb->context.preempt |= SIGNAL_DELAYED;
+    if (!IS_INTERNAL_TID(get_cur_tid())) {
+        assert(tcb);
+        __disable_preempt(tcb);
+
+        if ((tcb->context.preempt & ~SIGNAL_DELAYED) > 1) {
+            tcb->context.preempt |= SIGNAL_DELAYED;
+        } else {
+            __handle_signal(tcb, 0, NULL);
+        }
+
         __enable_preempt(tcb);
-        goto ret_exception;
     }
 
-    __handle_signal(tcb, 0, NULL);
-    __enable_preempt(tcb);
-
-ret_exception:
     DkExceptionReturn(event);
 }
 
@@ -629,14 +605,12 @@ void handle_signal (bool delayed_only)
     if ((tcb->context.preempt & ~SIGNAL_DELAYED) > 1) {
         debug("signal delayed (%d)\n", tcb->context.preempt & ~SIGNAL_DELAYED);
         tcb->context.preempt |= SIGNAL_DELAYED;
-        goto out;
+    } else {
+        if (!(delayed_only && !(tcb->context.preempt & SIGNAL_DELAYED))) {
+            __handle_signal(tcb, 0, NULL);
+        }
     }
 
-    if (delayed_only && !(tcb->context.preempt & SIGNAL_DELAYED))
-        goto out;
-
-    __handle_signal(tcb, 0, NULL);
-out:
     __enable_preempt(tcb);
     debug("__enable_preempt: %s:%d\n", __FILE__, __LINE__);
 }

--- a/LibOS/shim/src/shim-debug.map
+++ b/LibOS/shim/src/shim-debug.map
@@ -8,4 +8,5 @@ SHIM {
         __htonl; __ntohl; __htons; __ntohs; inet_pton;
         vfputchar; vfputs; vfprintf; snprintf;
         malloc; free; malloc_copy;
+        deliver_signal_on_sysret;
 };

--- a/LibOS/shim/src/sys/shim_sleep.c
+++ b/LibOS/shim/src/sys/shim_sleep.c
@@ -57,6 +57,8 @@ int shim_do_nanosleep (const struct __kernel_timespec * rqtp,
     unsigned long time = rqtp->tv_sec * 1000000L + rqtp->tv_nsec / 1000;
     unsigned long ret = DkThreadDelayExecution(time);
 
+    debug("regs: %p sp: %p stack: %p",
+          SHIM_GET_TLS()->context.regs, SHIM_GET_TLS()->context.sp, &time);
     if (ret < time) {
         if (rmtp) {
             unsigned long remtime = time - ret;

--- a/LibOS/shim/src/syscallas.S
+++ b/LibOS/shim/src/syscallas.S
@@ -22,6 +22,7 @@
 
 #include <shim_tls.h>
 #include <shim_unistd_defs.h>
+#include "asm-offsets.h"
 
 #include "asm-offsets.h"
 
@@ -29,10 +30,44 @@
         .type syscalldb, @function
         .extern shim_table, debug_unsupp
 
+        .global __syscallas_signal_allowed_0_begin
+        .global __syscallas_signal_allowed_0_end
+        .global __syscallas_signal_allowed_1_begin
+        .global __syscallas_signal_allowed_1_end
+        .global __syscallas_signal_allowed_2_begin
+        .global __syscallas_signal_allowed_2_end
+        .global __syscallas_need_emulate_jmp
+        .type __syscallas_signal_allowed_0_begin, @object
+        .type __syscallas_signal_allowed_0_end, @object
+        .type __syscallas_signal_allowed_1_begin, @object
+        .type __syscallas_signal_allowed_1_end, @object
+        .type __syscallas_signal_allowed_2_begin, @object
+        .type __syscallas_signal_allowed_2_end, @object
+        .type __syscallas_need_emulate_jmp, @object
+
+.macro CLEAR_SAVED_AREA_IN_SHIM_TLS
+        movq $0, %fs:(SHIM_TCB_OFFSET + TCB_SYSCALL_NR)
+        movq $0, %fs:(SHIM_TCB_OFFSET + TCB_SP)
+        movq $0, %fs:(SHIM_TCB_OFFSET + TCB_RET_IP)
+        movq $0, %fs:(SHIM_TCB_OFFSET + TCB_REGS)
+.endm
+
+.macro CHECK_SIGNAL_PENDING_BIT
+        lock btrq $SHIM_FLAG_SIGPENDING, %fs:(SHIM_TCB_OFFSET + TCB_FLAGS)
+.endm
+
+/* TODO: fix to use CHECK_SIGNAL_PENDING_BIT */
+.macro CHECK_SIGNAL_PENDING
+        movq %fs:(SHIM_TCB_OFFSET + TCB_TP), %rbx
+        addq $THREAD_HAS_SIGNAL, %rbx
+        movq (%rbx), %rcx
+        cmp $0, %rcx
+.endm
 
 syscalldb:
         .cfi_startproc
 
+__syscallas_signal_allowed_0_begin:
         # DEP 7/9/12: Push a stack pointer so clone can find the return address
         pushq %rbp
         .cfi_def_cfa_offset 16
@@ -49,6 +84,7 @@ syscalldb:
         movq (%rbx,%rax,8), %rbx
         cmp $0, %rbx
         je isundef
+__syscallas_signal_allowed_0_end:
 
 isdef:
         pushq %rdi
@@ -76,10 +112,15 @@ isdef:
         movq %r10, %rcx
         call *%rbx
 
-        movq $0, %fs:(SHIM_TCB_OFFSET + TCB_SYSCALL_NR)
-        movq $0, %fs:(SHIM_TCB_OFFSET + TCB_SP)
-        movq $0, %fs:(SHIM_TCB_OFFSET + TCB_RET_IP)
-        movq $0, %fs:(SHIM_TCB_OFFSET + TCB_REGS)
+.Lret_nosignal:
+        CHECK_SIGNAL_PENDING
+        //CHECK_SIGNAL_PENDING_BIT
+__syscallas_signal_allowed_1_begin:
+        ja .Lsignal_pending
+        //jc .Lsignal_pending
+
+.Lret_signal:
+	CLEAR_SAVED_AREA_IN_SHIM_TLS
 
         popq %r15
         popq %r14
@@ -94,19 +135,116 @@ isdef:
         popq %rsi
         popq %rdi
 
-        jmp ret
-
-isundef:
-#ifdef DEBUG
-        mov %rax, %rdi
-        call debug_unsupp
-#endif
-        movq $-38, %rax
-
 ret:
         popq %rbx
         popq %rbp
         retq
 
+isundef:
+#ifdef DEBUG
+        mov %rax, %rdi
+	call *debug_unsupp@GOTPCREL(%rip)
+#endif
+        movq $-38, %rax
+        jmp ret
+__syscallas_signal_allowed_1_end:
+
+.Lsignal_pending:
+        /*
+         * allocate signal stack frame
+         *
+         * struct shim_context: 16B align + 8
+         *                      sizeof(struct shim_context) = 0x38
+         * rip to signal handler: 8 bytes
+         * struct sigframe
+         *   restorer: 8 bytes
+         *   ucontext_t: 16 bytes align
+         *   siginfo_t
+         * struct _libc_fptstate: 64 bytes align: fpu_xstate_size
+         * extended area
+         * FP_XSTATE_MAGIC2
+         */
+#define SIGFRAME_SIZE_SUB       (SIGFRAME_SIZE + FP_XSTATE_MAGIC2_SIZE + 64)
+        movq %rsp, %rdi
+        subq $SIGFRAME_SIZE_SUB, %rdi
+        movq fpu_xstate_size@GOTPCREL(%rip), %rbx
+        subq (%rbx), %rdi
+        andq $(~15), %rdi
+        subq $8, %rdi
+
+        movq %rsp, %r11
+        movq %rdi, %rsp
+        pushfq
+        popq %rsi
+        movq %rax, %rdx
+        pushq %r11
+        call *deliver_signal_on_sysret@GOTPCREL(%rip)
+        popq %r11
+        cmp $0, %rax
+        je .Lsignal_not_delivered
+        jmp .Lret_signal
+
+.Lsignal_not_delivered:
+        movq %fs:(SHIM_TCB_OFFSET + TCB_SYSCALL_NR), %rax
+        movq %r11, %rsp
+        jmp .Lret_nosignal
+
         .cfi_endproc
         .size syscalldb, .-syscalldb
+
+        // void __sigreturn(mcontext_t * uc_mcontext)
+        .global __sigreturn
+        .type __sigreturn, @function
+__sigreturn:
+        CHECK_SIGNAL_PENDING_BIT
+        jnc .Lno_more_signal
+	retq
+
+__syscallas_signal_allowed_2_begin:
+.Lno_more_signal:
+	CLEAR_SAVED_AREA_IN_SHIM_TLS
+
+        movq %rdi, %rsp
+
+        // pop up gregs_t
+        popq %r8
+        popq %r9
+        popq %r10
+        popq %r11
+        popq %r12
+        popq %r13
+        popq %r14
+        popq %r15
+        popq %rdi
+        popq %rsi
+        popq %rbp
+        popq %rbx
+        popq %rdx
+
+        movq 2 * 8(%rsp), %rcx  // saved %rsp
+        movq 3 * 8(%rsp), %rax  // saved %rip
+        movq %rax, -128-8(%rcx) // 8 bytes below redzone
+
+        popq %rax
+        popq %rcx
+        // skip rsp, rip
+        addq $(2 * 8), %rsp
+
+        popfq
+
+        /*
+         * iretq or sysretq can't be used in user space.
+         *
+         * The following two instruction needs to be atomic regarding to
+         * interrupt by signal delivering.
+         * In signal handler in LibOS, if rip == __syscallas_need_emulate_jmp
+         * the following jmp instruction is emulated first, and then proceed to
+         * signal handling and deliver signal to user.
+         *
+         * If signal is delivered at __syscallas_need_emulate_jmp,
+         * the saved rip at 8 bytes below the redzone is clobbered.
+         */
+        movq -3 * 8(%rsp), %rsp
+__syscallas_need_emulate_jmp:
+        jmp *-128-8(%rsp)
+__syscallas_signal_allowed_2_end:

--- a/LibOS/shim/src/syscallas.S
+++ b/LibOS/shim/src/syscallas.S
@@ -23,6 +23,8 @@
 #include <shim_tls.h>
 #include <shim_unistd_defs.h>
 
+#include "asm-offsets.h"
+
         .global syscalldb
         .type syscalldb, @function
         .extern shim_table, debug_unsupp
@@ -62,22 +64,22 @@ isdef:
         pushq %r14
         pushq %r15
 
-        movq %rax, %fs:(SHIM_TCB_OFFSET + 24)
+        movq %rax, %fs:(SHIM_TCB_OFFSET + TCB_SYSCALL_NR)
         leaq 16(%rbp), %rax
-        movq %rax, %fs:(SHIM_TCB_OFFSET + 32)
+        movq %rax, %fs:(SHIM_TCB_OFFSET + TCB_SP)
         movq 8(%rbp), %rax
-        movq %rax, %fs:(SHIM_TCB_OFFSET + 40)
-        movq %rsp, %fs:(SHIM_TCB_OFFSET + 48)
+        movq %rax, %fs:(SHIM_TCB_OFFSET + TCB_RET_IP)
+        movq %rsp, %fs:(SHIM_TCB_OFFSET + TCB_REGS)
 
         /* Translating x86_64 kernel calling convention to user-space
          * calling convention */
         movq %r10, %rcx
         call *%rbx
 
-        movq $0, %fs:(SHIM_TCB_OFFSET + 24)
-        movq $0, %fs:(SHIM_TCB_OFFSET + 32)
-        movq $0, %fs:(SHIM_TCB_OFFSET + 40)
-        movq $0, %fs:(SHIM_TCB_OFFSET + 48)
+        movq $0, %fs:(SHIM_TCB_OFFSET + TCB_SYSCALL_NR)
+        movq $0, %fs:(SHIM_TCB_OFFSET + TCB_SP)
+        movq $0, %fs:(SHIM_TCB_OFFSET + TCB_RET_IP)
+        movq $0, %fs:(SHIM_TCB_OFFSET + TCB_REGS)
 
         popq %r15
         popq %r14

--- a/Pal/lib/atomic.h
+++ b/Pal/lib/atomic.h
@@ -176,4 +176,33 @@ static inline int64_t atomic_cmpxchg (struct atomic_int * v, int64_t old, int64_
     return cmpxchg(&v->counter, old, new);
 }
 
+static inline bool test_and_set_bit(long nr, volatile unsigned long *addr)
+{
+    bool cc_carry;
+    __asm__ __volatile__("lock btsq %2, %0\n"
+                         : "+m"(*addr), "=@ccc"(cc_carry)
+                         : "Ir"(nr)
+                         : "memory");
+    return cc_carry;
+}
+
+static inline bool test_and_clear_bit(long nr, volatile unsigned long *addr)
+{
+    bool cc_carry;
+    __asm__ __volatile__("lock btrq %2, %0\n"
+                         : "+m"(*addr), "=@ccc"(cc_carry)
+                         : "Ir"(nr)
+                         : "memory");
+    return cc_carry;
+}
+
+static inline void set_bit(long nr, volatile unsigned long *addr)
+{
+    test_and_set_bit(nr, addr);
+}
+
+static inline void clear_bit(long nr, volatile unsigned long *addr)
+{
+    test_and_clear_bit(nr, addr);
+}
 #endif /* _ATOMIC_INT_H_ */

--- a/Pal/src/host/Linux/db_main.c
+++ b/Pal/src/host/Linux/db_main.c
@@ -316,15 +316,8 @@ done_init:
 }
 
 /* the following code is borrowed from CPUID */
-
-#define WORD_EAX  0
-#define WORD_EBX  1
-#define WORD_ECX  2
-#define WORD_EDX  3
-#define WORD_NUM  4
-
-static void cpuid (unsigned int leaf, unsigned int subleaf,
-                   unsigned int words[])
+void cpuid (unsigned int leaf, unsigned int subleaf,
+            unsigned int words[])
 {
   asm("cpuid"
       : "=a" (words[WORD_EAX]),

--- a/Pal/src/host/Linux/db_misc.c
+++ b/Pal/src/host/Linux/db_misc.c
@@ -238,5 +238,6 @@ int _DkInstructionCacheFlush (const void * addr, int size)
 int _DkCpuIdRetrieve (unsigned int leaf, unsigned int subleaf,
                       unsigned int values[4])
 {
-    return -PAL_ERROR_NOTIMPLEMENTED;
+    cpuid(leaf, subleaf, values);
+    return 0;
 }

--- a/Pal/src/host/Linux/pal.map
+++ b/Pal/src/host/Linux/pal.map
@@ -29,6 +29,7 @@ PAL {
 
         DkSystemTimeQuery; DkRandomBitsRead;
         DkInstructionCacheFlush;
+        DkCpuIdRetrieve;
         DkObjectClose;
         # objects checkpoint?
         # objects reload?

--- a/Pal/src/host/Linux/pal_linux.h
+++ b/Pal/src/host/Linux/pal_linux.h
@@ -163,6 +163,14 @@ int _DkMutexUnlock (struct mutex_handle * mut);
 void init_child_process (PAL_HANDLE * parent, PAL_HANDLE * exec,
                          PAL_HANDLE * manifest);
 
+#define WORD_EAX  0
+#define WORD_EBX  1
+#define WORD_ECX  2
+#define WORD_EDX  3
+#define WORD_NUM  4
+
+void cpuid (unsigned int leaf, unsigned int subleaf,
+            unsigned int words[]);
 void signal_setup (void);
 
 unsigned long _DkSystemTimeQueryEarly (void);


### PR DESCRIPTION
    RFC: WIP: LibOS/shim_signal: deliver signal when user program running
    
    This patch is still Work-In-Progress.
    The purpose of this patch is to get feedback before going further
    and trigger discussion.
    I believe the patch is enough to show the idea and how to implement
    it.
    
    Deliver signal when executing in user program via signal stack
    frame, not direct calling handler within LibOS.
    
    With this patches, (emulated) signal is delivered only when
    user program is running by setting up signal stack frame.
    If LibOS or PAL is running with asynchronously signal, the (async)
    signal is queued and the signal stack frame is created right before
    system call is return.
    This also opens up the capability to support sigaltstack.
    
    The current implementation of invoking registered signal handler
    directly within LibOS is problematic.
    It causes several issues below and hard to solve them.
    
    - race condition in LibOS because invoking registered signal handler
      directly in host signal handler even when cpu is executing within
      LibOS. If the blocking emulated system call is executing, it's very
      likely. It incurs much complexity.
    
    - nested signal can't be handled well.
      If async signal(e.g. SIGALARM) is delivered and then synchronous
      signal(e.g. SIGSEGV) within signal handler is delieved,
      The current implementation tries to queue SIGSEGV, and loop in
      SIGSEGV.
    
    - sigaltstack can't be implemented well
      Typically language runtime uses sigaltstack. It's desirable to
      support those features well.
    
    Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/347)
<!-- Reviewable:end -->
