### PR TITLE
[PAL] Fix uninitialized field action.sa_flags

### DIFF
--- a/Pal/src/host/Linux/db_exception.c
+++ b/Pal/src/host/Linux/db_exception.c
@@ -86,6 +86,7 @@ int set_sighandler (int * sigs, int nsig, void * handler)
         action.sa_restorer = restore_rt;
 #endif
     } else {
+        action.sa_flags = 0x0u;
         action.sa_handler = SIG_IGN;
     }
 


### PR DESCRIPTION
action.sa_flags will only be initialized in the truth branch, while in the false branch,
only sa_handler is initialized. Before action.sa_flags |= SA_NOCLDWAIT,
action.sa_flags should be properly initialized (in this case 0x0u)

Signed-off-by: Gary <gang1.wang@intel.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/402)
<!-- Reviewable:end -->
