### PR TITLE
[Pal/Linux-SGX] calculate event_num correctly for SIGFPE

### DIFF
--- a/Pal/src/host/Linux-SGX/sgx_exception.c
+++ b/Pal/src/host/Linux-SGX/sgx_exception.c
@@ -253,16 +253,7 @@ static void _DkResumeSighandler (int signum, siginfo_t * info,
         INLINE_SYSCALL(exit, 1, 1);
     }
 
-    int event = 0;
-    switch(signum) {
-        case SIGBUS:
-        case SIGSEGV:
-            event = PAL_EVENT_MEMFAULT;
-            break;
-        case SIGILL:
-            event = PAL_EVENT_ILLEGAL;
-            break;
-    }
+    int event = get_event_num(signum);
 #if SGX_HAS_FSGSBASE != 0
     sgx_raise(event);
 #else


### PR DESCRIPTION
In case of SIGFPE in host, 0 is passed as event_num.
it should be PAL_EVENT_DIVZERO.

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/407)
<!-- Reviewable:end -->
