### PR TITLE
[Pal/Linux-SGX] Drop effectively unused manifest/exec fd

### DIFF
--- a/Pal/src/host/Linux-SGX/enclave_framework.c
+++ b/Pal/src/host/Linux-SGX/enclave_framework.c
@@ -645,7 +645,7 @@ int init_trusted_files (void)
     ssize_t cfgsize;
     int nuris, ret;
 
-    if (pal_sec.exec_fd != PAL_IDX_POISON) {
+    if (pal_sec.exec_name[0] != '\0') {
         ret = init_trusted_file("exec", pal_sec.exec_name);
         if (ret < 0)
             goto out;

--- a/Pal/src/host/Linux-SGX/pal_security.h
+++ b/Pal/src/host/Linux-SGX/pal_security.h
@@ -40,13 +40,11 @@ struct pal_sec {
 
     /* executable name, addr and size */
     PAL_SEC_STR     exec_name;
-    PAL_IDX         exec_fd;
     PAL_PTR         exec_addr;
     PAL_NUM         exec_size;
 
     /* manifest name, addr and size */
     PAL_SEC_STR     manifest_name;
-    PAL_IDX         manifest_fd;
     PAL_PTR         manifest_addr;
     PAL_NUM         manifest_size;
 

--- a/Pal/src/host/Linux-SGX/sgx_main.c
+++ b/Pal/src/host/Linux-SGX/sgx_main.c
@@ -770,14 +770,11 @@ static int load_enclave (struct pal_enclave * enclave,
     if (!pal_sec->instance_id)
         create_instance(&enclave->pal_sec);
 
-    pal_sec->manifest_fd = enclave->manifest;
     memcpy(pal_sec->manifest_name, manifest_uri, strlen(manifest_uri) + 1);
 
     if (enclave->exec == -1) {
-        pal_sec->exec_fd = PAL_IDX_POISON;
         memset(pal_sec->exec_name, 0, sizeof(PAL_SEC_STR));
     } else {
-        pal_sec->exec_fd = enclave->exec;
         memcpy(pal_sec->exec_name, exec_uri, strlen(exec_uri) + 1);
     }
 


### PR DESCRIPTION
## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [x] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes (reasons and measures)

exec_fd and manifest_fd were already mostly unused. Drop them to make it
more obvious that they are never used to read the executable or
manifest from the urts.

Part of issue #509.

## How to test this PR? (if applicable)

Run SGX regression tests to see that it doesn't break things.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/582)
<!-- Reviewable:end -->
