### PR TITLE
Null-terminate PAL_CPU_INFO strings

### DIFF
--- a/Pal/src/host/FreeBSD/db_main.c
+++ b/Pal/src/host/FreeBSD/db_main.c
@@ -340,21 +340,25 @@ void _DkGetCPUInfo (PAL_CPU_INFO * ci)
 {
     unsigned int words[WORD_NUM];
 
-    char * vendor_id = malloc(12);
+    const size_t VENDOR_ID_SIZE = 13;
+    char* vendor_id = malloc(VENDOR_ID_SIZE);
     cpuid(2, 0, words, 0);
 
     FOUR_CHARS_VALUE(&vendor_id[0], words[WORD_EBX]);
     FOUR_CHARS_VALUE(&vendor_id[4], words[WORD_EDX]);
     FOUR_CHARS_VALUE(&vendor_id[8], words[WORD_ECX]);
+    vendor_id[VENDOR_ID_SIZE - 1] = '\0';
     ci->cpu_vendor = vendor_id;
 
-    char * brand = malloc(48);
+    const size_t BRAND_SIZE = 49;
+    char* brand = malloc(BRAND_SIZE);
     cpuid(-2, 0x80000002, words, 0);
     memcpy(&brand[ 0], words, sizeof(unsigned int) * WORD_NUM);
     cpuid(-2, 0x80000003, words, 0);
     memcpy(&brand[16], words, sizeof(unsigned int) * WORD_NUM);
     cpuid(-2, 0x80000004, words, 0);
     memcpy(&brand[32], words, sizeof(unsigned int) * WORD_NUM);
+    brand[BRAND_SIZE - 1] = '\0';
     ci->cpu_brand = brand;
 
     cpuid(2, 1, words, 0);

--- a/Pal/src/host/Linux-SGX/db_main.c
+++ b/Pal/src/host/Linux-SGX/db_main.c
@@ -292,23 +292,27 @@ void _DkGetCPUInfo (PAL_CPU_INFO * ci)
 {
     unsigned int words[WORD_NUM];
 
-    char * vendor_id = malloc(12);
+    const size_t VENDOR_ID_SIZE = 13;
+    char* vendor_id = malloc(VENDOR_ID_SIZE);
     cpuid(0, 0, words);
 
     FOUR_CHARS_VALUE(&vendor_id[0], words[WORD_EBX]);
     FOUR_CHARS_VALUE(&vendor_id[4], words[WORD_EDX]);
     FOUR_CHARS_VALUE(&vendor_id[8], words[WORD_ECX]);
+    vendor_id[VENDOR_ID_SIZE - 1] = '\0';
     ci->cpu_vendor = vendor_id;
     // Must be an Intel CPU
     assert(!memcmp(vendor_id, "GenuineIntel", 12));
 
-    char * brand = malloc(48);
+    const size_t BRAND_SIZE = 49;
+    char* brand = malloc(BRAND_SIZE);
     cpuid(0x80000002, 0, words);
     memcpy(&brand[ 0], words, sizeof(unsigned int) * WORD_NUM);
     cpuid(0x80000003, 0, words);
     memcpy(&brand[16], words, sizeof(unsigned int) * WORD_NUM);
     cpuid(0x80000004, 0, words);
     memcpy(&brand[32], words, sizeof(unsigned int) * WORD_NUM);
+    brand[BRAND_SIZE - 1] = '\0';
     ci->cpu_brand = brand;
 
     /* According to SDM: EBX[15:0] is to enumerate processor topology 

--- a/Pal/src/host/Linux/db_main.c
+++ b/Pal/src/host/Linux/db_main.c
@@ -389,21 +389,25 @@ void _DkGetCPUInfo (PAL_CPU_INFO * ci)
 {
     unsigned int words[WORD_NUM];
 
-    char * vendor_id = malloc(12);
+    const size_t VENDOR_ID_SIZE = 13;
+    char* vendor_id = malloc(VENDOR_ID_SIZE);
     cpuid(0, 0, words);
 
     FOUR_CHARS_VALUE(&vendor_id[0], words[WORD_EBX]);
     FOUR_CHARS_VALUE(&vendor_id[4], words[WORD_EDX]);
     FOUR_CHARS_VALUE(&vendor_id[8], words[WORD_ECX]);
+    vendor_id[VENDOR_ID_SIZE - 1] = '\0';
     ci->cpu_vendor = vendor_id;
 
-    char * brand = malloc(48);
+    const size_t BRAND_SIZE = 49;
+    char* brand = malloc(BRAND_SIZE);
     cpuid(0x80000002, 0, words);
     memcpy(&brand[ 0], words, sizeof(unsigned int) * WORD_NUM);
     cpuid(0x80000003, 0, words);
     memcpy(&brand[16], words, sizeof(unsigned int) * WORD_NUM);
     cpuid(0x80000004, 0, words);
     memcpy(&brand[32], words, sizeof(unsigned int) * WORD_NUM);
+    brand[BRAND_SIZE - 1] = '\0';
     ci->cpu_brand = brand;
 
     if (!memcmp(vendor_id, "GenuineIntel", 12)) {


### PR DESCRIPTION
## Affected components

- [ ] README and global configuration
- [X] Linux PAL
- [X] SGX PAL
- [X] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes (reasons and measures)
Fixes a bug which was exposed by #464 (which changed the heap layout slightly). Strings in PAL_CPU_INFO were not null-terminated, but (un)luckily before #464 there were always zeros after the allocations, so the bug hasn't got exposed.

## How to test this PR? (if applicable)
```Bash
cd Pal/regression
../../Runtime/pal_loader ./Bootstrap
```

This should output `CPU vendor` and `CPU brand` without any garbage appended, even after modifying the initial heap layout with some additional allocations (e.g. by merging this branch with #464).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/465)
<!-- Reviewable:end -->
