### PR TITLE
[.dir-locals.el] add makefile-mode and asm-mode

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -3,5 +3,7 @@
          (fill-column . 100)))
  (c-mode . ((c-file-style . "k&r")
             (c-basic-offset . 4)))
+ (makefile-mode . ((indent-tabs-mode . t)))
+ (asm-mode . ((indent-tabs-mode . t)))
  ((nil . ((truncate-lines . t)))
           (text-mode . ((eval . ((turn-on-auto-fill)))))))


### PR DESCRIPTION
For Makefile, tab is needed.
For .S file, tab is used. (one exception is shim/src/syscall.S. other .S uses tab)

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md).

## Affected components

- [x] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes (reasons and measures)


## How to test this PR? (if applicable)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/617)
<!-- Reviewable:end -->
