### PR TITLE
[LibOS] select and variables: sleep when no fd with timeout > 0

### DIFF
--- a/LibOS/shim/src/sys/shim_poll.c
+++ b/LibOS/shim/src/sys/shim_poll.c
@@ -285,6 +285,8 @@ done_finding:
 
     if (!npals) {
         ret = 0;
+        if (timeout)
+            ret = DkThreadDelayExecution(timeout);
         goto done_polling;
     }
 


### PR DESCRIPTION
some applications use select(and its variants) for sleep with
no file descriptors.
honor timeout value when no file descriptor is given.

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md).

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [x] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes (reasons and measures)


## How to test this PR? (if applicable)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/525)
<!-- Reviewable:end -->
