### PR TITLE
[Build] Remove residual references to nonexistent exec_victim

### DIFF
--- a/LibOS/shim/test/native/manifest.template
+++ b/LibOS/shim/test/native/manifest.template
@@ -25,7 +25,5 @@ sgx.trusted_files.libc = file:$(LIBCDIR)/libc.so.6
 sgx.trusted_files.libdl = file:$(LIBCDIR)/libdl.so.2
 sgx.trusted_files.libm = file:$(LIBCDIR)/libm.so.6
 sgx.trusted_files.libpthread = file:$(LIBCDIR)/libpthread.so.0
-sgx.trusted_files.victim = file:exec_victim
-sgx.trusted_children.victim = file:exec_victim.sig
 
 sgx.trusted_files.unix_pipe = file:unix.c


### PR DESCRIPTION
PR #215 removed file `exec_victim.c` under `test/native`. However, there were still some residual references to this non-existent file in the `manifest`, which broke the build. This PR removes these residual references.

Note: this only affects the build of SGX PAL.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/391)
<!-- Reviewable:end -->
