### PR TITLE
Leave SECS.{mrenclave, mrsigner} uninitialized prior to ECREATE.

### DIFF
--- a/Pal/src/host/Linux-SGX/sgx_framework.c
+++ b/Pal/src/host/Linux-SGX/sgx_framework.c
@@ -146,8 +146,11 @@ int create_enclave(sgx_arch_secs_t * secs,
     secs->miscselect = token->miscselect_mask;
     memcpy(&secs->attributes, &token->attributes,
            sizeof(sgx_arch_attributes_t));
-    memcpy(&secs->mrenclave, &token->mrenclave, sizeof(sgx_arch_hash_t));
-    memcpy(&secs->mrsigner,  &token->mrsigner,  sizeof(sgx_arch_hash_t));
+    /* Do not initialize secs->mrsigner and secs->mrenclave here as they are
+     * not used by ECREATE to populate the internal SECS. SECS's mrenclave is
+     * computed dynamically and SECS's mrsigner is populated based on the
+     * SIGSTRUCT during EINIT (see pp21 for ECREATE and pp34 for
+     * EINIT in https://software.intel.com/sites/default/files/managed/48/88/329298-002.pdf). */
 
     if (baseaddr) {
         secs->baseaddr = (uint64_t) baseaddr & ~(secs->size - 1);


### PR DESCRIPTION
Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md).

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [x] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes (reasons and measures)

ECREATE does not require SECS.{mrsigner, mrenclave} to be initialized. SECS.mrenclave is computed dynamically and SECS.mrsigner is populated based on the SIGSTRUCT during EINIT ([see pp21 for ECREATE and pp34 for EINIT](https://software.intel.com/sites/default/files/managed/48/88/329298-002.pdf).

## How to test this PR? (if applicable)

Graphene-SGX should just continue to work after the change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/470)
<!-- Reviewable:end -->
