### PR TITLE
[Pal/Linux-SGX] Don't get PAL load address and name from urts

### DIFF
--- a/Pal/src/host/Linux-SGX/db_main.c
+++ b/Pal/src/host/Linux-SGX/db_main.c
@@ -133,8 +133,8 @@ void pal_linux_main(const char ** arguments, const char ** environments,
     int rv;
 
     /* relocate PAL itself */
-    pal_map.l_addr = (ElfW(Addr)) sec_info->enclave_addr;
-    pal_map.l_name = sec_info->enclave_image;
+    pal_map.l_addr = elf_machine_load_address();
+    pal_map.l_name = ENCLAVE_FILENAME;
     elf_get_dynamic_info((void *) pal_map.l_addr + elf_machine_dynamic(),
                          pal_map.l_info, pal_map.l_addr);
 

--- a/Pal/src/host/Linux-SGX/pal_linux.h
+++ b/Pal/src/host/Linux-SGX/pal_linux.h
@@ -35,6 +35,8 @@
 # include "sysdep-x86_64.h"
 #endif
 
+#define ENCLAVE_FILENAME RUNTIME_FILE("libpal-Linux-SGX.so")
+
 #define IS_ERR INTERNAL_SYSCALL_ERROR
 #define IS_ERR_P INTERNAL_SYSCALL_ERROR_P
 #define ERRNO INTERNAL_SYSCALL_ERRNO

--- a/Pal/src/host/Linux-SGX/pal_security.h
+++ b/Pal/src/host/Linux-SGX/pal_security.h
@@ -30,10 +30,6 @@ struct pal_sec {
     PAL_NUM         instance_id;
     PAL_IDX         ppid, pid, uid, gid;
 
-    /* file name of enclave image */
-    PAL_PTR         enclave_addr;
-    PAL_SEC_STR     enclave_image;
-
     /* enclave information */
     sgx_arch_hash_t         mrenclave;
     sgx_arch_hash_t         mrsigner;

--- a/Pal/src/host/Linux-SGX/sgx_main.c
+++ b/Pal/src/host/Linux-SGX/sgx_main.c
@@ -18,8 +18,6 @@
 #include <sysdep.h>
 #include <sysdeps/generic/ldsodefs.h>
 
-#define ENCLAVE_FILENAME RUNTIME_FILE("libpal-Linux-SGX.so")
-
 unsigned long pagesize  = PRESET_PAGESIZE;
 unsigned long pagemask  = ~(PRESET_PAGESIZE - 1);
 unsigned long pageshift = PRESET_PAGESIZE - 1;
@@ -467,8 +465,6 @@ int initialize_enclave (struct pal_enclave * enclave)
 
     struct pal_sec * pal_sec = &enclave->pal_sec;
 
-    pal_sec->enclave_addr = (PAL_PTR) (enclave_secs.baseaddr + pal_area->addr);
-
     pal_sec->heap_min = (void *) enclave_secs.baseaddr + heap_min;
     pal_sec->heap_max = (void *) enclave_secs.baseaddr + pal_area->addr - MEMORY_GAP;
 
@@ -770,9 +766,6 @@ static int load_enclave (struct pal_enclave * enclave,
     ret = initialize_enclave(enclave);
     if (ret < 0)
         return ret;
-
-    snprintf(pal_sec->enclave_image,  sizeof(PAL_SEC_STR), "%s",
-             ENCLAVE_FILENAME);
 
     if (!pal_sec->instance_id)
         create_instance(&enclave->pal_sec);


### PR DESCRIPTION
## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [x] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes (reasons and measures)

Don't get PAL load address and name from urts. Part of issue #509.

Should I also drop `enclave_addr` and `enclave_image` from the `pal_sec` struct, since they are now effectively unused? I'm in favor of doing so, but I'm not sure since `pal_sec` is used both as argument passing from urts to enclave as well as global PAL state.

## How to test this PR? (if applicable)

Run SGX regression test to see that it doesn't break things.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/577)
<!-- Reviewable:end -->
