### PR TITLE
Pal/Linux: specify loaded address of exec in child process

### DIFF
--- a/Pal/src/host/Linux/db_main.c
+++ b/Pal/src/host/Linux/db_main.c
@@ -289,6 +289,10 @@ void pal_linux_main (void * args)
     SET_HANDLE_TYPE(file, file);
     HANDLE_HDR(file)->flags |= RFD(0)|WFD(0)|WRITEABLE(0);
     file->file.fd = fd;
+    file->file.offset = 0;
+    file->file.append = false;
+    file->file.pass = false;
+    file->file.map_start = NULL;
     char * path = (void *) file + HANDLE_SIZE(file);
     get_norm_path(argv[0], path, 0, len + 1);
     file->file.realpath = path;

--- a/Pal/src/host/Linux/pal_host.h
+++ b/Pal/src/host/Linux/pal_host.h
@@ -90,6 +90,12 @@ typedef struct pal_handle
             PAL_BOL append;
             PAL_BOL pass;
             PAL_STR realpath;
+            /*
+             * map_start is to request this file should be mapped to this
+             * address. When fork is emulated, the address is already
+             * determined by parent process.
+             */
+            PAL_PTR map_start;
         } file;
         
         struct {


### PR DESCRIPTION
When fork emulation, the first exec file must be mapped to the
same address of the parent process.
If ASLR is enabled, the address can be different from the parent
without address specified. Then forked process can result in SEGV.
Pass the address for exec file to be mapped from parent process
to the child process. and use that address.
At the same time, file handle isn't initialized fully in
pal_linux_main(), so is initialized.

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/372)
<!-- Reviewable:end -->
