### PR TITLE
Pal/Linux-SGX: map manifest file as read only

### DIFF
--- a/Pal/src/host/Linux-SGX/sgx_main.c
+++ b/Pal/src/host/Linux-SGX/sgx_main.c
@@ -613,7 +613,7 @@ int load_manifest (int fd, struct config_store ** config_ptr)
 
     void * config_raw = (void *)
             INLINE_SYSCALL(mmap, 6, NULL, nbytes,
-                           PROT_READ|PROT_WRITE, MAP_PRIVATE,
+                           PROT_READ, MAP_PRIVATE,
                            fd, 0);
 
     if (IS_ERR_P(config_raw)) {

--- a/Pal/src/security/Linux/main.c
+++ b/Pal/src/security/Linux/main.c
@@ -154,7 +154,7 @@ int load_manifest (int fd, struct config_store * config)
 
     void * config_raw = (void *)
             INLINE_SYSCALL(mmap, 6, NULL, nbytes,
-                           PROT_READ|PROT_WRITE, MAP_PRIVATE,
+                           PROT_READ, MAP_PRIVATE,
                            fd, 0);
 
     if (IS_ERR_P(config_raw))


### PR DESCRIPTION
There is no point to map manifest file as writable.

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/409)
<!-- Reviewable:end -->
