### PR TITLE
[Pal/regression] Handle unopened broadcast stream

### DIFF
--- a/Pal/regression/03_Process.py
+++ b/Pal/regression/03_Process.py
@@ -27,9 +27,17 @@ regression.add_check(name="Process Channel Transmission",
                       check_times("Process Write 2 OK",            res[0].log, 3) and
                       check_times("Process Read 2: Hello World 2", res[0].log, 3))
 
+def check_broadcast_result(res):
+    if not check_times("Warning: broadcast stream is not open. "
+                       "Do you have a multicast route configured?",
+                       res[0].log, 0):
+        print("Could not open broadcast stream. Dou you have a multicast route configured?")
+
+    return (check_times("Broadcast Write OK",            res[0].log, 1) and
+            check_times("Broadcast Read: Hello World 1", res[0].log, 3))
+
 regression.add_check(name="Multi-Process Broadcast Channel Transmission",
-    check=lambda res: check_times("Broadcast Write OK",            res[0].log, 1) and
-                      check_times("Broadcast Read: Hello World 1", res[0].log, 3))
+                     check=check_broadcast_result)
 
 rv = regression.run_checks()
 if rv: sys.exit(rv)

--- a/Pal/regression/Process.c
+++ b/Pal/regression/Process.c
@@ -26,9 +26,14 @@ int main (int argc, char ** argv, char ** envp)
 
         DkStreamWrite(pal_control.parent_process, 0, 20, buffer1, NULL);
 
-        ret = DkStreamRead(pal_control.broadcast_stream, 0, 20, buffer5, NULL, 0);
-        if (ret > 0)
-            pal_printf("Broadcast Read: %s\n", buffer5);
+        if (pal_control.broadcast_stream == NULL) {
+            pal_printf("Warning: broadcast stream is not open. "
+                       "Do you have a multicast route configured?\n");
+        } else {
+            ret = DkStreamRead(pal_control.broadcast_stream, 0, 20, buffer5, NULL, 0);
+            if (ret > 0)
+                pal_printf("Broadcast Read: %s\n", buffer5);
+        }
 
         ret = DkStreamWrite(pal_control.parent_process, 0, 20, buffer1, NULL);
         if (ret > 0)
@@ -54,10 +59,14 @@ int main (int argc, char ** argv, char ** envp)
         }
 
         pal_printf("Broadcasting message\n");
-
-        ret = DkStreamWrite(pal_control.broadcast_stream, 0, 20, buffer1, NULL);
-        if (ret > 0)
-            pal_printf("Broadcast Write OK\n");
+        if (pal_control.broadcast_stream == NULL) {
+            pal_printf("Warning: broadcast stream is not open. "
+                       "Do you have a multicast route configured?\n");
+        } else {
+            ret = DkStreamWrite(pal_control.broadcast_stream, 0, 20, buffer1, NULL);
+            if (ret > 0)
+                pal_printf("Broadcast Write OK\n");
+        }
 
         for (int i = 0 ; i < 3 ; i++)
             if (children[i]) {


### PR DESCRIPTION
## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [x] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes (reasons and measures)

If the broadcast stream is not opened this most likely means that
there's no configured multicast route so add a helpful warning. Also no
point in trying to read/write from/to a non-existent stream.

Resolves #501.

## How to test this PR? (if applicable)

Run PAL regression tests with and without a configured multicast route.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/507)
<!-- Reviewable:end -->
