### PR TITLE
[Pal/Linux/security] adjust pal loader directory

### DIFF
--- a/Pal/src/security/Linux/Makefile
+++ b/Pal/src/security/Linux/Makefile
@@ -3,7 +3,7 @@ LD	= ld
 
 CFLAGS	= -Wall -fPIC -O2 -std=c11 -Wall -U_FORTIFY_SOURCE \
 	  -fno-stack-protector -fno-builtin \
-	  -DPAL_LOADER_PATH="$(abspath ../../libpal.so)" \
+	  -DRUNTIME_DIR=$(abspath $(RUNTIME_DIR)) \
 	  -I. -I../../host/Linux/include -I../.. -I../../../include -I../../host/Linux \
 	  -I../../../lib -I../../../linux-kernel/graphene
 LDFLAGS	= -shared -nostdlib -z combreloc -z defs --version-script pal-sec.map -e start

--- a/Pal/src/security/Linux/internal.h
+++ b/Pal/src/security/Linux/internal.h
@@ -10,7 +10,10 @@
 
 #include "api.h"
 
-#define PAL_LOADER  XSTRINGIFY(PAL_LOADER_PATH)
+/* RUNTIME_FILE() is defined in pal_internal.h, and including pal_internal.h
+ * causes compile issue. So PAL_LOADER is defined without RUNTIME_FILE
+ * as workaround. */
+#define PAL_LOADER  XSTRINGIFY(RUNTIME_DIR)"/pal-Linux"
 
 #ifdef __x86_64__
 # include "sysdep-x86_64.h"


### PR DESCRIPTION
Now pal-Linux isn't created in Pal/src any more.
Adjust its directory.

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/411)
<!-- Reviewable:end -->
