### PR TITLE
Explicitly return error instead of silently ignoring parameter.

### DIFF
--- a/LibOS/shim/src/sys/shim_socket.c
+++ b/LibOS/shim/src/sys/shim_socket.c
@@ -1192,6 +1192,9 @@ int shim_do_sendmmsg (int sockfd, struct mmsghdr * msg, int vlen, int flags)
 static ssize_t do_recvmsg (int fd, struct iovec * bufs, int nbufs, int flags,
                            struct sockaddr * addr, socklen_t * addrlen)
 {
+    /* TODO handle flags properly. For now, just return an error. */
+    if (flags) return -EINVAL;
+    
     struct shim_handle * hdl = get_fd_handle(fd, NULL, NULL);
     if (!hdl)
         return -EBADF;

--- a/LibOS/shim/src/sys/shim_socket.c
+++ b/LibOS/shim/src/sys/shim_socket.c
@@ -1192,8 +1192,11 @@ int shim_do_sendmmsg (int sockfd, struct mmsghdr * msg, int vlen, int flags)
 static ssize_t do_recvmsg (int fd, struct iovec * bufs, int nbufs, int flags,
                            struct sockaddr * addr, socklen_t * addrlen)
 {
-    /* TODO handle flags properly. For now, just return an error. */
-    if (flags) return -EINVAL;
+    /* TODO handle flags properly. For now, explicitly return an error. */
+    if (flags) {
+        debug("recvmsg()/recvmmsg()/recvfrom(): flags parameter unsupported.\n");
+        return -EOPNOTSUPP;
+    }
     
     struct shim_handle * hdl = get_fd_handle(fd, NULL, NULL);
     if (!hdl)


### PR DESCRIPTION
This is a simple improvement to address #326.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/387)
<!-- Reviewable:end -->
