### PR TITLE
[LibOS] debug_fputch buffer overflow

### DIFF
--- a/LibOS/shim/src/utils/printf.c
+++ b/LibOS/shim/src/utils/printf.c
@@ -50,10 +50,9 @@ debug_fputch (void * f, int ch, void * b)
     buf->buf[buf->end++] = ch;
 
     if (ch == '\n') {
-        if (debug_fputs(NULL, buf->buf, buf->end) == -1)
-            return -1;
+        int ret = debug_fputs(NULL, buf->buf, buf->end);
         buf->end = buf->start;
-        return 0;
+        return ret;
     }
 
 #if DEBUGBUF_BREAK == 1
@@ -69,6 +68,7 @@ debug_fputch (void * f, int ch, void * b)
 #else
     if (buf->end == DEBUGBUF_SIZE) {
         debug_fputs(NULL, buf->buf, buf->end);
+        buf->end = buf->start;
     }
 #endif
 


### PR DESCRIPTION
When debug buf reached to the end, it should be reset to the start after
output.
This can happen with string longer than 255.
debug_printf("%s",
"string-without-newline-longer-than-debug_buf-DEBUGBUF_SIZE=255"...);

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md).

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes (reasons and measures)


## How to test this PR? (if applicable)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/585)
<!-- Reviewable:end -->
