### PR TITLE
[LibOS] use %gs for libos tcb

### DIFF
--- a/LibOS/shim/include/shim_internal.h
+++ b/LibOS/shim/include/shim_internal.h
@@ -44,10 +44,10 @@
 /* important macros and static inline functions */
 static inline unsigned int get_cur_tid(void)
 {
-    return shim_get_tls()->tid;
+    return shim_get_tcb()->tid;
 }
 
-#define PAL_NATIVE_ERRNO        (shim_get_tls()->pal_errno)
+#define PAL_NATIVE_ERRNO        (shim_get_tcb()->pal_errno)
 
 #define INTERNAL_TID_BASE       ((IDTYPE) 1 << (sizeof(IDTYPE) * 8 - 1))
 
@@ -177,7 +177,7 @@ void syscall_wrapper_after_syscalldb(void);
 #define SHIM_ARG_TYPE long
 
 #ifdef PROFILE
-# define ENTER_TIME     shim_get_tls()->context.enter_time
+# define ENTER_TIME     shim_get_tcb()->context.enter_time
 # define BEGIN_SYSCALL_PROFILE()        \
     do { ENTER_TIME = GET_PROFILE_INTERVAL(); } while (0)
 # define END_SYSCALL_PROFILE(name)      \
@@ -195,7 +195,7 @@ void syscall_wrapper_after_syscalldb(void);
 void check_stack_hook (void);
 
 static inline int64_t get_cur_preempt (void) {
-    shim_tcb_t* tcb = shim_get_tls();
+    shim_tcb_t* tcb = shim_get_tcb();
     assert(tcb);
     return atomic_read(&tcb->context.preempt);
 }
