### PR TITLE
[Pal/Linux-SGX] Don't get heap min/max from urts

### DIFF
--- a/Pal/src/host/Linux-SGX/db_main.c
+++ b/Pal/src/host/Linux-SGX/db_main.c
@@ -215,16 +215,18 @@ void pal_linux_main(char * uptr_args, uint64_t args_size,
         return;
     }
 
+    pal_sec.heap_min = GET_ENCLAVE_TLS(heap_min);
+    pal_sec.heap_max = GET_ENCLAVE_TLS(heap_max);
     pal_sec.exec_addr = GET_ENCLAVE_TLS(exec_addr);
     pal_sec.exec_size = GET_ENCLAVE_TLS(exec_size);
 
     /* Zero the heap. We need to take care to not zero the exec area. */
 
-    void* zero1_start = sec_info.heap_min;
-    void* zero1_end = sec_info.heap_max;
+    void* zero1_start = pal_sec.heap_min;
+    void* zero1_end = pal_sec.heap_max;
 
-    void* zero2_start = sec_info.heap_max;
-    void* zero2_end = sec_info.heap_max;
+    void* zero2_start = pal_sec.heap_max;
+    void* zero2_end = pal_sec.heap_max;
 
     if (pal_sec.exec_addr != NULL) {
         zero1_end = MIN(zero1_end, pal_sec.exec_addr);
@@ -289,10 +291,6 @@ void pal_linux_main(char * uptr_args, uint64_t args_size,
     pal_sec.uid = sec_info.uid;
     pal_sec.gid = sec_info.gid;
 
-
-    /* TODO: remove with PR #589 */
-    pal_sec.heap_min = sec_info.heap_min;
-    pal_sec.heap_max = sec_info.heap_max;
 
     /* set up page allocator and slab manager */
     init_slab_mgr(pagesz);

--- a/Pal/src/host/Linux-SGX/generated-offsets.c
+++ b/Pal/src/host/Linux-SGX/generated-offsets.c
@@ -70,6 +70,8 @@ void dummy(void)
     OFFSET(SGX_ECALL_CALLED, enclave_tls, ecall_called);
     OFFSET(SGX_READY_FOR_EXCEPTIONS, enclave_tls, ready_for_exceptions);
     OFFSET(SGX_MANIFEST_SIZE, enclave_tls, manifest_size);
+    OFFSET(SGX_HEAP_MIN, enclave_tls, heap_min);
+    OFFSET(SGX_HEAP_MAX, enclave_tls, heap_max);
     OFFSET(SGX_EXEC_ADDR, enclave_tls, exec_addr);
     OFFSET(SGX_EXEC_SIZE, enclave_tls, exec_size);
 

--- a/Pal/src/host/Linux-SGX/sgx_main.c
+++ b/Pal/src/host/Linux-SGX/sgx_main.c
@@ -423,6 +423,8 @@ int initialize_enclave (struct pal_enclave * enclave)
                 gs->gpr = gs->ssa +
                     enclave->ssaframesize - sizeof(sgx_arch_gpr_t);
                 gs->manifest_size = manifest_size;
+                gs->heap_min = (void *) enclave_secs.baseaddr + heap_min;
+                gs->heap_max = (void *) enclave_secs.baseaddr + pal_area->addr - MEMORY_GAP;
                 if (exec_area) {
                     gs->exec_addr = (void *) enclave_secs.baseaddr + exec_area->addr;
                     gs->exec_size = exec_area->size;
@@ -466,11 +468,6 @@ int initialize_enclave (struct pal_enclave * enclave)
 
     create_tcs_mapper((void *) enclave_secs.baseaddr + tcs_area->addr,
                       enclave->thread_num);
-
-    struct pal_sec * pal_sec = &enclave->pal_sec;
-
-    pal_sec->heap_min = (void *) enclave_secs.baseaddr + heap_min;
-    pal_sec->heap_max = (void *) enclave_secs.baseaddr + pal_area->addr - MEMORY_GAP;
 
     struct enclave_dbginfo * dbg = (void *)
             INLINE_SYSCALL(mmap, 6, DBGINFO_ADDR,

--- a/Pal/src/host/Linux-SGX/sgx_tls.h
+++ b/Pal/src/host/Linux-SGX/sgx_tls.h
@@ -27,6 +27,8 @@ struct enclave_tls {
     uint64_t ecall_called;
     uint64_t ready_for_exceptions;
     uint64_t manifest_size;
+    void *   heap_min;
+    void *   heap_max;
     void *   exec_addr;
     uint64_t exec_size;
 };

--- a/Pal/src/host/Linux-SGX/signer/pal-sgx-sign
+++ b/Pal/src/host/Linux-SGX/signer/pal-sgx-sign
@@ -429,6 +429,8 @@ def gen_area_content(attr, areas):
         set_tls_field(t, SGX_SSA, ssa)
         set_tls_field(t, SGX_GPR, ssa + SSAFRAMESIZE - SGX_GPR_SIZE)
         set_tls_field(t, SGX_MANIFEST_SIZE, os.stat(manifest_area.file).st_size)
+        set_tls_field(t, SGX_HEAP_MIN, baseaddr() + enclave_heap_min)
+        set_tls_field(t, SGX_HEAP_MAX, baseaddr() + enclave_heap_max)
         if exec_area is not None:
             set_tls_field(t, SGX_EXEC_ADDR, baseaddr() + exec_area.addr)
             set_tls_field(t, SGX_EXEC_SIZE, exec_area.size)


### PR DESCRIPTION
## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [x] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes (reasons and measures)

Don't get heap min/max from urts
Instead pass them through the measured TLS.

Part of issue #509.

This depends on #573 (but is based on master to make the reviewable.io diff more useful).

I will cleanup the argument handling of `pal_linux_main` in a separate PR, which will also remove the TOCTOU bug which this change has, because is uses `sec_info`.

## How to test this PR? (if applicable)

Run SGX regression tests to see that it doesn't break things.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/589)
<!-- Reviewable:end -->
