### PR TITLE
[Pal/Linux-SGX] Ensure that ocall_exit never returns

### DIFF
--- a/Pal/src/host/Linux-SGX/enclave_ocalls.c
+++ b/Pal/src/host/Linux-SGX/enclave_ocalls.c
@@ -67,8 +67,13 @@ int printf(const char * fmt, ...);
 int ocall_exit(int exitcode)
 {
     int64_t code = exitcode;
-    SGX_OCALL(OCALL_EXIT, (void *) code);
-    /* never reach here */
+    // There are two reasons for this loop:
+    //  1. Ocalls can be interuppted.
+    //  2. We can't trust the outside to actually exit, so we need to ensure
+    //     that we never return even when the outside tries to trick us.
+    while (true) {
+        SGX_OCALL(OCALL_EXIT, (void *) code);
+    }
     return 0;
 }
 

--- a/Pal/src/host/Linux-SGX/enclave_ocalls.c
+++ b/Pal/src/host/Linux-SGX/enclave_ocalls.c
@@ -66,11 +66,10 @@ int printf(const char * fmt, ...);
 
 int ocall_exit(int exitcode)
 {
-    int retval = 0;
     int64_t code = exitcode;
     SGX_OCALL(OCALL_EXIT, (void *) code);
     /* never reach here */
-    return retval;
+    return 0;
 }
 
 int ocall_print_string (const char * str, unsigned int length)


### PR DESCRIPTION
## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [x] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes (reasons and measures)

OCALL_EXIT should never return. But the outside might try to trick the enclave, so add an infinite loop to ocall_exit to catch this.

This is probably exploitable but I didn't spend time to analyze which of the current usages was actually exploitable.

## How to test this PR? (if applicable)

AFAICS it's hard to add a test which simulates a malicious host with the current code. So no test case provided. If you want to play with it you can change `sgx_ocall_exit` in `sgx_enclave.c`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/522)
<!-- Reviewable:end -->
