### PR TITLE
[Pal/Linux-SGX] use type for enclave_tls instead of void*

### DIFF
--- a/Pal/src/host/Linux-SGX/sgx_tls.h
+++ b/Pal/src/host/Linux-SGX/sgx_tls.h
@@ -12,13 +12,13 @@ struct enclave_tls {
     uint64_t initial_stack_offset;
     void *   aep;
     void *   ssa;
-    void *   gpr;
+    sgx_arch_gpr_t * gpr;
     void *   exit_target;
     void *   fsbase;
     void *   stack;
     void *   ustack_top;
     void *   ustack;
-    void *   thread;
+    struct pal_handle_thread * thread;
 };
 
 #ifndef DEBUG


### PR DESCRIPTION
grp and thread member of struct enclave_tls is actually typed.
So use correct type for them instead of void *.
Also the use of void * to hide implementation is poor and not
type-safe. The right way is to hide the definition of struct.

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/415)
<!-- Reviewable:end -->
