### PR TITLE
[PAL] Fix an out of bounds read on generic.fds[]

### DIFF
--- a/Pal/src/host/FreeBSD/pal_host.h
+++ b/Pal/src/host/FreeBSD/pal_host.h
@@ -50,6 +50,7 @@ typedef struct mutex_handle {
 
 #define _DkInternalLock _DkMutexLock
 #define _DkInternalUnlock _DkMutexUnlock
+#define MAX_FDS         (3)
 typedef union pal_handle
 {
     /* TSAI: Here we define the internal types of PAL_HANDLE
@@ -87,7 +88,7 @@ typedef union pal_handle
 
     struct {
         PAL_HDR hdr;
-        PAL_IDX fds[2];
+        PAL_IDX fds[MAX_FDS];
         PAL_BOL nonblocking;
     } pipeprv;
 
@@ -175,7 +176,6 @@ typedef union pal_handle
 #define WFD(n)          (00010 << (n))
 #define WRITEABLE(n)    (00100 << (n))
 #define ERROR(n)        (01000 << (n))
-#define MAX_FDS         (3)
 #define HAS_FDS         (00077)
 
 #define HANDLE_TYPE(handle)  ((handle)->hdr.type)

--- a/Pal/src/host/Linux-SGX/pal_host.h
+++ b/Pal/src/host/Linux-SGX/pal_host.h
@@ -43,6 +43,7 @@ int _DkSpinUnlock (struct spinlock * lock);
 #define LOCK_INIT   { .value =  { 0 } }
 #define _DkInternalLock _DkSpinLock
 #define _DkInternalUnlock _DkSpinUnlock
+#define MAX_FDS           (3)
 
 void * malloc_untrusted (int size);
 void free_untrusted (void * mem);
@@ -88,7 +89,7 @@ typedef struct pal_handle
     PAL_HDR hdr;
     union {
         struct {
-            PAL_IDX fds[2];
+            PAL_IDX fds[MAX_FDS];
         } generic;
 
         struct {
@@ -107,7 +108,7 @@ typedef struct pal_handle
         } pipe;
 
         struct {
-            PAL_IDX fds[2];
+            PAL_IDX fds[MAX_FDS];
             PAL_BOL nonblocking;
         } pipeprv;
 
@@ -182,7 +183,6 @@ typedef struct pal_handle
 #define WFD(n)          (00010 << (n))
 #define WRITEABLE(n)    (00100 << (n))
 #define ERROR(n)        (01000 << (n))
-#define MAX_FDS         (3)
 #define HAS_FDS         (00077)
 
 #define HANDLE_TYPE(handle)  ((handle)->hdr.type)

--- a/Pal/src/host/Linux/pal_host.h
+++ b/Pal/src/host/Linux/pal_host.h
@@ -70,6 +70,8 @@ typedef struct {
 #endif
 } PAL_RESERVED_HDR;
 
+#define MAX_FDS         (3)
+
 typedef struct pal_handle
 {
     /* TSAI: Here we define the internal types of PAL_HANDLE
@@ -81,7 +83,7 @@ typedef struct pal_handle
 
     union {
         struct {
-            PAL_IDX fds[2];
+            PAL_IDX fds[MAX_FDS];
         } generic;
 
         struct {
@@ -105,7 +107,7 @@ typedef struct pal_handle
         } pipe;
 
         struct {
-            PAL_IDX fds[2];
+            PAL_IDX fds[MAX_FDS];
             PAL_BOL nonblocking;
         } pipeprv;
 
@@ -182,7 +184,6 @@ typedef struct pal_handle
 #define WFD(n)          (00010 << (n))
 #define WRITEABLE(n)    (00100 << (n))
 #define ERROR(n)        (01000 << (n))
-#define MAX_FDS         (3)
 #define HAS_FDS         (00077)
 
 #define HANDLE_TYPE(handle)  ((handle)->hdr.type)

--- a/Pal/src/host/Skeleton/pal_host.h
+++ b/Pal/src/host/Skeleton/pal_host.h
@@ -32,6 +32,7 @@
 
 typedef int PAL_LOCK;
 #define LOCK_INIT   (0)
+#define MAX_FDS     (3)
 
 typedef struct pal_handle
 {
@@ -44,7 +45,7 @@ typedef struct pal_handle
 
     union {
         struct {
-            PAL_IDX fds[2];
+            PAL_IDX fds[MAX_FDS];
         } generic;
 
         /* DP: Here we just define a placeholder fd; place your details here.


### PR DESCRIPTION
MAX_FDS is defined as 3, fds[MAX_FDS] is a 3-element array.
While i in for loop looping from 0 to MAX_FDS, will cause out-of-boundry read for generaic.fds which is a 2-element array.
The generic.fds defiend in pal_host.h should be correctly sized to match with both fds[MAX_FDS] and accommodate for the for loop.
Also fixed another out-of-boundary access for pipeprv

Signed-off-by: Gary <gang1.wang@intel.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/362)
<!-- Reviewable:end -->
