### PR TITLE
[LibOS] issue 449: use atomic for shim_context::preempt

### DIFF
--- a/LibOS/shim/include/shim_tls.h
+++ b/LibOS/shim/include/shim_tls.h
@@ -3,6 +3,22 @@
 
 #ifndef __ASSEMBLER__
 
+#ifdef IN_SHIM
+
+#include <shim_defs.h>
+#include <atomic.h>
+
+#else  /* !IN_SHIM */
+/* workaround to make glibc build
+ * the following structure must match to the one defined in pal/lib/atomic.h
+ */
+#ifdef __x86_64__
+struct atomic_int {
+    volatile int64_t counter;
+};
+#endif
+#endif /* IN_SHIM */
+
 #define SHIM_TLS_CANARY 0xdeadbeef
 
 struct lock_record {
@@ -40,14 +56,8 @@ struct shim_context {
     struct shim_regs *      regs;
     struct shim_context *   next;
     uint64_t                enter_time;
-    uint64_t                preempt;
+    struct atomic_int       preempt;
 };
-
-#ifdef IN_SHIM
-
-#include <shim_defs.h>
-
-#endif /* IN_SHIM */
 
 struct debug_buf;
 

--- a/LibOS/shim/include/shim_tls.h
+++ b/LibOS/shim/include/shim_tls.h
@@ -1,11 +1,8 @@
 #ifndef _SHIM_TLS_H_
 #define _SHIM_TLS_H_
 
-#ifndef __ASSEMBLER__
-
 #ifdef IN_SHIM
 
-#include <shim_defs.h>
 #include <atomic.h>
 
 #else  /* !IN_SHIM */
@@ -20,16 +17,6 @@ struct atomic_int {
 #endif /* IN_SHIM */
 
 #define SHIM_TLS_CANARY 0xdeadbeef
-
-struct lock_record {
-    enum { NO_LOCK, SEM_LOCK, READ_LOCK, WRITE_LOCK } type;
-    void * lock;
-    const char * filename;
-    int lineno;
-};
-
-#define NUM_LOCK_RECORD      32
-#define NUM_LOCK_RECORD_MASK (NUM_LOCK_RECORD - 1)
 
 struct shim_regs {
     unsigned long           orig_rax;
@@ -131,7 +118,5 @@ static inline __libc_tcb_t * shim_libc_tcb(void)
 }
 
 #endif /* IN_SHIM */
-
-#endif /* !__ASSEMBLER__ */
 
 #endif /* _SHIM_H_ */

--- a/LibOS/shim/src/bookkeep/shim_signal.c
+++ b/LibOS/shim/src/bookkeep/shim_signal.c
@@ -163,7 +163,7 @@ void deliver_signal (siginfo_t * info, PAL_CONTEXT * context)
     struct shim_thread * cur_thread = (struct shim_thread *) tcb->tp;
     int sig = info->si_signo;
 
-    __disable_preempt(tcb);
+    int64_t preempt = __disable_preempt(tcb);
 
     struct shim_signal * signal = __alloca(sizeof(struct shim_signal));
     /* save in signal */
@@ -172,7 +172,7 @@ void deliver_signal (siginfo_t * info, PAL_CONTEXT * context)
     __store_context(tcb, context, signal);
     signal->pal_context = context;
 
-    if (tcb->context.preempt > 1 ||
+    if (preempt > 1 ||
         __sigismember(&cur_thread->signal_mask, sig)) {
         struct shim_signal ** signal_log = NULL;
         if ((signal = malloc_copy(signal,sizeof(struct shim_signal))) &&
@@ -561,8 +561,8 @@ static void resume_upcall (PAL_PTR event, PAL_NUM arg, PAL_CONTEXT * context)
         return;
 
     if (!is_internal_tid(get_cur_tid())) {
-        __disable_preempt(tcb);
-        if (tcb->context.preempt <= 1)
+        int64_t preempt = __disable_preempt(tcb);
+        if (preempt <= 1)
             __handle_signal(tcb, 0);
         __enable_preempt(tcb);
     }
@@ -717,10 +717,10 @@ void handle_signal (void)
     if (!thread || !thread->has_signal.counter)
         return;
 
-    __disable_preempt(tcb);
+    int64_t preempt = __disable_preempt(tcb);
 
-    if (tcb->context.preempt > 1)
-        debug("signal delayed (%ld)\n", tcb->context.preempt);
+    if (preempt > 1)
+        debug("signal delayed (%ld)\n", preempt);
     else
         __handle_signal(tcb, 0);
 

--- a/LibOS/shim/src/syscallas.S
+++ b/LibOS/shim/src/syscallas.S
@@ -20,7 +20,6 @@
  * This file contains the entry point of system call table in library OS.
  */
 
-#include <shim_tls.h>
 #include <shim_unistd_defs.h>
 
 #include "asm-offsets.h"

--- a/Pal/lib/atomic.h
+++ b/Pal/lib/atomic.h
@@ -50,11 +50,7 @@ Copyright (C) 2005-2014 Rich Felker, et al.
 
 struct atomic_int {
     volatile int32_t counter;
-}
-#ifdef __GNUC__
-__attribute__((aligned(sizeof(uint32_t))))
-#endif
-;
+};
 #endif
 
 
@@ -72,11 +68,7 @@ __attribute__((aligned(sizeof(uint32_t))))
 
 struct atomic_int {
     volatile int64_t counter;
-}
-#ifdef __GNUC__
-__attribute__((aligned(sizeof(uint64_t))))
-#endif
-;
+};
 #endif
 
 #define LOCK_PREFIX     "\n\tlock; "


### PR DESCRIPTION
preempt_enable/disable(), __preempt_enable/disable() and other
functions touch shim_context::preempt with normal instruction. For
example preempt++ or preempt-- isn't atomic. Async signal can come
between such instructions and the integrity of preempt can be broken.

make shim_context::preempt atomic_inc and the logic is rewritten by
using atomic operation.

Fixes #449

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

Please fill in the following form before submitting this PR:

- Affected components
    - [ ] README and global configurations
    - [ ] Linux PAL
    - [ ] SGX PAL
    - [ ] FreeBSD PAL
    - [x] Library OS (i.e., SHIM), including GLIBC

- A brief description of this PR (describe the reasons and measures)




- How to test this PR?
    - [ ] Documentation-only; no need to test




Please follow the [coding style guidelines](CODESTYLE.md). Do not submit PRs which violate these rules.
- [ ] Comments and commit messages: no spelling or grammatical errors
- [ ] 4 spaces per indentation level, at most 100 chars per line
- [ ] Asterisks (`*`) next to types: `int* pointer;` (one pointer each line)
- [ ] Braces (`{`) begin in the same line as function names, `if`, `else`, `while`, `do`, `for`, `switch`, `union`, and `struct` keywords.
- [ ] Naming: Macros, constants - `NAMED_THIS_WAY`; global variables - `g_named_this_way`; others - `named_this_way`.
- Other styling issues may be pointed out by reviewers.


Please preserve the following checklist for reviewing:

- [ ] Pass all CI unit tests
- [ ] Resolve all discussions/requests from reviewers
- Reviewer approval (select one):
    - [ ] 3 approving reviews
    - [ ] 2 approving reviews and 5 days since the PR was created
    - [ ] The PR is from a maintainer; 1 approving review and 10 days since the PR was created

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/450)
<!-- Reviewable:end -->
