### PR TITLE
[LibOS] glibc: make shim_tcb_t in glibc tcb compile time option

### DIFF
--- a/LibOS/Makefile
+++ b/LibOS/Makefile
@@ -59,6 +59,14 @@ GLIBC_PATCHES = \
 	glibc-fix-warning.patch \
 	glibc-no-pie.patch
 
+# TODO: configuration
+# SHIM_TCB_USE_GS=yes
+SHIM_TCB_USE_GS=
+ifneq (SHIM_THREAD_USE_GS, "yes")
+GLIBC_PATCHES += \
+    glibc-add-shim-tcb.patch
+endif
+
 $(GLIBC_SRC)/configure: $(GLIBC_PATCHES) Makefile
 	[ -f $(GLIBC_SRC).tar.gz ] || \
 	for MIRROR in $(GLIBC_MIRRORS); do \

--- a/LibOS/Makefile
+++ b/LibOS/Makefile
@@ -62,7 +62,7 @@ GLIBC_PATCHES = \
 # TODO: configuration
 # SHIM_TCB_USE_GS=yes
 SHIM_TCB_USE_GS=
-ifneq (SHIM_THREAD_USE_GS, "yes")
+ifneq (SHIM_TCB_USE_GS, "yes")
 GLIBC_PATCHES += \
     glibc-add-shim-tcb.patch
 endif

--- a/LibOS/glibc-2.19.patch
+++ b/LibOS/glibc-2.19.patch
@@ -1350,25 +1350,6 @@ index cbb5e9e..9b87e25 100644
  
  /* Replacement type for __m128 since this file is included by ld.so,
     which is compiled with -mno-sse.  It must not change the alignment
-@@ -67,6 +69,10 @@ typedef struct
- # else
-   int __glibc_reserved1;
- # endif
-+
-+  shim_tcb_t shim_tcb;	/* For graphene, we allocate a shim_tcb
-+			   in the real tcb. */
-+
-   int rtld_must_xmm_save;
-   /* Reservation of some values for the TM ABI.  */
-   void *__private_tm[4];
-@@ -137,7 +143,6 @@ typedef struct
- # define GET_DTV(descr) \
-   (((tcbhead_t *) (descr))->dtv)
- 
--
- /* Code to initially initialize the thread pointer.  This might need
-    special attention since 'errno' is not yet available and if the
-    operation can cause a failure 'errno' must not be touched.
 @@ -154,7 +159,7 @@ typedef struct
       _head->self = _thrdescr;						      \
  									      \

--- a/LibOS/glibc-add-shim-tcb.patch
+++ b/LibOS/glibc-add-shim-tcb.patch
@@ -1,0 +1,15 @@
+diff --git a/nptl/sysdeps/x86_64/tls.h b/nptl/sysdeps/x86_64/tls.h
+index cbb5e9e..9b87e25 100644
+--- a/nptl/sysdeps/x86_64/tls.h
++++ b/nptl/sysdeps/x86_64/tls.h
+@@ -67,6 +67,10 @@ typedef struct
+ # else
+   int __glibc_reserved1;
+ # endif
++
++  shim_tcb_t shim_tcb;	/* For graphene, we allocate a shim_tcb
++			   in the real tcb. */
++
+   int rtld_must_xmm_save;
+   /* Reservation of some values for the TM ABI.  */
+   void *__private_tm[4];


### PR DESCRIPTION
This is a follow up patch of #556.
https://github.com/oscarlab/graphene/pull/556
With #556, LibOS doesn't always stash libos tcb into glibc tcb
depending on compile time option.
This patch makes it compile time option to add shim_tcb_t to glibc tcb.
So make it optional to embed shim_tcb_t into glibc tcb.

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md).

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes (reasons and measures)


## How to test this PR? (if applicable)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/601)
<!-- Reviewable:end -->
