### PR TITLE
[Pal] Use size_t instead of int for size parameter

### DIFF
--- a/Pal/src/host/FreeBSD/db_memory.c
+++ b/Pal/src/host/FreeBSD/db_memory.c
@@ -36,7 +36,7 @@
 #include <sys/sysctl.h>
 #include <sys/vmmeter.h>
 
-bool _DkCheckMemoryMappable (const void * addr, int size)
+bool _DkCheckMemoryMappable (const void * addr, size_t size)
 {
     return (addr <= DATA_END && addr + size >= TEXT_START);
 }

--- a/Pal/src/host/Linux-SGX/db_memory.c
+++ b/Pal/src/host/Linux-SGX/db_memory.c
@@ -46,7 +46,7 @@ static struct pal_vma {
 static unsigned int pal_nvmas = 0;
 static struct spinlock pal_vma_lock;
 
-bool _DkCheckMemoryMappable (const void * addr, int size)
+bool _DkCheckMemoryMappable (const void * addr, size_t size)
 {
     if (addr < DATA_END && addr + size > TEXT_START) {
         printf("address %p-%p is not mappable\n", addr, addr + size);

--- a/Pal/src/host/Linux/db_memory.c
+++ b/Pal/src/host/Linux/db_memory.c
@@ -35,7 +35,7 @@
 #include <asm/mman.h>
 #include <asm/fcntl.h>
 
-bool _DkCheckMemoryMappable (const void * addr, int size)
+bool _DkCheckMemoryMappable (const void * addr, size_t size)
 {
     return (addr < DATA_END && addr + size > TEXT_START);
 }

--- a/Pal/src/host/Skeleton/db_memory.c
+++ b/Pal/src/host/Skeleton/db_memory.c
@@ -30,7 +30,7 @@
 #include "pal_debug.h"
 #include "api.h"
 
-bool _DkCheckMemoryMappable (const void * addr, int size)
+bool _DkCheckMemoryMappable (const void * addr, size_t size)
 {
     return true;
 }

--- a/Pal/src/pal_internal.h
+++ b/Pal/src/pal_internal.h
@@ -267,7 +267,7 @@ void pal_main (
 unsigned long _DkGetPagesize (void);
 unsigned long _DkGetAllocationAlignment (void);
 void _DkGetAvailableUserAddressRange (PAL_PTR * start, PAL_PTR * end);
-bool _DkCheckMemoryMappable (const void * addr, int size);
+bool _DkCheckMemoryMappable (const void * addr, size_t size);
 PAL_NUM _DkGetProcessId (void);
 PAL_NUM _DkGetHostId (void);
 unsigned long _DkMemoryQuota (void);


### PR DESCRIPTION
Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md).

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [X] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes (reasons and measures)
- Changed `size` parameter type of `_DkCheckMemoryMappable` from `int` to `uint64_t` to enable using large memory chunks (`int` overflowed).

## How to test this PR? (if applicable)
Run regression tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/608)
<!-- Reviewable:end -->
