### PR TITLE
[Scripts/regression] Rename 'flaky' to 'ignore_failure'

### DIFF
--- a/Pal/regression/02_Memory.py
+++ b/Pal/regression/02_Memory.py
@@ -21,11 +21,11 @@ regression.add_check(name="Memory Allocation with Address",
 # enclave init. Therefore the memory protection and deallocation tests will
 # fail. By utilizing SGX2 it's possibile to fix this.
 
-regression.add_check(name="Memory Protection", flaky = sgx,
+regression.add_check(name="Memory Protection", ignore_failure = sgx,
     check=lambda res: "Memory Allocation Protection (RW) OK" in res[0].log and
                       "Memory Protection (R) OK" in res[0].log)
 
-regression.add_check(name="Memory Deallocation", flaky = sgx,
+regression.add_check(name="Memory Deallocation", ignore_failure = sgx,
     check=lambda res: "Memory Deallocation OK" in res[0].log)
 
 def check_quota(res):

--- a/Scripts/regression.py
+++ b/Scripts/regression.py
@@ -82,15 +82,15 @@ class Regression:
                     if run_times == times:
                         result = check(outputs)
                         if result:
-                            print '\033[92m[Success]\033[0m', name
+                            print '\033[92m[Success       ]\033[0m', name
                         else:
-                            print '\033[93m[Fail   ]\033[0m', name
+                            if ignore_failure:
+                                print '[Fail (Ignored)]', name
+                            else:
+                                print '\033[93m[Fail          ]\033[0m', name
+                                something_failed = 1
                             if timed_out : print 'Test timed out!'
                             keep_log = True
-                            if ignore_failure:
-                                print '   Ignoring failure.'
-                            else:
-                                something_failed = 1
                             
                 if self.keep_log and keep_log:
                     sargs = [re.sub(r"\W", '_', a).strip('_') for a in args]

--- a/Scripts/regression.py
+++ b/Scripts/regression.py
@@ -21,17 +21,17 @@ class Regression:
             self.timeout = timeout
         self.keep_log = (os.getenv('KEEP_LOG', '0') == '1')
 
-    def add_check(self, name, check, times = 1, flaky=0, args = []):
+    def add_check(self, name, check, times = 1, ignore_failure=0, args = []):
         combined_args = ' '.join(args)
         if not combined_args in self.runs:
             self.runs[combined_args] = []
-        self.runs[combined_args].append((name, check, flaky, times))
+        self.runs[combined_args].append((name, check, ignore_failure, times))
 
     def run_checks(self):
         something_failed = 0
         for combined_args in self.runs:
             needed_times = 1
-            for (name, check, flaky, times) in self.runs[combined_args]:
+            for (name, check, ignore_failure, times) in self.runs[combined_args]:
                 if needed_times < times:
                     needed_times = times
 
@@ -78,7 +78,7 @@ class Regression:
 
                 run_times = run_times + 1
                 keep_log = False
-                for (name, check, flaky, times) in self.runs[combined_args]:
+                for (name, check, ignore_failure, times) in self.runs[combined_args]:
                     if run_times == times:
                         result = check(outputs)
                         if result:
@@ -87,8 +87,8 @@ class Regression:
                             print '\033[93m[Fail   ]\033[0m', name
                             if timed_out : print 'Test timed out!'
                             keep_log = True
-                            if flaky:
-                                print '   This test is known not to work, but should be fixed'
+                            if ignore_failure:
+                                print '   Ignoring failure.'
                             else:
                                 something_failed = 1
                             


### PR DESCRIPTION
## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [x] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes (reasons and measures)

There are different reasons why a regression test failure should be ignored, so rename the option to avoid confusion if the test isn't flaky. See #503 for initial discussion.

Also move the output to the same line as the 'Fail' message.

## How to test this PR? (if applicable)

Run the PAL regression tests and see improved output (currently only really relevant on SGX).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/520)
<!-- Reviewable:end -->
