### PR TITLE
[LibOS] start.S: remove unnecessary movq

### DIFF
--- a/LibOS/shim/src/start.S
+++ b/LibOS/shim/src/start.S
@@ -53,8 +53,7 @@ shim_start:
     pushq %rbp
     movq %rsp, %rdx
 
-    movq shim_init@GOTPCREL(%rip), %r11
-    call *%r11
+    callq *shim_init@GOTPCREL(%rip)
 
     popq %rbp
     leaveq


### PR DESCRIPTION
callq can take memory address directly.
it's unnecesary to load the address to register.

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md).

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes (reasons and measures)


## How to test this PR? (if applicable)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/586)
<!-- Reviewable:end -->
