### PR TITLE
Put a timeout on the Python test.

### DIFF
--- a/Jenkinsfiles/Linux
+++ b/Jenkinsfiles/Linux
@@ -25,10 +25,12 @@ pipeline {
                             make
                             ./syscalls.sh
                             '''
-                        sh '''
-                            cd LibOS/shim/test/apps/python
-                            make regression
+                        timeout(time: 5, unit: 'MINUTES') {
+                            sh '''
+                                cd LibOS/shim/test/apps/python
+                                make regression
                             '''
+                        }
                         sh '''
                             cd LibOS/shim/test/apps/bash
                             make regression
@@ -79,4 +81,3 @@ pipeline {
                 }
         }
 }
-

--- a/Jenkinsfiles/Linux-Debug
+++ b/Jenkinsfiles/Linux-Debug
@@ -25,10 +25,12 @@ pipeline {
                             make
                             ./syscalls.sh
                             '''
-                        sh '''
-                            cd LibOS/shim/test/apps/python
-                            make regression
+                        timeout(time: 5, unit: 'MINUTES') {
+                            sh '''
+                                cd LibOS/shim/test/apps/python
+                                make regression
                             '''
+                        }
                         sh '''
                             cd LibOS/shim/test/apps/bash
                             make regression
@@ -72,4 +74,3 @@ pipeline {
                 }
         }
 }
-


### PR DESCRIPTION
Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md).

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [X] Library OS (i.e., SHIM), including GLIBC

## Description of the changes (reasons and measures)

The Jenkins test that runs Python on Linux PAL does not have a timeout (see job hang 189).  This test needs a timeout in case things go wrong.

## How to test this PR? (if applicable)

Just run a normal Jenkins job.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/479)
<!-- Reviewable:end -->
