### PR TITLE
[LibOS] shim_namei.c: Fix input absolute path error

### DIFF
--- a/LibOS/shim/src/fs/shim_namei.c
+++ b/LibOS/shim/src/fs/shim_namei.c
@@ -385,10 +385,12 @@ int __path_lookupat (struct shim_dentry * start, const char * path, int flags,
                         put_dentry(my_dent);
                         my_dent = root;
                         get_dentry(my_dent);
-                    } else // Relative path, stay in this dir
+                    } else {
+                        // Relative path, stay in this dir
                         put_dentry(my_dent);
                         my_dent = start;
                         get_dentry(my_dent);
+                    }
                 }
             }
         }

--- a/LibOS/shim/test/regression/40_proc_path.py
+++ b/LibOS/shim/test/regression/40_proc_path.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python2
+
+import os, sys
+from regression import Regression
+
+loader = sys.argv[1]
+
+# Running Bootstrap
+regression = Regression(loader, "proc-path")
+
+regression.add_check(name="Base /proc path present",
+    check=lambda res: "proc path test success" in res[0].out)
+
+rv = regression.run_checks()
+if rv: sys.exit(rv)

--- a/LibOS/shim/test/regression/proc-path.c
+++ b/LibOS/shim/test/regression/proc-path.c
@@ -1,0 +1,26 @@
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+int main(int argc, char ** argv)
+{
+    struct stat root, proc_root;
+
+    if (stat("/", &root) == -1) {
+        perror("stat");
+        exit(1);
+    }
+
+    if (stat("/proc/1/root", &proc_root) == -1) {
+        perror("stat");
+        exit(1);
+    }
+
+    if (root.st_dev == proc_root.st_dev &&
+        root.st_ino == proc_root.st_ino) {
+        printf("proc path test success\n");
+    } else {
+        printf("proc path test failure\n");
+    }
+}

--- a/LibOS/shim/test/regression/proc-path.manifest.template
+++ b/LibOS/shim/test/regression/proc-path.manifest.template
@@ -1,0 +1,19 @@
+loader.preload = file:../../src/libsysdb.so
+loader.env.LD_LIBRARY_PATH = /lib
+loader.debug_type = none
+loader.syscall_symbol = syscalldb
+
+fs.mount.lib.type = chroot
+fs.mount.lib.path = /lib
+fs.mount.lib.uri = file:../../../../Runtime
+
+fs.mount.bin.type = chroot
+fs.mount.bin.path = /bin
+fs.mount.bin.uri = file:/bin
+
+sys.brk.size = 32M
+sys.stack.size = 4M
+
+# sgx-related
+sgx.trusted_files.ld = file:../../../../Runtime/ld-linux-x86-64.so.2
+sgx.trusted_files.libc = file:../../../../Runtime/libc.so.6


### PR DESCRIPTION
If input absolute path, it will get wrong my_dent.

Signed-off-by: Zhang Chen <chen.zhang@intel.com>

Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md).

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes (reasons and measures)

This issue looks like a typo, missing parentheses after the "else".
If input absolute path, it will get wrong value of my_dent.

## How to test this PR? (if applicable)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/477)
<!-- Reviewable:end -->
