### PR TITLE
Jenkinsfiles: Optimize the docker file for ubuntu

### DIFF
--- a/Jenkinsfiles/ubuntu-16.04.dockerfile
+++ b/Jenkinsfiles/ubuntu-16.04.dockerfile
@@ -2,36 +2,38 @@
 FROM ubuntu:16.04
 
 # Add steps here to set up dependencies
-RUN apt-get update && apt-get install -y \
-    apache2-utils \
-    autoconf \
-    build-essential \
-    gawk \
-    gettext \
-    git \
-    libexpat1 \
-    libexpat1-dev \
-    libpcre3-dev \
-    libxml2-dev \
-    net-tools \
-    python \
-    python-crypto \
-    python-protobuf \
-    texinfo \
-    wget
+RUN apt-get update \
+    && apt-get install -y \
+       apache2-utils \
+       autoconf \
+       build-essential \
+       gawk \
+       gettext \
+       git \
+       libexpat1 \
+       libexpat1-dev \
+       libpcre3-dev \
+       libxml2-dev \
+       net-tools \
+       python \
+       python-crypto \
+       python-protobuf \
+       texinfo \
+       wget \
 
 # Add the user UID:1001, GID:1001, home at /leeroy
-RUN groupadd -r leeroy -g 1001 && useradd -u 1001 -r -g leeroy -m -d /leeroy -c "Leeroy Jenkins" leeroy && \
-    chmod 755 /leeroy
+    && groupadd -r leeroy -g 1001 \
+    && useradd -u 1001 -r -g leeroy -m -d /leeroy -c "Leeroy Jenkins" leeroy \
+    && chmod 755 /leeroy \
 
 # Make sure /leeroy can be written by leeroy
-RUN chown 1001 /leeroy
+    && chown 1001 /leeroy \
 
 # Blow away any random state
-RUN rm -f /leeroy/.rnd
+    && rm -f /leeroy/.rnd \
 
 # Make a directory for the intel driver
-RUN mkdir -p /opt/intel && chown 1001 /opt/intel
+    && mkdir -p /opt/intel && chown 1001 /opt/intel
 
 # Set the working directory to leeroy home directory
 WORKDIR /leeroy


### PR DESCRIPTION
The dockerfile instruction RUN will create new layers
when it is executed, original codes will increase the size of
the final image and causes potential cache issues.
So we need to employ shell tricks to keep the layers as small as possible.
Like #307.

Signed-off-by: Zhang Chen <chen.zhang@intel.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/373)
<!-- Reviewable:end -->
