### PR TITLE
[Pal/Linux-SGX] add operation suffix in sgx_entry.S

### DIFF
--- a/Pal/src/host/Linux-SGX/sgx_entry.S
+++ b/Pal/src/host/Linux-SGX/sgx_entry.S
@@ -8,19 +8,19 @@
 
 sgx_ecall:
 	# put entry address in RDX
-	lea sgx_entry(%rip), %rdx
+	leaq sgx_entry(%rip), %rdx
 
 	# other arguments: RDI - code, RSI - ms
 
 .Ldo_ecall:
 	# RBX has to be the TCS of the thread
-	mov current_tcs@gottpoff(%rip), %rbx
-	mov %fs:(%rbx), %rbx
+	movq current_tcs@gottpoff(%rip), %rbx
+	movq %fs:(%rbx), %rbx
 
 	# RCX has to be the AEP (Asynchronous Exit Pointer)
-	lea async_exit_pointer(%rip), %rcx
+	leaq async_exit_pointer(%rip), %rcx
 
-	mov $EENTER, %rax
+	movq $EENTER, %rax
 	ENCLU
 
 	.global async_exit_pointer
@@ -30,26 +30,26 @@ sgx_ecall:
 async_exit_pointer:
 	# because ERESUME doesn't restore FS/GS, we must do EENTER
 
-	mov current_tcs@gottpoff(%rip), %rbx
-	mov %fs:(%rbx), %rbx
+	movq current_tcs@gottpoff(%rip), %rbx
+	movq %fs:(%rbx), %rbx
 
-	lea double_async_exit(%rip), %rcx
+	leaq double_async_exit(%rip), %rcx
 
 	# put the exit address in RDX
-	lea .Lreal_resume(%rip), %rdx
+	leaq .Lreal_resume(%rip), %rdx
 
-	mov $EENTER, %rax
+	movq $EENTER, %rax
 	ENCLU
 
 .Lreal_resume:
 	# RBX has to be the TCS of the thread
-	mov current_tcs@gottpoff(%rip), %rbx
-	mov %fs:(%rbx), %rbx
+	movq current_tcs@gottpoff(%rip), %rbx
+	movq %fs:(%rbx), %rbx
 
 	# RCX has to be the AEP (Asynchronous Exit Pointer)
-	lea async_exit_pointer(%rip), %rcx
+	leaq async_exit_pointer(%rip), %rcx
 
-	mov $ERESUME, %rax
+	movq $ERESUME, %rax
 	ENCLU
 
 	.global double_async_exit
@@ -65,7 +65,7 @@ async_exit_pointer:
 	.type sgx_raise, @function
 
 sgx_raise:
-	lea .Lafter_resume(%rip), %rdx
+	leaq .Lafter_resume(%rip), %rdx
 	jmp .Ldo_ecall
 
 .Lafter_resume:
@@ -75,14 +75,14 @@ sgx_raise:
 sgx_entry:
 	# arguments: RDI - code, RSI - ms
 
-	lea ocall_table(%rip), %rbx
-	mov (%rbx,%rdi,8), %rbx
-	mov %rsi, %rdi
-	call *%rbx
+	leaq ocall_table(%rip), %rbx
+	movq (%rbx,%rdi,8), %rbx
+	movq %rsi, %rdi
+	callq *%rbx
 
-	mov %rax, %rdi
+	movq %rax, %rdi
 	# Not interrupted
-	xor %rsi, %rsi
+	xorq %rsi, %rsi
 
 	.global sgx_entry_return
 	.type sgx_entry_return, @function
@@ -104,7 +104,7 @@ rdfsbase:
 	.cfi_startproc
 
 	.byte 0xf3, 0x48, 0x0f, 0xae, 0xc0 /* RDFSBASE %RAX */
-	ret
+	retq
 
 	.cfi_endproc
 	.size rdfsbase, .-rdfsbase
@@ -120,7 +120,7 @@ wrfsbase:
 	.cfi_startproc
 
 	.byte 0xf3, 0x48, 0x0f, 0xae, 0xd7 /* WRFSBASE %RDI */
-	ret
+	retq
 
 	.cfi_endproc
 	.size wrfsbase, .-wrfsbase


### PR DESCRIPTION
For consistency, add operation suffix in sgx_entry.S
Other .S files in graphene use operation suffix.

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/395)
<!-- Reviewable:end -->
