### PR TITLE
bugfix: fix shim_fs.c's BEGIN_CP_FUNC

### DIFF
--- a/LibOS/shim/src/fs/shim_fs.c
+++ b/LibOS/shim/src/fs/shim_fs.c
@@ -561,9 +561,8 @@ BEGIN_CP_FUNC(mount)
         off = ADD_CP_OFFSET(sizeof(struct shim_mount));
         ADD_TO_CP_MAP(obj, off);
 
-        if (!mount->cpdata &&
-            mount->fs_ops &&
-            mount->fs_ops->checkpoint) {
+        mount->cpdata = NULL;
+        if (mount->fs_ops && mount->fs_ops->checkpoint) {
             void * cpdata = NULL;
             int bytes = mount->fs_ops->checkpoint(&cpdata, mount->data);
             if (bytes > 0) {


### PR DESCRIPTION
## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes (reasons and measures)

The mount->cpdata field is not reset to NULL; hence, the checkpoint callback is only called the first time a process forks.
Fixes #595.

## How to test this PR? (if applicable)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/596)
<!-- Reviewable:end -->
