### PR TITLE
Remove old/misleading comments in _DkVirtualMemoryAlloc

### DIFF
--- a/Pal/src/host/FreeBSD/db_memory.c
+++ b/Pal/src/host/FreeBSD/db_memory.c
@@ -48,7 +48,6 @@ int _DkVirtualMemoryAlloc (void ** paddr, uint64_t size, int alloc_type,
     int flags = HOST_FLAGS(alloc_type, prot|PAL_PROT_WRITECOPY);
     prot = HOST_PROT(prot);
 
-    /* The memory should have MAP_PRIVATE and MAP_ANONYMOUS */
     flags |= MAP_ANONYMOUS|(addr ? MAP_FIXED : 0);
     mem = (void *) ARCH_MMAP(addr, size, prot, flags, -1, 0);
 

--- a/Pal/src/host/Linux-SGX/db_memory.c
+++ b/Pal/src/host/Linux-SGX/db_memory.c
@@ -70,12 +70,6 @@ int _DkVirtualMemoryAlloc (void ** paddr, uint64_t size, int alloc_type, int pro
 {
     void * addr = *paddr, * mem;
 
-    //int flags = HOST_FLAGS(alloc_type, prot|PAL_PROT_WRITECOPY);
-    //prot = HOST_PROT(prot);
-    /* The memory should have MAP_PRIVATE and MAP_ANONYMOUS */
-    //flags |= MAP_ANONYMOUS|(addr ? MAP_FIXED : 0);
-    //mem = (void *) ARCH_MMAP(addr, size, prot, flags, -1, 0);
-
     if ((alloc_type & PAL_ALLOC_INTERNAL) && addr)
         return -PAL_ERROR_INVAL;
 

--- a/Pal/src/host/Linux/db_memory.c
+++ b/Pal/src/host/Linux/db_memory.c
@@ -48,7 +48,6 @@ int _DkVirtualMemoryAlloc (void ** paddr, uint64_t size, int alloc_type,
     int flags = HOST_FLAGS(alloc_type, prot|PAL_PROT_WRITECOPY);
     prot = HOST_PROT(prot);
 
-    /* The memory should have MAP_PRIVATE and MAP_ANONYMOUS */
     flags |= MAP_ANONYMOUS|(addr ? MAP_FIXED : 0);
     mem = (void *) ARCH_MMAP(addr, size, prot, flags, -1, 0);
 


### PR DESCRIPTION
## Affected components

- [ ] README and global configuration
- [x] Linux PAL
- [x] SGX PAL
- [x] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes (reasons and measures)

Remove misleading or old comments in `_DkVirtualMemoryAlloc`. See commit messages for details.

That the mapping in Linux/FreeBSD is usually shared and not private as the comment suggested is fine, tight?

## How to test this PR? (if applicable)

Only doc change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/502)
<!-- Reviewable:end -->
