### PR TITLE
[Pal/Linux-SGX] Initialize enclave info in pal_sec inside enclave

### DIFF
--- a/Pal/src/host/Linux-SGX/db_main.c
+++ b/Pal/src/host/Linux-SGX/db_main.c
@@ -152,7 +152,12 @@ void pal_linux_main(const char ** arguments, const char ** environments,
     setup_pal_map(&pal_map);
 
     /* initialize enclave properties */
-    init_enclave();
+    rv = init_enclave();
+    if (rv) {
+        SGX_DBG(DBG_E, "Failed to initalize enclave properties: %d\n", rv);
+        ocall_exit(rv);
+    }
+
     pal_state.start_time = start_time;
 
     /* if there is a parent, create parent handle */

--- a/Pal/src/host/Linux-SGX/enclave_framework.c
+++ b/Pal/src/host/Linux-SGX/enclave_framework.c
@@ -847,6 +847,24 @@ void test_dh (void)
 
 int init_enclave (void)
 {
+    // Get report to initialize info (MRENCLAVE, etc.) about this enclave from
+    // a trusted source.
+
+    // Since this report is only read by ourselves we can
+    // leave targetinfo zeroed.
+    sgx_arch_targetinfo_t targetinfo = {0};
+    struct pal_enclave_state reportdata = {0};
+    sgx_arch_report_t report;
+
+    int ret = sgx_report(&targetinfo, &reportdata, &report);
+    if (ret) {
+        SGX_DBG(DBG_E, "failed to get self report: %d\n", ret);
+        return -PAL_ERROR_INVAL;
+    }
+    memcpy(pal_sec.mrenclave, report.mrenclave, sizeof(pal_sec.mrenclave));
+    memcpy(pal_sec.mrsigner, report.mrsigner, sizeof(pal_sec.mrsigner));
+    pal_sec.enclave_attributes = report.attributes;
+
 #if 0
     /*
      * This enclave-specific key is a building block for authenticating

--- a/Pal/src/host/Linux-SGX/sgx_main.c
+++ b/Pal/src/host/Linux-SGX/sgx_main.c
@@ -480,13 +480,6 @@ int initialize_enclave (struct pal_enclave * enclave)
     pal_sec->manifest_addr = (void *) enclave_secs.baseaddr + manifest_area->addr;
     pal_sec->manifest_size = manifest_size;
 
-    memcpy(pal_sec->mrenclave, enclave_secs.mrenclave,
-           sizeof(sgx_arch_hash_t));
-    memcpy(pal_sec->mrsigner, enclave_secs.mrsigner,
-           sizeof(sgx_arch_hash_t));
-    memcpy(&pal_sec->enclave_attributes, &enclave_secs.attributes,
-           sizeof(sgx_arch_attributes_t));
-
     struct enclave_dbginfo * dbg = (void *)
             INLINE_SYSCALL(mmap, 6, DBGINFO_ADDR,
                            sizeof(struct enclave_dbginfo),


### PR DESCRIPTION
## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [x] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes (reasons and measures)

The pal_sec struct has fields with enclave information (mrenclave,
mrsigner, enclave_attributes). Their initialization had two problems:

 - mrenclave and mrsigner were read from the enclave_secs struct, but
   those field were never populated so they were always zeroed bytes.
   This broke the fork detection in db_process.c.

 - The enclave trusted the data initialized by pal_loader (i.e. outside
   the enclave). This is a problem for example when used to check for
   forks in db_process.c (Part of #509).

Fix this by reading those values from a self report early inside the
enclave.

## How to test this PR? (if applicable)

This fixes a bunch of regression tests which before failed since creating processes based on the same manifest were broken (since the MRENCLAVE was zeroed).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/511)
<!-- Reviewable:end -->
