### PR TITLE
[LibOS] Fix a memory leak in __map_elf_object() about variable pointer new_phdr

### DIFF
--- a/LibOS/shim/src/elf/shim_rtld.c
+++ b/LibOS/shim/src/elf/shim_rtld.c
@@ -404,10 +404,15 @@ call_lose:
     if (type == OBJECT_LOAD &&
         header->e_phoff + maplength <= (size_t) fbp_len) {
         ElfW(Phdr) * new_phdr = (ElfW(Phdr) *) malloc (maplength);
+        if (!new_phdr) {
+            errstring = "new_phdr malloc failure";
+            goto call_lose;
+        }
         if ((ret = (*seek) (file, header->e_phoff, SEEK_SET)) < 0 ||
             (ret = (*read) (file, new_phdr, maplength)) < 0) {
             errstring = "cannot read file data";
             errval = ret;
+            free(new_phdr);
             goto call_lose;
         }
         phdr = new_phdr;


### PR DESCRIPTION
new_phdr is allocated with malloc, if seek file or read file failed, the function will goto call_lose that will return NULL.
However, before returning NULL, there is no check inside call_lose to check if new_phdr was allocated successfully or not,
causing potencial resource leakage of new_phdr

Signed-off-by: Gary <gang1.wang@intel.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/353)
<!-- Reviewable:end -->
