### PR TITLE
[LibOS] Fix ref counting in path lookup/dcache

### DIFF
--- a/LibOS/shim/src/fs/shim_dcache.c
+++ b/LibOS/shim/src/fs/shim_dcache.c
@@ -250,6 +250,7 @@ __lookup_dcache (struct shim_dentry * start, const char * name, int namelen,
 
     /* If we are looking up an empty string, return start */
     if (namelen == 0) {
+        get_dentry(start);
         found = start;
         goto out;
     }


### PR DESCRIPTION
Fixes #157 

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes (reasons and measures)
Fixed incorrect reference counting in LibOS/fs

## How to test this PR? (if applicable)
Standard test suite.
Define `DEBUG_REF` to see refcounts in debug output.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/459)
<!-- Reviewable:end -->
