### PR TITLE
[Pal/Linux-SGX] make ocall return linux errno instead of pal errno.

### DIFF
--- a/Pal/src/host/Linux-SGX/db_events.c
+++ b/Pal/src/host/Linux-SGX/db_events.c
@@ -28,6 +28,7 @@
 #include "pal.h"
 #include "pal_internal.h"
 #include "pal_linux.h"
+#include "pal_linux_error.h"
 #include "pal_error.h"
 #include "pal_debug.h"
 #include "api.h"
@@ -67,16 +68,18 @@ int _DkEventSet (PAL_HANDLE event, int wakeup)
                 ret = ocall_futex((int *) &event->event.signaled->counter,
                                   FUTEX_WAKE, nwaiters, NULL);
 
-                if (ret < 0)
+                if (IS_ERR(ret)) {
                     atomic_set(event->event.signaled, 0);
+                    ret = unix_to_pal_error(ERRNO(ret));
+                }
             }
         }
     } else {
         // Only one thread wakes up, leave unsignaled
         ret = ocall_futex((int *) &event->event.signaled->counter,
                           FUTEX_WAKE, 1, NULL);
-        if (ret < 0)
-             return ret;
+        if (IS_ERR(ret))
+            return unix_to_pal_error(ERRNO(ret));
     }
 
     return ret;
