### PR TITLE
[LibOS] zero %rdx on entry of user program

### DIFF
--- a/LibOS/shim/src/elf/shim_rtld.c
+++ b/LibOS/shim/src/elf/shim_rtld.c
@@ -1591,8 +1591,8 @@ int execute_elf_object (struct shim_handle * exec, int argc, const char ** argp,
                     :
                     : "a"(entry),
                     "b"(argp),
-                    "D"(argc)
-
+                    "D"(argc),
+                    "d"(0)
                     : "memory");
 #else
 # error "architecture not supported"


### PR DESCRIPTION
As x86-64 unix ABI, %rdx on user program entry is a function pointer
which is registered as atexit. It should be zeroed unless LibOS needs
it. Otherwise random %rdx as function pointer is called by atexit and
can result in error. typically SEGV.

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/425)
<!-- Reviewable:end -->
