### PR TITLE
[Pal, Pal/Linux] Add fp registers definition to PAL_CONTEXT

### DIFF
--- a/Pal/src/host/Linux-SGX/db_exception.c
+++ b/Pal/src/host/Linux-SGX/db_exception.c
@@ -276,6 +276,7 @@ handle_event:
     ctx->r15 = uc->r15;
     ctx->efl = uc->rflags;
     ctx->rip = uc->rip;
+    ctx->fpregs = NULL; /* TODO construct fpregs */
 
     struct pal_frame * frame = get_frame(uc);
 

--- a/Pal/src/host/Linux/db_exception.c
+++ b/Pal/src/host/Linux/db_exception.c
@@ -191,9 +191,9 @@ void _DkGenericEventTrigger (PAL_IDX event_num, PAL_EVENT_HANDLER upcall,
                    offsetof(PAL_CONTEXT, fpregs),
                    "PAL_CONTEXT layout doesn't match gregset_t");
     _Static_assert(offsetof(mcontext_t, fpregs) == offsetof(PAL_CONTEXT, fpregs),
-                   "offsetof PAL_CONTEXT.fpregs doesn't patch to mcontext_t::fpregs");
+                   "offsetof PAL_CONTEXT.fpregs doesn't match mcontext_t::fpregs");
     _Static_assert(sizeof(uc->uc_mcontext.fpregs) == sizeof(PAL_PTR),
-                   "sizeof PAL_CONTEXT.fpregs doesn't match to fpregset_t");
+                   "PAL_CONTEXT assumes that uc_mcontext.fpregs is a pointer but it is not");
     (*upcall) ((PAL_PTR) &event, arg,
                uc ? (PAL_CONTEXT*)&uc->uc_mcontext : NULL);
 }
@@ -408,6 +408,6 @@ err:
 void _DkExceptionReturn (void * event)
 {
     /* nothing here.
-     * NOTE: mucontext_t is reused as PAL_CONTEXT by _DkGenericEventTrigger()
+     * NOTE: uc_mcontext is reused as PAL_CONTEXT by _DkGenericEventTrigger()
      */
 }

