### PR TITLE
[LibOS] make Libos clone abi same to kernel

### DIFF
--- a/LibOS/glibc-2.19.patch
+++ b/LibOS/glibc-2.19.patch
@@ -1368,36 +1368,14 @@ diff --git a/sysdeps/unix/sysv/linux/x86_64/clone.S b/sysdeps/unix/sysv/linux/x8
 index 0508730..e1b35ec 100644
 --- a/sysdeps/unix/sysv/linux/x86_64/clone.S
 +++ b/sysdeps/unix/sysv/linux/x86_64/clone.S
-@@ -59,11 +59,15 @@ ENTRY (__clone)
- 	jz	SYSCALL_ERROR_LABEL
- 
- 	/* Insert the argument onto the new stack.  */
--	subq	$16,%rsi
--	movq	%rcx,8(%rsi)
-+	subq	$24,%rsi
-+	movq	%rcx,16(%rsi)
- 
- 	/* Save the function pointer.  It will be popped off in the
- 	   child in the ebx frobbing below.  */
-+	movq	%rdi,8(%rsi)
-+
-+	/* Push an additional pointer as return address into the stack */
-+	leaq	L(clone_return)(%rip),%rdi
- 	movq	%rdi,0(%rsi)
- 
- 	/* Do the system call.  */
-@@ -76,8 +80,9 @@ ENTRY (__clone)
+@@ -76,5 +80,5 @@ ENTRY (__clone)
  	/* End FDE now, because in the child the unwind info will be
  	   wrong.  */
  	cfi_endproc;
 -	syscall
 +	SYSCALLDB
  
-+L(clone_return):
- 	testq	%rax,%rax
- 	jl	SYSCALL_ERROR_LABEL
- 	jz	L(thread_start)
-@@ -99,13 +104,14 @@ L(thread_start):
+@@ -99,10 +104,10 @@ L(thread_start):
  	movl	$-1, %eax
  	jne	2f
  	movl	$SYS_ify(getpid), %eax
@@ -1409,10 +1387,6 @@ index 0508730..e1b35ec 100644
  #endif
  
  	/* Set up arguments for the function call.  */
-+	addq	$8,%rsp		/* Skip the return address */
- 	popq	%rax		/* Function to call.  */
- 	popq	%rdi		/* Argument.  */
- 	call	*%rax
 diff --git a/sysdeps/unix/sysv/linux/x86_64/getcontext.S b/sysdeps/unix/sysv/linux/x86_64/getcontext.S
 index 140db03..6967f10 100644
 --- a/sysdeps/unix/sysv/linux/x86_64/getcontext.S

--- a/LibOS/shim/src/sys/shim_clone.c
+++ b/LibOS/shim/src/sys/shim_clone.c
@@ -270,7 +270,7 @@ int shim_do_clone (int flags, void * user_stack_addr, int * parent_tidptr,
             thread->stack_top = vma.addr + vma.length;
             thread->stack_red = thread->stack = vma.addr;
             tcb->shim_tcb.context.sp = user_stack_addr;
-            tcb->shim_tcb.context.ret_ip = *(void **) user_stack_addr;
+            tcb->shim_tcb.context.ret_ip = shim_get_tls()->context.ret_ip;
         }
 
         thread->is_alive = true;
@@ -318,7 +318,7 @@ int shim_do_clone (int flags, void * user_stack_addr, int * parent_tidptr,
     new_args.thread    = thread;
     new_args.parent    = self;
     new_args.stack     = user_stack_addr;
-    new_args.return_pc = *(void **) user_stack_addr;
+    new_args.return_pc = shim_get_tls()->context.ret_ip;
 
     // Invoke DkThreadCreate to spawn off a child process using the actual
     // "clone" system call. DkThreadCreate allocates a stack for the child


### PR DESCRIPTION
- Affected components
    - [ ] README and global configurations
    - [ ] Linux PAL
    - [ ] SGX PAL
    - [ ] FreeBSD PAL
    - [x] Library OS (i.e., SHIM), including GLIBC

- A brief description of this PR (describe the reasons and measures)
    [LibOS] make clone ABI match to kernel
    
    Currently child thread ret ip is taken from new child stack.
    But it can be get from parent thread context. Such a hack isn't
    needed.
    Now the modification to clone.S is not needed any more. So remove it.

- How to test this PR?
    - [ ] Documentation-only; no need to test
run the current regression test which uses clone syscall.
LibOS/shim/test/regression/futex tests

Please follow the [coding style guidelines](CODESTYLE.md). Do not submit PRs which violate these rules.
- [x] Comments and commit messages: no spelling or grammatical errors
- [x] 4 spaces per indention level, at most 100 chars per line
- [x] Asterisks (`*`) next to types: `int* pointer;` (one pointer each line)
- [x] Braces (`{`) begin in the same line as function names, if-else, while, switch, union, and struct keywords.
- [x] Naming: Macros - `NAMED_THIS_WAY`; global variables - `g_named_this_way`; others - `named_this_way`.
- Other styling issues may be pointed out by reviewers.


Please preserve the following checklist for reviewing:

- [ ] Pass all CI unit tests
- [ ] Resolve all discussions/requests from reviewers
- Reviewer approval (select one):
    - [ ] 3 approving reviews
    - [ ] 2 approving reviews and 5 days since the PR was created
    - [ ] The PR is from a maintainer; 1 approving review and 10 days since the PR was created

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/428)
<!-- Reviewable:end -->
