### PR TITLE
Ensure unit tests actually return a failure message

### DIFF
--- a/LibOS/shim/include/shim_fs.h
+++ b/LibOS/shim/include/shim_fs.h
@@ -71,6 +71,7 @@ struct shim_fs_ops {
     int (*move) (const char * trim_old_name, const char * trim_new_name);
     int (*copy) (const char * trim_old_name, const char * trim_new_name);
 
+    /* Returns 0 on success, -errno on error */
     int (*truncate) (struct shim_handle * hdl, uint64_t len);
 
     /* hstat: get status of the file */

--- a/LibOS/shim/src/fs/chroot/fs.c
+++ b/LibOS/shim/src/fs/chroot/fs.c
@@ -268,7 +268,7 @@ static int __query_attr (struct shim_dentry * dent,
     } else {
         /* DEP 3/18/17: Right now, we don't support hard links,
          * so just return 1;
-         */ 
+         */
         data->nlink = 1;
     }
 
@@ -929,6 +929,7 @@ out:
 static int chroot_truncate (struct shim_handle * hdl, uint64_t len)
 {
     int ret = 0;
+    uint64_t rv;
 
     if (NEED_RECREATE(hdl) && (ret = chroot_recreate(hdl)) < 0)
         return ret;
@@ -945,8 +946,10 @@ static int chroot_truncate (struct shim_handle * hdl, uint64_t len)
         struct shim_file_data * data = FILE_HANDLE_DATA(hdl);
         atomic_set(&data->size, len);
     }
-
-    if ((ret = DkStreamSetLength(hdl->pal_handle, len)) != len) {
+    rv = DkStreamSetLength(hdl->pal_handle, len);
+    if (rv) {
+        // For an error, cast it back down to an int return code
+        ret = -((int)rv);
         goto out;
     }
 

--- a/LibOS/shim/src/sys/shim_msgget.c
+++ b/LibOS/shim/src/sys/shim_msgget.c
@@ -792,7 +792,7 @@ static int __store_msg_persist (struct shim_msg_handle * msgq)
                         sizeof(struct msg_backup) * msgq->nmsgs +
                         msgq->currentsize;
 
-    if (DkStreamSetLength(file, expected_size) != expected_size)
+    if (DkStreamSetLength(file, expected_size))
         goto err_file;
 
     void * mem = (void *) DkStreamMap(file, NULL,

--- a/LibOS/shim/test/regression/30_futex.py
+++ b/LibOS/shim/test/regression/30_futex.py
@@ -11,4 +11,5 @@ regression = Regression(loader, "futex")
 regression.add_check(name="Futex Wake Test",
     check=lambda res: "Woke all kiddos" in res[0].out)
 
-regression.run_checks()
+rv = regression.run_checks()
+if rv: sys.exit(rv)

--- a/LibOS/shim/test/regression/30_mmap.py
+++ b/LibOS/shim/test/regression/30_mmap.py
@@ -29,5 +29,6 @@ if not sgx:
                          check=lambda res: "mmap test 5 passed" in res[0].out and \
                          "mmap test 8 passed" in res[0].out)
 
-                         
-regression.run_checks()
+
+rv = regression.run_checks()
+if rv: sys.exit(rv)

--- a/LibOS/shim/test/regression/90_large-mmap.py
+++ b/LibOS/shim/test/regression/90_large-mmap.py
@@ -15,4 +15,5 @@ regression.add_check(name="Large mmap",
     check=lambda res: "large-mmap: mmap 1 completed OK" in res[0].out and \
                      "large-mmap: mmap 2 completed OK" in res[0].out)
 
-regression.run_checks()
+rv = regression.run_checks()
+if rv: sys.exit(rv)

--- a/Pal/regression/00_Atomics.py
+++ b/Pal/regression/00_Atomics.py
@@ -22,4 +22,5 @@ regression.add_check(name="Atomic Math",
                      "Subtract LLONG_MIN: Both values match -9223372036854775808" in res[0].log and \
                      "Subtract LLONG_MAX: Both values match -9223372036854775807" in res[0].log)
 
-regression.run_checks()
+rv = regression.run_checks()
+if rv: sys.exit(rv)

--- a/Pal/regression/05_Process.py
+++ b/Pal/regression/05_Process.py
@@ -36,8 +36,7 @@ regression.add_check(name="Multi-Process Broadcast Channel Transmission",
                       check_times("Broadcast Read: Hello World 1", res[0].log, 3))
 
 rv = regression.run_checks()
-## dp : For now, let these tests fail.  We should fix this.
-#if rv: sys.exit(rv)
+if rv: sys.exit(rv)
 
 regression = Regression(loader, "Process2")
 
@@ -46,5 +45,4 @@ regression.add_check(name="Process Creation without Executable",
                       check_times("Binary 2 Preloaded", res[0].log, 2))
 
 rv = regression.run_checks()
-#if rv: sys.exit(rv)
-
+if rv: sys.exit(rv)

--- a/Pal/regression/05_Process.py
+++ b/Pal/regression/05_Process.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python2
+## This test is specifically for the reference monitor code, not process creation in general.
+## It is not well-tested right now, but keep the tests around for future work.
 
 import os, sys, mmap
 from regression import Regression
@@ -36,7 +38,8 @@ regression.add_check(name="Multi-Process Broadcast Channel Transmission",
                       check_times("Broadcast Read: Hello World 1", res[0].log, 3))
 
 rv = regression.run_checks()
-if rv: sys.exit(rv)
+## dp : For now, let these tests fail.  We should fix this.
+#if rv: sys.exit(rv)
 
 regression = Regression(loader, "Process2")
 
@@ -45,4 +48,4 @@ regression.add_check(name="Process Creation without Executable",
                       check_times("Binary 2 Preloaded", res[0].log, 2))
 
 rv = regression.run_checks()
-if rv: sys.exit(rv)
+#if rv: sys.exit(rv)

--- a/Pal/regression/06_AvxDisable.py
+++ b/Pal/regression/06_AvxDisable.py
@@ -15,7 +15,7 @@ def manifest_file(file):
 
 if not sgx:
   sys.exit(0)
-# Running AvxDisable 
+# Running AvxDisable
 regression = Regression(loader, "AvxDisable")
 
 regression.add_check(name="Disable AVX bit in XFRM",

--- a/Pal/src/db_streams.c
+++ b/Pal/src/db_streams.c
@@ -647,6 +647,7 @@ int64_t _DkStreamSetLength (PAL_HANDLE handle, uint64_t length)
 PAL_NUM
 DkStreamSetLength (PAL_HANDLE handle, PAL_NUM length)
 {
+    PAL_NUM rv = 0;
     ENTER_PAL_CALL(DkStreamSetLength);
 
     if (!handle) {
@@ -656,12 +657,16 @@ DkStreamSetLength (PAL_HANDLE handle, PAL_NUM length)
 
     int64_t ret = _DkStreamSetLength(handle, length);
 
+    // Convert failure to a positive value
     if (ret < 0) {
         _DkRaiseFailure(-ret);
-        ret = 0;
+        rv = -ret;
     }
 
-    LEAVE_PAL_CALL_RETURN(ret);
+    // At this point, ret should equal length
+    assert(ret == length);
+
+    LEAVE_PAL_CALL_RETURN(rv);
 }
 
 /* _DkStreamFlush for internal use. This function sync up the handle with

--- a/Pal/src/pal.h
+++ b/Pal/src/pal.h
@@ -325,6 +325,9 @@ DkStreamMap (PAL_HANDLE handle, PAL_PTR address, PAL_FLG prot,
 void
 DkStreamUnmap (PAL_PTR addr, PAL_NUM size);
 
+/* Sets the length of the file referenced by handle to length.  Returns the 0
+ * on success, a _positive_ errno on failure.
+ */
 PAL_NUM
 DkStreamSetLength (PAL_HANDLE handle, PAL_NUM length);
 


### PR DESCRIPTION
Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md).

## Affected components

- [ ] README and global configuration
- [X] Linux PAL
- [X] SGX PAL
- [ ] FreeBSD PAL
- [X] Common PAL code
- [X] Library OS (i.e., SHIM), including GLIBC

## Description of the changes (reasons and measures)

I noticed some of the unit tests are not checking and propagating the unit test return codes, so Jenkins will ignore failures.  This fixes that issue, except for the reference monitor tests, which is a whole other thing.

## How to test this PR? (if applicable)

Regular Jenkins tests suffice.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/533)
<!-- Reviewable:end -->