@@ -94,11 +97,13 @@ int _DkEventWaitTimeout (PAL_HANDLE event, uint64_t timeout)
         do {
             ret = ocall_futex((int *) &event->event.signaled->counter,
                               FUTEX_WAIT, 0, timeout ? &waittime : NULL);
-            if (ret < 0) {
-                if (ret == -PAL_ERROR_TRYAGAIN)
+            if (IS_ERR(ret)) {
+                if (ERRNO(ret) == EWOULDBLOCK) {
                     ret = 0;
-                else
+                } else {
+                    ret = unix_to_pal_error(ERRNO(ret));
                     break;
+                }
             }
         } while (event->event.isnotification &&
                  !atomic_read(event->event.signaled));
@@ -119,11 +124,13 @@ int _DkEventWait (PAL_HANDLE event)
         do {
             ret = ocall_futex((int *) &event->event.signaled->counter,
                               FUTEX_WAIT, 0, NULL);
-            if (ret < 0) {
-                if (ret == -PAL_ERROR_TRYAGAIN)
+            if (IS_ERR(ret)) {
+                if (ERRNO(ret) == EWOULDBLOCK) {
                     ret = 0;
-                else
+                } else {
+                    ret = unix_to_pal_error(ERRNO(ret));
                     break;
+                }
             }
         } while (event->event.isnotification &&
                  !atomic_read(event->event.signaled));

--- a/Pal/src/host/Linux-SGX/db_files.c
+++ b/Pal/src/host/Linux-SGX/db_files.c
@@ -29,6 +29,7 @@
 #include "pal.h"
 #include "pal_internal.h"
 #include "pal_linux.h"
+#include "pal_linux_error.h"
 #include "pal_debug.h"
 #include "pal_error.h"
 #include "api.h"
@@ -52,8 +53,8 @@ static int file_open (PAL_HANDLE * handle, const char * type, const char * uri,
     /* try to do the real open */
     int fd = ocall_open(uri, access|create|options, share);
 
-    if (fd < 0)
-        return fd;
+    if (IS_ERR(fd))
+        return unix_to_pal_error(ERRNO(fd));
 
     /* if try_create_path succeeded, prepare for the file handle */
     int len = strlen(uri);
@@ -112,7 +113,7 @@ static int64_t file_read (PAL_HANDLE handle, uint64_t offset, uint64_t count,
     void * umem;
     ret = ocall_map_untrusted(handle->file.fd, map_start,
                               map_end - map_start, PROT_READ, &umem);
-    if (ret < 0)
+    if (IS_ERR(ret))
         return -PAL_ERROR_DENIED;
 
     if (stubs) {
@@ -143,9 +144,8 @@ static int64_t file_write(PAL_HANDLE handle, uint64_t offset, uint64_t count,
 
     ret = ocall_map_untrusted(handle->file.fd, map_start,
                               map_end - map_start, PROT_WRITE, &umem);
-    if (ret < 0) {
+    if (IS_ERR(ret))
         return -PAL_ERROR_DENIED;
-    }
 
     if (offset + count > handle->file.total) {
         ocall_ftruncate(handle->file.fd, offset + count);
@@ -179,7 +179,8 @@ static int file_delete (PAL_HANDLE handle, int access)
     if (access)
         return -PAL_ERROR_INVAL;
 
-    return ocall_delete(handle->file.realpath);
+    int ret = ocall_delete(handle->file.realpath);
+    return IS_ERR(ret) ? unix_to_pal_error(ERRNO(ret)) : ret;
 }
 
 /* 'map' operation for file stream. */
@@ -200,9 +201,9 @@ static int file_map (PAL_HANDLE handle, void ** addr, int prot,
     if (!mem && !stubs && !(prot & PAL_PROT_WRITECOPY)) {
         ret = ocall_map_untrusted(handle->file.fd, offset, size,
                                   HOST_PROT(prot), &mem);
-        if (!ret)
+        if (!IS_ERR(ret))
             *addr = mem;
-        return ret;
+        return IS_ERR(ret) ? unix_to_pal_error(ERRNO(ret)) : ret;
     }
 
     if (!(prot & PAL_PROT_WRITECOPY) && (prot & PAL_PROT_WRITE)) {
@@ -227,9 +228,9 @@ static int file_map (PAL_HANDLE handle, void ** addr, int prot,
 
     ret = ocall_map_untrusted(handle->file.fd, map_start,
                               map_end - map_start, PROT_READ, &umem);
-    if (ret < 0) {
+    if (IS_ERR(ret)) {
         SGX_DBG(DBG_E, "file_map - ocall returned %d\n", ret);
-        return ret;
+        return unix_to_pal_error(ERRNO(ret));
     }
 
     if (stubs) {
@@ -256,8 +257,9 @@ static int file_map (PAL_HANDLE handle, void ** addr, int prot,
 static int64_t file_setlength (PAL_HANDLE handle, uint64_t length)
 {
     int ret = ocall_ftruncate(handle->file.fd, length);
-    if (ret < 0)
-        return ret;
+    if (IS_ERR(ret))
+        return unix_to_pal_error(ERRNO(ret));
+
     handle->file.total = length;
     return (int64_t) length;
 }
@@ -308,16 +310,16 @@ static int file_attrquery (const char * type, const char * uri,
         return -PAL_ERROR_INVAL;
     /* try to do the real open */
     int fd = ocall_open(uri, 0, 0);
-    if (fd < 0)
-        return fd;
+    if (IS_ERR(fd))
+        return unix_to_pal_error(ERRNO(fd));
 
     struct stat stat_buf;
     int ret = ocall_fstat(fd, &stat_buf);
     ocall_close(fd);
 
     /* if it failed, return the right error code */
-    if (ret < 0)
-        return ret;
+    if (IS_ERR(ret))
+        return unix_to_pal_error(ERRNO(ret));
 
     file_attrcopy(attr, &stat_buf);
     return 0;
@@ -331,8 +333,8 @@ static int file_attrquerybyhdl (PAL_HANDLE handle,
     struct stat stat_buf;
 
     int ret = ocall_fstat(fd, &stat_buf);
-    if (ret < 0)
-        return ret;
+    if (IS_ERR(ret))
+        return unix_to_pal_error(ERRNO(ret));
 
     file_attrcopy(attr, &stat_buf);
     return 0;
@@ -343,8 +345,8 @@ static int file_attrsetbyhdl (PAL_HANDLE handle,
 {
     int fd = handle->file.fd;
     int ret = ocall_fchmod(fd, attr->share_flags | 0600);
-    if (ret < 0)
-        return ret;
+    if (IS_ERR(ret))
+        return unix_to_pal_error(ERRNO(ret));
 
     return 0;
 }
@@ -355,8 +357,8 @@ static int file_rename (PAL_HANDLE handle, const char * type,
     if (!strcmp_static(type, "file"))
         return -PAL_ERROR_INVAL;
     int ret = ocall_rename(handle->file.realpath, uri);
-    if (ret < 0)
-        return ret;
+    if (IS_ERR(ret))
+        return unix_to_pal_error(ERRNO(ret));
 
     /* TODO: old realpath memory is potentially leaked here, and need
      * to check for strdup memory allocation failure. */
@@ -416,13 +418,14 @@ static int dir_open (PAL_HANDLE * handle, const char * type, const char * uri,
 
     if (create & PAL_CREATE_TRY) {
         ret = ocall_mkdir(uri, share);
-        if (ret == -PAL_ERROR_STREAMEXIST && (create & PAL_CREATE_ALWAYS))
-            return ret;
+        if (IS_ERR(ret) && ERRNO(ret) == EEXIST &&
+            create & PAL_CREATE_ALWAYS)
+            return -PAL_ERROR_STREAMEXIST;
     }
 
     ret = ocall_open(uri, O_DIRECTORY|options, 0);
-    if (ret < 0)
-        return ret;
+    if (IS_ERR(ret))
+        return unix_to_pal_error(ERRNO(ret));
 
     int len = strlen(uri);
     PAL_HANDLE hdl = malloc(HANDLE_SIZE(dir) + len + 1);
@@ -464,8 +467,8 @@ static int64_t dir_read (PAL_HANDLE handle, uint64_t offset, uint64_t count,
 
         int size = ocall_getdents(handle->dir.fd, dent_buf, DIRBUF_SIZE);
 
-        if (size < 0)
-            return size;
+        if (IS_ERR(size))
+            return unix_to_pal_error(ERRNO(size));
 
         if (size == 0) {
             handle->dir.endofstream = PAL_TRUE;
@@ -547,7 +550,8 @@ static int dir_delete (PAL_HANDLE handle, int access)
     if (ret < 0)
         return ret;
 
-    return ocall_delete(handle->dir.realpath);
+    ret = ocall_delete(handle->dir.realpath);
+    return IS_ERR(ret) ? unix_to_pal_error(ERRNO(ret)) : ret;
 }
 
 static int dir_rename (PAL_HANDLE handle, const char * type,
@@ -556,8 +560,8 @@ static int dir_rename (PAL_HANDLE handle, const char * type,
     if (!strcmp_static(type, "dir"))
         return -PAL_ERROR_INVAL;
     int ret = ocall_rename(handle->dir.realpath, uri);
-    if (ret < 0)
-        return ret;
+    if (IS_ERR(ret))
+        return unix_to_pal_error(ERRNO(ret));
 
     /* TODO: old realpath memory is potentially leaked here, and need
      * to check for strdup memory allocation failure. */

--- a/Pal/src/host/Linux-SGX/db_files.c
+++ b/Pal/src/host/Linux-SGX/db_files.c
@@ -76,7 +76,7 @@ static int file_open (PAL_HANDLE * handle, const char * type, const char * uri,
                 "This file is not trusted or allowed.\n", hdl->file.realpath,
                 PAL_STRERROR(-ret));
         free(hdl);
-        return -PAL_ERROR_DENIED;
+        return ret;
     }
 
     hdl->file.stubs = (PAL_PTR) stubs;
@@ -114,7 +114,7 @@ static int64_t file_read (PAL_HANDLE handle, uint64_t offset, uint64_t count,
     ret = ocall_map_untrusted(handle->file.fd, map_start,
                               map_end - map_start, PROT_READ, &umem);
     if (IS_ERR(ret))
-        return -PAL_ERROR_DENIED;
+        return unix_to_pal_error(ERRNO(ret));
 
     if (stubs) {
         ret = copy_and_verify_trusted_file(handle->file.realpath, umem,
@@ -145,7 +145,7 @@ static int64_t file_write(PAL_HANDLE handle, uint64_t offset, uint64_t count,
     ret = ocall_map_untrusted(handle->file.fd, map_start,
                               map_end - map_start, PROT_WRITE, &umem);
     if (IS_ERR(ret))
-        return -PAL_ERROR_DENIED;
+        return unix_to_pal_error(ERRNO(ret));
 
     if (offset + count > handle->file.total) {
         ocall_ftruncate(handle->file.fd, offset + count);

--- a/Pal/src/host/Linux-SGX/db_misc.c
+++ b/Pal/src/host/Linux-SGX/db_misc.c
@@ -198,7 +198,7 @@ int _DkCpuIdRetrieve (unsigned int leaf, unsigned int subleaf,
     if (!get_cpuid_from_cache(leaf, subleaf, values))
         return 0;
 
-    if (ocall_cpuid(leaf, subleaf, values) < 0)
+    if (IS_ERR(ocall_cpuid(leaf, subleaf, values)))
         return -PAL_ERROR_DENIED;
 
     add_cpuid_to_cache(leaf, subleaf, values);

--- a/Pal/src/host/Linux-SGX/db_mutex.c
+++ b/Pal/src/host/Linux-SGX/db_mutex.c
@@ -86,14 +86,14 @@ int _DkMutexLockTimeout (struct mutex_handle * m, uint64_t timeout)
          */
         ret = ocall_futex((int *) m->locked, FUTEX_WAIT, MUTEX_LOCKED, timeout == -1 ? NULL : &timeout);
 
-        if (ret < 0) {
-            if (-ret == EWOULDBLOCK) {
-                ret = -PAL_ERROR_TRYAGAIN;
+        if (IS_ERR(ret)) {
+            if (ERRNO(ret) == EWOULDBLOCK) {
+                    ret = -PAL_ERROR_TRYAGAIN;
+                    atomic_dec(&m->nwaiters);
+            } else {
+                ret = unix_to_pal_error(ERRNO(ret));
                 atomic_dec(&m->nwaiters);
-                goto out;
             }
-            ret = unix_to_pal_error(ERRNO(ret));
-            atomic_dec(&m->nwaiters);
             goto out;
         }
     }

--- a/Pal/src/host/Linux-SGX/db_object.c
+++ b/Pal/src/host/Linux-SGX/db_object.c
@@ -28,6 +28,7 @@
 #include "pal.h"
 #include "pal_internal.h"
 #include "pal_linux.h"
+#include "pal_linux_error.h"
 #include "pal_error.h"
 #include "pal_debug.h"
 #include "api.h"
@@ -75,8 +76,8 @@ static int _DkObjectWaitOne (PAL_HANDLE handle, int64_t timeout)
 
         uint64_t waittime = timeout;
         int ret = ocall_poll(fds, nfds, timeout >= 0 ? &waittime : NULL);
-        if (ret < 0)
-            return ret;
+        if (IS_ERR(ret))
+            return unix_to_pal_error(ERRNO(ret));
 
         if (!ret)
             return -PAL_ERROR_TRYAGAIN;
@@ -188,8 +189,8 @@ int _DkObjectsWaitAny (int count, PAL_HANDLE * handleArray, int64_t timeout,
 
     uint64_t waittime = timeout;
     ret = ocall_poll(fds, nfds, timeout >= 0 ? &waittime : NULL);
-    if (ret < 0)
-        return ret;
+    if (IS_ERR(ret))
+        return unix_to_pal_error(ERRNO(ret));
 
     if (!ret)
         return -PAL_ERROR_TRYAGAIN;

--- a/Pal/src/host/Linux-SGX/db_pipes.c
+++ b/Pal/src/host/Linux-SGX/db_pipes.c
@@ -29,6 +29,7 @@
 #include "pal.h"
 #include "pal_internal.h"
 #include "pal_linux.h"
+#include "pal_linux_error.h"
 #include "pal_error.h"
 #include "pal_security.h"
 #include "pal_debug.h"
@@ -74,8 +75,8 @@ static int pipe_listen (PAL_HANDLE * handle, PAL_NUM pipeid, int options)
     ret = ocall_sock_listen(AF_UNIX, pipe_type(options), 0,
                             (struct sockaddr *) &addr, &addrlen,
                             &sock_options);
-    if (ret < 0)
-        return ret;
+    if (IS_ERR(ret))
+        return -PAL_ERROR_DENIED;
 
     PAL_HANDLE hdl = malloc(HANDLE_SIZE(pipe));
     SET_HANDLE_TYPE(hdl, pipesrv);
@@ -98,8 +99,8 @@ static int pipe_waitforclient (PAL_HANDLE handle, PAL_HANDLE * client)
 
     struct sockopt sock_options;
     int ret = ocall_sock_accept(handle->pipe.fd, NULL, NULL, &sock_options);
-    if (ret < 0)
-        return ret;
+    if (IS_ERR(ret))
+        return unix_to_pal_error(ERRNO(ret));
 
     PAL_HANDLE clnt = malloc(HANDLE_SIZE(pipe));
     SET_HANDLE_TYPE(clnt, pipecli);
@@ -124,8 +125,8 @@ static int pipe_connect (PAL_HANDLE * handle, PAL_NUM pipeid, int options)
     ret = ocall_sock_connect(AF_UNIX, pipe_type(options), 0,
                              (void *) &addr, sizeof(struct sockaddr_un),
                              NULL, NULL, &sock_options);
-    if (ret < 0)
-        return ret;
+    if (IS_ERR(ret))
+        return unix_to_pal_error(ERRNO(ret));
 
     PAL_HANDLE hdl = malloc(HANDLE_SIZE(pipe));
     SET_HANDLE_TYPE(hdl, pipe);
@@ -147,8 +148,8 @@ static int pipe_private (PAL_HANDLE * handle, int options)
         type |= SOCK_NONBLOCK;
 
     ret = ocall_socketpair(AF_UNIX, type, 0, fds);
-    if (ret < 0)
-        return ret;
+    if (IS_ERR(ret))
+        return -PAL_ERROR_DENIED;
 
     PAL_HANDLE hdl = malloc(HANDLE_SIZE(pipeprv));
     SET_HANDLE_TYPE(hdl, pipeprv);
@@ -211,8 +212,8 @@ static int64_t pipe_read (PAL_HANDLE handle, uint64_t offset, uint64_t len,
              handle->pipe.fd;
     int bytes = ocall_sock_recv(fd, buffer, len, NULL, NULL);
 
-    if (bytes < 0)
-        return bytes;
+    if (IS_ERR(bytes))
+        return unix_to_pal_error(ERRNO(bytes));
 
     if (!bytes)
         return -PAL_ERROR_ENDOFSTREAM;
@@ -242,11 +243,12 @@ static int64_t pipe_write (PAL_HANDLE handle, uint64_t offset, uint64_t len,
     PAL_FLG writeable = IS_HANDLE_TYPE(handle, pipeprv) ? WRITEABLE(1) :
                         WRITEABLE(0);
 
-    if (bytes == -PAL_ERROR_TRYAGAIN)
-        HANDLE_HDR(handle)->flags &= ~writeable;
-
-    if (bytes < 0)
+    if (IS_ERR(bytes)) {
+        bytes = unix_to_pal_error(ERRNO(bytes));
+        if (bytes == -PAL_ERROR_TRYAGAIN)
+            HANDLE_HDR(handle)->flags &= ~writeable;
         return bytes;
+    }
 
     if (bytes == len)
         HANDLE_HDR(handle)->flags |= writeable;
@@ -352,8 +354,8 @@ static int pipe_attrquerybyhdl (PAL_HANDLE handle, PAL_STREAM_ATTR * attr)
 
     if (!IS_HANDLE_TYPE(handle, pipesrv)) {
         int ret = ocall_fionread(read_fd);
-        if (ret < 0)
-            return -ret;
+        if (IS_ERR(ret))
+            return unix_to_pal_error(ERRNO(ret));
 
         attr->pending_size = ret;
         attr->writeable    = flags & (
@@ -366,9 +368,9 @@ static int pipe_attrquerybyhdl (PAL_HANDLE handle, PAL_STREAM_ATTR * attr)
     struct pollfd pfd = { .fd = read_fd, .events = POLLIN, .revents = 0 };
     unsigned long waittime = 0;
     int ret = ocall_poll(&pfd, 1, &waittime);
-    if (ret < 0)
-        return ret;
-    
+    if (IS_ERR(ret))
+        return unix_to_pal_error(ERRNO(ret));
+
     attr->readable = (ret == 1 && pfd.revents == POLLIN);
 
     attr->disconnected = flags & ERROR(0);
@@ -389,8 +391,8 @@ static int pipe_attrsetbyhdl (PAL_HANDLE handle, PAL_STREAM_ATTR * attr)
 
     if (attr->nonblocking != *nonblocking) {
         int ret = ocall_fsetnonblock(handle->generic.fds[0], attr->nonblocking);
-        if (ret < 0)
-            return ret;
+        if (IS_ERR(ret))
+            return unix_to_pal_error(ERRNO(ret));
 
         *nonblocking = attr->nonblocking;
     }

--- a/Pal/src/host/Linux-SGX/db_pipes.c
+++ b/Pal/src/host/Linux-SGX/db_pipes.c
@@ -76,7 +76,7 @@ static int pipe_listen (PAL_HANDLE * handle, PAL_NUM pipeid, int options)
                             (struct sockaddr *) &addr, &addrlen,
                             &sock_options);
     if (IS_ERR(ret))
-        return -PAL_ERROR_DENIED;
+        return unix_to_pal_error(ERRNO(ret));
 
     PAL_HANDLE hdl = malloc(HANDLE_SIZE(pipe));
     SET_HANDLE_TYPE(hdl, pipesrv);
@@ -149,7 +149,7 @@ static int pipe_private (PAL_HANDLE * handle, int options)
 
     ret = ocall_socketpair(AF_UNIX, type, 0, fds);
     if (IS_ERR(ret))
-        return -PAL_ERROR_DENIED;
+        return unix_to_pal_error(ERRNO(ret));
 
     PAL_HANDLE hdl = malloc(HANDLE_SIZE(pipeprv));
     SET_HANDLE_TYPE(hdl, pipeprv);

--- a/Pal/src/host/Linux-SGX/db_process.c
+++ b/Pal/src/host/Linux-SGX/db_process.c
@@ -33,6 +33,7 @@
 #include "pal.h"
 #include "pal_internal.h"
 #include "pal_linux.h"
+#include "pal_linux_error.h"
 #include "pal_debug.h"
 #include "pal_error.h"
 #include "pal_security.h"
@@ -206,8 +207,8 @@ int _DkProcessCreate (PAL_HANDLE * handle, const char * uri, const char ** args)
     ret = ocall_create_process(uri, nargs, args,
                                proc_fds,
                                &child_pid);
-    if (ret < 0)
-        return ret;
+    if (IS_ERR(ret))
+        return unix_to_pal_error(ERRNO(ret));
 
     PAL_HANDLE proc = malloc(HANDLE_SIZE(process));
     SET_HANDLE_TYPE(proc, process);
@@ -349,7 +350,8 @@ static int64_t proc_read (PAL_HANDLE handle, uint64_t offset, uint64_t count,
     if (count >= (1ULL << (sizeof(unsigned int) * 8)))
         return -PAL_ERROR_INVAL;
 
-    return ocall_read(handle->process.stream_in, buffer, count);
+    int bytes = ocall_read(handle->process.stream_in, buffer, count);
+    return IS_ERR(bytes) ? unix_to_pal_error(ERRNO(bytes)) : bytes;
 }
 
 static int64_t proc_write (PAL_HANDLE handle, uint64_t offset, uint64_t count,
@@ -363,11 +365,12 @@ static int64_t proc_write (PAL_HANDLE handle, uint64_t offset, uint64_t count,
 
     int bytes = ocall_write(handle->process.stream_out, buffer, count);
 
-    if (bytes == -PAL_ERROR_TRYAGAIN)
-        HANDLE_HDR(handle)->flags &= ~WRITEABLE(1);
-
-    if (bytes < 0)
+    if (IS_ERR(bytes)) {
+        bytes = unix_to_pal_error(ERRNO(bytes));
+        if (bytes == -PAL_ERROR_TRYAGAIN)
+            HANDLE_HDR(handle)->flags &= ~WRITEABLE(1);
         return bytes;
+    }
 
     if (bytes == count)
         HANDLE_HDR(handle)->flags |= WRITEABLE(1);
@@ -438,9 +441,8 @@ static int proc_attrquerybyhdl (PAL_HANDLE handle, PAL_STREAM_ATTR * attr)
         return -PAL_ERROR_BADHANDLE;
 
     int ret = ocall_fionread(handle->process.stream_in);
-
-    if (ret < 0)
-        return -ret;
+    if (IS_ERR(ret))
+        return unix_to_pal_error(ERRNO(ret));
 
     memset(attr, 0, sizeof(PAL_STREAM_ATTR));
     attr->pending_size = ret;
@@ -459,9 +461,8 @@ static int proc_attrsetbyhdl (PAL_HANDLE handle, PAL_STREAM_ATTR * attr)
     if (attr->nonblocking != handle->process.nonblocking) {
         int ret = ocall_fsetnonblock(handle->process.stream_in,
                                      handle->process.nonblocking);
-
-        if (ret < 0)
-            return ret;
+        if (IS_ERR(ret))
+            return unix_to_pal_error(ERRNO(ret));
 
         handle->process.nonblocking = attr->nonblocking;
     }

--- a/Pal/src/host/Linux-SGX/db_rtld.c
+++ b/Pal/src/host/Linux-SGX/db_rtld.c
@@ -51,7 +51,7 @@ void _DkDebugAddMap (struct link_map * map)
     const ElfW(Phdr) * ph;
 
     int fd = ocall_open(map->l_name, O_RDONLY, 0);
-    if (fd < 0)
+    if (IS_ERR(fd))
         return;
 
     for (ph = phdr; ph < &phdr[ehdr->e_phnum]; ++ph)

--- a/Pal/src/host/Linux-SGX/db_sockets.c
+++ b/Pal/src/host/Linux-SGX/db_sockets.c
@@ -356,7 +356,7 @@ static int tcp_listen (PAL_HANDLE * handle, char * uri, int options)
                             bind_addr, &bind_addrlen,
                             &sock_options);
     if (IS_ERR(ret))
-        return -PAL_ERROR_DENIED;
+        return unix_to_pal_error(ERRNO(ret));
 
     *handle = socket_create_handle(pal_type_tcpsrv, ret, options,
                                    bind_addr, bind_addrlen, NULL, 0,

--- a/Pal/src/host/Linux-SGX/db_sockets.c
+++ b/Pal/src/host/Linux-SGX/db_sockets.c
@@ -29,6 +29,7 @@
 #include "pal.h"
 #include "pal_internal.h"
 #include "pal_linux.h"
+#include "pal_linux_error.h"
 #include "pal_debug.h"
 #include "pal_security.h"
 #include "pal_error.h"
@@ -354,8 +355,8 @@ static int tcp_listen (PAL_HANDLE * handle, char * uri, int options)
                             sock_type(SOCK_STREAM, options), 0,
                             bind_addr, &bind_addrlen,
                             &sock_options);
-    if (ret < 0)
-        return ret;
+    if (IS_ERR(ret))
+        return -PAL_ERROR_DENIED;
 
     *handle = socket_create_handle(pal_type_tcpsrv, ret, options,
                                    bind_addr, bind_addrlen, NULL, 0,
@@ -387,8 +388,8 @@ static int tcp_accept (PAL_HANDLE handle, PAL_HANDLE * client)
     struct sockopt sock_options;
     ret = ocall_sock_accept(handle->sock.fd, &dest_addr, &dest_addrlen,
                             &sock_options);
-    if (ret < 0)
-        return ret;
+    if (IS_ERR(ret))
+        return unix_to_pal_error(ERRNO(ret));
 
     *client = socket_create_handle(pal_type_tcp, ret, 0, bind_addr,
                                    bind_addrlen,
@@ -436,8 +437,8 @@ static int tcp_connect (PAL_HANDLE * handle, char * uri, int options)
                              sock_type(SOCK_STREAM, options), 0,
                              dest_addr, dest_addrlen,
                              bind_addr, &bind_addrlen, &sock_options);
-    if (ret < 0)
-        return ret;
+    if (IS_ERR(ret))
+        return unix_to_pal_error(ERRNO(ret));
 
     *handle = socket_create_handle(pal_type_tcp, ret, options,
                                    bind_addr, bind_addrlen,
@@ -497,8 +498,8 @@ static int64_t tcp_read (PAL_HANDLE handle, uint64_t offset, uint64_t len,
 
     int bytes = ocall_sock_recv(handle->sock.fd, buf, len, NULL, NULL);
 
-    if (bytes < 0)
-        return bytes;
+    if (IS_ERR(bytes))
+        return unix_to_pal_error(ERRNO(bytes));
 
     if (!bytes)
         return -PAL_ERROR_ENDOFSTREAM;
@@ -524,11 +525,12 @@ static int64_t tcp_write (PAL_HANDLE handle, uint64_t offset, uint64_t len,
 
     int bytes = ocall_sock_send(handle->sock.fd, buf, len, NULL, 0);
 
-    if (bytes == -PAL_ERROR_TRYAGAIN)
+    if (IS_ERR(bytes)) {
+        bytes = unix_to_pal_error(ERRNO(bytes));
+        if (bytes == -PAL_ERROR_TRYAGAIN)
             HANDLE_HDR(handle)->flags &= ~WRITEABLE(0);
-
-    if (bytes < 0)
         return bytes;
+    }
 
     if (bytes == len)
         HANDLE_HDR(handle)->flags |= WRITEABLE(0);
@@ -563,8 +565,8 @@ static int udp_bind (PAL_HANDLE * handle, char * uri, int options)
     ret = ocall_sock_listen(bind_addr->sa_family,
                             sock_type(SOCK_DGRAM, options), 0,
                             bind_addr, &bind_addrlen, &sock_options);
-    if (ret < 0)
-        return ret;
+    if (IS_ERR(ret))
+        return unix_to_pal_error(ERRNO(ret));
 
     *handle = socket_create_handle(pal_type_udpsrv, ret, options,
                                    bind_addr, bind_addrlen, NULL, 0,
@@ -603,8 +605,8 @@ static int udp_connect (PAL_HANDLE * handle, char * uri, int options)
                              dest_addr, dest_addrlen,
                              bind_addr, &bind_addrlen, &sock_options);
 
-    if (ret < 0)
-        return ret;
+    if (IS_ERR(ret))
+        return unix_to_pal_error(ERRNO(ret));
 
     *handle = socket_create_handle(dest_addr ? pal_type_udp :
                                    pal_type_udpsrv, ret, options,
@@ -661,7 +663,8 @@ static int64_t udp_receive (PAL_HANDLE handle, uint64_t offset, uint64_t len,
     if (len >= (1ULL << (sizeof(unsigned int) * 8)))
         return -PAL_ERROR_INVAL;
 
-    return ocall_sock_recv(handle->sock.fd, buf, len, NULL, NULL);
+    int ret = ocall_sock_recv(handle->sock.fd, buf, len, NULL, NULL);
+    return IS_ERR(ret) ? unix_to_pal_error(ERRNO(ret)) : ret;
 }
 
 static int64_t udp_receivebyaddr (PAL_HANDLE handle, uint64_t offset, uint64_t len,
@@ -685,8 +688,8 @@ static int64_t udp_receivebyaddr (PAL_HANDLE handle, uint64_t offset, uint64_t l
     int bytes = ocall_sock_recv(handle->sock.fd, buf, len, &conn_addr,
                                 &conn_addrlen);
 
-    if (bytes < 0)
-        return bytes;
+    if (IS_ERR(bytes))
+        return unix_to_pal_error(ERRNO(bytes));
 
     char * addr_uri = strcpy_static(addr, "udp:", addrlen);
     if (!addr_uri)
@@ -717,11 +720,12 @@ static int64_t udp_send (PAL_HANDLE handle, uint64_t offset, uint64_t len,
 
     int bytes = ocall_sock_send(handle->sock.fd, buf, len, NULL, 0);
 
-    if (bytes == -PAL_ERROR_TRYAGAIN)
-        HANDLE_HDR(handle)->flags &= ~WRITEABLE(0);
-
-    if (bytes < 0)
+    if (IS_ERR(bytes)) {
+        bytes = unix_to_pal_error(ERRNO(bytes));
+        if (bytes == -PAL_ERROR_TRYAGAIN)
+            HANDLE_HDR(handle)->flags &= ~WRITEABLE(0);
         return bytes;
+    }
 
     if (bytes == len)
         HANDLE_HDR(handle)->flags |= WRITEABLE(0);
@@ -765,11 +769,12 @@ static int64_t udp_sendbyaddr (PAL_HANDLE handle, uint64_t offset, uint64_t len,
     int bytes = ocall_sock_send(handle->sock.fd, buf, len, &conn_addr,
                                 conn_addrlen);
 
-    if (bytes == -PAL_ERROR_TRYAGAIN)
+    if (IS_ERR(bytes)) {
+        bytes = unix_to_pal_error(ERRNO(bytes));
+        if (bytes == -PAL_ERROR_TRYAGAIN)
             HANDLE_HDR(handle)->flags &= ~WRITEABLE(0);
-
-    if (bytes < 0)
         return bytes;
+    }
 
     if (bytes == len)
         HANDLE_HDR(handle)->flags |= WRITEABLE(0);
@@ -849,16 +854,16 @@ static int socket_attrquerybyhdl (PAL_HANDLE handle, PAL_STREAM_ATTR  * attr)
     if (!IS_HANDLE_TYPE(handle, tcpsrv)) {
         /* try use ioctl FIONEAD to get the size of socket */
         ret = ocall_fionread(fd);
-        if (ret < 0)
-            return ret;
+        if (IS_ERR(ret))
+            return unix_to_pal_error(ERRNO(ret));
         attr->pending_size = ret;
     }
 
     struct pollfd pfd = { .fd = fd, .events = POLLIN, .revents = 0 };
     unsigned long waittime = 0;
     ret = ocall_poll(&pfd, 1, &waittime);
-    if (ret < 0)
-        return ret;
+    if (IS_ERR(ret))
+        return unix_to_pal_error(ERRNO(ret));
     attr->readable = (ret == 1 && pfd.revents == POLLIN);
 
     return 0;
@@ -874,8 +879,8 @@ static int socket_attrsetbyhdl (PAL_HANDLE handle, PAL_STREAM_ATTR  * attr)
     if (attr->nonblocking != handle->sock.nonblocking) {
         ret = ocall_fsetnonblock(fd, attr->nonblocking);
 
-        if (ret < 0)
-            return ret;
+        if (IS_ERR(ret))
+            return unix_to_pal_error(ERRNO(ret));
 
         handle->sock.nonblocking = attr->nonblocking;
     }
@@ -892,8 +897,8 @@ static int socket_attrsetbyhdl (PAL_HANDLE handle, PAL_STREAM_ATTR  * attr)
             l.l_linger = attr->socket.linger;
             ret = ocall_sock_setopt(fd, SOL_SOCKET, SO_LINGER, &l,
                                     sizeof(struct __kernel_linger));
-            if (ret < 0)
-                return ret;
+            if (IS_ERR(ret))
+                return unix_to_pal_error(ERRNO(ret));
 
             handle->sock.linger = attr->socket.linger;
         }
@@ -902,8 +907,8 @@ static int socket_attrsetbyhdl (PAL_HANDLE handle, PAL_STREAM_ATTR  * attr)
             val = attr->socket.receivebuf;
             ret = ocall_sock_setopt(fd, SOL_SOCKET, SO_RCVBUF, &val,
                                     sizeof(int));
-            if (ret < 0)
-                return ret;
+            if (IS_ERR(ret))
+                return unix_to_pal_error(ERRNO(ret));
 
             handle->sock.receivebuf = attr->socket.receivebuf;
         }
@@ -912,8 +917,8 @@ static int socket_attrsetbyhdl (PAL_HANDLE handle, PAL_STREAM_ATTR  * attr)
             val = attr->socket.sendbuf;
             ret = ocall_sock_setopt(fd, SOL_SOCKET, SO_SNDBUF,
                                     &val, sizeof(int));
-            if (ret < 0)
-                return ret;
+            if (IS_ERR(ret))
+                return unix_to_pal_error(ERRNO(ret));
 
             handle->sock.sendbuf = attr->socket.sendbuf;
         }
@@ -922,8 +927,8 @@ static int socket_attrsetbyhdl (PAL_HANDLE handle, PAL_STREAM_ATTR  * attr)
             val = attr->socket.receivetimeout;
             ret = ocall_sock_setopt(fd, SOL_SOCKET, SO_RCVTIMEO,
                                     &val, sizeof(int));
-            if (ret < 0)
-                return ret;
+            if (IS_ERR(ret))
+                return unix_to_pal_error(ERRNO(ret));
 
             handle->sock.receivetimeout = attr->socket.receivetimeout;
         }
@@ -932,8 +937,8 @@ static int socket_attrsetbyhdl (PAL_HANDLE handle, PAL_STREAM_ATTR  * attr)
             val = attr->socket.sendtimeout;
             ret = ocall_sock_setopt(fd, SOL_SOCKET, SO_SNDTIMEO,
                                     &val, sizeof(int));
-            if (ret < 0)
-                return ret;
+            if (IS_ERR(ret))
+                return unix_to_pal_error(ERRNO(ret));
 
             handle->sock.sendtimeout = attr->socket.sendtimeout;
         }
@@ -946,8 +951,8 @@ static int socket_attrsetbyhdl (PAL_HANDLE handle, PAL_STREAM_ATTR  * attr)
             val = attr->socket.tcp_cork ? 1 : 0;
             ret = ocall_sock_setopt(fd, SOL_TCP, TCP_CORK,
                                     &val, sizeof(int));
-            if (ret < 0)
-                return ret;
+            if (IS_ERR(ret))
+                return unix_to_pal_error(ERRNO(ret));
 
             handle->sock.tcp_cork = attr->socket.tcp_cork;
         }
@@ -956,8 +961,8 @@ static int socket_attrsetbyhdl (PAL_HANDLE handle, PAL_STREAM_ATTR  * attr)
             val = attr->socket.tcp_keepalive ? 1 : 0;
             ret = ocall_sock_setopt(fd, SOL_SOCKET, SO_KEEPALIVE,
                                      &val, sizeof(int));
-            if (ret < 0)
-                return ret;
+            if (IS_ERR(ret))
+                return unix_to_pal_error(ERRNO(ret));
 
             handle->sock.tcp_keepalive = attr->socket.tcp_keepalive;
         }
@@ -966,8 +971,8 @@ static int socket_attrsetbyhdl (PAL_HANDLE handle, PAL_STREAM_ATTR  * attr)
             val = attr->socket.tcp_nodelay ? 1 : 0;
             ret = ocall_sock_setopt(fd, SOL_TCP, TCP_NODELAY,
                                     &val, sizeof(int));
-            if (ret < 0)
-                return ret;
+            if (IS_ERR(ret))
+                return unix_to_pal_error(ERRNO(ret));
 
             handle->sock.tcp_nodelay = attr->socket.tcp_nodelay;
         }
@@ -1102,11 +1107,12 @@ static int64_t mcast_send (PAL_HANDLE handle, uint64_t offset, uint64_t size,
     int bytes = ocall_sock_send(handle->mcast.srv, buf, size,
                                 NULL, 0);
 
-    if (bytes == -PAL_ERROR_TRYAGAIN)
-        HANDLE_HDR(handle)->flags &= ~WRITEABLE(1);
-
-    if (bytes < 0)
+    if (IS_ERR(bytes)) {
+        bytes = unix_to_pal_error(ERRNO(bytes));
+        if (bytes == -PAL_ERROR_TRYAGAIN)
+            HANDLE_HDR(handle)->flags &= ~WRITEABLE(1);
         return bytes;
+    }
 
     if (bytes == size)
         HANDLE_HDR(handle)->flags |= WRITEABLE(1);
@@ -1130,6 +1136,9 @@ static int64_t mcast_receive (PAL_HANDLE handle, uint64_t offset, uint64_t size,
 
     int bytes = ocall_sock_recv(handle->mcast.cli, buf, size, NULL,
                                 NULL);
+
+    if (IS_ERR(bytes))
+        bytes = unix_to_pal_error(ERRNO(bytes));
 
     if (bytes == -PAL_ERROR_TRYAGAIN)
         HANDLE_HDR(handle)->flags &= ~WRITEABLE(1);
@@ -1156,8 +1165,8 @@ static int mcast_attrquerybyhdl (PAL_HANDLE handle, PAL_STREAM_ATTR * attr)
         return -PAL_ERROR_BADHANDLE;
 
     int ret = ocall_fionread(handle->mcast.cli);
-    if (ret < 0)
-        return ret;
+    if (IS_ERR(ret))
+        return unix_to_pal_error(ERRNO(ret));
 
     memset(attr, 0, sizeof(PAL_STREAM_ATTR));
     attr->pending_size = ret;
@@ -1178,8 +1187,8 @@ static int mcast_attrsetbyhdl (PAL_HANDLE handle, PAL_STREAM_ATTR * attr)
     if (attr->nonblocking != *nonblocking) {
         int ret = ocall_fsetnonblock(handle->mcast.cli, *nonblocking);
 
-        if (ret < 0)
-            return ret;
+        if (IS_ERR(ret))
+            return unix_to_pal_error(ERRNO(ret));
 
         *nonblocking = attr->nonblocking;
     }

--- a/Pal/src/host/Linux-SGX/db_streams.c
+++ b/Pal/src/host/Linux-SGX/db_streams.c
@@ -296,7 +296,7 @@ int _DkSendHandle (PAL_HANDLE hdl, PAL_HANDLE cargo)
                              fds, nfds);
 
     free(hdl_data);
-    return IS_ERR(ret) ? -PAL_ERROR_DENIED : 0;
+    return IS_ERR(ret) ? unix_to_pal_error(ERRNO(ret)) : 0;
 }
 
 /* _DkRecvHandle for internal use. Receive and return a PAL_HANDLE over the
@@ -321,23 +321,24 @@ int _DkReceiveHandle(PAL_HANDLE hdl, PAL_HANDLE * cargo)
         return unix_to_pal_error(ERRNO(ret));
     if (ret < sizeof(struct hdl_header)) {
         /*
-         * This code block is just in case to cover all the possibility.
+         * This code block is just in case to cover all the possibilities
+         * to shield Iago attack.
+         * We know that the file descriptor is an unix domain socket with
+         * blocking mode and that the sender, _DkSendHandle() above, sends the
+         * header with single sendto syscall by ocall_sock_send() which
+         * transfers a message atomically.
          *
-         * read size == 0: return error to try again:
-         *                 This case won't happen because the file
-         *                 descriptor is Unix domain socket in blocking mode.
-         *                 It is actually EINTR.
+         * read size == 0: return error for the caller to try again.
+         *                 It should result in EINTR.
          *
-         * read size > 0: return partial read size and expect the caller
-         *                to handle it.
-         *                Actually this case won't happen because
-         *                This PAL API is used only for UNIX domain socket
-         *                and, the sender, _DkSendHandle, sends
-         *                struct hdl_header with single sendmsg() system call.
+         * read size > 0: return error for the caller to give up this file
+         *                descriptor.
+         *                If the header can't be send atomically for some
+         *                reason, the sender should get EMSGSIZE.
          */
         if (!ret)
             return -PAL_ERROR_TRYAGAIN;
-        return ret;
+        return -PAL_ERROR_DENIED;
     }
 
     // initialize variables to get body

--- a/Pal/src/host/Linux-SGX/db_streams.c
+++ b/Pal/src/host/Linux-SGX/db_streams.c
@@ -29,6 +29,7 @@
 #include "pal.h"
 #include "pal_internal.h"
 #include "pal_linux.h"
+#include "pal_linux_error.h"
 #include "pal_debug.h"
 #include "pal_error.h"
 #include "api.h"
@@ -285,9 +286,9 @@ int _DkSendHandle (PAL_HANDLE hdl, PAL_HANDLE cargo)
     ret = ocall_sock_send(ch, &hdl_hdr, sizeof(struct hdl_header), NULL, 0);
 
     // Unlock is error
-    if (ret < 0) {
+    if (IS_ERR(ret)) {
         free(hdl_data);
-        return ret;
+        return unix_to_pal_error(ERRNO(ret));
     }
 
     //  Send message
@@ -295,7 +296,7 @@ int _DkSendHandle (PAL_HANDLE hdl, PAL_HANDLE cargo)
                              fds, nfds);
 
     free(hdl_data);
-    return (ret < 0) ? -PAL_ERROR_DENIED : 0;
+    return IS_ERR(ret) ? -PAL_ERROR_DENIED : 0;
 }
 
 /* _DkRecvHandle for internal use. Receive and return a PAL_HANDLE over the
@@ -316,12 +317,27 @@ int _DkReceiveHandle(PAL_HANDLE hdl, PAL_HANDLE * cargo)
     int ret = ocall_sock_recv(ch, &hdl_hdr, sizeof(struct hdl_header), NULL,
                               NULL);
 
-    if (ret < 0 || ret < sizeof(struct hdl_header)) {
+    if (IS_ERR(ret))
+        return unix_to_pal_error(ERRNO(ret));
+    if (ret < sizeof(struct hdl_header)) {
+        /*
+         * This code block is just in case to cover all the possibility.
+         *
+         * read size == 0: return error to try again:
+         *                 This case won't happen because the file
+         *                 descriptor is Unix domain socket in blocking mode.
+         *                 It is actually EINTR.
+         *
+         * read size > 0: return partial read size and expect the caller
+         *                to handle it.
+         *                Actually this case won't happen because
+         *                This PAL API is used only for UNIX domain socket
+         *                and, the sender, _DkSendHandle, sends
+         *                struct hdl_header with single sendmsg() system call.
+         */
         if (!ret)
             return -PAL_ERROR_TRYAGAIN;
-
-        if (ret != -PAL_ERROR_INTERRUPTED)
-            return ret;
+        return ret;
     }
 
     // initialize variables to get body
@@ -337,8 +353,8 @@ int _DkReceiveHandle(PAL_HANDLE hdl, PAL_HANDLE * cargo)
     ret = ocall_sock_recv_fd(ch, buffer, hdl_hdr.data_size,
                              fds, &nfds);
 
-    if (ret < 0)
-        return ret;
+    if (IS_ERR(ret))
+        return unix_to_pal_error(ERRNO(ret));
 
     PAL_HANDLE handle = NULL;
     ret = handle_deserialize(&handle, buffer, hdl_hdr.data_size);

--- a/Pal/src/host/Linux-SGX/enclave_framework.c
+++ b/Pal/src/host/Linux-SGX/enclave_framework.c
@@ -2,6 +2,7 @@
 /* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
 
 #include <pal_linux.h>
+#include <pal_linux_error.h>
 #include <pal_internal.h>
 #include <pal_debug.h>
 #include <pal_security.h>
@@ -297,8 +298,10 @@ int load_trusted_file (PAL_HANDLE file, sgx_stub_t ** stubptr,
             goto failed;
 
         ret = ocall_map_untrusted(fd, offset, mapping_size, PROT_READ, &umem);
-        if (ret < 0)
+        if (IS_ERR(ret)) {
+            ret = unix_to_pal_error(ERRNO(ret));
             goto unmap;
+        }
 
         /*
          * To prevent TOCTOU attack when generating the file checksum, we

--- a/Pal/src/host/Linux-SGX/enclave_ocalls.c
+++ b/Pal/src/host/Linux-SGX/enclave_ocalls.c
@@ -19,7 +19,7 @@
     void * _tmp = sgx_ocalloc(len);     \
     if (_tmp == NULL) {                 \
         OCALL_EXIT();                   \
-        return -PAL_ERROR_DENIED;  /* TODO: remove this control-flow obfuscation */  \
+        return -EPERM;  /* TODO: remove this control-flow obfuscation */  \
     }                                   \
     (val) = (type) _tmp;                \
 } while (0)
@@ -59,7 +59,7 @@ int printf(const char * fmt, ...);
                 _ret = 0;                                               \
                 memcpy(var, user_var, size);                            \
             } else {                                                    \
-                _ret = -PAL_ERROR_DENIED;                               \
+                _ret = -EPERM;                                          \
             }                                                           \
         } _ret;                                                         \
     })
@@ -85,7 +85,7 @@ int ocall_print_string (const char * str, unsigned int length)
 
     if (!str || length <= 0) {
         OCALL_EXIT();
-        return -PAL_ERROR_DENIED;
+        return -EPERM;
     }
 
     ms->ms_str = COPY_TO_USER(str, length);
@@ -109,7 +109,7 @@ int ocall_alloc_untrusted (uint64_t size, void ** mem)
     if (!retval) {
         if (!sgx_is_completely_outside_enclave(ms->ms_mem, size)) {
             OCALL_EXIT();
-            return -PAL_ERROR_DENIED;
+            return -EPERM;
         }
         *mem = ms->ms_mem;
     }
@@ -135,7 +135,7 @@ int ocall_map_untrusted (int fd, uint64_t offset,
     if (!retval) {
         if (!sgx_is_completely_outside_enclave(ms->ms_mem, size)) {
             OCALL_EXIT();
-            return -PAL_ERROR_DENIED;
+            return -EPERM;
         }
         *mem = ms->ms_mem;
     }
@@ -149,7 +149,7 @@ int ocall_unmap_untrusted (const void * mem, uint64_t size)
 
     if (!sgx_is_completely_outside_enclave(mem, size)) {
         OCALL_EXIT();
-        return -PAL_ERROR_INVAL;
+        return -EINVAL;
     }
 
     ms_ocall_unmap_untrusted_t * ms;
@@ -221,7 +221,7 @@ int ocall_read (int fd, void * buf, unsigned int count)
 
     if (count > 4096) {
         retval = ocall_alloc_untrusted(ALLOC_ALIGNUP(count), &obuf);
-        if (retval < 0)
+        if (IS_ERR(retval))
             return retval;
     }
 
@@ -254,7 +254,7 @@ int ocall_write (int fd, const void * buf, unsigned int count)
 
     if (count > 4096) {
         retval = ocall_alloc_untrusted(ALLOC_ALIGNUP(count), &obuf);
-        if (retval < 0)
+        if (IS_ERR(retval))
             return retval;
     }
 
@@ -438,7 +438,7 @@ int ocall_futex (int * futex, int op, int val,
 
     if (!sgx_is_completely_outside_enclave(futex, sizeof(int))) {
         OCALL_EXIT();
-        return -PAL_ERROR_INVAL;
+        return -EINVAL;
     }
 
     ms->ms_futex = futex;
@@ -492,7 +492,7 @@ int ocall_sock_listen (int domain, int type, int protocol,
             !sgx_is_completely_outside_enclave(ms->ms_addr, bind_len) ||
             ms->ms_addrlen > bind_len)) {
             OCALL_EXIT();
-            return -PAL_ERROR_DENIED;
+            return -EPERM;
         }
 
         if (addr) {
@@ -523,7 +523,7 @@ int ocall_sock_accept (int sockfd, struct sockaddr * addr,
         if (len && (!sgx_is_completely_outside_enclave(ms->ms_addr, len) ||
                     ms->ms_addrlen > len)) {
             OCALL_EXIT();
-            return -PAL_ERROR_DENIED;
+            return -EPERM;
         }
 
         if (addr) {
@@ -562,7 +562,7 @@ int ocall_sock_connect (int domain, int type, int protocol,
             !sgx_is_completely_outside_enclave(ms->ms_bind_addr, bind_len) ||
             ms->ms_bind_addrlen > bind_len)) {
             OCALL_EXIT();
-            return -PAL_ERROR_DENIED;
+            return -EPERM;
         }
 
         if (bind_addr) {
@@ -596,7 +596,7 @@ int ocall_sock_recv (int sockfd, void * buf, unsigned int count,
         if (len && (!sgx_is_completely_outside_enclave(ms->ms_addr, len) ||
                     ms->ms_addrlen > len)) {
             OCALL_EXIT();
-            return -PAL_ERROR_DENIED;
+            return -EPERM;
         }
 
         COPY_FROM_USER(buf, ms->ms_buf, retval);
@@ -644,7 +644,7 @@ int ocall_sock_recv_fd (int sockfd, void * buf, unsigned int count,
         if (!sgx_is_completely_outside_enclave(ms->ms_fds, sizeof(int) * (*nfds)) ||
             ms->ms_nfds > (*nfds)) {
             OCALL_EXIT();
-            return -PAL_ERROR_DENIED;
+            return -EPERM;
         }
 
         COPY_FROM_USER(buf, ms->ms_buf, retval);

--- a/Pal/src/host/Linux-SGX/pal_linux_error.h
+++ b/Pal/src/host/Linux-SGX/pal_linux_error.h
@@ -36,6 +36,8 @@ int unix_to_pal_error (int unix_errno)
         case ECONNRESET:
         case EPIPE:
             return -PAL_ERROR_CONNFAILED;
+        case EPERM:
+            return -PAL_ERROR_DENIED;
         default:
             return -PAL_ERROR_DENIED;
     }

--- a/Pal/src/host/Linux-SGX/sgx_enclave.c
+++ b/Pal/src/host/Linux-SGX/sgx_enclave.c
@@ -50,7 +50,7 @@ static int sgx_ocall_alloc_untrusted(void * pms)
                                    PROT_READ|PROT_WRITE,
                                    MAP_ANONYMOUS|MAP_PRIVATE, -1, 0);
     if (IS_ERR_P(addr))
-        return -ENOMEM;
+        return -ERRNO_P(addr);
 
     ms->ms_mem = addr;
     return 0;
@@ -66,7 +66,7 @@ static int sgx_ocall_map_untrusted(void * pms)
                                    MAP_FILE|MAP_SHARED,
                                    ms->ms_fd, ms->ms_offset);
     if (IS_ERR_P(addr))
-        return -ENOMEM;
+        return -ERRNO_P(addr);
 
     ms->ms_mem = addr;
     return 0;
@@ -282,10 +282,8 @@ static int sgx_ocall_sock_listen(void * pms)
     ret = INLINE_SYSCALL(socket, 3, ms->ms_domain,
                          ms->ms_type|SOCK_CLOEXEC,
                          ms->ms_protocol);
-    if (IS_ERR(ret)) {
-        ret = -EPERM;
+    if (IS_ERR(ret))
         goto err;
-    }
 
     fd = ret;
     if (ms->ms_addr->sa_family == AF_INET6) {
@@ -305,19 +303,15 @@ static int sgx_ocall_sock_listen(void * pms)
     if (ms->ms_addr) {
         socklen_t addrlen;
         ret = INLINE_SYSCALL(getsockname, 3, fd, ms->ms_addr, &addrlen);
-        if (IS_ERR(ret)) {
-            ret = -EPERM;
+        if (IS_ERR(ret))
             goto err_fd;
-        }
         ms->ms_addrlen = addrlen;
     }
 
     if (ms->ms_type & SOCK_STREAM) {
         ret = INLINE_SYSCALL(listen, 2, fd, DEFAULT_BACKLOG);
-        if (IS_ERR(ret)) {
-            ret = -EPERM;
+        if (IS_ERR(ret))
             goto err_fd;
-        }
     }
 
     ret = sock_getopt(fd, &ms->ms_sockopt);
@@ -367,10 +361,8 @@ static int sgx_ocall_sock_connect(void * pms)
     ret = INLINE_SYSCALL(socket, 3, ms->ms_domain,
                          ms->ms_type|SOCK_CLOEXEC,
                          ms->ms_protocol);
-    if (IS_ERR(ret)) {
-        ret = -EPERM;
+    if (IS_ERR(ret))
         goto err;
-    }
 
     fd = ret;
     if (ms->ms_addr->sa_family == AF_INET6) {
@@ -403,10 +395,8 @@ static int sgx_ocall_sock_connect(void * pms)
         socklen_t addrlen;
         ret = INLINE_SYSCALL(getsockname, 3, fd, ms->ms_bind_addr,
                              &addrlen);
-        if (IS_ERR(ret)) {
-            ret = -EPERM;
+        if (IS_ERR(ret))
             goto err_fd;
-        }
         ms->ms_bind_addrlen = addrlen;
     }
 

--- a/Pal/src/host/Linux-SGX/sgx_enclave.c
+++ b/Pal/src/host/Linux-SGX/sgx_enclave.c
@@ -50,7 +50,7 @@ static int sgx_ocall_alloc_untrusted(void * pms)
                                    PROT_READ|PROT_WRITE,
                                    MAP_ANONYMOUS|MAP_PRIVATE, -1, 0);
     if (IS_ERR_P(addr))
-        return -PAL_ERROR_NOMEM;
+        return -ENOMEM;
 
     ms->ms_mem = addr;
     return 0;
@@ -66,7 +66,7 @@ static int sgx_ocall_map_untrusted(void * pms)
                                    MAP_FILE|MAP_SHARED,
                                    ms->ms_fd, ms->ms_offset);
     if (IS_ERR_P(addr))
-        return -PAL_ERROR_NOMEM;
+        return -ENOMEM;
 
     ms->ms_mem = addr;
     return 0;
@@ -102,7 +102,7 @@ static int sgx_ocall_open(void * pms)
     ODEBUG(OCALL_OPEN, ms);
     ret = INLINE_SYSCALL(open, 3, ms->ms_pathname, ms->ms_flags|O_CLOEXEC,
                          ms->ms_mode);
-    return IS_ERR(ret) ? unix_to_pal_error(ERRNO(ret)) : ret;
+    return ret;
 }
 
 static int sgx_ocall_close(void * pms)
@@ -119,7 +119,7 @@ static int sgx_ocall_read(void * pms)
     int ret;
     ODEBUG(OCALL_READ, ms);
     ret = INLINE_SYSCALL(read, 3, ms->ms_fd, ms->ms_buf, ms->ms_count);
-    return IS_ERR(ret) ? unix_to_pal_error(ERRNO(ret)) : ret;
+    return ret;
 }
 
 static int sgx_ocall_write(void * pms)
@@ -128,7 +128,7 @@ static int sgx_ocall_write(void * pms)
     int ret;
     ODEBUG(OCALL_WRITE, ms);
     ret = INLINE_SYSCALL(write, 3, ms->ms_fd, ms->ms_buf, ms->ms_count);
-    return IS_ERR(ret) ? unix_to_pal_error(ERRNO(ret)) : ret;
+    return ret;
 }
 
 static int sgx_ocall_fstat(void * pms)
@@ -137,7 +137,7 @@ static int sgx_ocall_fstat(void * pms)
     int ret;
     ODEBUG(OCALL_FSTAT, ms);
     ret = INLINE_SYSCALL(fstat, 2, ms->ms_fd, &ms->ms_stat);
-    return IS_ERR(ret) ? unix_to_pal_error(ERRNO(ret)) : ret;
+    return ret;
 }
 
 static int sgx_ocall_fionread(void * pms)
@@ -146,7 +146,7 @@ static int sgx_ocall_fionread(void * pms)
     int ret, val;
     ODEBUG(OCALL_FIONREAD, ms);
     ret = INLINE_SYSCALL(ioctl, 3, ms->ms_fd, FIONREAD, &val);
-    return IS_ERR(ret) ? unix_to_pal_error(ERRNO(ret)) : val;
+    return IS_ERR(ret) ? ret : val;
 }
 
 static int sgx_ocall_fsetnonblock(void * pms)
@@ -157,7 +157,7 @@ static int sgx_ocall_fsetnonblock(void * pms)
 
     ret = INLINE_SYSCALL(fcntl, 2, ms->ms_fd, F_GETFL);
     if (IS_ERR(ret))
-        return -ERRNO(ret);
+        return ret;
 
     flags = ret;
     if (ms->ms_nonblocking) {
@@ -170,7 +170,7 @@ static int sgx_ocall_fsetnonblock(void * pms)
                                  flags & ~O_NONBLOCK);
     }
 
-    return IS_ERR(ret) ? unix_to_pal_error(ERRNO(ret)) : 0;
+    return ret;
 }
 
 static int sgx_ocall_fchmod(void * pms)
@@ -179,7 +179,7 @@ static int sgx_ocall_fchmod(void * pms)
     int ret;
     ODEBUG(OCALL_FCHMOD, ms);
     ret = INLINE_SYSCALL(fchmod, 2, ms->ms_fd, ms->ms_mode);
-    return IS_ERR(ret) ? unix_to_pal_error(ERRNO(ret)) : ret;
+    return ret;
 }
 
 static int sgx_ocall_fsync(void * pms)
@@ -196,7 +196,7 @@ static int sgx_ocall_ftruncate(void * pms)
     int ret;
     ODEBUG(OCALL_FTRUNCATE, ms);
     ret = INLINE_SYSCALL(ftruncate, 2, ms->ms_fd, ms->ms_length);
-    return IS_ERR(ret) ? unix_to_pal_error(ERRNO(ret)) : ret;
+    return ret;
 }
 
 static int sgx_ocall_mkdir(void * pms)
@@ -205,7 +205,7 @@ static int sgx_ocall_mkdir(void * pms)
     int ret;
     ODEBUG(OCALL_MKDIR, ms);
     ret = INLINE_SYSCALL(mkdir, 2, ms->ms_pathname, ms->ms_mode);
-    return IS_ERR(ret) ? unix_to_pal_error(ERRNO(ret)) : ret;
+    return ret;
 }
 
 static int sgx_ocall_getdents(void * pms)
@@ -214,7 +214,7 @@ static int sgx_ocall_getdents(void * pms)
     int ret;
     ODEBUG(OCALL_GETDENTS, ms);
     ret = INLINE_SYSCALL(getdents64, 3, ms->ms_fd, ms->ms_dirp, ms->ms_size);
-    return IS_ERR(ret) ? unix_to_pal_error(ERRNO(ret)) : ret;
+    return ret;
 }
 
 static int sgx_ocall_wake_thread(void * pms)
@@ -233,7 +233,7 @@ static int sgx_ocall_create_process(void * pms)
     ODEBUG(OCALL_CREATE_PROCESS, ms);
     int ret = sgx_create_process(ms->ms_uri, ms->ms_nargs, ms->ms_args,
                                  ms->ms_proc_fds);
-    if (ret < 0)
+    if (IS_ERR(ret))
         return ret;
     ms->ms_pid = ret;
     return 0;
@@ -252,7 +252,7 @@ static int sgx_ocall_futex(void * pms)
     }
     ret = INLINE_SYSCALL(futex, 6, ms->ms_futex, ms->ms_op, ms->ms_val,
                          ts, NULL, 0);
-    return IS_ERR(ret) ? unix_to_pal_error(ERRNO(ret)) : ret;
+    return ret;
 }
 
 static int sgx_ocall_socketpair(void * pms)
@@ -263,7 +263,7 @@ static int sgx_ocall_socketpair(void * pms)
     ret = INLINE_SYSCALL(socketpair, 4, ms->ms_domain,
                          ms->ms_type|SOCK_CLOEXEC,
                          ms->ms_protocol, &ms->ms_sockfds);
-    return IS_ERR(ret) ? unix_to_pal_error(ERRNO(ret)) : ret;
+    return ret;
 }
 
 static int sock_getopt(int fd, struct sockopt * opt)
@@ -283,7 +283,7 @@ static int sgx_ocall_sock_listen(void * pms)
                          ms->ms_type|SOCK_CLOEXEC,
                          ms->ms_protocol);
     if (IS_ERR(ret)) {
-        ret = -PAL_ERROR_DENIED;
+        ret = -EPERM;
         goto err;
     }
 
@@ -299,16 +299,14 @@ static int sgx_ocall_sock_listen(void * pms)
                    sizeof(int));
 
     ret = INLINE_SYSCALL(bind, 3, fd, ms->ms_addr, ms->ms_addrlen);
-    if (IS_ERR(ret)) {
-        ret = unix_to_pal_error(ERRNO(ret));
+    if (IS_ERR(ret))
         goto err_fd;
-    }
 
     if (ms->ms_addr) {
         socklen_t addrlen;
         ret = INLINE_SYSCALL(getsockname, 3, fd, ms->ms_addr, &addrlen);
         if (IS_ERR(ret)) {
-            ret = -PAL_ERROR_DENIED;
+            ret = -EPERM;
             goto err_fd;
         }
         ms->ms_addrlen = addrlen;
@@ -317,13 +315,13 @@ static int sgx_ocall_sock_listen(void * pms)
     if (ms->ms_type & SOCK_STREAM) {
         ret = INLINE_SYSCALL(listen, 2, fd, DEFAULT_BACKLOG);
         if (IS_ERR(ret)) {
-            ret = -PAL_ERROR_DENIED;
+            ret = -EPERM;
             goto err_fd;
         }
     }
 
     ret = sock_getopt(fd, &ms->ms_sockopt);
-    if (ret < 0)
+    if (IS_ERR(ret))
         goto err_fd;
 
     return fd;
@@ -343,14 +341,12 @@ static int sgx_ocall_sock_accept(void * pms)
 
     ret = INLINE_SYSCALL(accept4, 4, ms->ms_sockfd, ms->ms_addr,
                          &addrlen, O_CLOEXEC);
-    if (IS_ERR(ret)) {
-        ret = unix_to_pal_error(ERRNO(ret));
+    if (IS_ERR(ret))
         goto err;
-    }
 
     fd = ret;
     ret = sock_getopt(fd, &ms->ms_sockopt);
-    if (ret < 0)
+    if (IS_ERR(ret))
         goto err_fd;
 
     ms->ms_addrlen = addrlen;
@@ -372,7 +368,7 @@ static int sgx_ocall_sock_connect(void * pms)
                          ms->ms_type|SOCK_CLOEXEC,
                          ms->ms_protocol);
     if (IS_ERR(ret)) {
-        ret = -PAL_ERROR_DENIED;
+        ret = -EPERM;
         goto err;
     }
 
@@ -386,10 +382,8 @@ static int sgx_ocall_sock_connect(void * pms)
     if (ms->ms_bind_addr && ms->ms_bind_addr->sa_family) {
         ret = INLINE_SYSCALL(bind, 3, fd, ms->ms_bind_addr,
                              ms->ms_bind_addrlen);
-        if (IS_ERR(ret)) {
-            ret = unix_to_pal_error(ERRNO(ret));
+        if (IS_ERR(ret))
             goto err_fd;
-        }
     }
 
     ret = INLINE_SYSCALL(connect, 3, fd, ms->ms_addr, ms->ms_addrlen);
@@ -402,24 +396,22 @@ static int sgx_ocall_sock_connect(void * pms)
                  ERRNO(ret) == -EWOULDBLOCK);
     }
 
-    if (IS_ERR(ret)) {
-        ret = unix_to_pal_error(ERRNO(ret));
+    if (IS_ERR(ret))
         goto err_fd;
-    }
 
     if (ms->ms_bind_addr && !ms->ms_bind_addr->sa_family) {
         socklen_t addrlen;
         ret = INLINE_SYSCALL(getsockname, 3, fd, ms->ms_bind_addr,
                              &addrlen);
         if (IS_ERR(ret)) {
-            ret = -PAL_ERROR_DENIED;
+            ret = -EPERM;
             goto err_fd;
         }
         ms->ms_bind_addrlen = addrlen;
     }
 
     ret = sock_getopt(fd, &ms->ms_sockopt);
-    if (ret < 0)
+    if (IS_ERR(ret))
         goto err_fd;
 
     return fd;
@@ -448,7 +440,7 @@ static int sgx_ocall_sock_recv(void * pms)
     if (!IS_ERR(ret) && addr)
         ms->ms_addrlen = addrlen;
 
-    return IS_ERR(ret) ? unix_to_pal_error(ERRNO(ret)) : ret;
+    return ret;
 }
 
 static int sgx_ocall_sock_send(void * pms)
@@ -472,7 +464,7 @@ static int sgx_ocall_sock_send(void * pms)
                          ms->ms_sockfd, ms->ms_buf, ms->ms_count, MSG_NOSIGNAL,
                          addr, addrlen);
 
-    return IS_ERR(ret) ? unix_to_pal_error(ERRNO(ret)) : ret;
+    return ret;
 }
 
 static int sgx_ocall_sock_recv_fd(void * pms)
@@ -513,11 +505,9 @@ static int sgx_ocall_sock_recv_fd(void * pms)
         } else {
             ms->ms_nfds = 0;
         }
-
-        return ret;
     }
 
-    return unix_to_pal_error(ERRNO(ret));
+    return ret;
 }
 
 static int sgx_ocall_sock_send_fd(void * pms)
@@ -571,7 +561,7 @@ static int sgx_ocall_sock_send_fd(void * pms)
 
     ret = INLINE_SYSCALL(sendmsg, 3, ms->ms_sockfd, &hdr, MSG_NOSIGNAL);
 
-    return IS_ERR(ret) ? unix_to_pal_error(ERRNO(ret)) : ret;
+    return ret;
 }
 
 static int sgx_ocall_sock_setopt(void * pms)
