### PR TITLE
[Pal/Linux-SGX] _DkEventWaitTimeout() doesn't return

### DIFF
--- a/LibOS/shim/test/regression/futex-timeout.c
+++ b/LibOS/shim/test/regression/futex-timeout.c
@@ -1,0 +1,22 @@
+/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
+/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
+
+#include <unistd.h>
+#include <stdio.h>
+#include <sys/syscall.h>
+#include <linux/futex.h>
+#include <sys/time.h>
+
+int main (int argc, const char ** argv)
+{
+    int myfutex = 0;
+    struct timespec t = {
+        .tv_sec = 1,
+        .tv_nsec = 0
+    };
+    printf("hello\n");
+    syscall(SYS_futex, &myfutex, FUTEX_WAIT, 0, &t, NULL, 0);
+    printf("world\n");
+
+    return 0;
+}

--- a/Pal/src/host/FreeBSD/db_events.c
+++ b/Pal/src/host/FreeBSD/db_events.c
@@ -75,7 +75,7 @@ int _DkEventSet (PAL_HANDLE event, int wakeup)
                              UMTX_OP_WAKE, 1, NULL, NULL);
     }
 
-    return IS_ERR(ret) ? PAL_ERROR_TRYAGAIN : ret;
+    return IS_ERR(ret) ? -PAL_ERROR_TRYAGAIN : ret;
 }
 
 int _DkEventWaitTimeout (PAL_HANDLE event, uint64_t timeout)

--- a/Pal/src/host/Linux-SGX/sgx_enclave.c
+++ b/Pal/src/host/Linux-SGX/sgx_enclave.c
@@ -238,6 +238,10 @@ static int sgx_ocall_create_process(void * pms)
     return 0;
 }
 
+/* sgx_ocall_futex return unix errno instead of PAL_ERROR
+ * because PAL_ERROR doesn't distinguish ETIMEDOUT and EAGAIN.
+ * In futex case, they needs to be distinguished.
+ */
 static int sgx_ocall_futex(void * pms)
 {
     ms_ocall_futex_t * ms = (ms_ocall_futex_t *) pms;
@@ -251,7 +255,7 @@ static int sgx_ocall_futex(void * pms)
     }
     ret = INLINE_SYSCALL(futex, 6, ms->ms_futex, ms->ms_op, ms->ms_val,
                          ts, NULL, 0);
-    return IS_ERR(ret) ? unix_to_pal_error(ERRNO(ret)) : ret;
+    return ret;
 }
 
 static int sgx_ocall_socketpair(void * pms)

--- a/Pal/src/host/Linux/db_events.c
+++ b/Pal/src/host/Linux/db_events.c
@@ -72,7 +72,7 @@ int _DkEventSet (PAL_HANDLE event, int wakeup)
                              NULL, NULL, 0);
     }
 
-    return IS_ERR(ret) ? PAL_ERROR_TRYAGAIN : ret;
+    return IS_ERR(ret) ? -PAL_ERROR_TRYAGAIN : ret;
 }
 
 int _DkEventWaitTimeout (PAL_HANDLE event, uint64_t timeout)

--- a/Pal/src/host/Linux/db_mutex.c
+++ b/Pal/src/host/Linux/db_mutex.c
@@ -130,14 +130,13 @@ int _DkMutexLockTimeout (struct mutex_handle * m, uint64_t timeout)
                     atomic_dec(&m->nwaiters);
                     goto out;
                 }
-            } else {
-#ifdef DEBUG_MUTEX
-                printf("futex failed (err = %d)\n", ERRNO(ret));
-#endif
-                ret = unix_to_pal_error(ERRNO(ret));
-                atomic_dec(&m->nwaiters);
-                goto out;
             }
+#ifdef DEBUG_MUTEX
+            printf("futex failed (err = %d)\n", ERRNO(ret));
+#endif
+            ret = unix_to_pal_error(ERRNO(ret));
+            atomic_dec(&m->nwaiters);
+            goto out;
         }
     }
 


### PR DESCRIPTION
_DkEventWaitTimeout() of Pal/Linux-SGX doesn't return. ETIMEDOUT and
ETRAYAGAIN are different meaing for futex(WAIT). but
unix_to_pal_error() combines into PAL_ERROR_TRYAGAIN. futex ocall
doesn't provide enough info.
So make ocall_futex() return unix error number and have
the callers of ocall_futex, e.g.  _DkEventWaitTimedout(), convert unix errno
into PAL ERROR NO.

_DkEventSet returned wrong value(positive value) on error. It should
return negated value.
_DkMutexLockTimeout has similar issue related to host futex call.
This patch fixes them too.

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

Please fill in the following form before submitting this PR:

- Affected components
    - [ ] README and global configurations
    - [x] Linux PAL
    - [x] SGX PAL
    - [x] FreeBSD PAL
    - [ ] Library OS (i.e., SHIM), including GLIBC

- A brief description of this PR (describe the reasons and measures)




- How to test this PR?
    - [ ] Documentation-only; no need to test
use futex-timeout.c which is included.



Please follow the [coding style guidelines](CODESTYLE.md). Do not submit PRs which violate these rules.
- [ ] Comments and commit messages: no spelling or grammatical errors
- [ ] 4 spaces per indentation level, at most 100 chars per line
- [ ] Asterisks (`*`) next to types: `int* pointer;` (one pointer each line)
- [ ] Braces (`{`) begin in the same line as function names, `if`, `else`, `while`, `do`, `for`, `switch`, `union`, and `struct` keywords.
- [ ] Naming: Macros, constants - `NAMED_THIS_WAY`; global variables - `g_named_this_way`; others - `named_this_way`.
- Other styling issues may be pointed out by reviewers.


Please preserve the following checklist for reviewing:

- [ ] Pass all CI unit tests
- [ ] Resolve all discussions/requests from reviewers
- Reviewer approval (select one):
    - [ ] 3 approving reviews
    - [ ] 2 approving reviews and 5 days since the PR was created
    - [ ] The PR is from a maintainer; 1 approving review and 10 days since the PR was created

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/438)
<!-- Reviewable:end -->
