### PR TITLE
LibOS/syscallas.S: shim_table should be referenced through GOT

### DIFF
--- a/LibOS/shim/src/syscallas.S
+++ b/LibOS/shim/src/syscallas.S
@@ -45,7 +45,7 @@ syscalldb:
         cmp $LIBOS_SYSCALL_BOUND, %rax
         jae isundef
 
-        leaq shim_table(%rip), %rbx
+        movq shim_table@GOTPCREL(%rip), %rbx
         movq (%rbx,%rax,8), %rbx
         cmp $0, %rbx
         je isundef


### PR DESCRIPTION
libsysdb.so is compiled as pic.

Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md).

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes (reasons and measures)


## How to test this PR? (if applicable)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/547)
<!-- Reviewable:end -->
