### PR TITLE
[Pal/Linux-SGX] signer should retrieve mrenclave from .sig

### DIFF
--- a/Pal/src/host/Linux-SGX/signer/pal-sgx-sign
+++ b/Pal/src/host/Linux-SGX/signer/pal-sgx-sign
@@ -252,6 +252,8 @@ def get_trusted_children(manifest, args):
             raise Exception('repeated key in manifest: sgx.trusted_children.' + key)
 
         target = resolve_uri(val)
+        if not target.endswith('.sig'):
+            target += '.sig'
         sig = open(target, 'rb').read()[960:992].encode('hex')
         targets[key] = (val, target, sig)
 


### PR DESCRIPTION
The current logic tries to retrieve mrenclave from target executable.
It should get it from .sig.

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md).

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [x] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes (reasons and measures)


## How to test this PR? (if applicable)
LibOS/shim/test/native/exec_fork

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/613)
<!-- Reviewable:end -->
