### PR TITLE
shim/src/Makefile: remove build files(libsyscalldb.*) on make clean

### DIFF
--- a/LibOS/shim/src/Makefile
+++ b/LibOS/shim/src/Makefile
@@ -130,4 +130,4 @@ elf/shim_rtld.o: $(wildcard elf/*.h)
 	@$(AS) $(ASFLAGS) $(defs) -E $< -o $@
 
 clean:
-	rm -rf $(addsuffix .o,$(objs)) $(shim_target) .lib
+	rm -rf $(addsuffix .o,$(objs)) $(shim_target) $(files_to_build) .lib


### PR DESCRIPTION
they are missed on "make clean" somehow.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/363)
<!-- Reviewable:end -->
