### PR TITLE
LibOS: replace void * with shim_tcb_t, __libc_tcb_t, shim_thread

### DIFF
--- a/LibOS/shim/include/shim_thread.h
+++ b/LibOS/shim/include/shim_thread.h
@@ -84,7 +84,7 @@ struct shim_thread {
     struct shim_handle * exec;
 
     void * stack, * stack_top, * stack_red;
-    void * tcb;
+    __libc_tcb_t * tcb;
     bool user_tcb; /* is tcb assigned by user? */
     void * frameptr;
 
@@ -146,8 +146,8 @@ void put_thread (struct shim_thread * thread);
 void get_simple_thread (struct shim_simple_thread * thread);
 void put_simple_thread (struct shim_simple_thread * thread);
 
-void allocate_tls (void * tcb_location, bool user, struct shim_thread * thread);
-void populate_tls (void * tcb_location, bool user);
+void allocate_tls (__libc_tcb_t * tcb_location, bool user, struct shim_thread * thread);
+void populate_tls (__libc_tcb_t * tcb_location, bool user);
 
 void debug_setprefix (shim_tcb_t * tcb);
 

--- a/LibOS/shim/include/shim_tls.h
+++ b/LibOS/shim/include/shim_tls.h
@@ -60,10 +60,11 @@ struct shim_context {
 
 struct debug_buf;
 
-typedef struct {
+typedef struct shim_tcb shim_tcb_t;
+struct shim_tcb {
     uint64_t                canary;
-    void *                  self;
-    void *                  tp;
+    shim_tcb_t *            self;
+    struct shim_thread *    tp;
     struct shim_context     context;
     unsigned int            tid;
     int                     pal_errno;
@@ -76,7 +77,7 @@ typedef struct {
         void * start, * end;
         void * cont_addr;
     } test_range;
-} shim_tcb_t;
+};
 
 #ifdef IN_SHIM
 

--- a/LibOS/shim/src/bookkeep/shim_thread.c
+++ b/LibOS/shim/src/bookkeep/shim_thread.c
@@ -748,7 +748,7 @@ BEGIN_RS_FUNC(running_thread)
 
         thread->pal_handle = handle;
     } else {
-        __libc_tcb_t * libc_tcb = (__libc_tcb_t *) thread->tcb;
+        __libc_tcb_t * libc_tcb = thread->tcb;
 
         if (libc_tcb) {
             shim_tcb_t * tcb = &libc_tcb->shim_tcb;

--- a/LibOS/shim/src/shim_init.c
+++ b/LibOS/shim/src/shim_init.c
@@ -202,9 +202,8 @@ void copy_tcb (shim_tcb_t * new_tcb, const shim_tcb_t * old_tcb)
 }
 
 /* This function is used to allocate tls before interpreter start running */
-void allocate_tls (void * tcb_location, bool user, struct shim_thread * thread)
+void allocate_tls (__libc_tcb_t * tcb, bool user, struct shim_thread * thread)
 {
-    __libc_tcb_t * tcb = tcb_location;
     assert(tcb);
     tcb->tcb = tcb;
     init_tcb(&tcb->shim_tcb);
@@ -223,9 +222,8 @@ void allocate_tls (void * tcb_location, bool user, struct shim_thread * thread)
     assert(shim_tls_check_canary());
 }
 
-void populate_tls (void * tcb_location, bool user)
+void populate_tls (__libc_tcb_t * tcb, bool user)
 {
-    __libc_tcb_t * tcb = (__libc_tcb_t *) tcb_location;
     assert(tcb);
     tcb->tcb = tcb;
     copy_tcb(&tcb->shim_tcb, shim_get_tls());

--- a/LibOS/shim/src/sys/shim_clone.c
+++ b/LibOS/shim/src/sys/shim_clone.c
@@ -109,14 +109,14 @@ int clone_implementation_wrapper(struct clone_args * arg)
         my_thread->tcb = __alloca(sizeof(__libc_tcb_t) + PTHREAD_PADDING);
     }
     allocate_tls(my_thread->tcb, my_thread->user_tcb, my_thread);
-    shim_tcb_t * tcb = &((__libc_tcb_t *) my_thread->tcb)->shim_tcb;
+    shim_tcb_t * tcb = &my_thread->tcb->shim_tcb;
     __disable_preempt(tcb); // Temporarily disable preemption, because the preemption
                             // will be re-enabled when the thread starts.
     debug_setbuf(tcb, true);
     debug("set tcb to %p (stack allocated? %d)\n", my_thread->tcb, stack_allocated);
 
     struct shim_regs regs;
-    regs = *((__libc_tcb_t *) arg->parent->tcb)->shim_tcb.context.regs;
+    regs = *arg->parent->tcb->shim_tcb.context.regs;
 
     if (my_thread->set_child_tid)
         *(my_thread->set_child_tid) = my_thread->tid;
@@ -257,9 +257,9 @@ int shim_do_clone (int flags, void * user_stack_addr, int * parent_tidptr,
         shim_tcb_t * old_shim_tcb = NULL;
 
         if (thread->tcb) {
-            tcb = (__libc_tcb_t *) thread->tcb;
+            tcb = thread->tcb;
         } else {
-            thread->tcb = tcb = (__libc_tcb_t *) self->tcb;
+            thread->tcb = tcb = self->tcb;
             old_shim_tcb = __alloca(sizeof(shim_tcb_t));
             memcpy(old_shim_tcb, &tcb->shim_tcb, sizeof(shim_tcb_t));
         }

--- a/LibOS/shim/src/sys/shim_exec.c
+++ b/LibOS/shim/src/sys/shim_exec.c
@@ -460,7 +460,7 @@ err:
 
     void * stack     = cur_thread->stack;
     void * stack_top = cur_thread->stack_top;
-    void * tcb       = cur_thread->tcb;
+    __libc_tcb_t * tcb = cur_thread->tcb;
     bool   user_tcb  = cur_thread->user_tcb;
     void * frameptr  = cur_thread->frameptr;
 


### PR DESCRIPTION
In shim_tcb_t and struct shim_thread, some void* can be replaced with
shim_tcb_t, __libc_tcb_t and struct shim_thread.
Also update related code to use them instead of void *.

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/370)
<!-- Reviewable:end -->
