### PR TITLE
[PAL] Rename PAL_EVENT_DIVZERO to PAL_EVENT_ARITHMETIC_ERROR

### DIFF
--- a/LibOS/shim/src/bookkeep/shim_signal.c
+++ b/LibOS/shim/src/bookkeep/shim_signal.c
@@ -231,7 +231,7 @@ out:
                        cur_process.vmid, IS_INTERNAL_TID(tid) ? 0 : tid);   \
     } while (0)
 
-static void divzero_upcall (PAL_PTR event, PAL_NUM arg, PAL_CONTEXT * context)
+static void arithmetic_error_upcall (PAL_PTR event, PAL_NUM arg, PAL_CONTEXT * context)
 {
     if (IS_INTERNAL_TID(get_cur_tid()) || is_internal(context)) {
         internal_fault("Internal arithmetic fault", arg, context);
@@ -477,12 +477,12 @@ ret_exception:
 
 int init_signal (void)
 {
-    DkSetExceptionHandler(&divzero_upcall,     PAL_EVENT_DIVZERO,      0);
-    DkSetExceptionHandler(&memfault_upcall,    PAL_EVENT_MEMFAULT,     0);
-    DkSetExceptionHandler(&illegal_upcall,     PAL_EVENT_ILLEGAL,      0);
-    DkSetExceptionHandler(&quit_upcall,        PAL_EVENT_QUIT,         0);
-    DkSetExceptionHandler(&suspend_upcall,     PAL_EVENT_SUSPEND,      0);
-    DkSetExceptionHandler(&resume_upcall,      PAL_EVENT_RESUME,       0);
+    DkSetExceptionHandler(&arithmetic_error_upcall, PAL_EVENT_ARITHMETIC_ERROR, 0);
+    DkSetExceptionHandler(&memfault_upcall,         PAL_EVENT_MEMFAULT,         0);
+    DkSetExceptionHandler(&illegal_upcall,          PAL_EVENT_ILLEGAL,          0);
+    DkSetExceptionHandler(&quit_upcall,             PAL_EVENT_QUIT,             0);
+    DkSetExceptionHandler(&suspend_upcall,          PAL_EVENT_SUSPEND,          0);
+    DkSetExceptionHandler(&resume_upcall,           PAL_EVENT_RESUME,           0);
     return 0;
 }
 

--- a/Pal/regression/01_Exception.py
+++ b/Pal/regression/01_Exception.py
@@ -8,17 +8,17 @@ loader = os.environ['PAL_LOADER']
 regression = Regression(loader, "Exception")
 
 regression.add_check(name="Exception Handling (Div-by-Zero)",
-    check=lambda res: any([line.startswith("Div-by-Zero Exception Handler") for line in res[0].log]))
+    check=lambda res: any([line.startswith("Arithmetic Exception Handler") for line in res[0].log]))
 
 regression.add_check(name="Exception Handling (Memory Fault)",
     check=lambda res: any([line.startswith("Memory Fault Exception Handler") for line in res[0].log]))
 
 regression.add_check(name="Exception Handler Swap",
-    check=lambda res: any([line.startswith("Div-by-Zero Exception Handler 1") for line in res[0].log]) and
-                      any([line.startswith("Div-by-Zero Exception Handler 2") for line in res[0].log]))
+    check=lambda res: any([line.startswith("Arithmetic Exception Handler 1") for line in res[0].log]) and
+                      any([line.startswith("Arithmetic Exception Handler 2") for line in res[0].log]))
 
 regression.add_check(name="Exception Handling (Set Context)",
-    check=lambda res: any([line.startswith("Div-by-Zero Exception Handler 1") for line in res[0].log]))
+    check=lambda res: any([line.startswith("Arithmetic Exception Handler 1") for line in res[0].log]))
 
 rv = regression.run_checks()
 if rv: sys.exit(rv)

