### PR TITLE
[LibOS] shim_signal: race in handle_signal() with SIGNAL_DELAYED

### DIFF
--- a/LibOS/shim/include/shim_tls.h
+++ b/LibOS/shim/include/shim_tls.h
@@ -16,6 +16,17 @@
 
 #else /* !__ASSEMBLER__ */
 
+/* work around to compile glibc */
+#ifndef _SHIM_ATOMIC_H_
+struct atomic_int {
+    volatile int64_t counter;
+}
+#ifdef __GNUC__
+__attribute__((aligned(sizeof(uint64_t))))
+#endif
+;
+#endif
+
 #define SHIM_TLS_CANARY 0xdeadbeef
 
 struct lock_record {

--- a/LibOS/shim/include/shim_tls.h
+++ b/LibOS/shim/include/shim_tls.h
@@ -52,14 +52,14 @@ struct shim_context {
     struct shim_regs *      regs;
     struct shim_context *   next;
     uint64_t                enter_time;
-    uint64_t                preempt;
+    struct atomic_int       preempt;
 };
 
 #ifdef IN_SHIM
 
 #include <shim_defs.h>
 
-#define SIGNAL_DELAYED       (0x80000000UL)
+#define SIGNAL_DELAYED       (0x40000000L)
 
 #endif /* IN_SHIM */
 

--- a/LibOS/shim/src/bookkeep/shim_signal.c
+++ b/LibOS/shim/src/bookkeep/shim_signal.c
@@ -592,9 +592,11 @@ void __handle_signal (shim_tcb_t * tcb, int sig, ucontext_t * uc)
 
     sig = begin_sig;
 
+    __preempt_clear_delayed(tcb);
     while (atomic_read(&thread->has_signal)) {
         struct shim_signal * signal = NULL;
 
+        __preempt_clear_delayed(tcb);
         for ( ; sig < end_sig ; sig++)
             if (!__sigismember(&thread->signal_mask, sig) &&
                 (signal = fetch_signal_log(tcb, thread, sig)))
@@ -609,7 +611,6 @@ void __handle_signal (shim_tcb_t * tcb, int sig, ucontext_t * uc)
         __handle_one_signal(tcb, sig, signal);
         free(signal);
         DkThreadYieldExecution();
-        __preempt_clear_delayed(tcb);
     }
 }
 

--- a/LibOS/shim/src/bookkeep/shim_signal.c
+++ b/LibOS/shim/src/bookkeep/shim_signal.c
@@ -630,15 +630,15 @@ void handle_signal (bool delayed_only)
     if ((preempt & ~SIGNAL_DELAYED) > 1) {
         debug("signal delayed (%d)\n", preempt & ~SIGNAL_DELAYED);
         __preempt_set_delayed(tcb);
-        goto out;
+        __enable_preempt(tcb);
+    } else {
+        do {
+            if (!delayed_only || (preempt & SIGNAL_DELAYED))
+                __handle_signal(tcb, 0, NULL);
+            preempt = atomic_cmpxchg(&tcb->context.preempt, 1, 0);
+        } while (preempt != 1);
     }
 
-    if (delayed_only && !(preempt & SIGNAL_DELAYED))
-        goto out;
-
-    __handle_signal(tcb, 0, NULL);
-out:
-    __enable_preempt(tcb);
     debug("__enable_preempt: %s:%d\n", __FILE__, __LINE__);
 }
 


### PR DESCRIPTION
Please fill in the following form before submitting this PR:

- Affected components
    - [ ] README and global configurations
    - [ ] Linux PAL
    - [ ] SGX PAL
    - [ ] FreeBSD PAL
    - [ ] Library OS (i.e., SHIM), including GLIBC

- A brief description of this PR (describe the reasons and measures)
[LibOS] shim_signal: race in handle_signal() with SIGNAL_DELAYED
    
handle_signal() should be careful when to discrement preempt
counter from 1 to 0. SIGNAL_DELAYED flag can be set at the same time.
    
Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>




- How to test this PR?
    - [ ] Documentation-only; no need to test
https://github.com/oscarlab/graphene/pull/452


Please follow the [coding style guidelines](CODESTYLE.md). Do not submit PRs which violate these rules.
- [ ] Comments and commit messages: no spelling or grammatical errors
- [ ] 4 spaces per indentation level, at most 100 chars per line
- [ ] Asterisks (`*`) next to types: `int* pointer;` (one pointer each line)
- [ ] Braces (`{`) begin in the same line as function names, `if`, `else`, `while`, `do`, `for`, `switch`, `union`, and `struct` keywords.
- [ ] Naming: Macros, constants - `NAMED_THIS_WAY`; global variables - `g_named_this_way`; others - `named_this_way`.
- Other styling issues may be pointed out by reviewers.


Please preserve the following checklist for reviewing:

- [ ] Pass all CI unit tests
- [ ] Resolve all discussions/requests from reviewers
- Reviewer approval (select one):
    - [ ] 3 approving reviews
    - [ ] 2 approving reviews and 5 days since the PR was created
    - [ ] The PR is from a maintainer; 1 approving review and 10 days since the PR was created

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/455)
<!-- Reviewable:end -->
