### PR TITLE
[LibOS] Fix uninitialized value new_shargs.first

### DIFF
--- a/LibOS/shim/src/sys/shim_exec.c
+++ b/LibOS/shim/src/sys/shim_exec.c
@@ -330,7 +330,7 @@ err:
     }
 
     if (ret == -EINVAL) { /* it's a shebang */
-        LISTP_TYPE(sharg) new_shargs;
+        LISTP_TYPE(sharg) new_shargs = LISTP_INIT;
         struct sharg * next = NULL;
         bool ended = false, started = false;
         char buf[80];


### PR DESCRIPTION
new_shargs used without initialization, could cause undefined behaviors as its contents are passed to other variables

Signed-off-by: Gary <gang1.wang@intel.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/361)
<!-- Reviewable:end -->
