### PR TITLE
[Pal/Linux-SGX] add rdtsc ocall and use it for rdtsc emulation

### DIFF
--- a/Pal/src/host/Linux-SGX/db_exception.c
+++ b/Pal/src/host/Linux-SGX/db_exception.c
@@ -236,8 +236,11 @@ void _DkExceptionHandler (unsigned int exit_info, sgx_context_t * uc)
         }
         if (instr[0] == 0x0f && instr[1] == 0x31) {
             uc->rip += 2;
-            uc->rdx = 0;
-            uc->rax = 0;
+            unsigned long high;
+            unsigned long low;
+            ocall_rdtsc(&low, &high);
+            uc->rdx = high;
+            uc->rax = low;
             restore_sgx_context(uc);
             return;
         }

--- a/Pal/src/host/Linux-SGX/enclave_ocalls.c
+++ b/Pal/src/host/Linux-SGX/enclave_ocalls.c
@@ -791,3 +791,16 @@ int ocall_load_debug(const char * command)
     OCALL_EXIT();
     return retval;
 }
+
+int ocall_rdtsc(unsigned long *low, unsigned long *high)
+{
+    int retval = 0;
+    ms_ocall_rdtsc_t * ms;
+    OCALLOC(ms, ms_ocall_rdtsc_t *, sizeof(*ms));
+
+    retval = SGX_OCALL(OCALL_RDTSC, ms);
+    *low = ms->low;
+    *high = ms->high;
+    OCALL_EXIT();
+    return retval;
+}

--- a/Pal/src/host/Linux-SGX/enclave_ocalls.h
+++ b/Pal/src/host/Linux-SGX/enclave_ocalls.h
@@ -103,3 +103,5 @@ int ocall_rename (const char * oldpath, const char * newpath);
 int ocall_delete (const char * pathname);
 
 int ocall_load_debug (const char * command);
+
+int ocall_rdtsc(unsigned long * low, unsigned long * high);

--- a/Pal/src/host/Linux-SGX/ocall_types.h
+++ b/Pal/src/host/Linux-SGX/ocall_types.h
@@ -53,6 +53,7 @@ enum {
     OCALL_RENAME,
     OCALL_DELETE,
     OCALL_LOAD_DEBUG,
+    OCALL_RDTSC,
     OCALL_NR,
 };
 
@@ -261,5 +262,11 @@ typedef struct {
 typedef struct {
     unsigned int ms_tid;
 } ms_ocall_schedule_t;
+
+typedef struct
+{
+    unsigned long low;
+    unsigned long high;
+} ms_ocall_rdtsc_t;
 
 #pragma pack(pop)

--- a/Pal/src/host/Linux-SGX/sgx_enclave.c
+++ b/Pal/src/host/Linux-SGX/sgx_enclave.c
@@ -666,6 +666,20 @@ static int sgx_ocall_load_debug(void * pms)
     return 0;
 }
 
+static int sgx_ocall_rdtsc(void * pms)
+{
+    ms_ocall_rdtsc_t * ms = (ms_ocall_rdtsc_t *) pms;
+    ODEBUG(OCALL_RDTSC, ms);
+    unsigned long low;
+    unsigned long high;
+
+    __asm__ __volatile__ ("rdtsc": "=a"(low), "=d"(high));
+
+    ms->low = low;
+    ms->high = high;
+    return 0;
+}
+
 void * ocall_table[OCALL_NR] = {
         [OCALL_EXIT]            = (void *) sgx_ocall_exit,
         [OCALL_PRINT_STRING]    = (void *) sgx_ocall_print_string,
@@ -704,6 +718,7 @@ void * ocall_table[OCALL_NR] = {
         [OCALL_RENAME]          = (void *) sgx_ocall_rename,
         [OCALL_DELETE]          = (void *) sgx_ocall_delete,
         [OCALL_LOAD_DEBUG]      = (void *) sgx_ocall_load_debug,
+        [OCALL_RDTSC]           = (void *) sgx_ocall_rdtsc,
     };
 
 #define EDEBUG(code, ms) do {} while (0)


### PR DESCRIPTION
The current implementation always returns 0 for rdtsc.
It causes some application to result in error. (divide by zero or NaN)
So emulate rdtsc by ocall instead of returning 0.

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/424)
<!-- Reviewable:end -->
