### PR TITLE
[LibOS] set_tid_address() sets the address to clear tid on thread exit

### DIFF
--- a/LibOS/shim/src/sys/shim_getpid.c
+++ b/LibOS/shim/src/sys/shim_getpid.c
@@ -57,8 +57,9 @@ pid_t shim_do_getppid (void)
 
 int shim_do_set_tid_address (int * tidptr)
 {
+    /* http://man7.org/linux/man-pages/man2/set_tid_address.2.html */
     struct shim_thread * cur = get_cur_thread();
-    cur->set_child_tid = tidptr;
+    cur->clear_child_tid = tidptr;
     return cur->tid;
 }
 


### PR DESCRIPTION
Not the address to set tid on thread creation.

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md).

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes (reasons and measures)


## How to test this PR? (if applicable)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/581)
<!-- Reviewable:end -->
