### PR TITLE
Pal/{Linux, Linux-SGX, FreeBSD}: remove close() right before dup2()

### DIFF
--- a/Pal/src/host/FreeBSD/db_process.c
+++ b/Pal/src/host/FreeBSD/db_process.c
@@ -137,7 +137,6 @@ static int child_process (void * param)
     struct proc_param * proc_param = param;
     int ret;
 
-    INLINE_SYSCALL(close, 1, PROC_INIT_FD);
     ret = INLINE_SYSCALL(dup2, 2, proc_param->parent->process.stream_in,
                          PROC_INIT_FD);
     if (IS_ERR(ret))

--- a/Pal/src/host/Linux-SGX/sgx_process.c
+++ b/Pal/src/host/Linux-SGX/sgx_process.c
@@ -87,7 +87,6 @@ int sgx_create_process (const char * uri, int nargs, const char ** args,
         for (int i = 0 ; i < 3 ; i++)
             INLINE_SYSCALL(close, 1, proc_fds[1][i]);
 
-        INLINE_SYSCALL(close, 1, PROC_INIT_FD);
         rete = INLINE_SYSCALL(dup2, 2, proc_fds[0][0], PROC_INIT_FD);
         if (IS_ERR(rete))
             goto out_child;

--- a/Pal/src/host/Linux/db_process.c
+++ b/Pal/src/host/Linux/db_process.c
@@ -142,7 +142,6 @@ static int child_process (void * param)
     struct proc_param * proc_param = param;
     int ret;
 
-    INLINE_SYSCALL(close, 1, PROC_INIT_FD);
     ret = INLINE_SYSCALL(dup2, 2, proc_param->parent->process.stream_in,
                          PROC_INIT_FD);
     if (IS_ERR(ret))


### PR DESCRIPTION
As dup2() system call closes target file descriptor, close() right
before dup2() doesn't make sense. or worse, it opens a window for race
condition.
So remove close() right before dup2()

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/375)
<!-- Reviewable:end -->
