### PR TITLE
Makefile: Use symlink instead of cp to populate Runtime dir

### DIFF
--- a/LibOS/Makefile
+++ b/LibOS/Makefile
@@ -7,11 +7,31 @@ GLIBC_SRC = glibc-2.19
 GLIBC_CHECKSUM = 18ad6db70724699d264add80b1f813630d0141cf3a3558b4e1a7c15f6beac796
 SHIM_DIR = shim
 BUILD_DIR = glibc-build
-GLIBC_TARGET = $(addprefix $(BUILD_DIR)/,libc.so.6 ld-linux-x86-64.so.2 libpthread.so.0 libm.so.6 libdl.so.2 libutil.so.1 crt1.o crti.o crtn.o liblibos.so.1 libnss_dns.so.2 libresolv.so.2)
+RUNTIME_DIR = $(CURDIR)/../Runtime
+GLIBC_LIBS = \
+	csu/crt1.o \
+	csu/crti.o \
+	csu/crtn.o \
+	dlfcn/libdl.so.2 \
+	elf/ld-linux-x86-64.so.2 \
+	libc.so \
+	libc.so.6 \
+	libos/liblibos.so.1 \
+	login/libutil.so.1 \
+	math/libm.so.6 \
+	nptl/libpthread.so.0 \
+	nptl_db/libthread_db.so.1 \
+	resolv/libnss_dns.so.2 \
+	resolv/libresolv.so.2 \
+	rt/librt.so.1
+GLIBC_TARGET = $(addprefix $(BUILD_DIR)/, $(GLIBC_LIBS))
+GLIBC_RUNTIME = $(addprefix $(RUNTIME_DIR)/, $(notdir $(GLIBC_TARGET)))
 
 .PHONY: all
-all: $(GLIBC_TARGET)
+all: $(GLIBC_TARGET) $(GLIBC_RUNTIME)
 	$(MAKE) -C $(SHIM_DIR) all
+
+include ../Makefile.rules
 
 .PHONY: format
 format:
@@ -48,6 +68,13 @@ ifeq ($(DEBUG),1)
 else
 	./buildglibc.py --quiet
 endif
+
+define LN_SF_TO_RUNTIME_DIR_template =
+$(RUNTIME_DIR)/$(notdir $(1)): $(1)
+	$$(call cmd,ln_sf)
+endef
+
+$(foreach lib,$(GLIBC_TARGET),$(eval $(call LN_SF_TO_RUNTIME_DIR_template,$(lib))))
 
 GLIBC_MIRRORS ?= https://ftp.gnu.org/gnu/ \
 		https://mirrors.kernel.org/gnu/ \

--- a/LibOS/buildglibc.py
+++ b/LibOS/buildglibc.py
@@ -116,29 +116,3 @@ if True:
     if numCPUs == 0:
         numCPUs = 1
     replaceAll('Makefile', r'# PARALLELMFLAGS = -j4', r'PARALLELMFLAGS = -j{0}'.format(numCPUs))
-
-
-link_binaries     = [ ( 'elf',    'ld-linux-x86-64.so.2' ),
-                      ( 'nptl',   'libpthread.so.0' ),
-                      ( '',       'libc.so' ),
-                      ( '',       'libc.so.6' ),
-                      ( 'nptl_db','libthread_db.so.1' ),
-                      ( 'math',   'libm.so.6' ),
-                      ( 'dlfcn',  'libdl.so.2' ),
-                      ( 'login',  'libutil.so.1' ),
-                      ( 'csu',    'crt1.o' ),
-                      ( 'csu',    'crti.o' ),
-                      ( 'csu',    'crtn.o' ),
-                      ( 'rt',     'librt.so.1' ),
-                      ( 'resolv', 'libnss_dns.so.2' ),
-                      ( 'resolv', 'libresolv.so.2' ),
-                      ( 'libos',  'liblibos.so.1' ) ]
-
-if True:
-
-    for (dir, bin) in link_binaries:
-        if os.path.lexists(installDir + '/' + bin):
-            continue
-
-        print installDir + '/' + bin + ' -> ' + buildDir + '/' + dir + '/' + bin
-        os.symlink(os.path.relpath(buildDir + '/' + dir + '/' + bin, installDir), installDir + '/' + bin)

