### PR TITLE
[LibOS] use static inline function instead of cpp macro

### DIFF
--- a/LibOS/shim/include/shim_internal.h
+++ b/LibOS/shim/include/shim_internal.h
@@ -42,14 +42,20 @@
 #include <atomic.h>
 #include <shim_tls.h>
 
-/* important macros */
-#define get_cur_tid()           (shim_get_tls()->tid)
+/* important macros and static inline functions */
+static inline unsigned int get_cur_tid(void)
+{
+    return shim_get_tls()->tid;
+}
+
 #define PAL_NATIVE_ERRNO        (shim_get_tls()->pal_errno)
 
 #define INTERNAL_TID_BASE       ((IDTYPE) 1 << (sizeof(IDTYPE) * 8 - 1))
-#define IS_INTERNAL_TID(tid)    ((tid) >= INTERNAL_TID_BASE)
-#define IS_INTERNAL(thread)     ((thread)->tid >= INTERNAL_TID_BASE)
-#define TID_PRINTFMT
+
+static inline bool is_internal_tid(unsigned int tid)
+{
+    return tid >= INTERNAL_TID_BASE;
+}
 
 struct debug_buf {
     int start;
@@ -467,24 +473,44 @@ static inline void enable_preempt (shim_tcb_t * tcb)
 
 #define DEBUG_LOCK      0
 
-#define lock_created(l)  ((l).lock != NULL)
+static inline bool __lock_created(LOCKTYPE * l)
+{
+    return l->lock != NULL;
+}
 
-#define clear_lock(l)  do { (l).lock = NULL; (l).owner = 0; } while (0)
+#define lock_created(l)  __lock_created(&(l))
 
-#define create_lock(l)                          \
-    do {                                        \
-        (l).lock = DkMutexCreate(0);               \
-        /* (l).owner = LOCK_FREE;               */ \
-        /* (l).reowned = 0;                     */ \
-    } while (0)
+static inline void __clear_lock(LOCKTYPE * l)
+{
+    l->lock = NULL;
+    l->owner = 0;
+}
 
-#define destroy_lock(l)                         \
-    do {                                        \
-        DkObjectClose((l).lock);                \
-    } while (0)
+#define clear_lock(l)  __clear_lock(&(l))
 
-#define try_create_lock(l)              \
-    do { if (!lock_created(l)) create_lock(l); } while (0)
+static inline void __create_lock(LOCKTYPE * l)
+{
+    l->lock = DkMutexCreate(0);
+    /* l->owner = LOCK_FREE; */
+    /* l->reowned = 0; */
+}
+
+#define create_lock(l)  __create_lock(&(l))
+
+static inline void __destroy_lock(LOCKTYPE * l)
+{
+    DkObjectClose(l->lock);
+}
+
+#define destroy_lock(l) __destroy_lock(&(l))
+
+static inline void ____try_create_lock(LOCKTYPE * l)
+{
+    if (!__lock_created(l))
+        __create_lock(l);
+}
+
+#define try_create_lock(l)  ____try_create_lock(&(l))
 
 #if DEBUG_LOCK == 1
 # define lock(l) __lock(&(l), #l, __FILE__, __LINE__)
@@ -583,9 +609,15 @@ static inline void create_event (AEVENTTYPE * e)
                                 PAL_OPTION_NONBLOCK);
 }
 
-#define event_created(e)    ((e)->event != NULL)
+static inline bool event_created (AEVENTTYPE * e)
+{
+    return e->event != NULL;
+}
 
-#define event_handle(e)     ((e)->event)
+static inline PAL_HANDLE event_handle (AEVENTTYPE * e)
+{
+    return e->event;
+}
 
 static inline void destroy_event (AEVENTTYPE * e)
 {
@@ -708,9 +740,11 @@ void __system_free (void * addr, size_t size);
 extern void * migrated_memory_start;
 extern void * migrated_memory_end;
 
-#define MEMORY_MIGRATED(mem)                                    \
-        ((void *) (mem) >= migrated_memory_start &&             \
-         (void *) (mem) < migrated_memory_end)
+static inline bool memory_migrated(void * mem)
+{
+    return mem >= migrated_memory_start && mem < migrated_memory_end;
+}
+
 
 extern void * __load_address, * __load_address_end;
 extern void * __code_address, * __code_address_end;
@@ -742,12 +776,12 @@ extern const char ** initial_envp;
         _stack;                                                     \
     })
 
-#define current_stack()                                             \
-    ({                                                              \
-        void * _rsp;                                                \
-        asm volatile ("movq %%rsp, %0" : "=r"(_rsp) :: "memory");   \
-        _rsp;                                                       \
-    })
+static_always_inline void * current_stack(void)
+{
+    void * _rsp;
+    asm volatile ("movq %%rsp, %0" : "=r"(_rsp) :: "memory");
+    return _rsp;
+}
 
 void get_brk_region (void ** start, void ** end, void ** current);
 

--- a/LibOS/shim/include/shim_thread.h
+++ b/LibOS/shim/include/shim_thread.h
@@ -136,6 +136,11 @@ static inline struct shim_thread * save_shim_thread_self(struct shim_thread * __
      return __self;
 }
 
+static inline bool is_internal(struct shim_thread *thread)
+{
+    return thread->tid >= INTERNAL_TID_BASE;
+}
+
 void get_thread (struct shim_thread * thread);
 void put_thread (struct shim_thread * thread);
 void get_simple_thread (struct shim_simple_thread * thread);
@@ -192,7 +197,7 @@ void set_cur_thread (struct shim_thread * thread)
         thread->tcb = container_of(tcb, __libc_tcb_t, shim_tcb);
         tid = thread->tid;
 
