### PR TITLE
[LibOS] use struct debug_buf instead of void * in shim_tcb_t

### DIFF
--- a/LibOS/shim/include/shim_tls.h
+++ b/LibOS/shim/include/shim_tls.h
@@ -57,6 +57,8 @@ struct shim_context {
 
 #endif /* IN_SHIM */
 
+struct debug_buf;
+
 typedef struct {
     uint64_t                canary;
     void *                  self;
@@ -64,7 +66,7 @@ typedef struct {
     struct shim_context     context;
     unsigned int            tid;
     int                     pal_errno;
-    void *                  debug_buf;
+    struct debug_buf *      debug_buf;
 
     /* This record is for testing the memory of user inputs.
      * If a segfault occurs with the range [start, end],

--- a/LibOS/shim/src/utils/printf.c
+++ b/LibOS/shim/src/utils/printf.c
@@ -78,7 +78,7 @@ debug_fputch (void * f, int ch, void * b)
 void debug_puts (const char * str)
 {
     int len = strlen(str);
-    struct debug_buf * buf = (struct debug_buf *) SHIM_GET_TLS()->debug_buf;
+    struct debug_buf * buf = SHIM_GET_TLS()->debug_buf;
 
     while (len) {
         int rem = DEBUGBUF_SIZE - 4 - buf->end;
@@ -131,7 +131,7 @@ void debug_setprefix (shim_tcb_t * tcb)
     if (!debug_handle)
         return;
 
-    struct debug_buf * buf = (struct debug_buf *) tcb->debug_buf;
+    struct debug_buf * buf = tcb->debug_buf;
     buf->start = buf->end = 0;
 
     if (tcb->tid && !IS_INTERNAL_TID(tcb->tid))


### PR DESCRIPTION
Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/420)
<!-- Reviewable:end -->
