### PR TITLE
[LibOS] remove unused struct un_conn in shim_socket.c

### DIFF
--- a/LibOS/shim/src/sys/shim_socket.c
+++ b/LibOS/shim/src/sys/shim_socket.c
@@ -651,12 +651,6 @@ static int inet_parse_addr (int domain, int type, const char * uri,
     return 0;
 }
 
-struct un_conn {
-    unsigned int pipeid;
-    unsigned char path_size;
-    char path[];
-} __attribute__((packed));
-
 int shim_do_listen (int sockfd, int backlog)
 {
     if (backlog < 0)


### PR DESCRIPTION
struct un_conn isn't used anywhere. So remove it.

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md).

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes (reasons and measures)


## How to test this PR? (if applicable)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/599)
<!-- Reviewable:end -->
