### PR TITLE
[Pal/Linux-SGX] Set PAL_ERRNO to PAL_ERROR_INTERRUPTED

### DIFF
--- a/Pal/src/host/Linux-SGX/db_exception.c
+++ b/Pal/src/host/Linux-SGX/db_exception.c
@@ -410,6 +410,11 @@ void _DkHandleExternalEvent (PAL_NUM event, sgx_context_t * uc)
         arch_store_frame(&frame->arch);
     }
 
+    /* We only end up in _DkHandleExternalEvent() if interrupted during
+     * host syscall; Dk* function will be unwound, so we must inform LibOS
+     * layer that PAL was interrupted (by setting PAL_ERRNO). */
+    _DkRaiseFailure(PAL_ERROR_INTERRUPTED);
+
     if (!_DkGenericSignalHandle(event, 0, frame, NULL)
         && event != PAL_EVENT_RESUME)
         _DkThreadExit();


### PR DESCRIPTION
## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [x] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes (reasons and measures)

Set PAL_ERRNO to PAL_ERROR_INTERRUPTED when interrupted by host signal.

Current Linux-SGX PAL signal handling unwinds all inner PAL frames if host signal interrupts Graphene while it waits on a long syscall. Because PAL frames are unwound, all inner logic of PAL setting `PAL_ERRNO = PAL_ERROR_INTERRUPTED` (using the `_DkRaiseFailure()` flow) is skipped. This PR retrofits this logic.

This particular bug was found in `LibOS/shim/test/apps/lmbench/lmbench-2.5/bin/linux/bw_tcp` test under SGX.

## How to test this PR? (if applicable)

Execute the test case `TCP socket bandwidth` of lmbench under Linux-SGX PAL. If manually:
```sh
lmbench-2.5/bin/linux$ SGX=1 ./pal_loader ./bw_tcp -s  # start server in one window
lmbench-2.5/bin/linux$ SGX=1 ./pal_loader ./bw_tcp 127.0.0.1  # start client in another window
# wait till client finishes talking to server
lmbench-2.5/bin/linux$ SGX=1 ./pal_loader ./bw_tcp -127.0.0.1  # start client again to terminate server
```

Without this PR, the server will crash after the second command because its own child process will send SIGCHLD while its parent process waits on `accept4()`. This will lead to incorrect PAL unwinding without setting a corresponding PAL_ERRNO.

With this PR, the test must finish correctly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/618)
<!-- Reviewable:end -->
