### PR TITLE
bugfix: shim_do_poll incorrectly setting revents wrt POLLERR and POLLHUP

### DIFF
--- a/LibOS/shim/src/sys/shim_poll.c
+++ b/LibOS/shim/src/sys/shim_poll.c
@@ -420,7 +420,7 @@ int shim_do_poll (struct pollfd * fds, nfds_t nfds, int timeout)
         if (polls[i].flags & RET_W)
             fds[i].revents |= (fds[i].events & (POLLOUT|POLLWRNORM));
         if (polls[i].flags & RET_E)
-            fds[i].revents |= (fds[i].events & (POLLERR|POLLHUP));
+            fds[i].revents |= (POLLERR|POLLHUP);
 
         if (fds[i].revents)
             ret++;


### PR DESCRIPTION
Fixes #389.

The function shim_do_poll has an error on the line that reads:

    fds[i].revents |= (fds[i].events & (POLLERR|POLLHUP));

Per the manpage, POLLERR and POLLUP are returned in `revents` and
ingnored in `events`.  Indeed, programs hsould not be setting, and
typically don't set -- `events` with these values.

The effect of this bug is, among others, that a process will never get a
disconnect evetn fro a peer socket.

Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md).

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [X] Library OS (i.e., SHIM), including GLIBC

## Description of the changes (reasons and measures)
Change shim_do_poll to obey POSIX semantics with regard to returning POLLERR and POLLUP regardless of whether the descriptor had them set as events.

## How to test this PR? (if applicable)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/592)
<!-- Reviewable:end -->
