### PR TITLE
[LibOS] remove unnecessary __alloca()

### DIFF
--- a/LibOS/shim/src/fs/chroot/fs.c
+++ b/LibOS/shim/src/fs/chroot/fs.c
@@ -168,7 +168,7 @@ static int make_uri (struct shim_dentry * dent)
     assert(mdata);
 
     struct shim_file_data * data = FILE_DENTRY_DATA(dent);
-    char * uri = __alloca(URI_MAX_SIZE);
+    char uri[URI_MAX_SIZE];
     int len = concat_uri(uri, URI_MAX_SIZE, data->type,
                          mdata->root_uri,
                          mdata->root_uri_len,

--- a/LibOS/shim/src/sys/shim_clone.c
+++ b/LibOS/shim/src/sys/shim_clone.c
@@ -115,8 +115,8 @@ int clone_implementation_wrapper(struct clone_args * arg)
     debug_setbuf(tcb, true);
     debug("set tcb to %p (stack allocated? %d)\n", my_thread->tcb, stack_allocated);
 
-    struct shim_regs * regs = __alloca(sizeof(struct shim_regs));
-    *regs = *((__libc_tcb_t *) arg->parent->tcb)->shim_tcb.context.regs;
+    struct shim_regs regs;
+    regs = *((__libc_tcb_t *) arg->parent->tcb)->shim_tcb.context.regs;
 
     if (my_thread->set_child_tid)
         *(my_thread->set_child_tid) = my_thread->tid;
@@ -144,7 +144,7 @@ int clone_implementation_wrapper(struct clone_args * arg)
     debug("child swapping stack to %p return %p: %d\n",
           stack, return_pc, my_thread->tid);
 
-    tcb->context.regs = regs;
+    tcb->context.regs = &regs;
     tcb->context.sp = stack;
     tcb->context.ret_ip = return_pc;
 
@@ -293,25 +293,25 @@ int shim_do_clone (int flags, void * user_stack_addr, int * parent_tidptr,
 
     enable_locking();
 
-    struct clone_args * new_args = __alloca(sizeof(struct clone_args));
-    memset(new_args, 0, sizeof(struct clone_args));
+    struct clone_args new_args;
+    memset(&new_args, 0, sizeof(new_args));
 
-    new_args->create_event = DkNotificationEventCreate(PAL_FALSE);
-    if (!new_args->create_event) {
+    new_args.create_event = DkNotificationEventCreate(PAL_FALSE);
+    if (!new_args.create_event) {
         ret = -PAL_ERRNO;
         goto clone_thread_failed;
     }
 
-    new_args->initialize_event = DkNotificationEventCreate(PAL_FALSE);
-    if (!new_args->initialize_event) {
+    new_args.initialize_event = DkNotificationEventCreate(PAL_FALSE);
+    if (!new_args.initialize_event) {
         ret = -PAL_ERRNO;
         goto clone_thread_failed;
     }
 
-    new_args->thread    = thread;
-    new_args->parent    = self;
-    new_args->stack     = user_stack_addr;
-    new_args->return_pc = *(void **) user_stack_addr;
+    new_args.thread    = thread;
+    new_args.parent    = self;
+    new_args.stack     = user_stack_addr;
+    new_args.return_pc = *(void **) user_stack_addr;
 
     // Invoke DkThreadCreate to spawn off a child process using the actual 
     // "clone" system call. DkThreadCreate allocates a stack for the child 
@@ -320,7 +320,7 @@ int shim_do_clone (int flags, void * user_stack_addr, int * parent_tidptr,
     // returns .The parent comes back here - however, the child is Happily 
     // running the function we gave to DkThreadCreate.
     PAL_HANDLE pal_handle = thread_create(clone_implementation_wrapper,
-                                          new_args, flags);
+                                          &new_args, flags);
     if (!pal_handle) {
         ret = -PAL_ERRNO;
         goto clone_thread_failed;
@@ -332,17 +332,17 @@ int shim_do_clone (int flags, void * user_stack_addr, int * parent_tidptr,
     if (set_parent_tid)
         *set_parent_tid = tid;
 
-    DkEventSet(new_args->create_event);
-    DkObjectsWaitAny(1, &new_args->initialize_event, NO_TIMEOUT);
-    DkObjectClose(new_args->initialize_event);
+    DkEventSet(new_args.create_event);
+    DkObjectsWaitAny(1, &new_args.initialize_event, NO_TIMEOUT);
+    DkObjectClose(new_args.initialize_event);
     put_thread(thread);
     return tid;
 
 clone_thread_failed:
-    if (new_args->create_event)
-        DkObjectClose(new_args->create_event);
-    if (new_args->initialize_event)
-        DkObjectClose(new_args->initialize_event);
+    if (new_args.create_event)
+        DkObjectClose(new_args.create_event);
+    if (new_args.initialize_event)
+        DkObjectClose(new_args.initialize_event);
 failed:
     if (thread)
         put_thread(thread);

--- a/LibOS/shim/src/sys/shim_pipe.c
+++ b/LibOS/shim/src/sys/shim_pipe.c
@@ -41,7 +41,7 @@ int create_pipes (IDTYPE * pipeid, PAL_HANDLE * srv, PAL_HANDLE * cli,
 {
     PAL_HANDLE hdl0 = NULL, hdl1 = NULL, hdl2 = NULL;
     int ret = 0;
-    char * uri = __alloca(PIPE_URI_SIZE);
+    char uri[PIPE_URI_SIZE];
 
     if ((ret = create_pipe(pipeid, uri, PIPE_URI_SIZE, &hdl0,
                            qstr)) < 0) {


### PR DESCRIPTION
remove abuse of __alloca() with normal variable on stack.
This patch cleans up abuse of __alloca().

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/399)
<!-- Reviewable:end -->
