### PR TITLE
[LibOS] Fix an uninitialized value n in wait_event

### DIFF
--- a/LibOS/shim/include/shim_internal.h
+++ b/LibOS/shim/include/shim_internal.h
@@ -607,7 +607,7 @@ static inline void wait_event (AEVENTTYPE * e)
 {
     if (e->event) {
         char byte;
-        int n;
+        int n = 0;
         do {
             if (!DkObjectsWaitAny(1, &e->event, NO_TIMEOUT))
                 continue;


### PR DESCRIPTION
Variable  n is used without initilization.
If if (!DkObjectsWaitAny(1, &e->event, NO_TIMEOUT)) condition is true,
then code will skip the assignment of n with n = DkStreamRead(e->event, 0, 1, &byte, NULL, 0);
and might finish the while loop. n should be properly initialized to prevent potenical undefined behavior
[482723]

Signed-off-by: Gary <gang1.wang@intel.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/358)
<!-- Reviewable:end -->
