### PR TITLE
Do not initialize SECS mrenclave and mrsigner before ECREATE.

### DIFF
--- a/LibOS/shim/src/sys/shim_socket.c
+++ b/LibOS/shim/src/sys/shim_socket.c
@@ -1192,6 +1192,9 @@ int shim_do_sendmmsg (int sockfd, struct mmsghdr * msg, int vlen, int flags)
 static ssize_t do_recvmsg (int fd, struct iovec * bufs, int nbufs, int flags,
                            struct sockaddr * addr, socklen_t * addrlen)
 {
+    /* TODO handle flags properly. For now, just return an error. */
+    if (flags) return -EINVAL;
+    
     struct shim_handle * hdl = get_fd_handle(fd, NULL, NULL);
     if (!hdl)
         return -EBADF;

--- a/LibOS/shim/src/sys/shim_socket.c
+++ b/LibOS/shim/src/sys/shim_socket.c
@@ -1192,8 +1192,11 @@ int shim_do_sendmmsg (int sockfd, struct mmsghdr * msg, int vlen, int flags)
 static ssize_t do_recvmsg (int fd, struct iovec * bufs, int nbufs, int flags,
                            struct sockaddr * addr, socklen_t * addrlen)
 {
-    /* TODO handle flags properly. For now, just return an error. */
-    if (flags) return -EINVAL;
+    /* TODO handle flags properly. For now, explicitly return an error. */
+    if (flags) {
+        debug("recvmsg()/recvmmsg()/recvfrom(): flags parameter unsupported.\n");
+        return -EOPNOTSUPP;
+    }
     
     struct shim_handle * hdl = get_fd_handle(fd, NULL, NULL);
     if (!hdl)

--- a/Pal/src/host/Linux-SGX/sgx_framework.c
+++ b/Pal/src/host/Linux-SGX/sgx_framework.c
@@ -146,8 +146,6 @@ int create_enclave(sgx_arch_secs_t * secs,
     secs->miscselect = token->miscselect_mask;
     memcpy(&secs->attributes, &token->attributes,
            sizeof(sgx_arch_attributes_t));
-    memcpy(&secs->mrenclave, &token->mrenclave, sizeof(sgx_arch_hash_t));
-    memcpy(&secs->mrsigner,  &token->mrsigner,  sizeof(sgx_arch_hash_t));
 
     if (baseaddr) {
         secs->baseaddr = (uint64_t) baseaddr & ~(secs->size - 1);


### PR DESCRIPTION
Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md).

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [x] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes (reasons and measures)

ECREATE does not require SECS.{mrsigner, mrenclave} to be initialized. SECS.mrenclave is computed dynamically and SECS.mrsigner is populated based on the SIGSTRUCT during EINIT ([see pp21 for ECREATE and pp34 for EINIT](https://software.intel.com/sites/default/files/managed/48/88/329298-002.pdf).

## How to test this PR? (if applicable)

Graphene-SGX should just continue to work after the change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/468)
<!-- Reviewable:end -->
