### PR TITLE
[Pal/Linux-SGX] Drop hashlib wrapper in pal-sgx-sign

### DIFF
--- a/Pal/src/host/Linux-SGX/signer/pal-sgx-sign
+++ b/Pal/src/host/Linux-SGX/signer/pal-sgx-sign
@@ -397,18 +397,7 @@ def generate_measurement(attr, areas):
         data = struct.pack("<8sQ48s", "EEXTEND", offset, "")
         digest.update(data)
 
-    class mrenclave_digest:
-        def __init__(self):
-            self.digest = hashlib.sha256()
-
-        def update(self, payload):
-            for er in range(0, len(payload), 64):
-                self.digest.update(payload[er:er+64])
-
-        def finalize(self):
-            return self.digest.digest()
-
-    mrenclave = mrenclave_digest()
+    mrenclave = hashlib.sha256()
     do_ecreate(mrenclave, attr['enclave_size'])
 
     def print_area(addr, size, flags, desc, measured):
@@ -512,7 +501,7 @@ def generate_measurement(attr, areas):
                 do_eadd(mrenclave, a, area.flags)
             print_area(area.addr, area.size, area.flags, area.desc, False)
 
-    return mrenclave.finalize()
+    return mrenclave.digest()
 
 """ Generate Sigstruct """
 


### PR DESCRIPTION
## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [x] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes (reasons and measures)

Using hashlib.sha256 directly produces the same result, makes the code
easier to review and significantly faster.

## How to test this PR? (if applicable)

Run SGX regression tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/572)
<!-- Reviewable:end -->
