### PR TITLE
Clarify in the readme that support@ is publicly archived

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ github Wiki page: <https://github.com/oscarlab/graphene/wiki>.
 
 ## 4. CONTACT
 
-For any questions or bug reports, please send an email to
-        <support@graphene-project.io>
-or post an issue on our github repository:
-        <https://github.com/oscarlab/graphene/issues>
+For any questions or bug reports, please send an email to <support@graphene-project.io> or post an
+issue on our GitHub repository: <https://github.com/oscarlab/graphene/issues>.
+
+Our mailing list is publicly archived [here](https://groups.google.com/forum/#!forum/graphene-support).


### PR DESCRIPTION
## Affected components

- [X] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes (reasons and measures)

Our current readme isn't clear about support@ being publicly archived. This PR tries to fix this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/628)
<!-- Reviewable:end -->
