### PR TITLE
[LibOS] Fix use-after-free in install_async_event()

### DIFF
--- a/LibOS/shim/src/shim_async.c
+++ b/LibOS/shim/src/shim_async.c
@@ -98,8 +98,8 @@ int64_t install_async_event (PAL_HANDLE object, unsigned long time,
          * There should be exactly only one timer pending
          */
 		listp_del(tmp, &async_list, list);
-        free(tmp);
         rv = tmp->expire_time - install_time;
+        free(tmp);
     } else
 	   tmp = NULL;
     


### PR DESCRIPTION
use after free issue, after tmp is freed, rv = tmp->expire_time - install_time is trying to access the member expire_time of release tmp buffer
[482631]

Signed-off-by: Gary <gang1.wang@intel.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/356)
<!-- Reviewable:end -->