@@ -582,7 +572,7 @@ static int sgx_ocall_sock_setopt(void * pms)
     ret = INLINE_SYSCALL(setsockopt, 5,
                          ms->ms_sockfd, ms->ms_level, ms->ms_optname,
                          ms->ms_optval, ms->ms_optlen);
-    return IS_ERR(ret) ? unix_to_pal_error(ERRNO(ret)) : ret;
+    return ret;
 }
 
 static int sgx_ocall_sock_shutdown(void * pms)
@@ -618,7 +608,7 @@ static int sgx_ocall_sleep(void * pms)
     ret = INLINE_SYSCALL(nanosleep, 2, &req, &rem);
     if (IS_ERR(ret) && ERRNO(ret) == EINTR)
         ms->ms_microsec = rem.tv_sec * 1000000 + rem.tv_nsec / 1000;
-    return IS_ERR(ret) ? unix_to_pal_error(ERRNO(ret)) : ret;
+    return ret;
 }
 
 static int sgx_ocall_poll(void * pms)
@@ -633,7 +623,7 @@ static int sgx_ocall_poll(void * pms)
         ts->tv_nsec = (ms->ms_timeout - ts->tv_sec * 1000000) * 1000;
     }
     ret = INLINE_SYSCALL(ppoll, 4, ms->ms_fds, ms->ms_nfds, ts, NULL);
