### PR TITLE
[Jenkins] Enable PAL regression tests on Linux-SGX

### DIFF
--- a/Jenkinsfiles/Linux-SGX
+++ b/Jenkinsfiles/Linux-SGX
@@ -32,7 +32,6 @@ pipeline {
                 }
                 stage('Test') {
                     steps {
-                    /*
                         timeout(time: 15, unit: 'MINUTES') {
                             sh '''
                                 cd Pal/regression
@@ -41,7 +40,6 @@ pipeline {
                                 make SGX_RUN=1 KEEP_LOG=1 regression
                                 '''
                         }
-                        */
                         timeout(time: 5, unit: 'MINUTES') {
                             sh '''
                                 cd LibOS/shim/test/regression


### PR DESCRIPTION
## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [x] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC
- [x] Jenkins

## Description of the changes (reasons and measures)

This enables the PAL regression tests for SGX. This PR depends on PR #511. See also #498 (the other issues/PRs linked there won't lead to hard failures).

## How to test this PR? (if applicable)

Run it on Jenkins. I did not test it myself since I don't have a Jenkins setup handy at the moment. But the change is pretty trivial so this is low risk and easy to revert or fix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/518)
<!-- Reviewable:end -->
