### PR TITLE
[LibOS/test/native] add manifest template to make exec_fork, script work

### DIFF
--- a/LibOS/shim/test/native/exec_fork.manifest.template
+++ b/LibOS/shim/test/native/exec_fork.manifest.template
@@ -14,17 +14,11 @@ fs.mount.bin.uri = file:/bin
 sys.brk.size = 32M
 sys.stack.size = 4M
 
-# allow to bind on port 8000
-net.allow_bind.1 = 127.0.0.1:8000
-# allow to connect to port 8000
-net.allow_peer.1 = 127.0.0.1:8000
-
-# sgx-related
 sgx.trusted_files.ld = file:$(LIBCDIR)/ld-linux-x86-64.so.2
 sgx.trusted_files.libc = file:$(LIBCDIR)/libc.so.6
 sgx.trusted_files.libdl = file:$(LIBCDIR)/libdl.so.2
 sgx.trusted_files.libm = file:$(LIBCDIR)/libm.so.6
 sgx.trusted_files.libpthread = file:$(LIBCDIR)/libpthread.so.0
 
-sgx.trusted_files.unix_pipe = file:unix.c
-sgx.trusted_files.tcp_c = file:tcp.c
+sgx.trusted_files.fork = file:fork
+sgx.trusted_children.fork = file:fork.sig

--- a/LibOS/shim/test/native/script.manifest.template
+++ b/LibOS/shim/test/native/script.manifest.template
@@ -14,17 +14,14 @@ fs.mount.bin.uri = file:/bin
 sys.brk.size = 32M
 sys.stack.size = 4M
 
-# allow to bind on port 8000
-net.allow_bind.1 = 127.0.0.1:8000
-# allow to connect to port 8000
-net.allow_peer.1 = 127.0.0.1:8000
-
-# sgx-related
 sgx.trusted_files.ld = file:$(LIBCDIR)/ld-linux-x86-64.so.2
 sgx.trusted_files.libc = file:$(LIBCDIR)/libc.so.6
 sgx.trusted_files.libdl = file:$(LIBCDIR)/libdl.so.2
 sgx.trusted_files.libm = file:$(LIBCDIR)/libm.so.6
 sgx.trusted_files.libpthread = file:$(LIBCDIR)/libpthread.so.0
 
-sgx.trusted_files.unix_pipe = file:unix.c
-sgx.trusted_files.tcp_c = file:tcp.c
+sgx.trusted_files.script1_sh = file:script1.sh
+sgx.trusted_files.script2_sh = file:script2.sh
+sgx.trusted_files.script3_sh = file:script3.sh
+sgx.trusted_files.helloworld = file:helloworld
+sgx.trusted_children.helloworld = file:helloworld.sig


### PR DESCRIPTION
tcp reads tcp.c. this patch also adds it to manifest.template to make tcp work.

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md).

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes (reasons and measures)


## How to test this PR? (if applicable)
LibOS/shim/test/native/{exec_fork, script, tcp}

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/614)
<!-- Reviewable:end -->
