### PR TITLE
[LibOS] Variable len is used without initilization

### DIFF
--- a/LibOS/shim/src/elf/shim_rtld.c
+++ b/LibOS/shim/src/elf/shim_rtld.c
@@ -1040,7 +1040,7 @@ static int __load_elf_object (struct shim_handle * file, void * addr,
                               int type, struct link_map * remap)
 {
     char * hdr = addr;
-    int len, ret = 0;
+    int len = 0, ret = 0;
 
     if (type == OBJECT_LOAD || type == OBJECT_REMAP) {
         hdr = __alloca(FILEBUF_SIZE);


### PR DESCRIPTION
Signed-off-by: Zhang Chen <chen.zhang@intel.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/369)
<!-- Reviewable:end -->
