### PR TITLE
Runtime/Makefile: all goal should be default

### DIFF
--- a/Runtime/Makefile
+++ b/Runtime/Makefile
@@ -1,9 +1,9 @@
+.PHONY: all
+all:
+
 .PHONY: clean
 clean:
 	rm -f *.a *.o *.so *.so.* pal_gdb* pal-* pal_sec*
-
-.PHONY: all
-all:
 
 .PHONY: format
 format:


### PR DESCRIPTION
Since clean rule is first target, just "make" means "make clean" as default goal.
This is a surprise. usually "make" means "make all".
So move all rule to the first target.

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/366)
<!-- Reviewable:end -->
