### PR TITLE
[Pal/Linux-SGX] segv in ocall udp_connect()

### DIFF
--- a/Pal/src/host/Linux-SGX/sgx_enclave.c
+++ b/Pal/src/host/Linux-SGX/sgx_enclave.c
@@ -375,7 +375,7 @@ static int sgx_ocall_sock_connect(void * pms)
     }
 
     fd = ret;
-    if (ms->ms_addr->sa_family == AF_INET6) {
+    if (ms->ms_addr && ms->ms_addr->sa_family == AF_INET6) {
         int ipv6only = 1;
         INLINE_SYSCALL(setsockopt, 5, fd, SOL_IPV6, IPV6_V6ONLY, &ipv6only,
                        sizeof(int));


### PR DESCRIPTION
in sgx_ocall_sock_connect() ms->ms_addr can be NULL. add NULL check.

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md).

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [x] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes (reasons and measures)


## How to test this PR? (if applicable)
LibOS/shim/test/native/udp

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/579)
<!-- Reviewable:end -->
