### PR TITLE
bugfix: Listenign unix domain socket pipeid likely always 0.

### DIFF
--- a/LibOS/shim/src/sys/shim_socket.c
+++ b/LibOS/shim/src/sys/shim_socket.c
@@ -504,7 +504,7 @@ int shim_do_bind (int sockfd, struct sockaddr * addr, socklen_t addrlen)
 
         struct shim_unix_data * data = malloc(sizeof(struct shim_unix_data));
 
-        data->pipeid = dent->rel_path.hash >> 32;
+        data->pipeid = dent->rel_path.hash;
         sock->addr.un.pipeid = data->pipeid;
         sock->addr.un.data = data;
         sock->addr.un.dentry = dent;
@@ -769,7 +769,7 @@ int shim_do_connect (int sockfd, struct sockaddr * addr, int addrlen)
 
         if (!(dent->state & DENTRY_VALID) || dent->state & DENTRY_NEGATIVE) {
             data = malloc(sizeof(struct shim_unix_data));
-            data->pipeid = dent->rel_path.hash >> 32;
+            data->pipeid = dent->rel_path.hash;
         } else if (dent->fs != &socket_builtin_fs) {
             ret = -ECONNREFUSED;
             goto out;


### PR DESCRIPTION
This is issue #390 on the Graphene project.

In the function shim_do_bind, if the socket has type AF_UNIX, its pipe
id is set to:

    data->pipeid = dent->rel_path.hash >> 32;

It seems that fs/shm_fs_hash.c's hash_one() function returns a 32-bit
hash, depsite having a return type of uint64_t (at least, empirically
this seems to be the case -- I haven't worked through the actual
code), after the bit shift, the listening socket has a pipeid of 0.  The
result is that a process can have only one listening unix domain socket.

I changed the statement to simply omit the bitshfit:

    data->pipeid = dent->rel_path.hash;

There is a similar one line change in shim_do_connect when connecting
to a UNIX domain socket and setting the pipeid for the connection.

Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md).

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes (reasons and measures)


## How to test this PR? (if applicable)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/593)
<!-- Reviewable:end -->
