### PR TITLE
[LibOS] clone shouldn't expose child thread until its init

### DIFF
--- a/LibOS/shim/src/sys/shim_clone.c
+++ b/LibOS/shim/src/sys/shim_clone.c
@@ -129,6 +129,10 @@ int clone_implementation_wrapper(struct clone_args * arg)
     my_thread->stack_top = vma.addr + vma.length;
     my_thread->stack_red = my_thread->stack = vma.addr;
 
+    /* until now we're not ready to be exposed to other thread */
+    add_thread(my_thread);
+    set_as_child(arg->parent, my_thread);
+
     /* Don't signal the initialize event until we are actually init-ed */ 
     DkEventSet(pcargs->initialize_event);
 
@@ -324,8 +328,6 @@ int shim_do_clone (int flags, void * user_stack_addr, int * parent_tidptr,
 
     thread->pal_handle = pal_handle;
     thread->in_vm = thread->is_alive = true;
-    add_thread(thread);
-    set_as_child(self, thread);
 
     if (set_parent_tid)
         *set_parent_tid = tid;


### PR DESCRIPTION
The final initialization of child thread of clone is done by
clone_implementation_wrapper(). Until the initialization completes,
child shim_thread shouldn't be exposed to other thread.
Otherwise other thread can access uninitialized shim_thread.
For example, other thread tries to send signal to that thread by
walking thread_list and access uninitialized member of shim_thread.
Defer add_thread() until initialization is complete.

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

Please fill in the following form before submitting this PR:

- Affected components
    - [ ] README and global configurations
    - [ ] Linux PAL
    - [ ] SGX PAL
    - [ ] FreeBSD PAL
    - [x] Library OS (i.e., SHIM), including GLIBC

- A brief description of this PR (describe the reasons and measures)




- How to test this PR?
    - [ ] Documentation-only; no need to test




Please follow the [coding style guidelines](CODESTYLE.md). Do not submit PRs which violate these rules.
- [ ] Comments and commit messages: no spelling or grammatical errors
- [ ] 4 spaces per indentation level, at most 100 chars per line
- [ ] Asterisks (`*`) next to types: `int* pointer;` (one pointer each line)
- [ ] Braces (`{`) begin in the same line as function names, `if`, `else`, `while`, `do`, `for`, `switch`, `union`, and `struct` keywords.
- [ ] Naming: Macros, constants - `NAMED_THIS_WAY`; global variables - `g_named_this_way`; others - `named_this_way`.
- Other styling issues may be pointed out by reviewers.


Please preserve the following checklist for reviewing:

- [ ] Pass all CI unit tests
- [ ] Resolve all discussions/requests from reviewers
- Reviewer approval (select one):
    - [ ] 3 approving reviews
    - [ ] 2 approving reviews and 5 days since the PR was created
    - [ ] The PR is from a maintainer; 1 approving review and 10 days since the PR was created

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/451)
<!-- Reviewable:end -->
