### PR TITLE
LibOS: Add error handling and remove unused variable in epoll_wait regression test

### DIFF
--- a/LibOS/shim/test/regression/epoll_wait_timeout.c
+++ b/LibOS/shim/test/regression/epoll_wait_timeout.c
@@ -19,37 +19,37 @@ static int create_and_bind (char *port) {
     struct addrinfo *result, *rp;
     int s, sfd;
 
-    memset (&hints, 0, sizeof (struct addrinfo));
+    memset(&hints, 0, sizeof (struct addrinfo));
     hints.ai_family = AF_UNSPEC;     /* Return IPv4 and IPv6 choices */
     hints.ai_socktype = SOCK_STREAM; /* We want a TCP socket */
     hints.ai_flags = AI_PASSIVE;     /* All interfaces */
 
-    s = getaddrinfo (NULL, port, &hints, &result);
+    s = getaddrinfo(NULL, port, &hints, &result);
     if (s != 0) {
-        fprintf (stderr, "getaddrinfo: %s\n", gai_strerror (s));
+        fprintf(stderr, "getaddrinfo: %s\n", gai_strerror (s));
         return -1;
     }
 
     for (rp = result; rp != NULL; rp = rp->ai_next) {
-        sfd = socket (rp->ai_family, rp->ai_socktype, rp->ai_protocol);
+        sfd = socket(rp->ai_family, rp->ai_socktype, rp->ai_protocol);
         if (sfd == -1)
             continue;
 
-        s = bind (sfd, rp->ai_addr, rp->ai_addrlen);
+        s = bind(sfd, rp->ai_addr, rp->ai_addrlen);
         if (s == 0) {
             /* We managed to bind successfully! */
             break;
         }
 
-        close (sfd);
+        close(sfd);
     }
 
     if (rp == NULL) {
-        fprintf (stderr, "Could not bind\n");
+        fprintf(stderr, "Could not bind\n");
         return -1;
     }
 
-    freeaddrinfo (result);
+    freeaddrinfo(result);
     return sfd;
 }
 
@@ -57,16 +57,16 @@ static int create_and_bind (char *port) {
 static int make_socket_non_blocking (int sfd) {
     int flags, s;
 
-    flags = fcntl (sfd, F_GETFL, 0);
+    flags = fcntl(sfd, F_GETFL, 0);
     if (flags == -1) {
-        perror ("fcntl");
+        perror("fcntl");
         return -1;
     }
 
     flags |= O_NONBLOCK;
-    s = fcntl (sfd, F_SETFL, flags);
+    s = fcntl(sfd, F_SETFL, flags);
     if (s == -1) {
-        perror ("fcntl");
+        perror("fcntl");
         return -1;
     }
 
@@ -96,31 +96,35 @@ int main (int argc, char *argv[]) {
 
     s = listen(sfd, SOMAXCONN);
     if (s == -1) {
-        perror ("listen");
+        perror("listen");
         return 1;
     }
 
     efd = epoll_create1(0);
     if (efd == -1) {
-        perror ("epoll_create");
+        perror("epoll_create");
         return 1;
     }
 
     event.data.fd = sfd;
     event.events = EPOLLIN | EPOLLET;
-    s = epoll_ctl (efd, EPOLL_CTL_ADD, sfd, &event);
+    s = epoll_ctl(efd, EPOLL_CTL_ADD, sfd, &event);
     if (s == -1) {
-        perror ("epoll_ctl");
+        perror("epoll_ctl");
         return 1;
     }
 
-    events = calloc (MAXEVENTS, sizeof event);
+    events = calloc(MAXEVENTS, sizeof event);
 
     /* epoll_wait with 1 second timeout */
-    n = epoll_wait (efd, events, MAXEVENTS, 1000);
+    n = epoll_wait(efd, events, MAXEVENTS, 1000);
+    if (n == -1) {
+        perror("epoll_wait");
+        return 1;
+    }
 
     printf("epoll_wait test passed\n");
-    free (events);
-    close (sfd);
+    free(events);
+    close(sfd);
     return 0;
 }


### PR DESCRIPTION
Signed-off-by: Zhang Chen <chen.zhang@intel.com>

Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md).

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes (reasons and measures)
LibOS: Add missed exception handler and remove unused variable

## How to test this PR? (if applicable)
Goto libos/shim/test/regression
make regression

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/540)
<!-- Reviewable:end -->
