### PR TITLE
Set the correct file type (regular file) for /proc/cpuinfo 

### DIFF
--- a/LibOS/shim/src/fs/proc/info.c
+++ b/LibOS/shim/src/fs/proc/info.c
@@ -27,7 +27,7 @@ static int proc_info_stat (const char * name, struct stat * buf)
 {
     memset(buf, 0, sizeof(struct stat));
     buf->st_dev = buf->st_ino = 1;
-    buf->st_mode = 0444|S_IFDIR;
+    buf->st_mode = 0444|S_IFREG;
     buf->st_uid = 0;
     buf->st_gid = 0;
     buf->st_size = 0;


### PR DESCRIPTION
The type for /proc/cpuinfo and /proc/meminfo should be a regular file, not a directory.  This addresses issue #308 (xgboost doesn't work in python).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/408)
<!-- Reviewable:end -->
