### PR TITLE
[Pal/Linux-SGX] Propagate untrusted environment variables to untrusted child process

### DIFF
--- a/Pal/src/host/Linux-SGX/sgx_process.c
+++ b/Pal/src/host/Linux-SGX/sgx_process.c
@@ -91,7 +91,8 @@ int sgx_create_process (const char * uri, int nargs, const char ** args,
         if (IS_ERR(rete))
             goto out_child;
 
-        rete = INLINE_SYSCALL(execve, 3, PAL_LOADER, argv, NULL);
+        extern char** environ;
+        rete = INLINE_SYSCALL(execve, 3, PAL_LOADER, argv, environ);
 
         /* shouldn't get to here */
         SGX_DBG(DBG_E, "unexpected failure of new process\n");


### PR DESCRIPTION


## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [x] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes (reasons and measures)

This PR forces untrusted SGX PAL to propagate untrusted environment variables to untrusted child process.

Propagating untrusted environment variables to the child process does not harm security of enclaves. This propagation is required for e.g. debugging multi-process applications and for network proxy settings.

Note that trusted environment variables are correctly passed from parent enclave to child enclave using the checkpoint/restore protocol.

## How to test this PR? (if applicable)

Debug any multi-process process with GDB and check environment variables of the child inferior:
```sh
inferior 2
show environment
# should not be empty
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/631)
<!-- Reviewable:end -->
