### PR TITLE
Turn on the empty-body compiler warning

### DIFF
--- a/LibOS/shim/src/Makefile
+++ b/LibOS/shim/src/Makefile
@@ -15,7 +15,8 @@ CFLAGS	= -Wall -fPIC -std=gnu99 -fgnu89-inline -Winline -Wwrite-strings \
 	  -fno-stack-protector -fno-builtin -Wno-inline \
 	  -I../include -I../../../Pal/lib -I../../../Pal/include/pal
 
-EXTRAFLAGS = -Wextra -Wno-unused-parameter -Wno-sign-compare
+EXTRAFLAGS = -Wextra -Wno-unused-parameter -Wno-sign-compare \
+      -Wempty-body
 
 CFLAGS += $(EXTRAFLAGS)
 

--- a/Pal/src/host/Linux-SGX/Makefile.am
+++ b/Pal/src/host/Linux-SGX/Makefile.am
@@ -10,7 +10,8 @@ CFLAGS	= -Wall -fPIC -O2 -maes -std=c11 -U_FORTIFY_SOURCE \
 	  -fno-omit-frame-pointer \
 	  -fno-stack-protector -fno-builtin -DIN_ENCLAVE
 
-EXTRAFLAGS = -Wextra -Wno-unused-parameter -Wno-sign-compare
+EXTRAFLAGS = -Wextra -Wno-unused-parameter -Wno-sign-compare \
+      -Wempty-body
 
 CFLAGS += $(EXTRAFLAGS)
 

--- a/Pal/src/host/Linux/Makefile.am
+++ b/Pal/src/host/Linux/Makefile.am
@@ -10,7 +10,8 @@ LD	= ld
 CFLAGS	= -Wall -fPIC -O2 -std=c11 -U_FORTIFY_SOURCE \
 	  -fno-stack-protector -fno-builtin
 
-EXTRAFLAGS = -Wextra -Wno-unused-parameter -Wno-sign-compare
+EXTRAFLAGS = -Wextra -Wno-unused-parameter -Wno-sign-compare \
+      -Wempty-body
 
 CFLAGS += $(EXTRAFLAGS)
 


### PR DESCRIPTION
Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md).

## Affected components

- [ ] README and global configuration
- [X] Linux PAL
- [X] SGX PAL
- [ ] FreeBSD PAL
- [X] Common PAL code
- [X] Library OS (i.e., SHIM), including GLIBC

## Description of the changes (reasons and measures)

Enable -Wempty-body warning.  This one "just works"

## How to test this PR? (if applicable)

make/Jenkins

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/535)
<!-- Reviewable:end -->
