### PR TITLE
[Pal/Linux-SGX] generate asm offsets and use them

### DIFF
--- a/LibOS/shim/src/asm-offsets.c
+++ b/LibOS/shim/src/asm-offsets.c
@@ -1,11 +1,9 @@
+#include <asm-offsets-build.h>
+
 #include <stddef.h>
 
 #include <shim_internal.h>
 #include <shim_tls.h>
-
-#define OFFSET_T(name, str_t, member)                       \
-    asm volatile(".ascii \" #define " #name " %0 \"\n"::    \
-                 "i"(offsetof(str_t, member)))
 
 void dummy(void)
 {

--- a/Pal/include/pal/asm-offsets-build.h
+++ b/Pal/include/pal/asm-offsets-build.h
@@ -1,0 +1,1 @@
+../../src/asm-offsets-build.h

--- a/Pal/src/asm-offsets-build.h
+++ b/Pal/src/asm-offsets-build.h
@@ -1,0 +1,10 @@
+#ifndef ASM_OFFSETS_BUILD_H
+#define ASM_OFFSETS_BUILD_H
+
+#define DEFINE(name, value)     \
+    __asm__ volatile(".ascii \" #define " #name " %0 \"\n":: "i"(value))
+
+#define OFFSET(name, str, member)   DEFINE(name, offsetof(struct str, member))
+#define OFFSET_T(name, str_t, member) DEFINE(name, offsetof(str_t, member))
+
+#endif /* ASM_OFFSETS_BUILD_H */

--- a/Pal/src/host/Linux-SGX/.gitignore
+++ b/Pal/src/host/Linux-SGX/.gitignore
@@ -1,4 +1,6 @@
-pal-sgx
+/asm-offsets.h
+/asm-offsets.s
+/pal-sgx
 
 *.pem
 *.pub

--- a/Pal/src/host/Linux-SGX/Makefile
+++ b/Pal/src/host/Linux-SGX/Makefile
@@ -90,8 +90,12 @@ debugger/sgx_gdb.so: debugger/sgx_gdb.c debugger/sgx_gdb.h sgx_arch.h
 	$(CC) -Wall -fPIC -O2 -std=c11 -c debugger/sgx_gdb.c -o debugger/sgx_gdb.o
 	$(LD) -shared debugger/sgx_gdb.o -o debugger/sgx_gdb.so -lc
 
+enclave_entry.o sgx_entry.o: asm-offsets.h
+
 sgx-driver/isgx_version.h:
 	$(MAKE) -C sgx-driver $(notdir $<)
+
+include ../../../../Makefile.rules
 
 CLEAN_FILES += $(notdir $(pal_static) $(pal_lib) $(pal_sec) $(pal_loader))
 CLEAN_FILES += debugger/sgx_gdb.o

--- a/Pal/src/host/Linux-SGX/asm-offsets.c
+++ b/Pal/src/host/Linux-SGX/asm-offsets.c
@@ -1,0 +1,69 @@
+#include <stddef.h>
+
+#include "sgx_arch.h"
+#include "sgx_tls.h"
+
+#include <asm-offsets-build.h>
+
+void dummy(void)
+{
+    /* sgx_arch_gpr_t */
+    OFFSET_T(SGX_GPR_RAX, sgx_arch_gpr_t, rax);
+    OFFSET_T(SGX_GPR_RCX, sgx_arch_gpr_t, rcx);
+    OFFSET_T(SGX_GPR_RDX, sgx_arch_gpr_t, rdx);
+    OFFSET_T(SGX_GPR_RBX, sgx_arch_gpr_t, rbx);
+    OFFSET_T(SGX_GPR_RSP, sgx_arch_gpr_t, rsp);
+    OFFSET_T(SGX_GPR_RBP, sgx_arch_gpr_t, rbp);
+    OFFSET_T(SGX_GPR_RSI, sgx_arch_gpr_t, rsi);
+    OFFSET_T(SGX_GPR_RDI, sgx_arch_gpr_t, rdi);
+    OFFSET_T(SGX_GPR_R8, sgx_arch_gpr_t, r8);
+    OFFSET_T(SGX_GPR_R9, sgx_arch_gpr_t, r9);
+    OFFSET_T(SGX_GPR_R10, sgx_arch_gpr_t, r10);
+    OFFSET_T(SGX_GPR_R11, sgx_arch_gpr_t, r11);
+    OFFSET_T(SGX_GPR_R12, sgx_arch_gpr_t, r12);
+    OFFSET_T(SGX_GPR_R13, sgx_arch_gpr_t, r13);
+    OFFSET_T(SGX_GPR_R14, sgx_arch_gpr_t, r14);
+    OFFSET_T(SGX_GPR_R15, sgx_arch_gpr_t, r15);
+    OFFSET_T(SGX_GPR_RFLAGS, sgx_arch_gpr_t, rflags);
+    OFFSET_T(SGX_GPR_RIP, sgx_arch_gpr_t, rip);
+    OFFSET_T(SGX_GPR_EXITINFO, sgx_arch_gpr_t, exitinfo);
+
+    /* sgx_context_t */
+    OFFSET_T(SGX_CONTEXT_RAX, sgx_context_t, rax);
+    OFFSET_T(SGX_CONTEXT_RCX, sgx_context_t, rcx);
+    OFFSET_T(SGX_CONTEXT_RDX, sgx_context_t, rdx);
+    OFFSET_T(SGX_CONTEXT_RBX, sgx_context_t, rbx);
+    OFFSET_T(SGX_CONTEXT_RSP, sgx_context_t, rsp);
+    OFFSET_T(SGX_CONTEXT_RBP, sgx_context_t, rbp);
+    OFFSET_T(SGX_CONTEXT_RSI, sgx_context_t, rsi);
+    OFFSET_T(SGX_CONTEXT_RDI, sgx_context_t, rdi);
+    OFFSET_T(SGX_CONTEXT_R8, sgx_context_t, r8);
+    OFFSET_T(SGX_CONTEXT_R9, sgx_context_t, r9);
+    OFFSET_T(SGX_CONTEXT_R10, sgx_context_t, r10);
+    OFFSET_T(SGX_CONTEXT_R11, sgx_context_t, r11);
+    OFFSET_T(SGX_CONTEXT_R12, sgx_context_t, r12);
+    OFFSET_T(SGX_CONTEXT_R13, sgx_context_t, r13);
+    OFFSET_T(SGX_CONTEXT_R14, sgx_context_t, r14);
+    OFFSET_T(SGX_CONTEXT_R15, sgx_context_t, r15);
+    OFFSET_T(SGX_CONTEXT_RFLAGS, sgx_context_t, rflags);
+    OFFSET_T(SGX_CONTEXT_RIP, sgx_context_t, rip);
+    DEFINE(SGX_CONTEXT_SIZE, sizeof(sgx_context_t));
+
+    /* struct enclave_tls */
+    OFFSET(SGX_ENCLAVE_SIZE, enclave_tls, enclave_size);
+    OFFSET(SGX_TCS_OFFSET, enclave_tls, tcs_offset);
+    OFFSET(SGX_INITIAL_STACK_OFFSET, enclave_tls, initial_stack_offset);
+    OFFSET(SGX_AEP, enclave_tls, aep);
+    OFFSET(SGX_SSA, enclave_tls, ssa);
+    OFFSET(SGX_GPR, enclave_tls, gpr);
+    OFFSET(SGX_EXIT_TARGET, enclave_tls, exit_target);
+    OFFSET(SGX_FSBASE, enclave_tls, fsbase);
+    OFFSET(SGX_STACK, enclave_tls, stack);
+    OFFSET(SGX_USTACK_TOP, enclave_tls, ustack_top);
+    OFFSET(SGX_USTACK, enclave_tls, ustack);
+    OFFSET(SGX_THREAD, enclave_tls, thread);
+
+    /* sgx_arch_tcs_t */
+    DEFINE(TCS_SIZE, sizeof(sgx_arch_tcs_t));
+}
+

--- a/Pal/src/host/Linux-SGX/enclave_entry.S
+++ b/Pal/src/host/Linux-SGX/enclave_entry.S
@@ -1,5 +1,5 @@
 #include "sgx_arch.h"
-#include "sgx_tls.h"
+#include "asm-offsets.h"
 
 	.extern ecall_table
 	.extern enclave_ecall_pal_main
@@ -140,48 +140,49 @@ enclave_entry:
 	je 1f
 	movq %rax, %rsi
 1:
-	subq $0x90, %rsi
+	subq $SGX_CONTEXT_SIZE, %rsi
 
 	# we have exitinfo in RDI, swap with the one on GPR
 	# and dump into the context
 	xchgq %rdi, SGX_GPR_RDI(%rbx)
-	movq %rdi, 0x38(%rsi)
+	movq %rdi, SGX_CONTEXT_RDI(%rsi)
 
 	# dump the rest of context
 	movq SGX_GPR_RAX(%rbx), %rdi
-	movq %rdi, 0x00(%rsi)
+	movq %rdi, SGX_CONTEXT_RAX(%rsi)
 	movq SGX_GPR_RCX(%rbx), %rdi
-	movq %rdi, 0x08(%rsi)
+	movq %rdi, SGX_CONTEXT_RCX(%rsi)
 	movq SGX_GPR_RDX(%rbx), %rdi
-	movq %rdi, 0x10(%rsi)
+	movq %rdi, SGX_CONTEXT_RDX(%rsi)
 	movq SGX_GPR_RBX(%rbx), %rdi
-	movq %rdi, 0x18(%rsi)
+	movq %rdi, SGX_CONTEXT_RBX(%rsi)
 	movq SGX_GPR_RSP(%rbx), %rdi
-	movq %rdi, 0x20(%rsi)
+	movq %rdi, SGX_CONTEXT_RSP(%rsi)
 	movq SGX_GPR_RBP(%rbx), %rdi
-	movq %rdi, 0x28(%rsi)
+	movq %rdi, SGX_CONTEXT_RBP(%rsi)
 	movq SGX_GPR_RSI(%rbx), %rdi
-	movq %rdi, 0x30(%rsi)
+	movq %rdi, SGX_CONTEXT_RSI(%rsi)
+	/* rdi is saved above */
 	movq SGX_GPR_R8(%rbx), %rdi
-	movq %rdi, 0x40(%rsi)
+	movq %rdi, SGX_CONTEXT_R8(%rsi)
 	movq SGX_GPR_R9(%rbx), %rdi
-	movq %rdi, 0x48(%rsi)
+	movq %rdi, SGX_CONTEXT_R9(%rsi)
 	movq SGX_GPR_R10(%rbx), %rdi
-	movq %rdi, 0x50(%rsi)
+	movq %rdi, SGX_CONTEXT_R10(%rsi)
 	movq SGX_GPR_R11(%rbx), %rdi
-	movq %rdi, 0x58(%rsi)
+	movq %rdi, SGX_CONTEXT_R11(%rsi)
 	movq SGX_GPR_R12(%rbx), %rdi
-	movq %rdi, 0x60(%rsi)
+	movq %rdi, SGX_CONTEXT_R12(%rsi)
 	movq SGX_GPR_R13(%rbx), %rdi
-	movq %rdi, 0x68(%rsi)
+	movq %rdi, SGX_CONTEXT_R13(%rsi)
 	movq SGX_GPR_R14(%rbx), %rdi
-	movq %rdi, 0x70(%rsi)
+	movq %rdi, SGX_CONTEXT_R14(%rsi)
 	movq SGX_GPR_R15(%rbx), %rdi
-	movq %rdi, 0x78(%rsi)
+	movq %rdi, SGX_CONTEXT_R15(%rsi)
 	movq SGX_GPR_RFLAGS(%rbx), %rdi
-	movq %rdi, 0x80(%rsi)
+	movq %rdi, SGX_CONTEXT_RFLAGS(%rsi)
 	movq SGX_GPR_RIP(%rbx), %rdi
-	movq %rdi, 0x88(%rsi)
+	movq %rdi, SGX_CONTEXT_RIP(%rsi)
 
 	movq %rsi, SGX_GPR_RSP(%rbx)
 	movq %rsi, SGX_GPR_RSI(%rbx)

--- a/Pal/src/host/Linux-SGX/sgx_arch.h
+++ b/Pal/src/host/Linux-SGX/sgx_arch.h
@@ -272,29 +272,6 @@ typedef uint8_t sgx_arch_key128_t[16] __attribute__((aligned(16)));
 #define KEYPOLICY_MRENCLAVE     1
 #define KEYPOLICY_MRSIGNER      2
 
-#define SGX_GPR_RAX             0x00
-#define SGX_GPR_RCX             0x08
-#define SGX_GPR_RDX             0x10
-#define SGX_GPR_RBX             0x18
-#define SGX_GPR_RSP             0x20
-#define SGX_GPR_RBP             0x28
-#define SGX_GPR_RSI             0x30
-#define SGX_GPR_RDI             0x38
-#define SGX_GPR_R8              0x40
-#define SGX_GPR_R9              0x48
-#define SGX_GPR_R10             0x50
-#define SGX_GPR_R11             0x58
-#define SGX_GPR_R12             0x60
-#define SGX_GPR_R13             0x68
-#define SGX_GPR_R14             0x70
-#define SGX_GPR_R15             0x78
-#define SGX_GPR_RFLAGS          0x80
-#define SGX_GPR_RIP             0x88
-#define SGX_GPR_EXITINFO        0xa0
-
-#define TCS_SIZE    4096
-#define TCS_SHIFT   12
-
 #define XSAVE_SIZE  512
 
 #define STACK_ALIGN 0xfffffffffffffff0

--- a/Pal/src/host/Linux-SGX/sgx_entry.S
+++ b/Pal/src/host/Linux-SGX/sgx_entry.S
@@ -1,6 +1,8 @@
 #include "pal_linux_defs.h"
 #include "sgx_arch.h"
 
+#include "asm-offsets.h"
+
 	.extern tcs_base
 
 	.global sgx_ecall

--- a/Pal/src/host/Linux-SGX/sgx_tls.h
+++ b/Pal/src/host/Linux-SGX/sgx_tls.h
@@ -4,8 +4,6 @@
 #ifndef __SGX_TLS_H__
 #define __SGX_TLS_H__
 
-#ifndef __ASSEMBLER__
-
 struct enclave_tls {
     uint64_t enclave_size;
     uint64_t tcs_offset;
@@ -40,23 +38,5 @@ extern uint64_t dummy_debug_variable;
              "i" (offsetof(struct enclave_tls, member)));           \
     } while (0)
 # endif
-
-#else /* !__ASSEMBLER__ */
-
-/* update these constant according to struct enclave_tls */
-#define SGX_ENCLAVE_SIZE            0x00
-#define SGX_TCS_OFFSET              0x08
-#define SGX_INITIAL_STACK_OFFSET    0x10
-#define SGX_AEP                     0x18
-#define SGX_SSA                     0x20
-#define SGX_GPR                     0x28
-#define SGX_EXIT_TARGET             0x30
-#define SGX_FSBASE                  0x38
-#define SGX_STACK                   0x40
-#define SGX_USTACK_TOP              0x48
-#define SGX_USTACK                  0x50
-#define SGX_THREAD                  0x58
-
-#endif
 
 #endif /* __SGX_TLS_H__ */


### PR DESCRIPTION
This patch auto-generates asm offsets for Pal/Linux-SGX and uses them.
Also to share the generation logic among Pal and LibOS, header file for
it is created under Pal.

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md).

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [x] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes (reasons and measures)


## How to test this PR? (if applicable)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/551)
<!-- Reviewable:end -->
