### PR TITLE
[Pal/Linux-SGX] Makefile.Test processes comment out lines

### DIFF
--- a/Pal/src/host/Linux-SGX/Makefile.Test
+++ b/Pal/src/host/Linux-SGX/Makefile.Test
@@ -23,7 +23,7 @@ $(SGX_SIGNER_KEY):
 	$(error "Cannot find any enclave key. Generate $(abspath $(SGX_SIGNER_KEY)) or specify 'SGX_SIGNER_KEY=' with make")
 
 prerequisite = \
-	for f in `grep -Po 'sgx.trusted_children.[^\\s=]+\\s*=\\s*file:\\K\\S+' $(1)`; do \
+	for f in `sed -e 's/\#.*//g' $(1) | grep -Po 'sgx.trusted_children.[^\\s=]+\\s*=\\s*file:\\K\\S+'`; do \
 		$(MAKE) $${f%.sig}.manifest.sgx; \
 	done
 


### PR DESCRIPTION
Makefile.Test unnecessarily recreates .manifest.sgx of
commented sgx.trusted_children because it processes commented
lines in .manifest.sgx.
Teach Makefile.Test to skip commented out lines. in .manifest.sgx.

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md).

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [x] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes (reasons and measures)


## How to test this PR? (if applicable)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/607)
<!-- Reviewable:end -->
