### PR TITLE
[Pal] Add %i support to printf

### DIFF
--- a/Pal/lib/stdlib/printfmt.c
+++ b/Pal/lib/stdlib/printfmt.c
@@ -196,6 +196,7 @@ vfprintfmt(int (*_fputch)(void *, int, void *), void * f, void * putdat,
 
 		// (signed) decimal
 		case 'd':
+		case 'i':
 			num = getint(ap, lflag);
 #if !defined(__i386__)
 			if ((long long) num < 0) {


### PR DESCRIPTION
## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [x] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes (reasons and measures)

Adds `%i` support to printf (Alias of `%d`).

## How to test this PR? (if applicable)

Use "%i" with `printf` & co. Since there are no tests for printf I didn't implemented a test for this simple change. I you think there should be tests for printf I can add some.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/537)
<!-- Reviewable:end -->
