### PR TITLE
[LibOS] Improve the for condition expression to avoid dereference

### DIFF
--- a/LibOS/shim/src/sys/shim_poll.c
+++ b/LibOS/shim/src/sys/shim_poll.c
@@ -126,7 +126,7 @@ static int __do_poll (int npolls, struct poll_handle * polls,
 
     lock(map->lock);
 
-    for (p = polls ; p < &polls[npolls] ; p++) {
+    for (p = polls ; p < polls + npolls ; p++) {
         bool do_r = p->flags & DO_R;
         bool do_w = p->flags & DO_W;
 


### PR DESCRIPTION
polls was constructed by nfds, with last index as nfds - 1. When calling __do_poll, nfds was passed as a parameter and used as index to refer polls as npolls.

Signed-off-by: Gary <gang1.wang@intel.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/351)
<!-- Reviewable:end -->