-    return IS_ERR(ret) ? unix_to_pal_error(ERRNO(ret)) : ret;
+    return ret;
 }
 
 static int sgx_ocall_rename(void * pms)
@@ -642,7 +632,7 @@ static int sgx_ocall_rename(void * pms)
     int ret;
     ODEBUG(OCALL_RENAME, ms);
     ret = INLINE_SYSCALL(rename, 2, ms->ms_oldpath, ms->ms_newpath);
-    return IS_ERR(ret) ? unix_to_pal_error(ERRNO(ret)) : ret;
+    return ret;
 }
 
 static int sgx_ocall_delete(void * pms)
@@ -656,7 +646,7 @@ static int sgx_ocall_delete(void * pms)
     if (IS_ERR(ret) && ERRNO(ret) == EISDIR)
         ret = INLINE_SYSCALL(rmdir, 1, ms->ms_pathname);
 
-    return IS_ERR(ret) ? unix_to_pal_error(ERRNO(ret)) : ret;
+    return ret;
 }
 
 void load_gdb_command (const char * command);

--- a/Pal/src/host/Linux-SGX/sgx_process.c
+++ b/Pal/src/host/Linux-SGX/sgx_process.c
@@ -56,13 +56,13 @@ int sgx_create_process (const char * uri, int nargs, const char ** args,
     int fds[6] = { -1, -1, -1, -1, -1, -1 };
 
     if (!uri || !strpartcmp_static(uri, "file:"))
-        return -PAL_ERROR_INVAL;
+        return -EINVAL;
 
     if (IS_ERR((ret = INLINE_SYSCALL(pipe, 1, &fds[0]))) ||
         IS_ERR((ret = INLINE_SYSCALL(pipe, 1, &fds[2]))) ||
         IS_ERR((ret = INLINE_SYSCALL(socketpair, 4, AF_UNIX, SOCK_STREAM,
                                      0, &fds[4])))) {
-        ret = -PAL_ERROR_DENIED;
+        ret = -EPERM;
         goto out;
     }
 
@@ -79,7 +79,7 @@ int sgx_create_process (const char * uri, int nargs, const char ** args,
     ret = ARCH_VFORK();
 
     if (IS_ERR(ret)) {
-        ret = -PAL_ERROR_DENIED;
+        ret = -EPERM;
         goto out;
     }
 
@@ -102,7 +102,7 @@ out_child:
     }
 
     if (IS_ERR(rete)) {
-        ret = -PAL_ERROR_DENIED;
+        ret = -EPERM;
         goto out;
     }
 
@@ -128,18 +128,18 @@ out_child:
                          sizeof(struct proc_args));
 
     if (IS_ERR(ret) || ret < sizeof(struct proc_args)) {
-        ret = -PAL_ERROR_DENIED;
+        ret = -EPERM;
         goto out;
     }
 
     ret = INLINE_SYSCALL(read, 3, pipe_in, &rete, sizeof(int));
 
     if (IS_ERR(ret) || ret < sizeof(int)) {
-        ret = -PAL_ERROR_DENIED;
+        ret = -EPERM;
         goto out;
     }
 
