### PR TITLE
[LibOS] Explicitly return error if flags parameter set for recvmsg/re…

### DIFF
--- a/LibOS/shim/src/sys/shim_socket.c
+++ b/LibOS/shim/src/sys/shim_socket.c
@@ -1192,6 +1192,12 @@ int shim_do_sendmmsg (int sockfd, struct mmsghdr * msg, int vlen, int flags)
 static ssize_t do_recvmsg (int fd, struct iovec * bufs, int nbufs, int flags,
                            struct sockaddr * addr, socklen_t * addrlen)
 {
+    /* TODO handle flags properly. For now, explicitly return an error. */
+    if (flags) {
+        debug("recvmsg()/recvmmsg()/recvfrom(): flags parameter unsupported.\n");
+        return -EOPNOTSUPP;
+    }
+
     struct shim_handle * hdl = get_fd_handle(fd, NULL, NULL);
     if (!hdl)
         return -EBADF;


### PR DESCRIPTION
…cvmmsg/recvfrom

Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md).

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes (reasons and measures)

This is a resubmission of #387. Sorry for the confusion. Still learning about the proper git workflows.

## How to test this PR? (if applicable)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/474)
<!-- Reviewable:end -->
