### PR TITLE
[Pal] race condition of DkEvent

### DIFF
--- a/Pal/src/host/FreeBSD/db_events.c
+++ b/Pal/src/host/FreeBSD/db_events.c
@@ -52,6 +52,24 @@ void _DkEventDestroy (PAL_HANDLE handle)
     free(handle);
 }
 
+/*
+ * Set:
+ * set event.signaled = 1
+ * if event.nwaiters > 0
+ *     wakeup
+ *
+ * Wait:
+ * inc event.nwaiters
+ * if not signaled:
+ *    // this check must be after incrementing event.nwaiters
+ *    // not to lose wakeup because waker only wakes up sleepers only
+ *    // when there are sleepers.
+ *    // It may cause spurious wakeup, but doesn't lose wakeup.
+ *    sleep
+ * dec event.nwaiters
+ *
+ */
+
 int _DkEventSet (PAL_HANDLE event, int wakeup)
 {
     int ret = 0;

--- a/Pal/src/host/Linux-SGX/db_events.c
+++ b/Pal/src/host/Linux-SGX/db_events.c
@@ -86,10 +86,9 @@ int _DkEventWaitTimeout (PAL_HANDLE event, uint64_t timeout)
 {
     int ret = 0;
 
+    atomic_inc(&event->event.nwaiters);
     if (!event->event.isnotification || !atomic_read(event->event.signaled)) {
         unsigned long waittime = timeout;
-
-        atomic_inc(&event->event.nwaiters);
 
         do {
             ret = ocall_futex((int *) &event->event.signaled->counter,
@@ -103,8 +102,8 @@ int _DkEventWaitTimeout (PAL_HANDLE event, uint64_t timeout)
         } while (event->event.isnotification &&
                  !atomic_read(event->event.signaled));
 
-        atomic_dec(&event->event.nwaiters);
     }
+    atomic_dec(&event->event.nwaiters);
 
     return ret;
 }
@@ -113,8 +112,8 @@ int _DkEventWait (PAL_HANDLE event)
 {
     int ret = 0;
 
+    atomic_inc(&event->event.nwaiters);
     if (!event->event.isnotification || !atomic_read(event->event.signaled)) {
-        atomic_inc(&event->event.nwaiters);
 
         do {
             ret = ocall_futex((int *) &event->event.signaled->counter,
@@ -128,8 +127,8 @@ int _DkEventWait (PAL_HANDLE event)
         } while (event->event.isnotification &&
                  !atomic_read(event->event.signaled));
 
-        atomic_dec(&event->event.nwaiters);
     }
+    atomic_dec(&event->event.nwaiters);
 
     return ret;
 }

--- a/Pal/src/host/Linux-SGX/db_events.c
+++ b/Pal/src/host/Linux-SGX/db_events.c
@@ -52,6 +52,24 @@ int _DkEventCreate (PAL_HANDLE * event, bool initialState, bool isnotification)
     return 0;
 }
 
+/*
+ * Set:
+ * set event.signaled = 1
+ * if event.nwaiters > 0
+ *     wakeup
+ *
+ * Wait:
+ * inc event.nwaiters
+ * if not signaled:
+ *    // this check must be after incrementing event.nwaiters
+ *    // not to lose wakeup because waker only wakes up sleepers only
+ *    // when there are sleepers.
+ *    // It may cause spurious wakeup, but doesn't lose wakeup.
+ *    sleep
+ * dec event.nwaiters
+ *
+ */
+
 int _DkEventSet (PAL_HANDLE event, int wakeup)
 {
     int ret = 0;

--- a/Pal/src/host/Linux/db_events.c
+++ b/Pal/src/host/Linux/db_events.c
@@ -48,6 +48,24 @@ int _DkEventCreate (PAL_HANDLE * event, bool initialState, bool isnotification)
     return 0;
 }
 
+/*
+ * Set:
+ * set event.signaled = 1
+ * if event.nwaiters > 0
+ *     wakeup
+ *
+ * Wait:
+ * inc event.nwaiters
+ * if not signaled:
+ *    // this check must be after incrementing event.nwaiters
+ *    // not to lose wakeup because waker only wakes up sleepers only
+ *    // when there are sleepers.
+ *    // It may cause spurious wakeup, but doesn't lose wakeup.
+ *    sleep
+ * dec event.nwaiters
+ *
+ */
+
 int _DkEventSet (PAL_HANDLE event, int wakeup)
 {
     int ret = 0;

--- a/Pal/src/host/Linux/db_events.c
+++ b/Pal/src/host/Linux/db_events.c
@@ -79,14 +79,13 @@ int _DkEventWaitTimeout (PAL_HANDLE event, uint64_t timeout)
 {
     int ret = 0;
 
+    atomic_inc(&event->event.nwaiters);
     if (!event->event.isnotification || !atomic_read(&event->event.signaled)) {
         struct timespec waittime;
         unsigned long sec = timeout / 1000000UL;
         unsigned long microsec = timeout - (sec * 1000000UL);
         waittime.tv_sec = sec;
         waittime.tv_nsec = microsec * 1000;
-
-        atomic_inc(&event->event.nwaiters);
 
         do {
             ret = INLINE_SYSCALL(futex, 6, &event->event.signaled, FUTEX_WAIT,
@@ -103,8 +102,8 @@ int _DkEventWaitTimeout (PAL_HANDLE event, uint64_t timeout)
         } while (event->event.isnotification &&
                  !atomic_read(&event->event.signaled));
 
-        atomic_dec(&event->event.nwaiters);
     }
+    atomic_dec(&event->event.nwaiters);
 
     return ret;
 }
@@ -113,8 +112,8 @@ int _DkEventWait (PAL_HANDLE event)
 {
     int ret = 0;
 
+    atomic_inc(&event->event.nwaiters);
     if (!event->event.isnotification || !atomic_read(&event->event.signaled)) {
-        atomic_inc(&event->event.nwaiters);
 
         do {
             ret = INLINE_SYSCALL(futex, 6, &event->event.signaled, FUTEX_WAIT,
@@ -131,8 +130,8 @@ int _DkEventWait (PAL_HANDLE event)
         } while (event->event.isnotification &&
                  !atomic_read(&event->event.signaled));
 
-        atomic_dec(&event->event.nwaiters);
     }
+    atomic_dec(&event->event.nwaiters);
 
     return ret;
 }


### PR DESCRIPTION
There is a race condition of _DkEventSet and _DkEventWait.
In the following case, _DkEventWait won't be unblocked as expected.

_DkEventSet()           _DkEventWait()
    |                       |
    |                       V
    V                     read(signaled)
  cmpxchg(signaled)         |
  read(nwaiters)            V
    |                     inc(nwaiters)
    |                     sleep: this sleep won't be waken up
    |                     dec(nwaiters)
    |                       |
    V                       V

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

Please fill in the following form before submitting this PR:

- Affected components
    - [ ] README and global configurations
    - [ ] Linux PAL
    - [ ] SGX PAL
    - [ ] FreeBSD PAL
    - [ ] Library OS (i.e., SHIM), including GLIBC

- A brief description of this PR (describe the reasons and measures)




- How to test this PR?
    - [ ] Documentation-only; no need to test




Please follow the [coding style guidelines](CODESTYLE.md). Do not submit PRs which violate these rules.
- [ ] Comments and commit messages: no spelling or grammatical errors
- [ ] 4 spaces per indentation level, at most 100 chars per line
- [ ] Asterisks (`*`) next to types: `int* pointer;` (one pointer each line)
- [ ] Braces (`{`) begin in the same line as function names, `if`, `else`, `while`, `do`, `for`, `switch`, `union`, and `struct` keywords.
- [ ] Naming: Macros, constants - `NAMED_THIS_WAY`; global variables - `g_named_this_way`; others - `named_this_way`.
- Other styling issues may be pointed out by reviewers.


Please preserve the following checklist for reviewing:

- [ ] Pass all CI unit tests
- [ ] Resolve all discussions/requests from reviewers
- Reviewer approval (select one):
    - [ ] 3 approving reviews
    - [ ] 2 approving reviews and 5 days since the PR was created
    - [ ] The PR is from a maintainer; 1 approving review and 10 days since the PR was created

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/436)
<!-- Reviewable:end -->
