### PR TITLE
[README] Fix enclave siging key variable name

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ If you don't have a private key, create it with the following command:
 
 You could either put the generated enclave key to the default path,
 'host/Linux-SGX/signer/enclave-key.pem', or specify the key through environment
-variable 'SGX_ENCLAVE_KEY' when building Graphene with SGX support. 
+variable 'SGX_SIGNER_KEY' when building Graphene with SGX support. 
 
 After signing the enclaves, users may ship the application files with the
 built Graphene Library OS, along with a SGX-specific manifest (.manifest.sgx


### PR DESCRIPTION
## Affected components

- [x] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes (reasons and measures)

The variable with the path to the enclave siging key is called SGX_SIGNER_KEY not SGX_ENCLAVE_KEY.

Fix the README.

## How to test this PR? (if applicable)

Only doc change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/499)
<!-- Reviewable:end -->
