### PR TITLE
Compilation and warning fixes for the PAL Skeleton on Linux

### DIFF
--- a/Pal/src/host/Skeleton/db_devices.c
+++ b/Pal/src/host/Skeleton/db_devices.c
@@ -74,9 +74,10 @@ static int parse_device_uri (const char ** uri, const char ** type,
     return 0;
 }
 
-static int char_read (PAL_HANDLE handle, int offset, int count, void * buffer);
-static int char_write (PAL_HANDLE handle, int offset, int count,
-                       const void * buffer);
+static int64_t char_read (PAL_HANDLE handle, uint64_t offset, uint64_t count,
+                          void * buffer);
+static int64_t char_write (PAL_HANDLE handle, uint64_t offset, uint64_t count,
+                           const void * buffer);
 static int term_attrquery (const char * type, const char * uri,
                            PAL_STREAM_ATTR * attr);
 static int term_attrquerybyhdl (PAL_HANDLE hdl,
@@ -118,14 +119,14 @@ static struct handle_ops term_ops = {
     };
 
 /* 'read' operation for character streams. */
-static int char_read (PAL_HANDLE handle, int offset, int size, void * buffer)
+static int64_t char_read (PAL_HANDLE handle, uint64_t offset, uint64_t size, void * buffer)
 {
     return -PAL_ERROR_NOTIMPLEMENTED;
 }
 
 /* 'write' operation for character streams. */
-static int char_write (PAL_HANDLE handle, int offset, int size,
-                      const void * buffer)
+static int64_t char_write (PAL_HANDLE handle, uint64_t offset, uint64_t size,
+                           const void * buffer)
 {
     return -PAL_ERROR_NOTIMPLEMENTED;
 }
@@ -138,7 +139,7 @@ static int dev_open (PAL_HANDLE * handle, const char * type, const char * uri,
 }
 
 /* 'read' operation for device stream */
-static int dev_read (PAL_HANDLE handle, int offset, int size, void * buffer)
+static int64_t dev_read (PAL_HANDLE handle, uint64_t offset, uint64_t size, void * buffer)
 {
     const struct handle_ops * ops = DEVICE_OPS(handle);
 
@@ -149,8 +150,8 @@ static int dev_read (PAL_HANDLE handle, int offset, int size, void * buffer)
 }
 
 /* 'write' operation for device stream */
-static int dev_write (PAL_HANDLE handle, int offset, int size,
-                      const void * buffer)
+static int64_t dev_write (PAL_HANDLE handle, uint64_t offset, uint64_t size,
+                          const void * buffer)
 {
     const struct handle_ops * ops = DEVICE_OPS(handle);
 

--- a/Pal/src/host/Skeleton/db_files.c
+++ b/Pal/src/host/Skeleton/db_files.c
@@ -39,15 +39,15 @@ static int file_open (PAL_HANDLE * handle, const char * type, const char * uri,
 }
 
 /* 'read' operation for file streams. */
-static int file_read (PAL_HANDLE handle, int offset, int count,
-                      void * buffer)
+static int64_t file_read (PAL_HANDLE handle, uint64_t offset, uint64_t count,
+                          void * buffer)
 {
     return -PAL_ERROR_NOTIMPLEMENTED;
 }
 
 /* 'write' operation for file streams. */
-static int file_write (PAL_HANDLE handle, int offset, int count,
-                       const void * buffer)
+static int64_t file_write (PAL_HANDLE handle, uint64_t offset, uint64_t count,
+                           const void * buffer)
 {
     return -PAL_ERROR_NOTIMPLEMENTED;
 }
@@ -68,13 +68,13 @@ static int file_delete (PAL_HANDLE handle, int access)
 
 /* 'map' operation for file stream. */
 static int file_map (PAL_HANDLE handle, void ** addr, int prot,
-                     int offset, int size)
+                     uint64_t offset, uint64_t size)
 {
     return -PAL_ERROR_NOTIMPLEMENTED;
 }
 
 /* 'setlength' operation for file stream. */
-static int file_setlength (PAL_HANDLE handle, int length)
+static int64_t file_setlength (PAL_HANDLE handle, uint64_t length)
 {
     return -PAL_ERROR_NOTIMPLEMENTED;
 }
@@ -142,7 +142,7 @@ static int dir_open (PAL_HANDLE * handle, const char * type, const char * uri,
 
 /* 'read' operation for directory stream. Directory stream will not
    need a 'write' operat4on. */
-int dir_read (PAL_HANDLE handle, int offset, int count, void * buf)
+int64_t dir_read (PAL_HANDLE handle, uint64_t offset, uint64_t count, void * buf)
 {
     return -PAL_ERROR_NOTIMPLEMENTED;
 }

--- a/Pal/src/host/Skeleton/db_pipes.c
+++ b/Pal/src/host/Skeleton/db_pipes.c
@@ -87,15 +87,15 @@ static int pipe_open (PAL_HANDLE *handle, const char * type,
 }
 
 /* 'read' operation of pipe stream. offset does not apply here. */
-static int pipe_read (PAL_HANDLE handle, int offset, int len,
-                      void * buffer)
+static int64_t pipe_read (PAL_HANDLE handle, uint64_t offset, uint64_t len,
+                          void * buffer)
 {
     return -PAL_ERROR_NOTIMPLEMENTED;
 }
 
 /* 'write' operation of pipe stream. offset does not apply here. */
-static int pipe_write (PAL_HANDLE handle, int offset, int len,
-                       const void * buffer)
+static int64_t pipe_write (PAL_HANDLE handle, uint64_t offset, uint64_t len,
+                           const void * buffer)
 {
     return -PAL_ERROR_NOTIMPLEMENTED;
 }

--- a/Pal/src/host/Skeleton/db_process.c
+++ b/Pal/src/host/Skeleton/db_process.c
@@ -51,14 +51,14 @@ int _DkProcessSandboxCreate (const char * manifest, int flags)
     return -PAL_ERROR_NOTIMPLEMENTED;
 }
 
-static int proc_read (PAL_HANDLE handle, int offset, int count,
+static int64_t proc_read (PAL_HANDLE handle, uint64_t offset, uint64_t count,
                           void * buffer)
 {
     return -PAL_ERROR_NOTIMPLEMENTED;
 }
 
-static int proc_write (PAL_HANDLE handle, int offset, int count,
-                       const void * buffer)
+static int64_t proc_write (PAL_HANDLE handle, uint64_t offset, uint64_t count,
+                           const void * buffer)
 {
     return -PAL_ERROR_NOTIMPLEMENTED;
 }

--- a/Pal/src/host/Skeleton/db_rtld.c
+++ b/Pal/src/host/Skeleton/db_rtld.c
@@ -36,11 +36,7 @@
 
 #include <sysdeps/generic/ldsodefs.h>
 #include <elf/elf.h>
-#ifdef __APPLE__
 #include <dlfcn.h>
-#else
-#include <bits/dlfcn.h>
-#endif 
 
 void _DkDebugAddMap (struct link_map * map)
 {

--- a/Pal/src/host/Skeleton/db_sockets.c
+++ b/Pal/src/host/Skeleton/db_sockets.c
@@ -75,13 +75,13 @@ static int tcp_open (PAL_HANDLE *handle, const char * type, const char * uri,
 }
 
 /* 'read' operation of tcp stream */
-static int tcp_read (PAL_HANDLE handle, int offset, int len, void * buf)
+static int64_t tcp_read (PAL_HANDLE handle, uint64_t offset, uint64_t len, void * buf)
 {
     return -PAL_ERROR_NOTIMPLEMENTED;
 }
 
 /* write' operation of tcp stream */
-static int tcp_write (PAL_HANDLE handle, int offset, int len, const void * buf)
+static int64_t tcp_write (PAL_HANDLE handle, uint64_t offset, uint64_t len, const void * buf)
 {
     return -PAL_ERROR_NOTIMPLEMENTED;
 }
@@ -118,24 +118,24 @@ static int udp_open (PAL_HANDLE *hdl, const char * type, const char * uri,
     return -PAL_ERROR_NOTSUPPORT;
 }
 
-static int udp_receive (PAL_HANDLE handle, int offset, int len, void * buf)
+static int64_t udp_receive (PAL_HANDLE handle, uint64_t offset, uint64_t len, void * buf)
 {
     return -PAL_ERROR_NOTIMPLEMENTED;
 }
 
-static int udp_receivebyaddr (PAL_HANDLE handle, int offset, int len,
+static int64_t udp_receivebyaddr (PAL_HANDLE handle, uint64_t offset, uint64_t len,
                               void * buf, char * addr, int addrlen)
 {
     return -PAL_ERROR_NOTIMPLEMENTED;
 }
 
-static int udp_send (PAL_HANDLE handle, int offset, int len, const void * buf)
+static int64_t udp_send (PAL_HANDLE handle, uint64_t offset, uint64_t len, const void * buf)
 {
     return -PAL_ERROR_NOTIMPLEMENTED;
 }
 
-static int udp_sendbyaddr (PAL_HANDLE handle, int offset, int len,
-                           const void * buf, const char * addr, int addrlen)
+static int64_t udp_sendbyaddr (PAL_HANDLE handle, uint64_t offset, uint64_t len,
+                               const void * buf, const char * addr, int addrlen)
 {
     return -PAL_ERROR_NOTIMPLEMENTED;
 }
@@ -196,13 +196,13 @@ PAL_HANDLE _DkBroadcastStreamOpen (void)
     return NULL;
 }
 
-static int mcast_send (PAL_HANDLE handle, int offset, int size,
-                       const void * buf)
+static int64_t mcast_send (PAL_HANDLE handle, uint64_t offset, uint64_t size,
+                           const void * buf)
 {
     return -PAL_ERROR_NOTIMPLEMENTED;
 }
 
-static int mcast_receive (PAL_HANDLE handle, int offset, int size, void * buf)
+static int64_t mcast_receive (PAL_HANDLE handle, uint64_t offset, uint64_t size, void * buf)
 {
     return -PAL_ERROR_NOTIMPLEMENTED;
 }


### PR DESCRIPTION
After the PR that fixes the skeleton build on OS X, I realized that, at least on Ubuntu 14.04, it still doesn't compile.  So this PR fixes those errors and warnings (at least from 'make' in the Skeleton directory).

All of these issues amount to the signature not matching pal_internal.h, except for one bad include.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/355)
<!-- Reviewable:end -->
