### PR TITLE
[Pal/Linux-SGX] clear flags register on eexit

### DIFF
--- a/Pal/src/host/Linux-SGX/enclave_entry.S
+++ b/Pal/src/host/Linux-SGX/enclave_entry.S
@@ -1,6 +1,11 @@
 #include "sgx_arch.h"
 #include "asm-offsets.h"
 
+.macro CLEAR_FLAGS
+	movb $0, %ah
+	sahf
+.endm
+
 # In some cases, like bogus parameters passed to enclave_entry, it's tricky to
 # return cleanly (passing the correct return address to EEXIT, OCALL_EXIT can
 # be interrupted, etc.). Since those cases should only ever happen with a
@@ -117,6 +122,7 @@ enclave_entry:
 	# clear the registers
 	xorq %rdi, %rdi
 	xorq %rsi, %rsi
+	CLEAR_FLAGS
 
 	# exit address in RDX, mov it to RBX
 	movq %rdx, %rbx
@@ -219,6 +225,7 @@ enclave_entry:
 	# clear the registers
 	xorq %rdi, %rdi
 	xorq %rsi, %rsi
+	CLEAR_FLAGS
 
 	# exit address in RDX, mov it to RBX
 	movq %rdx, %rbx
@@ -275,6 +282,7 @@ sgx_ocall:
 	xorq %r14, %r14
 	xorq %r15, %r15
 	xorq %rbp, %rbp
+	CLEAR_FLAGS
 
 	movq %rsp, %gs:SGX_STACK
 


### PR DESCRIPTION
on eexit, flags register should be cleared to avoid information leak.

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md).

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [x] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes (reasons and measures)


## How to test this PR? (if applicable)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/621)
<!-- Reviewable:end -->
