### PR TITLE
[Pal/Linux-SGX] Fix "encalve" typos

### DIFF
--- a/Pal/src/host/Linux-SGX/enclave_framework.c
+++ b/Pal/src/host/Linux-SGX/enclave_framework.c
@@ -1020,7 +1020,7 @@ int _DkStreamAttestationRequest (PAL_HANDLE stream, void * data,
     }
 
     if (ret == 1) {
-        SGX_DBG(DBG_S, "Not an allowed encalve (mrenclave = %s)\n",
+        SGX_DBG(DBG_S, "Not an allowed enclave (mrenclave = %s)\n",
                 alloca_bytes2hexstr(att.mrenclave));
         ret = -PAL_ERROR_DENIED;
         goto out;

--- a/Pal/src/host/Linux-SGX/signer/pal-sgx-get-token
+++ b/Pal/src/host/Linux-SGX/signer/pal-sgx-get-token
@@ -42,7 +42,7 @@ def read_sigstruct(sig):
     fields['miscmask']  = ( 904, "4s",   'miscmask')
     fields['attrs']     = ( 928, "8s8s", 'flags', 'xfrms')
     fields['attrmask']  = ( 944, "8s8s", 'flagmask', 'xfrmmask')
-    fields['mrencalve'] = ( 960, "32s",  'mrenclave')
+    fields['mrenclave'] = ( 960, "32s",  'mrenclave')
     fields['isvprodid'] = (1024, "<H",   'isvprodid')
     fields['isvsvn']    = (1026, "<H",   'isvsvn')
 

--- a/Pal/src/host/Linux-SGX/signer/pal-sgx-sign
+++ b/Pal/src/host/Linux-SGX/signer/pal-sgx-sign
@@ -532,7 +532,7 @@ def generate_sigstruct(attr, args, mrenclave):
     fields['miscmask']  = ( 904, "4s",   attr['miscs'])
     fields['attrs']     = ( 928, "8s8s", attr['flags'], attr['xfrms'])
     fields['attrmask']  = ( 944, "8s8s", attr['flags'], attr['xfrms'])
-    fields['mrencalve'] = ( 960, "32s",  mrenclave)
+    fields['mrenclave'] = ( 960, "32s",  mrenclave)
     fields['isvprodid'] = (1024, "<H",   attr['isvprodid'])
     fields['isvsvn']    = (1026, "<H",   attr['isvsvn'])
 


### PR DESCRIPTION
## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [x] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes (reasons and measures)

Fix typos.

## How to test this PR? (if applicable)

One typo only affects a debug message. The other two are field names which aren't used (But are covered by the SGX tests anyway).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/500)
<!-- Reviewable:end -->
