### PR TITLE
[Pal/Linux-SGX] Clear "extented state" (FPU regs & co) before EEXIT

### DIFF
--- a/Pal/src/host/Linux-SGX/asm-offsets.c
+++ b/Pal/src/host/Linux-SGX/asm-offsets.c
@@ -2,6 +2,7 @@
 
 #include "sgx_arch.h"
 #include "sgx_tls.h"
+#include "pal_security.h"
 
 #include <asm-offsets-build.h>
 
@@ -68,5 +69,11 @@ void dummy(void)
 
     /* sgx_arch_tcs_t */
     DEFINE(TCS_SIZE, sizeof(sgx_arch_tcs_t));
+
+    /* sgx_arch_attributes_t */
+    OFFSET_T(SGX_ARCH_ATTRIBUTES_XFRM, sgx_arch_attributes_t, xfrm);
+
+    /* struct pal_sec */
+    OFFSET(PAL_SEC_ENCLAVE_ATTRIBUTES, pal_sec, enclave_attributes);
 }
 

--- a/Pal/src/host/Linux-SGX/enclave_entry.S
+++ b/Pal/src/host/Linux-SGX/enclave_entry.S
@@ -120,8 +120,8 @@ enclave_entry:
 
 	# exit address in RDX, mov it to RBX
 	movq %rdx, %rbx
-	movq $EEXIT, %rax
-	ENCLU
+
+	jmp .Lclear_and_eexit
 
 .Lhandle_exception:
 	# If this enclave thread has not been initialized yet, we should not
@@ -226,9 +226,36 @@ enclave_entry:
 
 	# exit address in RDX, mov it to RBX
 	movq %rdx, %rbx
+	# fallthrough
+
+	# Clear other registers and similar state and then call EEXIT
+	#
+	# Arguments for EEXIT/untrusted code (not cleared):
+	#
+	#     %rbx: exit target
+	#     %rsp: untrusted stack
+	#     %rdi, %rsi: (optional) arguments to untrusted code.
+.Lclear_and_eexit:
+	# %rax is argument to EEXIT
+	# %rbx is argument to EEXIT
+	# %rcx is set to AEP by EEXIT
+	xorq %rdx, %rdx
+	# %rsi, %rdi are arguments to the untrusted code
+	xorq %rbp, %rbp
+	# %rsp points to untrusted stack
+	xorq %r8, %r8
+	xorq %r9, %r9
+	xorq %r10, %r10
+	xorq %r11, %r11
+	xorq %r12, %r12
+	xorq %r13, %r13
+	xorq %r14, %r14
+	subq %r15, %r15 # use sub to set flags to a fixed value
+
 	movq $EEXIT, %rax
 	ENCLU
 
+	ud2 # We should never get here.
 
 	.global sgx_ocall
 	.type sgx_ocall, @function
@@ -268,17 +295,6 @@ sgx_ocall:
 
 	movq $1, %gs:SGX_OCALL_PREPARED
 
-	xorq %rdx, %rdx
-	xorq %r8, %r8
-	xorq %r9, %r9
-	xorq %r10, %r10
-	xorq %r11, %r11
-	xorq %r12, %r12
-	xorq %r13, %r13
-	xorq %r14, %r14
-	xorq %r15, %r15
-	xorq %rbp, %rbp
-
 	movq %rsp, %gs:SGX_STACK
 
 	# It's ok to use the untrusted stack and exit target below without
@@ -289,8 +305,7 @@ sgx_ocall:
 	andq $STACK_ALIGN, %rsp
 
 	movq %gs:SGX_EXIT_TARGET, %rbx
-	movq $EEXIT, %rax
-	ENCLU
+	jmp .Lclear_and_eexit
 
 .Lreturn_from_ocall:
 	# PAL convention:

--- a/Pal/src/host/Linux-SGX/enclave_entry.S
+++ b/Pal/src/host/Linux-SGX/enclave_entry.S
@@ -157,7 +157,7 @@ enclave_entry:
 	## so the CPU pushed some untrusted %rsp into SGX_GPR_RSP. Thus, we
 	## cannot trust value in SGX_GPR_RSP and should fall-back to using
 	## SGX_STACK (which was updated with the last known good in-enclave
