### PR TITLE
[Pal/Linux-SGX] Don't get exec addr/size from urts

### DIFF
--- a/Pal/src/host/Linux-SGX/db_main.c
+++ b/Pal/src/host/Linux-SGX/db_main.c
@@ -215,6 +215,9 @@ void pal_linux_main(char * uptr_args, uint64_t args_size,
         return;
     }
 
+    pal_sec.exec_addr = GET_ENCLAVE_TLS(exec_addr);
+    pal_sec.exec_size = GET_ENCLAVE_TLS(exec_size);
+
     /* Zero the heap. We need to take care to not zero the exec area. */
 
     void* zero1_start = sec_info.heap_min;
@@ -223,9 +226,9 @@ void pal_linux_main(char * uptr_args, uint64_t args_size,
     void* zero2_start = sec_info.heap_max;
     void* zero2_end = sec_info.heap_max;
 
-    if (sec_info.exec_addr != NULL) {
-        zero1_end = MIN(zero1_end, sec_info.exec_addr);
-        zero2_start = MIN(zero2_start, sec_info.exec_addr + sec_info.exec_size);
+    if (pal_sec.exec_addr != NULL) {
+        zero1_end = MIN(zero1_end, pal_sec.exec_addr);
+        zero2_start = MIN(zero2_start, pal_sec.exec_addr + pal_sec.exec_size);
     }
 
     memset(zero1_start, 0, zero1_end - zero1_start);
@@ -290,10 +293,6 @@ void pal_linux_main(char * uptr_args, uint64_t args_size,
     /* TODO: remove with PR #589 */
     pal_sec.heap_min = sec_info.heap_min;
     pal_sec.heap_max = sec_info.heap_max;
-
-    /* TODO: remove with PR #588 */
-    pal_sec.exec_addr = sec_info.exec_addr;
-    pal_sec.exec_size = sec_info.exec_size;
 
     /* set up page allocator and slab manager */
     init_slab_mgr(pagesz);

--- a/Pal/src/host/Linux-SGX/generated-offsets.c
+++ b/Pal/src/host/Linux-SGX/generated-offsets.c
@@ -70,6 +70,8 @@ void dummy(void)
     OFFSET(SGX_ECALL_CALLED, enclave_tls, ecall_called);
     OFFSET(SGX_READY_FOR_EXCEPTIONS, enclave_tls, ready_for_exceptions);
     OFFSET(SGX_MANIFEST_SIZE, enclave_tls, manifest_size);
+    OFFSET(SGX_EXEC_ADDR, enclave_tls, exec_addr);
+    OFFSET(SGX_EXEC_SIZE, enclave_tls, exec_size);
 
     /* sgx_arch_tcs_t */
     OFFSET_T(TCS_OSSA, sgx_arch_tcs_t, ossa);

--- a/Pal/src/host/Linux-SGX/sgx_main.c
+++ b/Pal/src/host/Linux-SGX/sgx_main.c
@@ -423,6 +423,10 @@ int initialize_enclave (struct pal_enclave * enclave)
                 gs->gpr = gs->ssa +
                     enclave->ssaframesize - sizeof(sgx_arch_gpr_t);
                 gs->manifest_size = manifest_size;
+                if (exec_area) {
+                    gs->exec_addr = (void *) enclave_secs.baseaddr + exec_area->addr;
+                    gs->exec_size = exec_area->size;
+                }
             }
         } else if (strcmp_static(areas[i].desc, "tcs")) {
             data = (void *) INLINE_SYSCALL(mmap, 6, NULL, areas[i].size,
@@ -467,11 +471,6 @@ int initialize_enclave (struct pal_enclave * enclave)
 
     pal_sec->heap_min = (void *) enclave_secs.baseaddr + heap_min;
     pal_sec->heap_max = (void *) enclave_secs.baseaddr + pal_area->addr - MEMORY_GAP;
-
-    if (exec_area) {
-        pal_sec->exec_addr = (void *) enclave_secs.baseaddr + exec_area->addr;
-        pal_sec->exec_size = exec_area->size;
-    }
 
     struct enclave_dbginfo * dbg = (void *)
             INLINE_SYSCALL(mmap, 6, DBGINFO_ADDR,

--- a/Pal/src/host/Linux-SGX/sgx_tls.h
+++ b/Pal/src/host/Linux-SGX/sgx_tls.h
@@ -27,6 +27,8 @@ struct enclave_tls {
     uint64_t ecall_called;
     uint64_t ready_for_exceptions;
     uint64_t manifest_size;
+    void *   exec_addr;
+    uint64_t exec_size;
 };
 
 #ifndef DEBUG

--- a/Pal/src/host/Linux-SGX/signer/pal-sgx-sign
+++ b/Pal/src/host/Linux-SGX/signer/pal-sgx-sign
@@ -429,6 +429,9 @@ def gen_area_content(attr, areas):
         set_tls_field(t, SGX_SSA, ssa)
         set_tls_field(t, SGX_GPR, ssa + SSAFRAMESIZE - SGX_GPR_SIZE)
         set_tls_field(t, SGX_MANIFEST_SIZE, os.stat(manifest_area.file).st_size)
+        if exec_area is not None:
+            set_tls_field(t, SGX_EXEC_ADDR, baseaddr() + exec_area.addr)
+            set_tls_field(t, SGX_EXEC_SIZE, exec_area.size)
 
     tcs_area.content = tcs_data
     tls_area.content = tls_data


### PR DESCRIPTION
## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [x] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes (reasons and measures)

Don't get exec addr/size from urts.
Instead pass them through the measured TLS.

Part of issue #509.

This depends on #573 (but is based on master to make the reviewable.io diff more useful).

I will cleanup the argument handling of `pal_linux_main` in a separate PR, which will also remove the TOCTOU bug which this change has, because is uses `sec_info`.

## How to test this PR? (if applicable)

Run regression tests to see that it doesn't break things.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/588)
<!-- Reviewable:end -->
