### PR TITLE
[LibOS] Don't use uninitialized return value in walk_mounts()

### DIFF
--- a/LibOS/shim/src/fs/shim_fs.c
+++ b/LibOS/shim/src/fs/shim_fs.c
@@ -508,7 +508,7 @@ int walk_mounts (int (*walk) (struct shim_mount * mount, void * arg),
                  void * arg)
 {
     struct shim_mount * mount, * n;
-    int ret;
+    int ret = 0;
     int nsrched = 0;
 
     lock(mount_list_lock);


### PR DESCRIPTION
ret is declared without initialization. It depends on (ret = (*walk) (mount, arg) for the initial assignment;
however, the list might be NULL and the assignment can not be performed leaving ret in un-initialized state.
Thus ret should be properly initialized in this case

Signed-off-by: Gary <gang1.wang@intel.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/354)
<!-- Reviewable:end -->
