### PR TITLE
[LibOS] Check return values of init_brk*() calls

### DIFF
--- a/LibOS/shim/include/shim_internal.h
+++ b/LibOS/shim/include/shim_internal.h
@@ -753,6 +753,8 @@ void get_brk_region (void ** start, void ** end, void ** current);
 
 int init_randgen (void);
 int reset_brk (void);
+struct shim_handle;
+int init_brk_from_executable (struct shim_handle * exec);
 int init_brk_region (void * brk_region);
 int init_heap (void);
 int init_internal_map (void);

--- a/LibOS/shim/src/elf/shim_rtld.c
+++ b/LibOS/shim/src/elf/shim_rtld.c
@@ -1481,8 +1481,6 @@ int init_internal_map (void)
     return 0;
 }
 
-int init_brk_from_executable (struct shim_handle * exec);
-
 int init_loader (void)
 {
     struct shim_thread * cur_thread = get_cur_thread();

--- a/LibOS/shim/src/elf/shim_rtld.c
+++ b/LibOS/shim/src/elf/shim_rtld.c
@@ -1509,7 +1509,11 @@ int init_loader (void)
         exec_map = __search_map_by_handle(exec);
     }
 
-    init_brk_from_executable(exec);
+    ret = init_brk_from_executable(exec);
+    if (ret < 0) {
+        debug("init_brk_from_executable failed: %d\n", ret);
+        goto out;
+    }
 
     if (!interp_map
         && __need_interp(exec_map)
@@ -1531,7 +1535,12 @@ int init_brk_from_executable (struct shim_handle * exec)
          * Chia-Che 8/24/2017:
          * initialize brk region at the end of the executable data segment.
          */
-        init_brk_region((void *) ALIGN_UP(exec_map->l_map_end));
+        void *ptr = (void *) ALIGN_UP(exec_map->l_map_end);
+        int ret = init_brk_region(ptr);
+        if (ret < 0) {
+            debug("init_brk_region(%p) failed: %d\n", ptr, ret);
+            return ret;
+        }
     }
 
     return 0;

--- a/LibOS/shim/src/sys/shim_exec.c
+++ b/LibOS/shim/src/sys/shim_exec.c
@@ -180,7 +180,12 @@ retry_dump_vmas:
     if ((ret = load_elf_object(cur_thread->exec, NULL, 0)) < 0)
         shim_terminate();
 
-    init_brk_from_executable(cur_thread->exec);
+    ret = init_brk_from_executable(cur_thread->exec);
+    if (ret < 0) {
+        debug("init_brk_from_executable failed: %d\n", ret);
+        return ret;
+    }
+
     load_elf_interp(cur_thread->exec);
 
     SAVE_PROFILE_INTERVAL(load_new_executable_for_exec);

--- a/LibOS/shim/src/sys/shim_exec.c
+++ b/LibOS/shim/src/sys/shim_exec.c
@@ -71,8 +71,6 @@ static elf_auxv_t *  new_auxp;
 
 #define REQUIRED_ELF_AUXV       6
 
-int init_brk_from_executable (struct shim_handle * exec);
-
 int shim_do_execve_rtld (struct shim_handle * hdl, const char ** argv,
                          const char ** envp)
 {


### PR DESCRIPTION
Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md).

## Affected components

- [ ] README and global configuration
- [X] Linux PAL
- [x] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes (reasons and measures)
- Properly check return values of `init_brk_from_executable()` and `init_brk_region()` calls.
- This is related to https://github.com/oscarlab/graphene/issues/431

## How to test this PR? (if applicable)
Run regression  tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/619)
<!-- Reviewable:end -->