-    if (rete < 0) {
+    if (IS_ERR(rete)) {
         ret = rete;
         goto out;
     }
@@ -151,7 +151,7 @@ out_child:
 
     ret = child;
 out:
-    if (ret < 0) {
+    if (IS_ERR(ret)) {
         for (int i = 0 ; i < 6 ; i++)
             if (fds[i] >= 0)
                 INLINE_SYSCALL(close, 1, fds[i]);
@@ -171,13 +171,13 @@ int sgx_init_child_process (struct pal_sec * pal_sec)
         return 0;
 
     if (IS_ERR(ret))
-        return -PAL_ERROR_DENIED;
+        return ret;
 
     int child_status = 0;
     ret = INLINE_SYSCALL(write, 3, proc_args.proc_fds[1], &child_status,
                          sizeof(int));
     if (IS_ERR(ret))
-        return -PAL_ERROR_DENIED;
+        return ret;
 
     memcpy(pal_sec->exec_name, proc_args.exec_name, sizeof(PAL_SEC_STR));
     pal_sec->instance_id   = proc_args.instance_id;

--- a/Pal/src/host/Linux-SGX/sgx_process.c
+++ b/Pal/src/host/Linux-SGX/sgx_process.c
@@ -61,10 +61,8 @@ int sgx_create_process (const char * uri, int nargs, const char ** args,
     if (IS_ERR((ret = INLINE_SYSCALL(pipe, 1, &fds[0]))) ||
         IS_ERR((ret = INLINE_SYSCALL(pipe, 1, &fds[2]))) ||
         IS_ERR((ret = INLINE_SYSCALL(socketpair, 4, AF_UNIX, SOCK_STREAM,
-                                     0, &fds[4])))) {
-        ret = -EPERM;
+                                     0, &fds[4]))))
         goto out;
-    }
 
     int proc_fds[2][3] = {
         { fds[0], fds[3], fds[4] },
@@ -78,10 +76,8 @@ int sgx_create_process (const char * uri, int nargs, const char ** args,
 
     ret = ARCH_VFORK();
 
-    if (IS_ERR(ret)) {
-        ret = -EPERM;
+    if (IS_ERR(ret))
         goto out;
-    }
 
     if (!ret) {
         for (int i = 0 ; i < 3 ; i++)


### PR DESCRIPTION
Fixes #515.

This patch makes ocall return value to linux errno instead of pal errno.
As the side effect, _DkEventWaitTimeout() is fixed so that it returns
timeout. https://github.com/oscarlab/graphene/pull/438

_DkEventWaitTimeout() of Pal/Linux-SGX doesn't return. ETIMEDOUT and
ETRAYAGAIN are different meaing for futex(WAIT). but unix_to_pal_error()
combines into PAL_ERROR_TRYAGAIN. futex ocall doesn't provide enough info.
So make ocall return unix error number and have the callers of ocall
convert unix errno into pal errno.

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md).

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [x] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes (reasons and measures)


## How to test this PR? (if applicable)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/554)
<!-- Reviewable:end -->
