### PR TITLE
[LibOS] fix futex signature

### DIFF
--- a/LibOS/shim/include/shim_handle.h
+++ b/LibOS/shim/include/shim_handle.h
@@ -283,7 +283,7 @@ DEFINE_LIST(futex_waiter);
 DEFINE_LISTP(futex_waiter);
 DEFINE_LIST(shim_futex_handle);
 struct shim_futex_handle {
-    unsigned int *      uaddr;
+    int *   uaddr;
     LISTP_TYPE(futex_waiter) waiters;
     struct shim_vma *   vma;
     LIST_TYPE(shim_futex_handle) list;

--- a/LibOS/shim/include/shim_table.h
+++ b/LibOS/shim/include/shim_table.h
@@ -451,8 +451,8 @@ int shim_do_chroot (const char * filename);
 pid_t shim_do_gettid (void);
 int shim_do_tkill (int pid, int sig);
 time_t shim_do_time (time_t * tloc);
-int shim_do_futex (unsigned int * uaddr, int op, int val, void * utime,
-                   unsigned int * uaddr2, int val3);
+int shim_do_futex (int * uaddr, int op, int val, void * utime,
+                   int * uaddr2, int val3);
 int shim_do_sched_getaffinity (pid_t pid, size_t len,
                                __kernel_cpu_set_t * user_mask_ptr);
 int shim_do_set_tid_address (int * tidptr);
@@ -730,8 +730,8 @@ int shim_lremovexattr (const char * path, const char * name);
 int shim_fremovexattr (int fd, const char * name);
 int shim_tkill (int pid, int sig);
 time_t shim_time (time_t * tloc);
-int shim_futex (unsigned int * uaddr, int op, int val, void * utime,
-                unsigned int * uaddr2, int val3);
+int shim_futex (int * uaddr, int op, int val, void * utime,
+                int * uaddr2, int val3);
 int shim_sched_setaffinity (pid_t pid, size_t len,
                             __kernel_cpu_set_t * user_mask_ptr);
 int shim_sched_getaffinity (pid_t pid, size_t len,

--- a/LibOS/shim/src/shim_syscalls.c
+++ b/LibOS/shim/src/shim_syscalls.c
@@ -797,8 +797,8 @@ DEFINE_SHIM_SYSCALL (tkill, 2, shim_do_tkill, int, pid_t, pid, int, sig)
 DEFINE_SHIM_SYSCALL (time, 1, shim_do_time, time_t, time_t *, tloc)
 
 /* futex: sys/shim_futex.c */
-DEFINE_SHIM_SYSCALL (futex, 6, shim_do_futex, int, unsigned int *, uaddr,
-                     int, op, int, val, void *, utime, unsigned int *, uaddr2,
+DEFINE_SHIM_SYSCALL (futex, 6, shim_do_futex, int, int *, uaddr,
+                     int, op, int, val, void *, utime, int *, uaddr2,
                      int, val3)
 
 SHIM_SYSCALL_PASSTHROUGH (sched_setaffinity, 3, int, pid_t, pid, size_t, len,

--- a/LibOS/shim/src/sys/shim_futex.c
+++ b/LibOS/shim/src/sys/shim_futex.c
@@ -56,8 +56,8 @@ DEFINE_LISTP(shim_futex_handle);
 static LISTP_TYPE(shim_futex_handle) futex_list = LISTP_INIT;
 static LOCKTYPE futex_list_lock;
 
-int shim_do_futex (unsigned int * uaddr, int op, int val, void * utime,
-                   unsigned int * uaddr2, int val3)
+int shim_do_futex (int * uaddr, int op, int val, void * utime,
+                   int * uaddr2, int val3)
 {
     struct shim_futex_handle * tmp = NULL, * futex = NULL, * futex2 = NULL;
     struct shim_handle * hdl = NULL, * hdl2 = NULL;
@@ -156,6 +156,7 @@ int shim_do_futex (unsigned int * uaddr, int op, int val, void * utime,
          * FUTEX_WAIT_BITSET with val3 specified as
          * FUTEX_BITSET_MATCH_ANY. */
 
+            /* FALLTHROUGH */
         case FUTEX_WAIT:
             if (utime && timeout_us == NO_TIMEOUT) {
                 struct timespec *ts = (struct timespec*) utime;
@@ -283,7 +284,7 @@ int shim_do_futex (unsigned int * uaddr, int op, int val, void * utime,
                 ret = -EAGAIN;
                 break;
             }
-
+            /* FALLTHROUGH */
         case FUTEX_REQUEUE: {
             assert(futex2);
             struct futex_waiter * waiter, * wtmp;


### PR DESCRIPTION
Futex word is int, not unsigned int.
So it should use int * instead of unsigned int *.
Also add fallthrough directive for lint to eliminate warning.
I believe fallthrough of switch clause is intentional, not bug.

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

Please fill in the following form before submitting this PR:

- Affected components
    - [ ] README and global configurations
    - [ ] Linux PAL
    - [ ] SGX PAL
    - [ ] FreeBSD PAL
    - [x] Library OS (i.e., SHIM), including GLIBC

- A brief description of this PR (describe the reasons and measures)




- How to test this PR?
    - [ ] Documentation-only; no need to test
just run any tests which uses futex. LibOS/shim/test/native/futextest.pthread.c




Please follow the [coding style guidelines](CODESTYLE.md). Do not submit PRs which violate these rules.
- [ ] Comments and commit messages: no spelling or grammatical errors
- [ ] 4 spaces per indentation level, at most 100 chars per line
- [ ] Asterisks (`*`) next to types: `int* pointer;` (one pointer each line)
- [ ] Braces (`{`) begin in the same line as function names, `if`, `else`, `while`, `do`, `for`, `switch`, `union`, and `struct` keywords.
- [ ] Naming: Macros, constants - `NAMED_THIS_WAY`; global variables - `g_named_this_way`; others - `named_this_way`.
- Other styling issues may be pointed out by reviewers.


Please preserve the following checklist for reviewing:

- [ ] Pass all CI unit tests
- [ ] Resolve all discussions/requests from reviewers
- Reviewer approval (select one):
    - [ ] 3 approving reviews
    - [ ] 2 approving reviews and 5 days since the PR was created
    - [ ] The PR is from a maintainer; 1 approving review and 10 days since the PR was created

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/432)
<!-- Reviewable:end -->
