### PR TITLE
Enable Wunused-parameter warning as part of Wextra

### DIFF
--- a/LibOS/shim/include/shim_internal.h
+++ b/LibOS/shim/include/shim_internal.h
@@ -420,7 +420,7 @@ static inline void enable_locking (void)
 static inline PAL_HANDLE thread_create (void * func, void * arg, int option)
 {
     assert(lock_enabled);
-    return DkThreadCreate(func, arg, option);
+    return DkThreadCreate(func, arg);
 }
 
 static inline void __disable_preempt (shim_tcb_t * tcb)

--- a/LibOS/shim/src/bookkeep/shim_signal.c
+++ b/LibOS/shim/src/bookkeep/shim_signal.c
@@ -477,12 +477,12 @@ ret_exception:
 
 int init_signal (void)
 {
-    DkSetExceptionHandler(&arithmetic_error_upcall, PAL_EVENT_ARITHMETIC_ERROR, 0);
-    DkSetExceptionHandler(&memfault_upcall,         PAL_EVENT_MEMFAULT,         0);
-    DkSetExceptionHandler(&illegal_upcall,          PAL_EVENT_ILLEGAL,          0);
-    DkSetExceptionHandler(&quit_upcall,             PAL_EVENT_QUIT,             0);
-    DkSetExceptionHandler(&suspend_upcall,          PAL_EVENT_SUSPEND,          0);
-    DkSetExceptionHandler(&resume_upcall,           PAL_EVENT_RESUME,           0);
+    DkSetExceptionHandler(&arithmetic_error_upcall,     PAL_EVENT_ARITHMETIC_ERROR);
+    DkSetExceptionHandler(&memfault_upcall,    PAL_EVENT_MEMFAULT);
+    DkSetExceptionHandler(&illegal_upcall,     PAL_EVENT_ILLEGAL);
+    DkSetExceptionHandler(&quit_upcall,        PAL_EVENT_QUIT);
+    DkSetExceptionHandler(&suspend_upcall,     PAL_EVENT_SUSPEND);
+    DkSetExceptionHandler(&resume_upcall,      PAL_EVENT_RESUME);
     return 0;
 }
 

