### PR TITLE
bugfix: ocall_sock_send and ocall_sock_recv can overflow stack.

### DIFF
--- a/Pal/src/host/Linux-SGX/enclave_ocalls.c
+++ b/Pal/src/host/Linux-SGX/enclave_ocalls.c
@@ -219,7 +219,7 @@ int ocall_read (int fd, void * buf, unsigned int count)
     int retval = 0;
     void * obuf = NULL;
 
-    if (count > 4096) {
+    if (count > PRESET_PAGESIZE) {
         retval = ocall_alloc_untrusted(ALLOC_ALIGNUP(count), &obuf);
         if (IS_ERR(retval))
             return retval;
@@ -252,7 +252,7 @@ int ocall_write (int fd, const void * buf, unsigned int count)
     int retval = 0;
     void * obuf = NULL;
 
-    if (count > 4096) {
+    if (count > PRESET_PAGESIZE) {
         retval = ocall_alloc_untrusted(ALLOC_ALIGNUP(count), &obuf);
         if (IS_ERR(retval))
             return retval;
@@ -584,7 +584,7 @@ int ocall_sock_recv (int sockfd, void * buf, unsigned int count,
     void *obuf = NULL;
     unsigned int len = addrlen ? *addrlen : 0;
 
-    if ((count + len) > 4096) {
+    if ((count + len) > PRESET_PAGESIZE) {
         retval = ocall_alloc_untrusted(ALLOC_ALIGNUP(count), &obuf);
         if (retval < 0)
             return retval;
@@ -631,7 +631,7 @@ int ocall_sock_send (int sockfd, const void * buf, unsigned int count,
     int retval = 0;
     void *obuf = NULL;
 
-    if ((count + addrlen) > 4096) {
+    if ((count + addrlen) > PRESET_PAGESIZE) {
         retval = ocall_alloc_untrusted(ALLOC_ALIGNUP(count), &obuf);
         if (retval < 0)
             return retval;


### PR DESCRIPTION
Fixes #442.

In Pal/src/host/Linux/SGX/encalve_ocalls.c, the ocall_sock_recv and
ocall_sock_send will copy the respective buffer arguments to the
untrusted host process by adjusing the stack.  In the case of
ocall_sock_recv, this occurs in the line

    ms->ms_buf = ALLOC_IN_USER(buf, count);

and in the case of ocall_sock_send, the line

    ms->ms_buf = COPY_TO_USER(buf, count);

Note that both ALLOC_IN_USER and COPY_TO_USER will eventually call
enclave_framework.c's sgx_ocalloc function, which adjusts the stack.

The problem, of course, is that if if the buffer is too big, the stack
will overflow.

The fix is to apply the same check that ocall_read and ocall_write do;
that is, if the buffer to be allocated is too large to fit on the stack,
call ocall_alloc_untursted to allocate som untrusted heap memory.

Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md).

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [X] Library OS (i.e., SHIM), including GLIBC

## Description of the changes (reasons and measures)


## How to test this PR? (if applicable)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/594)
<!-- Reviewable:end -->
