### PR TITLE
[Pal/Linux-SGX] close fd for pal code

### DIFF
--- a/Pal/src/host/Linux-SGX/sgx_main.c
+++ b/Pal/src/host/Linux-SGX/sgx_main.c
@@ -473,6 +473,8 @@ add_pages:
         if (data)
             INLINE_SYSCALL(munmap, 2, data, areas[i].size);
     }
+    INLINE_SYSCALL(close, 1,pal_area->fd);
+    pal_area->fd = -1;
 
     TRY(init_enclave, &enclave_secs, &enclave_sigstruct, &enclave_token);
 


### PR DESCRIPTION
the file descriptor of pal isn't closed and isn't used after
initialize_enclave(). Close it after it's used.

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/422)
<!-- Reviewable:end -->
