### PR TITLE
[Scripts/regression] Treat timeouts as failure

### DIFF
--- a/Scripts/regression.py
+++ b/Scripts/regression.py
@@ -81,7 +81,7 @@ class Regression:
                 for (name, check, ignore_failure, times) in self.runs[combined_args]:
                     if run_times == times:
                         result = check(outputs)
-                        if result:
+                        if not timed_out and result:
                             print '\033[92m[Success       ]\033[0m', name
                         else:
                             if ignore_failure:


### PR DESCRIPTION
## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes (reasons and measures)

[Scripts/regression] Treat timeouts as failure

## How to test this PR? (if applicable)

Modify a regression test to output the expected text but never terminate. This should be treated as test failed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/610)
<!-- Reviewable:end -->
