### PR TITLE
[Pal/{Linux, FreeBSD}] _DkReceiveHandle access uninitialized header

### DIFF
--- a/Pal/src/host/Linux/db_streams.c
+++ b/Pal/src/host/Linux/db_streams.c
@@ -392,13 +392,26 @@ int _DkReceiveHandle(PAL_HANDLE hdl, PAL_HANDLE * cargo)
     hdr.msg_flags = 0;
 
     int ret = INLINE_SYSCALL(recvmsg, 3, ch, &hdr, 0);
-
-    if (IS_ERR(ret) || (size_t)ret < sizeof(struct hdl_header)) {
-        if (!IS_ERR(ret))
+    if (IS_ERR(ret))
+        return unix_to_pal_error(ERRNO(ret));
+    if ((size_t)ret < sizeof(struct hdl_header)) {
+        /*
+         * This code block is just in case to cover all the possibilities.
+         * We know that the file descriptor is an unix domain socket with
+         * blocking mode and that the sender, _DkSendHandle() above, sends the
+         * header with single sendmsg syscall which transfers message atomically.
+         *
+         * read size == 0: return error for the caller to try again.
+         *                 It should result in EINTR.
+         *
+         * read size > 0: return error for the caller to give up this file
+         *                descriptor.
+         *                If the header can't be send atomically for some
+         *                reason, the sender should get EMSGSIZE.
+         */
+        if (!ret)
             return -PAL_ERROR_TRYAGAIN;
-
-        if (ERRNO(ret) != EINTR && ERRNO(ret) != ERESTART)
-            return -ERRNO(ret);
+        return -PAL_ERROR_DENIED;
     }
 
     // initialize variables to get body


### PR DESCRIPTION
On EINTR or ERESTART, it accesses uninitialized header wrongly.

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md).

## Affected components

- [ ] README and global configuration
- [x] Linux PAL
- [ ] SGX PAL
- [x] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes (reasons and measures)


## How to test this PR? (if applicable)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/630)
<!-- Reviewable:end -->
