### PR TITLE
[PAL] Fix the missing of closing the cached_file

### DIFF
--- a/Pal/src/db_rtld.c
+++ b/Pal/src/db_rtld.c
@@ -801,6 +801,7 @@ map_next:
     }
 
     obj->map.l_name = obj->map_name;
+    _DkObjectClose(cached_file);
     return &obj->map;
 
 out_more_mapped:


### PR DESCRIPTION
cached_file is a PAL_HANDLE, which in the case of out will be released by _DkObjectClose(cached_file).
In the normal case, before returning &obj->map, this resource allocated within the function should
also be released to prevent it leaking out side of the function scope.

Signed-off-by: Gary <gang1.wang@intel.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/401)
<!-- Reviewable:end -->
