### PR TITLE
[Pal] remove unused save_return_point macro

### DIFF
--- a/Pal/src/host/FreeBSD/db_exception.c
+++ b/Pal/src/host/FreeBSD/db_exception.c
@@ -206,11 +206,6 @@ struct exception_handler * pal_handlers [PAL_EVENT_NUM_BOUND] = {
         &handler_Failure,
     };
 
-#define save_return_point(ptr)                      \
-    asm volatile ("leaq 0(%%rip), %%rax\r\n"        \
-                  "movq %%rax, %0\r\n"              \
-                  : "=b"(ptr) :: "memory", "rax")
-
 static int get_event_num (int signum)
 {
     switch(signum) {

--- a/Pal/src/host/FreeBSD/db_exception2.c
+++ b/Pal/src/host/FreeBSD/db_exception2.c
@@ -117,11 +117,6 @@ typedef struct {
 
 #define SIGNAL_MASK_TIME 1000
 
-#define save_return_point(ptr)                      \
-    asm volatile ("leaq 0(%%rip), %%rax\r\n"        \
-                  "movq %%rax, %0\r\n"              \
-                  : "=b"(ptr) :: "memory", "rax")
-
 static int get_event_num (int signum)
 {
     switch(signum) {

--- a/Pal/src/host/Linux-SGX/db_exception.c
+++ b/Pal/src/host/Linux-SGX/db_exception.c
@@ -45,11 +45,6 @@ typedef struct exception_event {
     struct pal_frame *  frame;
 } PAL_EVENT;
 
-#define save_return_point(ptr)                      \
-    asm volatile ("leaq 0(%%rip), %%rax\r\n"        \
-                  "movq %%rax, %0\r\n"              \
-                  : "=b"(ptr) :: "memory", "rax")
-
 void _DkGenericEventTrigger (PAL_IDX event_num, PAL_EVENT_HANDLER upcall,
                              PAL_NUM arg, struct pal_frame * frame,
                              PAL_CONTEXT * context)


### PR DESCRIPTION
Since save_return_point isn't used, so remove it.

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/413)
<!-- Reviewable:end -->
