### PR TITLE
Fix return code handling in _DkEventWaitTimeout

### DIFF
--- a/Pal/regression/02_Event.py
+++ b/Pal/regression/02_Event.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python2
+
+import os, sys
+from regression import Regression
+
+loader = os.environ['PAL_LOADER']
+
+regression = Regression(loader, "Event")
+
+regression.add_check(name="Wait for event with too short timeout",
+    check=lambda res: "Wait with too short timeout ok." in res[0].log)
+
+regression.add_check(name="Wait for event with long enough timeout",
+    check=lambda res: "Wait with long enough timeout ok." in res[0].log)
+
+rv = regression.run_checks()
+if rv: sys.exit(rv)

--- a/Pal/regression/Event.c
+++ b/Pal/regression/Event.c
@@ -1,0 +1,72 @@
+#include "pal.h"
+#include "pal_debug.h"
+#include "pal_error.h"
+
+static PAL_HANDLE event1;
+volatile int timeouts = 0;
+
+int thread2_run(void* args) {
+    pal_printf("Second thread started.\n");
+    DkThreadDelayExecution(3000000);
+
+    pal_printf("Sending event ...\n");
+    DkEventSet(event1);
+    pal_printf("End of second thread.\n");
+    DkThreadExit();
+
+    return 0;
+}
+
+void pal_failure_handler(PAL_PTR event, PAL_NUM error, PAL_CONTEXT* context) {
+    pal_printf("pal_failure_handler called\n");
+
+    if (error == PAL_ERROR_TRYAGAIN) {
+        pal_printf("Timeout event received.\n");
+        timeouts += 1;
+    }
+
+    DkExceptionReturn(event);
+}
+
+int main() {
+    pal_printf("Started main thread.\n");
+
+    DkSetExceptionHandler(pal_failure_handler, PAL_EVENT_FAILURE, 0);
+
+    event1 = DkNotificationEventCreate(0);
+    if (event1 == NULL) {
+        pal_printf("DkNotificationEventCreate failed\n");
+        return 1;
+    }
+
+    PAL_HANDLE thread2 = DkThreadCreate(thread2_run, 0, 0);
+    if (thread2 == NULL) {
+        pal_printf("DkThreadCreate failed\n");
+        return 1;
+    }
+    unsigned long t_start = DkSystemTimeQuery();
+
+    pal_printf("Testing wait with too short timeout ...\n");
+    DkObjectsWaitAny(1, &event1, 1000000);
+    unsigned long t_wait1 = DkSystemTimeQuery();
+    unsigned long dt_wait1 = t_wait1 - t_start;
+    pal_printf("Wait returned after %lu us.\n", dt_wait1);
+    pal_printf("Timeout count: %d\n", timeouts);
+    if (dt_wait1 > 1000000 && dt_wait1 < 1100000 && timeouts == 1) {
+        pal_printf("Wait with too short timeout ok.\n");
+    }
+
+    pal_printf("Testing wait with long enough timeout ...\n");
+    DkObjectsWaitAny(1, &event1, 5000000);
+    unsigned long t_wait2 = DkSystemTimeQuery();
+    unsigned long dt_wait2 = t_wait2 - t_start;
+    pal_printf("Wait returned after %lu us since start.\n", dt_wait2);
+    pal_printf("Timeout count: %d\n", timeouts);
+    if (dt_wait2 > 3000000 && dt_wait2 < 3100000 && timeouts == 1) {
+        pal_printf("Wait with long enough timeout ok.\n");
+    }
+
+    pal_printf("End of main thread.\n");
+    return 0;
+}
+

--- a/Pal/src/host/Linux-SGX/db_events.c
+++ b/Pal/src/host/Linux-SGX/db_events.c
@@ -95,7 +95,7 @@ int _DkEventWaitTimeout (PAL_HANDLE event, uint64_t timeout)
             ret = ocall_futex((int *) &event->event.signaled->counter,
                               FUTEX_WAIT, 0, timeout ? &waittime : NULL);
             if (ret < 0) {
-                if (ret == -PAL_ERROR_TRYAGAIN)
+                if (ret == -PAL_ERROR_TRYAGAIN && atomic_read(event->event.signaled) != 0)
                     ret = 0;
                 else
                     break;


### PR DESCRIPTION
## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [x] SGX PAL
- [ ] FreeBSD PAL
- [x] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes (reasons and measures)

FUTEX_WAIT fails with EAGAIN if the supplied value doesn't match the
futex value and ETIMEDOUT in case of a timeout. PAL maps both return
errnos to PAL_ERROR_TRYAGAIN. So weed need to check which case happened
to avoid calling FUTEX_WAIT again in case of a timeout.

Also add regression test timeout handling when waiting for events.

## How to test this PR? (if applicable)

See included regression test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/514)
<!-- Reviewable:end -->
