### PR TITLE
[LibOS] implement mincore() system call

### DIFF
--- a/LibOS/shim/include/shim_table.h
+++ b/LibOS/shim/include/shim_table.h
@@ -359,6 +359,7 @@ int shim_do_sched_yield (void);
 void * shim_do_mremap (void * addr, size_t old_len, size_t new_len,
                        int flags, void * new_addr);
 int shim_do_msync (void * start, size_t len, int flags);
+int shim_do_mincore (void * start, size_t len, unsigned char * vec);
 int shim_do_dup (int fd);
 int shim_do_dup2 (int oldfd, int newfd);
 int shim_do_pause (void);

--- a/LibOS/shim/src/shim_syscalls.c
+++ b/LibOS/shim/src/shim_syscalls.c
@@ -231,8 +231,9 @@ SHIM_SYSCALL_PASSTHROUGH (mremap, 5, void *, void *, addr, size_t, old_len,
 
 SHIM_SYSCALL_PASSTHROUGH (msync, 3, int, void *, start, size_t, len, int, flags)
 
-SHIM_SYSCALL_PASSTHROUGH (mincore, 3, int, void *, start, size_t, len,
-                          unsigned char *, vec)
+/* mincore: sys/shim_mmap.c */
+DEFINE_SHIM_SYSCALL (mincore, 3, shim_do_mincore, int, void *, start,
+                     size_t, len, unsigned char *, vec)
 
 SHIM_SYSCALL_PASSTHROUGH (madvise, 3, int, void *, start, size_t, len,
                           int, behavior)

--- a/LibOS/shim/test/apps/ltp/PASSED
+++ b/LibOS/shim/test/apps/ltp/PASSED
@@ -358,6 +358,10 @@ mkdirat01,2
 mkdirat01,3
 mkdirat01,4
 mkdirat01,5
+mincore01,1
+mincore01,2
+mincore01,3
+mincore01,4
 mlock03,1
 mmap001,1
 mmap001,2


### PR DESCRIPTION
Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

Please fill in the following form before submitting this PR:

- Affected components
    - [ ] README and global configurations
    - [ ] Linux PAL
    - [ ] SGX PAL
    - [ ] FreeBSD PAL
    - [x] Library OS (i.e., SHIM), including GLIBC

- A brief description of this PR (describe the reasons and measures)
implements mincore system call



- How to test this PR?
    - [ ] Documentation-only; no need to test
ltp includes tests for mincore



Please follow the [coding style guidelines](CODESTYLE.md). Do not submit PRs which violate these rules.
- [ ] Comments and commit messages: no spelling or grammatical errors
- [ ] 4 spaces per indention level, at most 100 chars per line
- [ ] Asterisks (`*`) next to types: `int* pointer;` (one pointer each line)
- [ ] Braces (`{`) begin in the same line as function names, if-else, while, switch, union, and struct keywords.
- [ ] Naming: Macros - `NAMED_THIS_WAY`; global variables - `g_named_this_way`; others - `named_this_way`.
- Other styling issues may be pointed out by reviewers.


Please preserve the following checklist for reviewing:

- [ ] Pass all CI unit tests
- [ ] Resolve all discussions/requests from reviewers
- Reviewer approval (select one):
    - [ ] 3 approving reviews
    - [ ] 2 approving reviews and 5 days since the PR was created
    - [ ] The PR is from a maintainer; 1 approving review and 10 days since the PR was created

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/427)
<!-- Reviewable:end -->
