### PR TITLE
[Pal] return value is -PAL_ERROR_XXX

### DIFF
--- a/Pal/src/host/Linux-SGX/db_sockets.c
+++ b/Pal/src/host/Linux-SGX/db_sockets.c
@@ -150,7 +150,7 @@ static int inet_create_uri (char * uri, int count, struct sockaddr * addr,
 
     if (addr->sa_family == AF_INET) {
         if (addrlen != sizeof(struct sockaddr_in))
-            return PAL_ERROR_INVAL;
+            return -PAL_ERROR_INVAL;
 
         struct sockaddr_in * addr_in = (struct sockaddr_in *) addr;
         char * addr = (char *) &addr_in->sin_addr.s_addr;
@@ -164,7 +164,7 @@ static int inet_create_uri (char * uri, int count, struct sockaddr * addr,
                        __ntohs(addr_in->sin_port));
     } else if (addr->sa_family == AF_INET6) {
         if (addrlen != sizeof(struct sockaddr_in6))
-            return PAL_ERROR_INVAL;
+            return -PAL_ERROR_INVAL;
 
         struct sockaddr_in6 * addr_in6 = (struct sockaddr_in6 *) addr;
         unsigned short * addr = (unsigned short *) &addr_in6->sin6_addr.s6_addr;

--- a/Pal/src/host/Linux-SGX/sgx_graphene.c
+++ b/Pal/src/host/Linux-SGX/sgx_graphene.c
@@ -51,7 +51,7 @@ int _DkEventSet (PAL_HANDLE event, int wakeup)
                              NULL, NULL, 0);
     }
 
-    return IS_ERR(ret) ? PAL_ERROR_TRYAGAIN : ret;
+    return IS_ERR(ret) ? -PAL_ERROR_TRYAGAIN : ret;
 }
 
 int _DkEventWait (PAL_HANDLE event)

--- a/Pal/src/host/Linux/db_events.c
+++ b/Pal/src/host/Linux/db_events.c
@@ -72,7 +72,7 @@ int _DkEventSet (PAL_HANDLE event, int wakeup)
                              NULL, NULL, 0);
     }
 
-    return IS_ERR(ret) ? PAL_ERROR_TRYAGAIN : ret;
+    return IS_ERR(ret) ? -PAL_ERROR_TRYAGAIN : ret;
 }
 
 int _DkEventWaitTimeout (PAL_HANDLE event, uint64_t timeout)

--- a/Pal/src/host/Linux/db_sockets.c
+++ b/Pal/src/host/Linux/db_sockets.c
@@ -157,7 +157,7 @@ static int inet_create_uri (char * uri, int count, struct sockaddr * addr,
 
     if (addr->sa_family == AF_INET) {
         if (addrlen != sizeof(struct sockaddr_in))
-            return PAL_ERROR_INVAL;
+            return -PAL_ERROR_INVAL;
 
         struct sockaddr_in * addr_in = (struct sockaddr_in *) addr;
         char * addr = (char *) &addr_in->sin_addr.s_addr;
@@ -171,7 +171,7 @@ static int inet_create_uri (char * uri, int count, struct sockaddr * addr,
                        __ntohs(addr_in->sin_port));
     } else if (addr->sa_family == AF_INET6) {
         if (addrlen != sizeof(struct sockaddr_in6))
-            return PAL_ERROR_INVAL;
+            return -PAL_ERROR_INVAL;
 
         struct sockaddr_in6 * addr_in6 = (struct sockaddr_in6 *) addr;
         unsigned short * addr = (unsigned short *) &addr_in6->sin6_addr.s6_addr;


### PR DESCRIPTION
Some _Dk functions returns positive error code accidentally.
It should return negated error value.

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

Please fill in the following form before submitting this PR:

- Affected components
    - [ ] README and global configurations
    - [x] Linux PAL
    - [x] SGX PAL
    - [x] FreeBSD PAL
    - [ ] Library OS (i.e., SHIM), including GLIBC

- A brief description of this PR (describe the reasons and measures)




- How to test this PR?
    - [ ] Documentation-only; no need to test




Please follow the [coding style guidelines](CODESTYLE.md). Do not submit PRs which violate these rules.
- [ ] Comments and commit messages: no spelling or grammatical errors
- [ ] 4 spaces per indentation level, at most 100 chars per line
- [ ] Asterisks (`*`) next to types: `int* pointer;` (one pointer each line)
- [ ] Braces (`{`) begin in the same line as function names, `if`, `else`, `while`, `do`, `for`, `switch`, `union`, and `struct` keywords.
- [ ] Naming: Macros, constants - `NAMED_THIS_WAY`; global variables - `g_named_this_way`; others - `named_this_way`.
- Other styling issues may be pointed out by reviewers.


Please preserve the following checklist for reviewing:

- [ ] Pass all CI unit tests
- [ ] Resolve all discussions/requests from reviewers
- Reviewer approval (select one):
    - [ ] 3 approving reviews
    - [ ] 2 approving reviews and 5 days since the PR was created
    - [ ] The PR is from a maintainer; 1 approving review and 10 days since the PR was created

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/439)
<!-- Reviewable:end -->
