### PR TITLE
[LibOS] ltp automake version doesn't always match

### DIFF
--- a/LibOS/shim/test/apps/ltp/Makefile
+++ b/LibOS/shim/test/apps/ltp/Makefile
@@ -17,7 +17,6 @@ $(SRCDIR).tar.xz:
 
 $(SRCDIR)/configure: $(SRCDIR).tar.xz
 	tar -xmJf $<
-	cd $(SRCDIR) && make autotools
 
 $(BUILDDIR)/runltp: $(SRCDIR)/configure
 	cd $(SRCDIR) && ./configure


### PR DESCRIPTION
The version of automake used by ltp and the one in host doesn't
necessarily match. If they don't, the following error shows up for
make to fail.
issue aclocal and automake for such cases.

> configure.ac:4: error: version mismatch.  This is Automake 1.15.1,
> configure.ac:4: but the definition used by this AM_INIT_AUTOMAKE
> configure.ac:4: comes from Automake 1.15.  You should recreate
> configure.ac:4: aclocal.m4 with aclocal and run automake again.
> Makefile:78: recipe for target 'm4/Makefile.in' failed

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md).

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes (reasons and measures)


## How to test this PR? (if applicable)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/542)
<!-- Reviewable:end -->