--- a/LibOS/shim/src/bookkeep/shim_thread.c
+++ b/LibOS/shim/src/bookkeep/shim_thread.c
@@ -742,7 +742,7 @@ BEGIN_RS_FUNC(running_thread)
                                  NUM_SIGS);
 
     if (cur_thread) {
-        PAL_HANDLE handle = DkThreadCreate(resume_wrapper, thread, 0);
+        PAL_HANDLE handle = DkThreadCreate(resume_wrapper, thread);
         if (!thread)
             return -PAL_ERRNO;
 

--- a/LibOS/shim/src/shim_checkpoint.c
+++ b/LibOS/shim/src/shim_checkpoint.c
@@ -401,7 +401,7 @@ static int send_checkpoint_by_gipc (PAL_HANDLE gipc_store,
     }
 
     hdr_size = ALIGN_UP(hdr_size);
-    int npages = DkPhysicalMemoryCommit(gipc_store, 1, &hdr_addr, &hdr_size, 0);
+    int npages = DkPhysicalMemoryCommit(gipc_store, 1, &hdr_addr, &hdr_size);
     if (!npages)
         return -EPERM;
 
@@ -428,7 +428,7 @@ static int send_checkpoint_by_gipc (PAL_HANDLE gipc_store,
     /* Chia-Che: sending an empty page can't ever be a smart idea.
        we might rather fail here */
     npages = DkPhysicalMemoryCommit(gipc_store, nentries, gipc_addrs,
-                                    gipc_sizes, 0);
+                                    gipc_sizes);
 
     if (npages < total_pages) {
         debug("gipc supposed to send %d pages, but only %d pages sent\n",
@@ -682,7 +682,7 @@ int init_from_checkpoint_file (const char * filename,
         argv[1] = dentry_get_path(file, true, NULL);
         argv[2] = 0;
 
-        PAL_HANDLE proc = DkProcessCreate(NULL, 0, argv);
+        PAL_HANDLE proc = DkProcessCreate(NULL, argv);
         if (!proc) {
             ret = -PAL_ERRNO;
             goto out;
@@ -915,8 +915,7 @@ int do_migrate_process (int (*migrate) (struct shim_cp_store *,
      * the latency of forking.
      */
     PAL_HANDLE proc = DkProcessCreate(exec ? qstrgetstr(&exec->uri) :
-                                      pal_control.executable,
-                                      0, argv);
+                                      pal_control.executable, argv);
 
     if (!proc) {
         ret = -PAL_ERRNO;

--- a/LibOS/shim/src/shim_init.c
+++ b/LibOS/shim/src/shim_init.c
@@ -682,7 +682,7 @@ int shim_init (int argc, void * args, void ** return_stack)
 
     debug("host: %s\n", PAL_CB(host_type));
 
-    DkSetExceptionHandler(&handle_failure, PAL_EVENT_FAILURE, 0);
+    DkSetExceptionHandler(&handle_failure, PAL_EVENT_FAILURE);
 
     allocsize = PAL_CB(alloc_align);
     allocshift = allocsize - 1;
@@ -952,12 +952,12 @@ static int open_pal_handle (const char * uri, void * obj)
         hdl = DkStreamOpen(uri, 0,
                            PAL_SHARE_OWNER_X|PAL_SHARE_OWNER_W|
                            PAL_SHARE_OWNER_R,
-                           PAL_CREAT_TRY|PAL_CREAT_ALWAYS,
+                           PAL_CREATE_TRY|PAL_CREATE_ALWAYS,
                            0);
     else
         hdl = DkStreamOpen(uri, PAL_ACCESS_RDWR,
                            PAL_SHARE_OWNER_W|PAL_SHARE_OWNER_R,
-                           PAL_CREAT_TRY|PAL_CREAT_ALWAYS,
+                           PAL_CREATE_TRY|PAL_CREATE_ALWAYS,
                            0);
 
     if (!hdl) {

--- a/LibOS/shim/src/sys/shim_msgget.c
+++ b/LibOS/shim/src/sys/shim_msgget.c
@@ -782,7 +782,7 @@ static int __store_msg_persist (struct shim_msg_handle * msgq)
     snprintf(fileuri, 20, "file:msgq.%08x", msgq->msqid);
 
     PAL_HANDLE file = DkStreamOpen(fileuri, PAL_ACCESS_RDWR, 0600,
-                                   PAL_CREAT_TRY, 0);
+                                   PAL_CREATE_TRY, 0);
     if (!file) {
         ret = -PAL_ERRNO;
         goto out;

--- a/Pal/lib/api.h
+++ b/Pal/lib/api.h
@@ -68,6 +68,9 @@ typedef ptrdiff_t ssize_t;
 
 #define static_strlen(str) (sizeof(str) - 1)
 
+/* Turning off unused-parameter warning for keeping function signatures */
+#define __UNUSED(x) do { (void)(x); } while (0)
+
 /* Libc functions */
 
 /* Libc String functions string.h/stdlib.h */

--- a/Pal/lib/crypto/adapters/mbedtls_adapter.c
+++ b/Pal/lib/crypto/adapters/mbedtls_adapter.c
@@ -18,6 +18,7 @@
 #include <errno.h>
 #include <stdint.h>
 #include <limits.h>
+#include "api.h"
 #include "pal.h"
 #include "pal_crypto.h"
 #include "pal_error.h"
@@ -37,6 +38,7 @@ int _DkRandomBitsRead(void *buffer, int size);
  * and nonzero for failure. */
 static int RandomWrapper(void *private, unsigned char *data, size_t size)
 {
+    __UNUSED(private);
     return _DkRandomBitsRead(data, size) != size;
 }
 

--- a/Pal/lib/crypto/adapters/mbedtls_dh.c
+++ b/Pal/lib/crypto/adapters/mbedtls_dh.c
@@ -17,6 +17,7 @@
 
 #include <errno.h>
 #include <limits.h>
+#include "api.h"
 #include "pal.h"
 #include "pal_error.h"
 #include "pal_crypto.h"
@@ -33,6 +34,7 @@ int _DkRandomBitsRead(void *buffer, int size);
  * and nonzero for failure. */
 static int RandomWrapper(void *private, unsigned char *data, size_t size)
 {
+    __UNUSED(private);
     return _DkRandomBitsRead(data, size) != size;
 }
 

--- a/Pal/lib/crypto/mbedtls/aesni.c
+++ b/Pal/lib/crypto/mbedtls/aesni.c
@@ -34,6 +34,8 @@
 
 #include "mbedtls/aesni.h"
 
+#include "api.h"
+
 #include <string.h>
 
 #ifndef asm
@@ -64,6 +66,7 @@ int mbedtls_aesni_has_support( unsigned int what )
     return( ( c & what ) != 0 );
 #else
     /* CPUID not allowed within the enclave. Assume we have AES-NI. */
+    __UNUSED(what);
     return 1;
 #endif
 }

--- a/Pal/lib/crypto/mbedtls/rsa.c
+++ b/Pal/lib/crypto/mbedtls/rsa.c
@@ -645,6 +645,8 @@ int mbedtls_rsa_rsaes_pkcs1_v15_encrypt( mbedtls_rsa_context *ctx,
 }
 #endif /* MBEDTLS_PKCS1_V15 */
 
+
+#ifdef MBEDTLS_PKCS1
 /*
  * Add the message padding, then do an RSA operation
  */
@@ -673,6 +675,7 @@ int mbedtls_rsa_pkcs1_encrypt( mbedtls_rsa_context *ctx,
             return( MBEDTLS_ERR_RSA_INVALID_PADDING );
     }
 }
+#endif /* MBEDTLS_PKCS1 */
 
 #if defined(MBEDTLS_PKCS1_V21)
 /*
@@ -885,6 +888,7 @@ int mbedtls_rsa_rsaes_pkcs1_v15_decrypt( mbedtls_rsa_context *ctx,
 }
 #endif /* MBEDTLS_PKCS1_V15 */
 
+#ifdef MBEDTLS_PKCS1
 /*
  * Do an RSA operation, then remove the message padding
  */
@@ -915,6 +919,7 @@ int mbedtls_rsa_pkcs1_decrypt( mbedtls_rsa_context *ctx,
             return( MBEDTLS_ERR_RSA_INVALID_PADDING );
     }
 }
+#endif /* MBEDTLS_PKCS1 */
 
 #if defined(MBEDTLS_PKCS1_V21)
 /*

--- a/Pal/lib/slabmgr.h
+++ b/Pal/lib/slabmgr.h
@@ -429,7 +429,7 @@ static inline void * slab_alloc_debug (SLAB_MGR mgr, int size,
 #endif
 
 // Returns user buffer size (i.e. excluding size of control structures).
-static inline size_t slab_get_buf_size(SLAB_MGR mgr, const void * ptr)
+static inline size_t slab_get_buf_size(const void * ptr)
 {
     assert(ptr);
 

--- a/Pal/lib/stdlib/printfmt.c
+++ b/Pal/lib/stdlib/printfmt.c
@@ -291,6 +291,8 @@ struct sprintbuf {
 static int
 sprintputch(void * f, int ch, struct sprintbuf * b)
 {
+    __UNUSED(f);
+
 	if (b->cnt >= b->max)
 		return -1;
 

--- a/Pal/regression/Directory.c
+++ b/Pal/regression/Directory.c
@@ -52,7 +52,7 @@ int main (int argc, char ** argv, char ** envp)
     PAL_HANDLE dir4 = DkStreamOpen("dir:dir_nonexist.tmp",
                                    PAL_ACCESS_RDONLY,
                                    PAL_SHARE_OWNER_R|PAL_SHARE_OWNER_W|PAL_SHARE_OWNER_X,
-                                   PAL_CREAT_TRY|PAL_CREAT_ALWAYS, 0);
+                                   PAL_CREATE_TRY|PAL_CREATE_ALWAYS, 0);
     if (dir4) {
         pal_printf("Directory Creation Test 1 OK\n");
         DkObjectClose(dir4);
@@ -61,7 +61,7 @@ int main (int argc, char ** argv, char ** envp)
     PAL_HANDLE dir5 = DkStreamOpen("dir:dir_nonexist.tmp",
                                    PAL_ACCESS_RDONLY,
                                    PAL_SHARE_OWNER_R|PAL_SHARE_OWNER_W|PAL_SHARE_OWNER_X,
-                                   PAL_CREAT_TRY|PAL_CREAT_ALWAYS, 0);
+                                   PAL_CREATE_TRY|PAL_CREATE_ALWAYS, 0);
     if (dir5) {
         DkObjectClose(dir5);
     } else {
@@ -71,7 +71,7 @@ int main (int argc, char ** argv, char ** envp)
     PAL_HANDLE dir6 = DkStreamOpen("dir:dir_nonexist.tmp",
                                    PAL_ACCESS_RDWR,
                                    PAL_SHARE_OWNER_R|PAL_SHARE_OWNER_W,
-                                   PAL_CREAT_TRY, 0);
+                                   PAL_CREATE_TRY, 0);
     if (dir6) {
         pal_printf("Directory Creation Test 3 OK\n");
         DkObjectClose(dir6);

--- a/Pal/regression/Exception.c
+++ b/Pal/regression/Exception.c
@@ -43,17 +43,17 @@ int main (void)
 {
     volatile long i;
 
-    DkSetExceptionHandler(handler1, PAL_EVENT_ARITHMETIC_ERROR, 0);
+    DkSetExceptionHandler(handler1, PAL_EVENT_ARITHMETIC_ERROR);
     i = 0;
     i = 1 / i;
     __asm__ volatile("nop");
 
-    DkSetExceptionHandler(handler2, PAL_EVENT_ARITHMETIC_ERROR, 0);
+    DkSetExceptionHandler(handler2, PAL_EVENT_ARITHMETIC_ERROR);
     i = 0;
     i = 1 / i;
     __asm__ volatile("nop");
 
-    DkSetExceptionHandler(handler3, PAL_EVENT_MEMFAULT, 0);
+    DkSetExceptionHandler(handler3, PAL_EVENT_MEMFAULT);
     *(volatile long *) 0x1000 = 0;
     __asm__ volatile("nop");
 

--- a/Pal/regression/File.c
+++ b/Pal/regression/File.c
@@ -116,7 +116,7 @@ int main (int argc, char ** argv, char ** envp)
     PAL_HANDLE file4 = DkStreamOpen("file:file_nonexist.tmp",
                                     PAL_ACCESS_RDWR,
                                     PAL_SHARE_OWNER_R|PAL_SHARE_OWNER_W,
-                                    PAL_CREAT_TRY|PAL_CREAT_ALWAYS, 0);
+                                    PAL_CREATE_TRY|PAL_CREATE_ALWAYS, 0);
     if (file4)
         pal_printf("File Creation Test 1 OK\n");
 
@@ -124,7 +124,7 @@ int main (int argc, char ** argv, char ** envp)
     PAL_HANDLE file5 = DkStreamOpen("file:file_nonexist.tmp",
                                     PAL_ACCESS_RDWR,
                                     PAL_SHARE_OWNER_R|PAL_SHARE_OWNER_W,
-                                    PAL_CREAT_TRY|PAL_CREAT_ALWAYS, 0);
+                                    PAL_CREATE_TRY|PAL_CREATE_ALWAYS, 0);
     if (file5) {
         DkObjectClose(file5);
     } else {
@@ -134,7 +134,7 @@ int main (int argc, char ** argv, char ** envp)
     PAL_HANDLE file6 = DkStreamOpen("file:file_nonexist.tmp",
                                     PAL_ACCESS_RDWR,
                                     PAL_SHARE_OWNER_R|PAL_SHARE_OWNER_W,
-                                    PAL_CREAT_TRY, 0);
+                                    PAL_CREATE_TRY, 0);
     if (file6) {
         pal_printf("File Creation Test 3 OK\n");
         DkObjectClose(file6);

--- a/Pal/regression/Ipc.c
+++ b/Pal/regression/Ipc.c
@@ -26,7 +26,7 @@ int main (int argc, char ** argv, char ** envp)
     char gipc_uri[20];
     int ret;
 
-    DkSetExceptionHandler(handler, PAL_EVENT_MEMFAULT, 0);
+    DkSetExceptionHandler(handler, PAL_EVENT_MEMFAULT);
 
     if (argc > 1 && !memcmp(argv[1], "Child", 6)) {
         /* private memory */
@@ -192,7 +192,7 @@ int main (int argc, char ** argv, char ** envp)
         }
     } else {
         PAL_STR args[3] = { "Ipc", "Child", 0 };
-        PAL_HANDLE proc = DkProcessCreate("file:Ipc", 0, args);
+        PAL_HANDLE proc = DkProcessCreate("file:Ipc", args);
 
         if (!proc)
             return 0;
@@ -216,7 +216,7 @@ int main (int argc, char ** argv, char ** envp)
                 PAL_PTR mem_addr = mem1;
                 PAL_NUM mem_size = UNIT;
 
-                if (DkPhysicalMemoryCommit(ipc1, 1, &mem_addr, &mem_size, 0)) {
+                if (DkPhysicalMemoryCommit(ipc1, 1, &mem_addr, &mem_size)) {
                     pal_printf("[Test 1] Physical Memory Commit OK\n");
                     memcpy(mem1, "Hello World, Alice", 20);
                     pal_printf("[Test 1] Sender   After  Commit: %s\n",
@@ -251,7 +251,7 @@ int main (int argc, char ** argv, char ** envp)
                 PAL_PTR mem_addr = mem2;
                 PAL_NUM mem_size = UNIT;
 
-                if (DkPhysicalMemoryCommit(ipc2, 1, &mem_addr, &mem_size, 0)) {
+                if (DkPhysicalMemoryCommit(ipc2, 1, &mem_addr, &mem_size)) {
                     pal_printf("[Test 2] Physical Memory Commit OK\n");
                     memcpy(mem2, "Hello World, Alice", 20);
                     pal_printf("[Test 2] Sender   After  Commit: %s\n",
@@ -293,7 +293,7 @@ int main (int argc, char ** argv, char ** envp)
                 PAL_PTR mem_addr = mem3;
                 PAL_NUM mem_size = UNIT;
 
-                if (DkPhysicalMemoryCommit(ipc3, 1, &mem_addr, &mem_size, 0)) {
+                if (DkPhysicalMemoryCommit(ipc3, 1, &mem_addr, &mem_size)) {
                     pal_printf("[Test 3] Physical Memory Commit OK\n");
                     DkStreamWrite(proc, 0, 20, gipc_uri, NULL);
                     pal_printf("[Test 3] Sender   After  Commit: %s\n",
@@ -331,7 +331,7 @@ int main (int argc, char ** argv, char ** envp)
                 PAL_PTR mem_addr = mem4;
                 PAL_NUM mem_size = UNIT;
 
-                if (DkPhysicalMemoryCommit(ipc4, 1, &mem_addr, &mem_size, 0)) {
+                if (DkPhysicalMemoryCommit(ipc4, 1, &mem_addr, &mem_size)) {
                     pal_printf("[Test 4] Physical Memory Commit OK\n");
                     DkStreamWrite(proc, 0, 20, gipc_uri, NULL);
                     DkStreamRead(proc, 0, sizeof(int), &ret, NULL, 0);
@@ -364,7 +364,7 @@ int main (int argc, char ** argv, char ** envp)
 
                 DkStreamWrite(proc, 0, 20, gipc_uri, NULL);
 
-                if (DkPhysicalMemoryCommit(ipc5, 1, &mem_addr, &mem_size, 0)) {
+                if (DkPhysicalMemoryCommit(ipc5, 1, &mem_addr, &mem_size)) {
                     pal_printf("[Test 5] Physical Memory Commit OK\n");
                     DkStreamRead(proc, 0, sizeof(int), &ret, NULL, 0);
                 }

--- a/Pal/regression/Memory.c
+++ b/Pal/regression/Memory.c
@@ -23,7 +23,7 @@ void handler (PAL_PTR event, PAL_NUM arg, PAL_CONTEXT * context)
 int main (int argc, char ** argv, char ** envp)
 {
     volatile int c;
-    DkSetExceptionHandler(handler, PAL_EVENT_MEMFAULT, 0);
+    DkSetExceptionHandler(handler, PAL_EVENT_MEMFAULT);
 
     void * mem1 = (void *) DkVirtualMemoryAlloc(NULL, UNIT * 4, 0,
                                                 PAL_PROT_READ|PAL_PROT_WRITE);

--- a/Pal/regression/Process.c
+++ b/Pal/regression/Process.c
@@ -50,7 +50,7 @@ int main (int argc, char ** argv, char ** envp)
         for (int i = 0 ; i < 3 ; i++) {
             pal_printf("Creating process\n");
 
-            children[i] = DkProcessCreate("file:Process", 0, args);
+            children[i] = DkProcessCreate("file:Process", args);
 
             if (children[i]) {
                 pal_printf("Process created %d\n", i + 1);

--- a/Pal/regression/Process2.c
+++ b/Pal/regression/Process2.c
@@ -8,6 +8,6 @@
 int main (int argc, char ** argv, char ** envp)
 {
     PAL_STR args[1] = { 0 };
-    DkProcessCreate("file:Bootstrap", 0, args);
+    DkProcessCreate("file:Bootstrap", args);
     return 0;
 }

--- a/Pal/regression/Process3.c
+++ b/Pal/regression/Process3.c
@@ -11,7 +11,7 @@ int main (int argc, char ** argv, char ** envp)
 
     // Hack to differentiate parent from child
     if (argc == 1) {
-        PAL_HANDLE child = DkProcessCreate(NULL, 0, args);
+        PAL_HANDLE child = DkProcessCreate(NULL, args);
 
         if (child)
             pal_printf("Create Process without Executable OK\n");

--- a/Pal/regression/SendHandle.c
+++ b/Pal/regression/SendHandle.c
@@ -64,12 +64,12 @@ int main (int argc, char ** argv)
     } else {
         const char *args[3] = { "SendHandle", "Child", NULL };
 
-        PAL_HANDLE child = DkProcessCreate("file:SendHandle", 0, args);
+        PAL_HANDLE child = DkProcessCreate("file:SendHandle", args);
 
         if (child) {
             // Sending pipe handle
             handles[0] = DkStreamOpen("pipe.srv:1", PAL_ACCESS_RDWR,
-                                      0, PAL_CREAT_TRY, 0);
+                                      0, PAL_CREATE_TRY, 0);
 
             if (handles[0]) {
                 pal_printf("Send Handle OK\n");
@@ -89,7 +89,7 @@ int main (int argc, char ** argv)
 
             // Sending udp handle
             handles[1] = DkStreamOpen("udp.srv:127.0.0.1:8000", PAL_ACCESS_RDWR,
-                                      0, PAL_CREAT_TRY, 0);
+                                      0, PAL_CREATE_TRY, 0);
 
             if (handles[1]) {
                 pal_printf("Send Handle OK\n");
@@ -108,7 +108,7 @@ int main (int argc, char ** argv)
             }
 
             handles[2] = DkStreamOpen("file:to_send.tmp", PAL_ACCESS_RDWR,
-                                      0600, PAL_CREAT_TRY, 0);
+                                      0600, PAL_CREATE_TRY, 0);
 
             if (handles[2]) {
                 pal_printf("Send Handle OK\n");

--- a/Pal/regression/Thread.c
+++ b/Pal/regression/Thread.c
@@ -44,7 +44,7 @@ int main (int argc, const char ** argv, const char ** envp)
     __asm__ volatile("mov %%fs:0, %0" : "=r"(ptr1) :: "memory");
     pal_printf("Private Message (FS Segment) 1: %s\n", ptr1);
 
-    PAL_HANDLE thread1 = DkThreadCreate(callback1, "Hello World", 0);
+    PAL_HANDLE thread1 = DkThreadCreate(callback1, "Hello World");
 
     if (thread1) {
         pal_printf("Child Thread Created\n");

--- a/Pal/src/db_exception.c
+++ b/Pal/src/db_exception.c
@@ -61,7 +61,7 @@ PAL_EVENT_HANDLER _DkGetExceptionHandler (PAL_NUM event)
 }
 
 PAL_BOL
-DkSetExceptionHandler (PAL_EVENT_HANDLER handler, PAL_NUM event, PAL_FLG flags)
+DkSetExceptionHandler (PAL_EVENT_HANDLER handler, PAL_NUM event)
 {
     ENTER_PAL_CALL(DkSetExceptionHandler);
 

--- a/Pal/src/db_ipc.c
+++ b/Pal/src/db_ipc.c
@@ -48,7 +48,7 @@ DkCreatePhysicalMemoryChannel (PAL_NUM * key)
 
 PAL_NUM
 DkPhysicalMemoryCommit (PAL_HANDLE channel, PAL_NUM entries, PAL_PTR * addrs,
-                        PAL_NUM * sizes, PAL_FLG flags)
+                        PAL_NUM * sizes)
 {
     ENTER_PAL_CALL(DkPhysicalMemoryCommit);
 
@@ -57,7 +57,7 @@ DkPhysicalMemoryCommit (PAL_HANDLE channel, PAL_NUM entries, PAL_PTR * addrs,
         LEAVE_PAL_CALL_RETURN(0);
     }
 
-    int ret = _DkPhysicalMemoryCommit(channel, entries, addrs, sizes, flags);
+    int ret = _DkPhysicalMemoryCommit(channel, entries, addrs, sizes);
 
     if (ret < 0) {
         _DkRaiseFailure(-ret);

--- a/Pal/src/db_main.c
+++ b/Pal/src/db_main.c
@@ -202,7 +202,7 @@ static void set_debug_type (void)
         ret = _DkStreamOpen(&handle, cfgbuf,
                             PAL_ACCESS_RDWR,
                             PAL_SHARE_OWNER_R|PAL_SHARE_OWNER_W,
-                            PAL_CREAT_TRY, 0);
+                            PAL_CREATE_TRY, 0);
         goto out;
     }
 
@@ -221,7 +221,7 @@ out:
 static int loader_filter (const char * key, int len)
 {
     /* try to do this as fast as possible */
-    return (key[0] == 'l' && key[1] == 'o' && key[2] == 'a' && key[3] == 'd' &&
+    return (len > 7 && key[0] == 'l' && key[1] == 'o' && key[2] == 'a' && key[3] == 'd' &&
             key[4] == 'e' && key[5] == 'r' && key[6] == '.') ? 0 : 1;
 }
 

--- a/Pal/src/db_process.c
+++ b/Pal/src/db_process.c
@@ -36,7 +36,7 @@
 #include "api.h"
 
 PAL_HANDLE
-DkProcessCreate (PAL_STR uri, PAL_FLG flags, PAL_STR * args)
+DkProcessCreate (PAL_STR uri, PAL_STR * args)
 {
     ENTER_PAL_CALL(DkProcessCreate);
 
@@ -50,7 +50,7 @@ DkProcessCreate (PAL_STR uri, PAL_FLG flags, PAL_STR * args)
     log_stream(uri);
 
     PAL_HANDLE handle = NULL;
-    int ret = _DkProcessCreate(&handle, uri, flags, args);
+    int ret = _DkProcessCreate(&handle, uri, args);
 
     if (ret < 0) {
         _DkRaiseFailure(-ret);

--- a/Pal/src/db_rtld.c
+++ b/Pal/src/db_rtld.c
@@ -63,9 +63,9 @@ static struct link_map * resolve_map (const char **strtab, ElfW(Sym) ** ref)
     return 0;
 }
 
-extern ElfW(Addr) resolve_rtld (const char * sym_name);
-
-#define RESOLVE_RTLD(sym_name)      resolve_rtld(sym_name)
+/* Define RESOLVE_RTLD as 0 since we rely on resolve_map on
+ * all current PAL platforms */
+#define RESOLVE_RTLD(sym_name)      0
 #define RESOLVE_MAP(strtab, ref)    resolve_map(strtab, ref)
 
 #include "dynamic_link.h"
@@ -611,7 +611,7 @@ void cache_elf_object (PAL_HANDLE handle, struct link_map * map)
         ret = _DkStreamOpen(&cached_file, uri,
                             PAL_ACCESS_RDWR,
                             PAL_SHARE_OWNER_W|PAL_SHARE_OWNER_R,
-                            PAL_CREAT_TRY|PAL_CREAT_ALWAYS, 0);
+                            PAL_CREATE_TRY|PAL_CREATE_ALWAYS, 0);
 
         if (ret != -PAL_ERROR_STREAMEXIST)
             break;
@@ -1205,7 +1205,10 @@ static int relocate_elf_object (struct link_map * l)
 
 void DkDebugAttachBinary (PAL_STR uri, PAL_PTR start_addr)
 {
-#ifdef DEBUG
+#ifndef DEBUG
+    __UNUSED(uri);
+    __UNUSED(start_addr);
+#else
     if (!strpartcmp_static(uri, "file:"))
         return;
 
@@ -1261,7 +1264,9 @@ void DkDebugAttachBinary (PAL_STR uri, PAL_PTR start_addr)
 
 void DkDebugDetachBinary (PAL_PTR start_addr)
 {
-#ifdef DEBUG
+#ifndef DEBUG
+    __UNUSED(start_addr);
+#else
     for (struct link_map * l = loaded_maps; l; l = l->l_next)
         if (l->l_map_start == (ElfW(Addr)) start_addr) {
             _DkDebugDelMap(l);

--- a/Pal/src/db_threading.c
+++ b/Pal/src/db_threading.c
@@ -33,13 +33,13 @@
 /* PAL call DkThreadCreate: create a thread inside the current
    process */
 PAL_HANDLE
-DkThreadCreate (PAL_PTR addr, PAL_PTR param, PAL_FLG flags)
+DkThreadCreate (PAL_PTR addr, PAL_PTR param)
 {
     ENTER_PAL_CALL(DkThreadCreate);
 
     PAL_HANDLE handle = NULL;
     int ret = _DkThreadCreate (&handle, (int (*)(void *)) addr,
-                               (const void *) param, flags);
+                               (const void *) param);
 
     if (ret < 0) {
         _DkRaiseFailure(-ret);

--- a/Pal/src/host/FreeBSD/db_files.c
+++ b/Pal/src/host/FreeBSD/db_files.c
@@ -325,11 +325,11 @@ static int dir_open (PAL_HANDLE * handle, const char * type, const char * uri,
     int ret;
     int mode = HOST_PERM(share);
 
-    if (create & PAL_CREAT_TRY) {
+    if (create & PAL_CREATE_TRY) {
         ret = INLINE_SYSCALL(mkdir, 2, uri, mode);
 
         if (IS_ERR(ret) && ERRNO(ret) == EEXIST &&
-            create & PAL_CREAT_ALWAYS)
+            create & PAL_CREATE_ALWAYS)
             return -PAL_ERROR_STREAMEXIST;
     }
 

--- a/Pal/src/host/FreeBSD/db_process.c
+++ b/Pal/src/host/FreeBSD/db_process.c
@@ -156,8 +156,7 @@ failed:
     return 0;
 }
 
-int _DkProcessCreate (PAL_HANDLE * handle,
-                      const char * uri, int flags, const char ** args)
+int _DkProcessCreate (PAL_HANDLE * handle, const char * uri, const char ** args)
 {
     PAL_HANDLE exec = NULL;
     PAL_HANDLE parent_handle = NULL, child_handle = NULL;

--- a/Pal/src/host/FreeBSD/db_rtld.c
+++ b/Pal/src/host/FreeBSD/db_rtld.c
@@ -169,9 +169,3 @@ void setup_pal_map (struct link_map * pal_map)
     pal_map->l_prev = pal_map->l_next = NULL;
     loaded_maps = pal_map;
 }
-ElfW(Addr) resolve_rtld (const char * sym_name)
-{
-    /* We are not using this, because in Linux we can rely on
-       rtld_map to directly lookup symbols */
-    return 0;
-}

--- a/Pal/src/host/FreeBSD/db_threading.c
+++ b/Pal/src/host/FreeBSD/db_threading.c
@@ -46,7 +46,7 @@
    inside the current process. The arguments callback and param
    specify the starting function and parameters */
 int _DkThreadCreate (PAL_HANDLE * handle, int (*callback) (void *),
-                     const void * param, int flags)
+                     const void * param)
 {
    void * child_stack = NULL;
 

--- a/Pal/src/host/FreeBSD/pal_freebsd.h
+++ b/Pal/src/host/FreeBSD/pal_freebsd.h
@@ -130,8 +130,8 @@ static inline int HOST_FILE_OPEN (int access_type, int create_type,
         int options)
 {
     return ((access_type)|
-            (create_type & PAL_CREAT_TRY ? O_CREAT : 0) |
-            (create_type & PAL_CREAT_ALWAYS ? O_EXCL : 0) |
+            (create_type & PAL_CREATE_TRY ? O_CREAT : 0) |
+            (create_type & PAL_CREATE_ALWAYS ? O_EXCL : 0) |
             (options));
 }
 

--- a/Pal/src/host/Linux-SGX/Makefile.am
+++ b/Pal/src/host/Linux-SGX/Makefile.am
@@ -10,7 +10,7 @@ CFLAGS	= -Wall -fPIC -O2 -maes -std=c11 -U_FORTIFY_SOURCE \
 	  -fno-omit-frame-pointer \
 	  -fno-stack-protector -fno-builtin -DIN_ENCLAVE
 
-EXTRAFLAGS = -Wextra -Wno-unused-parameter -Wno-sign-compare
+EXTRAFLAGS = -Wextra -Wno-sign-compare
 
 CFLAGS += $(EXTRAFLAGS)
 

--- a/Pal/src/host/Linux-SGX/db_devices.c
+++ b/Pal/src/host/Linux-SGX/db_devices.c
@@ -126,6 +126,14 @@ static int open_standard_term (PAL_HANDLE * handle, const char * param,
 static int term_open (PAL_HANDLE *handle, const char * type, const char * uri,
                       int access, int share, int create, int options)
 {
+    if (!strcmp_static(type, "tty"))
+        return -PAL_ERROR_INVAL;
+
+    if (!WITHIN_MASK(share, PAL_SHARE_MASK) ||
+        !WITHIN_MASK(create, PAL_CREATE_MASK) ||
+        !WITHIN_MASK(options, PAL_OPTION_MASK))
+        return -PAL_ERROR_INVAL;
+
     const char * term = NULL;
     const char * param = NULL;
 
@@ -148,6 +156,7 @@ static int term_open (PAL_HANDLE *handle, const char * type, const char * uri,
 
 static int term_close (PAL_HANDLE handle)
 {
+    __UNUSED(handle);
     return 0;
 }
 
@@ -155,6 +164,11 @@ static int term_close (PAL_HANDLE handle)
 static int term_attrquery (const char * type, const char * uri,
                            PAL_STREAM_ATTR * attr)
 {
+    __UNUSED(uri);
+
+    if (!strcmp_static(type, "tty"))
+        return -PAL_ERROR_INVAL;
+
     attr->handle_type = pal_type_dev;
     attr->readable  = PAL_TRUE;
     attr->writeable = PAL_TRUE;
@@ -188,6 +202,9 @@ static struct handle_ops term_ops = {
 static int64_t char_read (PAL_HANDLE handle, uint64_t offset, uint64_t size,
                           void * buffer)
 {
+    if (offset)
+        return -PAL_ERROR_INVAL;
+
     int fd = handle->dev.fd_in;
 
     if (fd == PAL_IDX_POISON)
@@ -203,6 +220,9 @@ static int64_t char_read (PAL_HANDLE handle, uint64_t offset, uint64_t size,
 static int64_t char_write (PAL_HANDLE handle, uint64_t offset, uint64_t size,
                            const void * buffer)
 {
+    if (offset)
+        return -PAL_ERROR_INVAL;
+
     int fd = handle->dev.fd_out;
 
     if (fd == PAL_IDX_POISON)
@@ -218,6 +238,9 @@ static int64_t char_write (PAL_HANDLE handle, uint64_t offset, uint64_t size,
 static int dev_open (PAL_HANDLE * handle, const char * type, const char * uri,
                      int access, int share, int create, int options)
 {
+    if (!strcmp_static(type, "dev"))
+        return -PAL_ERROR_INVAL;
+
     struct handle_ops * ops = NULL;
     char* dev_type = NULL;
     int ret = 0;
@@ -346,6 +369,9 @@ dev_attrcopy (PAL_STREAM_ATTR * attr, struct stat * stat)
 static int dev_attrquery (const char * type, const char * uri,
                           PAL_STREAM_ATTR * attr)
 {
+    if (!strcmp_static(type, "dev"))
+        return -PAL_ERROR_INVAL;
+
     struct handle_ops * ops = NULL;
     char* dev_type = NULL;
     int ret = 0;

--- a/Pal/src/host/Linux-SGX/db_files.c
+++ b/Pal/src/host/Linux-SGX/db_files.c
@@ -47,6 +47,8 @@ typedef __kernel_pid_t pid_t;
 static int file_open (PAL_HANDLE * handle, const char * type, const char * uri,
                       int access, int share, int create, int options)
 {
+    if (!strcmp_static(type, "file"))
+        return -PAL_ERROR_INVAL;
     /* try to do the real open */
     int fd = ocall_open(uri, access|create|options, share);
 
@@ -302,6 +304,8 @@ file_attrcopy (PAL_STREAM_ATTR * attr, struct stat * stat)
 static int file_attrquery (const char * type, const char * uri,
                            PAL_STREAM_ATTR * attr)
 {
+    if (!strcmp_static(type, "file") && !strcmp_static(type, "dir") )
+        return -PAL_ERROR_INVAL;
     /* try to do the real open */
     int fd = ocall_open(uri, 0, 0);
     if (fd < 0)
@@ -348,6 +352,8 @@ static int file_attrsetbyhdl (PAL_HANDLE handle,
 static int file_rename (PAL_HANDLE handle, const char * type,
                         const char * uri)
 {
+    if (!strcmp_static(type, "file"))
+        return -PAL_ERROR_INVAL;
     int ret = ocall_rename(handle->file.realpath, uri);
     if (ret < 0)
         return ret;
@@ -401,11 +407,16 @@ struct handle_ops file_ops = {
 static int dir_open (PAL_HANDLE * handle, const char * type, const char * uri,
                      int access, int share, int create, int options)
 {
+    if (!strcmp_static(type, "dir"))
+        return -PAL_ERROR_INVAL;
+    if (!WITHIN_MASK(access, PAL_ACCESS_MASK))
+        return -PAL_ERROR_INVAL;
+
     int ret;
 
-    if (create & PAL_CREAT_TRY) {
+    if (create & PAL_CREATE_TRY) {
         ret = ocall_mkdir(uri, share);
-        if (ret == -PAL_ERROR_STREAMEXIST && (create & PAL_CREAT_ALWAYS))
+        if (ret == -PAL_ERROR_STREAMEXIST && (create & PAL_CREATE_ALWAYS))
             return ret;
     }
 
@@ -436,6 +447,9 @@ static int dir_open (PAL_HANDLE * handle, const char * type, const char * uri,
 static int64_t dir_read (PAL_HANDLE handle, uint64_t offset, uint64_t count,
                          void * buf)
 {
+    if (offset)
+        return -PAL_ERROR_INVAL;
+
     void * dent_buf = (void *) handle->dir.buf ? : __alloca(DIRBUF_SIZE);
     void * ptr = (void *) handle->dir.ptr;
     void * end = (void *) handle->dir.end;
@@ -539,6 +553,8 @@ static int dir_delete (PAL_HANDLE handle, int access)
 static int dir_rename (PAL_HANDLE handle, const char * type,
                        const char * uri)
 {
+    if (!strcmp_static(type, "dir"))
+        return -PAL_ERROR_INVAL;
     int ret = ocall_rename(handle->dir.realpath, uri);
     if (ret < 0)
         return ret;

--- a/Pal/src/host/Linux-SGX/db_ipc.c
+++ b/Pal/src/host/Linux-SGX/db_ipc.c
@@ -29,6 +29,12 @@
 #include "pal_internal.h"
 #include "pal_error.h"
 
+/* Mute warning for the file with all unimplemented functions
+ * Remove the following pragma when implementing the functions
+ */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+
 int gipc_open (PAL_HANDLE * handle, const char * type, const char * uri,
                int access, int share, int create, int options)
 {
@@ -58,7 +64,7 @@ int _DkCreatePhysicalMemoryChannel (PAL_HANDLE * handle, uint64_t * key)
 }
 
 int _DkPhysicalMemoryCommit (PAL_HANDLE channel, int entries,
-                             PAL_PTR * addrs, PAL_NUM * sizes, int flags)
+                             PAL_PTR * addrs, PAL_NUM * sizes)
 {
     return -PAL_ERROR_NOTIMPLEMENTED;
 }
@@ -68,3 +74,5 @@ int _DkPhysicalMemoryMap (PAL_HANDLE channel, int entries,
 {
     return -PAL_ERROR_NOTIMPLEMENTED;
 }
+
+#pragma GCC diagnostic pop

--- a/Pal/src/host/Linux-SGX/db_main.c
+++ b/Pal/src/host/Linux-SGX/db_main.c
@@ -82,7 +82,7 @@ PAL_NUM _DkGetHostId (void)
 void setup_pal_map (struct link_map * map);
 static struct link_map pal_map;
 
-int init_untrusted_slab_mgr (int pagesize);
+void init_untrusted_slab_mgr ();
 int init_enclave (void);
 int init_enclave_key (void);
 int init_child_process (PAL_HANDLE * parent_handle);
@@ -113,11 +113,11 @@ static PAL_HANDLE setup_file_handle (const char * name, int fd)
 
 static int loader_filter (const char * key, int len)
 {
-    if (key[0] == 'l' && key[1] == 'o' && key[2] == 'a' && key[3] == 'd' &&
+    if (len > 7 && key[0] == 'l' && key[1] == 'o' && key[2] == 'a' && key[3] == 'd' &&
         key[4] == 'e' && key[5] == 'r' && key[6] == '.')
         return 0;
 
-    if (key[0] == 's' && key[1] == 'g' && key[2] == 'x' && key[3] == '.')
+    if (len > 4 && key[0] == 's' && key[1] == 'g' && key[2] == 'x' && key[3] == '.')
         return 0;
 
     return 1;
@@ -144,7 +144,7 @@ void pal_linux_main(const char ** arguments, const char ** environments,
 
     /* set up page allocator and slab manager */
     init_slab_mgr(pagesz);
-    init_untrusted_slab_mgr(pagesz);
+    init_untrusted_slab_mgr();
     init_pages();
     init_enclave_key();
 

--- a/Pal/src/host/Linux-SGX/db_memory.c
+++ b/Pal/src/host/Linux-SGX/db_memory.c
@@ -68,6 +68,9 @@ bool _DkCheckMemoryMappable (const void * addr, int size)
 
 int _DkVirtualMemoryAlloc (void ** paddr, uint64_t size, int alloc_type, int prot)
 {
+    if (!WITHIN_MASK(prot, PAL_PROT_MASK))
+        return -PAL_ERROR_INVAL;
+
     void * addr = *paddr, * mem;
 
     if ((alloc_type & PAL_ALLOC_INTERNAL) && addr)
@@ -117,6 +120,11 @@ int _DkVirtualMemoryFree (void * addr, uint64_t size)
 
 int _DkVirtualMemoryProtect (void * addr, uint64_t size, int prot)
 {
+    static struct atomic_int at_cnt = {.counter = 0};
+
+    if (atomic_cmpxchg(&at_cnt, 0, 1) == 0)
+        SGX_DBG(DBG_M, "[Warning] DkVirtualMemoryProtect (0x%p, %lu, %d) is unimplemented",
+                addr, size, prot);
     return 0;
 }
 

--- a/Pal/src/host/Linux-SGX/db_misc.c
+++ b/Pal/src/host/Linux-SGX/db_misc.c
@@ -77,6 +77,9 @@ int _DkRandomBitsRead (void * buffer, int size)
 
 int _DkInstructionCacheFlush (const void * addr, int size)
 {
+    __UNUSED(addr);
+    __UNUSED(size);
+
     return -PAL_ERROR_NOTIMPLEMENTED;
 }
 

--- a/Pal/src/host/Linux-SGX/db_pipes.c
+++ b/Pal/src/host/Linux-SGX/db_pipes.c
@@ -168,7 +168,11 @@ static int pipe_private (PAL_HANDLE * handle, int options)
 static int pipe_open (PAL_HANDLE *handle, const char * type, const char * uri,
                       int access, int share, int create, int options)
 {
-    options &= PAL_OPTION_MASK;
+    if (!WITHIN_MASK(access, PAL_ACCESS_MASK) ||
+        !WITHIN_MASK(share, PAL_SHARE_MASK) ||
+        !WITHIN_MASK(create, PAL_CREATE_MASK) ||
+        !WITHIN_MASK(options, PAL_OPTION_MASK))
+        return -PAL_ERROR_INVAL;
 
     if (strcmp_static(type, "pipe") && !*uri)
         return pipe_private(handle, options);
@@ -192,6 +196,9 @@ static int pipe_open (PAL_HANDLE *handle, const char * type, const char * uri,
 static int64_t pipe_read (PAL_HANDLE handle, uint64_t offset, uint64_t len,
                           void * buffer)
 {
+    if (offset)
+        return -PAL_ERROR_INVAL;
+
     if (!IS_HANDLE_TYPE(handle, pipecli) &&
         !IS_HANDLE_TYPE(handle, pipeprv) &&
         !IS_HANDLE_TYPE(handle, pipe))
@@ -217,6 +224,9 @@ static int64_t pipe_read (PAL_HANDLE handle, uint64_t offset, uint64_t len,
 static int64_t pipe_write (PAL_HANDLE handle, uint64_t offset, uint64_t len,
                            const void * buffer)
 {
+    if (offset)
+        return -PAL_ERROR_INVAL;
+
     if (!IS_HANDLE_TYPE(handle, pipecli) &&
         !IS_HANDLE_TYPE(handle, pipeprv) &&
         !IS_HANDLE_TYPE(handle, pipe))

--- a/Pal/src/host/Linux-SGX/db_process.c
+++ b/Pal/src/host/Linux-SGX/db_process.c
@@ -189,8 +189,7 @@ static int check_child_mrenclave (sgx_arch_hash_t * mrenclave,
     return 1;
 }
 
-int _DkProcessCreate (PAL_HANDLE * handle, const char * uri,
-                      int flags, const char ** args)
+int _DkProcessCreate (PAL_HANDLE * handle, const char * uri, const char ** args)
 {
     /* only access creating process with regular file */
     if (!strpartcmp_static(uri, "file:"))
@@ -255,6 +254,8 @@ struct check_parent_param {
 static int check_parent_mrenclave (sgx_arch_hash_t * mrenclave,
                                    void * signed_data, void * check_param)
 {
+    __UNUSED(mrenclave);
+
     struct pal_enclave_state * remote_state = signed_data;
     struct proc_attestation_param * data = (void *) &remote_state->data;
 
@@ -333,12 +334,18 @@ void _DkProcessExit (int exitcode)
 
 int _DkProcessSandboxCreate (const char * manifest, int flags)
 {
+    __UNUSED(manifest);
+    __UNUSED(flags);
+
     return -PAL_ERROR_NOTIMPLEMENTED;
 }
 
 static int64_t proc_read (PAL_HANDLE handle, uint64_t offset, uint64_t count,
                           void * buffer)
 {
+    if (offset)
+        return -PAL_ERROR_INVAL;
+
     if (count >= (1ULL << (sizeof(unsigned int) * 8)))
         return -PAL_ERROR_INVAL;
 
@@ -348,6 +355,9 @@ static int64_t proc_read (PAL_HANDLE handle, uint64_t offset, uint64_t count,
 static int64_t proc_write (PAL_HANDLE handle, uint64_t offset, uint64_t count,
                            const void * buffer)
 {
+    if (offset)
+        return -PAL_ERROR_INVAL;
+
     if (count >= (1ULL << (sizeof(unsigned int) * 8)))
         return -PAL_ERROR_INVAL;
 

--- a/Pal/src/host/Linux-SGX/db_rtld.c
+++ b/Pal/src/host/Linux-SGX/db_rtld.c
@@ -171,10 +171,3 @@ void setup_pal_map (struct link_map * pal_map)
     pal_map->l_prev = pal_map->l_next = NULL;
     loaded_maps = pal_map;
 }
-
-ElfW(Addr) resolve_rtld (const char * sym_name)
-{
-    /* We are not using this, because in Linux we can rely on
-       rtld_map to directly lookup symbols */
-    return 0;
-}

--- a/Pal/src/host/Linux-SGX/db_sockets.c
+++ b/Pal/src/host/Linux-SGX/db_sockets.c
@@ -456,6 +456,12 @@ static int tcp_connect (PAL_HANDLE * handle, char * uri, int options)
 static int tcp_open (PAL_HANDLE *handle, const char * type, const char * uri,
                      int access, int share, int create, int options)
 {
+    if (!WITHIN_MASK(access, PAL_ACCESS_MASK) ||
+        !WITHIN_MASK(share, PAL_SHARE_MASK) ||
+        !WITHIN_MASK(create, PAL_CREATE_MASK) ||
+        !WITHIN_MASK(options, PAL_OPTION_MASK))
+        return -PAL_ERROR_INVAL;
+
     int uri_len = strlen(uri) + 1;
 
     if (uri_len > PAL_SOCKADDR_SIZE)
@@ -477,6 +483,9 @@ static int tcp_open (PAL_HANDLE *handle, const char * type, const char * uri,
 static int64_t tcp_read (PAL_HANDLE handle, uint64_t offset, uint64_t len,
                          void * buf)
 {
+    if (offset)
+        return -PAL_ERROR_INVAL;
+
     if (!IS_HANDLE_TYPE(handle, tcp) || !handle->sock.conn)
         return -PAL_ERROR_NOTCONNECTION;
 
@@ -501,6 +510,9 @@ static int64_t tcp_read (PAL_HANDLE handle, uint64_t offset, uint64_t len,
 static int64_t tcp_write (PAL_HANDLE handle, uint64_t offset, uint64_t len,
                           const void * buf)
 {
+    if (offset)
+        return -PAL_ERROR_INVAL;
+
     if (!IS_HANDLE_TYPE(handle, tcp) || !handle->sock.conn)
         return -PAL_ERROR_NOTCONNECTION;
 
@@ -611,6 +623,12 @@ static int udp_connect (PAL_HANDLE * handle, char * uri, int options)
 static int udp_open (PAL_HANDLE *hdl, const char * type, const char * uri,
                      int access, int share, int create, int options)
 {
+    if (!WITHIN_MASK(access, PAL_ACCESS_MASK) ||
+        !WITHIN_MASK(share, PAL_SHARE_MASK) ||
+        !WITHIN_MASK(create, PAL_CREATE_MASK) ||
+        !WITHIN_MASK(options, PAL_OPTION_MASK))
+        return -PAL_ERROR_INVAL;
+
     char buf[PAL_SOCKADDR_SIZE];
     int len = strlen(uri);
 
@@ -618,7 +636,6 @@ static int udp_open (PAL_HANDLE *hdl, const char * type, const char * uri,
         return -PAL_ERROR_TOOLONG;
 
     memcpy(buf, uri, len + 1);
-    options &= PAL_OPTION_MASK;
 
     if (strcmp_static(type, "udp.srv"))
         return udp_bind(hdl, buf, options);
@@ -632,6 +649,9 @@ static int udp_open (PAL_HANDLE *hdl, const char * type, const char * uri,
 static int64_t udp_receive (PAL_HANDLE handle, uint64_t offset, uint64_t len,
                             void * buf)
 {
+    if (offset)
+        return -PAL_ERROR_INVAL;
+
     if (!IS_HANDLE_TYPE(handle, udp))
         return -PAL_ERROR_NOTCONNECTION;
 
@@ -647,6 +667,9 @@ static int64_t udp_receive (PAL_HANDLE handle, uint64_t offset, uint64_t len,
 static int64_t udp_receivebyaddr (PAL_HANDLE handle, uint64_t offset, uint64_t len,
                                   void * buf, char * addr, int addrlen)
 {
+    if (offset)
+        return -PAL_ERROR_INVAL;
+
     if (!IS_HANDLE_TYPE(handle, udpsrv))
         return -PAL_ERROR_NOTCONNECTION;
 
@@ -680,6 +703,9 @@ static int64_t udp_receivebyaddr (PAL_HANDLE handle, uint64_t offset, uint64_t l
 static int64_t udp_send (PAL_HANDLE handle, uint64_t offset, uint64_t len,
                          const void * buf)
 {
+    if (offset)
+        return -PAL_ERROR_INVAL;
+
     if (!IS_HANDLE_TYPE(handle, udp))
         return -PAL_ERROR_NOTCONNECTION;
 
@@ -708,6 +734,9 @@ static int64_t udp_send (PAL_HANDLE handle, uint64_t offset, uint64_t len,
 static int64_t udp_sendbyaddr (PAL_HANDLE handle, uint64_t offset, uint64_t len,
                                const void * buf, const char * addr, int addrlen)
 {
+    if (offset)
+        return -PAL_ERROR_INVAL;
+
     if (!IS_HANDLE_TYPE(handle, udpsrv))
         return -PAL_ERROR_NOTCONNECTION;
 
@@ -1061,6 +1090,9 @@ PAL_HANDLE _DkBroadcastStreamOpen (void)
 static int64_t mcast_send (PAL_HANDLE handle, uint64_t offset, uint64_t size,
                            const void * buf)
 {
+    if (offset)
+        return -PAL_ERROR_INVAL;
+
     if (handle->mcast.srv == PAL_IDX_POISON)
         return -PAL_ERROR_BADHANDLE;
 
@@ -1087,6 +1119,9 @@ static int64_t mcast_send (PAL_HANDLE handle, uint64_t offset, uint64_t size,
 static int64_t mcast_receive (PAL_HANDLE handle, uint64_t offset, uint64_t size,
                               void * buf)
 {
+    if (offset)
+        return -PAL_ERROR_INVAL;
+
     if (handle->mcast.cli == PAL_IDX_POISON)
         return -PAL_ERROR_BADHANDLE;
 

--- a/Pal/src/host/Linux-SGX/db_streams.c
+++ b/Pal/src/host/Linux-SGX/db_streams.c
@@ -74,11 +74,6 @@ out:
     return (mode & acc);
 }
 
-int handle_set_cloexec (PAL_HANDLE handle, bool enable)
-{
-    return -PAL_ERROR_NOTIMPLEMENTED;
-}
-
 /* _DkStreamUnmap for internal use. Unmap stream at certain memory address.
    The memory is unmapped as a whole.*/
 int _DkStreamUnmap (void * addr, uint64_t size)

--- a/Pal/src/host/Linux-SGX/db_threading.c
+++ b/Pal/src/host/Linux-SGX/db_threading.c
@@ -83,7 +83,7 @@ void pal_start_thread (void)
    inside the current process. The arguments callback and param
    specify the starting function and parameters */
 int _DkThreadCreate (PAL_HANDLE * handle, int (*callback) (void *),
-                     const void * param, int flags)
+                     const void * param)
 {
     PAL_HANDLE new_thread = malloc(HANDLE_SIZE(thread));
     SET_HANDLE_TYPE(new_thread, thread);

--- a/Pal/src/host/Linux-SGX/enclave_untrusted.c
+++ b/Pal/src/host/Linux-SGX/enclave_untrusted.c
@@ -54,7 +54,7 @@ static inline void __free (void * addr, int size)
 
 static SLAB_MGR untrusted_slabmgr = NULL;
 
-void init_untrusted_slab_mgr (int pagesize)
+void init_untrusted_slab_mgr ()
 {
     if (untrusted_slabmgr)
         return;

--- a/Pal/src/host/Linux-SGX/sgx_enclave.c
+++ b/Pal/src/host/Linux-SGX/sgx_enclave.c
@@ -268,6 +268,8 @@ static int sgx_ocall_socketpair(void * pms)
 
 static int sock_getopt(int fd, struct sockopt * opt)
 {
+    SGX_DBG(DBG_M, "sock_getopt (fd = %d, sockopt addr = %p) is not implemented \
+            always returns 0\n", fd, opt);
     return 0;
 }
 

--- a/Pal/src/host/Linux-SGX/sgx_exception.c
+++ b/Pal/src/host/Linux-SGX/sgx_exception.c
@@ -202,6 +202,8 @@ void sgx_entry_return (void);
 static void _DkTerminateSighandler (int signum, siginfo_t * info,
                                     struct ucontext * uc)
 {
+    __UNUSED(info);
+
     unsigned long rip = uc->uc_mcontext.gregs[REG_RIP];
 
     if (rip != (unsigned long) async_exit_pointer) {
@@ -216,6 +218,8 @@ static void _DkTerminateSighandler (int signum, siginfo_t * info,
 static void _DkResumeSighandler (int signum, siginfo_t * info,
                                  struct ucontext * uc)
 {
+    __UNUSED(info);
+
     unsigned long rip = uc->uc_mcontext.gregs[REG_RIP];
 
     if (rip != (unsigned long) async_exit_pointer) {

--- a/Pal/src/host/Linux-SGX/sgx_graphene.c
+++ b/Pal/src/host/Linux-SGX/sgx_graphene.c
@@ -94,6 +94,8 @@ struct printbuf {
 static int
 fputch(void * f, int ch, struct printbuf * b)
 {
+    __UNUSED(f);
+
     b->buf[b->idx++] = ch;
     if (b->idx == PRINTBUF_SIZE - 1) {
         INLINE_SYSCALL(write, 3, 2, b->buf, b->idx);

--- a/Pal/src/host/Linux-SGX/sgx_rtld.c
+++ b/Pal/src/host/Linux-SGX/sgx_rtld.c
@@ -34,6 +34,9 @@ __asm__ (".pushsection \".debug_gdb_scripts\", \"MS\",@progbits,1\r\n"
      ".asciz \"" PAL_FILE("host/Linux-SGX/debugger/pal-gdb.py") "\"\r\n"
      ".popsection\r\n");
 
+/* This function is hooked by our gdb integration script and should be
+ * left as is. */
 void load_gdb_command (const char * command)
 {
+    __UNUSED(command);
 }

--- a/Pal/src/host/Linux/Makefile.am
+++ b/Pal/src/host/Linux/Makefile.am
@@ -10,7 +10,7 @@ LD	= ld
 CFLAGS	= -Wall -fPIC -O2 -std=c11 -U_FORTIFY_SOURCE \
 	  -fno-stack-protector -fno-builtin
 
-EXTRAFLAGS = -Wextra -Wno-unused-parameter -Wno-sign-compare
+EXTRAFLAGS = -Wextra -Wno-sign-compare
 
 CFLAGS += $(EXTRAFLAGS)
 

--- a/Pal/src/host/Linux/db_devices.c
+++ b/Pal/src/host/Linux/db_devices.c
@@ -119,6 +119,14 @@ static int open_standard_term(PAL_HANDLE* handle, const char* param, int access)
 /* 'open' operation for terminal stream */
 static int term_open(PAL_HANDLE* handle, const char* type, const char* uri, int access, int share,
                      int create, int options) {
+    if (!strcmp_static(type, "tty"))
+        return -PAL_ERROR_INVAL;
+
+    if (!WITHIN_MASK(share, PAL_SHARE_MASK) ||
+        !WITHIN_MASK(create, PAL_CREATE_MASK) ||
+        !WITHIN_MASK(options, PAL_OPTION_MASK))
+        return -PAL_ERROR_INVAL;
+
     const char* term  = NULL;
     const char* param = NULL;
 
@@ -140,11 +148,19 @@ static int term_open(PAL_HANDLE* handle, const char* type, const char* uri, int 
 }
 
 static int term_close(PAL_HANDLE handle) {
+    __UNUSED(handle);
+
     return 0;
 }
 
 /* 'attrquery' operation for terminal stream */
-static int term_attrquery(const char* type, const char* uri, PAL_STREAM_ATTR* attr) {
+static int term_attrquery(const char* type, const char* uri, PAL_STREAM_ATTR* attr)
+{
+    __UNUSED(uri);
+
+    if (!strcmp_static(type, "tty"))
+        return -PAL_ERROR_INVAL;
+
     attr->handle_type  = pal_type_dev;
     attr->readable     = PAL_TRUE;
     attr->writeable    = PAL_TRUE;
@@ -174,6 +190,9 @@ static struct handle_ops term_ops = {
 
 /* 'read' operation for character streams. */
 static int64_t char_read(PAL_HANDLE handle, uint64_t offset, uint64_t size, void* buffer) {
+    if (offset)
+        return -PAL_ERROR_INVAL;
+
     int fd = handle->dev.fd_in;
 
     if (fd == PAL_IDX_POISON)
@@ -189,6 +208,9 @@ static int64_t char_read(PAL_HANDLE handle, uint64_t offset, uint64_t size, void
 
 /* 'write' operation for character streams. */
 static int64_t char_write(PAL_HANDLE handle, uint64_t offset, uint64_t size, const void* buffer) {
+    if (offset)
+        return -PAL_ERROR_INVAL;
+
     int fd = handle->dev.fd_out;
 
     if (fd == PAL_IDX_POISON)
@@ -205,6 +227,9 @@ static int64_t char_write(PAL_HANDLE handle, uint64_t offset, uint64_t size, con
 /* 'open' operation for device streams */
 static int dev_open(PAL_HANDLE* handle, const char* type, const char* uri, int access, int share,
                     int create, int options) {
+    if (!strcmp_static(type, "dev"))
+        return -PAL_ERROR_INVAL;
+
     struct handle_ops* ops = NULL;
     char* dev_type   = NULL;
     int ret                = 0;
@@ -348,6 +373,9 @@ static inline void dev_attrcopy(PAL_STREAM_ATTR* attr, struct stat* stat) {
 
 /* 'attrquery' operation for device streams */
 static int dev_attrquery(const char* type, const char* uri, PAL_STREAM_ATTR* attr) {
+    if (!strcmp_static(type, "dev"))
+        return -PAL_ERROR_INVAL;
+
     struct handle_ops* ops = NULL;
     char* dev_type   = NULL;
     int ret                = 0;

--- a/Pal/src/host/Linux/db_exception.c
+++ b/Pal/src/host/Linux/db_exception.c
@@ -208,6 +208,8 @@ static void _DkGenericSighandler (int signum, siginfo_t * info,
 static void _DkTerminateSighandler (int signum, siginfo_t * info,
                                     struct ucontext * uc)
 {
+    __UNUSED(info);
+
     int event_num = get_event_num(signum);
     if (event_num == -1)
         return;
@@ -245,6 +247,9 @@ static void _DkTerminateSighandler (int signum, siginfo_t * info,
 static void _DkPipeSighandler (int signum, siginfo_t * info,
                                struct ucontext * uc)
 {
+    assert(signum == SIGPIPE);
+    __UNUSED(info);
+
     uintptr_t rip = uc->uc_mcontext.gregs[REG_RIP];
     assert(ADDR_IN_PAL(rip)); // This signal can only happens inside PAL
     return;

--- a/Pal/src/host/Linux/db_files.c
+++ b/Pal/src/host/Linux/db_files.c
@@ -45,6 +45,9 @@ typedef __kernel_pid_t pid_t;
 static int file_open (PAL_HANDLE * handle, const char * type, const char * uri,
                       int access, int share, int create, int options)
 {
+    if (!strcmp_static(type, "file"))
+        return -PAL_ERROR_INVAL;
+
     /* try to do the real open */
     int ret = INLINE_SYSCALL(open, 3, uri,
                              HOST_ACCESS(access)|create|options|O_CLOEXEC,
@@ -225,6 +228,9 @@ file_attrcopy (PAL_STREAM_ATTR * attr, struct stat * stat)
 static int file_attrquery (const char * type, const char * uri,
                            PAL_STREAM_ATTR * attr)
 {
+    if (!strcmp_static(type, "file") && !strcmp_static(type, "dir"))
+        return -PAL_ERROR_INVAL;
+
     struct stat stat_buf;
     /* try to do the real open */
     int ret = INLINE_SYSCALL(stat, 2, uri, &stat_buf);
@@ -268,6 +274,9 @@ static int file_attrsetbyhdl (PAL_HANDLE handle,
 static int file_rename (PAL_HANDLE handle, const char * type,
                         const char * uri)
 {
+    if (!strcmp_static(type, "file"))
+        return -PAL_ERROR_INVAL;
+
     int ret = INLINE_SYSCALL(rename, 2, handle->file.realpath, uri);
 
     if (IS_ERR(ret))
@@ -320,13 +329,18 @@ struct handle_ops file_ops = {
 static int dir_open (PAL_HANDLE * handle, const char * type, const char * uri,
                      int access, int share, int create, int options)
 {
-    int ret;
+    if (!strcmp_static(type, "dir"))
+        return -PAL_ERROR_INVAL;
+    if (!WITHIN_MASK(access, PAL_ACCESS_MASK))
+        return -PAL_ERROR_INVAL;
 
-    if (create & PAL_CREAT_TRY) {
+    int ret = 0;
+
+    if (create & PAL_CREATE_TRY) {
         ret = INLINE_SYSCALL(mkdir, 2, uri, share);
 
         if (IS_ERR(ret) && ERRNO(ret) == EEXIST &&
-            create & PAL_CREAT_ALWAYS)
+            create & PAL_CREATE_ALWAYS)
             return -PAL_ERROR_STREAMEXIST;
     }
 
@@ -375,6 +389,9 @@ struct linux_dirent64 {
    need a 'write' operat4on. */
 int64_t dir_read (PAL_HANDLE handle, uint64_t offset, uint64_t count, void * buf)
 {
+    if (offset)
+        return -PAL_ERROR_INVAL;
+
     void * dent_buf = (void *) handle->dir.buf ? : __alloca(DIRBUF_SIZE);
     void * ptr = (void *) handle->dir.ptr;
     void * end = (void *) handle->dir.end;
@@ -486,6 +503,9 @@ static int dir_delete (PAL_HANDLE handle, int access)
 static int dir_rename (PAL_HANDLE handle, const char * type,
                        const char * uri)
 {
+    if (!strcmp_static(type, "dir"))
+        return -PAL_ERROR_INVAL;
+
     int ret = INLINE_SYSCALL(rename, 2, handle->dir.realpath, uri);
 
     if (IS_ERR(ret))

--- a/Pal/src/host/Linux/db_ipc.c
+++ b/Pal/src/host/Linux/db_ipc.c
@@ -37,6 +37,15 @@
 int gipc_open (PAL_HANDLE * handle, const char * type, const char * uri,
                int access, int share, int create, int options)
 {
+    if (!strcmp_static(type, "gipc"))
+        return -PAL_ERROR_INVAL;
+
+    if (!WITHIN_MASK(access, PAL_ACCESS_MASK) ||
+        !WITHIN_MASK(share, PAL_SHARE_MASK) ||
+        !WITHIN_MASK(create, PAL_CREATE_MASK) ||
+        !WITHIN_MASK(options, PAL_OPTION_MASK))
+        return -PAL_ERROR_INVAL;
+
     int64_t token;
     int rv;
 
@@ -71,6 +80,8 @@ int gipc_close (PAL_HANDLE handle)
 
 const char * gipc_getrealpath (PAL_HANDLE handle)
 {
+    __UNUSED(handle);
+
     return GIPC_FILE;
 }
 
@@ -110,7 +121,7 @@ int _DkCreatePhysicalMemoryChannel (PAL_HANDLE * handle, uint64_t * key)
 }
 
 int _DkPhysicalMemoryCommit (PAL_HANDLE channel, int entries,
-                             PAL_PTR * addrs, PAL_NUM * sizes, int flags)
+                             PAL_PTR * addrs, PAL_NUM * sizes)
 {
     int fd = channel->gipc.fd;
     struct gipc_send gs;

--- a/Pal/src/host/Linux/db_misc.c
+++ b/Pal/src/host/Linux/db_misc.c
@@ -232,6 +232,9 @@ int _DkSegmentRegisterGet (int reg, void ** addr)
 
 int _DkInstructionCacheFlush (const void * addr, int size)
 {
+    __UNUSED(addr);
+    __UNUSED(size);
+
     return -PAL_ERROR_NOTIMPLEMENTED;
 }
 

--- a/Pal/src/host/Linux/db_pipes.c
+++ b/Pal/src/host/Linux/db_pipes.c
@@ -302,7 +302,11 @@ static int pipe_private (PAL_HANDLE * handle, int options)
 static int pipe_open (PAL_HANDLE *handle, const char * type, const char * uri,
                       int access, int share, int create, int options)
 {
-    options &= PAL_OPTION_MASK;
+    if (!WITHIN_MASK(access, PAL_ACCESS_MASK) ||
+        !WITHIN_MASK(share, PAL_SHARE_MASK) ||
+        !WITHIN_MASK(create, PAL_CREATE_MASK) ||
+        !WITHIN_MASK(options, PAL_OPTION_MASK))
+        return -PAL_ERROR_INVAL;
 
     if (strcmp_static(type, "pipe") && !*uri)
         return pipe_private(handle, options);
@@ -326,6 +330,9 @@ static int pipe_open (PAL_HANDLE *handle, const char * type, const char * uri,
 static int64_t pipe_read (PAL_HANDLE handle, uint64_t offset, uint64_t len,
                           void * buffer)
 {
+    if (offset)
+        return -PAL_ERROR_INVAL;
+
     if (!IS_HANDLE_TYPE(handle, pipecli) &&
         !IS_HANDLE_TYPE(handle, pipeprv) &&
         !IS_HANDLE_TYPE(handle, pipe))
@@ -375,6 +382,9 @@ static int64_t pipe_read (PAL_HANDLE handle, uint64_t offset, uint64_t len,
 static int64_t pipe_write (PAL_HANDLE handle, uint64_t offset, uint64_t len,
                            const void * buffer)
 {
+    if (offset)
+        return -PAL_ERROR_INVAL;
+
     if (!IS_HANDLE_TYPE(handle, pipecli) &&
         !IS_HANDLE_TYPE(handle, pipeprv) &&
         !IS_HANDLE_TYPE(handle, pipe))

--- a/Pal/src/host/Linux/db_process.c
+++ b/Pal/src/host/Linux/db_process.c
@@ -163,9 +163,9 @@ failed:
     return ret;
 }
 
-int _DkProcessCreate (PAL_HANDLE * handle,
-                      const char * uri, int flags, const char ** args)
+int _DkProcessCreate (PAL_HANDLE * handle, const char * uri, const char ** args)
 {
+
     PAL_HANDLE exec = NULL;
     PAL_HANDLE parent_handle = NULL, child_handle = NULL;
     int ret;
@@ -496,6 +496,9 @@ int _DkProcessSandboxCreate (const char * manifest, int flags)
 static int64_t proc_read (PAL_HANDLE handle, uint64_t offset, uint64_t count,
                       void * buffer)
 {
+    if (offset)
+        return -PAL_ERROR_INVAL;
+
     int64_t bytes = INLINE_SYSCALL(read, 3, handle->process.stream_in, buffer,
                                    count);
 
@@ -515,6 +518,9 @@ static int64_t proc_read (PAL_HANDLE handle, uint64_t offset, uint64_t count,
 static int64_t proc_write (PAL_HANDLE handle, uint64_t offset, uint64_t count,
                        const void * buffer)
 {
+    if (offset)
+        return -PAL_ERROR_INVAL;
+
     int64_t bytes = INLINE_SYSCALL(write, 3, handle->process.stream_out, buffer,
                                    count);
 

--- a/Pal/src/host/Linux/db_rtld.c
+++ b/Pal/src/host/Linux/db_rtld.c
@@ -105,6 +105,8 @@ void _DkDebugAddMap (struct link_map * map)
 
     dbg->r_state = RT_CONSISTENT;
     pal_dl_debug_state();
+#else
+    __UNUSED(map);
 #endif
 }
 
@@ -146,6 +148,8 @@ void _DkDebugDelMap (struct link_map * map)
 
     dbg->r_state = RT_CONSISTENT;
     pal_dl_debug_state();
+#else
+    __UNUSED(map);
 #endif
 }
 
@@ -239,10 +243,3 @@ void setup_vdso_map (ElfW(Addr) addr)
 #endif
 }
 #endif
-
-ElfW(Addr) resolve_rtld (const char * sym_name)
-{
-    /* We are not using this, because in Linux we can rely on
-       rtld_map to directly lookup symbols */
-    return 0;
-}

--- a/Pal/src/host/Linux/db_sockets.c
+++ b/Pal/src/host/Linux/db_sockets.c
@@ -558,6 +558,11 @@ failed:
 static int tcp_open (PAL_HANDLE *handle, const char * type, const char * uri,
                      int access, int share, int create, int options)
 {
+    if (!WITHIN_MASK(access, PAL_ACCESS_MASK) ||
+        !WITHIN_MASK(share, PAL_SHARE_MASK) ||
+        !WITHIN_MASK(create, PAL_CREATE_MASK))
+        return -PAL_ERROR_INVAL;
+
     int uri_len = strlen(uri) + 1;
 
     if (uri_len > PAL_SOCKADDR_SIZE)
@@ -579,6 +584,9 @@ static int tcp_open (PAL_HANDLE *handle, const char * type, const char * uri,
 static int64_t tcp_read (PAL_HANDLE handle, uint64_t offset, uint64_t len,
                          void * buf)
 {
+    if (offset)
+        return -PAL_ERROR_INVAL;
+
     if (!IS_HANDLE_TYPE(handle, tcp) || !handle->sock.conn)
         return -PAL_ERROR_NOTCONNECTION;
 
@@ -612,6 +620,9 @@ static int64_t tcp_read (PAL_HANDLE handle, uint64_t offset, uint64_t len,
 static int64_t tcp_write (PAL_HANDLE handle, uint64_t offset, uint64_t len,
                           const void * buf)
 {
+    if (offset)
+        return -PAL_ERROR_INVAL;
+
     if (!IS_HANDLE_TYPE(handle, tcp) || !handle->sock.conn)
         return -PAL_ERROR_NOTCONNECTION;
 
@@ -776,6 +787,12 @@ failed:
 static int udp_open (PAL_HANDLE *hdl, const char * type, const char * uri,
                      int access, int share, int create, int options)
 {
+    if (!WITHIN_MASK(access, PAL_ACCESS_MASK) ||
+        !WITHIN_MASK(share, PAL_SHARE_MASK) ||
+        !WITHIN_MASK(create, PAL_CREATE_MASK) ||
+        !WITHIN_MASK(options, PAL_OPTION_MASK))
+        return -PAL_ERROR_INVAL;
+
     char buf[PAL_SOCKADDR_SIZE];
     int len = strlen(uri);
 
@@ -783,7 +800,6 @@ static int udp_open (PAL_HANDLE *hdl, const char * type, const char * uri,
         return -PAL_ERROR_TOOLONG;
 
     memcpy(buf, uri, len + 1);
-    options &= PAL_OPTION_MASK;
 
     if (strcmp_static(type, "udp.srv"))
         return udp_bind(hdl, buf, options);
@@ -797,6 +813,9 @@ static int udp_open (PAL_HANDLE *hdl, const char * type, const char * uri,
 static int64_t udp_receive (PAL_HANDLE handle, uint64_t offset, uint64_t len,
                             void * buf)
 {
+    if (offset)
+        return -PAL_ERROR_INVAL;
+
     if (!IS_HANDLE_TYPE(handle, udp))
         return -PAL_ERROR_NOTCONNECTION;
 
@@ -826,6 +845,9 @@ static int64_t udp_receive (PAL_HANDLE handle, uint64_t offset, uint64_t len,
 static int64_t udp_receivebyaddr (PAL_HANDLE handle, uint64_t offset, uint64_t len,
                                   void * buf, char * addr, int addrlen)
 {
+    if (offset)
+        return -PAL_ERROR_INVAL;
+
     if (!IS_HANDLE_TYPE(handle, udpsrv))
         return -PAL_ERROR_NOTCONNECTION;
 
@@ -867,6 +889,9 @@ static int64_t udp_receivebyaddr (PAL_HANDLE handle, uint64_t offset, uint64_t l
 static int64_t udp_send (PAL_HANDLE handle, uint64_t offset, uint64_t len,
                          const void * buf)
 {
+    if (offset)
+        return -PAL_ERROR_INVAL;
+
     if (!IS_HANDLE_TYPE(handle, udp))
         return -PAL_ERROR_NOTCONNECTION;
 
@@ -901,6 +926,9 @@ static int64_t udp_send (PAL_HANDLE handle, uint64_t offset, uint64_t len,
 static int64_t udp_sendbyaddr (PAL_HANDLE handle, uint64_t offset, uint64_t len,
                                const void * buf, const char * addr, int addrlen)
 {
+    if (offset)
+        return -PAL_ERROR_INVAL;
+
     if (!IS_HANDLE_TYPE(handle, udpsrv))
         return -PAL_ERROR_NOTCONNECTION;
 
@@ -1338,6 +1366,9 @@ err:
 static int64_t mcast_send (PAL_HANDLE handle, uint64_t offset, uint64_t size,
                            const void * buf)
 {
+    if (offset)
+        return -PAL_ERROR_INVAL;
+
     if (handle->mcast.srv == PAL_IDX_POISON)
         return -PAL_ERROR_BADHANDLE;
 
@@ -1378,6 +1409,9 @@ static int64_t mcast_send (PAL_HANDLE handle, uint64_t offset, uint64_t size,
 static int64_t mcast_receive (PAL_HANDLE handle, uint64_t offset, uint64_t size,
                               void * buf)
 {
+    if (offset)
+        return -PAL_ERROR_INVAL;
+
     if (handle->mcast.cli == PAL_IDX_POISON)
         return -PAL_ERROR_BADHANDLE;
 

--- a/Pal/src/host/Linux/db_threading.c
+++ b/Pal/src/host/Linux/db_threading.c
@@ -84,7 +84,7 @@ int pal_thread_init (void * tcbptr)
    inside the current process. The arguments callback and param
    specify the starting function and parameters */
 int _DkThreadCreate (PAL_HANDLE * handle, int (*callback) (void *),
-                     const void * param, int flags)
+                     const void * param)
 {
     void * stack = NULL;
     int ret = _DkVirtualMemoryAlloc(&stack, THREAD_STACK_SIZE + ALT_STACK_SIZE,

--- a/Pal/src/host/Skeleton/db_ipc.c
+++ b/Pal/src/host/Skeleton/db_ipc.c
@@ -57,7 +57,7 @@ int _DkCreatePhysicalMemoryChannel (PAL_HANDLE * handle, unsigned long * key)
 }
 
 int _DkPhysicalMemoryCommit (PAL_HANDLE channel, int entries, PAL_PTR * addrs,
-                             PAL_NUM * sizes, int flags)
+                             PAL_NUM * sizes)
 {
     return -PAL_ERROR_NOTIMPLEMENTED;
 }

--- a/Pal/src/host/Skeleton/db_pipes.c
+++ b/Pal/src/host/Skeleton/db_pipes.c
@@ -68,7 +68,7 @@ static int pipe_open (PAL_HANDLE *handle, const char * type,
     PAL_IDX connid = 0;
 
     if (*endptr == ':') {
-        if (create & PAL_CREAT_TRY)
+        if (create & PAL_CREATE_TRY)
             return -PAL_ERROR_INVAL;
 
         connid = strtol(endptr + 1, &endptr, 10);

--- a/Pal/src/host/Skeleton/db_rtld.c
+++ b/Pal/src/host/Skeleton/db_rtld.c
@@ -45,9 +45,3 @@ void _DkDebugAddMap (struct link_map * map)
 void _DkDebugDelMap (struct link_map * map)
 {
 }
-
-ElfW(Addr) resolve_rtld (const char * sym_name)
-{
-    /* Not yet implemented */
-    return 0;
-}

--- a/Pal/src/host/Skeleton/db_threading.c
+++ b/Pal/src/host/Skeleton/db_threading.c
@@ -34,7 +34,7 @@
    inside the current process. The arguments callback and param
    specify the starting function and parameters */
 int _DkThreadCreate (PAL_HANDLE * handle, int (*callback) (void *),
-                     const void * param, int flags)
+                     const void * param)
 {
     return -PAL_ERROR_NOTIMPLEMENTED;
 }

--- a/Pal/src/pal.h
+++ b/Pal/src/pal.h
@@ -216,6 +216,8 @@ PAL_CONTROL * pal_control_addr (void);
 #define PAL_PROT_EXEC       0x4     /* 0x4 Page can be executed. */
 #define PAL_PROT_WRITECOPY  0x8     /* 0x8 Copy on write */
 
+#define PAL_PROT_MASK       0xF
+
 
 // If addr != NULL, then the returned region is always exactly at addr.
 PAL_PTR
@@ -241,7 +243,7 @@ DkVirtualMemoryProtect (PAL_PTR addr, PAL_NUM size, PAL_FLG prot);
 #define PAL_PROCESS_MASK         0x0
 
 PAL_HANDLE
-DkProcessCreate (PAL_STR uri, PAL_FLG flags, PAL_STR * args);
+DkProcessCreate (PAL_STR uri, PAL_STR * args);
 
 void
 DkProcessExit (PAL_NUM exitCode);
@@ -287,15 +289,17 @@ DkProcessSandboxCreate (PAL_STR manifest, PAL_FLG flags);
 #define PAL_SHARE_MASK      0777
 
 /* Stream Create Flags */
-#define PAL_CREAT_TRY        0100       /* 0100 Create file if file not
+#define PAL_CREATE_TRY        0100       /* 0100 Create file if file not
                                            exist (O_CREAT) */
-#define PAL_CREAT_ALWAYS     0200       /* 0300 Create file and fail if file
+#define PAL_CREATE_ALWAYS     0200       /* 0300 Create file and fail if file
                                            already exist (O_CREAT|O_EXCL) */
-#define PAL_CREAT_MASK       0300
+#define PAL_CREATE_MASK       0300
 
 /* Stream Option Flags */
 #define PAL_OPTION_NONBLOCK     04000
 #define PAL_OPTION_MASK         04000
+
+#define WITHIN_MASK(val, mask)  (((val)|(mask)) == (mask))
 
 PAL_HANDLE
 DkStreamOpen (PAL_STR uri, PAL_FLG access, PAL_FLG share_flags,
@@ -385,7 +389,7 @@ DkStreamChangeName (PAL_HANDLE handle, PAL_STR uri);
 #define PAL_THREAD_MASK         0
 
 PAL_HANDLE
-DkThreadCreate (PAL_PTR addr, PAL_PTR param, PAL_FLG flags);
+DkThreadCreate (PAL_PTR addr, PAL_PTR param);
 
 // assuming duration to be in microseconds
 PAL_NUM
@@ -424,8 +428,7 @@ DkThreadResume (PAL_HANDLE thread);
 typedef void (*PAL_EVENT_HANDLER) (PAL_PTR event, PAL_NUM arg, PAL_CONTEXT *);
 
 PAL_BOL
-DkSetExceptionHandler (PAL_EVENT_HANDLER handler, PAL_NUM event,
-                       PAL_FLG flags);
+DkSetExceptionHandler (PAL_EVENT_HANDLER handler, PAL_NUM event);
 
 void DkExceptionReturn (PAL_PTR event);
 
@@ -500,8 +503,7 @@ PAL_HANDLE
 DkCreatePhysicalMemoryChannel (PAL_NUM * key);
 
 PAL_NUM
-DkPhysicalMemoryCommit (PAL_HANDLE channel, PAL_NUM entries, PAL_PTR * addrs,
-                        PAL_NUM * sizes, PAL_FLG flags);
+DkPhysicalMemoryCommit (PAL_HANDLE channel, PAL_NUM entries, PAL_PTR * addrs, PAL_NUM * sizes);
 
 PAL_NUM
 DkPhysicalMemoryMap (PAL_HANDLE channel, PAL_NUM entries, PAL_PTR * addrs,

--- a/Pal/src/pal_internal.h
+++ b/Pal/src/pal_internal.h
@@ -298,13 +298,13 @@ PAL_HANDLE _DkBroadcastStreamOpen (void);
 
 /* DkProcess and DkThread calls */
 int _DkThreadCreate (PAL_HANDLE * handle, int (*callback) (void *),
-                     const void * parem, int flags);
+                     const void * param);
 void _DkThreadExit (void);
 int _DkThreadDelayExecution (unsigned long * duration);
 void _DkThreadYieldExecution (void);
 int _DkThreadResume (PAL_HANDLE threadHandle);
 int _DkProcessCreate (PAL_HANDLE * handle, const char * uri,
-                      int flags, const char ** args);
+                      const char ** args);
 void _DkProcessExit (int exitCode);
 int _DkProcessSandboxCreate (const char * manifest, int flags);
 
@@ -350,7 +350,7 @@ int _DkSegmentRegisterGet (int reg, void ** addr);
 int _DkInstructionCacheFlush (const void * addr, int size);
 int _DkCreatePhysicalMemoryChannel (PAL_HANDLE * handle, uint64_t * key);
 int _DkPhysicalMemoryCommit (PAL_HANDLE channel, int entries,
-                             PAL_PTR * addrs, PAL_NUM * sizes, int flags);
+                             PAL_PTR * addrs, PAL_NUM * sizes);
 int _DkPhysicalMemoryMap (PAL_HANDLE channel, int entries,
                           PAL_PTR * addrs, PAL_NUM * sizes, PAL_FLG * prots);
 int _DkCpuIdRetrieve (unsigned int leaf, unsigned int subleaf, unsigned int values[4]);

--- a/Pal/src/printf.c
+++ b/Pal/src/printf.c
@@ -39,6 +39,8 @@ struct printbuf {
 static int
 fputch(void * f, int ch, struct printbuf * b)
 {
+    __UNUSED(f);
+
     b->buf[b->idx++] = ch;
     if (b->idx == PRINTBUF_SIZE - 1) {
         _DkPrintConsole(b->buf, b->idx);

--- a/Pal/test/Broadcast.c
+++ b/Pal/test/Broadcast.c
@@ -18,7 +18,7 @@ int main (int argc, char ** argv)
 
         for (i = 0 ; i < 4 ; i++) {
             id[0] = '0' + i + 1;
-            proc[i] = DkProcessCreate ("file:Broadcast", 0, newargs);
+            proc[i] = DkProcessCreate ("file:Broadcast", newargs);
         }
 
         DkThreadDelayExecution(1000000);

--- a/Pal/test/Event.c
+++ b/Pal/test/Event.c
@@ -37,7 +37,7 @@ int main (int argc, char ** argv)
         return -1;
     }
 
-    thd1 = DkThreadCreate(&thread_1, 0, 0);
+    thd1 = DkThreadCreate(&thread_1, 0);
 
     if (thd1 == NULL) {
         pal_printf("DkThreadCreate failed\n");

--- a/Pal/test/Exception.c
+++ b/Pal/test/Exception.c
@@ -24,7 +24,7 @@ int main (void)
 {
     pal_printf("Enter Main Thread\n");
 
-    DkSetExceptionHandler(handler, PAL_EVENT_ARITHMETIC_ERROR, 0);
+    DkSetExceptionHandler(handler, PAL_EVENT_ARITHMETIC_ERROR);
 
     i =  1 / i;
 

--- a/Pal/test/Failure.c
+++ b/Pal/test/Failure.c
@@ -22,7 +22,7 @@ int main (int argc, char ** argv, char ** envp)
 {
     pal_printf("Enter Main Thread\n");
 
-    DkSetExceptionHandler(FailureHandler, PAL_EVENT_FAILURE, 0);
+    DkSetExceptionHandler(FailureHandler, PAL_EVENT_FAILURE);
 
     PAL_HANDLE out = DkStreamOpen("foo:unknown", PAL_ACCESS_WRONLY, 0, 0, 0);
 

--- a/Pal/test/File.c
+++ b/Pal/test/File.c
@@ -16,7 +16,7 @@ int main (int argc, char ** argv, char ** envp)
 
     PAL_HANDLE out = DkStreamOpen(file_uri, PAL_ACCESS_RDWR,
                                   PAL_SHARE_OWNER_W | PAL_SHARE_OWNER_R,
-                                  PAL_CREAT_TRY, 0);
+                                  PAL_CREATE_TRY, 0);
 
     if (out == NULL) {
         pal_printf("DkStreamOpen failed\n");

--- a/Pal/test/Fork.c
+++ b/Pal/test/Fork.c
@@ -19,7 +19,7 @@ PAL_HANDLE _fork (void * args)
     if (args == NULL) {
         struct stack_frame cur_frame = *frame;
         pal_printf("return address is %08x\n", cur_frame.ret);
-        return DkThreadCreate(&_fork, &cur_frame, 0);
+        return DkThreadCreate(&_fork, &cur_frame);
     }
     else {
         struct stack_frame * las_frame = (struct stack_frame *) args;

--- a/Pal/test/HandleSend.c
+++ b/Pal/test/HandleSend.c
@@ -27,7 +27,7 @@ int main (int argc, char ** argv)
 
         // Sending pipe handle
         handles[0] = DkStreamOpen("pipe.srv:012", PAL_ACCESS_RDWR,
-                                  0, PAL_CREAT_TRY, 0);
+                                  0, PAL_CREATE_TRY, 0);
         if (!handles[0]) {
             pal_printf("Parent: DkStreamOpen for pipe failed\n");
             goto out;
@@ -35,7 +35,7 @@ int main (int argc, char ** argv)
 
         // Sending pipe handle
         handles[1] = DkStreamOpen("udp:127.0.0.1:8000", PAL_ACCESS_RDWR,
-                                  0, PAL_CREAT_TRY, 0);
+                                  0, PAL_CREATE_TRY, 0);
         if (!handles[1]) {
             pal_printf("Parent: DkStreamOpen for socket failed\n");
             goto out;
@@ -45,7 +45,7 @@ int main (int argc, char ** argv)
             snprintf(uri, 80, "file:test_file_%d", i - 2);
 
             handles[i] = DkStreamOpen(uri, PAL_ACCESS_RDWR, 0600,
-                                      PAL_CREAT_TRY, 0);
+                                      PAL_CREATE_TRY, 0);
             if (!handles[i]) {
                 pal_printf("Parent: DkStreamOpen failed\n");
                 goto out;
@@ -69,7 +69,7 @@ int main (int argc, char ** argv)
         }
 
         pal_printf("Parent: Forking child\n");
-        child = DkProcessCreate ("file:HandleSend", 0, args);
+        child = DkProcessCreate ("file:HandleSend", args);
 
         if (!child) {
             pal_printf("Parent: Failed creating process\n");

--- a/Pal/test/Ipc.c
+++ b/Pal/test/Ipc.c
@@ -35,14 +35,14 @@ int main(int argc, char ** argv)
 
         snprintf(uri, 20, "gipc:%lld", key);
 
-        PAL_HANDLE phdl = DkProcessCreate("file:Ipc", 0, args);
+        PAL_HANDLE phdl = DkProcessCreate("file:Ipc", args);
 
         if (phdl == NULL)
             pal_printf ("ProcessCreate Failed\n");
 
         PAL_PTR addr = (PAL_PTR) mem;
         PAL_NUM size = pal_control.alloc_align;
-        DkPhysicalMemoryCommit(chdl, 1, &addr, &size, 0);
+        DkPhysicalMemoryCommit(chdl, 1, &addr, &size);
         DkObjectClose(chdl);
 
         char x;

--- a/Pal/test/Pipe.c
+++ b/Pal/test/Pipe.c
@@ -18,7 +18,7 @@ int main (int argc, char ** argv)
     snprintf(uri, 40, "pipe.srv:%d", pipeid);
 
     PAL_HANDLE srv = DkStreamOpen(uri, 0, 0,
-                                  PAL_CREAT_TRY|PAL_CREAT_ALWAYS, 0);
+                                  PAL_CREATE_TRY|PAL_CREATE_ALWAYS, 0);
 
     if (!srv) {
         pal_printf("not able to create server (%s)\n", uri);
@@ -28,7 +28,7 @@ int main (int argc, char ** argv)
     snprintf(uri, 40, "pipe:%d", pipeid);
 
     PAL_HANDLE cli = DkStreamOpen(uri, PAL_ACCESS_RDWR, 0,
-                                  PAL_CREAT_TRY|PAL_CREAT_ALWAYS, 0);
+                                  PAL_CREATE_TRY|PAL_CREATE_ALWAYS, 0);
 
     if (!cli) {
         pal_printf("not able to create client\n");

--- a/Pal/test/Process.c
+++ b/Pal/test/Process.c
@@ -27,7 +27,7 @@ int main (int argc, char ** argv)
 
         const char * newargs[4] = { "Process", "0", time_arg, NULL };
 
-        PAL_HANDLE proc = DkProcessCreate ("file:Process", 0, newargs);
+        PAL_HANDLE proc = DkProcessCreate ("file:Process", newargs);
 
         if (!proc)
             pal_printf("Can't create process\n");
@@ -44,7 +44,7 @@ int main (int argc, char ** argv)
             snprintf(count_arg, 8, "%d", count);
             const char * newargs[4] = { "Process", count_arg, argv[2], NULL };
 
-            PAL_HANDLE proc = DkProcessCreate ("file:Process", 0, newargs);
+            PAL_HANDLE proc = DkProcessCreate ("file:Process", newargs);
 
             if (!proc)
                 pal_printf("Can't creste process\n");

--- a/Pal/test/Select.c
+++ b/Pal/test/Select.c
@@ -30,7 +30,7 @@ int main() {
     handles[2] = DkStreamOpen("pipe:", PAL_ACCESS_RDWR, 0, 0, 0);
     wakeup = handles[2];
 
-    PAL_HANDLE thd = DkThreadCreate(&thread, NULL, 0);
+    PAL_HANDLE thd = DkThreadCreate(&thread, NULL);
 
     if (thd == NULL) {
         pal_printf("DkThreadCreate failed\n");

--- a/Pal/test/Server.c
+++ b/Pal/test/Server.c
@@ -32,7 +32,7 @@ int main (int argc, char ** argv)
     snprintf(uri, 60, "tcp.srv:127.0.0.1:%s", argv[1]);
 
     PAL_HANDLE srv = DkStreamOpen(uri, PAL_ACCESS_RDWR, 0,
-                                  PAL_CREAT_TRY, 0);
+                                  PAL_CREATE_TRY, 0);
 
     if (srv == NULL) {
         pal_printf("DkStreamOpen failed\n");

--- a/Pal/test/Tcp.c
+++ b/Pal/test/Tcp.c
@@ -34,7 +34,7 @@ int main (int argc, char ** argv)
         DkStreamGetName(srv, addr, 40);
         pal_printf("server bound on %s\n", addr);
 
-        PAL_HANDLE proc = DkProcessCreate("file:Tcp", 0, newargs);
+        PAL_HANDLE proc = DkProcessCreate("file:Tcp", newargs);
 
         for (i = 0 ; i < NTRIES ; i++) {
             PAL_HANDLE cli = DkStreamWaitForClient(srv);

--- a/Pal/test/Thread.c
+++ b/Pal/test/Thread.c
@@ -32,14 +32,14 @@ int main() {
 
     PAL_HANDLE thd1, thd2;
 
-    thd1 = DkThreadCreate(&thread_1, NULL, 0);
+    thd1 = DkThreadCreate(&thread_1, NULL);
 
     if (thd1 == NULL) {
         pal_printf("DkThreadCreate failed\n");
         return -1;
     }
 
-    thd2 = DkThreadCreate(&thread_2, NULL, 0);
+    thd2 = DkThreadCreate(&thread_2, NULL);
 
     if (thd2 == NULL) {
         pal_printf("DkThreadCreate failed\n");

--- a/Pal/test/Udp.c
+++ b/Pal/test/Udp.c
@@ -28,7 +28,7 @@ int main (int argc, char ** argv)
         DkStreamGetName(srv, addr, 40);
         pal_printf("server bound on %s\n", addr);
 
-        PAL_HANDLE proc = DkProcessCreate("file:Udp", 0, newargs);
+        PAL_HANDLE proc = DkProcessCreate("file:Udp", newargs);
 
         for (i = 0 ; i < NTRIES ; i++) {
             char buffer[20];

--- a/Pal/test/Wait.c
+++ b/Pal/test/Wait.c
@@ -38,14 +38,14 @@ int main() {
     event1 = DkNotificationEventCreate (0);
     event2 = DkNotificationEventCreate (0);
 
-    thd1 = DkThreadCreate(&thread_1, 0, 0);
+    thd1 = DkThreadCreate(&thread_1, 0);
 
     if (thd1 == NULL) {
         pal_printf("DkThreadCreate failed\n");
         return -1;
     }
 
-    thd2 = DkThreadCreate(&thread_2, 0, 0);
+    thd2 = DkThreadCreate(&thread_2, 0);
 
     if (thd2 == NULL) {
         pal_printf("DkThreadCreate failed\n");

--- a/Pal/test/Yield.c
+++ b/Pal/test/Yield.c
@@ -27,7 +27,7 @@ int main (void)
     pal_printf("Enter Parent Thread\n");
 
     parent_thread = pal_control.first_thread;
-    child_thread = DkThreadCreate(&child, NULL, 0);
+    child_thread = DkThreadCreate(&child, NULL);
 
     if (child_thread == NULL) {
         pal_printf("DkThreadCreate failed\n");


### PR DESCRIPTION
This PR turns on Wunused-parameter sub flag of Wextra. For the functions whose signatures need to be kept, we use " __attribute__((unused))" to tag the unused parameters, to get rid of the warnings. 

Currently this is only enabled under Linux-SGX. Will turn on this flags for other components after a round of reviews.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/385)
<!-- Reviewable:end -->