--- a/LibOS/shim/src/Makefile
+++ b/LibOS/shim/src/Makefile
@@ -71,7 +71,7 @@ CFLAGS += -DPROFILE
 endif
 
 $(files_to_install): $(RUNTIME_DIR)/%: %
-	cp -f $< $@
+	$(call cmd,ln_sf)
 
 ifeq ($(findstring x86_64,$(SYS))$(findstring linux,$(SYS)),x86_64linux)
 libsysdb.so: $(addsuffix .o,$(objs)) $(filter %.map %.lds,$(LDFLAGS)) \
@@ -87,7 +87,7 @@ libsysdb_debug.so: $(addsuffix .o,$(filter-out syscallas,$(objs))) \
 
 .lib/host_endian.h: ../../../Pal/src/host/$(PAL_HOST)/host_endian.h
 	@mkdir -p .lib
-	cp -f $< $@
+	$(call cmd,ln_sf)
 
 .PHONY: $(graphene_lib)
 $(graphene_lib): .lib/host_endian.h

--- a/Makefile.rules
+++ b/Makefile.rules
@@ -44,3 +44,7 @@ quiet_cmd_asm_offsets_h = [ $@ ]
 asm-offsets.h: asm-offsets.s
 	$(call cmd,asm_offsets_h)
 CLEAN_FILES += asm-offests.h
+
+
+quiet_cmd_ln_sf = [ $@ ]
+      cmd_ln_sf = ln -sf $(abspath $<) $@

--- a/Pal/src/Makefile
+++ b/Pal/src/Makefile
@@ -1,6 +1,7 @@
 export PAL_DIR = $(CURDIR)
 export RUNTIME_DIR = $(CURDIR)/../../Runtime
 
+include ../../Makefile.rules
 include Makefile.Host
 
 # Customizable PAL Targets
@@ -85,7 +86,7 @@ all: $(files_to_build) $(files_to_install)
 
 $(LIB_DIR)/host_endian.h: $(HOST_DIR)/host_endian.h
 	@mkdir -p $(LIB_DIR)
-	cp -f $< $@
+	$(call cmd,ln_sf)
 
 .PHONY: $(host_lib) $(graphene_lib) $(pal_lib) $(pal_sec)
 
@@ -98,7 +99,7 @@ $(host_lib): $(graphene_lib)
 $(pal_loader) $(pal_sec): $(host_lib)
 
 $(runtime_loader): $(pal_loader)
-	cp -f $< $@
+	$(call cmd,ln_sf)
 
 ifneq ($(pal_lib),)
 $(pal_lib): $(addprefix $(OBJ_DIR)/,$(addsuffix .o,$(objs))) \
@@ -107,7 +108,7 @@ $(pal_lib): $(addprefix $(OBJ_DIR)/,$(addsuffix .o,$(objs))) \
 	$(LD) $(LDFLAGS) -o $@ $(filter-out %.map %.lds,$^) $(LDFLAGS-suffix)
 
 $(runtime_lib): $(pal_lib)
-	cp -f $< $@
+	$(call cmd,ln_sf)
 endif
 
 ifneq ($(pal_sec),)
@@ -115,16 +116,12 @@ $(pal_sec): $(graphene_lib)
 	@[ ! -d security/$(PAL_HOST) ] || $(MAKE) -C security/$(PAL_HOST)
 
 $(runtime_sec): $(pal_sec)
-	cp -f $< $@
+	$(call cmd,ln_sf)
 endif
 
 ifneq ($(pal_gdb),)
 $(runtime_gdb): $(pal_gdb)
-ifeq ($(abspath $(pal_gdb)),$(pal_gdb))
-	ln -sf $< $@
-else
-	ln -sf ../Pal/src/$< $@
-endif
+	$(call cmd,ln_sf)
 endif
 
 ifneq ($(pal_lib_post),)


### PR DESCRIPTION
Currently cp to Runtime dir is used. Sometimes it is confusing when
binary re-build under Pal or LibOS. So symlink is better. Use symlink
instead of cp to populate Runtime dir.
This patch create ln_sf rule and use it instead of cp. and applies to
other recipe with cp.
In this context, creating symlink of glibc libraries is mess. this
patch also cleans it up to use Makefile instead of embedding the logic
into python script.

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/367)
<!-- Reviewable:end -->
