### PR TITLE
[Linux-SGX PAL] Add exitless system calls

### DIFF
--- a/Pal/src/host/Linux-SGX/Makefile
+++ b/Pal/src/host/Linux-SGX/Makefile
@@ -9,9 +9,9 @@ defs	= -DIN_PAL -DPAL_DIR=$(PAL_DIR) -DRUNTIME_DIR=$(RUNTIME_DIR)
 enclave-objs = $(addprefix db_,files devices pipes sockets streams memory \
 		 threading mutex events process object main rtld \
 		 exception misc ipc spinlock) \
-	       $(addprefix enclave_,ocalls ecalls framework pages untrusted) 
+	       $(addprefix enclave_,ocalls ecalls framework pages untrusted rpcqueue)
 enclave-asm-objs = enclave_entry 
-urts-objs = $(addprefix sgx_,enclave framework main rtld thread process exception graphene)
+urts-objs = $(addprefix sgx_,enclave framework main rtld thread process exception graphene rpcqueue)
 urts-asm-objs = sgx_entry
 graphene_lib = .lib/graphene-lib.a
 headers	= $(wildcard *.h) $(wildcard ../../*.h) $(wildcard ../../../lib/*.h) \

--- a/Pal/src/host/Linux-SGX/db_exception.c
+++ b/Pal/src/host/Linux-SGX/db_exception.c
@@ -127,7 +127,7 @@ extern void arch_exception_return (void) __asm__ ("arch_exception_return_asm");
 void _DkExceptionRealHandler (int event, PAL_NUM arg, struct pal_frame * frame,
                               PAL_CONTEXT * context)
 {
-    if (frame) {
+    if (!frame) {
         frame = __alloca(sizeof(struct pal_frame));
         frame->identifier = PAL_FRAME_IDENTIFIER;
         frame->func     = &_DkExceptionRealHandler;

--- a/Pal/src/host/Linux-SGX/ecall_types.h
+++ b/Pal/src/host/Linux-SGX/ecall_types.h
@@ -8,9 +8,11 @@ enum {
 };
 
 struct pal_sec;
+struct rpc_queue;
 
 typedef struct {
     const char ** ms_arguments;
     const char ** ms_environments;
     struct pal_sec * ms_sec_info;
+    struct rpc_queue * rpc_queue; /* pointer to RPC queue in untrusted mem */
 } ms_ecall_enclave_start_t;

--- a/Pal/src/host/Linux-SGX/enclave_ecalls.c
+++ b/Pal/src/host/Linux-SGX/enclave_ecalls.c
@@ -7,6 +7,7 @@
 #include <api.h>
 
 #include "ecall_types.h"
+#include "rpcqueue.h"
 
 #define SGX_CAST(type, item) ((type) (item))
 
