### PR TITLE
[LibOS] Properly set shim_dentry.type

### DIFF
--- a/LibOS/shim/src/fs/chroot/fs.c
+++ b/LibOS/shim/src/fs/chroot/fs.c
@@ -228,9 +228,9 @@ static int __query_attr (struct shim_dentry * dent,
     /* need to correct the data type */
     if (data->type == FILE_UNKNOWN)
         switch (pal_attr.handle_type) {
-            case pal_type_file: data->type = FILE_REGULAR;  break;
-            case pal_type_dir:  data->type = FILE_DIR;      break;
-            case pal_type_dev:  data->type = FILE_DEV;      break;
+            case pal_type_file: data->type = FILE_REGULAR; if (dent) dent->type = S_IFREG; break;
+            case pal_type_dir:  data->type = FILE_DIR;     if (dent) dent->type = S_IFDIR; break;
+            case pal_type_dev:  data->type = FILE_DEV;     if (dent) dent->type = S_IFCHR; break;
         }
 
     data->mode = (pal_attr.readable  ? S_IRUSR : 0) |

--- a/LibOS/shim/src/fs/shim_namei.c
+++ b/LibOS/shim/src/fs/shim_namei.c
@@ -541,8 +541,10 @@ int open_namei (struct shim_handle * hdl, struct shim_dentry * start,
         newly_created = 1;
 
         // If we didn't get an error and made a directory, set the dcache dir flag
-        if (flags & O_DIRECTORY)
+        if (flags & O_DIRECTORY) {
             mydent->state |= DENTRY_ISDIRECTORY;
+            mydent->type = S_IFDIR;
+        }
 
         // Once the dentry is creat-ed, drop the negative flag
         mydent->state &= ~DENTRY_NEGATIVE;
@@ -651,6 +653,9 @@ out:
 static inline void set_dirent_type (mode_t * type, int d_type)
 {
     switch (d_type) {
+        case LINUX_DT_DIR:
+            *type = S_IFDIR;
+            return;
         case LINUX_DT_FIFO:
             *type = S_IFIFO;
             return;

--- a/LibOS/shim/src/sys/shim_open.c
+++ b/LibOS/shim/src/sys/shim_open.c
@@ -387,7 +387,7 @@ size_t shim_do_getdents (int fd, struct linux_dirent * buf, size_t count)
             memcpy(b->d_name, name, len + 1);                           \
                                                                         \
             bt->pad = 0;                                                \
-            bt->d_type = type ? : get_dirent_type(dent->mode);          \
+            bt->d_type = type;                                          \
                                                                         \
             b = (void *) bt + sizeof(struct linux_dirent_tail);         \
             bytes += DIRENT_SIZE(len);                                  \
@@ -416,7 +416,7 @@ size_t shim_do_getdents (int fd, struct linux_dirent * buf, size_t count)
         dent = *dirhdl->ptr;
         /* DEP 3/3/17: We need to filter negative dentries */
         if (!(dent->state & DENTRY_NEGATIVE))
-            ASSIGN_DIRENT(dent, dentry_get_name(dent), 0);
+            ASSIGN_DIRENT(dent, dentry_get_name(dent), get_dirent_type(dent->type));
         put_dentry(dent);
         *(dirhdl->ptr++) = NULL;
     }
@@ -484,7 +484,7 @@ size_t shim_do_getdents64 (int fd, struct linux_dirent64 * buf, size_t count)
             b->d_ino = dent->ino;                                       \
             b->d_off = ++dirhdl->offset;                                \
             b->d_reclen = DIRENT_SIZE(len);                             \
-            b->d_type = type ? : get_dirent_type(dent->mode);           \
+            b->d_type = type;                                           \
                                                                         \
             memcpy(b->d_name, name, len + 1);                           \
                                                                         \
@@ -513,7 +513,7 @@ size_t shim_do_getdents64 (int fd, struct linux_dirent64 * buf, size_t count)
         dent = *dirhdl->ptr;
         /* DEP 3/3/17: We need to filter negative dentries */
         if (!(dent->state & DENTRY_NEGATIVE))
-            ASSIGN_DIRENT(dent, dentry_get_name(dent), 0);
+            ASSIGN_DIRENT(dent, dentry_get_name(dent), get_dirent_type(dent->type));
         put_dentry(dent);
         *(dirhdl->ptr++) = NULL;
     }

--- a/LibOS/shim/test/regression/30_getdents.py
+++ b/LibOS/shim/test/regression/30_getdents.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python2
+
+import os, sys, mmap
+from regression import Regression
+
+loader = sys.argv[1]
+
+# Running Bootstrap
+regression = Regression(loader, "getdents", None, 10000)
+
+# This doesn't catch extraneous entries, but should be fine
+# until the LTP test can be run (need symlink support)
+regression.add_check(name="Directory listing (32-bit)",
+    check=lambda res: "getdents: setup ok" in res[0].out and \
+                      "getdents32: . [0x4]" in res[0].out and \
+                      "getdents32: .. [0x4]" in res[0].out and \
+                      "getdents32: file1 [0x8]" in res[0].out and \
+                      "getdents32: file2 [0x8]" in res[0].out and \
+                      "getdents32: dir3 [0x4]" in res[0].out)
+
+regression.add_check(name="Directory listing (64-bit)",
+    check=lambda res: "getdents: setup ok" in res[0].out and \
+                      "getdents64: . [0x4]" in res[0].out and \
+                      "getdents64: .. [0x4]" in res[0].out and \
+                      "getdents64: file1 [0x8]" in res[0].out and \
+                      "getdents64: file2 [0x8]" in res[0].out and \
+                      "getdents64: dir3 [0x4]" in res[0].out)
+
+rv = regression.run_checks()
+if rv: sys.exit(rv)

--- a/LibOS/shim/test/regression/getdents.c
+++ b/LibOS/shim/test/regression/getdents.c
@@ -1,0 +1,92 @@
+#include <dirent.h>
+#include <fcntl.h>
+#include <inttypes.h>
+#include <stdio.h>
+#include <sys/syscall.h>
+
+struct linux_dirent {
+    unsigned long   d_ino;
+    unsigned long   d_off;
+    unsigned short  d_reclen;
+    char            d_name[];
+};
+
+struct linux_dirent64 {
+    uint64_t        d_ino;
+    int64_t         d_off;
+    unsigned short  d_reclen;
+    unsigned char   d_type;
+    char            d_name[];
+};
+
+#define BUF_SIZE 512
+
+int main() {
+    int rv, fd, offs;
+    const mode_t perm = S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH;
+    char buf[BUF_SIZE];
+
+    // setup
+    // We test a directory one level below root so ".." is also present in SGX.
+    rv = mkdir("root", perm);
+    if (rv) { perror ("mkdir 1"); return 1; }
+    rv = mkdir("root/testdir", perm);
+    if (rv) { perror ("mkdir 2"); return 1; }
+    rv = creat("root/testdir/file1", perm);
+    if (rv < 0) { perror ("creat 1"); return 1; }
+    rv = close(rv);
+    if (rv) { perror ("close 1"); return 1; }
+    rv = creat("root/testdir/file2", perm);
+    if (rv < 0) { perror ("creat 2"); return 1; }
+    rv = close(rv);
+    if (rv) { perror ("close 2"); return 1; }
+    rv = mkdir("root/testdir/dir3", perm);
+    if (rv) { perror ("mkdir 3"); return 1; }
+    // enable symlink when implemented, or just use the LTP test
+    // rv = symlink("root/testdir/file2", "root/testdir/link4");
+    // if (rv) { perror ("symlink"); return 1; }
+    printf("getdents: setup ok\n");
+
+    // 32-bit listing
+    fd = open("root/testdir", O_RDONLY | O_DIRECTORY);
+    if (fd < 0) { perror ("open 1"); return 1; }
+
+    while (1) {
+        int count = syscall(SYS_getdents, fd, buf, BUF_SIZE);
+        if (count < 0) { perror ("getdents32"); return 1; }
+        if (count == 0) break;
+        for (offs = 0; offs < count; ) {
+            struct linux_dirent *d32 = (struct linux_dirent *) (buf + offs);
+            char d_type = *(buf + offs + d32->d_reclen - 1);
+            printf("getdents32: %s [0x%x]\n", d32->d_name, d_type);
+            offs += d32->d_reclen;
+        }
+    }
+    rv = close(fd);
+    if (rv) { perror ("close 1"); return 1; }
+
+    // 64-bit listing
+    fd = open("root/testdir", O_RDONLY | O_DIRECTORY);
+    if (fd < 0) { perror ("open 2"); return 1; }
+
+    while (1) {
+        int count = syscall(SYS_getdents64, fd, buf, BUF_SIZE);
+        if (count < 0) { perror ("getdents64"); return 1; }
+        if (count == 0) break;
+        for (offs = 0; offs < count; ) {
+            struct linux_dirent64 *d64 = (struct linux_dirent64 *) (buf + offs);
+            printf("getdents64: %s [0x%x]\n", d64->d_name, d64->d_type);
+            offs += d64->d_reclen;
+        }
+    }
+    rv = close(fd);
+    if (rv) { perror ("close 2"); return 1; }
+
+    // cleanup
+    remove("root/testdir/file1");
+    remove("root/testdir/file2");
+    remove("root/testdir/dir3");
+    remove("root/testdir");
+    remove("root");
+    return 0;
+}

--- a/LibOS/shim/test/regression/getdents.manifest.template
+++ b/LibOS/shim/test/regression/getdents.manifest.template
@@ -1,0 +1,12 @@
+loader.preload = file:$(SHIMPATH)
+loader.env.LD_LIBRARY_PATH = /lib
+loader.debug_type = inline
+
+fs.mount.lib.type = chroot
+fs.mount.lib.path = /lib
+fs.mount.lib.uri = file:$(LIBCDIR)
+
+sgx.trusted_files.ld = file:$(LIBCDIR)/ld-linux-x86-64.so.2
+sgx.trusted_files.libc = file:$(LIBCDIR)/libc.so.6
+
+sgx.allowed_files.test = file:root


### PR DESCRIPTION
Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md).

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes (reasons and measures)
- Properly set `shim_dentry.type` field in all cases (fixes incorrect `d_type` field in directory enumeration).
- Added standalone regression test for `getdents` syscall since the LTP one fails (`symlink` is unimplemented).

## How to test this PR? (if applicable)
- Run the regression test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/569)
<!-- Reviewable:end -->
