### PR TITLE
Fix parse_stream_uri and parse_device_uri semantics

### DIFF
--- a/Pal/src/host/FreeBSD/db_pipes.c
+++ b/Pal/src/host/FreeBSD/db_pipes.c
@@ -306,7 +306,7 @@ static int pipe_private (PAL_HANDLE * handle, int options)
 static int pipe_open (PAL_HANDLE *handle, const char * type, const char * uri,
                       int access, int share, int create, int options)
 {
-    if (strpartcmp_static(type, "pipe:") && !*uri)
+    if (strcmp_static(type, "pipe") && !*uri)
         return pipe_private(handle, options);
 
     char * endptr;
@@ -317,10 +317,10 @@ static int pipe_open (PAL_HANDLE *handle, const char * type, const char * uri,
 
     options = HOST_OPTIONS(options & PAL_OPTION_MASK);
 
-    if (strpartcmp_static(type, "pipe.srv:"))
+    if (strcmp_static(type, "pipe.srv"))
         return pipe_listen(handle, pipeid, options);
 
-    if (strpartcmp_static(type, "pipe:"))
+    if (strcmp_static(type, "pipe"))
         return pipe_connect(handle, pipeid, options);
 
     return -PAL_ERROR_INVAL;

--- a/Pal/src/host/FreeBSD/db_sockets.c
+++ b/Pal/src/host/FreeBSD/db_sockets.c
@@ -548,10 +548,10 @@ static int tcp_open (PAL_HANDLE *handle, const char * type, const char * uri,
     char uri_buf[PAL_SOCKADDR_SIZE];
     memcpy(uri_buf, uri, uri_len);
 
-    if (strpartcmp_static(type, "tcp.srv:"))
+    if (strcmp_static(type, "tcp.srv"))
         return tcp_listen(handle, uri_buf, options);
 
-    if (strpartcmp_static(type, "tcp:"))
+    if (strcmp_static(type, "tcp"))
         return tcp_connect(handle, uri_buf, options);
 
     return -PAL_ERROR_NOTSUPPORT;
@@ -770,10 +770,10 @@ static int udp_open (PAL_HANDLE *hdl, const char * type, const char * uri,
     memcpy(buf, uri, len + 1);
     options &= PAL_OPTION_MASK;
 
-    if (!strpartcmp_static(type, "udp.srv:"))
+    if (!strcmp_static(type, "udp.srv"))
         return udp_bind(hdl, buf, options);
 
-    if (!strpartcmp_static(type, "udp:"))
+    if (!strcmp_static(type, "udp"))
         return udp_connect(hdl, buf, options);
 
     return -PAL_ERROR_NOTSUPPORT;

--- a/Pal/src/host/Linux-SGX/db_devices.c
+++ b/Pal/src/host/Linux-SGX/db_devices.c
@@ -58,10 +58,9 @@ static const struct handle_ops * pal_device_ops [PAL_DEVICE_TYPE_BOUND] = {
             &term_ops,
         };
 
-/* parse-device_uri scan the uri, parse the prefix of the uri and search
-   for stream handler wich will open or access the device */
-static int parse_device_uri (const char ** uri, const char ** type,
-                             struct handle_ops ** ops)
+/* parse_device_uri scans the uri, parses the prefix of the uri and searches
+   for stream handler wich will open or access the device. */
+static int parse_device_uri(const char ** uri, char ** type, struct handle_ops ** ops)
 {
     struct handle_ops * dops = NULL;
     const char * p, * u = (*uri);
@@ -75,8 +74,12 @@ static int parse_device_uri (const char ** uri, const char ** type,
         return -PAL_ERROR_NOTSUPPORT;
 
     *uri = (*p) ? p + 1 : p;
-    if (type)
-        *type = u;
+    if (type) {
+        *type = malloc_copy(u, p - u + 1);
+        if (!*type)
+            return -PAL_ERROR_NOMEM;
+        (*type)[p - u] = '\0';
+    }
     if (ops)
         *ops = dops;
     return 0;
@@ -216,7 +219,7 @@ static int dev_open (PAL_HANDLE * handle, const char * type, const char * uri,
                      int access, int share, int create, int options)
 {
     struct handle_ops * ops = NULL;
-    const char * dev_type = NULL;
+    char* dev_type = NULL;
     int ret = 0;
 
     ret = parse_device_uri(&uri, &dev_type, &ops);
@@ -233,8 +236,10 @@ static int dev_open (PAL_HANDLE * handle, const char * type, const char * uri,
     hdl->dev.fd_out = PAL_IDX_POISON;
     *handle = hdl;
 
-    return ops->open(handle, dev_type, uri,
-                     access, share, create, options);
+    ret = ops->open(handle, dev_type, uri,
+                    access, share, create, options);
+    free(dev_type);
+    return ret;
 }
 
 /* 'read' operation for device stream */
@@ -342,7 +347,7 @@ static int dev_attrquery (const char * type, const char * uri,
                           PAL_STREAM_ATTR * attr)
 {
     struct handle_ops * ops = NULL;
-    const char * dev_type = NULL;
+    char* dev_type = NULL;
     int ret = 0;
 
     ret = parse_device_uri(&uri, &dev_type, &ops);
@@ -353,7 +358,9 @@ static int dev_attrquery (const char * type, const char * uri,
     if (!ops || !ops->attrquery)
         return -PAL_ERROR_NOTSUPPORT;
 
-    return ops->attrquery(dev_type, uri, attr);
+    ret = ops->attrquery(dev_type, uri, attr);
+    free(dev_type);
+    return ret;
 }
 
 /* 'attrquerybyhdl' operation for device stream */

--- a/Pal/src/host/Linux-SGX/db_pipes.c
+++ b/Pal/src/host/Linux-SGX/db_pipes.c
@@ -170,7 +170,7 @@ static int pipe_open (PAL_HANDLE *handle, const char * type, const char * uri,
 {
     options &= PAL_OPTION_MASK;
 
-    if (strpartcmp_static(type, "pipe:") && !*uri)
+    if (strcmp_static(type, "pipe") && !*uri)
         return pipe_private(handle, options);
 
     char * endptr;
@@ -179,10 +179,10 @@ static int pipe_open (PAL_HANDLE *handle, const char * type, const char * uri,
     if (*endptr)
         return -PAL_ERROR_INVAL;
 
-    if (strpartcmp_static(type, "pipe.srv:"))
+    if (strcmp_static(type, "pipe.srv"))
         return pipe_listen(handle, pipeid, options);
 
-    if (strpartcmp_static(type, "pipe:"))
+    if (strcmp_static(type, "pipe"))
         return pipe_connect(handle, pipeid, options);
 
     return -PAL_ERROR_INVAL;

--- a/Pal/src/host/Linux-SGX/db_sockets.c
+++ b/Pal/src/host/Linux-SGX/db_sockets.c
@@ -464,10 +464,10 @@ static int tcp_open (PAL_HANDLE *handle, const char * type, const char * uri,
     char uri_buf[PAL_SOCKADDR_SIZE];
     memcpy(uri_buf, uri, uri_len);
 
-    if (strpartcmp_static(type, "tcp.srv:"))
+    if (strcmp_static(type, "tcp.srv"))
         return tcp_listen(handle, uri_buf, options);
 
-    if (strpartcmp_static(type, "tcp:"))
+    if (strcmp_static(type, "tcp"))
         return tcp_connect(handle, uri_buf, options);
 
     return -PAL_ERROR_NOTSUPPORT;
@@ -620,10 +620,10 @@ static int udp_open (PAL_HANDLE *hdl, const char * type, const char * uri,
     memcpy(buf, uri, len + 1);
     options &= PAL_OPTION_MASK;
 
-    if (strpartcmp_static(type, "udp.srv:"))
+    if (strcmp_static(type, "udp.srv"))
         return udp_bind(hdl, buf, options);
 
-    if (strpartcmp_static(type, "udp:"))
+    if (strcmp_static(type, "udp"))
         return udp_connect(hdl, buf, options);
 
     return -PAL_ERROR_NOTSUPPORT;

--- a/Pal/src/host/Linux/db_pipes.c
+++ b/Pal/src/host/Linux/db_pipes.c
@@ -304,7 +304,7 @@ static int pipe_open (PAL_HANDLE *handle, const char * type, const char * uri,
 {
     options &= PAL_OPTION_MASK;
 
-    if (strpartcmp_static(type, "pipe:") && !*uri)
+    if (strcmp_static(type, "pipe") && !*uri)
         return pipe_private(handle, options);
 
     char * endptr;
@@ -313,10 +313,10 @@ static int pipe_open (PAL_HANDLE *handle, const char * type, const char * uri,
     if (*endptr)
         return -PAL_ERROR_INVAL;
 
-    if (strpartcmp_static(type, "pipe.srv:"))
+    if (strcmp_static(type, "pipe.srv"))
         return pipe_listen(handle, pipeid, options);
 
-    if (strpartcmp_static(type, "pipe:"))
+    if (strcmp_static(type, "pipe"))
         return pipe_connect(handle, pipeid, options);
 
     return -PAL_ERROR_INVAL;

--- a/Pal/src/host/Linux/db_sockets.c
+++ b/Pal/src/host/Linux/db_sockets.c
@@ -566,10 +566,10 @@ static int tcp_open (PAL_HANDLE *handle, const char * type, const char * uri,
     char uri_buf[PAL_SOCKADDR_SIZE];
     memcpy(uri_buf, uri, uri_len);
 
-    if (strpartcmp_static(type, "tcp.srv:"))
+    if (strcmp_static(type, "tcp.srv"))
         return tcp_listen(handle, uri_buf, options);
 
-    if (strpartcmp_static(type, "tcp:"))
+    if (strcmp_static(type, "tcp"))
         return tcp_connect(handle, uri_buf, options);
 
     return -PAL_ERROR_NOTSUPPORT;
@@ -785,10 +785,10 @@ static int udp_open (PAL_HANDLE *hdl, const char * type, const char * uri,
     memcpy(buf, uri, len + 1);
     options &= PAL_OPTION_MASK;
 
-    if (strpartcmp_static(type, "udp.srv:"))
+    if (strcmp_static(type, "udp.srv"))
         return udp_bind(hdl, buf, options);
 
-    if (strpartcmp_static(type, "udp:"))
+    if (strcmp_static(type, "udp"))
         return udp_connect(hdl, buf, options);
 
     return -PAL_ERROR_NOTSUPPORT;

--- a/Pal/src/host/Skeleton/db_devices.c
+++ b/Pal/src/host/Skeleton/db_devices.c
@@ -50,10 +50,9 @@ static const struct handle_ops * pal_device_ops [PAL_DEVICE_TYPE_BOUND] = {
             &term_ops,
         };
 
-/* parse-device_uri scan the uri, parse the prefix of the uri and search
-   for stream handler wich will open or access the device */
-static int parse_device_uri (const char ** uri, const char ** type,
-                             struct handle_ops ** ops)
+/* parse_device_uri scans the uri, parses the prefix of the uri and searches
+   for stream handler wich will open or access the device. */
+static int parse_device_uri(const char ** uri, char ** type, struct handle_ops ** ops)
 {
     struct handle_ops * dops = NULL;
     const char * p, * u = (*uri);
@@ -67,8 +66,12 @@ static int parse_device_uri (const char ** uri, const char ** type,
         return -PAL_ERROR_NOTSUPPORT;
 
     *uri = (*p) ? p + 1 : p;
-    if (type)
-        *type = u;
+    if (type) {
+        *type = malloc_copy(u, p - u + 1);
+        if (!*type)
+            return -PAL_ERROR_NOMEM;
+        (*type)[p - u] = '\0';
+    }
     if (ops)
         *ops = dops;
     return 0;
@@ -215,7 +218,9 @@ static int dev_attrquery (const char * type, const char * uri,
     if (!ops || !ops->attrquery)
         return -PAL_ERROR_NOTSUPPORT;
 
-    return ops->attrquery(dev_type, uri, attr);
+    ret = ops->attrquery(dev_type, uri, attr);
+    free(dev_type);
+    return ret;
 }
 
 /* 'attrquerybyhdl' operation for device stream */

--- a/Pal/src/host/Skeleton/db_pipes.c
+++ b/Pal/src/host/Skeleton/db_pipes.c
@@ -60,7 +60,7 @@ static int pipe_open (PAL_HANDLE *handle, const char * type,
                       const char * uri, int access, int share,
                       int create, int options)
 {
-    if (strpartcmp_static(type, "pipe:") && !*uri)
+    if (strcmp_static(type, "pipe") && !*uri)
         return pipe_private(handle);
 
     char * endptr;
@@ -77,10 +77,10 @@ static int pipe_open (PAL_HANDLE *handle, const char * type,
     if (*endptr)
         return -PAL_ERROR_INVAL;
 
-    if (strpartcmp_static(type, "pipe.srv:"))
+    if (strcmp_static(type, "pipe.srv"))
         return pipe_listen(handle, pipeid, create);
 
-    if (strpartcmp_static(type, "pipe:"))
+    if (strcmp_static(type, "pipe"))
         return pipe_connect(handle, pipeid, connid, create);
 
     return -PAL_ERROR_INVAL;

--- a/Pal/src/host/Skeleton/db_sockets.c
+++ b/Pal/src/host/Skeleton/db_sockets.c
@@ -65,10 +65,10 @@ static int tcp_open (PAL_HANDLE *handle, const char * type, const char * uri,
     char uri_buf[PAL_SOCKADDR_SIZE];
     memcpy(uri_buf, uri, uri_len);
 
-    if (!strpartcmp_static(type, "tcp.srv:"))
+    if (!strcmp_static(type, "tcp.srv"))
         return tcp_listen(handle, uri_buf, create);
 
-    if (!strpartcmp_static(type, "tcp:"))
+    if (!strcmp_static(type, "tcp"))
         return tcp_connect(handle, uri_buf, create);
 
     return -PAL_ERROR_NOTSUPPORT;
@@ -109,10 +109,10 @@ static int udp_open (PAL_HANDLE *hdl, const char * type, const char * uri,
 
     memcpy(buf, uri, len + 1);
 
-    if (strpartcmp_static(type, "udp.srv:"))
+    if (strcmp_static(type, "udp.srv"))
         return udp_bind(hdl, buf, create);
 
-    if (strpartcmp_static(type, "udp:"))
+    if (strcmp_static(type, "udp"))
         return udp_connect(hdl, buf);
 
     return -PAL_ERROR_NOTSUPPORT;


### PR DESCRIPTION
Fixes  #463.

## Affected components

- [ ] README and global configuration
- [X] Linux PAL
- [X] SGX PAL
- [X] FreeBSD PAL
- [X] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes (reasons and measures)
See  #463.

Please verify that I patched all relevant places which depend on those functions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/464)
<!-- Reviewable:end -->