@@ -16,6 +17,28 @@ void pal_linux_main (const char ** arguments, const char ** environments,
 void pal_start_thread (void);
 
 extern void * enclave_base, * enclave_top;
+
+/* returns 0 if rpc_queue is valid, otherwise 1 */
+static int set_rpc_queue(rpc_queue_t* untrusted_rpc_queue) {
+    g_rpc_queue = untrusted_rpc_queue;
+    if (!g_rpc_queue)
+        return 0;
+
+    if (sgx_is_within_enclave(g_rpc_queue, sizeof(*g_rpc_queue)))
+        return 1;
+
+    if (g_rpc_queue->rpc_threads_num > MAX_RPC_THREADS)
+        return 1;
+
+    /* re-initialize rest fields for safety */
+    atomic_set(&g_rpc_queue->lock, SPIN_UNLOCKED);
+    g_rpc_queue->front = 0;
+    g_rpc_queue->rear  = 0;
+    for (size_t i = 0; i < RPC_QUEUE_SIZE; i++)
+        g_rpc_queue->q[i] = NULL;
+
+    return 0;
+}
 
 int handle_ecall (long ecall_index, void * ecall_args, void * exit_target,
                   void * untrusted_stack, void * enclave_base_addr)
@@ -44,6 +67,9 @@ int handle_ecall (long ecall_index, void * ecall_args, void * exit_target,
                     (ms_ecall_enclave_start_t *) ecall_args;
 
             if (!ms) return -PAL_ERROR_INVAL;
+
+            if (set_rpc_queue(ms->rpc_queue))
+                return -PAL_ERROR_DENIED;
 
             pal_linux_main(ms->ms_arguments, ms->ms_environments,
                            ms->ms_sec_info);

--- a/Pal/src/host/Linux-SGX/enclave_ocalls.c
+++ b/Pal/src/host/Linux-SGX/enclave_ocalls.c
@@ -6,6 +6,7 @@
  */
 
 #include "pal_linux.h"
+#include "pal_linux_error.h"
 #include "pal_internal.h"
 #include "pal_debug.h"
 #include "enclave_ocalls.h"
@@ -14,102 +15,197 @@
 #include <api.h>
 
 #include <asm/errno.h>
+#include <linux/futex.h>
+#include "rpcqueue.h"
 
-#define OCALLOC(val, type, len) do {    \
-    void * _tmp = sgx_ocalloc(len);     \
-    if (_tmp == NULL) {                 \
-        OCALL_EXIT();                   \
-        return -PAL_ERROR_DENIED;  /* TODO: remove this control-flow obfuscation */  \
-    }                                   \
-    (val) = (type) _tmp;                \
-} while (0)
+rpc_queue_t* g_rpc_queue;  /* pointer to untrusted queue */
 
-int printf(const char * fmt, ...);
+static void* alloc_in_user(void* ptr, uint64_t size) {
+    if (!sgx_is_within_enclave(ptr, size))
+        return ptr;
 
-#define SGX_OCALL(code, ms) sgx_ocall(code, ms)
+    /* we assume that sgx_ocalloc never fails because it allocates on stack
+     * (interface similar to alloca); for same reason there is no sgx_ocfree */
+    return sgx_ocalloc(size);
+}
 
-#define OCALL_EXIT()                                    \
-    do {                                                \
-        sgx_ocfree();                                   \
-    } while (0)
+static void* copy_to_user(const void* ptr, uint64_t size) {
+    if (!sgx_is_within_enclave(ptr, size))
+        return (void*)ptr;
 
-#define ALLOC_IN_USER(ptr, size)                    \
-    ({                                              \
-        __typeof__(ptr) tmp = ptr;                  \
-        if (sgx_is_within_enclave(ptr, size)) {     \
-            OCALLOC(tmp, __typeof__(tmp), size);    \
-        }; tmp;                                     \
-    })
+    void* tmp = sgx_ocalloc(size);
+    memcpy(tmp, ptr, size);
+    return tmp;
+}
 
-#define COPY_TO_USER(ptr, size)                     \
-    ({                                              \
-        __typeof__(ptr) tmp = ptr;                  \
-        if (sgx_is_within_enclave(ptr, size)) {     \
-            OCALLOC(tmp, __typeof__(tmp), size);    \
-            memcpy((void *) tmp, ptr, size);        \
-        }; tmp;                                     \
-    })
+static void copy_from_user(void* ptr, const void* user_ptr, uint64_t size) {
+    if (sgx_is_within_enclave(user_ptr, size) ||
+            !sgx_is_within_enclave(ptr, size))
+        return;
 
-#define COPY_FROM_USER(var, user_var, size)                 \
-    ({                                                      \
-        int _ret = 0;                                       \
-        if (var != user_var) {                              \
-            if (sgx_is_within_enclave(user_var, size) ||    \
-                !sgx_is_within_enclave(var, size)) {        \
-                _ret = -PAL_ERROR_DENIED;                   \
-            } else {                                        \
-                _ret = 0;                                   \
-                memcpy(var, user_var, size);                \
-            }                                               \
-        } _ret;                                             \
-    })
+    memcpy(ptr, user_ptr, size);
+}
+
+static int sgx_exitless_ocall(int code, void* ms) {
+    /* perform OCALL with enclave exit if no RPC queue */
+    if (!g_rpc_queue)
+        return sgx_ocall(code, ms);
+
+    /* allocate request on OCALL stack; it is automatically freed on OCALL end;
+     * note that request's lock is used in futex() and must be aligned to 4B
+     * so we pad OCALL stack to 4B alignment with dummy chars */
+    char* dummy;
+    do {
+        dummy = sgx_ocalloc(sizeof(*dummy));
+    } while ((uint64_t)dummy % 4 != 0);
+
+    rpc_request_t* req = sgx_ocalloc(sizeof(*req));
+    req->ocall_index = code;
+    req->buffer      = ms;
+    atomic_set(&req->lock, REQ_LOCKED_NO_WAITERS);
+
+    /* enqueue OCALL into RPC queue; some RPC thread will dequeue it, issue a syscall
+     * and, after syscall is finished, unlock it by setting lock=REQ_UNLOCKED */
+    req = rpc_enqueue(g_rpc_queue, req);
+    if (!req) {
+        /* no space in queue: all RPC threads are busy with outstanding ocalls */
+        return -ENOMEM;
+    }
+
+    /* wait till request processing is finished; try spinlock first */
+    int timedout = rpc_spin_lock_timeout(&req->lock, RPC_SPIN_LOCK_TIMEOUT);
+
+    /* at this point:
+     * - either RPC thread is done with OCALL and moved lock in REQ_UNLOCKED state,
+     *   and our enclave thread grabbed lock but it doesn't matter at this point
+     *   (OCALL is done, timedout = 0, no need to wait on futex)
+     * - or OCALL is still pending and lock is still in REQ_LOCKED_NO_WAITERS
+     *   (OCALL is not done, timedout != 0, let's wait on futex) */
+
+    if (timedout) {
+        /* OCALL takes a lot of time, so fallback to waiting on a futex;
+         * note that at this point we exit the enclave to perform syscall;
+         * this code is based on Mutex 2 from Futexes are Tricky */
+        int c;
+
+        /* at this point can be a subtle data race: RPC thread is only now done
+         * with OCALL and moved lock in REQ_UNLOCKED state; in this racey case,
+         * lock = REQ_UNLOCKED = 0 and we do not wait on futex (note that our enclave
+         * thread grabbed lock but it doesn't matter at this point) */
+        if ((c = atomic_cmpxchg(&req->lock, REQ_UNLOCKED, REQ_LOCKED_NO_WAITERS))) {
+            do {
+                /* at this point lock = REQ_LOCKED_*; before waiting on futex, need to
+                 * move lock to REQ_LOCKED_WITH_WAITERS; note that check on cmpxchg of
+                 * lock = REQ_UNLOCKED = 0 is for the same data race as above */
+                if (c == REQ_LOCKED_WITH_WAITERS ||  /* shortcut: don't need to move lock state */
+                    atomic_cmpxchg(&req->lock, REQ_LOCKED_NO_WAITERS, REQ_LOCKED_WITH_WAITERS)) {
+
+                    /* allocate futex args on OCALL stack; automatically freed on OCALL end */
+                    ms_ocall_futex_t * ms = sgx_ocalloc(sizeof(*ms));
+                    ms->ms_futex = (int*)&req->lock.counter;
+                    ms->ms_op = FUTEX_WAIT_PRIVATE;
+                    ms->ms_val = REQ_LOCKED_WITH_WAITERS;
+                    ms->ms_timeout = OCALL_NO_TIMEOUT;
+
+                    /* at this point, futex(wait) syscall expects lock to be in state
+                     * REQ_LOCKED_WITH_WAITERS set by enclave thread above; if RPC
+                     * thread moved it back to REQ_UNLOCKED, futex() immediately returns */
+                    int ret = sgx_ocall(OCALL_FUTEX, ms);
+                    if (ret < 0 && ret != -PAL_ERROR_TRYAGAIN)
+                        return -ENOMEM;
+                }
+            } while ((c = atomic_cmpxchg(&req->lock, REQ_UNLOCKED, REQ_LOCKED_WITH_WAITERS)));
+            /* while-loop is required for spurious futex wake-ups: our enclave thread
+             * must wait until lock moves to REQ_UNLOCKED (note that enclave thread
+             * grabs lock but it doesn't matter at this point) */
+        }
+    }
+
+    return req->result;
+}
+
+/* Adding new OCALLs (syscalls):
+ *   1. Add new enum for OCALL (in ocall_types.h)
+ *   2. Add new ms_ocall_*_t struct which captures all OCALL args (in ocall_types.h)
+ *   3. Add new sgx_*() function which is executed in untrusted PAL and issues
+ *      an actual syscall (in sgx_enclave.c)
+ *   4. Register this sgx_*() function in ocall_table (in sgx_enclave.c)
+ *   5. Add new ocall_*() function which is executed in trusted PAL and performs
+ *      an OCALL into untrusted PAL to call sgx_*()
+ *
+ * For step (5), the pattern to write new ocall_*() function is:
+ *
+ * int ocall_new_syscall (void* arg1, void* arg2) {
+ *    int retval = 0;
+ *
+ *    // get new stack frame on enclave thread's untrusted stack (OCALL stack)
+ *    void* frame = sgx_ocget_frame();
+ *
+ *    // push struct with all OCALL args on current OCALL stack frame
+ *    ms_ocall_new_syscall_t * ms = sgx_ocalloc(sizeof(*ms));
+ *    ms->ms_arg1 = arg1;
+ *    ms->ms_arg2 = arg2;
+ *
+ *    // perform exitless OCALL
+ *    retval = sgx_exitless_ocall(OCALL_NEW_SYSCALL, ms);
+ *
+ *    // free (pop) current OCALL stack frame and return;
+ *    // this automatically frees all args pushed on OCALL stack
+ *    sgx_ocfree_frame(frame);
+ *    return retval;
+ * }
+ *
+ * Most new syscalls should use sgx_exitless_ocall() for performance reasons.
+ * If new syscall _needs_ to perform enclave exit, replace with sgx_ocall().
+ */
 
 int ocall_exit(int exitcode)
 {
     int retval = 0;
     int64_t code = exitcode;
-    SGX_OCALL(OCALL_EXIT, (void *) code);
-    /* never reach here */
+    sgx_ocall(OCALL_EXIT, (void *) code);
+    /* NOTREACHED */
     return retval;
 }
 
 int ocall_print_string (const char * str, unsigned int length)
 {
     int retval = 0;
-    ms_ocall_print_string_t * ms;
-    OCALLOC(ms, ms_ocall_print_string_t *, sizeof(*ms));
+    void* frame = sgx_ocget_frame();
 
     if (!str || length <= 0) {
-        OCALL_EXIT();
+        sgx_ocfree_frame(frame);
         return -PAL_ERROR_DENIED;
     }
 
-    ms->ms_str = COPY_TO_USER(str, length);
+    ms_ocall_print_string_t * ms = sgx_ocalloc(sizeof(*ms));
+    ms->ms_str = copy_to_user(str, length);
     ms->ms_length = length;
 
-    retval = SGX_OCALL(OCALL_PRINT_STRING, ms);
-    OCALL_EXIT();
+    retval = sgx_exitless_ocall(OCALL_PRINT_STRING, ms);
+
+    sgx_ocfree_frame(frame);
     return retval;
 }
 
 int ocall_alloc_untrusted (uint64_t size, void ** mem)
 {
     int retval = 0;
-    ms_ocall_alloc_untrusted_t * ms;
+    void* frame = sgx_ocget_frame();
 
-    OCALLOC(ms, ms_ocall_alloc_untrusted_t *, sizeof(*ms));
-
+    ms_ocall_alloc_untrusted_t * ms = sgx_ocalloc(sizeof(*ms));
     ms->ms_size = size;
 
-    retval = SGX_OCALL(OCALL_ALLOC_UNTRUSTED, ms);
+    retval = sgx_exitless_ocall(OCALL_ALLOC_UNTRUSTED, ms);
     if (!retval) {
         if (sgx_is_within_enclave(ms->ms_mem, size)) {
-            OCALL_EXIT();
+            sgx_ocfree_frame(frame);
             return -PAL_ERROR_DENIED;
         }
         *mem = ms->ms_mem;
     }
-    OCALL_EXIT();
+
+    sgx_ocfree_frame(frame);
     return retval;
 }
 
@@ -118,44 +214,44 @@ int ocall_map_untrusted (int fd, uint64_t offset,
                          void ** mem)
 {
     int retval = 0;
-    ms_ocall_map_untrusted_t * ms;
+    void* frame = sgx_ocget_frame();
 
-    OCALLOC(ms, ms_ocall_map_untrusted_t *, sizeof(*ms));
-
+    ms_ocall_map_untrusted_t * ms = sgx_ocalloc(sizeof(*ms));
     ms->ms_fd = fd;
     ms->ms_offset = offset;
     ms->ms_size = size;
     ms->ms_prot = prot;
 
-    retval = SGX_OCALL(OCALL_MAP_UNTRUSTED, ms);
+    retval = sgx_exitless_ocall(OCALL_MAP_UNTRUSTED, ms);
     if (!retval) {
         if (sgx_is_within_enclave(ms->ms_mem, size)) {
-            OCALL_EXIT();
+            sgx_ocfree_frame(frame);
             return -PAL_ERROR_DENIED;
         }
         *mem = ms->ms_mem;
     }
-    OCALL_EXIT();
+
+    sgx_ocfree_frame(frame);
     return retval;
 }
 
 int ocall_unmap_untrusted (const void * mem, uint64_t size)
 {
     int retval = 0;
+    void* frame = sgx_ocget_frame();
 
     if (sgx_is_within_enclave(mem, size)) {
-        OCALL_EXIT();
+        sgx_ocfree_frame(frame);
         return -PAL_ERROR_INVAL;
     }
 
-    ms_ocall_unmap_untrusted_t * ms;
-    OCALLOC(ms, ms_ocall_unmap_untrusted_t *, sizeof(*ms));
-
+    ms_ocall_unmap_untrusted_t * ms = sgx_ocalloc(sizeof(*ms));
     ms->ms_mem  = mem;
     ms->ms_size = size;
 
-    retval = SGX_OCALL(OCALL_UNMAP_UNTRUSTED, ms);
-    OCALL_EXIT();
+    retval = sgx_exitless_ocall(OCALL_UNMAP_UNTRUSTED, ms);
+
+    sgx_ocfree_frame(frame);
     return retval;
 }
 
@@ -163,13 +259,13 @@ int ocall_cpuid (unsigned int leaf, unsigned int subleaf,
                  unsigned int values[4])
 {
     int retval = 0;
-    ms_ocall_cpuid_t * ms;
-    OCALLOC(ms, ms_ocall_cpuid_t *, sizeof(*ms));
+    void* frame = sgx_ocget_frame();
 
+    ms_ocall_cpuid_t * ms = sgx_ocalloc(sizeof(*ms));
     ms->ms_leaf = leaf;
     ms->ms_subleaf = subleaf;
 
-    retval = SGX_OCALL(OCALL_CPUID, ms);
+    retval = sgx_exitless_ocall(OCALL_CPUID, ms);
     if (!retval) {
         values[0] = ms->ms_values[0];
         values[1] = ms->ms_values[1];
@@ -177,42 +273,47 @@ int ocall_cpuid (unsigned int leaf, unsigned int subleaf,
         values[3] = ms->ms_values[3];
     }
 
-    OCALL_EXIT();
+    sgx_ocfree_frame(frame);
     return retval;
 }
 
 int ocall_open (const char * pathname, int flags, unsigned short mode)
 {
     int retval = 0;
-    int len = pathname ? strlen(pathname) + 1 : 0;
-    ms_ocall_open_t * ms;
-    OCALLOC(ms, ms_ocall_open_t *, sizeof(*ms));
+    void* frame = sgx_ocget_frame();
 
-    ms->ms_pathname = COPY_TO_USER(pathname, len);
+    int len = pathname ? strlen(pathname) + 1 : 0;
+
+    ms_ocall_open_t * ms = sgx_ocalloc(sizeof(*ms));
+    ms->ms_pathname = copy_to_user(pathname, len);
     ms->ms_flags = flags;
     ms->ms_mode = mode;
 
-    retval = SGX_OCALL(OCALL_OPEN, ms);
-    OCALL_EXIT();
+    retval = sgx_exitless_ocall(OCALL_OPEN, ms);
+
+    sgx_ocfree_frame(frame);
     return retval;
 }
 
 int ocall_close (int fd)
 {
     int retval = 0;
-    ms_ocall_close_t *ms;
-    OCALLOC(ms, ms_ocall_close_t *, sizeof(*ms));
+    void* frame = sgx_ocget_frame();
 
+    ms_ocall_close_t *ms = sgx_ocalloc(sizeof(*ms));
     ms->ms_fd = fd;
 
-    retval = SGX_OCALL(OCALL_CLOSE, ms);
-    OCALL_EXIT();
+    retval = sgx_exitless_ocall(OCALL_CLOSE, ms);
+
+    sgx_ocfree_frame(frame);
     return retval;
 }
 
 int ocall_read (int fd, void * buf, unsigned int count)
 {
     int retval = 0;
+    void* frame = sgx_ocget_frame();
+
     void * obuf = NULL;
 
     if (count > 4096) {
@@ -221,21 +322,20 @@ int ocall_read (int fd, void * buf, unsigned int count)
             return retval;
     }
 
-    ms_ocall_read_t * ms;
-    OCALLOC(ms, ms_ocall_read_t *, sizeof(*ms));
-
+    ms_ocall_read_t * ms = sgx_ocalloc(sizeof(*ms));
     ms->ms_fd = fd;
     if (obuf)
         ms->ms_buf = obuf;
     else
-        OCALLOC(ms->ms_buf, void *, count);
+        ms->ms_buf = sgx_ocalloc(count);
     ms->ms_count = count;
 
-    retval = SGX_OCALL(OCALL_READ, ms);
+    retval = sgx_exitless_ocall(OCALL_READ, ms);
 
     if (retval > 0)
         memcpy(buf, ms->ms_buf, retval);
-    OCALL_EXIT();
+
+    sgx_ocfree_frame(frame);
 
     if (obuf)
         ocall_unmap_untrusted(obuf, ALLOC_ALIGNUP(count));
@@ -246,6 +346,8 @@ int ocall_read (int fd, void * buf, unsigned int count)
 int ocall_write (int fd, const void * buf, unsigned int count)
 {
     int retval = 0;
+    void* frame = sgx_ocget_frame();
+
     void * obuf = NULL;
 
     if (count > 4096) {
@@ -254,20 +356,19 @@ int ocall_write (int fd, const void * buf, unsigned int count)
             return retval;
     }
 
-    ms_ocall_write_t * ms;
-    OCALLOC(ms, ms_ocall_write_t *, sizeof(*ms));
-
+    ms_ocall_write_t * ms = sgx_ocalloc(sizeof(*ms));
     ms->ms_fd = fd;
     if (obuf) {
         ms->ms_buf = obuf;
         memcpy(obuf, buf, count);
     } else {
-        ms->ms_buf = COPY_TO_USER(buf, count);
+        ms->ms_buf = copy_to_user(buf, count);
     }
     ms->ms_count = count;
 
-    retval = SGX_OCALL(OCALL_WRITE, ms);
-    OCALL_EXIT();
+    retval = sgx_exitless_ocall(OCALL_WRITE, ms);
+
+    sgx_ocfree_frame(frame);
 
     if (obuf)
         ocall_unmap_untrusted(obuf, ALLOC_ALIGNUP(count));
@@ -278,121 +379,132 @@ int ocall_write (int fd, const void * buf, unsigned int count)
 int ocall_fstat (int fd, struct stat * buf)
 {
     int retval = 0;
-    ms_ocall_fstat_t * ms;
-    OCALLOC(ms, ms_ocall_fstat_t *, sizeof(*ms));
+    void* frame = sgx_ocget_frame();
 
+    ms_ocall_fstat_t * ms = sgx_ocalloc(sizeof(*ms));
     ms->ms_fd = fd;
 
-    retval = SGX_OCALL(OCALL_FSTAT, ms);
+    retval = sgx_exitless_ocall(OCALL_FSTAT, ms);
     if (!retval)
         memcpy(buf, &ms->ms_stat, sizeof(struct stat));
-    OCALL_EXIT();
+
+    sgx_ocfree_frame(frame);
     return retval;
 }
 
 int ocall_fionread (int fd)
 {
     int retval = 0;
-    ms_ocall_fionread_t * ms;
-    OCALLOC(ms, ms_ocall_fionread_t *, sizeof(*ms));
+    void* frame = sgx_ocget_frame();
 
+    ms_ocall_fionread_t * ms = sgx_ocalloc(sizeof(*ms));
     ms->ms_fd = fd;
 
-    retval = SGX_OCALL(OCALL_FIONREAD, ms);
-    OCALL_EXIT();
+    retval = sgx_exitless_ocall(OCALL_FIONREAD, ms);
+
+    sgx_ocfree_frame(frame);
     return retval;
 }
 
 int ocall_fsetnonblock (int fd, int nonblocking)
 {
     int retval = 0;
-    ms_ocall_fsetnonblock_t * ms;
-    OCALLOC(ms, ms_ocall_fsetnonblock_t *, sizeof(*ms));
+    void* frame = sgx_ocget_frame();
 
+    ms_ocall_fsetnonblock_t * ms = sgx_ocalloc(sizeof(*ms));
     ms->ms_fd = fd;
     ms->ms_nonblocking = nonblocking;
 
-    retval = SGX_OCALL(OCALL_FSETNONBLOCK, ms);
-    OCALL_EXIT();
+    retval = sgx_exitless_ocall(OCALL_FSETNONBLOCK, ms);
+
+    sgx_ocfree_frame(frame);
     return retval;
 }
 
 int ocall_fchmod (int fd, unsigned short mode)
 {
     int retval = 0;
-    ms_ocall_fchmod_t * ms;
-    OCALLOC(ms, ms_ocall_fchmod_t *, sizeof(*ms));
+    void* frame = sgx_ocget_frame();
 
+    ms_ocall_fchmod_t * ms = sgx_ocalloc(sizeof(*ms));
     ms->ms_fd = fd;
     ms->ms_mode = mode;
 
-    retval = SGX_OCALL(OCALL_FCHMOD, ms);
-    OCALL_EXIT();
+    retval = sgx_exitless_ocall(OCALL_FCHMOD, ms);
+
+    sgx_ocfree_frame(frame);
     return retval;
 }
 
 int ocall_fsync (int fd)
 {
     int retval = 0;
-    ms_ocall_fsync_t * ms;
-    OCALLOC(ms, ms_ocall_fsync_t *, sizeof(*ms));
+    void* frame = sgx_ocget_frame();
 
+    ms_ocall_fsync_t * ms = sgx_ocalloc(sizeof(*ms));
     ms->ms_fd = fd;
 
-    retval = SGX_OCALL(OCALL_FSYNC, ms);
-    OCALL_EXIT();
+    retval = sgx_exitless_ocall(OCALL_FSYNC, ms);
+
+    sgx_ocfree_frame(frame);
     return retval;
 }
 
 int ocall_ftruncate (int fd, uint64_t length)
 {
     int retval = 0;
-    ms_ocall_ftruncate_t * ms;
-    OCALLOC(ms, ms_ocall_ftruncate_t *, sizeof(*ms));
+    void* frame = sgx_ocget_frame();
 
+    ms_ocall_ftruncate_t * ms = sgx_ocalloc(sizeof(*ms));
     ms->ms_fd = fd;
     ms->ms_length = length;
 
-    retval = SGX_OCALL(OCALL_FTRUNCATE, ms);
-    OCALL_EXIT();
+    retval = sgx_exitless_ocall(OCALL_FTRUNCATE, ms);
+
+    sgx_ocfree_frame(frame);
     return retval;
 }
 
 int ocall_mkdir (const char * pathname, unsigned short mode)
 {
     int retval = 0;
-    int len = pathname ? strlen(pathname) + 1 : 0;
-    ms_ocall_mkdir_t * ms;
-    OCALLOC(ms, ms_ocall_mkdir_t *, sizeof(*ms));
+    void* frame = sgx_ocget_frame();
 
-    ms->ms_pathname = COPY_TO_USER(pathname, len);
+    int len = pathname ? strlen(pathname) + 1 : 0;
+
+    ms_ocall_mkdir_t * ms = sgx_ocalloc(sizeof(*ms));
+    ms->ms_pathname = copy_to_user(pathname, len);
     ms->ms_mode = mode;
 
-    retval = SGX_OCALL(OCALL_MKDIR, ms);
-    OCALL_EXIT();
+    retval = sgx_exitless_ocall(OCALL_MKDIR, ms);
+
+    sgx_ocfree_frame(frame);
     return retval;
 }
 
 int ocall_getdents (int fd, struct linux_dirent64 * dirp, unsigned int size)
 {
     int retval = 0;
-    ms_ocall_getdents_t * ms;
-    OCALLOC(ms, ms_ocall_getdents_t *, sizeof(*ms));
+    void* frame = sgx_ocget_frame();
 
+    ms_ocall_getdents_t * ms = sgx_ocalloc(sizeof(*ms));
     ms->ms_fd = fd;
-    ms->ms_dirp = ALLOC_IN_USER(dirp, size);
+    ms->ms_dirp = alloc_in_user(dirp, size);
     ms->ms_size = size;
 
-    retval = SGX_OCALL(OCALL_GETDENTS, ms);
+    retval = sgx_exitless_ocall(OCALL_GETDENTS, ms);
     if (retval > 0)
-        COPY_FROM_USER(dirp, ms->ms_dirp, retval);
-    OCALL_EXIT();
+        copy_from_user(dirp, ms->ms_dirp, retval);
+
+    sgx_ocfree_frame(frame);
     return retval;
 }
 
 int ocall_wake_thread (void * tcs)
 {
-    return SGX_OCALL(OCALL_WAKE_THREAD, tcs);
+    /* NOTE: since this can be executed from within signal handler and sends
+     *       SIGCONT to other enclave threads, cannot use exitless here */
+    return sgx_ocall(OCALL_WAKE_THREAD, tcs);
 }
 
 int ocall_create_process (const char * uri,
@@ -401,19 +513,19 @@ int ocall_create_process (const char * uri,
                           unsigned int * pid)
 {
     int retval = 0;
-    int ulen = uri ? strlen(uri) + 1 : 0;
-    ms_ocall_create_process_t * ms;
-    OCALLOC(ms, ms_ocall_create_process_t *,
-            sizeof(*ms) + sizeof(const char *) * nargs);
+    void* frame = sgx_ocget_frame();
 
-    ms->ms_uri = uri ? COPY_TO_USER(uri, ulen) : NULL;
+    int ulen = uri ? strlen(uri) + 1 : 0;
+
+    ms_ocall_create_process_t * ms = sgx_ocalloc(sizeof(*ms) + sizeof(char *) * nargs);
+    ms->ms_uri = uri ? copy_to_user(uri, ulen) : NULL;
     ms->ms_nargs = nargs;
     for (int i = 0 ; i < nargs ; i++) {
         int len = args[i] ? strlen(args[i]) + 1 : 0;
-        ms->ms_args[i] = args[i] ? COPY_TO_USER(args[i], len) : NULL;
+        ms->ms_args[i] = args[i] ? copy_to_user(args[i], len) : NULL;
     }
 
-    retval = SGX_OCALL(OCALL_CREATE_PROCESS, ms);
+    retval = sgx_exitless_ocall(OCALL_CREATE_PROCESS, ms);
     if (!retval) {
         if (pid)
             *pid = ms->ms_pid;
@@ -421,7 +533,8 @@ int ocall_create_process (const char * uri,
         procfds[1] = ms->ms_proc_fds[1];
         procfds[2] = ms->ms_proc_fds[2];
     }
-    OCALL_EXIT();
+
+    sgx_ocfree_frame(frame);
     return retval;
 }
 
@@ -429,21 +542,22 @@ int ocall_futex (int * futex, int op, int val,
                  const uint64_t * timeout)
 {
     int retval = 0;
-    ms_ocall_futex_t * ms;
-    OCALLOC(ms, ms_ocall_futex_t *, sizeof(*ms));
+    void* frame = sgx_ocget_frame();
 
     if (sgx_is_within_enclave(futex, sizeof(int))) {
-        OCALL_EXIT();
+        sgx_ocfree_frame(frame);
         return -PAL_ERROR_INVAL;
     }
 
+    ms_ocall_futex_t * ms = sgx_ocalloc(sizeof(*ms));
     ms->ms_futex = futex;
     ms->ms_op = op;
     ms->ms_val = val;
     ms->ms_timeout = timeout ? *timeout : OCALL_NO_TIMEOUT;
 
-    retval = SGX_OCALL(OCALL_FUTEX, ms);
-    OCALL_EXIT();
+    retval = sgx_exitless_ocall(OCALL_FUTEX, ms);
+
+    sgx_ocfree_frame(frame);
     return retval;
 }
 
@@ -451,19 +565,20 @@ int ocall_socketpair (int domain, int type, int protocol,
                       int sockfds[2])
 {
     int retval = 0;
-    ms_ocall_socketpair_t * ms;
-    OCALLOC(ms, ms_ocall_socketpair_t *, sizeof(*ms));
+    void* frame = sgx_ocget_frame();
 
+    ms_ocall_socketpair_t * ms = sgx_ocalloc(sizeof(*ms));
     ms->ms_domain = domain;
     ms->ms_type = type;
     ms->ms_protocol = protocol;
 
-    retval = SGX_OCALL(OCALL_SOCKETPAIR, ms);
+    retval = sgx_exitless_ocall(OCALL_SOCKETPAIR, ms);
     if (!retval) {
         sockfds[0] = ms->ms_sockfds[0];
         sockfds[1] = ms->ms_sockfds[1];
     }
-    OCALL_EXIT();
+
+    sgx_ocfree_frame(frame);
     return retval;
 }
 
@@ -472,33 +587,35 @@ int ocall_sock_listen (int domain, int type, int protocol,
                        struct sockopt * sockopt)
 {
     int retval = 0;
-    unsigned int bind_len = *addrlen;
-    ms_ocall_sock_listen_t * ms;
-    OCALLOC(ms, ms_ocall_sock_listen_t *, sizeof(*ms));
+    void* frame = sgx_ocget_frame();
 
+    unsigned int bind_len = *addrlen;
+
+    ms_ocall_sock_listen_t * ms = sgx_ocalloc(sizeof(*ms));
     ms->ms_domain = domain;
     ms->ms_type = type;
     ms->ms_protocol = protocol;
-    ms->ms_addr = COPY_TO_USER(addr, bind_len);
+    ms->ms_addr = copy_to_user(addr, bind_len);
     ms->ms_addrlen = bind_len;
 
-    retval = SGX_OCALL(OCALL_SOCK_LISTEN, ms);
+    retval = sgx_exitless_ocall(OCALL_SOCK_LISTEN, ms);
     if (retval >= 0) {
         if (addrlen && (
             sgx_is_within_enclave(ms->ms_addr, bind_len) ||
             ms->ms_addrlen > bind_len)) {
-            OCALL_EXIT();
+            sgx_ocfree_frame(frame);
             return -PAL_ERROR_DENIED;
         }
 
         if (addr) {
-            COPY_FROM_USER(addr, ms->ms_addr, ms->ms_addrlen);
+            copy_from_user(addr, ms->ms_addr, ms->ms_addrlen);
             *addrlen = ms->ms_addrlen;
         }
         if (sockopt)
             *sockopt = ms->ms_sockopt;
     }
-    OCALL_EXIT();
+
+    sgx_ocfree_frame(frame);
     return retval;
 }
 
@@ -506,30 +623,32 @@ int ocall_sock_accept (int sockfd, struct sockaddr * addr,
                        unsigned int * addrlen, struct sockopt * sockopt)
 {
     int retval = 0;
-    unsigned int len = addrlen ? *addrlen : 0;
-    ms_ocall_sock_accept_t * ms;
-    OCALLOC(ms, ms_ocall_sock_accept_t *, sizeof(*ms));
+    void* frame = sgx_ocget_frame();
 
+    unsigned int len = addrlen ? *addrlen : 0;
+
+    ms_ocall_sock_accept_t * ms = sgx_ocalloc(sizeof(*ms));
     ms->ms_sockfd = sockfd;
-    ms->ms_addr = COPY_TO_USER(addr, len);
+    ms->ms_addr = copy_to_user(addr, len);
     ms->ms_addrlen = len;
 
-    retval = SGX_OCALL(OCALL_SOCK_ACCEPT, ms);
+    retval = sgx_exitless_ocall(OCALL_SOCK_ACCEPT, ms);
     if (retval >= 0) {
         if (len && (sgx_is_within_enclave(ms->ms_addr, len) ||
                     ms->ms_addrlen > len)) {
-            OCALL_EXIT();
+            sgx_ocfree_frame(frame);
             return -PAL_ERROR_DENIED;
         }
 
         if (addr) {
-            COPY_FROM_USER(addr, ms->ms_addr, ms->ms_addrlen);
+            copy_from_user(addr, ms->ms_addr, ms->ms_addrlen);
             *addrlen = ms->ms_addrlen;
         }
         if (sockopt)
             *sockopt = ms->ms_sockopt;
     }
-    OCALL_EXIT();
+
+    sgx_ocfree_frame(frame);
     return retval;
 }
 
@@ -540,36 +659,38 @@ int ocall_sock_connect (int domain, int type, int protocol,
                         unsigned int * bind_addrlen, struct sockopt * sockopt)
 {
     int retval = 0;
-    unsigned int bind_len = bind_addrlen ? *bind_addrlen : 0;
-    ms_ocall_sock_connect_t * ms;
-    OCALLOC(ms, ms_ocall_sock_connect_t *, sizeof(*ms));
+    void* frame = sgx_ocget_frame();
 
+    unsigned int bind_len = bind_addrlen ? *bind_addrlen : 0;
+
+    ms_ocall_sock_connect_t * ms = sgx_ocalloc(sizeof(*ms));
     ms->ms_domain = domain;
     ms->ms_type = type;
     ms->ms_protocol = protocol;
-    ms->ms_addr = COPY_TO_USER(addr, addrlen);
+    ms->ms_addr = copy_to_user(addr, addrlen);
     ms->ms_addrlen = addrlen;
-    ms->ms_bind_addr = bind_addr ? COPY_TO_USER(bind_addr, bind_len) : NULL;
+    ms->ms_bind_addr = bind_addr ? copy_to_user(bind_addr, bind_len) : NULL;
     ms->ms_bind_addrlen = bind_len;
 
-    retval = SGX_OCALL(OCALL_SOCK_CONNECT, ms);
+    retval = sgx_exitless_ocall(OCALL_SOCK_CONNECT, ms);
     if (retval >= 0) {
         if (bind_len && (
             sgx_is_within_enclave(ms->ms_bind_addr, bind_len) ||
             ms->ms_bind_addrlen > bind_len)) {
-            OCALL_EXIT();
+            sgx_ocfree_frame(frame);
             return -PAL_ERROR_DENIED;
         }
 
         if (bind_addr) {
-            COPY_FROM_USER(bind_addr, ms->ms_bind_addr,
+            copy_from_user(bind_addr, ms->ms_bind_addr,
                            ms->ms_bind_addrlen);
             *bind_addrlen = ms->ms_bind_addrlen;
         }
         if (sockopt)
             *sockopt = ms->ms_sockopt;
     }
-    OCALL_EXIT();
+
+    sgx_ocfree_frame(frame);
     return retval;
 }
 
@@ -577,30 +698,32 @@ int ocall_sock_recv (int sockfd, void * buf, unsigned int count,
                      struct sockaddr * addr, unsigned int * addrlen)
 {
     int retval = 0;
-    unsigned int len = addrlen ? *addrlen : 0;
-    ms_ocall_sock_recv_t * ms;
-    OCALLOC(ms, ms_ocall_sock_recv_t *, sizeof(*ms));
+    void* frame = sgx_ocget_frame();
 
+    unsigned int len = addrlen ? *addrlen : 0;
+
+    ms_ocall_sock_recv_t * ms = sgx_ocalloc(sizeof(*ms));
     ms->ms_sockfd = sockfd;
-    ms->ms_buf = ALLOC_IN_USER(buf, count);
+    ms->ms_buf = alloc_in_user(buf, count);
     ms->ms_count = count;
-    ms->ms_addr = addr ? ALLOC_IN_USER(addr, len) : NULL;
+    ms->ms_addr = addr ? alloc_in_user(addr, len) : NULL;
     ms->ms_addrlen = len;
 
-    retval = SGX_OCALL(OCALL_SOCK_RECV, ms);
+    retval = sgx_exitless_ocall(OCALL_SOCK_RECV, ms);
     if (retval >= 0) {
         if (len && (sgx_is_within_enclave(ms->ms_addr, len) ||
                     ms->ms_addrlen > len)) {
-            OCALL_EXIT();
+            sgx_ocfree_frame(frame);
             return -PAL_ERROR_DENIED;
         }
 
-        COPY_FROM_USER(buf, ms->ms_buf, retval);
-        COPY_FROM_USER(addr, ms->ms_addr, ms->ms_addrlen);
+        copy_from_user(buf, ms->ms_buf, retval);
+        copy_from_user(addr, ms->ms_addr, ms->ms_addrlen);
         if (addrlen)
             *addrlen = ms->ms_addrlen;
     }
-    OCALL_EXIT();
+
+    sgx_ocfree_frame(frame);
     return retval;
 }
 
@@ -608,17 +731,18 @@ int ocall_sock_send (int sockfd, const void * buf, unsigned int count,
                      const struct sockaddr * addr, unsigned int addrlen)
 {
     int retval = 0;
-    ms_ocall_sock_send_t * ms;
-    OCALLOC(ms, ms_ocall_sock_send_t *, sizeof(*ms));
+    void* frame = sgx_ocget_frame();
 
+    ms_ocall_sock_send_t * ms = sgx_ocalloc(sizeof(*ms));
     ms->ms_sockfd = sockfd;
-    ms->ms_buf = COPY_TO_USER(buf, count);
+    ms->ms_buf = copy_to_user(buf, count);
     ms->ms_count = count;
-    ms->ms_addr = addr ? COPY_TO_USER(addr, addrlen) : NULL;
+    ms->ms_addr = addr ? copy_to_user(addr, addrlen) : NULL;
     ms->ms_addrlen = addrlen;
 
-    retval = SGX_OCALL(OCALL_SOCK_SEND, ms);
-    OCALL_EXIT();
+    retval = sgx_exitless_ocall(OCALL_SOCK_SEND, ms);
+
+    sgx_ocfree_frame(frame);
     return retval;
 }
 
@@ -626,28 +750,29 @@ int ocall_sock_recv_fd (int sockfd, void * buf, unsigned int count,
                         unsigned int * fds, unsigned int * nfds)
 {
     int retval = 0;
-    ms_ocall_sock_recv_fd_t * ms;
-    OCALLOC(ms, ms_ocall_sock_recv_fd_t *, sizeof(*ms));
+    void* frame = sgx_ocget_frame();
 
+    ms_ocall_sock_recv_fd_t * ms = sgx_ocalloc(sizeof(*ms));
     ms->ms_sockfd = sockfd;
-    ms->ms_buf = ALLOC_IN_USER(buf, count);
+    ms->ms_buf = alloc_in_user(buf, count);
     ms->ms_count = count;
-    ms->ms_fds = fds ? ALLOC_IN_USER(fds, sizeof(int) * (*nfds)) : NULL;
+    ms->ms_fds = fds ? alloc_in_user(fds, sizeof(int) * (*nfds)) : NULL;
     ms->ms_nfds = *nfds;
 
-    retval = SGX_OCALL(OCALL_SOCK_RECV_FD, ms);
+    retval = sgx_exitless_ocall(OCALL_SOCK_RECV_FD, ms);
     if (retval >= 0) {
         if (sgx_is_within_enclave(ms->ms_fds, sizeof(int) * (*nfds)) ||
             ms->ms_nfds > (*nfds)) {
-            OCALL_EXIT();
+            sgx_ocfree_frame(frame);
             return -PAL_ERROR_DENIED;
         }
 
-        COPY_FROM_USER(buf, ms->ms_buf, retval);
-        COPY_FROM_USER(fds, ms->ms_fds, sizeof(int) * ms->ms_nfds);
+        copy_from_user(buf, ms->ms_buf, retval);
+        copy_from_user(fds, ms->ms_fds, sizeof(int) * ms->ms_nfds);
         *nfds = ms->ms_nfds;
     }
-    OCALL_EXIT();
+
+    sgx_ocfree_frame(frame);
     return retval;
 }
 
@@ -655,17 +780,18 @@ int ocall_sock_send_fd (int sockfd, const void * buf, unsigned int count,
                         const unsigned int * fds, unsigned int nfds)
 {
     int retval = 0;
-    ms_ocall_sock_send_fd_t * ms;
-    OCALLOC(ms, ms_ocall_sock_send_fd_t *, sizeof(*ms));
+    void* frame = sgx_ocget_frame();
 
+    ms_ocall_sock_send_fd_t * ms = sgx_ocalloc(sizeof(*ms));
     ms->ms_sockfd = sockfd;
-    ms->ms_buf = COPY_TO_USER(buf, count);
+    ms->ms_buf = copy_to_user(buf, count);
     ms->ms_count = count;
-    ms->ms_fds = fds ? COPY_TO_USER(fds, sizeof(int) * nfds) : NULL;
+    ms->ms_fds = fds ? copy_to_user(fds, sizeof(int) * nfds) : NULL;
     ms->ms_nfds = nfds;
 
-    retval = SGX_OCALL(OCALL_SOCK_SEND_FD, ms);
-    OCALL_EXIT();
+    retval = sgx_exitless_ocall(OCALL_SOCK_SEND_FD, ms);
+
+    sgx_ocfree_frame(frame);
     return retval;
 }
 
@@ -673,121 +799,134 @@ int ocall_sock_setopt (int sockfd, int level, int optname,
                        const void * optval, unsigned int optlen)
 {
     int retval = 0;
-    ms_ocall_sock_setopt_t * ms;
-    OCALLOC(ms, ms_ocall_sock_setopt_t *, sizeof(*ms));
+    void* frame = sgx_ocget_frame();
 
+    ms_ocall_sock_setopt_t * ms = sgx_ocalloc(sizeof(*ms));
     ms->ms_sockfd = sockfd;
     ms->ms_level = level;
     ms->ms_optname = optname;
-    ms->ms_optval = COPY_TO_USER(optval, optlen);
+    ms->ms_optval = copy_to_user(optval, optlen);
     ms->ms_optlen = optlen;
 
-    retval = SGX_OCALL(OCALL_SOCK_SETOPT, ms);
-    OCALL_EXIT();
+    retval = sgx_exitless_ocall(OCALL_SOCK_SETOPT, ms);
+
+    sgx_ocfree_frame(frame);
     return retval;
 }
 
 int ocall_sock_shutdown (int sockfd, int how)
 {
     int retval = 0;
-    ms_ocall_sock_shutdown_t * ms;
-    OCALLOC(ms, ms_ocall_sock_shutdown_t *, sizeof(*ms));
+    void* frame = sgx_ocget_frame();
 
+    ms_ocall_sock_shutdown_t * ms = sgx_ocalloc(sizeof(*ms));
     ms->ms_sockfd = sockfd;
     ms->ms_how = how;
 
-    retval = SGX_OCALL(OCALL_SOCK_SHUTDOWN, ms);
-    OCALL_EXIT();
+    retval = sgx_exitless_ocall(OCALL_SOCK_SHUTDOWN, ms);
+
+    sgx_ocfree_frame(frame);
     return retval;
 }
 
 int ocall_gettime (unsigned long * microsec)
 {
     int retval = 0;
-    ms_ocall_gettime_t * ms;
-    OCALLOC(ms, ms_ocall_gettime_t *, sizeof(*ms));
+    void* frame = sgx_ocget_frame();
 
-    retval = SGX_OCALL(OCALL_GETTIME, ms);
+    ms_ocall_gettime_t * ms = sgx_ocalloc(sizeof(*ms));
+
+    retval = sgx_exitless_ocall(OCALL_GETTIME, ms);
     if (!retval)
         *microsec = ms->ms_microsec;
-    OCALL_EXIT();
+
+    sgx_ocfree_frame(frame);
     return retval;
 }
 
 int ocall_sleep (unsigned long * microsec)
 {
     int retval = 0;
-    ms_ocall_sleep_t * ms;
-    OCALLOC(ms, ms_ocall_sleep_t *, sizeof(*ms));
+    void* frame = sgx_ocget_frame();
 
+    ms_ocall_sleep_t * ms = sgx_ocalloc(sizeof(*ms));
     ms->ms_microsec = microsec ? *microsec : 0;
 
-    retval = SGX_OCALL(OCALL_SLEEP, ms);
+    retval = sgx_ocall(OCALL_SLEEP, ms);
     if (microsec) {
         if (!retval)
             *microsec = 0;
         else if (retval == -EINTR)
             *microsec = ms->ms_microsec;
     }
-    OCALL_EXIT();
+
+    sgx_ocfree_frame(frame);
     return retval;
 }
 
 int ocall_poll (struct pollfd * fds, int nfds, uint64_t * timeout)
 {
     int retval = 0;
-    ms_ocall_poll_t * ms;
-    OCALLOC(ms, ms_ocall_poll_t *, sizeof(*ms));
+    void* frame = sgx_ocget_frame();
 
-    ms->ms_fds = COPY_TO_USER(fds, sizeof(struct pollfd) * nfds);
+    ms_ocall_poll_t * ms = sgx_ocalloc(sizeof(*ms));
+    ms->ms_fds = copy_to_user(fds, sizeof(struct pollfd) * nfds);
     ms->ms_nfds = nfds;
     ms->ms_timeout = timeout ? *timeout : OCALL_NO_TIMEOUT;
 
-    retval = SGX_OCALL(OCALL_POLL, ms);
+    retval = sgx_exitless_ocall(OCALL_POLL, ms);
     if (retval == -EINTR && timeout)
         *timeout = ms->ms_timeout;
     if (retval >= 0)
-        COPY_FROM_USER(fds, ms->ms_fds, sizeof(struct pollfd) * nfds);
-    OCALL_EXIT();
+        copy_from_user(fds, ms->ms_fds, sizeof(struct pollfd) * nfds);
+
+    sgx_ocfree_frame(frame);
     return retval;
 }
 
 int ocall_rename (const char * oldpath, const char * newpath)
 {
     int retval = 0;
+    void* frame = sgx_ocget_frame();
+
     int oldlen = oldpath ? strlen(oldpath) + 1 : 0;
     int newlen = newpath ? strlen(newpath) + 1 : 0;
-    ms_ocall_rename_t * ms;
-    OCALLOC(ms, ms_ocall_rename_t *, sizeof(*ms));
 
-    ms->ms_oldpath = COPY_TO_USER(oldpath, oldlen);
-    ms->ms_newpath = COPY_TO_USER(newpath, newlen);
+    ms_ocall_rename_t * ms = sgx_ocalloc(sizeof(*ms));
+    ms->ms_oldpath = copy_to_user(oldpath, oldlen);
+    ms->ms_newpath = copy_to_user(newpath, newlen);
 
-    retval = SGX_OCALL(OCALL_RENAME, ms);
-    OCALL_EXIT();
+    retval = sgx_exitless_ocall(OCALL_RENAME, ms);
+
+    sgx_ocfree_frame(frame);
     return retval;
 }
 
 int ocall_delete (const char * pathname)
 {
     int retval = 0;
+    void* frame = sgx_ocget_frame();
+
     int len = pathname ? strlen(pathname) + 1 : 0;
-    ms_ocall_delete_t * ms;
-    OCALLOC(ms, ms_ocall_delete_t *, sizeof(*ms));
 
-    ms->ms_pathname = COPY_TO_USER(pathname, len);
+    ms_ocall_delete_t * ms = sgx_ocalloc(sizeof(*ms));
+    ms->ms_pathname = copy_to_user(pathname, len);
 
-    retval = SGX_OCALL(OCALL_DELETE, ms);
-    OCALL_EXIT();
+    retval = sgx_exitless_ocall(OCALL_DELETE, ms);
+
+    sgx_ocfree_frame(frame);
     return retval;
 }
 
 int ocall_load_debug(const char * command)
 {
     int retval = 0;
+    void* frame = sgx_ocget_frame();
+
     int len = strlen(command);
-    const char * ms = COPY_TO_USER(command, len + 1);
-    retval = SGX_OCALL(OCALL_LOAD_DEBUG, (void *) ms);
-    OCALL_EXIT();
+    const char * ms = copy_to_user(command, len + 1);
+    retval = sgx_exitless_ocall(OCALL_LOAD_DEBUG, (void *) ms);
+
+    sgx_ocfree_frame(frame);
     return retval;
 }

--- a/Pal/src/host/Linux-SGX/enclave_rpcqueue.c
+++ b/Pal/src/host/Linux-SGX/enclave_rpcqueue.c
@@ -1,0 +1,57 @@
+#include <assert.h>
+#include "rpcqueue.h"
+
+void rpc_spin_lock(struct atomic_int* p) {
+    while (atomic_cmpxchg(p, SPIN_UNLOCKED, SPIN_LOCKED)) {
+        while (atomic_read(p) == SPIN_LOCKED)
+            cpu_relax();
+    }
+}
+
+/* returns 0 if acquired lock; 1 if timed out (counted as # of iterations) */
+int rpc_spin_lock_timeout(struct atomic_int* p, uint64_t iterations) {
+    while (atomic_cmpxchg(p, SPIN_UNLOCKED, SPIN_LOCKED)) {
+        while (atomic_read(p) == SPIN_LOCKED) {
+            if (iterations-- == 0)  return 1;
+            cpu_relax();
+        }
+    }
+    return 0;
+}
+
+void rpc_spin_unlock(struct atomic_int* p) {
+    atomic_set(p, SPIN_UNLOCKED);
+}
+
+rpc_request_t* rpc_enqueue(rpc_queue_t* q, rpc_request_t* req) {
+    rpc_spin_lock(&q->lock);
+
+    if (q->rear - q->front >= RPC_QUEUE_SIZE) {
+        rpc_spin_unlock(&q->lock);
+        return NULL;
+    }
+
+    assert(q->q[q->rear % RPC_QUEUE_SIZE] == NULL);
+    q->q[q->rear % RPC_QUEUE_SIZE] = req;
+    q->rear++;
+
+    rpc_spin_unlock(&q->lock);
+    return req;
+}
+
+rpc_request_t* rpc_dequeue(rpc_queue_t* q) {
+    rpc_spin_lock(&q->lock);
+
+    if (q->front == q->rear) {
+        rpc_spin_unlock(&q->lock);
+        return NULL;
+    }
+
+    assert(q->q[q->front % RPC_QUEUE_SIZE] != NULL);
+    rpc_request_t* req = q->q[q->front % RPC_QUEUE_SIZE];
+    q->q[q->front % RPC_QUEUE_SIZE] = NULL;
+    q->front++;
+
+    rpc_spin_unlock(&q->lock);
+    return req;
+}

--- a/Pal/src/host/Linux-SGX/rpcqueue.h
+++ b/Pal/src/host/Linux-SGX/rpcqueue.h
@@ -1,0 +1,82 @@
+/*
+ * RPC threads are helper threads that run in untrusted mode alongside
+ * enclave threads. RPC threads issue system calls on behalf of enclave
+ * threads. This allows "exitless" design when app threads never leave
+ * the enclave (except for a few syscalls where there is no benefit).
+ *
+ * "Exitless" design alleviates expensive OCALLs/ECALLs. This was first
+ * proposed by SCONE (by Arnautov et al at OSDI 2016) and by Eleos
+ * (by Orenbach et al at EuroSys 2017).
+ *
+ * Brief description: user must specify "sgx.rpc_thread_num = 2" in manifest
+ * to create two RPC threads. If user specifies "0" or omits this directive,
+ * then no RPC threads are created and all syscalls perform an enclave exit
+ * (as in previous versions of Graphene-SGX).
+ *
+ * All enclave and RPC threads work on a single shared RPC queue (global
+ * variable `g_rpc_queue`). To issue syscall, enclave thread enqueues syscall
+ * request in the queue and spins waiting for result. RPC threads spin
+ * waiting for syscall requests; when request comes, first lucky RPC thread
+ * grabs request, issues syscall to OS, and notifies enclave thread by
+ * releasing the request lock. RPC queue is implemented as a FIFO ring buffer
+ * with one global lock.
+ *
+ * RPC queue can have up to RPC_QUEUE_SIZE requests simultaneously. All
+ * requests are allocated on the untrusted stack of the enclave thread;
+ * enclave thread owns its requests and pops them off stack when done with
+ * the system call. After enqueuing the request, enclave thread first spins
+ * for some time in hope the system call returns immediately (fast path),
+ * then sleeps waiting on futex (slow path, useful for blocking syscalls).
+ *
+ * NOTE: number of created RPC threads must match max number of simultaneous
+ * enclave threads. If there are more RPC threads, CPU time is wasted. If there
+ * are less, some enclave threads may starve, especially if there are many
+ * blocking syscalls by other enclave threads.
+ *
+ * Prototype code was written by Meni Orenbach and adapted to Graphene-SGX
+ * by Dmitrii Kuvaiskii.
+ */
+#ifndef QUEUE_H_
+#define QUEUE_H_
+
+#include <stdint.h>
+#include <stddef.h>
+#include <atomic.h>
+
+#define RPC_QUEUE_SIZE 1024         /* max # of requests in RPC queue */
+#define MAX_RPC_THREADS 64          /* max number of RPC threads */
+#define RPC_SPIN_LOCK_TIMEOUT 4096  /* # of iterations to spin before sleeping */
+
+#define SPIN_UNLOCKED           0
+#define SPIN_LOCKED             1
+
+/* RPC requests use spinlocks + futexes, based on Futexes are Tricky;
+ * Note that ordering is important due to atomic-dec in unlock logic */
+#define REQ_UNLOCKED            SPIN_UNLOCKED
+#define REQ_LOCKED_NO_WAITERS   SPIN_LOCKED
+#define REQ_LOCKED_WITH_WAITERS (SPIN_LOCKED+1)
+
+typedef struct {
+    int result;
+    int ocall_index;
+    void* buffer;
+    struct atomic_int lock;  /* can be REQ_UNLOCKED/LOCKED/WAITERS */
+} rpc_request_t;
+
+typedef struct rpc_queue {
+    uint64_t front, rear;
+    rpc_request_t* q[RPC_QUEUE_SIZE]; /* queue of syscall requests */
+    int rpc_threads[MAX_RPC_THREADS]; /* RPC threads (thread IDs) */
+    volatile size_t rpc_threads_num;  /* number of RPC threads */
+    struct atomic_int lock;           /* global lock for enclave and RPC threads */
+} rpc_queue_t;
+
+extern rpc_queue_t* g_rpc_queue;  /* global RPC queue */
+
+void rpc_spin_lock(struct atomic_int* p);
+int  rpc_spin_lock_timeout(struct atomic_int* p, uint64_t iterations);
+void rpc_spin_unlock(struct atomic_int* p);
+rpc_request_t* rpc_enqueue(rpc_queue_t* q, rpc_request_t* req);
+rpc_request_t* rpc_dequeue(rpc_queue_t* q);
+
+#endif /* QUEUE_H_ */

--- a/Pal/src/host/Linux-SGX/sgx_api.h
+++ b/Pal/src/host/Linux-SGX/sgx_api.h
@@ -24,8 +24,9 @@
 
 int sgx_ocall (unsigned long code, void * ms);
 
+void * sgx_ocget_frame (void);
 void * sgx_ocalloc (uint64_t size);
-void sgx_ocfree (void);
+void sgx_ocfree_frame (void * frame);
 
 bool sgx_is_within_enclave (const void * addr, uint64_t size);
 

--- a/Pal/src/host/Linux-SGX/sgx_enclave.c
+++ b/Pal/src/host/Linux-SGX/sgx_enclave.c
@@ -6,6 +6,7 @@
 #include "sgx_internal.h"
 #include "pal_security.h"
 #include "pal_linux_error.h"
+#include "rpcqueue.h"
 
 #include <asm/mman.h>
 #include <asm/ioctls.h>
@@ -13,8 +14,10 @@
 #include <linux/fs.h>
 #include <linux/in.h>
 #include <linux/in6.h>
+#include <linux/futex.h>
 #include <math.h>
 #include <asm/errno.h>
+#include <linux/signal.h>
 
 #ifndef SOL_IPV6
 # define SOL_IPV6 41
@@ -30,6 +33,14 @@ static int sgx_ocall_exit(void* prv)
         SGX_DBG(DBG_E, "Saturation error in exit code %d, getting rounded down to %u\n", rv, (uint8_t) rv);
         rv = 255;
     }
+
+    /* kill all app threads if no more enclave threads */
+    int num_enclave_threads = unmap_tcs();
+    if (num_enclave_threads <= 0) {
+        INLINE_SYSCALL(exit_group, 1, rv);
+        return 0;
+    }
+
     INLINE_SYSCALL(exit, 1, (int)rv);
     return 0;
 }
@@ -220,7 +231,7 @@ static int sgx_ocall_getdents(void * pms)
 static int sgx_ocall_wake_thread(void * pms)
 {
     ODEBUG(OCALL_WAKE_THREAD, pms);
-    return pms ? interrupt_thread(pms) : clone_thread();
+    return pms ? interrupt_thread(pms) : clone_thread(NULL);
 }
 
 int sgx_create_process (const char * uri,
@@ -709,12 +720,82 @@ sgx_ocall_fn_t ocall_table[OCALL_NR] = {
 
 #define EDEBUG(code, ms) do {} while (0)
 
+rpc_queue_t* g_rpc_queue = NULL; /* pointer to untrusted queue */
+
+int sigfillset(sigset_t *set);
+int sigdelset(sigset_t *set, int signo);
+int pthread_sigmask(int how, const sigset_t *restrict set, sigset_t *restrict oset);
+
+static void* rpc_thread_loop(void* encl) {
+    long mytid = INLINE_SYSCALL(gettid, 0);
+
+    /* this RPC thread needs current_enclave for some sgx_ocall's */
+    current_enclave = (struct pal_enclave *)encl;
+
+    /* block all signals except SIGUSR2 for RPC thread */
+    sigset_t mask;
+    sigfillset(&mask);
+    sigdelset(&mask, SIGUSR2);
+    pthread_sigmask(SIG_SETMASK, &mask, NULL);
+
+    rpc_spin_lock(&g_rpc_queue->lock);
+    g_rpc_queue->rpc_threads[g_rpc_queue->rpc_threads_num] = mytid;
+    g_rpc_queue->rpc_threads_num++;
+    rpc_spin_unlock(&g_rpc_queue->lock);
+
+    while (1) {
+        rpc_request_t* req = rpc_dequeue(g_rpc_queue);
+        if (!req) {
+            cpu_relax();
+            continue;
+        }
+
+        /* call actual function and notify awaiting enclave thread when done */
+        typedef int (*bridge_fn_t)(const void*);
+        bridge_fn_t bridge = (bridge_fn_t)(ocall_table[req->ocall_index]);
+        req->result = bridge(req->buffer);
+
+        /* this code is based on Mutex 2 from Futexes are Tricky */
+        if (!atomic_dec_and_test(&req->lock)) {
+            /* new value of lock is not REQ_UNLOCKED (0), that means
+             * old value was REQ_LOCKED_WITH_WAITERS (2) -> must wake waiters */
+            atomic_set(&req->lock, REQ_UNLOCKED);
+            int ret = INLINE_SYSCALL(futex, 6, (int*)&req->lock.counter,
+                         FUTEX_WAKE_PRIVATE, 1, NULL, NULL, 0);
+            if (ret == -1)
+                SGX_DBG(DBG_E, "RPC thread failed to wake up enclave thread\n");
+        }
+    }
+
+    /* NOTREACHED */
+    return 0;
+}
+
+static void start_rpc(size_t num_of_threads) {
+    g_rpc_queue = (rpc_queue_t*) INLINE_SYSCALL(mmap, 6, NULL, sizeof(rpc_queue_t),
+            PROT_READ|PROT_WRITE, MAP_ANONYMOUS|MAP_PRIVATE, -1, 0);
+
+    for (size_t i = 0; i < num_of_threads; i++)
+        clone_thread(rpc_thread_loop);
+
+    while (g_rpc_queue->rpc_threads_num != current_enclave->rpc_thread_num) {
+        /* wait until all RPC threads are initialized in rpc_thread_loop */
+        INLINE_SYSCALL(sched_yield, 0);
+    }
+}
+
 int ecall_enclave_start (const char ** arguments, const char ** environments)
 {
+    g_rpc_queue = NULL;
+
+    if (current_enclave->rpc_thread_num > 0)
+        start_rpc(current_enclave->rpc_thread_num);
+
     ms_ecall_enclave_start_t ms;
     ms.ms_arguments = arguments;
     ms.ms_environments = environments;
     ms.ms_sec_info = PAL_SEC();
+    ms.rpc_queue = g_rpc_queue;
     EDEBUG(ECALL_ENCLAVE_START, &ms);
     return sgx_ecall(ECALL_ENCLAVE_START, &ms);
 }

--- a/Pal/src/host/Linux-SGX/sgx_internal.h
+++ b/Pal/src/host/Linux-SGX/sgx_internal.h
@@ -67,6 +67,7 @@ struct pal_enclave {
     unsigned long baseaddr;
     unsigned long size;
     unsigned long thread_num;
+    unsigned long rpc_thread_num;
     unsigned long ssaframesize;
 
     /* files */
@@ -117,11 +118,11 @@ void double_async_exit (void);
 #endif
 
 int interrupt_thread (void * tcs);
-int clone_thread (void);
+int clone_thread (void *(*start_routine)(void*));
 
 void create_tcs_mapper (void * tcs_base, unsigned int thread_num);
 void map_tcs (unsigned int tid);
-void unmap_tcs (void);
+int unmap_tcs (void);
 
 extern __thread struct pal_enclave * current_enclave;
 

--- a/Pal/src/host/Linux-SGX/sgx_rpcqueue.c
+++ b/Pal/src/host/Linux-SGX/sgx_rpcqueue.c
@@ -1,0 +1,4 @@
+#include "rpcqueue.h"
+
+/* duplicates functionality outside of enclave */
+#include "enclave_rpcqueue.c"

--- a/Pal/src/host/Linux-SGX/sgx_thread.c
+++ b/Pal/src/host/Linux-SGX/sgx_thread.c
@@ -12,6 +12,7 @@
 
 #include "sgx_enclave.h"
 #include "debugger/sgx_gdb.h"
+#include "rpcqueue.h"
 
 __thread struct pal_enclave * current_enclave;
 __thread sgx_arch_tcs_t * current_tcs;
@@ -48,17 +49,27 @@ void map_tcs (unsigned int tid)
         }
 }
 
-void unmap_tcs (void)
+int unmap_tcs (void)
 {
     int index = current_tcs - enclave_tcs;
     struct thread_map * map = &enclave_thread_map[index];
     if (index >= enclave_thread_num)
-        return;
+        return 0;
     SGX_DBG(DBG_I, "unmap TCS at 0x%08lx\n", map->tcs);
     current_tcs = NULL;
     ((struct enclave_dbginfo *) DBGINFO_ADDR)->thread_tids[index] = 0;
     map->tid = 0;
     map->tcs = NULL;
+
+    /* return number of live enclave threads */
+    static struct atomic_int exclusion = { .counter = 0 };
+    rpc_spin_lock(&exclusion);
+    int res = 0;
+    for (int i = 0; i < enclave_thread_num; i++)
+        if (enclave_thread_map[i].tid)
+            res++;
+    rpc_spin_unlock(&exclusion);
+    return res;
 }
 
 static void * thread_start (void * arg)
@@ -77,10 +88,14 @@ static void * thread_start (void * arg)
     return NULL;
 }
 
-int clone_thread (void)
+int clone_thread (void *(*start_routine)(void*))
 {
     pthread_t thread;
-    return pthread_create(&thread, NULL, thread_start, current_enclave);
+
+    if (!start_routine)
+        start_routine = thread_start;
+
+    return pthread_create(&thread, NULL, start_routine, current_enclave);
 }
 
 int interrupt_thread (void * tcs)


### PR DESCRIPTION
This PR succeeds PR #235.

This PR adds the ability to invoke system calls in an "exitless" fashion (aka asynchronously), similar to solutions from [Eleos by Orenbach](https://dl.acm.org/citation.cfm?id=3064219) and [SCONE by Arnautov et al](https://dl.acm.org/citation.cfm?id=3026930).

New directive `sgx.rpc_thread_num = X` in the manifest instructs Graphene-SGX to create X outside-enclave RPC threads that spin-wait for syscalls (and any OCALLs in general) on a shared queue. In-enclave threads do not exit the enclave now but instead enqueue the syscall in the queue and wait for it to be processed by an RPC thread. Not to waste CPU resources, enclave threads first spin (in the hope syscall will return immediately) and then sleep on a futex.

This PR reserves the SIGUSR2 signal for internal usage. In particular, when a signal arrives to the enclave application (e.g. SIGINT or SIGCONT), RPC threads are notified using SIGUSR2. This notification is required in case RPC threads are blocked on system calls; POSIX mandates that signals interrupt such blocked system calls ([`signal` manpage](http://man7.org/linux/man-pages/man7/signal.7.html)).

Omitting `sgx.rpc_thread_num` defaults to the old way of executing syscalls: exiting the enclave, executing the syscall, and re-entering it again.

This PR is stable. It works with multi-process applications and correctly handles signals.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/405)
<!-- Reviewable:end -->
