### PR TITLE
[LibOS] test program for sigsuspend and alarm

### DIFF
--- a/LibOS/shim/test/regression/sigsuspend.c
+++ b/LibOS/shim/test/regression/sigsuspend.c
@@ -1,0 +1,60 @@
+/* Copyright 2019 Intel Corporation.
+ * Copyright 2019 Isaku Yamahata <isaku.yamahata at intel com>
+                                 <isaku.yamahata at gmail com>
+   This file is part of Graphene Library OS.
+
+   Graphene Library OS is free software: you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public License
+   as published by the Free Software Foundation, either version 3 of the
+   License, or (at your option) any later version.
+
+   Graphene Library OS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
+
+#include <stdbool.h>
+
+#include <err.h>
+#include <signal.h>
+#include <stdio.h>
+#include <time.h>
+#include <unistd.h>
+
+volatile int sigcount = 0;
+
+void handler(int sig)
+{
+    sigcount++;
+}
+
+int main(void)
+{
+    sigset_t mask;
+    sigemptyset(&mask);
+    sigaddset(&mask, SIGALRM);
+
+    int ret = sigprocmask(SIG_BLOCK, &mask, NULL);
+    if (ret < 0)
+        errx(ret, "sigprocmask");
+
+    signal(SIGALRM, &handler);
+    sigemptyset(&mask);
+    int count = 0;
+    while (true) {
+        printf("count %d sigcount %d\n", count, sigcount);
+        fflush(stdout);
+
+        struct timespec t = {
+            .tv_sec = 1,
+            .tv_nsec = 0
+        };
+        alarm(1);
+        nanosleep(&t, NULL);
+        sigsuspend(&mask);
+        count++;
+    }
+}


### PR DESCRIPTION
This test program shows race condition between thread_sleep() and
thread_wakeup() and DkThreadResume(thread->pal_handle).

With graphene, sigsuspend doesn't return or results in assert.
> assert failed shim_syscalls.c:260 preempt == get_cur_preempt() (value:0)

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

Please fill in the following form before submitting this PR:

- Affected components
    - [ ] README and global configurations
    - [ ] Linux PAL
    - [ ] SGX PAL
    - [ ] FreeBSD PAL
    - [x] Library OS (i.e., SHIM), including GLIBC

- A brief description of this PR (describe the reasons and measures)




- How to test this PR?
    - [ ] Documentation-only; no need to test
no need to test because this is a test program



Please follow the [coding style guidelines](CODESTYLE.md). Do not submit PRs which violate these rules.
- [ ] Comments and commit messages: no spelling or grammatical errors
- [ ] 4 spaces per indentation level, at most 100 chars per line
- [ ] Asterisks (`*`) next to types: `int* pointer;` (one pointer each line)
- [ ] Braces (`{`) begin in the same line as function names, `if`, `else`, `while`, `do`, `for`, `switch`, `union`, and `struct` keywords.
- [ ] Naming: Macros, constants - `NAMED_THIS_WAY`; global variables - `g_named_this_way`; others - `named_this_way`.
- Other styling issues may be pointed out by reviewers.


Please preserve the following checklist for reviewing:

- [ ] Pass all CI unit tests
- [ ] Resolve all discussions/requests from reviewers
- Reviewer approval (select one):
    - [ ] 3 approving reviews
    - [ ] 2 approving reviews and 5 days since the PR was created
    - [ ] The PR is from a maintainer; 1 approving review and 10 days since the PR was created

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/452)
<!-- Reviewable:end -->
