### PR TITLE
[Pal/regression] Disable memory protection and deallocation tests on SGX

### DIFF
--- a/Pal/regression/02_Memory.py
+++ b/Pal/regression/02_Memory.py
@@ -20,11 +20,11 @@ regression.add_check(name="Memory Allocation with Address",
 # Memory protection and deallocation can't be tested on SGX since we can't
 # unmap a page or change it's protection (SGX2 makes this possible).
 if not sgx:
-    regression.add_check(name="Memory Protection", flaky = sgx,
+    regression.add_check(name="Memory Protection",
         check=lambda res: "Memory Allocation Protection (RW) OK" in res[0].log and
                           "Memory Protection (R) OK" in res[0].log)
 
-    regression.add_check(name="Memory Deallocation", flaky = sgx,
+    regression.add_check(name="Memory Deallocation",
         check=lambda res: "Memory Deallocation OK" in res[0].log)
 
 def check_quota(res):

--- a/Pal/regression/02_Memory.py
+++ b/Pal/regression/02_Memory.py
@@ -18,7 +18,7 @@ regression.add_check(name="Memory Allocation with Address",
     check=lambda res: "Memory Allocation with Address OK" in res[0].log)
 
 # Memory protection and deallocation can't be tested on SGX since we can't
-# unmap a page or change it's protection (SGX2 makes this possible).
+# unmap a page or change its protection (SGX2 makes this possible).
 if not sgx:
     regression.add_check(name="Memory Protection",
         check=lambda res: "Memory Allocation Protection (RW) OK" in res[0].log and

--- a/Pal/regression/02_Memory.py
+++ b/Pal/regression/02_Memory.py
@@ -17,12 +17,15 @@ regression.add_check(name="Memory Allocation",
 regression.add_check(name="Memory Allocation with Address",
     check=lambda res: "Memory Allocation with Address OK" in res[0].log)
 
-regression.add_check(name="Memory Protection", flaky = sgx,
-    check=lambda res: "Memory Allocation Protection (RW) OK" in res[0].log and
-                      "Memory Protection (R) OK" in res[0].log)
+# Memory protection and deallocation can't be tested on SGX since we can't
+# unmap a page or change it's protection (SGX2 makes this possible).
+if not sgx:
+    regression.add_check(name="Memory Protection", flaky = sgx,
+        check=lambda res: "Memory Allocation Protection (RW) OK" in res[0].log and
+                          "Memory Protection (R) OK" in res[0].log)
 
-regression.add_check(name="Memory Deallocation", flaky = sgx,
-    check=lambda res: "Memory Deallocation OK" in res[0].log)
+    regression.add_check(name="Memory Deallocation", flaky = sgx,
+        check=lambda res: "Memory Deallocation OK" in res[0].log)
 
 def check_quota(res):
     for line in res[0].log:


### PR DESCRIPTION
## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [x] SGX PAL
- [ ] FreeBSD PAL
- [x] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes (reasons and measures)

SGX1 does not support changing the protection of a page nor (un-)mapping
of a page.

Therefore we can't test memory protection.

Since the allocation/deallocation API is inspired by the mmap/munmap,
mapping over an already allocated area and freeing an unallocated area
are both fine so testing if a free was successful is also not possible
(without significant changes, like exposing the internal allocation
list).

By using SGX2 features it will be possible to implement this in the
future.

## How to test this PR? (if applicable)

Run regression tests. With non-SGX PALs the memory protection/deallocation test should be runs, on SGX not.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/503)
<!-- Reviewable:end -->
