### PR TITLE
[LibOS] Fix the storage leaks pointed by new_map in case of malloc fails to fd_new

### DIFF
--- a/LibOS/shim/src/bookkeep/shim_handle.c
+++ b/LibOS/shim/src/bookkeep/shim_handle.c
@@ -652,6 +652,9 @@ int dup_handle_map (struct shim_handle_map ** new,
     struct shim_handle_map * new_map =
                 get_new_handle_map(old_map->fd_size);
 
+    if (!new_map)
+        return -ENOMEM;
+
     new_map->fd_top = old_map->fd_top;
 
     if (old_map->fd_top == FD_NULL)
@@ -676,6 +679,7 @@ int dup_handle_map (struct shim_handle_map ** new,
                 }
                 unlock(old_map->lock);
                 *new = NULL;
+                free(new_map);
                 return -ENOMEM;
             }
 


### PR DESCRIPTION
get_new_handle_map will return a pointer for new_map, which could be NULL after examing the implementation of get_new_handle_map function.
In this case, accessing new_map->fd_top will cause undefined behavior. We need to add a check for new_map before accessing its member.
if the code error out and function return the error, allocated new_map is not freed, causing potencial information leakage
[482567]

Signed-off-by: Gary <gang1.wang@intel.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/359)
<!-- Reviewable:end -->
