### PR TITLE
[LibOS] Remove unnecessary SIGNAL_DELAYED flag 

### DIFF
--- a/LibOS/shim/include/shim_tls.h
+++ b/LibOS/shim/include/shim_tls.h
@@ -47,8 +47,6 @@ struct shim_context {
 
 #include <shim_defs.h>
 
-#define SIGNAL_DELAYED       (0x80000000UL)
-
 #endif /* IN_SHIM */
 
 struct debug_buf;

--- a/LibOS/shim/src/bookkeep/shim_signal.c
+++ b/LibOS/shim/src/bookkeep/shim_signal.c
@@ -162,7 +162,7 @@ void deliver_signal (siginfo_t * info, PAL_CONTEXT * context)
     __store_context(tcb, context, signal);
     signal->pal_context = context;
 
-    if ((tcb->context.preempt & ~SIGNAL_DELAYED) > 1 ||
+    if (tcb->context.preempt > 1 ||
         __sigismember(&cur_thread->signal_mask, sig)) {
         struct shim_signal ** signal_log = NULL;
         if ((signal = malloc_copy(signal,sizeof(struct shim_signal))) &&
@@ -551,11 +551,8 @@ static void resume_upcall (PAL_PTR event, PAL_NUM arg, PAL_CONTEXT * context)
 
     if (!is_internal_tid(get_cur_tid())) {
         __disable_preempt(tcb);
-        if ((tcb->context.preempt & ~SIGNAL_DELAYED) > 1) {
-            tcb->context.preempt |= SIGNAL_DELAYED;
-        } else {
+        if (tcb->context.preempt <= 1)
             __handle_signal(tcb, 0);
-        }
         __enable_preempt(tcb);
     }
     DkExceptionReturn(event);
@@ -695,11 +692,10 @@ void __handle_signal (shim_tcb_t * tcb, int sig)
         __handle_one_signal(tcb, sig, signal);
         free(signal);
         DkThreadYieldExecution();
-        tcb->context.preempt &= ~SIGNAL_DELAYED;
     }
 }
 
-void handle_signal (bool delayed_only)
+void handle_signal (void)
 {
     shim_tcb_t * tcb = shim_get_tls();
     assert(tcb);
@@ -712,12 +708,10 @@ void handle_signal (bool delayed_only)
 
     __disable_preempt(tcb);
 
-    if ((tcb->context.preempt & ~SIGNAL_DELAYED) > 1) {
-        debug("signal delayed (%ld)\n", tcb->context.preempt & ~SIGNAL_DELAYED);
-        tcb->context.preempt |= SIGNAL_DELAYED;
-    } else if (!(delayed_only && !(tcb->context.preempt & SIGNAL_DELAYED))) {
+    if (tcb->context.preempt > 1)
+        debug("signal delayed (%ld)\n", tcb->context.preempt);
+    else
         __handle_signal(tcb, 0);
-    }
 
     __enable_preempt(tcb);
     debug("__enable_preempt: %s:%d\n", __FILE__, __LINE__);

--- a/LibOS/shim/src/shim_malloc.c
+++ b/LibOS/shim/src/shim_malloc.c
@@ -82,7 +82,7 @@ void * __system_malloc (size_t size)
             /* If the allocation is interrupted by signal, try to handle the
              * signal and then retry the allocation. */
             if (PAL_NATIVE_ERRNO == PAL_ERROR_INTERRUPTED) {
-                handle_signal(true);
+                handle_signal();
                 continue;
             }
 


### PR DESCRIPTION
## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [X] Library OS (i.e., SHIM), including GLIBC

## Description of the changes (reasons and measures)

Fixes #512. Closes #455.

This PR removes the unnecessary `SIGNAL_DELAYED` flag embedded in `tcb.context.preempt` but never actually needed. This flag is set to indicate that there is at least one signal which is delayed (pending). `handle_signal()` checked if this flag is not set as a performance optimization (because `__handle_signal()` correctly doesn't deliver any signals if there are none, but must iterate through signal log). The only time this flag would be checked was in `__system_malloc()` for a rare case when malloc (for an internal Graphene object) is interrupted by a signal. This event is so rare that it doesn't make sense to keep `SIGNAL_DELAYED`.

By removing `SIGNAL_DELAYED`, we eliminate a data race on this flag. Consequently, #450 may be simplified significantly. And #455 will not be needed at all.

## How to test this PR? (if applicable)

All apps should continue working as-is. There is no logic change.

Note that `tcb.context.preempt` is still susceptible to data races because operations on its are not atomic. See #450 which fixes this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/523)
<!-- Reviewable:end -->
