### PR TITLE
[Pal/Linux-SGX] Don't get manifest addr/size from urts

### DIFF
--- a/Pal/src/host/Linux-SGX/generated-offsets.c
+++ b/Pal/src/host/Linux-SGX/generated-offsets.c
@@ -69,6 +69,7 @@ void dummy(void)
     OFFSET(SGX_OCALL_PREPARED, enclave_tls, ocall_prepared);
     OFFSET(SGX_ECALL_CALLED, enclave_tls, ecall_called);
     OFFSET(SGX_READY_FOR_EXCEPTIONS, enclave_tls, ready_for_exceptions);
+    OFFSET(SGX_MANIFEST_SIZE, enclave_tls, manifest_size);
 
     /* sgx_arch_tcs_t */
     OFFSET_T(TCS_OSSA, sgx_arch_tcs_t, ossa);

--- a/Pal/src/host/Linux-SGX/pal_security.h
+++ b/Pal/src/host/Linux-SGX/pal_security.h
@@ -43,10 +43,7 @@ struct pal_sec {
     PAL_PTR         exec_addr;
     PAL_NUM         exec_size;
 
-    /* manifest name, addr and size */
     PAL_SEC_STR     manifest_name;
-    PAL_PTR         manifest_addr;
-    PAL_NUM         manifest_size;
 
     /* need three proc fds if it has a parent */
     PAL_IDX         proc_fds[3];

--- a/Pal/src/host/Linux-SGX/sgx_tls.h
+++ b/Pal/src/host/Linux-SGX/sgx_tls.h
@@ -20,6 +20,7 @@ struct enclave_tls {
     uint64_t ocall_prepared;
     uint64_t ecall_called;
     uint64_t ready_for_exceptions;
+    uint64_t manifest_size;
 };
 
 #ifndef DEBUG

--- a/Pal/src/host/Linux-SGX/sgx_tls.h
+++ b/Pal/src/host/Linux-SGX/sgx_tls.h
@@ -4,6 +4,12 @@
 #ifndef __SGX_TLS_H__
 #define __SGX_TLS_H__
 
+/*
+ * Beside the classic thread local storage (like ustack, thread, etc.) the TLS
+ * area is also used to pass parameters needed during enclave or thread
+ * initialization. Some of them are thread specific (like tcs_offset) and some
+ * of them are identical for all threads (like enclave_size).
+ */
 struct enclave_tls {
     uint64_t enclave_size;
     uint64_t tcs_offset;

--- a/Pal/src/host/Linux-SGX/signer/pal-sgx-sign
+++ b/Pal/src/host/Linux-SGX/signer/pal-sgx-sign
@@ -386,6 +386,7 @@ def baseaddr():
         return 0
 
 def gen_area_content(attr, areas):
+    manifest_area = find_area(areas, 'manifest')
     exec_area = find_area(areas, 'exec', True)
     pal_area = find_area(areas, 'pal')
     ssa_area = find_area(areas, 'ssa')
@@ -427,6 +428,7 @@ def gen_area_content(attr, areas):
         set_tls_field(t, SGX_INITIAL_STACK_OFFSET, stacks[t].addr + stacks[t].size)
         set_tls_field(t, SGX_SSA, ssa)
         set_tls_field(t, SGX_GPR, ssa + SSAFRAMESIZE - SGX_GPR_SIZE)
+        set_tls_field(t, SGX_MANIFEST_SIZE, os.stat(manifest_area.file).st_size)
 
     tcs_area.content = tcs_data
     tls_area.content = tls_data


### PR DESCRIPTION
## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [x] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes (reasons and measures)

Don't get manifest addr/size from urts.

Instead we use the fact that the manifest is always placed at the top of
the enclave address range. The manifest size is stored inside the TLS
like we have already done for the enclave size.

Part of issue #509.

Depends on PR #573 to make sense.

## How to test this PR? (if applicable)

Run SGX regression test to see that it doesn't break things.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/580)
<!-- Reviewable:end -->