-	## %rsp during Leexit).
+	## %rsp before EEXIT in sgx_ocall).
 
 	movq SGX_GPR_RSP(%rbx), %rsi
 	movq %gs:SGX_STACK, %rax
@@ -268,7 +268,6 @@ sgx_ocall:
 
 	movq $1, %gs:SGX_OCALL_PREPARED
 
-.Leexit:
 	xorq %rdx, %rdx
 	xorq %r8, %r8
 	xorq %r9, %r9

--- a/Pal/src/host/Linux-SGX/enclave_entry.S
+++ b/Pal/src/host/Linux-SGX/enclave_entry.S
@@ -236,6 +236,24 @@ enclave_entry:
 	#     %rsp: untrusted stack
 	#     %rdi, %rsi: (optional) arguments to untrusted code.
 .Lclear_and_eexit:
+
+	# Clear "extended" state (FPU aka x87, SSE, AVX, ...).
+
+	leaq .Lxrstor_init_arg(%rip), %rcx
+	# pal_sec.enclave_attributes.xfrm will always be zero before
+	# init_enclave has been called by pal_linux_main. So during early init
+	# nothing should use features not covered by fxrstor, like AVX.
+	movq (pal_sec + PAL_SEC_ENCLAVE_ATTRIBUTES + SGX_ARCH_ATTRIBUTES_XFRM)(%rip), %rax
+	testq $XSAVE_NON_FX_MASK, %rax
+	je 1f
+	mov $0xffffffff, %edx
+	mov $0xffffffff, %eax
+	xrstor (%rcx)
+	jmp 2f
+1:
+	fxrstor (%rcx)
+2:
+
 	# %rax is argument to EEXIT
 	# %rbx is argument to EEXIT
 	# %rcx is set to AEP by EEXIT
@@ -256,6 +274,31 @@ enclave_entry:
 	ENCLU
 
 	ud2 # We should never get here.
+
+	# fxsave/xsave area to reset extended state.
+	#
+	# The first 512 B are used by fxrstor. We set FCW = 0x037f and MXCSR =
+	# 0x1f80 and the rest to 0 (same values as xrstor uses in
+	# initialization mode).
+	#
+	# The fxsave area is followed by the 64 B xsave header. We use the
+	# "compact" format (XCOMP_BV[63] = 1). Since the rest of XSTATE_BV and
+	# XCOMP_BV are 0s, xrstor initializes all components (assuming it's
+	# called with RFBM set to all 1s). The fxsave area is ignored (because
+	# we request initialization not restore). And thanks to the compact
+	# format we don't need to provide anything after the header.
+.section .rodata
+	.balign 64
+.Lxrstor_init_arg:
+	.byte 0x7f, 0x03 	# FCW
+	.skip 6, 0
+	.byte 0x80, 0x1f, 0, 0 	# MXCSR
+	.skip 500, 0	 	# rest of fxstore area
+
+	.skip 15, 0	 	# XSTATE_BV and XCOMP_BV[55:0]
+	.byte 0x80	 	# XCOMP_BV[63:56] i.e. "compact" format
+	.skip 48, 0	 	# rest of xsave header
+.previous
 
 	.global sgx_ocall
 	.type sgx_ocall, @function

--- a/Pal/src/host/Linux-SGX/sgx_arch.h
+++ b/Pal/src/host/Linux-SGX/sgx_arch.h
@@ -283,6 +283,7 @@ typedef uint8_t sgx_arch_key128_t[16] __attribute__((aligned(16)));
 
 #define STACK_ALIGN 0xfffffffffffffff0
 #define XSAVE_ALIGN 0xffffffffffffffc0
+#define XSAVE_NON_FX_MASK 0xfffffffffffffffc
 
 #define RETURN_FROM_OCALL 0xffffffffffffffff
 


### PR DESCRIPTION
## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [x] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes (reasons and measures)

[Pal/Linux-SGX] Clear "extented state" (FPU regs & co) before EEXIT

They could contain sensitive information.

## How to test this PR? (if applicable)

Run regression tests to see that it doesn't break things.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/626)
<!-- Reviewable:end -->
