### PR TITLE
[Pal/Linux-SGX] db_misc.c warning

### DIFF
--- a/Pal/src/host/Linux-SGX/db_misc.c
+++ b/Pal/src/host/Linux-SGX/db_misc.c
@@ -59,6 +59,7 @@ int _DkRandomBitsRead (void * buffer, int size)
                     *(uint16_t *)(buffer + i) = rand & 0xffff;
                     i += 2;
                     rand >>= 16;
+                    /* FALLTHROUGH */
                 case 1:
                     *(uint8_t *)(buffer + i) = rand & 0xff;
                     i++;


### PR DESCRIPTION
> db_misc.c: In function _DkRandomBitsRead:
> db_misc.c:64:26: warning: this statement may fall through [-Wimplicit-fallthrough=]
>                      rand >>= 16;
>                      ~~~~~^~~~~~
> db_misc.c:65:17: note: here
>                  case 1:
>                  ^~~~

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md).

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [x] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes (reasons and measures)


## How to test this PR? (if applicable)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/558)
<!-- Reviewable:end -->
