### PR TITLE
[LibOS] shim_async clean up

### DIFF
--- a/LibOS/shim/include/shim_utils.h
+++ b/LibOS/shim/include/shim_utils.h
@@ -237,7 +237,6 @@ int init_async (void);
 int64_t install_async_event (PAL_HANDLE object, unsigned long time,
                               void (*callback) (IDTYPE caller, void * arg),
                               void * arg);
-int create_async_helper (void);
 struct shim_thread * terminate_async_helper (void);
 
 extern struct config_store * root_config;

--- a/LibOS/shim/src/sys/shim_alarm.c
+++ b/LibOS/shim/src/sys/shim_alarm.c
@@ -40,8 +40,12 @@ void signal_alarm (IDTYPE target, void * arg)
 int shim_do_alarm (unsigned int seconds)
 {
     uint64_t usecs = 1000000ULL * seconds;
-    uint64_t usecs_left = install_async_event(NULL, usecs, &signal_alarm, NULL);
-    // Alarm expects the number of seconds remaining.  Round up.
+
+    int64_t ret = install_async_event(NULL, usecs, &signal_alarm, NULL);
+    if (ret < 0)
+        return ret;
+
+    uint64_t usecs_left = (uint64_t) ret;
     int secs = usecs_left / 1000000ULL;
     if (usecs_left % 1000000ULL) secs++;
     return secs;


### PR DESCRIPTION
shim_async_helper() has race conditions and unprotected access.
- next_event can be freed by install_async_event() while sleeping with
  DkObjectsWaitAny(). So the list should be traversed.
- Currently local object list is allocated as 31 + 1 length.  But event
  list can be longer than that. In such case, allocate longer array
  dynamically.
- next_event isn't updated on some execution path
- latest_time isn't updated properly,
- removed ugly gotos.
- This patch also removes suspicious optimization with next_event and
  dynamically lengthen local_object_list when the list becomes long.

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md).

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes (reasons and measures)


## How to test this PR? (if applicable)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/562)
<!-- Reviewable:end -->
