### PR TITLE
[Pal/Linux-SGX] Drop unused SGX_HAS_FSGSBASE flag

### DIFF
--- a/Pal/src/host/Linux-SGX/db_exception.c
+++ b/Pal/src/host/Linux-SGX/db_exception.c
@@ -190,13 +190,6 @@ void restore_sgx_context (sgx_context_t * uc)
 
 void _DkExceptionHandler (unsigned int exit_info, sgx_context_t * uc)
 {
-#if SGX_HAS_FSGSBASE == 0
-    /* set the FS first if necessary */
-    uint64_t fsbase = (uint64_t) GET_ENCLAVE_TLS(fsbase);
-    if (fsbase)
-        wrfsbase(fsbase);
-#endif
-
     union {
         sgx_arch_exitinfo_t info;
         int intval;

--- a/Pal/src/host/Linux-SGX/enclave_entry.S
+++ b/Pal/src/host/Linux-SGX/enclave_entry.S
@@ -97,26 +97,6 @@ enclave_entry:
 	cmpl $0, %edi
 	jne .Lhandle_exception
 
-#if SGX_HAS_FSGSBASE == 0
-	movq %gs:SGX_FSBASE, %rdi
-	cmpq $0, %rdi
-	je .Ljust_resume
-
-	movq SGX_GPR_RSP(%rbx), %rsi
-	subq $16, %rsi
-	movq %rsi, SGX_GPR_RSP(%rbx)
-
-	# try to push rip and fsbase onto the stack
-	movq %rdi, (%rsi)
-	movq SGX_GPR_RIP(%rbx), %rdi
-	movq %rdi, 8(%rsi)
-
-	# new RIP is the resume point
-	leaq .Lafter_resume(%rip), %rdi
-	movq %rdi, SGX_GPR_RIP(%rbx)
-
-.Ljust_resume:
-#endif
 	# clear the registers
 	xorq %rdi, %rdi
 	xorq %rsi, %rsi
@@ -125,15 +105,6 @@ enclave_entry:
 	movq %rdx, %rbx
 	movq $EEXIT, %rax
 	ENCLU
-
-#if SGX_HAS_FSGSBASE == 0
-.Lafter_resume:
-	movq %rbx, -8(%rsp)
-	popq %rbx
-	.byte 0xf3, 0x48, 0x0f, 0xae, 0xd3 /* WRFSBASE %RBX */
-	movq -16(%rsp), %rbx
-	retq
-#endif
 
 	## There is a race between host signal delivery and restoring %rsp
 	## in this entry code. We must be careful to setup %rsp.

--- a/Pal/src/host/Linux-SGX/pal_linux_defs.h
+++ b/Pal/src/host/Linux-SGX/pal_linux_defs.h
@@ -15,8 +15,6 @@
 #define DEBUG_ECALL         (0)
 #define DEBUG_OCALL         (0)
 
-#define SGX_HAS_FSGSBASE    (1)
-
 #define TRUSTED_STUB_SIZE   (PRESET_PAGESIZE * 4)
 
 #define CACHE_FILE_STUBS    (1)

--- a/Pal/src/host/Linux-SGX/sgx_arch.h
+++ b/Pal/src/host/Linux-SGX/sgx_arch.h
@@ -101,10 +101,8 @@ typedef struct {
     uint64_t urbp;
     uint32_t exitinfo;
     uint32_t reserved;
-#if SGX_HAS_FSGSBASE == 1
     uint64_t fsbase;
     uint64_t gsbase;
-#endif
 } sgx_arch_gpr_t;
 
 typedef struct {

--- a/Pal/src/host/Linux-SGX/sgx_entry.S
+++ b/Pal/src/host/Linux-SGX/sgx_entry.S
@@ -26,38 +26,6 @@ sgx_ecall:
 	.global async_exit_pointer
 	.type async_exit_pointer, @function
 
-#if SGX_HAS_FSGSBASE == 0
-async_exit_pointer:
-	# because ERESUME doesn't restore FS/GS, we must do EENTER
-
-	movq current_tcs@gottpoff(%rip), %rbx
-	movq %fs:(%rbx), %rbx
-
-	leaq double_async_exit(%rip), %rcx
-
-	# put the exit address in RDX
-	leaq .Lreal_resume(%rip), %rdx
-
-	movq $EENTER, %rax
-	ENCLU
-
-.Lreal_resume:
-	# RBX has to be the TCS of the thread
-	movq current_tcs@gottpoff(%rip), %rbx
-	movq %fs:(%rbx), %rbx
-
-	# RCX has to be the AEP (Asynchronous Exit Pointer)
-	leaq async_exit_pointer(%rip), %rcx
-
-	movq $ERESUME, %rax
-	ENCLU
-
-	.global double_async_exit
-	.type double_async_exit, @function
-
-double_async_exit:
-	ENCLU
-#else
 async_exit_pointer:
 	ENCLU
 
@@ -70,7 +38,6 @@ sgx_raise:
 
 .Lafter_resume:
 	retq
-#endif
 
 sgx_entry:
 	# arguments: RDI - code, RSI - ms

--- a/Pal/src/host/Linux-SGX/sgx_internal.h
+++ b/Pal/src/host/Linux-SGX/sgx_internal.h
@@ -112,9 +112,6 @@ int sgx_ecall (long ecall_no, void * ms);
 int sgx_raise (int event);
 
 void async_exit_pointer (void);
-#if SGX_HAS_FSGSBASE == 0
-void double_async_exit (void);
-#endif
 
 int interrupt_thread (void * tcs);
 int clone_thread (void);


### PR DESCRIPTION
## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [x] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes (reasons and measures)

SGX_HAS_FSGSBASE has been hardcoded to 1 since the beginning.

Also the Intel SDM doesn't mention that the FS/GS handling in SGX can be
unavailable on some hardware.

So just drop it.

Closes #545.

## How to test this PR? (if applicable)

SGX regression tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/553)
<!-- Reviewable:end -->