--- a/Pal/src/host/Linux/db_exception.c
+++ b/Pal/src/host/Linux/db_exception.c
@@ -136,8 +136,10 @@ void _DkGenericEventTrigger (PAL_IDX event_num, PAL_EVENT_HANDLER upcall,
     PAL_EVENT event;
     event.event_num = event_num;
 
-    if (uc)
+    if (uc) {
         memcpy(&event.context, uc->uc_mcontext.gregs, sizeof(PAL_CONTEXT));
+        event.context.fpregs = uc->uc_mcontext.fpregs;
+    }
 
     event.uc = uc;
 

--- a/Pal/src/pal.h
+++ b/Pal/src/pal.h
@@ -92,10 +92,132 @@ typedef struct {
     PAL_NUM rdi, rsi, rbp, rbx, rdx, rax, rcx;
     PAL_NUM rsp, rip;
     PAL_NUM efl, csgsfs, err, trapno, oldmask, cr2;
+    PAL_PTR fpregs;
 #else
 # error "Unsupported architecture"
 #endif
 } PAL_CONTEXT;
+
+#ifdef __x86_64__
+union pal_csgsfs {
+    struct {
+        uint16_t cs;
+        uint16_t gs;
+        uint16_t fs;
+        uint16_t ss;
+    };
+    uint64_t csgsfs;
+};
+
+/* adopt Linux style fp layout */
+#define PAL_FP_XSTATE_MAGIC1        0x46505853U
+#define PAL_FP_XSTATE_MAGIC2        0x46505845U
+#define PAL_FP_XSTATE_MAGIC2_SIZE   sizeof(PAL_FP_XSTATE_MAGIC2)
+
+enum PAL_XFEATURE {
+    PAL_XFEATURE_FP,
+    PAL_XFEATURE_SSE,
+    PAL_XFEATURE_YMM,
+    PAL_XFEATURE_BNDREGS,
+    PAL_XFEATURE_BNDCSR,
+    PAL_XFEATURE_OPMASK,
+    PAL_XFEATURE_ZMM_Hi256,
+    PAL_XFEATURE_Hi16_ZMM,
+    PAL_XFEATURE_PT_UNIMPLEMENTED_SO_FAR,
+    PAL_XFEATURE_PKRU,
+
+    PAL_XFEATURE_MAX,
+};
+
+#define PAL_XFEATURE_MASK_FP                (1UL << PAL_XFEATURE_FP)
+#define PAL_XFEATURE_MASK_SSE               (1UL << PAL_XFEATURE_SSE)
+#define PAL_XFEATURE_MASK_YMM               (1UL << PAL_XFEATURE_YMM)
+#define PAL_XFEATURE_MASK_BNDREGS           (1UL << PAL_XFEATURE_BNDREGS)
+#define PAL_XFEATURE_MASK_BNDCSR            (1UL << PAL_XFEATURE_BNDCSR)
+#define PAL_XFEATURE_MASK_OPMASK            (1UL << PAL_XFEATURE_OPMASK)
+#define PAL_XFEATURE_MASK_ZMM_Hi256         (1UL << PAL_XFEATURE_ZMM_Hi256)
+#define PAL_XFEATURE_MASK_Hi16_ZMM          (1UL << PAL_XFEATURE_Hi16_ZMM)
+#define PAL_XFEATURE_MASK_PT                (1UL << PAL_XFEATURE_PT_UNIMPLEMENTED_SO_FAR)
+#define PAL_XFEATURE_MASK_PKRU              (1UL << PAL_XFEATURE_PKRU)
+
+#define PAL_XFEATURE_MASK_FPSSE             (PAL_XFEATURE_MASK_FP \
+                                             | PAL_XFEATURE_MASK_SSE)
+#define PAL_XFEATURE_MASK_AVX512            (PAL_XFEATURE_MASK_OPMASK \
+                                             | PAL_XFEATURE_MASK_ZMM_Hi256 \
+                                             | PAL_XFEATURE_MASK_Hi16_ZMM)
+
+typedef struct {
+    uint32_t magic1;        /* PAL_FP_XSTATE_MAGIC1 */
+    uint32_t extended_size; /* xsave_size */
+    uint64_t xfeatures;     /* XSAVE feature */
+    uint32_t xstate_size;   /* xsave_size + PAL_FP_STATE_MAGIC2_SIZE */
+    uint32_t padding[7];
+} PAL_FPX_SW_BYTES;
+
+typedef struct {
+    uint32_t cwd;
+    uint32_t swd;
+    uint32_t twd;
+    uint32_t fip;
+    uint32_t fcs;
+    uint32_t foo;
+    uint32_t fos;
+    uint32_t st_space[20];
+    uint8_t ftop;
+    uint8_t changed;
+    uint8_t lookahead;
+    uint8_t no_update;
+    uint8_t rm;
+    uint8_t alimit;
+    void * info; /* struct math_emu_info */
+    uint32_t entry_eip;
+} PAL_SWREGS_STATE;
+
+typedef struct {
+    uint16_t significand[4];
+    uint16_t exponent;
+    uint16_t padding[3];
+} PAL_FPXREG;
+
+typedef struct {
+    uint32_t element[4];
+} PAL_XMMREG;
+
+typedef struct {
+    /* 64-bit FXSAVE format.  */
+    uint16_t cwd;
+    uint16_t swd;
+    uint16_t ftw;
+    uint16_t fop;
+    uint64_t rip;
+    uint64_t rdp;
+    uint32_t mxcsr;
+    uint32_t mxcr_mask;
+    PAL_FPXREG st[8];
+    PAL_XMMREG xmm[16];
+    union {
+        uint32_t padding[24];
+        struct {
+            uint32_t padding2[12];
+            PAL_FPX_SW_BYTES sw_reserved;
+        };
+    };
+} PAL_FPSTATE;
+
+typedef struct {
+    uint64_t xfeatures;
+    uint64_t xcomp_bv;
+    uint64_t reserved[6];
+} __attribute__((packed)) PAL_XSTATE_HEADER;
+
+typedef struct {
+    PAL_FPSTATE fpstate;
+    PAL_XSTATE_HEADER header;
+} __attribute__((packed, aligned(64))) PAL_XREGS_STATE;
+
+#else
+# error "Unsupported architecture"
+#endif
 
 #define PAL_TRUE  true
 #define PAL_FALSE false


### PR DESCRIPTION
Now fp registers aren't handled when unix signal is emulated.
As a first step to address it,  add fp registers to PAL_CONTEXT and
make Pal/Linux pass it. Pal/Linux-SGX part will follow as another patch.
LibOS part needs discussion on how unix(Linux) signal should be emulated.

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/397)
<!-- Reviewable:end -->
