### PR TITLE
[Pal/Linux-SGX] more friendly message when thread is lacking

### DIFF
--- a/Pal/src/host/Linux-SGX/sgx_thread.c
+++ b/Pal/src/host/Linux-SGX/sgx_thread.c
@@ -68,7 +68,10 @@ static void * thread_start (void * arg)
     current_enclave = arg;
 
     if (!current_tcs) {
-        SGX_DBG(DBG_E, "Cannot attach to any TCS!\n");
+        SGX_DBG(DBG_E,
+                "There are no available TCS pages left for a new thread!\n"
+                "Please try to increase sgx.thread_num in the manifest.\n"
+                "The current value is %d\n", enclave_thread_num);
         return NULL;
     }
 


### PR DESCRIPTION
Add more user friendly message when the number of thread is
too small for user program.

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md).

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [x] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes (reasons and measures)


## How to test this PR? (if applicable)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/552)
<!-- Reviewable:end -->
