### PR TITLE
Fix .gitignore files to prevent host_endian.h checked in

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 /Runtime/
 *~
+.lib/
 /Jenkinsfiles/Jenkinsfile-*
 /Jenkinsfiles/JenkinsfileSGX-*
 
-.lib

--- a/Pal/src/.gitignore
+++ b/Pal/src/.gitignore
@@ -1,4 +1,3 @@
-/host_endian.h
 *.o
 *.so
 *.a


### PR DESCRIPTION
Current .gitignore will let automated-generated host_endian.h checked in. Fix it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/393)
<!-- Reviewable:end -->