@@ -474,7 +474,7 @@ static inline int64_t __disable_preempt (shim_tcb_t * tcb)
 
 static inline void disable_preempt (shim_tcb_t * tcb)
 {
-    if (!tcb && !(tcb = shim_get_tls()))
+    if (!tcb && !(tcb = shim_get_tcb()))
         return;
 
     __disable_preempt(tcb);
@@ -493,7 +493,7 @@ void __handle_signal (shim_tcb_t * tcb, int sig);
 
 static inline void enable_preempt (shim_tcb_t * tcb)
 {
-    if (!tcb && !(tcb = shim_get_tls()))
+    if (!tcb && !(tcb = shim_get_tcb()))
         return;
 
     int64_t preempt = atomic_read(&tcb->context.preempt);
@@ -542,7 +542,7 @@ static void lock(struct shim_lock* l)
     if (!lock_enabled || !l->lock)
         return;
 
-    shim_tcb_t * tcb = shim_get_tls();
+    shim_tcb_t * tcb = shim_get_tcb();
     disable_preempt(tcb);
 
 #if DEBUG_LOCK == 1
@@ -567,7 +567,7 @@ static inline void unlock(struct shim_lock* l)
     if (!lock_enabled || !l->lock)
         return;
 
-    shim_tcb_t* tcb = shim_get_tls();
+    shim_tcb_t* tcb = shim_get_tcb();
 
 #if DEBUG_LOCK == 1
     debug("unlock(%s=%p) %s:%d\n", name, l, file, line);
@@ -583,7 +583,7 @@ static inline bool locked(struct shim_lock* l)
     if (!lock_enabled || !l->lock)
         return false;
 
-    shim_tcb_t* tcb = shim_get_tls();
+    shim_tcb_t* tcb = shim_get_tcb();
     return tcb->tid == l->owner;
 }
 

--- a/LibOS/shim/include/shim_thread.h
+++ b/LibOS/shim/include/shim_thread.h
@@ -82,8 +82,7 @@ struct shim_thread {
     struct shim_handle * exec;
 
     void * stack, * stack_top, * stack_red;
-    __libc_tcb_t * tcb;
-    bool user_tcb; /* is tcb assigned by user? */
+    unsigned long fs_base;
     shim_tcb_t * shim_tcb;
     void * frameptr;
 
@@ -145,8 +144,8 @@ void put_thread (struct shim_thread * thread);
 void get_simple_thread (struct shim_simple_thread * thread);
 void put_simple_thread (struct shim_simple_thread * thread);
 
-void allocate_tls (__libc_tcb_t * tcb_location, bool user, struct shim_thread * thread);
-void populate_tls (__libc_tcb_t * tcb_location, bool user);
+void allocate_tls (unsigned long fs_base, struct shim_thread * thread);
+void populate_tls (unsigned long fs_base);
 
 void debug_setprefix (shim_tcb_t * tcb);
 
@@ -186,7 +185,7 @@ void set_cur_thread (struct shim_thread * thread)
     IDTYPE tid = 0;
 
     if (thread) {
-        __libc_tcb_t * libc_tcb = tcb->tp ? tcb->tp->tcb : NULL;
+        unsigned long fs_base = tcb->tp ? tcb->tp->fs_base : 0;
         if (tcb->tp && tcb->tp != thread)
             put_thread(tcb->tp);
 
@@ -194,8 +193,7 @@ void set_cur_thread (struct shim_thread * thread)
             get_thread(thread);
 
         tcb->tp = thread;
-        if (libc_tcb)
-            thread->tcb = libc_tcb;
+        thread->fs_base = fs_base;
         thread->shim_tcb = tcb;
         tid = thread->tid;
 

--- a/LibOS/shim/include/shim_thread.h
+++ b/LibOS/shim/include/shim_thread.h
@@ -360,6 +360,6 @@ bool check_on_stack (struct shim_thread * cur_thread, void * mem)
 
 int init_stack (const char ** argv, const char ** envp,
                 int ** argcpp, const char *** argpp,
-                elf_auxv_t ** auxpp, size_t reserve);
+                elf_auxv_t ** auxpp);
 
 #endif /* _SHIM_THREAD_H_ */

--- a/LibOS/shim/include/shim_thread.h
+++ b/LibOS/shim/include/shim_thread.h
@@ -144,8 +144,8 @@ void put_thread (struct shim_thread * thread);
 void get_simple_thread (struct shim_simple_thread * thread);
 void put_simple_thread (struct shim_simple_thread * thread);
 
-void allocate_tls (unsigned long fs_base, struct shim_thread * thread);
-void populate_tls (unsigned long fs_base);
+void init_fs_base (unsigned long fs_base, struct shim_thread * thread);
+void update_fs_base (unsigned long fs_base);
 
 void debug_setprefix (shim_tcb_t * tcb);
 

--- a/LibOS/shim/include/shim_thread.h
+++ b/LibOS/shim/include/shim_thread.h
@@ -122,14 +122,14 @@ int init_thread (void);
 static inline struct shim_thread * shim_thread_self(void)
 {
     /* TODO: optimize to use single movq %gs:<offset> */
-    shim_tcb_t * shim_tcb = shim_get_tls();
+    shim_tcb_t * shim_tcb = shim_get_tcb();
     return shim_tcb->tp;
 }
 
 static inline struct shim_thread * save_shim_thread_self(struct shim_thread * __self)
 {
     /* TODO: optimize to use single movq %gs:<offset> */
-    shim_tcb_t * shim_tcb = shim_get_tls();
+    shim_tcb_t * shim_tcb = shim_get_tcb();
     shim_tcb->tp = __self;
     return __self;
 }
@@ -181,7 +181,7 @@ static inline
 __attribute__((always_inline))
 void set_cur_thread (struct shim_thread * thread)
 {
-    shim_tcb_t * tcb = shim_get_tls();
+    shim_tcb_t * tcb = shim_get_tcb();
     IDTYPE tid = 0;
 
     if (thread) {

--- a/LibOS/shim/include/shim_tls.h
+++ b/LibOS/shim/include/shim_tls.h
@@ -73,12 +73,6 @@ struct shim_tcb {
 #include <stddef.h>
 
 void init_tcb (shim_tcb_t * tcb);
-struct __libc_tcb_t;
-typedef struct __libc_tcb_t __libc_tcb_t;
-
-/* don't define struct __libc_tcb_t. just type to point to libc tls
- * LibOS doesn't access this structure as it's private to libc.
- */
 
 static inline shim_tcb_t * shim_get_tls(void)
 {

--- a/LibOS/shim/include/shim_tls.h
+++ b/LibOS/shim/include/shim_tls.h
@@ -74,7 +74,7 @@ struct shim_tcb {
 
 void init_tcb (shim_tcb_t * tcb);
 
-static inline shim_tcb_t * shim_get_tls(void)
+static inline shim_tcb_t * shim_get_tcb(void)
 {
     PAL_TCB * tcb = pal_get_tcb();
     return (shim_tcb_t*)tcb->libos_tcb;

--- a/LibOS/shim/src/bookkeep/shim_signal.c
+++ b/LibOS/shim/src/bookkeep/shim_signal.c
@@ -152,7 +152,7 @@ void __store_context (shim_tcb_t * tcb, PAL_CONTEXT * pal_context,
 
 void deliver_signal (siginfo_t * info, PAL_CONTEXT * context)
 {
-    shim_tcb_t * tcb = shim_get_tls();
+    shim_tcb_t * tcb = shim_get_tcb();
     assert(tcb);
 
     // Signals should not be delivered before the user process starts
@@ -247,7 +247,7 @@ static void arithmetic_error_upcall (PAL_PTR event, PAL_NUM arg, PAL_CONTEXT * c
 
 static void memfault_upcall (PAL_PTR event, PAL_NUM arg, PAL_CONTEXT * context)
 {
-    shim_tcb_t * tcb = shim_get_tls();
+    shim_tcb_t * tcb = shim_get_tcb();
     assert(tcb);
 
     if (tcb->test_range.cont_addr && arg
@@ -362,7 +362,7 @@ bool test_user_memory (void * addr, size_t size, bool write)
 
     /* Non-SGX path: check if [addr, addr+size) is addressable by touching
      * a byte of each page; invalid access will be caught in memfault_upcall */
-    shim_tcb_t * tcb = shim_get_tls();
+    shim_tcb_t * tcb = shim_get_tcb();
     assert(tcb && tcb->tp);
     __disable_preempt(tcb);
 
@@ -433,7 +433,7 @@ bool test_user_string (const char * addr)
 
     /* Non-SGX path: check if [addr, addr+size) is addressable by touching
      * a byte of each page; invalid access will be caught in memfault_upcall. */
-    shim_tcb_t * tcb = shim_get_tls();
+    shim_tcb_t * tcb = shim_get_tcb();
     assert(tcb && tcb->tp);
     __disable_preempt(tcb);
 
@@ -565,7 +565,7 @@ static void resume_upcall (PAL_PTR event, PAL_NUM arg, PAL_CONTEXT * context)
 {
     __UNUSED(arg);
     __UNUSED(context);
-    shim_tcb_t * tcb = shim_get_tls();
+    shim_tcb_t * tcb = shim_get_tcb();
     if (!tcb || !tcb->tp)
         return;
 
@@ -718,7 +718,7 @@ void __handle_signal (shim_tcb_t * tcb, int sig)
 
 void handle_signal (void)
 {
-    shim_tcb_t * tcb = shim_get_tls();
+    shim_tcb_t * tcb = shim_get_tcb();
     assert(tcb);
 
     struct shim_thread * thread = (struct shim_thread *) tcb->tp;

--- a/LibOS/shim/src/bookkeep/shim_thread.c
+++ b/LibOS/shim/src/bookkeep/shim_thread.c
@@ -20,6 +20,7 @@
  * This file contains codes to maintain bookkeeping of threads in library OS.
  */
 
+#include <shim_defs.h>
 #include <shim_internal.h>
 #include <shim_thread.h>
 #include <shim_handle.h>
@@ -688,10 +689,10 @@ BEGIN_RS_FUNC(thread)
     if (thread->cwd)
         get_dentry(thread->cwd);
 
-    DEBUG_RS("tid=%d,tgid=%d,parent=%d,stack=%p,frameptr=%p,tcb=%p",
+    DEBUG_RS("tid=%d,tgid=%d,parent=%d,stack=%p,frameptr=%p,tcb=%p,shim_tcb=%p",
              thread->tid, thread->tgid,
              thread->parent ? thread->parent->tid : thread->tid,
-             thread->stack, thread->frameptr, thread->tcb);
+             thread->stack, thread->frameptr, thread->tcb, thread->shim_tcb);
 }
 END_RS_FUNC(thread)
 
@@ -707,27 +708,27 @@ BEGIN_CP_FUNC(running_thread)
     DO_CP(thread, thread, &new_thread);
     ADD_CP_FUNC_ENTRY((ptr_t) new_thread - base);
 
-    if (!thread->user_tcb && thread->tcb) {
-        ptr_t toff = ADD_CP_OFFSET(sizeof(__libc_tcb_t));
-        new_thread->tcb = (void *) (base + toff);
-        memcpy(new_thread->tcb, thread->tcb, sizeof(__libc_tcb_t));
+    if (thread->shim_tcb) {
+        ptr_t toff = ADD_CP_OFFSET(sizeof(shim_tcb_t));
+        new_thread->shim_tcb = (void *)(base + toff);
+        memcpy(new_thread->shim_tcb, thread->shim_tcb, sizeof(shim_tcb_t));
     }
 }
 END_CP_FUNC(running_thread)
 
-int resume_wrapper (void * param)
+static int resume_wrapper (void * param)
 {
     struct shim_thread * thread = (struct shim_thread *) param;
     assert(thread);
 
     __libc_tcb_t * libc_tcb = thread->tcb;
     assert(libc_tcb);
-    shim_tcb_t * tcb = &libc_tcb->shim_tcb;
+    shim_tcb_t * tcb = thread->shim_tcb;
     assert(tcb->context.regs && tcb->context.regs->rsp);
 
     thread->in_vm = thread->is_alive = true;
     allocate_tls(libc_tcb, thread->user_tcb, thread);
-    debug_setbuf(tcb, true);
+    debug_setbuf(tcb, false);
     debug("set tcb to %p\n", libc_tcb);
 
     object_wait_with_retry(thread_start_event);
@@ -747,6 +748,8 @@ BEGIN_RS_FUNC(running_thread)
 
     if (!thread->user_tcb)
         CP_REBASE(thread->tcb);
+    if (thread->shim_tcb)
+        CP_REBASE(thread->shim_tcb);
 
     if (thread->set_child_tid) {
         /* CLONE_CHILD_SETTID */
@@ -764,10 +767,15 @@ BEGIN_RS_FUNC(running_thread)
 
         thread->pal_handle = handle;
     } else {
+        if (thread->shim_tcb) {
+            memcpy(shim_get_tls(), thread->shim_tcb, sizeof(shim_tcb_t));
+            thread->shim_tcb = shim_get_tls();
+        }
+        debug_setbuf(thread->shim_tcb, false);
         __libc_tcb_t * libc_tcb = thread->tcb;
 
         if (libc_tcb) {
-            shim_tcb_t * tcb = &libc_tcb->shim_tcb;
+            shim_tcb_t * tcb = thread->shim_tcb;
             assert(tcb->context.regs && tcb->context.regs->rsp);
             tcb->debug_buf = shim_get_tls()->debug_buf;
             allocate_tls(libc_tcb, thread->user_tcb, thread);
@@ -783,9 +791,11 @@ BEGIN_RS_FUNC(running_thread)
              * frameptr = NULL
              * tcb = NULL
              * user_tcb = false
+             * shim_tcb = NULL
              * in_vm = false
              */
-            init_tcb(&shim_libc_tcb()->shim_tcb);
+            thread->shim_tcb = shim_get_tls();
+            init_tcb(thread->shim_tcb);
             set_cur_thread(thread);
         }
 

--- a/LibOS/shim/src/bookkeep/shim_thread.c
+++ b/LibOS/shim/src/bookkeep/shim_thread.c
@@ -721,15 +721,15 @@ static int resume_wrapper (void * param)
     struct shim_thread * thread = (struct shim_thread *) param;
     assert(thread);
 
-    __libc_tcb_t * libc_tcb = thread->tcb;
-    assert(libc_tcb);
+    unsigned long fs_base = thread->fs_base;
+    assert(fs_base);
     shim_tcb_t * tcb = thread->shim_tcb;
     assert(tcb->context.regs && tcb->context.regs->rsp);
 
     thread->in_vm = thread->is_alive = true;
-    allocate_tls(libc_tcb, thread->user_tcb, thread);
+    allocate_tls(fs_base, thread);
     debug_setbuf(tcb, false);
-    debug("set tcb to %p\n", libc_tcb);
+    debug("set fs_base to 0x%lx\n", fs_base);
 
     object_wait_with_retry(thread_start_event);
 
@@ -746,8 +746,6 @@ BEGIN_RS_FUNC(running_thread)
 
     thread->vmid = cur_process.vmid;
 
-    if (!thread->user_tcb)
-        CP_REBASE(thread->tcb);
     if (thread->shim_tcb)
         CP_REBASE(thread->shim_tcb);
 
@@ -772,17 +770,17 @@ BEGIN_RS_FUNC(running_thread)
             thread->shim_tcb = shim_get_tls();
         }
         debug_setbuf(thread->shim_tcb, false);
-        __libc_tcb_t * libc_tcb = thread->tcb;
+        unsigned long fs_base = thread->fs_base;
 
-        if (libc_tcb) {
+        if (fs_base) {
             shim_tcb_t * tcb = thread->shim_tcb;
             assert(tcb->context.regs && tcb->context.regs->rsp);
             tcb->debug_buf = shim_get_tls()->debug_buf;
-            allocate_tls(libc_tcb, thread->user_tcb, thread);
+            allocate_tls(fs_base, thread);
             /* Temporarily disable preemption until the thread resumes. */
             __disable_preempt(tcb);
             debug_setprefix(tcb);
-            debug("after resume, set tcb to %p\n", libc_tcb);
+            debug("after resume, set tcb to 0x%lx\n", fs_base);
         } else {
             /*
              * In execve case, the following holds:
@@ -790,7 +788,6 @@ BEGIN_RS_FUNC(running_thread)
              * stack_top = NULL
              * frameptr = NULL
              * tcb = NULL
-             * user_tcb = false
              * shim_tcb = NULL
              * in_vm = false
              */

--- a/LibOS/shim/src/bookkeep/shim_thread.c
+++ b/LibOS/shim/src/bookkeep/shim_thread.c
@@ -104,7 +104,7 @@ struct shim_thread * __get_cur_thread (void)
 
 shim_tcb_t * __get_cur_tcb (void)
 {
-    return shim_get_tls();
+    return shim_get_tcb();
 }
 
 IDTYPE get_pid (void)
@@ -766,8 +766,8 @@ BEGIN_RS_FUNC(running_thread)
         thread->pal_handle = handle;
     } else {
         if (thread->shim_tcb) {
-            memcpy(shim_get_tls(), thread->shim_tcb, sizeof(shim_tcb_t));
-            thread->shim_tcb = shim_get_tls();
+            memcpy(shim_get_tcb(), thread->shim_tcb, sizeof(shim_tcb_t));
+            thread->shim_tcb = shim_get_tcb();
         }
         debug_setbuf(thread->shim_tcb, false);
         unsigned long fs_base = thread->fs_base;
@@ -775,7 +775,7 @@ BEGIN_RS_FUNC(running_thread)
         if (fs_base) {
             shim_tcb_t * tcb = thread->shim_tcb;
             assert(tcb->context.regs && tcb->context.regs->rsp);
-            tcb->debug_buf = shim_get_tls()->debug_buf;
+            tcb->debug_buf = shim_get_tcb()->debug_buf;
             init_fs_base(fs_base, thread);
             /* Temporarily disable preemption until the thread resumes. */
             __disable_preempt(tcb);
@@ -791,7 +791,7 @@ BEGIN_RS_FUNC(running_thread)
              * shim_tcb = NULL
              * in_vm = false
              */
-            thread->shim_tcb = shim_get_tls();
+            thread->shim_tcb = shim_get_tcb();
             init_tcb(thread->shim_tcb);
             set_cur_thread(thread);
         }

--- a/LibOS/shim/src/bookkeep/shim_thread.c
+++ b/LibOS/shim/src/bookkeep/shim_thread.c
@@ -727,7 +727,7 @@ static int resume_wrapper (void * param)
     assert(tcb->context.regs && tcb->context.regs->rsp);
 
     thread->in_vm = thread->is_alive = true;
-    allocate_tls(fs_base, thread);
+    init_fs_base(fs_base, thread);
     debug_setbuf(tcb, false);
     debug("set fs_base to 0x%lx\n", fs_base);
 
@@ -776,7 +776,7 @@ BEGIN_RS_FUNC(running_thread)
             shim_tcb_t * tcb = thread->shim_tcb;
             assert(tcb->context.regs && tcb->context.regs->rsp);
             tcb->debug_buf = shim_get_tls()->debug_buf;
-            allocate_tls(fs_base, thread);
+            init_fs_base(fs_base, thread);
             /* Temporarily disable preemption until the thread resumes. */
             __disable_preempt(tcb);
             debug_setprefix(tcb);

--- a/LibOS/shim/src/elf/shim_rtld.c
+++ b/LibOS/shim/src/elf/shim_rtld.c
@@ -1608,7 +1608,7 @@ noreturn void execute_elf_object(struct shim_handle* exec, int* argcp, const cha
     ElfW(Addr) entry = interp_map ? interp_map->l_entry : exec_map->l_entry;
 
     /* Ready to start execution, re-enable preemption. */
-    shim_tcb_t* tcb = shim_get_tls();
+    shim_tcb_t* tcb = shim_get_tcb();
     __enable_preempt(tcb);
 
 #if defined(__x86_64__)

--- a/LibOS/shim/src/generated-offsets.c
+++ b/LibOS/shim/src/generated-offsets.c
@@ -7,7 +7,7 @@
 
 void dummy(void)
 {
-    OFFSET_T(SHIM_TCB_OFFSET, __libc_tcb_t, shim_tcb);
+    OFFSET_T(SHIM_TCB_OFFSET, PAL_TCB, libos_tcb);
     OFFSET_T(TCB_REGS, shim_tcb_t, context.regs);
     OFFSET(SHIM_REGS_RSP, shim_regs, rsp);
     OFFSET(SHIM_REGS_R15, shim_regs, r15);

--- a/LibOS/shim/src/ipc/shim_ipc_helper.c
+++ b/LibOS/shim/src/ipc/shim_ipc_helper.c
@@ -792,7 +792,7 @@ static void shim_ipc_helper_prepare(void* arg) {
         return;
 
     unsigned long fs_base = 0;
-    allocate_tls(fs_base, self);
+    init_fs_base(fs_base, self);
     debug_setbuf(shim_get_tls(), true);
 
     lock(&ipc_helper_lock);

--- a/LibOS/shim/src/ipc/shim_ipc_helper.c
+++ b/LibOS/shim/src/ipc/shim_ipc_helper.c
@@ -793,7 +793,7 @@ static void shim_ipc_helper_prepare(void* arg) {
 
     unsigned long fs_base = 0;
     init_fs_base(fs_base, self);
-    debug_setbuf(shim_get_tls(), true);
+    debug_setbuf(shim_get_tcb(), true);
 
     lock(&ipc_helper_lock);
     bool notme = (self != ipc_helper_thread);

--- a/LibOS/shim/src/ipc/shim_ipc_helper.c
+++ b/LibOS/shim/src/ipc/shim_ipc_helper.c
@@ -791,10 +791,9 @@ static void shim_ipc_helper_prepare(void* arg) {
     if (!arg)
         return;
 
-    __libc_tcb_t* tcb = NULL;
-    allocate_tls(tcb, false, self);
+    unsigned long fs_base = 0;
+    allocate_tls(fs_base, self);
     debug_setbuf(shim_get_tls(), true);
-    debug("Set tcb to %p\n", tcb);
 
     lock(&ipc_helper_lock);
     bool notme = (self != ipc_helper_thread);

--- a/LibOS/shim/src/ipc/shim_ipc_helper.c
+++ b/LibOS/shim/src/ipc/shim_ipc_helper.c
@@ -791,10 +791,10 @@ static void shim_ipc_helper_prepare(void* arg) {
     if (!arg)
         return;
 
-    __libc_tcb_t tcb;
-    allocate_tls(&tcb, false, self);
-    debug_setbuf(&tcb.shim_tcb, true);
-    debug("Set tcb to %p\n", &tcb);
+    __libc_tcb_t* tcb = NULL;
+    allocate_tls(tcb, false, self);
+    debug_setbuf(shim_get_tls(), true);
+    debug("Set tcb to %p\n", tcb);
 
     lock(&ipc_helper_lock);
     bool notme = (self != ipc_helper_thread);

--- a/LibOS/shim/src/shim_async.c
+++ b/LibOS/shim/src/shim_async.c
@@ -145,7 +145,7 @@ static void shim_async_helper(void * arg) {
         return;
 
     unsigned long fs_base = 0;
-    allocate_tls(fs_base, self);
+    init_fs_base(fs_base, self);
     debug_setbuf(shim_get_tls(), true);
 
     lock(&async_helper_lock);

--- a/LibOS/shim/src/shim_async.c
+++ b/LibOS/shim/src/shim_async.c
@@ -144,10 +144,10 @@ static void shim_async_helper(void * arg) {
     if (!arg)
         return;
 
-    __libc_tcb_t tcb;
-    allocate_tls(&tcb, false, self);
-    debug_setbuf(&tcb.shim_tcb, true);
-    debug("Set tcb to %p\n", &tcb);
+    __libc_tcb_t* tcb = NULL;
+    allocate_tls(tcb, false, self);
+    debug_setbuf(shim_get_tls(), true);
+    debug("Set tcb to %p\n", tcb);
 
     lock(&async_helper_lock);
     bool notme = (self != async_helper_thread);

--- a/LibOS/shim/src/shim_async.c
+++ b/LibOS/shim/src/shim_async.c
@@ -146,7 +146,7 @@ static void shim_async_helper(void * arg) {
 
     unsigned long fs_base = 0;
     init_fs_base(fs_base, self);
-    debug_setbuf(shim_get_tls(), true);
+    debug_setbuf(shim_get_tcb(), true);
 
     lock(&async_helper_lock);
     bool notme = (self != async_helper_thread);

--- a/LibOS/shim/src/shim_async.c
+++ b/LibOS/shim/src/shim_async.c
@@ -144,10 +144,9 @@ static void shim_async_helper(void * arg) {
     if (!arg)
         return;
 
-    __libc_tcb_t* tcb = NULL;
-    allocate_tls(tcb, false, self);
+    unsigned long fs_base = 0;
+    allocate_tls(fs_base, self);
     debug_setbuf(shim_get_tls(), true);
-    debug("Set tcb to %p\n", tcb);
 
     lock(&async_helper_lock);
     bool notme = (self != async_helper_thread);

--- a/LibOS/shim/src/shim_checkpoint.c
+++ b/LibOS/shim/src/shim_checkpoint.c
@@ -1301,7 +1301,7 @@ void restore_context (struct shim_context * context)
     *(unsigned long*) (regs.rsp - RED_ZONE_SIZE - 8) = regs.rip;
 
     /* Ready to resume execution, re-enable preemption. */
-    shim_tcb_t * tcb = shim_get_tls();
+    shim_tcb_t * tcb = shim_get_tcb();
     __enable_preempt(tcb);
 
     memset(context, 0, sizeof(struct shim_context));

--- a/LibOS/shim/src/shim_init.c
+++ b/LibOS/shim/src/shim_init.c
@@ -374,7 +374,7 @@ copy_envp:
 
 int init_stack (const char ** argv, const char ** envp,
                 int ** argcpp, const char *** argpp,
-                elf_auxv_t ** auxpp, size_t reserve)
+                elf_auxv_t ** auxpp)
 {
     uint64_t stack_size = get_rlimit_cur(RLIMIT_STACK);
 
@@ -398,7 +398,7 @@ int init_stack (const char ** argv, const char ** envp,
     if (initial_envp)
         envp = initial_envp;
 
-    int ret = populate_user_stack(stack, stack_size - reserve,
+    int ret = populate_user_stack(stack, stack_size,
                                   auxpp, argcpp, &argv, &envp);
     if (ret < 0)
         return ret;
@@ -771,7 +771,7 @@ noreturn void* shim_init (int argc, void * args)
     RUN_INIT(init_mount);
     RUN_INIT(init_important_handles);
     RUN_INIT(init_async);
-    RUN_INIT(init_stack, argv, envp, &argcp, &argp, &auxp, 0);
+    RUN_INIT(init_stack, argv, envp, &argcp, &argp, &auxp);
     RUN_INIT(init_loader);
     RUN_INIT(init_ipc_helper);
     RUN_INIT(init_signal);

--- a/LibOS/shim/src/shim_init.c
+++ b/LibOS/shim/src/shim_init.c
@@ -206,7 +206,7 @@ void init_tcb (shim_tcb_t * tcb)
 }
 
 /* This function is used to allocate tls before interpreter start running */
-void allocate_tls (unsigned long fs_base, struct shim_thread * thread)
+void init_fs_base (unsigned long fs_base, struct shim_thread * thread)
 {
     shim_tcb_t * shim_tcb = shim_get_tls();
     init_tcb(shim_tcb);
@@ -225,7 +225,7 @@ void allocate_tls (unsigned long fs_base, struct shim_thread * thread)
     assert(shim_tls_check_canary());
 }
 
-void populate_tls (unsigned long fs_base)
+void update_fs_base (unsigned long fs_base)
 {
     shim_tcb_t * shim_tcb = shim_get_tls();
 
@@ -676,7 +676,7 @@ noreturn void* shim_init (int argc, void * args)
 
     /* create the initial TCB, shim can not be run without a tcb */
     unsigned long fs_base = 0;
-    allocate_tls(fs_base, NULL);
+    init_fs_base(fs_base, NULL);
     __disable_preempt(shim_get_tls()); // Temporarily disable preemption for delaying any signal
                                        // that arrives during initialization
     debug_setbuf(shim_get_tls(), true);

--- a/LibOS/shim/src/shim_syscalls.c
+++ b/LibOS/shim/src/shim_syscalls.c
@@ -591,8 +591,8 @@ void* shim_do_arch_prctl(int code, void* addr) {
             if (!addr)
                 return (void*)-EINVAL;
 
-            populate_tls(addr, true);
-            debug("set tcb to %p\n", (void*)addr);
+            populate_tls((unsigned long)addr);
+            debug("set fs_base to 0x%lx\n", (unsigned long)addr);
             return NULL;
 
         case ARCH_GET_FS:

--- a/LibOS/shim/src/shim_syscalls.c
+++ b/LibOS/shim/src/shim_syscalls.c
@@ -591,7 +591,7 @@ void* shim_do_arch_prctl(int code, void* addr) {
             if (!addr)
                 return (void*)-EINVAL;
 
-            populate_tls((unsigned long)addr);
+            update_fs_base((unsigned long)addr);
             debug("set fs_base to 0x%lx\n", (unsigned long)addr);
             return NULL;
 

--- a/LibOS/shim/src/sys/shim_clone.c
+++ b/LibOS/shim/src/sys/shim_clone.c
@@ -125,11 +125,11 @@ static int clone_implementation_wrapper(struct clone_args * arg)
     struct shim_thread* my_thread = arg->thread;
     assert(my_thread);
 
-    allocate_tls(my_thread->fs_base, my_thread); /* set up TCB */
+    init_fs_base(my_thread->fs_base, my_thread); /* set up TCB */
     shim_tcb_t * tcb = my_thread->shim_tcb;
 
     /* only now we can call LibOS/PAL functions because they require a set-up TCB;
-     * do not move the below functions before allocate_tls()! */
+     * do not move the below functions before init_fs_base()! */
     object_wait_with_retry(arg->create_event);
     DkObjectClose(arg->create_event);
 

--- a/LibOS/shim/src/sys/shim_exec.c
+++ b/LibOS/shim/src/sys/shim_exec.c
@@ -212,9 +212,7 @@ static int shim_do_execve_rtld (struct shim_handle * hdl, const char ** argv,
     int * new_argcp = &new_argc;
     const char ** new_argp;
     elf_auxv_t * new_auxp;
-    size_t reserve = 0;
-    if ((ret = init_stack(argv, envp, &new_argcp, &new_argp, &new_auxp,
-                          reserve)) < 0)
+    if ((ret = init_stack(argv, envp, &new_argcp, &new_argp, &new_auxp)) < 0)
         return ret;
 
     __disable_preempt(shim_get_tls()); // Temporarily disable preemption

--- a/LibOS/shim/src/sys/shim_exec.c
+++ b/LibOS/shim/src/sys/shim_exec.c
@@ -214,7 +214,7 @@ static int shim_do_execve_rtld (struct shim_handle * hdl, const char ** argv,
     if ((ret = init_stack(argv, envp, &new_argcp, &new_argp, &new_auxp)) < 0)
         return ret;
 
-    __disable_preempt(shim_get_tls()); // Temporarily disable preemption
+    __disable_preempt(shim_get_tcb()); // Temporarily disable preemption
                                        // during execve().
     SAVE_PROFILE_INTERVAL(alloc_new_stack_for_exec);
 

--- a/LibOS/shim/src/sys/shim_exec.c
+++ b/LibOS/shim/src/sys/shim_exec.c
@@ -88,7 +88,7 @@ noreturn static void __shim_do_execve_rtld (struct execve_rtld_arg * __arg)
     int ret = 0;
 
     unsigned long fs_base = 0;
-    populate_tls(fs_base);
+    update_fs_base(fs_base);
     debug("set fs_base to 0x%lx\n", fs_base);
 
     UPDATE_PROFILE_INTERVAL();

--- a/LibOS/shim/src/sys/shim_fork.c
+++ b/LibOS/shim/src/sys/shim_fork.c
@@ -86,6 +86,7 @@ int shim_do_fork (void)
 
     new_thread->tcb      = cur_thread->tcb;
     new_thread->user_tcb = cur_thread->user_tcb;
+    new_thread->shim_tcb = cur_thread->shim_tcb;
     new_thread->tgid     = new_thread->tid;
     new_thread->in_vm    = false;
     new_thread->is_alive = true;
@@ -100,6 +101,7 @@ int shim_do_fork (void)
     lock(&new_thread->lock);
     struct shim_handle_map * handle_map = new_thread->handle_map;
     new_thread->handle_map = NULL;
+    new_thread->shim_tcb = NULL;
     unlock(&new_thread->lock);
     if (handle_map)
         put_handle_map(handle_map);

--- a/LibOS/shim/src/sys/shim_fork.c
+++ b/LibOS/shim/src/sys/shim_fork.c
@@ -84,8 +84,7 @@ int shim_do_fork (void)
     if (!new_thread)
         return -ENOMEM;
 
-    new_thread->tcb      = cur_thread->tcb;
-    new_thread->user_tcb = cur_thread->user_tcb;
+    new_thread->fs_base  = cur_thread->fs_base;
     new_thread->shim_tcb = cur_thread->shim_tcb;
     new_thread->tgid     = new_thread->tid;
     new_thread->in_vm    = false;

--- a/LibOS/shim/src/sys/shim_migrate.c
+++ b/LibOS/shim/src/sys/shim_migrate.c
@@ -261,7 +261,7 @@ int shim_do_checkpoint(const char* filename) {
     if (ret < 0)
         return ret;
 
-    shim_tcb_t* tcb = shim_get_tls();
+    shim_tcb_t* tcb = shim_get_tcb();
     assert(tcb && tcb->tp);
     struct shim_signal signal;
     __store_context(tcb, NULL, &signal);

--- a/LibOS/shim/src/sys/shim_sigaction.c
+++ b/LibOS/shim/src/sys/shim_sigaction.c
@@ -163,7 +163,7 @@ int shim_do_sigaltstack (const stack_t * ss, stack_t * oss)
     if (oss)
         *oss = *cur_ss;
 
-    void * sp = (void *)shim_get_tls()->context.regs->rsp;
+    void * sp = (void *)shim_get_tcb()->context.regs->rsp;
     /* check if thread is currently executing on an active altstack */
     if (!(cur_ss->ss_flags & SS_DISABLE) &&
         sp &&

--- a/LibOS/shim/src/sys/shim_vfork.c
+++ b/LibOS/shim/src/sys/shim_vfork.c
@@ -76,8 +76,7 @@ int shim_do_vfork(void) {
     new_thread->is_alive  = true;
     new_thread->stack     = cur_thread->stack;
     new_thread->stack_top = cur_thread->stack_top;
-    new_thread->tcb       = cur_thread->tcb;
-    new_thread->user_tcb  = cur_thread->user_tcb;
+    new_thread->fs_base   = cur_thread->fs_base;
     cur_thread->stack     = dummy_stack;
     cur_thread->stack_top = dummy_stack + stack_size;
     cur_thread->frameptr  = NULL;

--- a/LibOS/shim/src/syscallas.S
+++ b/LibOS/shim/src/syscallas.S
@@ -20,6 +20,7 @@
  * This file contains the entry point of system call table in library OS.
  */
 
+#include <shim_defs.h>
 #include <shim_unistd_defs.h>
 
 #include "asm-offsets.h"
@@ -76,7 +77,7 @@ syscalldb:
         cmp $0, %rbx
         je isundef
 
-        movq %rbp, %fs:(SHIM_TCB_OFFSET + TCB_REGS)
+        movq %rbp, %gs:(SHIM_TCB_OFFSET + TCB_REGS)
 
         /* Translating x86_64 kernel calling convention to user-space
          * calling convention */
@@ -84,7 +85,7 @@ syscalldb:
         andq $~0xF, %rsp  # Required by System V AMD64 ABI.
         call *%rbx
 
-        movq $0, %fs:(SHIM_TCB_OFFSET + TCB_REGS)
+        movq $0, %gs:(SHIM_TCB_OFFSET + TCB_REGS)
 
 ret:
         movq %rbp, %rsp

--- a/LibOS/shim/src/utils/printf.c
+++ b/LibOS/shim/src/utils/printf.c
@@ -64,7 +64,7 @@ static int debug_fputch(void* f, int ch, void* b) {
 
 void debug_puts(const char* str) {
     int len               = strlen(str);
-    struct debug_buf* buf = shim_get_tls()->debug_buf;
+    struct debug_buf* buf = shim_get_tcb()->debug_buf;
 
     while (len) {
         int rem     = DEBUGBUF_SIZE - 4 - buf->end;
@@ -95,11 +95,11 @@ void debug_puts(const char* str) {
 }
 
 void debug_putch(int ch) {
-    debug_fputch(NULL, ch, shim_get_tls()->debug_buf);
+    debug_fputch(NULL, ch, shim_get_tcb()->debug_buf);
 }
 
 void debug_vprintf(const char* fmt, va_list ap) {
-    vfprintfmt((void*)debug_fputch, NULL, shim_get_tls()->debug_buf, fmt, ap);
+    vfprintfmt((void*)debug_fputch, NULL, shim_get_tcb()->debug_buf, fmt, ap);
 }
 
 void debug_printf(const char* fmt, ...) {

--- a/LibOS/shim/test/regression/Makefile
+++ b/LibOS/shim/test/regression/Makefile
@@ -23,6 +23,7 @@ CFLAGS-multi_pthread = -pthread
 CFLAGS-exit_group = -pthread
 CFLAGS-abort_multithread = -pthread
 CFLAGS-eventfd = -pthread
+CFLAGS-futex = -pthread
 CFLAGS-spinlock += -I$(PALDIR)/../lib -pthread
 
 %: %.c

--- a/LibOS/shim/test/regression/futex.c
+++ b/LibOS/shim/test/regression/futex.c
@@ -10,90 +10,73 @@
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <unistd.h>
+#include <errno.h>
+#include <pthread.h>
 
 // 64kB stack
 #define FIBER_STACK (1024 * 64)
 #define THREADS     2
 static int myfutex = 0;
-struct atomic_int {
-    volatile int counter;
-};
-static struct atomic_int my_counter;
-
-static inline void atomic_inc(struct atomic_int* v) {
-    asm volatile("lock; incl %0" : "+m"(v->counter));
-}
 
 static int futex(int* uaddr, int futex_op, int val, const struct timespec* timeout, int* uaddr2,
                  int val3) {
     return syscall(SYS_futex, uaddr, futex_op, val, timeout, uaddr, val3);
 }
 
-int thread_function(void* argument) {
+void* thread_function(void* argument) {
     int* ptr = (int*)argument;
     int rv;
-    atomic_inc(&my_counter);
 
     // Sleep on the futex
     rv = futex(&myfutex, FUTEX_WAIT_BITSET, 0, NULL, NULL, *ptr);
     assert(rv == 0);
     // printf("child thread %d awakened\n", getpid());
-    return 0;
+    return NULL;
 }
 
 int main(int argc, const char** argv) {
-    void* stacks[THREADS];
-    pid_t pids[THREADS];
-    int varx[THREADS];
-    my_counter.counter = 0;
+    pthread_t thread[THREADS];
+    static int varx[THREADS];
 
     for (int i = 0; i < THREADS; i++) {
         varx[i] = (1 << i);
 
-        // Allocate the stack
-        stacks[i] = malloc(FIBER_STACK);
-        if (stacks[i] == 0) {
-            perror("malloc: could not allocate stack");
-            _exit(1);
-        }
-
-        // Call the clone system call to create the child thread
-        pids[i] = clone(&thread_function, (void*)stacks[i] + FIBER_STACK,
-                        CLONE_FS | CLONE_FILES | CLONE_SIGHAND | CLONE_VM | CLONE_THREAD, &varx[i]);
-
-        // printf("clone() creates new thread %d\n", pids[i]);
-
-        if (pids[i] == -1) {
-            perror("clone");
+        int ret = pthread_create(&thread[i], NULL, &thread_function, &varx[i]);
+        if (ret) {
+            errno = ret;
+            perror("pthread_create");
             _exit(2);
         }
     }
 
-    // Make sure the threads are sleeping
-    do {
-        sleep(1);
-    } while (my_counter.counter != THREADS);
-
     printf("Waking up kiddos\n");
     /* Wake in reverse order */
     for (int i = THREADS - 1; i >= 0; i--) {
-        pid_t pid;
         int rv;
         int var = (1 << i);
 
         // Wake up the thread
-        rv = futex(&myfutex, FUTEX_WAKE_BITSET, 1, NULL, NULL, var);
+        do {
+            rv = futex(&myfutex, FUTEX_WAKE_BITSET, 1, NULL, NULL, var);
+            if (rv == 0) {
+                // the thread of thread_function() may not reach
+                // futex(FUTEX_WAIT_BITSET) yet.
+                // Wait for the thread to sleep and try again.
+                // Since synchronization primitive, futex, is being tested,
+                // futex can't be used here. resort to use sleep.
+                sleep(1);
+            }
+        } while (rv == 0);
+        printf("FUTEX_WAKE_BITSET i = %d rv = %d\n", i, rv);
         assert(rv == 1);
 
         // Wait for the child thread to exit
-        pid = waitpid(pids[i], NULL, __WALL);
-        if (pid == -1) {
-            perror("waitpid");
+        int ret = pthread_join(thread[i], NULL);
+        if (ret) {
+            errno = ret;
+            perror("pthread_join");
             _exit(3);
         }
-
-        // Free the stack
-        free(stacks[i]);
     }
 
     printf("Woke all kiddos\n");

--- a/LibOS/shim/test/regression/futex.manifest.template
+++ b/LibOS/shim/test/regression/futex.manifest.template
@@ -18,4 +18,5 @@ net.rules.2 = 0.0.0.0:0-65535:127.0.0.1:8000
 
 sgx.trusted_files.ld = file:../../../../Runtime/ld-linux-x86-64.so.2
 sgx.trusted_files.libc = file:../../../../Runtime/libc.so.6
+sgx.trusted_files.libpthread = file:../../../../Runtime/libpthread.so.0
 sgx.thread_num = 4

--- a/Pal/src/pal.h
+++ b/Pal/src/pal.h
@@ -85,21 +85,12 @@ typedef union pal_handle
 
 #endif /* !IN_PAL */
 
-/* TODO: introduce configuration system in long term and
-         make SHIM_TCB_USE_GS easily configurable without source code
-         modification */
-//#define SHIM_TCB_USE_GS 1
-#undef SHIM_TCB_USE_GS
-
-#if defined(IN_PAL) || defined(SHIM_TCB_USE_GS)
 #define PAL_LIBOS_TCB_SIZE  256
 
 typedef struct pal_tcb {
     struct pal_tcb * self;
     /* uint64_t for alignment */
-#ifdef SHIM_TCB_USE_GS
     uint64_t libos_tcb[(PAL_LIBOS_TCB_SIZE + sizeof(uint64_t) - 1) / sizeof(uint64_t)];
-#endif
     /* data private to PAL implementation follows this struct. */
 } PAL_TCB;
 
@@ -111,7 +102,6 @@ static inline PAL_TCB * pal_get_tcb (void)
              : "i" (offsetof(struct pal_tcb, self)));
     return tcb;
 }
-#endif
 
 typedef struct {
 #ifdef __x86_64__


### PR DESCRIPTION
For static binary support, %fs register can't be used for shim tls
because it's already used by libc.
Use part of PAL TCB TLS to stash shim tls.

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md).

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [x] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes (reasons and measures)


## How to test this PR? (if applicable)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/556)
<!-- Reviewable:end -->
