### PR TITLE
[LibOS] Fix the storage of local_objects leaks in shim_async_helper

### DIFF
--- a/LibOS/shim/src/shim_async.c
+++ b/LibOS/shim/src/shim_async.c
@@ -281,6 +281,7 @@ update_list:
     unlock(async_helper_lock);
     put_thread(self);
     debug("async helper thread terminated\n");
+    free(local_objects);
 
     DkThreadExit();
 }


### PR DESCRIPTION
before DkThreadExit(), allocated resource local_objects were not freed, causing resource leakage of local_objects content

Signed-off-by: Gary <gang1.wang@intel.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/360)
<!-- Reviewable:end -->