--- a/Pal/regression/Exception.c
+++ b/Pal/regression/Exception.c
@@ -8,7 +8,7 @@
 
 void handler1 (PAL_PTR event, PAL_NUM arg, PAL_CONTEXT * context)
 {
-    pal_printf("Div-by-Zero Exception Handler 1: %p, rip = %p\n",
+    pal_printf("Arithmetic Exception Handler 1: %p, rip = %p\n",
                arg, context->rip);
 
     while (*(unsigned char *) context->rip != 0x90)
@@ -19,7 +19,7 @@ void handler1 (PAL_PTR event, PAL_NUM arg, PAL_CONTEXT * context)
 
 void handler2 (PAL_PTR event, PAL_NUM arg, PAL_CONTEXT * context)
 {
-    pal_printf("Div-by-Zero Exception Handler 2: %p, rip = %p\n",
+    pal_printf("Arithmetic Exception Handler 2: %p, rip = %p\n",
                arg, context->rip);
 
     while (*(unsigned char *) context->rip != 0x90)
@@ -43,12 +43,12 @@ int main (void)
 {
     volatile long i;
 
-    DkSetExceptionHandler(handler1, PAL_EVENT_DIVZERO, 0);
+    DkSetExceptionHandler(handler1, PAL_EVENT_ARITHMETIC_ERROR, 0);
     i = 0;
     i = 1 / i;
     __asm__ volatile("nop");
 
-    DkSetExceptionHandler(handler2, PAL_EVENT_DIVZERO, 0);
+    DkSetExceptionHandler(handler2, PAL_EVENT_ARITHMETIC_ERROR, 0);
     i = 0;
     i = 1 / i;
     __asm__ volatile("nop");

--- a/Pal/src/db_exception.c
+++ b/Pal/src/db_exception.c
@@ -40,13 +40,13 @@ struct pal_event_handler {
 };
 
 struct pal_event_handler handlers[] = {
-        [PAL_EVENT_DIVZERO]     = INIT_EVENT_HANDLER,
-        [PAL_EVENT_MEMFAULT]    = INIT_EVENT_HANDLER,
-        [PAL_EVENT_ILLEGAL]     = INIT_EVENT_HANDLER,
-        [PAL_EVENT_QUIT]        = INIT_EVENT_HANDLER,
-        [PAL_EVENT_SUSPEND]     = INIT_EVENT_HANDLER,
-        [PAL_EVENT_RESUME]      = INIT_EVENT_HANDLER,
-        [PAL_EVENT_FAILURE]     = INIT_EVENT_HANDLER,
+        [PAL_EVENT_ARITHMETIC_ERROR] = INIT_EVENT_HANDLER,
+        [PAL_EVENT_MEMFAULT]         = INIT_EVENT_HANDLER,
+        [PAL_EVENT_ILLEGAL]          = INIT_EVENT_HANDLER,
+        [PAL_EVENT_QUIT]             = INIT_EVENT_HANDLER,
+        [PAL_EVENT_SUSPEND]          = INIT_EVENT_HANDLER,
+        [PAL_EVENT_RESUME]           = INIT_EVENT_HANDLER,
+        [PAL_EVENT_FAILURE]          = INIT_EVENT_HANDLER,
     };
 
 PAL_EVENT_HANDLER _DkGetExceptionHandler (PAL_NUM event)

--- a/Pal/src/host/FreeBSD/db_exception.c
+++ b/Pal/src/host/FreeBSD/db_exception.c
@@ -209,7 +209,7 @@ struct exception_handler * pal_handlers [PAL_EVENT_NUM_BOUND] = {
 static int get_event_num (int signum)
 {
     switch(signum) {
-        case SIGFPE:                return PAL_EVENT_DIVZERO;
+        case SIGFPE:                return PAL_EVENT_ARITHMETIC_ERROR;
         case SIGSEGV: case SIGBUS:  return PAL_EVENT_MEMFAULT;
         case SIGILL:                return PAL_EVENT_ILLEGAL;
         case SIGTERM:               return PAL_EVENT_QUIT;
@@ -289,7 +289,7 @@ static bool _DkGenericSignalHandle (int event_num, siginfo_t * info,
         PAL_NUM arg = 0;
 
 
-        if (event_num == PAL_EVENT_DIVZERO ||
+        if (event_num == PAL_EVENT_ARITHMETIC_ERROR ||
             event_num == PAL_EVENT_MEMFAULT ||
             event_num == PAL_EVENT_ILLEGAL)
             arg = (PAL_NUM) (info ? info->si_addr : 0);
@@ -541,7 +541,7 @@ void signal_setup (void)
         goto err;
     }
 
-    if ((ret = _DkPersistentEventUpcall(PAL_EVENT_DIVZERO,  NULL, 0)) < 0)
+    if ((ret = _DkPersistentEventUpcall(PAL_EVENT_ARITHMETIC_ERROR,  NULL, 0)) < 0)
         goto err;
 
     if ((ret = _DkPersistentEventUpcall(PAL_EVENT_MEMFAULT,  NULL, 0)) < 0)

--- a/Pal/src/host/FreeBSD/db_exception2.c
+++ b/Pal/src/host/FreeBSD/db_exception2.c
@@ -120,7 +120,7 @@ typedef struct {
 static int get_event_num (int signum)
 {
     switch(signum) {
-        case SIGFPE:                return PAL_EVENT_DIVZERO;
+        case SIGFPE:                return PAL_EVENT_ARITHMETIC_ERROR;
         case SIGSEGV: case SIGBUS:  return PAL_EVENT_MEMFAULT;
         case SIGILL:  case SIGSYS:  return PAL_EVENT_ILLEGAL;
         case SIGTERM:               return PAL_EVENT_QUIT;
@@ -194,7 +194,7 @@ static bool _DkGenericSignalHandle (int event_num, siginfo_t * info,
     if (upcall) {
         PAL_NUM arg = 0;
 
-        if (event_num == PAL_EVENT_DIVZERO ||
+        if (event_num == PAL_EVENT_ARITHMETIC_ERROR ||
             event_num == PAL_EVENT_MEMFAULT ||
             event_num == PAL_EVENT_ILLEGAL)
             arg = (PAL_NUM) (info ? info->si_addr : 0);
@@ -347,18 +347,18 @@ struct signal_ops {
 };
 
 struct signal_ops on_signals[] = {
-        [PAL_EVENT_DIVZERO]     = { .signum = { SIGFPE, 0 },
-                                    .handler = _DkGenericSighandler },
-        [PAL_EVENT_MEMFAULT]    = { .signum = { SIGSEGV, SIGBUS, 0 },
-                                    .handler = _DkGenericSighandler },
-        [PAL_EVENT_ILLEGAL]     = { .signum = { SIGILL,  SIGSYS, 0 },
-                                    .handler = _DkGenericSighandler },
-        [PAL_EVENT_QUIT]        = { .signum = { SIGTERM, 0, 0 },
-                                    .handler = _DkTerminateSighandler },
-        [PAL_EVENT_SUSPEND]     = { .signum = { SIGINT, 0 },
-                                    .handler = _DkTerminateSighandler },
-        [PAL_EVENT_RESUME]      = { .signum = { SIGCONT, 0 },
-                                    .handler = _DkGenericSighandler },
+        [PAL_EVENT_ARITHMETIC_ERROR] = { .signum = { SIGFPE, 0 },
+                                         .handler = _DkGenericSighandler },
+        [PAL_EVENT_MEMFAULT]         = { .signum = { SIGSEGV, SIGBUS, 0 },
+                                         .handler = _DkGenericSighandler },
+        [PAL_EVENT_ILLEGAL]          = { .signum = { SIGILL,  SIGSYS, 0 },
+                                         .handler = _DkGenericSighandler },
+        [PAL_EVENT_QUIT]             = { .signum = { SIGTERM, 0, 0 },
+                                         .handler = _DkTerminateSighandler },
+        [PAL_EVENT_SUSPEND]          = { .signum = { SIGINT, 0 },
+                                         .handler = _DkTerminateSighandler },
+        [PAL_EVENT_RESUME]           = { .signum = { SIGCONT, 0 },
+                                         .handler = _DkGenericSighandler },
     };
 
 static int _DkPersistentSighandlerSetup (int event_num)
@@ -387,7 +387,7 @@ void signal_setup (void)
         goto err;
 
     int events[] = {
-        PAL_EVENT_DIVZERO,
+        PAL_EVENT_ARITHMETIC_ERROR,
         PAL_EVENT_MEMFAULT,
         PAL_EVENT_ILLEGAL,
         PAL_EVENT_QUIT,

--- a/Pal/src/host/Linux-SGX/db_exception.c
+++ b/Pal/src/host/Linux-SGX/db_exception.c
@@ -243,7 +243,7 @@ void _DkExceptionHandler (unsigned int exit_info, sgx_context_t * uc)
 
     switch (ei.info.vector) {
         case SGX_EXCEPTION_VECTOR_DE:
-            event_num = PAL_EVENT_DIVZERO;
+            event_num = PAL_EVENT_ARITHMETIC_ERROR;
             break;
         case SGX_EXCEPTION_VECTOR_AC:
             event_num = PAL_EVENT_MEMFAULT;

--- a/Pal/src/host/Linux-SGX/sgx_exception.c
+++ b/Pal/src/host/Linux-SGX/sgx_exception.c
@@ -187,7 +187,7 @@ int unset_sighandler (int * sigs, int nsig)
 static int get_event_num (int signum)
 {
     switch(signum) {
-        case SIGFPE:                return PAL_EVENT_DIVZERO;
+        case SIGFPE:                return PAL_EVENT_ARITHMETIC_ERROR;
         case SIGSEGV: case SIGBUS:  return PAL_EVENT_MEMFAULT;
         case SIGILL:                return PAL_EVENT_ILLEGAL;
         case SIGTERM:               return PAL_EVENT_QUIT;

--- a/Pal/src/host/Linux/db_exception.c
+++ b/Pal/src/host/Linux/db_exception.c
@@ -121,7 +121,7 @@ typedef struct {
 static int get_event_num (int signum)
 {
     switch(signum) {
-        case SIGFPE:                return PAL_EVENT_DIVZERO;
+        case SIGFPE:                return PAL_EVENT_ARITHMETIC_ERROR;
         case SIGSEGV: case SIGBUS:  return PAL_EVENT_MEMFAULT;
         case SIGILL:  case SIGSYS:  return PAL_EVENT_ILLEGAL;
         case SIGTERM:               return PAL_EVENT_QUIT;
@@ -153,7 +153,7 @@ static bool _DkGenericSignalHandle (int event_num, siginfo_t * info,
     if (upcall) {
         PAL_NUM arg = 0;
 
-        if (event_num == PAL_EVENT_DIVZERO ||
+        if (event_num == PAL_EVENT_ARITHMETIC_ERROR ||
             event_num == PAL_EVENT_MEMFAULT ||
             event_num == PAL_EVENT_ILLEGAL)
             arg = (PAL_NUM) (info ? info->si_addr : 0);
@@ -180,9 +180,9 @@ static void _DkGenericSighandler (int signum, siginfo_t * info,
         int tid = INLINE_SYSCALL(gettid, 0);
         const char * name = "exception";
         switch(event_num) {
-            case PAL_EVENT_DIVZERO:  name = "div-by-zero exception"; break;
-            case PAL_EVENT_MEMFAULT: name = "memory fault"; break;
-            case PAL_EVENT_ILLEGAL:  name = "illegal instruction"; break;
+            case PAL_EVENT_ARITHMETIC_ERROR: name = "arithmetic exception"; break;
+            case PAL_EVENT_MEMFAULT:         name = "memory fault"; break;
+            case PAL_EVENT_ILLEGAL:          name = "illegal instruction"; break;
         }
 
         printf("*** An unexpected %s occurred inside PAL. Exiting the thread. "
@@ -295,18 +295,18 @@ struct signal_ops {
 };
 
 struct signal_ops on_signals[] = {
-        [PAL_EVENT_DIVZERO]     = { .signum = { SIGFPE, 0 },
-                                    .handler = _DkGenericSighandler },
-        [PAL_EVENT_MEMFAULT]    = { .signum = { SIGSEGV, SIGBUS, 0 },
-                                    .handler = _DkGenericSighandler },
-        [PAL_EVENT_ILLEGAL]     = { .signum = { SIGILL,  SIGSYS, 0 },
-                                    .handler = _DkGenericSighandler },
-        [PAL_EVENT_QUIT]        = { .signum = { SIGTERM, 0, 0 },
-                                    .handler = _DkTerminateSighandler },
-        [PAL_EVENT_SUSPEND]     = { .signum = { SIGINT, 0 },
-                                    .handler = _DkTerminateSighandler },
-        [PAL_EVENT_RESUME]      = { .signum = { SIGCONT, 0 },
-                                    .handler = _DkTerminateSighandler },
+        [PAL_EVENT_ARITHMETIC_ERROR] = { .signum = { SIGFPE, 0 },
+                                         .handler = _DkGenericSighandler },
+        [PAL_EVENT_MEMFAULT]         = { .signum = { SIGSEGV, SIGBUS, 0 },
+                                         .handler = _DkGenericSighandler },
+        [PAL_EVENT_ILLEGAL]          = { .signum = { SIGILL,  SIGSYS, 0 },
+                                         .handler = _DkGenericSighandler },
+        [PAL_EVENT_QUIT]             = { .signum = { SIGTERM, 0, 0 },
+                                         .handler = _DkTerminateSighandler },
+        [PAL_EVENT_SUSPEND]          = { .signum = { SIGINT, 0 },
+                                         .handler = _DkTerminateSighandler },
+        [PAL_EVENT_RESUME]           = { .signum = { SIGCONT, 0 },
+                                         .handler = _DkTerminateSighandler },
     };
 
 static int _DkPersistentSighandlerSetup (int event_num)
@@ -335,7 +335,7 @@ void signal_setup (void)
         goto err;
 
     int events[] = {
-        PAL_EVENT_DIVZERO,
+        PAL_EVENT_ARITHMETIC_ERROR,
         PAL_EVENT_MEMFAULT,
         PAL_EVENT_ILLEGAL,
         PAL_EVENT_QUIT,

--- a/Pal/src/pal.h
+++ b/Pal/src/pal.h
@@ -398,22 +398,22 @@ PAL_BOL
 DkThreadResume (PAL_HANDLE thread);
 
 /* Exception Handling */
-/* Div-by-zero */
-#define PAL_EVENT_DIVZERO       1
+/* arithmetic error (div-by-zero, floating point exception, etc.) */
+#define PAL_EVENT_ARITHMETIC_ERROR 1
 /* segmentation fault, protection fault, bus fault */
-#define PAL_EVENT_MEMFAULT      2
+#define PAL_EVENT_MEMFAULT         2
 /* illegal instructions */
-#define PAL_EVENT_ILLEGAL       3
+#define PAL_EVENT_ILLEGAL          3
 /* terminated by external program */
-#define PAL_EVENT_QUIT          4
+#define PAL_EVENT_QUIT             4
 /* suspended by external program */
-#define PAL_EVENT_SUSPEND       5
+#define PAL_EVENT_SUSPEND          5
 /* continued by external program */
-#define PAL_EVENT_RESUME        6
+#define PAL_EVENT_RESUME           6
 /* failure within PAL calls */
-#define PAL_EVENT_FAILURE       7
+#define PAL_EVENT_FAILURE          7
 
-#define PAL_EVENT_NUM_BOUND     8
+#define PAL_EVENT_NUM_BOUND        8
 
 #define PAL_EVENT_PRIVATE      0x0001       /* upcall specific to thread */
 #define PAL_EVENT_RESET        0x0002       /* reset the event upcall */

--- a/Pal/test/Exception.c
+++ b/Pal/test/Exception.c
@@ -24,7 +24,7 @@ int main (void)
 {
     pal_printf("Enter Main Thread\n");
 
-    DkSetExceptionHandler(handler, PAL_EVENT_DIVZERO, 0);
+    DkSetExceptionHandler(handler, PAL_EVENT_ARITHMETIC_ERROR, 0);
 
     i =  1 / i;
 


### PR DESCRIPTION
Fixes #480.

## Affected components

- [ ] README and global configuration
- [X] Linux PAL
- [X] SGX PAL
- [X] FreeBSD PAL
- [X] Common PAL code
- [X] Library OS (i.e., SHIM), including GLIBC

## Description of the changes (reasons and measures)

See #480.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/490)
<!-- Reviewable:end -->
