### PR TITLE
[Pal/regression] Document why memory permission/dealloc test fail on SGX

### DIFF
--- a/Pal/regression/02_Memory.py
+++ b/Pal/regression/02_Memory.py
@@ -17,6 +17,10 @@ regression.add_check(name="Memory Allocation",
 regression.add_check(name="Memory Allocation with Address",
     check=lambda res: "Memory Allocation with Address OK" in res[0].log)
 
+# SGX1 does not support unmapping a page or changing its permission after
+# enclave init. Therefore the memory protection and deallocation tests will
+# fail. By utilizing SGX2 it's possibile to fix this.
+
 regression.add_check(name="Memory Protection", flaky = sgx,
     check=lambda res: "Memory Allocation Protection (RW) OK" in res[0].log and
                       "Memory Protection (R) OK" in res[0].log)


### PR DESCRIPTION
## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [x] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes (reasons and measures)

This is an alternative to PR #503. It just documents the reason why those tests will fail.

## How to test this PR? (if applicable)

Doc only.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/521)
<!-- Reviewable:end -->
