### PR TITLE
[Pal/Linux] block signals instead of queuing signal

### DIFF
--- a/Pal/src/host/Linux/db_exception.c
+++ b/Pal/src/host/Linux/db_exception.c
@@ -95,7 +95,7 @@ int set_sighandler (int * sigs, int nsig, void * handler)
         action.sa_flags |= SA_NOCLDWAIT;
 
     __sigemptyset((__sigset_t *) &action.sa_mask);
-    /* mask all the asynchronous signals whose signal hanlder is
+    /* mask all the asynchronous signals whose hanlder is
        _DkTerminateSighandler */
     __sigaddset((__sigset_t *) &action.sa_mask, SIGTERM);
     __sigaddset((__sigset_t *) &action.sa_mask, SIGINT);

--- a/Pal/src/host/Linux/pal_host.h
+++ b/Pal/src/host/Linux/pal_host.h
@@ -181,12 +181,10 @@ typedef struct pal_handle
 
 #define HANDLE_TYPE(handle)  ((handle)->hdr.type)
 
-extern void __check_pending_event (void);
-
-#define LEAVE_PAL_CALL() do { __check_pending_event(); } while (0)
+#define LEAVE_PAL_CALL() do { /* nothing */ } while (0)
 
 #define LEAVE_PAL_CALL_RETURN(retval) \
-    do { __check_pending_event(); return (retval); } while (0)
+    do { return (retval); } while (0)
 
 #if TRACE_HEAP_LEAK == 1
 

--- a/Pal/src/host/Linux/pal_linux.h
+++ b/Pal/src/host/Linux/pal_linux.h
@@ -185,8 +185,6 @@ struct event_queue {
 DEFINE_LISTP(event_queue);
 typedef struct pal_tcb {
     struct pal_tcb *  self;
-    int               pending_event;
-    LISTP_TYPE(event_queue) pending_queue;
     PAL_HANDLE        handle;
     void *            alt_stack;
     int               (*callback) (void *);


### PR DESCRIPTION
The malloc implementation of Pal/Linux isn't async signal safe. and
the queuing logic causes uninitialized PAL_CONTEXT when calling signal
handler of LibOS. On the other hand, LibOS signal handlers aren't
aware of uninitialized PAL_CONTEXT and PAL_CONTEXT is ignored when
returning from signal handler. which causes SEGV or other unexpected
issues.

Block all async signal while servicing signals so that the logic to
queue signal can be removed and the code is simplified.

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/406)
<!-- Reviewable:end -->