-        if (!IS_INTERNAL(thread) && !thread->signal_logs)
+        if (!is_internal(thread) && !thread->signal_logs)
             thread->signal_logs = malloc(sizeof(struct shim_signal_log) *
                                          NUM_SIGS);
     } else if (tcb->tp) {

--- a/LibOS/shim/src/bookkeep/shim_handle.c
+++ b/LibOS/shim/src/bookkeep/shim_handle.c
@@ -520,7 +520,7 @@ static void destroy_handle (struct shim_handle * hdl)
 {
     destroy_lock(hdl->lock);
 
-    if (MEMORY_MIGRATED(hdl))
+    if (memory_migrated(hdl))
         memset(hdl, 0, sizeof(struct shim_handle));
     else
         free_mem_obj_to_mgr(handle_mgr, hdl);

--- a/LibOS/shim/src/bookkeep/shim_thread.c
+++ b/LibOS/shim/src/bookkeep/shim_thread.c
@@ -148,7 +148,7 @@ static IDTYPE get_internal_pid (void)
     internal_tid_alloc_idx++;
     IDTYPE idx = internal_tid_alloc_idx;
     unlock(thread_list_lock);
-    assert(IS_INTERNAL_TID(idx));
+    assert(is_internal_tid(idx));
     return idx;
 }
 
@@ -326,7 +326,7 @@ void put_thread (struct shim_thread * thread)
         if (thread->exec)
             put_handle(thread->exec);
 
-        if (!IS_INTERNAL(thread))
+        if (!is_internal(thread))
             release_pid(thread->tid);
 
         if (thread->pal_handle &&
@@ -387,7 +387,7 @@ void set_as_child (struct shim_thread * parent,
 
 void add_thread (struct shim_thread * thread)
 {
-    if (IS_INTERNAL(thread) || !list_empty(thread, list))
+    if (is_internal(thread) || !list_empty(thread, list))
         return;
 
     struct shim_thread * tmp, * prev = NULL;
@@ -415,7 +415,7 @@ void del_thread (struct shim_thread * thread)
     debug("del_thread(%p, %d, %ld)\n", thread, thread ? thread->tid : -1,
           atomic_read(&thread->ref_count));
 
-    if (IS_INTERNAL(thread) || list_empty(thread, list)) {
+    if (is_internal(thread) || list_empty(thread, list)) {
         debug("del_thread: internal\n");
         return;
     }

--- a/LibOS/shim/src/shim_malloc.c
+++ b/LibOS/shim/src/shim_malloc.c
@@ -222,7 +222,7 @@ extern_alias(calloc);
 void * realloc(void * ptr, size_t new_size)
 {
     /* TODO: We can't deal with this case right now */
-    assert(!MEMORY_MIGRATED(ptr));
+    assert(!memory_migrated(ptr));
 
     size_t old_size = slab_get_buf_size(slab_mgr, ptr);
 
@@ -287,7 +287,7 @@ void free (void * mem)
 {
     if (!mem)
         return;
-    if (MEMORY_MIGRATED(mem)) {
+    if (memory_migrated(mem)) {
         INC_PROFILE_OCCURENCE(free_migrated);
         return;
     }

--- a/LibOS/shim/src/sys/shim_exit.c
+++ b/LibOS/shim/src/sys/shim_exit.c
@@ -68,7 +68,7 @@ int thread_exit(struct shim_thread * self, bool send_ipc)
     int exit_code = self->exit_code;
     self->is_alive = false;
 
-    if (IS_INTERNAL(self))
+    if (is_internal(self))
         goto out;
 
     struct shim_handle_map * handle_map = self->handle_map;
@@ -170,7 +170,7 @@ int shim_do_exit_group (int error_code)
 {
     INC_PROFILE_OCCURENCE(syscall_use_ipc);
     struct shim_thread * cur_thread = get_cur_thread();
-    assert(!IS_INTERNAL(cur_thread));
+    assert(!is_internal(cur_thread));
 
     if (debug_handle)
         sysparser_printf("---- shim_exit_group (returning %d)\n", error_code);
@@ -200,7 +200,7 @@ int shim_do_exit (int error_code)
 {
     INC_PROFILE_OCCURENCE(syscall_use_ipc);
     struct shim_thread * cur_thread = get_cur_thread();
-    assert(!IS_INTERNAL(cur_thread));
+    assert(!is_internal(cur_thread));
 
     if (debug_handle)
         sysparser_printf("---- shim_exit (returning %d)\n", error_code);

--- a/LibOS/shim/src/utils/printf.c
+++ b/LibOS/shim/src/utils/printf.c
@@ -134,7 +134,7 @@ void debug_setprefix (shim_tcb_t * tcb)
     struct debug_buf * buf = tcb->debug_buf;
     buf->start = buf->end = 0;
 
-    if (tcb->tid && !IS_INTERNAL_TID(tcb->tid))
+    if (tcb->tid && !is_internal_tid(tcb->tid))
         fprintfmt(debug_fputch, NULL, buf, TID_PREFIX, tcb->tid);
     else if (cur_process.vmid)
         fprintfmt(debug_fputch, NULL, buf, VMID_PREFIX,

--- a/LibOS/shim/src/utils/strobjs.c
+++ b/LibOS/shim/src/utils/strobjs.c
@@ -57,7 +57,7 @@ int free_str_obj (struct shim_str * str)
     if (str == NULL)
         return 0;
 
-    if (MEMORY_MIGRATED(str)) {
+    if (memory_migrated(str)) {
         memset(str, 0, sizeof(struct shim_str));
         return 0;
     }


### PR DESCRIPTION
Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md).

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes (reasons and measures)


## How to test this PR? (if applicable)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/603)
<!-- Reviewable:end -->
