### PR TITLE
[LibOS] glibc-2.19/syscalldb.h: use callq indirect call with memory

### DIFF
--- a/LibOS/glibc-2.19/syscalldb.h
+++ b/LibOS/glibc-2.19/syscalldb.h
@@ -6,15 +6,13 @@
 .type syscalldb, @function
 
 # if defined(PSEUDO) && defined(SYSCALL_NAME) && defined(SYSCALL_SYMBOL)
-#  define SYSCALLDB				\
-    subq $128, %rsp;            \
-    movq syscalldb@GOTPCREL(%rip), %rcx;	\
-    call *%rcx;					\
+#  define SYSCALLDB                     \
+    subq $128, %rsp;                    \
+    callq *syscalldb@GOTPCREL(%rip);    \
     addq $128, %rsp
 # else
-#  define SYSCALLDB				\
-    movq syscalldb@GOTPCREL(%rip), %rcx;	\
-    call *%rcx
+#  define SYSCALLDB                             \
+    callq *syscalldb@GOTPCREL(%rip)
 # endif
 
 #else /* !__ASSEMBLER__ */
@@ -22,15 +20,13 @@ asm (
 ".weak syscalldb\r\n"
 ".type syscalldb, @function\r\n");
 
-#define SYSCALLDB							      \
-	"subq $128, %%rsp\n\t"						      \
-	"movq syscalldb@GOTPCREL(%%rip), %%rcx\n\t"			      \
-	"callq *%%rcx\n\t"						      \
-	"addq $128, %%rsp\n\t"
+#define SYSCALLDB                           \
+    "subq $128, %%rsp\n\t"                  \
+    "callq *syscalldb@GOTPCREL(%%rip)\n\t"  \
+    "addq $128, %%rsp\n\t"
 
-#define SYSCALLDB_ASM							      \
-	"movq syscalldb@GOTPCREL(%rip), %rbx\n\t"			      \
-	"callq *%rbx\n\t"
+#define SYSCALLDB_ASM                       \
+    "callq *syscalldb@GOTPCREL(%rip)\n\t"
 
 long int glibc_option (const char * opt);
 


### PR DESCRIPTION
indirect call of memory value is usable. So we don't have to
load pointer value for callq.

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md).

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes (reasons and measures)


## How to test this PR? (if applicable)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/546)
<!-- Reviewable:end -->
