### PR TITLE
[LibOS] pause() exits without waiting

### DIFF
--- a/LibOS/shim/src/sys/shim_sleep.c
+++ b/LibOS/shim/src/sys/shim_sleep.c
@@ -34,18 +34,11 @@
 
 #include <errno.h>
 
-#define SHIM_DEFAULT_SLEEP 1000
-
 int shim_do_pause (void)
 {
-    while (1) {
-        unsigned long ret = DkThreadDelayExecution(SHIM_DEFAULT_SLEEP);
-
-        if (!ret)
-            break;
-    }
-
-    return 0;
+    /* ~0ULL micro sec ~= 805675 years */
+    DkThreadDelayExecution(~((PAL_NUM)0));
+    return -EINTR;
 }
 
 int shim_do_nanosleep (const struct __kernel_timespec * rqtp,

--- a/LibOS/shim/test/native/pause.c
+++ b/LibOS/shim/test/native/pause.c
@@ -1,0 +1,27 @@
+#include <assert.h>
+#include <errno.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+void handler(int signal)
+{
+    printf("hello world\n");
+}
+
+int main(int argc, char ** argv)
+{
+    if (signal(SIGALRM, &handler) < 0)
+        return EXIT_FAILURE;
+
+    if (alarm(1) < 0)
+        return EXIT_FAILURE;
+
+    int ret = pause();
+    assert(ret == -1);
+    assert(errno == EINTR);
+
+    printf("good bye\n");
+    return 0;
+}

--- a/Pal/src/host/FreeBSD/db_threading.c
+++ b/Pal/src/host/FreeBSD/db_threading.c
@@ -85,11 +85,15 @@ int _DkThreadDelayExecution (unsigned long * duration)
     struct timespec sleeptime;
     struct timespec remainingtime;
 
-    long sec = (unsigned long) *duration / 1000000;
-    long microsec = (unsigned long) *duration - (sec * 1000000);
-
-    sleeptime.tv_sec = sec;
-    sleeptime.tv_nsec = microsec * 1000;
+#define VERY_LONG_TIME_IN_US    (1000000L * 60 * 60 * 24 * 365 * 128)
+    if (*duration > VERY_LONG_TIME_IN_US) {
+        /* avoid overflow with time_t */
+        sleeptime.tv_sec  = VERY_LONG_TIME_IN_US / 1000000;
+        sleeptime.tv_nsec = 0;
+    } else {
+        sleeptime.tv_sec = *duration / 1000000;
+        sleeptime.tv_nsec = (*duration - sleeptime.tv_sec * 1000000) * 1000;
+    }
 
     int ret = INLINE_SYSCALL(nanosleep, 2, &sleeptime, &remainingtime);
 

--- a/Pal/src/host/Linux/db_threading.c
+++ b/Pal/src/host/Linux/db_threading.c
@@ -139,11 +139,15 @@ int _DkThreadDelayExecution (unsigned long * duration)
     struct timespec sleeptime;
     struct timespec remainingtime;
 
-    long sec = (unsigned long) *duration / 1000000;
-    long microsec = (unsigned long) *duration - (sec * 1000000);
-
-    sleeptime.tv_sec = sec;
-    sleeptime.tv_nsec = microsec * 1000;
+#define VERY_LONG_TIME_IN_US    (1000000L * 60 * 60 * 24 * 365 * 128)
+    if (*duration > VERY_LONG_TIME_IN_US) {
+        /* avoid overflow with time_t */
+        sleeptime.tv_sec  = VERY_LONG_TIME_IN_US / 1000000;
+        sleeptime.tv_nsec = 0;
+    } else {
+        sleeptime.tv_sec = *duration / 1000000;
+        sleeptime.tv_nsec = (*duration - sleeptime.tv_sec * 1000000) * 1000;
+    }
 
     int ret = INLINE_SYSCALL(nanosleep, 2, &sleeptime, &remainingtime);
 


### PR DESCRIPTION
error of DkDelayExecution call should be checked by PAL_NATIVE_ERRNO.
not return value. and pause return value is always EINTR. not 0.

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md).

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes (reasons and measures)


## How to test this PR? (if applicable)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/565)
<!-- Reviewable:end -->
