### PR TITLE
LibOS: add check printf format

### DIFF
--- a/LibOS/shim/include/shim_checkpoint.h
+++ b/LibOS/shim/include/shim_checkpoint.h
@@ -139,7 +139,7 @@ struct shim_cp_store {
 };
 
 #define CP_FUNC_ARGS                                    \
-    struct shim_cp_store * store, void * obj, int size, void ** objp
+    struct shim_cp_store * store, void * obj, size_t size, void ** objp
 
 #define RS_FUNC_ARGS                                    \
     struct shim_cp_entry * entry, ptr_t base, ptr_t * offset, long rebase
@@ -197,13 +197,13 @@ enum {
         tmp->cp_type = CP_##type;                                   \
         tmp->cp_un.cp_val = (ptr_t) (value);                        \
         if (DEBUG_CHECKPOINT)                                       \
-            debug("ADD CP_" #type "(%p) >%d\n", tmp->cp_un.cp_val,  \
+            debug("ADD CP_" #type "(0x%08lx) >%ld\n", tmp->cp_un.cp_val, \
                   store->offset);                                   \
     tmp; })
 
 #define ADD_CP_OFFSET(size)                                         \
     ({                                                              \
-        int _size = ((size) + sizeof(void *) - 1) &                 \
+        size_t _size = ((size) + sizeof(void *) - 1) &              \
                     ~(sizeof(void *) - 1);                          \
         struct shim_cp_entry * oob =                                \
                 (void *) base +                                     \
@@ -212,7 +212,7 @@ enum {
         oob->cp_un.cp_val = (ptr_t) _size;                          \
         ptr_t _off = (ptr_t) __ADD_CP_OFFSET(_size);                \
         if (DEBUG_CHECKPOINT)                                       \
-            debug("ADD OFFSET(%d) >%d\n", (size), store->offset);   \
+            debug("ADD OFFSET(%lu) >%ld\n", (size), store->offset); \
     _off; })
 
 #define ADD_CP_FUNC_ENTRY(value)                                    \
@@ -223,7 +223,7 @@ enum {
         tmp->cp_type = CP_FUNC_TYPE;                                \
         tmp->cp_un.cp_val = (ptr_t) (value);                        \
         if (DEBUG_CHECKPOINT)                                       \
-            debug("ADD %s(%p) >%d\n", CP_FUNC_NAME, (value),        \
+            debug("ADD %s(0x%08lx) >%ld\n", CP_FUNC_NAME, (value),  \
                   store->offset);                                   \
     tmp; })
 
@@ -371,7 +371,7 @@ get_cp_map_entry (void * map, void * addr, bool create);
 
 #if DEBUG_RESUME == 1
 # define DEBUG_RS(fmt, ...)                                              \
-    debug("GET %s(%p): " fmt "\n", CP_FUNC_NAME, entry->cp_un.cp_val,    \
+    debug("GET %s(0x%08lx): " fmt "\n", CP_FUNC_NAME, entry->cp_un.cp_val, \
           ##__VA_ARGS__)
 #else
 # define DEBUG_RS(...) do {} while (0)

--- a/LibOS/shim/include/shim_internal.h
+++ b/LibOS/shim/include/shim_internal.h
@@ -65,10 +65,10 @@ extern PAL_HANDLE debug_handle;
 
 # include <stdarg.h>
 
-void debug_printf (const char * fmt, ...);
+void debug_printf (const char * fmt, ...) __attribute__((format (printf, 1, 2)));
 void debug_puts (const char * str);
 void debug_putch (int ch);
-void debug_vprintf (const char * fmt, va_list * ap);
+void debug_vprintf (const char * fmt, va_list * ap) __attribute__((format (printf, 1, 0)));
 
 # define VMID_PREFIX     "[P%05u] "
 # define TID_PREFIX      "[%-6u] "
@@ -82,8 +82,8 @@ void debug_vprintf (const char * fmt, va_list * ap);
 /* print system messages */
 #define SYSPRINT_BUFFER_SIZE    256
 
-void handle_printf (PAL_HANDLE hdl, const char * fmt, ...);
-void handle_vprintf (PAL_HANDLE hdl, const char * fmt, va_list * ap);
+void handle_printf (PAL_HANDLE hdl, const char * fmt, ...) __attribute__((format (printf, 2, 3)));
+void handle_vprintf (PAL_HANDLE hdl, const char * fmt, va_list * ap) __attribute__((format (printf, 2, 0)));
 
 #define __sys_printf(fmt, ...)                                              \
     do {                                                                    \

--- a/LibOS/shim/src/bookkeep/shim_thread.c
+++ b/LibOS/shim/src/bookkeep/shim_thread.c
@@ -412,8 +412,8 @@ void add_thread (struct shim_thread * thread)
 
 void del_thread (struct shim_thread * thread)
 {
-    debug("del_thread(%p, %d, %d)\n", thread, thread ? thread->tid : -1,
-            thread->ref_count);
+    debug("del_thread(%p, %d, %ld)\n", thread, thread ? thread->tid : -1,
+          atomic_read(&thread->ref_count));
 
     if (IS_INTERNAL(thread) || list_empty(thread, list)) {
         debug("del_thread: internal\n");
@@ -480,7 +480,7 @@ int check_last_thread (struct shim_thread * self)
         }
     }
 
-    debug("this is the only thread\n", self->tid);
+    debug("this is the only thread %d\n", self->tid);
     unlock(thread_list_lock);
     return 0;
 }

--- a/LibOS/shim/src/bookkeep/shim_vma.c
+++ b/LibOS/shim/src/bookkeep/shim_vma.c
@@ -1132,8 +1132,8 @@ BEGIN_RS_FUNC(vma)
 
     SAVE_PROFILE_INTERVAL(vma_add_bookkeep);
 
-    DEBUG_RS("vma: %p-%p flags %x prot %p\n", vma->addr, vma->addr + vma->length,
-             vma->flags, vma->prot);
+    DEBUG_RS("vma: %p-%p flags %x prot 0x%08x\n",
+             vma->addr, vma->addr + vma->length, vma->flags, vma->prot);
 
     if (!(vma->flags & VMA_UNMAPPED)) {
         if (vma->file) {
@@ -1186,12 +1186,12 @@ BEGIN_RS_FUNC(vma)
         get_handle(vma->file);
 
     if (vma->file)
-        DEBUG_RS("%p-%p,size=%d,prot=%08x,flags=%08x,off=%d,path=%s,uri=%s",
+        DEBUG_RS("%p-%p,size=%ld,prot=%08x,flags=%08x,off=%ld,path=%s,uri=%s",
                  vma->addr, vma->addr + vma->length, vma->length,
                  vma->prot, vma->flags, vma->offset,
                  qstrgetstr(&vma->file->path), qstrgetstr(&vma->file->uri));
     else
-        DEBUG_RS("%p-%p,size=%d,prot=%08x,flags=%08x,off=%d",
+        DEBUG_RS("%p-%p,size=%ld,prot=%08x,flags=%08x,off=%ld",
                  vma->addr, vma->addr + vma->length, vma->length,
                  vma->prot, vma->flags, vma->offset);
 }
@@ -1251,7 +1251,7 @@ void debug_print_vma_list (void)
             }
         }
 
-        sys_printf("[%p-%p] prot=%08x flags=%08x%s%s offset=%d%s%s%s%s\n",
+        sys_printf("[%p-%p] prot=%08x flags=%08x%s%s offset=%ld%s%s%s%s\n",
                    vma->start, vma->end,
                    vma->prot,
                    vma->flags & ~(VMA_INTERNAL|VMA_UNMAPPED|VMA_TAINTED|VMA_CP),

--- a/LibOS/shim/src/elf/shim_rtld.c
+++ b/LibOS/shim/src/elf/shim_rtld.c
@@ -795,7 +795,7 @@ static int __remove_elf_object (struct link_map * l)
 
 static int __free_elf_object (struct link_map * l)
 {
-    debug("removing %s as runtime object loaded at %p\n", l->l_name,
+    debug("removing %s as runtime object loaded at 0x%08lx\n", l->l_name,
           l->l_map_start);
 
     struct loadcmd *c = l->loadcmds;
@@ -1101,7 +1101,7 @@ int reload_elf_object (struct shim_handle * file)
     if (!map)
         return -ENOENT;
 
-    debug("reloading %s as runtime object loaded at %p-%p\n",
+    debug("reloading %s as runtime object loaded at 0x%08lx-0x%08lx\n",
           qstrgetstr(&file->uri), map->l_map_start, map->l_map_end);
 
     return __load_elf_object(file, NULL, OBJECT_REMAP, map);
@@ -1539,7 +1539,7 @@ int init_brk_from_executable (struct shim_handle * exec)
 
 int register_library (const char * name, unsigned long load_address)
 {
-    debug("glibc register library %s loaded at %p\n",
+    debug("glibc register library %s loaded at 0x%08lx\n",
           name, load_address);
 
     struct shim_handle * hdl = get_new_handle();
@@ -1625,7 +1625,7 @@ BEGIN_CP_FUNC(library)
             DO_CP_MEMBER(handle, map, new_map, l_file);
 
         if (map->l_ld) {
-            int size = sizeof(ElfW(Dyn)) * map->l_ldnum;
+            size_t size = sizeof(ElfW(Dyn)) * map->l_ldnum;
             ElfW(Dyn) * ld = (void *) (base + ADD_CP_OFFSET(size));
             memcpy(ld, map->l_ld, size);
             new_map->l_ld = ld;
@@ -1639,14 +1639,14 @@ BEGIN_CP_FUNC(library)
         }
 
         if (map->l_name) {
-            int namelen = strlen(map->l_name);
+            size_t namelen = strlen(map->l_name);
             char * name = (char *) (base + ADD_CP_OFFSET(namelen + 1));
             memcpy(name, map->l_name, namelen + 1);
             new_map->l_name = name;
         }
 
         if (map->l_soname) {
-            int sonamelen = strlen(map->l_soname);
+            size_t sonamelen = strlen(map->l_soname);
             char * soname = (char *) (base + ADD_CP_OFFSET(sonamelen + 1));
             memcpy(soname, map->l_soname, sonamelen + 1);
             new_map->l_soname = soname;
@@ -1703,7 +1703,7 @@ BEGIN_RS_FUNC(library)
 
     SAVE_PROFILE_INTERVAL(add_or_replace_library);
 
-    DEBUG_RS("base=%p,name=%s", map->l_addr, map->l_name);
+    DEBUG_RS("base=0x%08lx,name=%s", map->l_addr, map->l_name);
 }
 END_RS_FUNC(library)
 
@@ -1722,7 +1722,7 @@ BEGIN_CP_FUNC(loaded_libraries)
         map = map->l_next;
     }
 
-    ADD_CP_FUNC_ENTRY(new_interp_map);
+    ADD_CP_FUNC_ENTRY((ptr_t)new_interp_map);
 }
 END_CP_FUNC(loaded_libraries)
 

--- a/LibOS/shim/src/fs/shim_dcache.c
+++ b/LibOS/shim/src/fs/shim_dcache.c
@@ -392,7 +392,7 @@ BEGIN_RS_FUNC(dentry)
         listp_add_tail(dent, &dent->parent->children, siblings);
     }
 
-    DEBUG_RS("hash=%08x,path=%s,fs=%s", dent->rel_path.hash,
+    DEBUG_RS("hash=%08lx,path=%s,fs=%s", dent->rel_path.hash,
              dentry_get_path(dent, true, NULL),
              dent->fs ? qstrgetstr(&dent->fs->path) : NULL);
 }

--- a/LibOS/shim/src/fs/shim_fs.c
+++ b/LibOS/shim/src/fs/shim_fs.c
@@ -175,7 +175,7 @@ static int __mount_one_other (const char * key, int keylen)
     debug("mounting as %s filesystem: from %s to %s\n", t, uri, p);
 
     if ((ret = mount_fs(t, uri, p, NULL, NULL, 1)) < 0) {
-        debug("mounting %s on %s (type=%s) failed (%e)\n", uri, p, t,
+        debug("mounting %s on %s (type=%s) failed (%d)\n", uri, p, t,
               -ret);
         return ret;
     }
@@ -650,7 +650,7 @@ BEGIN_CP_FUNC(all_mounts)
     unlock(mount_list_lock);
 
     /* add an empty entry to mark as migrated */
-    ADD_CP_FUNC_ENTRY(0);
+    ADD_CP_FUNC_ENTRY(0UL);
 }
 END_CP_FUNC(all_mounts)
 

--- a/LibOS/shim/src/ipc/shim_ipc_nsimpl.h
+++ b/LibOS/shim/src/ipc/shim_ipc_nsimpl.h
@@ -149,7 +149,7 @@ void CONCAT3(debug_print, NS, ranges) (void)
             IDTYPE base = RANGE_SIZE * off + 1;
             struct shim_ipc_info * p = r->owner;
 
-            sys_printf("%04u - %04u: owner %010u, port \"%s\" lease %u\n",
+            sys_printf("%04u - %04u: owner %010u, port \"%s\" lease %lu\n",
                        base, base + RANGE_SIZE - 1,
                        p->vmid, qstrgetstr(&p->uri), r->lease);
 
@@ -162,7 +162,7 @@ void CONCAT3(debug_print, NS, ranges) (void)
                     continue;
 
                 p = s->owner;
-                sys_printf("   %04u: owner %010u, port \"%s\" lease %u\n",
+                sys_printf("   %04u: owner %010u, port \"%s\" lease %lu\n",
                            base + k, p->vmid,
                            qstrgetstr(&p->uri), s->lease);
             }
@@ -1270,7 +1270,7 @@ int NS_SEND(renew) (IDTYPE base, IDTYPE size)
     msgin->base = base;
     msgin->size = size;
 
-    debug("ipc send to %u: " NS_CODE_STR(RENEW) "(%u, %u)\n", base, size);
+    debug("ipc send to : " NS_CODE_STR(RENEW) "(%u, %u)\n", base, size);
     ret = send_ipc_message(msg, port);
     put_ipc_port(port);
 out:
@@ -1746,7 +1746,7 @@ int CONCAT2(NS, add_key) (NS_KEY * key, IDTYPE id)
     INIT_LIST_HEAD(k, hlist);
     listp_add(k, head, hlist);
 
-    debug("add key/id pair (%u, %u) to hash list: %p\n",
+    debug("add key/id pair (%lu, %u) to hash list: %p\n",
           KEY_HASH(key), id, head);
     ret = 0;
 out:
@@ -1806,7 +1806,7 @@ int NS_SEND(findkey) (NS_KEY * key)
     NS_MSG_TYPE(findkey) * msgin = (void *) &msg->msg.msg;
     KEY_COPY(&msgin->key, key);
 
-    debug("ipc send to %u: " NS_CODE_STR(FINDKEY) "(%u)\n",
+    debug("ipc send to %u: " NS_CODE_STR(FINDKEY) "(%lu)\n",
           dest, KEY_HASH(key));
 
     ret = do_ipc_duplex(msg, port, NULL, NULL);
@@ -1825,7 +1825,7 @@ int NS_CALLBACK(findkey) (IPC_CALLBACK_ARGS)
     int ret = 0;
     NS_MSG_TYPE(findkey) * msgin  = (void *) &msg->msg;
 
-    debug("ipc callback from %u: " NS_CODE_STR(FINDKEY) "(%u)\n",
+    debug("ipc callback from %u: " NS_CODE_STR(FINDKEY) "(%lu)\n",
           msg->src, KEY_HASH(&msgin->key));
 
     ret = CONCAT2(NS, get_key)(&msgin->key, false);
@@ -1871,7 +1871,7 @@ int NS_SEND(tellkey) (struct shim_ipc_port * port, IDTYPE dest, NS_KEY * key,
         msgin->id = id;
         msg->seq  = seq;
 
-        debug("ipc send to %u: IPC_SYSV_TELLKEY(%u, %u)\n", dest,
+        debug("ipc send to %u: IPC_SYSV_TELLKEY(%lu, %u)\n", dest,
               KEY_HASH(key), id);
 
         ret = send_ipc_message(msg, port);
@@ -1886,7 +1886,7 @@ int NS_SEND(tellkey) (struct shim_ipc_port * port, IDTYPE dest, NS_KEY * key,
     KEY_COPY(&msgin->key, key);
     msgin->id = id;
 
-    debug("ipc send to %u: IPC_SYSV_TELLKEY(%u, %u)\n", dest,
+    debug("ipc send to %u: IPC_SYSV_TELLKEY(%lu, %u)\n", dest,
           KEY_HASH(key), id);
 
     ret = do_ipc_duplex(msg, port, NULL, NULL);
@@ -1902,7 +1902,7 @@ int NS_CALLBACK(tellkey) (IPC_CALLBACK_ARGS)
     int ret = 0;
     NS_MSG_TYPE(tellkey) * msgin = (void *) &msg->msg;
 
-    debug("ipc callback from %u: " NS_CODE_STR(TELLKEY) "(%u, %u)\n",
+    debug("ipc callback from %u: " NS_CODE_STR(TELLKEY) "(%lu, %u)\n",
           msg->src, KEY_HASH(&msgin->key), msgin->id);
 
     ret = CONCAT2(NS, add_key)(&msgin->key, msgin->id);

--- a/LibOS/shim/src/ipc/shim_ipc_sysv.c
+++ b/LibOS/shim/src/ipc/shim_ipc_sysv.c
@@ -411,7 +411,7 @@ int ipc_sysv_msgmov_send (struct shim_ipc_port * port, IDTYPE dest,
     if (nscores)
         memcpy(msgin->scores, scores, sizeof(struct sysv_score) * nscores);
 
-    debug("ipc send to %u: IPC_SYSV_MSGMOV(%ld)\n", dest, msgid);
+    debug("ipc send to %u: IPC_SYSV_MSGMOV(%d)\n", dest, msgid);
     int ret = send_ipc_message(msg, port);
     SAVE_PROFILE_INTERVAL(ipc_sysv_msgmov_send);
     return ret;
@@ -424,7 +424,7 @@ int ipc_sysv_msgmov_callback (IPC_CALLBACK_ARGS)
     struct shim_ipc_sysv_msgmov * msgin =
                 (struct shim_ipc_sysv_msgmov *) &msg->msg;
 
-    debug("ipc callback from %u: IPC_SYSV_MSGMOV(%ld)\n", msg->src,
+    debug("ipc callback from %u: IPC_SYSV_MSGMOV(%d)\n", msg->src,
           msgin->msgid);
 
     struct shim_msg_handle * msgq = get_msg_handle_by_id(msgin->msgid);
@@ -794,7 +794,7 @@ int ipc_sysv_semmov_send (struct shim_ipc_port * port, IDTYPE dest,
            sizeof(struct sem_client_backup) * nsrcs,
            scores, sizeof(struct sysv_score) * nscores);
 
-    debug("ipc send to %u: IPC_SYSV_SEMMOV(%ld)\n", semid);
+    debug("ipc send to : IPC_SYSV_SEMMOV(%d)\n", semid);
 
     int ret = send_ipc_message(msg, port);
     SAVE_PROFILE_INTERVAL(ipc_sysv_semmov_send);
@@ -808,7 +808,7 @@ int ipc_sysv_semmov_callback (IPC_CALLBACK_ARGS)
     struct shim_ipc_sysv_semmov * msgin =
                 (struct shim_ipc_sysv_semmov *) &msg->msg;
 
-    debug("ipc callback from %u: IPC_SYSV_SEMMOV(%ld)\n", msg->src,
+    debug("ipc callback from %u: IPC_SYSV_SEMMOV(%d)\n", msg->src,
           msgin->semid);
 
     struct sem_backup * sems = msgin->sems;
@@ -1020,7 +1020,7 @@ int __balance_sysv_score (struct sysv_balance_policy * policy,
 
         s->score = (s->score >= policy->score_decay) ?
                     s->score - policy->score_decay : 0;
-        debug("balance: %u => %d\n", s->vmid, s->score);
+        debug("balance: %u => %ld\n", s->vmid, s->score);
     }
 
     if (!chosen) {
@@ -1033,7 +1033,7 @@ int __balance_sysv_score (struct sysv_balance_policy * policy,
     if (chosen->score > policy->score_max)
         chosen->score = policy->score_max;
 
-    debug("balance: %u => %d\n", chosen->vmid, chosen->score);
+    debug("balance: %u => %ld\n", chosen->vmid, chosen->score);
 
     if (!src || chosen != highest ||
         chosen->score < (owner ? owner->score : 0) + policy->balance_threshold)

--- a/LibOS/shim/src/shim_async.c
+++ b/LibOS/shim/src/shim_async.c
@@ -64,7 +64,7 @@ int64_t install_async_event (PAL_HANDLE object, unsigned long time,
     unsigned long install_time = DkSystemTimeQuery();
     int64_t rv = 0;
     
-    debug("install async event at %llu\n", install_time);
+    debug("install async event at %lu\n", install_time);
 
     event->callback     = callback;
     event->arg          = arg;
@@ -194,7 +194,7 @@ static void shim_async_helper (void * arg)
         
         if (!polled) {
             if (next_event) {
-                debug("async event trigger at %llu\n",
+                debug("async event trigger at %lu\n",
                       next_event->expire_time);
 
                 next_event->callback(next_event->caller, next_event->arg);
@@ -226,7 +226,7 @@ update_status:
 
         listp_for_each_entry_safe(tmp, n, &async_list, list) {
             if (tmp->object == polled) {
-                debug("async event trigger at %llu\n",
+                debug("async event trigger at %lu\n",
                       latest_time);
                 unlock(async_helper_lock);
                 tmp->callback(tmp->caller, tmp->arg);
@@ -256,7 +256,7 @@ update_list:
                     break;
                 }
 
-                debug("async event trigger at %llu (expire at %llu)\n",
+                debug("async event trigger at %lu (expire at %lu)\n",
                       latest_time, tmp->expire_time);
                 listp_del(tmp, &async_list, list);
                 unlock(async_helper_lock);

--- a/LibOS/shim/src/shim_checkpoint.c
+++ b/LibOS/shim/src/shim_checkpoint.c
@@ -232,7 +232,7 @@ BEGIN_CP_FUNC(migratable)
     DO_CP_SIZE(memory, &__migratable, &__migratable_end - &__migratable,
                &mem_entry);
 
-    struct shim_cp_entry * entry = ADD_CP_FUNC_ENTRY(0);
+    struct shim_cp_entry * entry = ADD_CP_FUNC_ENTRY(0UL);
     mem_entry->paddr = (void **) &entry->cp_un.cp_val;
 }
 END_CP_FUNC(migratable)
@@ -572,10 +572,10 @@ int restore_checkpoint (struct cp_header * cphdr, struct mem_header * memhdr,
     int ret = 0;
 
     if (type)
-        debug("restore checkpoint at %p rebased from %p (%s only)\n",
+        debug("restore checkpoint at 0x%08lx rebased from %p (%s only)\n",
               base, cphdr->addr, CP_FUNC_NAME(type));
     else
-        debug("restore checkpoint at %p rebased from %p\n",
+        debug("restore checkpoint at 0x%08lx rebased from %p\n",
               base, cphdr->addr);
 
     if (memhdr && memhdr->nentries) {
@@ -632,7 +632,7 @@ next:
         cpent = NEXT_CP_ENTRY();
     }
 
-    debug("successfully restore checkpoint loaded at %p - %p\n",
+    debug("successfully restore checkpoint loaded at 0x%08lx - 0x%08lx\n",
           base, base + cphdr->size);
 
     return 0;
@@ -1003,7 +1003,7 @@ int do_migrate_process (int (*migrate) (struct shim_cp_store *,
     unsigned long checkpoint_size = cpstore.offset + cpstore.mem_size;
 
     /* Checkpoint data created. */
-    debug("checkpoint of %u bytes created, %lu microsecond is spent.\n",
+    debug("checkpoint of %lu bytes created, %lu microsecond is spent.\n",
           checkpoint_size, checkpoint_time);
 
     hdr.checkpoint.hdr.addr = (void *) cpstore.base;

--- a/LibOS/shim/src/shim_debug.c
+++ b/LibOS/shim/src/shim_debug.c
@@ -148,7 +148,7 @@ BEGIN_CP_FUNC(gdb_map)
         memcpy(newm, m, sizeof(struct gdb_link_map));
         newm->l_prev = newm->l_next = NULL;
 
-        int len = strlen(newm->l_name);
+        size_t len = strlen(newm->l_name);
         newm->l_name = (char *) (base + ADD_CP_OFFSET(len + 1));
         memcpy(newm->l_name, m->l_name, len + 1);
 

--- a/LibOS/shim/src/shim_init.c
+++ b/LibOS/shim/src/shim_init.c
@@ -156,7 +156,7 @@ long int glibc_option (const char * opt)
     if (strcmp_static(opt, "heap_size")) {
         ssize_t ret = get_config(root_config, "glibc.heap_size", cfg, CONFIG_MAX);
         if (ret <= 0) {
-            debug("no glibc option: %s (err=%d)\n", opt, ret);
+            debug("no glibc option: %s (err=%ld)\n", opt, ret);
             return -ENOENT;
         }
 
@@ -277,7 +277,7 @@ void * allocate_stack (size_t size, size_t protect_size, bool user)
     if (bkeep_mprotect(stack, size, PROT_READ|PROT_WRITE, flags) < 0)
         return NULL;
 
-    debug("allocated stack at %p (size = %d)\n", stack, size);
+    debug("allocated stack at %p (size = %ld)\n", stack, size);
     return stack;
 }
 

--- a/LibOS/shim/src/shim_malloc.c
+++ b/LibOS/shim/src/shim_malloc.c
@@ -89,7 +89,7 @@ void * __system_malloc (size_t size)
                 continue;
             }
 
-            debug("failed to allocate memory (%d)\n", -PAL_ERRNO);
+            debug("failed to allocate memory (%ld)\n", -PAL_ERRNO);
             bkeep_munmap(addr, alloc_size, flags);
             return NULL;
         }

--- a/LibOS/shim/src/shim_parser.c
+++ b/LibOS/shim/src/shim_parser.c
@@ -509,7 +509,7 @@ void parse_syscall_before (int sysno, const char * name, int nr, ...)
 
     PUTCH(')');
 dotdotdot:
-    PRINTF(" ...\n", name);
+    PRINTF(" ... %s\n", name);
     va_end(ap);
 }
 
@@ -557,7 +557,7 @@ void parse_syscall_after (int sysno, const char * name, int nr, ...)
 
     if (is_pointer(ret_type)) {
         if (ret_ptr < -4095L)
-            PRINTF(") = %p\n", ret_ptr);
+            PRINTF(") = 0x%08lx\n", ret_ptr);
         else
             PRINTF(") = %ld\n", (long) ret_ptr);
     } else {
@@ -870,7 +870,7 @@ static void parse_timespec (const char * type, va_list * ap)
         return;
     }
 
-    PRINTF("[%ld,%lld]", tv->tv_sec, tv->tv_nsec);
+    PRINTF("[%ld,%ld]", tv->tv_sec, tv->tv_nsec);
 }
 
 static void parse_sockaddr (const char * type, va_list *ap)

--- a/LibOS/shim/src/shim_random.c
+++ b/LibOS/shim/src/shim_random.c
@@ -37,7 +37,7 @@ int init_randgen (void)
     if (DkRandomBitsRead (&randval, sizeof(randval)) < sizeof(randval))
         return -EACCES;
 
-    debug("initial random value: %08llx\n", randval);
+    debug("initial random value: %08lx\n", randval);
     create_lock(randgen_lock);
     return 0;
 }

--- a/LibOS/shim/src/sys/shim_brk.c
+++ b/LibOS/shim/src/sys/shim_brk.c
@@ -223,7 +223,7 @@ out:
 BEGIN_CP_FUNC(brk)
 {
     if (region.brk_start) {
-        ADD_CP_FUNC_ENTRY(region.brk_start);
+        ADD_CP_FUNC_ENTRY((ptr_t)region.brk_start);
         ADD_CP_ENTRY(ADDR, region.brk_current);
         ADD_CP_ENTRY(SIZE, region.brk_end - region.brk_start);
         assert(brk_max_size);

--- a/LibOS/shim/src/sys/shim_epoll.c
+++ b/LibOS/shim/src/sys/shim_epoll.c
@@ -411,7 +411,7 @@ BEGIN_CP_FUNC(epoll_fd)
     LISTP_TYPE(shim_epoll_fd) * new_list = (LISTP_TYPE(shim_epoll_fd) *) objp;
     struct shim_epoll_fd * epoll_fd;
 
-    debug("checkpoint epoll: %p -> %p (base = %p)\n", old_list, new_list, base);
+    debug("checkpoint epoll: %p -> %p (base = 0x%08lx)\n", old_list, new_list, base);
 
     INIT_LISTP(new_list);
 

--- a/LibOS/shim/src/sys/shim_msgget.c
+++ b/LibOS/shim/src/sys/shim_msgget.c
@@ -905,7 +905,7 @@ static int __load_msg_persist (struct shim_msg_handle * msgq, bool readmsg)
         struct msg_backup * m = mem;
         mem += sizeof(struct msg_backup) + m->size;
 
-        debug("load msg: type=%d, size=%d\n", m->type, m->size);
+        debug("load msg: type=%ld, size=%d\n", m->type, m->size);
 
         if (!mtype || mtype->type != m->type)
             mtype = __add_msg_type(m->type, &msgq->types, &msgq->ntypes,


### PR DESCRIPTION
This patch adds printf format check and fixes most of found issues.
ADD_CP_ENTRY was given up due to type issue.
It requires to change function signature. So I didn't address it at
this time.

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/380)
<!-- Reviewable:end -->
