### PR TITLE
[*/regression] Use uniform and cleaner SGX environment check

### DIFF
--- a/LibOS/shim/test/regression/30_mmap.py
+++ b/LibOS/shim/test/regression/30_mmap.py
@@ -2,10 +2,7 @@ import os, sys, mmap
 from regression import Regression
 
 loader = sys.argv[1]
-try:
-    sgx = os.environ['SGX_RUN']
-except KeyError:
-    sgx = False
+sgx = os.environ.get('SGX_RUN') == '1'
 
 # Running Bootstrap
 regression = Regression(loader, "mmap-file", None, 60000)

--- a/Pal/regression/00_Atomics.py
+++ b/Pal/regression/00_Atomics.py
@@ -3,7 +3,6 @@ from regression import Regression
 
 loader = os.environ['PAL_LOADER']
 is_sgx = 'SGX_RUN' in os.environ and os.environ['SGX_RUN'] == '1'
-success = True
 
 def manifest_file(file):
     if is_sgx:

--- a/Pal/regression/00_Atomics.py
+++ b/Pal/regression/00_Atomics.py
@@ -2,10 +2,10 @@ import os, sys, mmap
 from regression import Regression
 
 loader = os.environ['PAL_LOADER']
-is_sgx = 'SGX_RUN' in os.environ and os.environ['SGX_RUN'] == '1'
+sgx = os.environ.get('SGX_RUN') == '1'
 
 def manifest_file(file):
-    if is_sgx:
+    if sgx:
         return file + '.manifest.sgx'
     else:
         return file + '.manifest'

--- a/Pal/regression/00_Bootstrap.py
+++ b/Pal/regression/00_Bootstrap.py
@@ -2,13 +2,10 @@ import os, sys, mmap
 from regression import Regression
 
 loader = os.environ['PAL_LOADER']
-try:
-    sgx = os.environ['SGX_RUN']
-except KeyError:
-    sgx = False
+sgx = os.environ.get('SGX_RUN') == '1'
 
 def manifest_file(file):
-    if 'SGX_RUN' in os.environ and os.environ['SGX_RUN'] == '1':
+    if sgx:
         return file + '.manifest.sgx'
     else:
         return file + '.manifest'

--- a/Pal/regression/02_Memory.py
+++ b/Pal/regression/02_Memory.py
@@ -2,10 +2,7 @@ import os, sys, mmap
 from regression import Regression
 
 loader = os.environ['PAL_LOADER']
-try:
-    sgx = os.environ['SGX_RUN']
-except KeyError:
-    sgx = 0
+sgx = os.environ.get('SGX_RUN') == '1'
 
 regression = Regression(loader, "Memory")
 

--- a/Pal/regression/04_Ipc.py
+++ b/Pal/regression/04_Ipc.py
@@ -2,10 +2,7 @@ import os, sys, mmap
 from regression import Regression
 
 loader = os.environ['PAL_LOADER']
-try:
-    sgx = os.environ['SGX_RUN']
-except KeyError:
-    sgx = 0
+sgx = os.environ.get('SGX_RUN') == '1'
 
 if sgx:
     print("Bulk IPC not supported on SGX")

--- a/Pal/regression/06_AvxDisable.py
+++ b/Pal/regression/06_AvxDisable.py
@@ -3,7 +3,7 @@ from regression import Regression
 
 loader = os.environ['PAL_LOADER']
 
-sgx = os.environ.get('SGX_RUN', False)
+sgx = os.environ.get('SGX_RUN') == '1'
 
 def manifest_file(file):
     if sgx:


### PR DESCRIPTION
## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [x] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes (reasons and measures)

[*/regression] Use uniform and cleaner SGX environment check

As suggested by @yamahata in PR #612.

## How to test this PR? (if applicable)

Run Pal/shim regression tests. SGX detection should still work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/616)
<!-- Reviewable:end -->
