### PR TITLE
[LibOS] Support of SGX PAL for test_user_memory/string

### DIFF
--- a/LibOS/shim/include/shim_vma.h
+++ b/LibOS/shim/include/shim_vma.h
@@ -133,6 +133,9 @@ int lookup_vma (void * addr, struct shim_vma_val * vma);
 int lookup_overlap_vma (void * addr, uint64_t length,
                         struct shim_vma_val * vma);
 
+/* True if [addr, addr+length) is found in one VMA (valid memory region) */
+bool is_in_one_vma (void * addr, size_t length);
+
 /*
  * Looking for an unmapped space and then adding the corresponding bookkeeping
  * (more info in bookkeep/shim_vma.c).

--- a/LibOS/shim/src/sys/shim_getrlimit.c
+++ b/LibOS/shim/src/sys/shim_getrlimit.c
@@ -57,7 +57,7 @@ int shim_do_getrlimit (int resource, struct __kernel_rlimit * rlim)
 
         case RLIMIT_DATA:
             rlim->rlim_cur = brk_max_size;
-            rlim->rlim_max = brk_max_size;
+            rlim->rlim_max = RLIM_INFINITY;
             return 0;
 
         default:

--- a/LibOS/shim/src/sys/shim_mmap.c
+++ b/LibOS/shim/src/sys/shim_mmap.c
@@ -54,11 +54,11 @@ void * shim_do_mmap (void * addr, size_t length, int prot, int flags, int fd,
     if (fd >= 0 && !ALIGNED(offset))
         return (void *) -EINVAL;
 
+    if (!length || !access_ok(addr, length))
+        return (void*) -EINVAL;
+
     if (!ALIGNED(length))
         length = ALIGN_UP(length);
-
-    if (addr + length < addr)
-        return (void *) -EINVAL;
 
     /* ignore MAP_32BIT when MAP_FIXED is set */
     if ((flags & (MAP_32BIT|MAP_FIXED)) == (MAP_32BIT|MAP_FIXED))
@@ -167,6 +167,9 @@ int shim_do_munmap (void * addr, size_t length)
      * length. munmap() will automatically round up the length.
      */
     if (!addr || !ALIGNED(addr))
+        return -EINVAL;
+
+    if (!length || !access_ok(addr, length))
         return -EINVAL;
 
     if (!ALIGNED(length))

--- a/LibOS/shim/test/regression/30_stat.py
+++ b/LibOS/shim/test/regression/30_stat.py
@@ -1,0 +1,16 @@
+import os, sys, mmap
+from regression import Regression
+
+loader = sys.argv[1]
+
+# Running stat
+regression = Regression(loader, "stat_invalid_args")
+
+regression.add_check(name="Stat with invalid arguments",
+    check=lambda res: "stat(invalid-path-ptr) correctly returns error" in res[0].out and \
+                      "stat(invalid-buf-ptr) correctly returns error" in res[0].out and \
+                      "lstat(invalid-path-ptr) correctly returns error" in res[0].out and \
+                      "lstat(invalid-buf-ptr) correctly returns error" in res[0].out)
+
+rv = regression.run_checks()
+if rv: sys.exit(rv)

--- a/LibOS/shim/test/regression/stat_invalid_args.c
+++ b/LibOS/shim/test/regression/stat_invalid_args.c
@@ -1,0 +1,37 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <errno.h>
+
+int main (int argc, char** argv) {
+    int r;
+    struct stat buf;
+
+    char* goodpath = argv[0];
+    char* badpath  = (void*)-1;
+
+    struct stat* goodbuf = &buf;
+    struct stat* badbuf  = (void*)-1;
+
+    /* check stat() */
+    r = stat(badpath, goodbuf);
+    if (r == -1 && errno == EFAULT)
+        printf("stat(invalid-path-ptr) correctly returns error\n");
+
+    r = stat(goodpath, badbuf);
+    if (r == -1 && errno == EFAULT)
+        printf("stat(invalid-buf-ptr) correctly returns error\n");
+
+    /* check lstat() */
+    r = lstat(badpath, goodbuf);
+    if (r == -1 && errno == EFAULT)
+        printf("lstat(invalid-path-ptr) correctly returns error\n");
+
+    r = lstat(goodpath, badbuf);
+    if (r == -1 && errno == EFAULT)
+        printf("lstat(invalid-buf-ptr) correctly returns error\n");
+
+    return 0;
+}


### PR DESCRIPTION
Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md).

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes (reasons and measures)

Previously, `test_user_memory(addr, size)` and `test_user_string(addr)` failed on Linux-SGX PAL. These two functions are supposed to check if the user-supplied buffer/string are accessible inside LibOS.

The original implementation had only one option: these functions setup a segfault handler to catch memory errors (see `tcb.test_range` and `memfault_upcall()`) and access one byte of each page in the user-supplied buffer/string. If some byte is inaccessible, then an exception is raised which is caught by the segfault handler. The handler checks the faulting address (stored in `siginfo_t.si_addr`) and redirected back to the function (so it can return with failure).

This option doesn't work under SGX because there is no *trusted* field that contains the faulting address. SGX v1 doesn't have such a field at all, SGX v2 introduces a field in SSA.MISC region but only at the 4K-page granularity. Therefore, the above option doesn't work for Linux-SGX.

This PR adds a second option, specifically used for Linux-SGX PAL: `test_user_memory()` and `test_user_string()` consult the LibOS's internal VMA bookkeeping. If the buffer/string is not contained in any VMA, then these functions fail. This option is slightly slower than the first one since it requires traversing a list of VMAs. Thus, we only use this option for Linux-SGX and fallback to the previous option for all other PALs (by checking the PAL name string at initialization time).

## How to test this PR? (if applicable)

New regression test `stat_invalid_args.c` and the corresponding Python script `30_stat.py` are added under `LibOS/shim/test/regression`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/492)
<!-- Reviewable:end -->
