### PR TITLE
[LibOS] shim_thread.h/shim_tls.h: use static inline instead of macro

### DIFF
--- a/LibOS/shim/include/shim_thread.h
+++ b/LibOS/shim/include/shim_thread.h
@@ -121,16 +121,20 @@ struct shim_simple_thread {
 
 int init_thread (void);
 
-#define SHIM_THREAD_SELF()                                     \
-    ({ struct shim_thread * __self;                            \
-        asm ("movq %%fs:%c1,%q0" : "=r" (__self)               \
-           : "i" (offsetof(__libc_tcb_t, shim_tcb.tp)));       \
-      __self; })
+static inline struct shim_thread * SHIM_THREAD_SELF(void)
+{
+    struct shim_thread * __self;
+    asm ("movq %%fs:%c1,%q0" : "=r" (__self)
+         : "i" (offsetof(__libc_tcb_t, shim_tcb.tp)));
+    return __self;
+}
 
-#define SAVE_SHIM_THREAD_SELF(__self)                         \
-  ({ asm ("movq %q0,%%fs:%c1" : : "r" (__self),               \
-          "i" (offsetof(__libc_tcb_t, shim_tcb.tp)));         \
-     __self; })
+static inline struct shim_thread * SAVE_SHIM_THREAD_SELF(struct shim_thread * __self)
+{
+     asm ("movq %q0,%%fs:%c1" : : "r" (__self),
+          "i" (offsetof(__libc_tcb_t, shim_tcb.tp)));
+     return __self;
+}
 
 void get_thread (struct shim_thread * thread);
 void put_thread (struct shim_thread * thread);

--- a/LibOS/shim/include/shim_tls.h
+++ b/LibOS/shim/include/shim_tls.h
@@ -95,23 +95,29 @@ typedef struct
 
 #include <stddef.h>
 
-#define SHIM_TLS_CHECK_CANARY()                                \
-    ({ uint64_t __canary;                                      \
-        asm ("movq %%fs:%c1,%q0" : "=r" (__canary)             \
-           : "i" (offsetof(__libc_tcb_t, shim_tcb.canary)));   \
-      __canary == SHIM_TLS_CANARY; })
+static inline bool SHIM_TLS_CHECK_CANARY(void)
+{
+    uint64_t __canary;
+    asm ("movq %%fs:%c1,%q0" : "=r" (__canary)
+         : "i" (offsetof(__libc_tcb_t, shim_tcb.canary)));
+    return __canary == SHIM_TLS_CANARY;
+}
 
-#define SHIM_GET_TLS()                                         \
-    ({ shim_tcb_t *__self;                                     \
-        asm ("movq %%fs:%c1,%q0" : "=r" (__self)               \
-           : "i" (offsetof(__libc_tcb_t, shim_tcb.self)));     \
-      __self; })
+static inline shim_tcb_t * SHIM_GET_TLS(void)
+{
+    shim_tcb_t *__self;
+    asm ("movq %%fs:%c1,%q0" : "=r" (__self)
+         : "i" (offsetof(__libc_tcb_t, shim_tcb.self)));
+    return __self;
+}
 
-#define GET_LIBC_TCB()                                         \
-    ({ void *__self;                                           \
-        asm ("movq %%fs:%c1,%q0" : "=r" (__self)               \
-           : "i" (offsetof(__libc_tcb_t, tcb)));               \
-      __self; })
+static inline __libc_tcb_t * SHIM_LIBC_TCB(void)
+{
+    __libc_tcb_t *__self;
+    asm ("movq %%fs:%c1,%q0" : "=r" (__self)
+         : "i" (offsetof(__libc_tcb_t, tcb)));
+    return __self;
+}
 
 #endif /* IN_SHIM */
 


### PR DESCRIPTION
macro is used unnecessarily. Use static inline function instead of CPP
MACRO.

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>