### PR TITLE
[CI/Testing] Re-enable the PAL unit tests on SGX

### DIFF
--- a/Jenkinsfiles/Linux-SGX
+++ b/Jenkinsfiles/Linux-SGX
@@ -32,7 +32,6 @@ pipeline {
                 }
                 stage('Test') {
                     steps {
-                    /*
                         timeout(time: 15, unit: 'MINUTES') {
                             sh '''
                                 cd Pal/regression
@@ -41,7 +40,6 @@ pipeline {
                                 make SGX_RUN=1 KEEP_LOG=1 regression
                                 '''
                         }
-                        */
                         timeout(time: 5, unit: 'MINUTES') {
                             sh '''
                                 cd LibOS/shim/test/regression


### PR DESCRIPTION
Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md).

## Affected components

- [X] README and global configuration
- [ ] Linux PAL
- [X] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes (reasons and measures)

At some point in trying to bring up CI, the SGX PAL was unstable enough that we couldn't reliably run the PAL unit tests.  They pass when I run them locally, and I think the code is more stable.  If one of them becomes flaky again, we should open an issue and track it.

## How to test this PR? (if applicable)

Normal Jenkins SGX run.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/575)
<!-- Reviewable:end -->
