### PR TITLE
[Pal] show file name on config file error

### DIFF
--- a/Pal/src/db_main.c
+++ b/Pal/src/db_main.c
@@ -337,8 +337,11 @@ has_manifest:
         root_config->free = free;
 
         const char * errstring = NULL;
-        if ((ret = read_config(root_config, loader_filter, &errstring)) < 0)
+        if ((ret = read_config(root_config, loader_filter, &errstring)) < 0) {
+            if (_DkStreamGetName(manifest_handle, uri_buf, URI_MAX) > 0)
+                printf("reading manifest \"%s\" failed\n", uri_buf);
             init_fail(-ret, errstring);
+        }
 
         pal_state.root_config = root_config;
 


### PR DESCRIPTION
When pal hit error in config file, show the file name for user.
Sometimes it's difficult to identify corresponding config file
when fork/exec are involved.

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md).

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [x] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes (reasons and measures)


## How to test this PR? (if applicable)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/615)
<!-- Reviewable:end -->
