### PR TITLE
[Linux PAL] Ensure the usage of alternative stack for host exception handling

### DIFF
--- a/Pal/regression/Exception.c
+++ b/Pal/regression/Exception.c
@@ -6,10 +6,18 @@
 #include "pal.h"
 #include "pal_debug.h"
 
+static void* get_stack (void) {
+    void* stack;
+    __asm__ volatile ("mov %%rsp, %0" : "=r"(stack) :: "memory");
+    return stack;
+}
+
 void handler1 (PAL_PTR event, PAL_NUM arg, PAL_CONTEXT * context)
 {
     pal_printf("Div-by-Zero Exception Handler 1: %p, rip = %p\n",
                arg, context->rip);
+
+    pal_printf("stack in handler: %p\n", get_stack());
 
     while (*(unsigned char *) context->rip != 0x90)
         context->rip++;
@@ -22,6 +30,8 @@ void handler2 (PAL_PTR event, PAL_NUM arg, PAL_CONTEXT * context)
     pal_printf("Div-by-Zero Exception Handler 2: %p, rip = %p\n",
                arg, context->rip);
 
+    pal_printf("stack in handler: %p\n", get_stack());
+
     while (*(unsigned char *) context->rip != 0x90)
         context->rip++;
 
@@ -33,6 +43,8 @@ void handler3 (PAL_PTR event, PAL_NUM arg, PAL_CONTEXT * context)
     pal_printf("Memory Fault Exception Handler: %p, rip = %p\n",
                arg, context->rip);
 
+    pal_printf("stack in handler: %p\n", get_stack());
+
     while (*(unsigned char *) context->rip != 0x90)
         context->rip++;
 
@@ -42,6 +54,8 @@ void handler3 (PAL_PTR event, PAL_NUM arg, PAL_CONTEXT * context)
 int main (void)
 {
     volatile long i;
+
+    pal_printf("stack in main: %p\n", get_stack());
 
     DkSetExceptionHandler(handler1, PAL_EVENT_DIVZERO, 0);
     i = 0;

--- a/Pal/src/host/Linux/db_exception.c
+++ b/Pal/src/host/Linux/db_exception.c
@@ -80,7 +80,7 @@ int set_sighandler (int * sigs, int nsig, void * handler)
 
     if (handler) {
         action.sa_handler = (void (*)(int)) handler;
-        action.sa_flags = SA_SIGINFO;
+        action.sa_flags = SA_SIGINFO|SA_ONSTACK;
 #if !defined(__i386__)
         action.sa_flags |= SA_RESTORER;
         action.sa_restorer = restore_rt;

--- a/Pal/src/host/Linux/db_threading.c
+++ b/Pal/src/host/Linux/db_threading.c
@@ -65,7 +65,7 @@ int pal_thread_init (void * tcbptr)
         void * alt_stack_top = (void *) ((uint64_t) tcb & ~15);
         assert(alt_stack_top > tcb->alt_stack);
         stack_t ss;
-        ss.ss_sp    = alt_stack_top;
+        ss.ss_sp    = tcb->alt_stack;
         ss.ss_flags = 0;
         ss.ss_size  = alt_stack_top - tcb->alt_stack;
 


### PR DESCRIPTION
Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md).

## Affected components

- [ ] README and global configuration
- [x] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes (reasons and measures)

Fixes #486.

The new host exception handling scheme in the Linux PAL is supposed to use an alternate stack to prevent mixing the PAL exception handler frame with LibOS/application frames. The previous implementation is not using the assigned alternate stack because `SA_ONSTACK` is not given as a flag to the `sigaction` system call. This PR adds the `SA_ONSTACK` flag.

This PR also fixes another issue with alternate stack assignment. The stack pointer given to the `sigaltstack` system call, i.e.,`ss.ss_sp`, should point to the bottom of the stack instead of the top.

A regression test is added for the Linux PAL only to check if the alternate stack is ever used.

## How to test this PR? (if applicable)

Running the `Exception` test in the PAL regression test directory. A good output should look like this:
```
$ ../../Runtime/pal_loader Exception
stack in main: 0x7ffc29766618
Div-by-Zero Exception Handler 1: 0x40043d, rip = 0x40043d
stack in handler: 0x7ffc29765e40
Div-by-Zero Exception Handler 2: 0x40046a, rip = 0x40046a
stack in handler: 0x7ffc29765e40
Memory Fault Exception Handler: 0x1000, rip = 0x400484
stack in handler: 0x7ffc29765e40
```

The stack pointer in the main function should not be on the same page with the stack pointers inside the handlers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/527)
<!-- Reviewable:end -->
