### PR TITLE
[LibOS] shim_futex.c:Remove duplicate codes in FUTEX_WAIT_BITSET

### DIFF
--- a/LibOS/shim/src/sys/shim_futex.c
+++ b/LibOS/shim/src/sys/shim_futex.c
@@ -135,18 +135,18 @@ int shim_do_futex (int * uaddr, int op, int val, void * utime,
                 struct timespec *ts = (struct timespec*) utime;
                 // Round to microsecs
                 timeout_us = (ts->tv_sec * 1000000) + (ts->tv_nsec / 1000);
-                // Check for the CLOCK_REALTIME flag
-                if (futex_op == FUTEX_WAIT_BITSET)  {
-                    // DEP 1/28/17: Should really differentiate clocks, but
-                    // Graphene only has one for now.
-                    //&& 0 != (op & FUTEX_CLOCK_REALTIME)) {
-                    uint64_t current_time = DkSystemTimeQuery();
-                    if (current_time == 0) {
-                        ret = -EINVAL;
-                        break;
-                    }
-                    timeout_us -= current_time;
+
+                /* Check for the CLOCK_REALTIME flag
+                 * DEP 1/28/17: Should really differentiate clocks, but
+                 * Graphene only has one for now.
+                 * if (futex_op & FUTEX_CLOCK_REALTIME) { */
+
+                uint64_t current_time = DkSystemTimeQuery();
+                if (current_time == 0) {
+                    ret = -EINVAL;
+                    break;
                 }
+                timeout_us -= current_time;
             }
 
         /* Note: for FUTEX_WAIT, timeout is interpreted as a relative


### PR DESCRIPTION
No need to check NO_TIMEOUT twice when FUTEX_WAIT_BITSET.

Signed-off-by: Zhang Chen <chen.zhang@intel.com>

Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md).

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes (reasons and measures)

No need to check NO_TIMEOUT twice when FUTEX_WAIT_BITSET, so remove duplicate codes.

## How to test this PR? (if applicable)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/478)
<!-- Reviewable:end -->
