### PR TITLE
[PAL] Fix misplacing the handling code for child process in DkProcessCreate

### DIFF
--- a/Pal/src/host/FreeBSD/db_process.c
+++ b/Pal/src/host/FreeBSD/db_process.c
@@ -152,8 +152,7 @@ static int child_process (void * param)
 
 failed:
     /* fail is it gets here */
-    _DkThreadExit();
-    return 0;
+    return -PAL_ERROR_DENIED;
 }
 
 int _DkProcessCreate (PAL_HANDLE * handle, const char * uri, const char ** args)
@@ -267,8 +266,8 @@ int _DkProcessCreate (PAL_HANDLE * handle, const char * uri, const char ** args)
     }
 
     if (!ret) {
-        child_process(&param);
-        return 0;
+        ret = child_process(&param);
+        goto out; /* if child_process returned, there was a failure */
     }
 
     child_handle->process.pid = ret;

--- a/Pal/src/host/Linux/db_process.c
+++ b/Pal/src/host/Linux/db_process.c
@@ -157,11 +157,10 @@ static int child_process (void * param)
 
     INLINE_SYSCALL(execve, 3, PAL_LOADER, proc_param->argv,
                    linux_state.environ);
-    ret = -PAL_ERROR_DENIED;
 
 failed:
     /* fail is it gets here */
-    return ret;
+    return -PAL_ERROR_DENIED;
 }
 
 int _DkProcessCreate (PAL_HANDLE * handle, const char * uri, const char ** args)
@@ -291,7 +290,6 @@ int _DkProcessCreate (PAL_HANDLE * handle, const char * uri, const char ** args)
 #endif
 
     ret = ARCH_VFORK();
-    int child_ret = 0;
 
     if (IS_ERR(ret)) {
         ret = -PAL_ERROR_DENIED;
@@ -299,13 +297,8 @@ int _DkProcessCreate (PAL_HANDLE * handle, const char * uri, const char ** args)
     }
 
     if (!ret) {
-        child_ret = child_process(&param);
-        return 0;
-    }
-
-    if (child_ret < 0) {
-        ret = child_ret;
-        goto out;
+        ret = child_process(&param);
+        goto out; /* if child_process returned, there was a failure */
     }
 
     proc_args->pal_sec.process_id = ret;


### PR DESCRIPTION
The code that handles the failure of child process creation has been misplaced outside of the scope.

Signed-off-by: Gary <gang1.wang@intel.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/404)
<!-- Reviewable:end -->
