### PR TITLE
[Docs] Simplify our PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,37 +1,15 @@
-Please fill in the following form before submitting this PR:
+Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](CODESTYLE.md).
 
-- Affected components
-    - [ ] README and global configurations
-    - [ ] Linux PAL
-    - [ ] SGX PAL
-    - [ ] FreeBSD PAL
-    - [ ] Library OS (i.e., SHIM), including GLIBC
+## Affected components
 
-- A brief description of this PR (describe the reasons and measures)
+- [ ] README and global configuration
+- [ ] Linux PAL
+- [ ] SGX PAL
+- [ ] FreeBSD PAL
+- [ ] Library OS (i.e., SHIM), including GLIBC
 
-
-
-
-- How to test this PR?
-    - [ ] Documentation-only; no need to test
+## Description of the changes (reasons and measures)
 
 
+## How to test this PR?
 
-
-Please follow the [coding style guidelines](CODESTYLE.md). Do not submit PRs which violate these rules.
-- [ ] Comments and commit messages: no spelling or grammatical errors
-- [ ] 4 spaces per indentation level, at most 100 chars per line
-- [ ] Asterisks (`*`) next to types: `int* pointer;` (one pointer each line)
-- [ ] Braces (`{`) begin in the same line as function names, `if`, `else`, `while`, `do`, `for`, `switch`, `union`, and `struct` keywords.
-- [ ] Naming: Macros, constants - `NAMED_THIS_WAY`; global variables - `g_named_this_way`; others - `named_this_way`.
-- Other styling issues may be pointed out by reviewers.
-
-
-Please preserve the following checklist for reviewing:
-
-- [ ] Pass all CI unit tests
-- [ ] Resolve all discussions/requests from reviewers
-- Reviewer approval (select one):
-    - [ ] 3 approving reviews
-    - [ ] 2 approving reviews and 5 days since the PR was created
-    - [ ] The PR is from a maintainer; 1 approving review and 10 days since the PR was created


### PR DESCRIPTION
Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](CODESTYLE.md).

## Affected components

- [X] README and global configurations
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes (reasons and measures)

Because we implemented most of our checks programmatically (in custom Reviewable's status check script and in `make format`, with Jenkins integration coming soon) I think it's a good moment to simplify our PR template, which is quite dense now.

## How to test this PR?

Documentation-only; no need to test
