### PR TITLE
[LibOS/test/native] add test program to include syscall instruction

### DIFF
--- a/LibOS/shim/test/regression/30_syscall-redirect.py
+++ b/LibOS/shim/test/regression/30_syscall-redirect.py
@@ -1,0 +1,20 @@
+import os, sys, mmap
+from regression import Regression
+
+loader = sys.argv[1]
+sgx = os.environ.get('SGX_RUN') == '1'
+
+# This test is only meaningful on SGX PAL because only SGX catches raw syscalls
+# and redirects to Graphene's LibOS. If we will add seccomp to Linux PAL, then
+# we should allow this test on Linux PAL as well.
+if not sgx:
+    sys.exit(0)
+
+# Running Syscall Instruction Example
+regression = Regression(loader, "syscall")
+
+regression.add_check(name="Syscall Instruction Redirection",
+    check=lambda res: "Hello world" in res[0].out)
+
+rv = regression.run_checks()
+if rv: sys.exit(rv)

--- a/LibOS/shim/test/regression/Makefile
+++ b/LibOS/shim/test/regression/Makefile
@@ -41,6 +41,9 @@ shared_object: %: %.c
 	@echo [ $@ ]
 	@$(CC) $(CFLAGS) -o $@ -fPIC -pie $< \
 	$(shell echo $@ | sed 's/^[^\.]*//g' | sed 's/\./ -l/g')
+
+syscall: CFLAGS += -I$(PALDIR)/../include -I$(PALDIR)/host/$(PAL_HOST)
+
 else
 .IGNORE: $(special_executables) $(c_executables) $(cxx_executables)
 $(special_executables) $(c_executables) $(cxx_executables):

--- a/LibOS/shim/test/regression/syscall.c
+++ b/LibOS/shim/test/regression/syscall.c
@@ -1,0 +1,8 @@
+#include <sys/syscall.h>
+#include <sysdep-x86_64.h>
+
+int main(int argc, char** argv) {
+    const char buf[] = "Hello world\n";
+    INLINE_SYSCALL(write, 3, 1, buf, sizeof(buf) - 1);
+    return 0;
+}


### PR DESCRIPTION
Add a test program which include syscall instruction to test
SIGILL hook logic.

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/414)
<!-- Reviewable:end -->
