### PR TITLE
[RFC] Linux-SGX PAL: use dedicated stack for host signal handling and etc

### DIFF
--- a/Pal/lib/api.h
+++ b/Pal/lib/api.h
@@ -121,6 +121,9 @@ void vfprintfmt (int (*_fputch)(void *, int, void *), void * f, void * putdat,
 
 int snprintf (char * buf, int n, const char * fmt, ...);
 
+int ffs (int x);
+int ffsl (long int x);
+
 /* Miscelleneous */
 
 int inet_pton4 (const char *src, int len, void *dst);

--- a/Pal/lib/atomic.h
+++ b/Pal/lib/atomic.h
@@ -184,4 +184,33 @@ static inline int64_t atomic_cmpxchg (struct atomic_int * v, int64_t old, int64_
     return cmpxchg(&v->counter, old, new);
 }
 
+static inline bool test_and_set_bit(long nr, volatile unsigned long *addr)
+{
+    bool cc_carry;
+    __asm__ __volatile__("lock btsq %2, %0\n"
+                         : "+m"(*addr), "=@ccc"(cc_carry)
+                         : "Ir"(nr)
+                         : "memory");
+    return cc_carry;
+}
+
+static inline bool test_and_clear_bit(long nr, volatile unsigned long *addr)
+{
+    bool cc_carry;
+    __asm__ __volatile__("lock btrq %2, %0\n"
+                         : "+m"(*addr), "=@ccc"(cc_carry)
+                         : "Ir"(nr)
+                         : "memory");
+    return cc_carry;
+}
+
+static inline void set_bit(long nr, volatile unsigned long *addr)
+{
+    test_and_set_bit(nr, addr);
+}
+
+static inline void clear_bit(long nr, volatile unsigned long *addr)
+{
+    test_and_clear_bit(nr, addr);
+}
 #endif /* _ATOMIC_INT_H_ */

--- a/Pal/lib/atomic.h
+++ b/Pal/lib/atomic.h
@@ -168,6 +168,14 @@ static inline int64_t cmpxchg(volatile int64_t *p, int64_t t, int64_t s)
     return t;
 }
 
+static inline int atomic_add_return(int64_t i, struct atomic_int *v)
+{
+    return _atomic_add(i, v);
+}
+
+#define atomic_inc_return(v)    atomic_add_return(1, v)
+
+
 /* Helper function to atomically compare-and-swap the value in v.
  * If v == old, it sets v = new.
  * Returns the value originally in v. */

--- a/Pal/lib/string/ffs.c
+++ b/Pal/lib/string/ffs.c
@@ -1,0 +1,46 @@
+/* ffs -- find first set bit in a word, counted from least significant end.
+   For AMD x86-64.
+   This file is part of the GNU C Library.
+   Copyright (C) 1991-2014 Free Software Foundation, Inc.
+   Contributed by Ulrich Drepper <drepper@cygnus.com>.
+
+   The GNU C Library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.
+
+   The GNU C Library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with the GNU C Library; if not, see
+   <http://www.gnu.org/licenses/>.  */
+
+#include "api.h"
+
+int ffs (int x)
+{
+  int cnt;
+  int tmp;
+
+  __asm__ ("bsfl %2,%0\n"           /* Count low bits in X and store in %1.  */
+           "cmovel %1,%0\n"         /* If number was zero, use -1 as result.  */
+           : "=&r" (cnt), "=r" (tmp) : "rm" (x), "1" (-1));
+
+  return cnt + 1;
+}
+
+int
+ffsl (long int x)
+{
+  long int cnt;
+  long int tmp;
+
+  __asm__ ("bsfq %2,%0\n"           /* Count low bits in X and store in %1.  */
+           "cmoveq %1,%0\n"         /* If number was zero, use -1 as result.  */
+           : "=&r" (cnt), "=r" (tmp) : "rm" (x), "1" (-1));
+
+  return cnt + 1;
+}

--- a/Pal/src/host/Linux-SGX/asm-offsets.c
+++ b/Pal/src/host/Linux-SGX/asm-offsets.c
@@ -1,5 +1,6 @@
 #include <stddef.h>
 
+#include <pal.h>
 #include "sgx_arch.h"
 #include "sgx_tls.h"
 
@@ -68,5 +69,9 @@ void dummy(void)
 
     /* sgx_arch_tcs_t */
     DEFINE(TCS_SIZE, sizeof(sgx_arch_tcs_t));
-}
 
+    /* fp regs */
+    OFFSET_T(XSAVE_HEADER_OFFSET, PAL_XREGS_STATE, header);
+    DEFINE(PAL_XSTATE_ALIGN, PAL_XSTATE_ALIGN);
+    DEFINE(PAL_FP_XSTATE_MAGIC2_SIZE, PAL_FP_XSTATE_MAGIC2_SIZE);
+}

--- a/Pal/src/host/Linux-SGX/asm-offsets.c
+++ b/Pal/src/host/Linux-SGX/asm-offsets.c
@@ -54,6 +54,8 @@ void dummy(void)
     OFFSET(SGX_ENCLAVE_SIZE, enclave_tls, enclave_size);
     OFFSET(SGX_TCS_OFFSET, enclave_tls, tcs_offset);
     OFFSET(SGX_INITIAL_STACK_OFFSET, enclave_tls, initial_stack_offset);
+    OFFSET(SGX_SIG_STACK_LOW, enclave_tls, sig_stack_low);
+    OFFSET(SGX_SIG_STACK_HIGH, enclave_tls, sig_stack_high);
     OFFSET(SGX_AEP, enclave_tls, aep);
     OFFSET(SGX_SSA, enclave_tls, ssa);
     OFFSET(SGX_GPR, enclave_tls, gpr);

--- a/Pal/src/host/Linux-SGX/asm-offsets.c
+++ b/Pal/src/host/Linux-SGX/asm-offsets.c
@@ -1,6 +1,6 @@
 #include <stddef.h>
 
-#include <pal.h>
+#include "pal.h"
 #include "sgx_arch.h"
 #include "sgx_tls.h"
 
@@ -49,6 +49,8 @@ void dummy(void)
     OFFSET_T(SGX_CONTEXT_RFLAGS, sgx_context_t, rflags);
     OFFSET_T(SGX_CONTEXT_RIP, sgx_context_t, rip);
     DEFINE(SGX_CONTEXT_SIZE, sizeof(sgx_context_t));
+    DEFINE(SGX_CONTEXT_XSTATE_ALIGN_SUB,
+           sizeof(sgx_context_t) % PAL_XSTATE_ALIGN);
 
     /* struct enclave_tls */
     OFFSET(SGX_ENCLAVE_SIZE, enclave_tls, enclave_size);

--- a/Pal/src/host/Linux-SGX/asm-offsets.c
+++ b/Pal/src/host/Linux-SGX/asm-offsets.c
@@ -3,6 +3,7 @@
 #include "pal.h"
 #include "sgx_arch.h"
 #include "sgx_tls.h"
+#include "enclave_ocalls.h"
 
 #include <asm-offsets-build.h>
 
@@ -62,6 +63,7 @@ void dummy(void)
     OFFSET(SGX_FLAGS, enclave_tls, flags);
     OFFSET(SGX_PENDING_ASYNC_EVENT, enclave_tls, pending_async_event);
     OFFSET(SGX_EVENT_NEST, enclave_tls, event_nest.counter);
+    OFFSET(SGX_OCALL_MARKER, enclave_tls, ocall_marker);
     OFFSET(SGX_AEP, enclave_tls, aep);
     OFFSET(SGX_SSA, enclave_tls, ssa);
     OFFSET(SGX_GPR, enclave_tls, gpr);
@@ -93,4 +95,14 @@ void dummy(void)
     DEFINE(PAL_EVENT_QUIT, PAL_EVENT_QUIT);
     DEFINE(PAL_EVENT_SUSPEND, PAL_EVENT_SUSPEND);
     DEFINE(PAL_EVENT_RESUME, PAL_EVENT_RESUME);
+
+    /* ocall_marker_buf */
+    OFFSET(OCALL_MARKER_RBX, ocall_marker_buf, rbx);
+    OFFSET(OCALL_MARKER_RBP, ocall_marker_buf, rbp);
+    OFFSET(OCALL_MARKER_R12, ocall_marker_buf, r12);
+    OFFSET(OCALL_MARKER_R13, ocall_marker_buf, r13);
+    OFFSET(OCALL_MARKER_R14, ocall_marker_buf, r14);
+    OFFSET(OCALL_MARKER_R15, ocall_marker_buf, r15);
+    OFFSET(OCALL_MARKER_RSP, ocall_marker_buf, rsp);
+    OFFSET(OCALL_MARKER_RIP, ocall_marker_buf, rip);
 }

--- a/Pal/src/host/Linux-SGX/asm-offsets.c
+++ b/Pal/src/host/Linux-SGX/asm-offsets.c
@@ -96,6 +96,9 @@ void dummy(void)
     DEFINE(PAL_EVENT_SUSPEND, PAL_EVENT_SUSPEND);
     DEFINE(PAL_EVENT_RESUME, PAL_EVENT_RESUME);
 
+    /* PAL ERROR */
+    DEFINE(PAL_ERROR_INTERRUPTED, PAL_ERROR_INTERRUPTED);
+
     /* ocall_marker_buf */
     OFFSET(OCALL_MARKER_RBX, ocall_marker_buf, rbx);
     OFFSET(OCALL_MARKER_RBP, ocall_marker_buf, rbp);

--- a/Pal/src/host/Linux-SGX/asm-offsets.c
+++ b/Pal/src/host/Linux-SGX/asm-offsets.c
@@ -53,11 +53,15 @@ void dummy(void)
            sizeof(sgx_context_t) % PAL_XSTATE_ALIGN);
 
     /* struct enclave_tls */
+    OFFSET(SGX_SELF, enclave_tls, self);
     OFFSET(SGX_ENCLAVE_SIZE, enclave_tls, enclave_size);
     OFFSET(SGX_TCS_OFFSET, enclave_tls, tcs_offset);
     OFFSET(SGX_INITIAL_STACK_OFFSET, enclave_tls, initial_stack_offset);
     OFFSET(SGX_SIG_STACK_LOW, enclave_tls, sig_stack_low);
     OFFSET(SGX_SIG_STACK_HIGH, enclave_tls, sig_stack_high);
+    OFFSET(SGX_FLAGS, enclave_tls, flags);
+    OFFSET(SGX_PENDING_ASYNC_EVENT, enclave_tls, pending_async_event);
+    OFFSET(SGX_EVENT_NEST, enclave_tls, event_nest.counter);
     OFFSET(SGX_AEP, enclave_tls, aep);
     OFFSET(SGX_SSA, enclave_tls, ssa);
     OFFSET(SGX_GPR, enclave_tls, gpr);
@@ -71,6 +75,12 @@ void dummy(void)
     OFFSET(SGX_ECALL_CALLED, enclave_tls, ecall_called);
     OFFSET(SGX_READY_FOR_EXCEPTIONS, enclave_tls, ready_for_exceptions);
 
+    DEFINE(SGX_TLS_FLAGS_ASYNC_EVENT_PENDING_BIT,
+           SGX_TLS_FLAGS_ASYNC_EVENT_PENDING_BIT);
+    DEFINE(SGX_TLS_FLAGS_EVENT_EXECUTING_BIT,
+           SGX_TLS_FLAGS_EVENT_EXECUTING_BIT);
+    DEFINE(PAL_ASYNC_EVENT_MASK, PAL_ASYNC_EVENT_MASK);
+
     /* sgx_arch_tcs_t */
     DEFINE(TCS_SIZE, sizeof(sgx_arch_tcs_t));
 
@@ -78,4 +88,9 @@ void dummy(void)
     OFFSET_T(XSAVE_HEADER_OFFSET, PAL_XREGS_STATE, header);
     DEFINE(PAL_XSTATE_ALIGN, PAL_XSTATE_ALIGN);
     DEFINE(PAL_FP_XSTATE_MAGIC2_SIZE, PAL_FP_XSTATE_MAGIC2_SIZE);
+
+    /* PAL_EVENT */
+    DEFINE(PAL_EVENT_QUIT, PAL_EVENT_QUIT);
+    DEFINE(PAL_EVENT_SUSPEND, PAL_EVENT_SUSPEND);
+    DEFINE(PAL_EVENT_RESUME, PAL_EVENT_RESUME);
 }

--- a/Pal/src/host/Linux-SGX/db_exception.c
+++ b/Pal/src/host/Linux-SGX/db_exception.c
@@ -39,29 +39,75 @@
 #include <linux/signal.h>
 #include <ucontext.h>
 
-typedef struct exception_event {
+char * __bytes2hexdump(void * hex, size_t size, char * str, size_t len)
+{
+    static const char * ch = "0123456789abcdef";
+    assert(len >= size * 3 + 1);
+
+    uint8_t * hex_ = hex;
+    for (size_t i = 0 ; i < size ; i++) {
+        uint8_t h = hex_[i];
+        str[i * 3] = ch[h / 16];
+        str[i * 3 + 1] = ch[h % 16];
+        str[i * 3 + 2] = ' ';
+    }
+
+    str[size * 3] = 0;
+    return str;
+}
+
+#define alloca_bytes2hexdump(array, size)                               \
+    __bytes2hexdump((array), (size), __alloca((size) * 3 + 1), (size) * 3 + 1)
+
+static inline struct atomic_int * get_event_nest()
+{
+    struct enclave_tls * tls = get_enclave_tls();
+    return &tls->event_nest;
+}
+
+typedef struct {
     PAL_IDX             event_num;
     PAL_CONTEXT *       context;
+    sgx_context_t *     uc;
+    PAL_XREGS_STATE *   xregs_state;
+    bool                retry_event;
 } PAL_EVENT;
 
 static void _DkGenericEventTrigger (PAL_IDX event_num, PAL_EVENT_HANDLER upcall,
-                                    PAL_NUM arg, PAL_CONTEXT * context)
+                                    PAL_NUM arg, PAL_CONTEXT * ctx,
+                                    sgx_context_t * uc,
+                                    PAL_XREGS_STATE * xregs_state,
+                                    bool retry_event)
 {
-    struct exception_event event;
+    assert((((uintptr_t)xregs_state) % PAL_XSTATE_ALIGN) == 0);
+    assert((PAL_XREGS_STATE*) (uc + 1) == xregs_state);
 
-    event.event_num = event_num;
-    event.context = context;
+    PAL_EVENT event = {
+        .event_num = event_num,
+        .context = ctx,
+        .uc = uc,
+        .xregs_state = xregs_state,
+        .retry_event = retry_event,
+    };
 
-    (*upcall) ((PAL_PTR) &event, arg, context);
+    SGX_DBG(DBG_E, "_DkGenericEventTrigger\n");
+    (*upcall) ((PAL_PTR) &event, arg, ctx);
+    SGX_DBG(DBG_E, "_DkGenericEventTriger done\n");
 }
 
 static bool
-_DkGenericSignalHandle (int event_num, PAL_NUM arg, PAL_CONTEXT * context)
+_DkGenericSignalHandle (int event_num, PAL_NUM arg, PAL_CONTEXT * context,
+                        sgx_context_t * uc, PAL_XREGS_STATE * xregs_state,
+                        bool retry_event)
 {
+    assert((((uintptr_t)xregs_state) % PAL_XSTATE_ALIGN) == 0);
+    assert((PAL_XREGS_STATE*) (uc + 1) == xregs_state);
+
     PAL_EVENT_HANDLER upcall = _DkGetExceptionHandler(event_num);
 
     if (upcall) {
-        _DkGenericEventTrigger(event_num, upcall, arg, context);
+        _DkGenericEventTrigger(event_num, upcall, arg, context, uc, xregs_state,
+                               retry_event);
         return true;
     }
 
@@ -72,18 +118,27 @@ _DkGenericSignalHandle (int event_num, PAL_NUM arg, PAL_CONTEXT * context)
         ((void *) (addr) > TEXT_START && (void *) (addr) < TEXT_END)
 
 static void restore_sgx_context (sgx_context_t * uc,
-                                 PAL_XREGS_STATE * xregs_state)
+                                 PAL_XREGS_STATE * xregs_state,
+                                 bool retry_event)
 {
-    SGX_DBG(DBG_E, "uc %p rsp 0x%08lx &rsp: %p rip 0x%08lx &rip: %p\n",
-            uc, uc->rsp, &uc->rsp, uc->rip, &uc->rip);
-    if (xregs_state == NULL)
-        xregs_state = (PAL_XREGS_STATE*)SYNTHETIC_STATE;
+    atomic_dec(get_event_nest());
+    assert((((uintptr_t)xregs_state) % PAL_XSTATE_ALIGN) == 0);
+    assert((PAL_XREGS_STATE*) (uc + 1) == xregs_state);
+
     restore_xregs(xregs_state);
-    __restore_sgx_context(uc);
+    if (retry_event)
+        __restore_sgx_context_retry(uc);
+    else
+        __restore_sgx_context(uc);
 }
 
-static void restore_pal_context (sgx_context_t * uc, PAL_CONTEXT * ctx)
+static void restore_pal_context (
+    sgx_context_t * uc, PAL_XREGS_STATE * xregs_state,
+    PAL_CONTEXT * ctx, bool retry_event)
 {
+    assert((((uintptr_t)xregs_state) % PAL_XSTATE_ALIGN) == 0);
+    assert((PAL_XREGS_STATE*) (uc + 1) == xregs_state);
+
     uc->rax = ctx->rax;
     uc->rbx = ctx->rbx;
     uc->rcx = ctx->rcx;
@@ -103,12 +158,22 @@ static void restore_pal_context (sgx_context_t * uc, PAL_CONTEXT * ctx)
     uc->rflags = ctx->efl;
     uc->rip = ctx->rip;
 
-    restore_sgx_context(uc, ctx->fpregs);
+    if (ctx->fpregs == NULL)
+        memcpy(xregs_state, &SYNTHETIC_STATE, SYNTHETIC_STATE_SIZE);
+    else if (xregs_state != ctx->fpregs)
+        memcpy(xregs_state, ctx->fpregs,
+               ctx->fpregs->fpstate.sw_reserved.xstate_size);
+    /* TODO sanity check of user supplied ctx->fpregs */
+
+    restore_sgx_context(uc, xregs_state, retry_event);
 }
 
 static void save_pal_context (PAL_CONTEXT * ctx, sgx_context_t * uc,
                               PAL_XREGS_STATE * xregs_state)
 {
+    assert((((uintptr_t)xregs_state) % PAL_XSTATE_ALIGN) == 0);
+    assert((PAL_XREGS_STATE*) (uc + 1) == xregs_state);
+
     memset(ctx, 0, sizeof(*ctx));
 
     ctx->rax = uc->rax;
@@ -148,6 +213,62 @@ static void save_pal_context (PAL_CONTEXT * ctx, sgx_context_t * uc,
         PAL_FP_XSTATE_MAGIC2;
 }
 
+static void _DkExceptionHandlerLoop (PAL_CONTEXT * ctx, sgx_context_t * uc,
+                                     PAL_XREGS_STATE * xregs_state)
+{
+    if (GET_ENCLAVE_TLS(event_nest.counter) > 0)
+        SGX_DBG(DBG_E, "ctx %p uc %p xresg %p flags 0x%lx sigbit 0x%lx\n",
+                ctx, uc, xregs_state,
+                GET_ENCLAVE_TLS(flags), GET_ENCLAVE_TLS(pending_async_event));
+    struct enclave_tls * tls = get_enclave_tls();
+    do {
+        int event_num = ffsl(GET_ENCLAVE_TLS(pending_async_event));
+        if (event_num-- > 0 &&
+            test_and_clear_bit(event_num, &tls->pending_async_event)) {
+            SGX_DBG(DBG_E, "event_num %d flags 0x%lx sigbit 0x%lx\n",
+                    event_num,
+                    GET_ENCLAVE_TLS(flags), GET_ENCLAVE_TLS(pending_async_event));
+
+            ctx->err = 0;
+            ctx->trapno = event_num;    // TODO: this is pal event #. linux
+                                        // trapno is required?
+            ctx->oldmask = 0;
+            ctx->cr2 = 0;
+
+            _DkGenericSignalHandle(event_num, 0, ctx, uc, xregs_state, false);
+            continue;
+        }
+    } while (test_and_clear_bit(SGX_TLS_FLAGS_ASYNC_EVENT_PENDING_BIT,
+                                &tls->flags));
+    if (GET_ENCLAVE_TLS(event_nest.counter) > 0)
+        SGX_DBG(DBG_E, "Loop exiting\n");
+}
+
+void _DkExceptionHandlerMore (sgx_context_t * uc)
+{
+    atomic_inc(get_event_nest());
+
+    PAL_XREGS_STATE * xregs_state = (PAL_XREGS_STATE *)(uc + 1);
+    SGX_DBG(DBG_E, "uc %p xregs_state %p nest %ld flasg 0x%lx async 0x%lx\n",
+            uc, xregs_state, atomic_read(get_event_nest()),
+            GET_ENCLAVE_TLS(flags), GET_ENCLAVE_TLS(pending_async_event));
+    assert((((uintptr_t)xregs_state) % PAL_XSTATE_ALIGN) == 0);
+    save_xregs(xregs_state);
+
+    PAL_CONTEXT ctx;
+    save_pal_context(&ctx, uc, xregs_state);
+    _DkExceptionHandlerLoop(&ctx, uc, xregs_state);
+    restore_pal_context(uc, xregs_state, &ctx, true);
+}
+
+static void _DkExceptionHandlerRetrun (
+    sgx_context_t * uc, PAL_XREGS_STATE * xregs_state, bool retry_event)
+{
+    PAL_CONTEXT ctx;
+    save_pal_context(&ctx, uc, xregs_state);
+    restore_pal_context(uc, xregs_state, &ctx, retry_event);
+}
+
 /*
  * return value:
  *  true:  #UD is handled.
@@ -183,13 +304,19 @@ static bool handle_ud(sgx_context_t * uc)
         /* syscall: LibOS may know how to handle this */
         return false;
     }
-    SGX_DBG(DBG_E, "Unknown or illegal instruction at RIP 0x%016lx\n", uc->rip);
+    SGX_DBG(DBG_E, "Unknown or illegal instruction at RIP 0x%016lx %s\n",
+            uc->rip,
+            alloca_bytes2hexdump(instr, 32 /* at least 2 instructions */));
     return false;
 }
 
 void _DkExceptionHandler (unsigned int exit_info, sgx_context_t * uc)
 {
+    int64_t nest = atomic_inc_return(get_event_nest());
+    bool retry_event = (nest == 1);
+
     PAL_XREGS_STATE * xregs_state = (PAL_XREGS_STATE *)(uc + 1);
+    SGX_DBG(DBG_E, "uc %p xregs_state %p\n", uc, xregs_state);
     assert((((uintptr_t)xregs_state) % PAL_XSTATE_ALIGN) == 0);
     save_xregs(xregs_state);
 
@@ -198,6 +325,10 @@ void _DkExceptionHandler (unsigned int exit_info, sgx_context_t * uc)
         sgx_arch_exitinfo_t info;
         unsigned int intval;
     } ei = { .intval = exit_info };
+    SGX_DBG(DBG_E,
+            "exit_info 0x%08x vector 0x%04x type 0x%04x reserved %x valid %d\n",
+            exit_info, ei.info.vector, ei.info.type, ei.info.reserved,
+            ei.info.valid);
 
     int event_num;
     if (!ei.info.valid) {
@@ -209,7 +340,7 @@ void _DkExceptionHandler (unsigned int exit_info, sgx_context_t * uc)
             break;
         case SGX_EXCEPTION_VECTOR_UD:
             if (handle_ud(uc)) {
-                restore_sgx_context(uc, xregs_state);
+                _DkExceptionHandlerRetrun(uc, xregs_state, retry_event);
                 /* NOTREACHED */
             }
             event_num = PAL_EVENT_ILLEGAL;
@@ -225,7 +356,8 @@ void _DkExceptionHandler (unsigned int exit_info, sgx_context_t * uc)
         case SGX_EXCEPTION_VECTOR_DB:
         case SGX_EXCEPTION_VECTOR_BP:
         default:
-            restore_sgx_context(uc, xregs_state);
+            _DkExceptionHandlerRetrun(uc, xregs_state, retry_event);
+            /* NOTREACHED */
             return;
         }
     }
@@ -251,6 +383,9 @@ void _DkExceptionHandler (unsigned int exit_info, sgx_context_t * uc)
                uc->r12, uc->r13, uc->r14, uc->r15,
                uc->rflags, uc->rip);
 #ifdef DEBUG
+        printf("%s\n",
+               alloca_bytes2hexdump((uint8_t*)uc->rip,
+                                    32 /* at least 2 instructions */));
         printf("pausing for debug\n");
         while (true)
             __asm__ volatile("pause");
@@ -258,8 +393,16 @@ void _DkExceptionHandler (unsigned int exit_info, sgx_context_t * uc)
         _DkThreadExit();
     }
 
+    if (nest > 1 &&
+        (event_num == PAL_EVENT_QUIT ||
+         event_num == PAL_EVENT_SUSPEND ||
+         event_num == PAL_EVENT_RESUME)) {
+        /* TODO: optimize out save/restore xregs */
+        restore_sgx_context(uc, xregs_state, false);
+        /* NOTREACHED */
+    }
+
     PAL_CONTEXT ctx;
-    save_pal_context(&ctx, uc, xregs_state);
 
     /* TODO: save EXINFO in MISC regsion and populate those */
     ctx.err = 0;
@@ -267,6 +410,8 @@ void _DkExceptionHandler (unsigned int exit_info, sgx_context_t * uc)
     ctx.oldmask = 0;
     ctx.cr2 = 0;
 
+    struct enclave_tls * tls = get_enclave_tls();
+    clear_bit(event_num, &tls->pending_async_event);
     PAL_NUM arg = 0;
     switch (event_num) {
     case PAL_EVENT_ILLEGAL:
@@ -282,8 +427,10 @@ void _DkExceptionHandler (unsigned int exit_info, sgx_context_t * uc)
         /* nothing */
         break;
     }
-    _DkGenericSignalHandle(event_num, arg, &ctx);
-    restore_pal_context(uc, &ctx);
+
+    save_pal_context(&ctx, uc, xregs_state);
+    _DkGenericSignalHandle(event_num, arg, &ctx, uc, xregs_state, retry_event);
+    restore_pal_context(uc, xregs_state, &ctx, retry_event);
 }
 
 void _DkRaiseFailure (int error)
@@ -293,9 +440,13 @@ void _DkRaiseFailure (int error)
     if (!upcall)
         return;
 
-    PAL_EVENT event;
-    event.event_num = PAL_EVENT_FAILURE;
-    event.context   = NULL;
+    PAL_EVENT event = {
+        .event_num   = PAL_EVENT_FAILURE,
+        .context     = NULL,
+        .uc          = NULL,
+        .xregs_state = NULL,
+        .retry_event = false
+    };
 
     (*upcall) ((PAL_PTR) &event, error, NULL);
 }
@@ -303,18 +454,29 @@ void _DkRaiseFailure (int error)
 void _DkExceptionReturn (void * event)
 {
     PAL_EVENT * e = event;
-    sgx_context_t uc;
     PAL_CONTEXT * ctx = e->context;
 
     if (!ctx) {
         return;
     }
-    restore_pal_context(&uc, ctx);
+
+    SGX_DBG(DBG_E,
+            "uc %p rsp 0x%08lx &rsp: %p rip 0x%08lx &rip: %p "
+            "xregs_state %p event_nest %ld\n",
+            e->uc, e->uc->rsp, &e->uc->rsp, e->uc->rip, &e->uc->rip, e->xregs_state,
+            atomic_read(get_event_nest()));
+    assert((((uintptr_t)e->xregs_state) % PAL_XSTATE_ALIGN) == 0);
+    assert((PAL_XREGS_STATE*) (e->uc + 1) == e->xregs_state);
+
+    restore_pal_context(e->uc, e->xregs_state, ctx, e->retry_event);
 }
 
 void _DkHandleExternalEvent (PAL_NUM event, sgx_context_t * uc,
                              PAL_XREGS_STATE * xregs_state)
 {
+    int64_t nest = atomic_inc_return(get_event_nest());
+    bool retry_event = (nest == 1);
+
     assert((((uintptr_t)xregs_state) % PAL_XSTATE_ALIGN) == 0);
     assert((PAL_XREGS_STATE*) (uc + 1) == xregs_state);
 
@@ -329,10 +491,19 @@ void _DkHandleExternalEvent (PAL_NUM event, sgx_context_t * uc,
 
     if (event != 0) {
         assert(uc->rax == -PAL_ERROR_INTERRUPTED);
-        if (!_DkGenericSignalHandle(event, 0, &ctx)
+        set_bit(SGX_TLS_FLAGS_EVENT_EXECUTING_BIT, &get_enclave_tls()->flags);
+        SGX_DBG(DBG_E,
+                "event %ld uc %p rsp 0x%08lx &rsp: %p rip 0x%08lx &rip: %p "
+                "xregs_state %p event_nest %ld\n",
+                event, uc, uc->rsp, &uc->rsp, uc->rip, &uc->rip, xregs_state,
+                nest);
+        if (test_and_clear_bit(event,
+                               &get_enclave_tls()->pending_async_event) &&
+            !_DkGenericSignalHandle(event, 0, &ctx, uc, xregs_state,
+                                    retry_event)
             && event != PAL_EVENT_RESUME)
             _DkThreadExit();
     }
 
-    restore_sgx_context(uc, ctx.fpregs);
+    restore_pal_context(uc, xregs_state, &ctx, retry_event);
 }

--- a/Pal/src/host/Linux-SGX/enclave_ecalls.c
+++ b/Pal/src/host/Linux-SGX/enclave_ecalls.c
@@ -61,6 +61,8 @@ void handle_ecall (long ecall_index, void * ecall_args, void * exit_target,
     SET_ENCLAVE_TLS(exit_target, exit_target);
     SET_ENCLAVE_TLS(ustack_top,  untrusted_stack);
     SET_ENCLAVE_TLS(ustack,      untrusted_stack);
+    SET_ENCLAVE_TLS(event_nest.counter, 0L);
+    mb();
 
     if (atomic_cmpxchg(&enclave_start_called, 0, 1) == 0) {
         // ENCLAVE_START not yet called, so only valid ecall is ENCLAVE_START.

--- a/Pal/src/host/Linux-SGX/enclave_ecalls.c
+++ b/Pal/src/host/Linux-SGX/enclave_ecalls.c
@@ -75,6 +75,8 @@ void handle_ecall (long ecall_index, void * ecall_args, void * exit_target,
 
         if (!ms) return;
 
+        /* xsave size must be initizlied early */
+        init_xsave_size(ms->ms_sec_info->enclave_attributes.xfrm);
         pal_linux_main(ms->ms_arguments, ms->ms_environments,
                        ms->ms_sec_info);
     } else {

--- a/Pal/src/host/Linux-SGX/enclave_entry.S
+++ b/Pal/src/host/Linux-SGX/enclave_entry.S
@@ -23,6 +23,11 @@
 	.byte 0xf3, 0x48, 0x0f, 0xae, 0xd3 /* WRFSBASE %RBX */
 .endm
 
+.macro CLEAR_FLAGS
+	movb $0, %ah
+	sahf
+.endm
+
 .macro SGX_TLS_FLAGS_SET_EXECUTING_BIT reg
 	movq %gs:SGX_SELF, \reg
 	lock btsq $SGX_TLS_FLAGS_EVENT_EXECUTING_BIT, SGX_FLAGS(\reg)
@@ -144,6 +149,7 @@ enclave_entry:
 	# clear the registers
 	xorq %rdi, %rdi
 	xorq %rsi, %rsi
+	CLEAR_FLAGS
 
 	# exit address in RDX, mov it to RBX
 	movq %rdx, %rbx
@@ -299,6 +305,7 @@ enclave_entry:
 	# clear the registers
 	xorq %rdi, %rdi
 	xorq %rsi, %rsi
+	CLEAR_FLAGS
 
 	# exit address in RDX, mov it to RBX
 	movq %rdx, %rbx
@@ -400,6 +407,7 @@ sgx_ocall:
 	xorq %r14, %r14
 	xorq %r15, %r15
 	xorq %rbp, %rbp
+	CLEAR_FLAGS
 
 	movq %rsp, %gs:SGX_STACK
 

--- a/Pal/src/host/Linux-SGX/enclave_entry.S
+++ b/Pal/src/host/Linux-SGX/enclave_entry.S
@@ -586,6 +586,27 @@ restore_xregs:
 	fxrstor64 (%rdi)
 	retq
 
+	# struct ocall_merker_ret ocall_marker_save(struct ocall_marker_buf * marker);
+	.global ocall_marker_save
+	.type ocall_marker_save, @function
+ocall_marker_save:
+	movq %rbx, OCALL_MARKER_RBX(%rdi)
+	movq %rbp, OCALL_MARKER_RBP(%rdi)
+	movq %r12, OCALL_MARKER_R12(%rdi)
+	movq %r13, OCALL_MARKER_R13(%rdi)
+	movq %r14, OCALL_MARKER_R14(%rdi)
+	movq %r15, OCALL_MARKER_R15(%rdi)
+	leaq 8(%rsp), %rdx	# stack pointer of the caller
+	movq %rdx, OCALL_MARKER_RSP(%rdi)
+	movq (%rsp), %rax	# caller's rip
+	movq %rax, OCALL_MARKER_RIP(%rdi)
+
+	xchgq %rdi, %gs:SGX_OCALL_MARKER
+	movq %rdi, %rdx
+
+	xorq %rax, %rax
+	retq
+
 /*
  * sgx_report:
  * Generate SGX hardware signed report.

--- a/Pal/src/host/Linux-SGX/enclave_entry.S
+++ b/Pal/src/host/Linux-SGX/enclave_entry.S
@@ -482,10 +482,10 @@ __restore_sgx_context:
 
 	popq %r14
 	popq %r15
-	popfq
 
 	/* void to clobber red zone */
-	subq $(REDZONE_SIZE + 8), -13 * 8(%rsp)
+	subq $(REDZONE_SIZE + 8), -12 * 8(%rsp)
+	popfq
 	movq -13 * 8(%rsp), %rsp
 	retq $REDZONE_SIZE
 
@@ -531,10 +531,10 @@ __restore_sgx_context_retry:
 	jc .Ltry_again
 
 	popq %r15
-	popfq
 
 	/* avoid to clobber red zone */
-	subq $(REDZONE_SIZE + 8), -13 * 8(%rsp)
+	subq $(REDZONE_SIZE + 8), -12 * 8(%rsp)
+	popfq
 	movq -13 * 8(%rsp), %rsp
 	retq $REDZONE_SIZE
 

--- a/Pal/src/host/Linux-SGX/enclave_entry.S
+++ b/Pal/src/host/Linux-SGX/enclave_entry.S
@@ -341,6 +341,52 @@ sgx_ocall:
 	popq %rbp
 	retq
 
+	# void save_xregs(uint64_t xsave_area)
+	.global save_xregs
+	.type save_xregs, @function
+save_xregs:
+	fwait
+	movq xsave_enabled@GOTPCREL(%rip), %rax
+	movl (%rax), %eax
+	cmpl $0, %eax
+	jz 1f
+
+	## clear xsave header
+	movq $0, XSAVE_HEADER_OFFSET + 0 * 8(%rdi)
+	movq $0, XSAVE_HEADER_OFFSET + 1 * 8(%rdi)
+	movq $0, XSAVE_HEADER_OFFSET + 2 * 8(%rdi)
+	movq $0, XSAVE_HEADER_OFFSET + 3 * 8(%rdi)
+	movq $0, XSAVE_HEADER_OFFSET + 4 * 8(%rdi)
+	movq $0, XSAVE_HEADER_OFFSET + 5 * 8(%rdi)
+	movq $0, XSAVE_HEADER_OFFSET + 6 * 8(%rdi)
+	movq $0, XSAVE_HEADER_OFFSET + 7 * 8(%rdi)
+
+	movl $0xffffffff, %eax
+	movl $0xffffffff, %edx
+	xsave64 (%rdi)
+	retq
+1:
+	fxsave64 (%rdi)
+	retq
+
+
+	# void restore_xregs(uint64_t xsave_area)
+	.global restore_xregs
+	.type restore_xregs, @function
+restore_xregs:
+	movq xsave_enabled@GOTPCREL(%rip), %rax
+	movl (%rax), %eax
+	cmpl $0, %eax
+	jz 1f
+
+	movl $0xffffffff, %eax
+	movl $0xffffffff, %edx
+	xrstor64 (%rdi)
+	retq
+1:
+	fxrstor64 (%rdi)
+	retq
+
 /*
  * sgx_report:
  * Generate SGX hardware signed report.

--- a/Pal/src/host/Linux-SGX/enclave_entry.S
+++ b/Pal/src/host/Linux-SGX/enclave_entry.S
@@ -165,7 +165,7 @@ enclave_entry:
 	je 1f
 	movq %rax, %rsi
 1:
-	subq $SGX_CONTEXT_SIZE, %rsi
+	subq $(SGX_CONTEXT_SIZE + REDZONE_SIZE), %rsi
 
 	# we have exitinfo in RDI, swap with the one on GPR
 	# and dump into the context

--- a/Pal/src/host/Linux-SGX/enclave_entry.S
+++ b/Pal/src/host/Linux-SGX/enclave_entry.S
@@ -302,6 +302,73 @@ enclave_entry:
 
 	# FP registers are saved on entry of _DkExceptionHandler()
 
+	movq %gs:SGX_STACK, %rax
+	cmpq $0, %rax
+	je 2f
+	cmpq $0, %gs:SGX_OCALL_PREPARED
+	jne 1f
+	FAIL_LOOP
+1:
+	movq SGX_CONTEXT_RIP(%rsi), %rax
+	leaq .Locall_about_to_eexit_begin(%rip), %rax
+	jb 1f
+	leaq .Locall_about_to_eexit_end(%rip), %rax
+	jae 1f
+	/*
+	 * We're about to eexit for ocall,
+	 * [.Locall_about_to_eexit_begin, .Locall_about_to_eexit_end)
+	 * the stack points to untrusted area, but we're still within enclave.
+	 * We do the following in C code so that ocall is interrupted.
+	 * ocall_marker_clear()
+	 * ocall_marker_check()
+	 */
+	movq $0, %rax
+	xchgq %rax, %gs:SGX_OCALL_MARKER
+	movq $-PAL_ERROR_INTERRUPTED, %rsi
+	movq %rsi, SGX_GPR_RAX(%rbx)
+	movq $0, %rsi
+	movq %rsi, SGX_GPR_RDX(%rbx)
+	movq OCALL_MARKER_RBX(%rax), %rsi
+	movq %rsi, SGX_GPR_RBX(%rbx)
+	movq OCALL_MARKER_RBP(%rax), %rsi
+	movq %rsi, SGX_GPR_RBP(%rbx)
+	movq OCALL_MARKER_R12(%rax), %rsi
+	movq %rsi, SGX_GPR_R12(%rbx)
+	movq OCALL_MARKER_R13(%rax), %rsi
+	movq %rsi, SGX_GPR_R13(%rbx)
+	movq OCALL_MARKER_R14(%rax), %rsi
+	movq %rsi, SGX_GPR_R14(%rbx)
+	movq OCALL_MARKER_R15(%rax), %rsi
+	movq %rsi, SGX_GPR_R15(%rbx)
+	movq OCALL_MARKER_RSP(%rax), %rsi
+	movq %rsi, SGX_GPR_RSP(%rbx)
+	movq OCALL_MARKER_RIP(%rax), %rsi
+	movq %rsi, SGX_GPR_RIP(%rbx)
+	jmp 2f
+1:
+	/*
+	 * We're aright after eenter, but not establish stack set.
+	 * establish stack within enclave for __restore_sgx_context[_retry]
+	 */
+	# we know that ocall actually successfully completed. don't abort ocall.
+	# ocall_marker_clear()
+	movq $0, %rax
+	xchgq %rax, %gs:SGX_OCALL_MARKER
+
+	# trick to %rsp to point to trusted area
+	movq %gs:SGX_STACK, %rax
+	movq %rax, SGX_CONTEXT_RSP(%rsi)
+
+	# If we're at .Lreturn_from_ocall_rsp_is_set, the situation is unstable.
+	# emulate xchgq %rsp, %gs:SGX_STACK
+	movq SGX_CONTEXT_RIP(%rsi), %rax
+	leaq .Lreturn_from_ocall_rsp_is_zero(%rip), %rax
+	jne 2f
+	leaq .Lreturn_from_ocall_rsp_is_set(%rip), %rax
+	movq $0, %gs:SGX_STACK
+	movq %rax, SGX_CONTEXT_RIP(%rsi)
+2:
+
 	# clear the registers
 	xorq %rdi, %rdi
 	xorq %rsi, %rsi
@@ -389,9 +456,6 @@ sgx_ocall:
 	pushq %rcx
 	pushq $0        # place holder for RAX
 
-	movq $1, %gs:SGX_OCALL_PREPARED
-
-.Leexit:
 	movq %rdi, %rbx
 	movq SYNTHETIC_STATE@GOTPCREL(%rip), %rdi
 	callq restore_xregs
@@ -409,8 +473,10 @@ sgx_ocall:
 	xorq %rbp, %rbp
 	CLEAR_FLAGS
 
+	movq $1, %gs:SGX_OCALL_PREPARED
 	movq %rsp, %gs:SGX_STACK
 
+.Locall_about_to_eexit_begin:
 	# It's ok to use the untrusted stack and exit target below without
 	# checks since the processor will ensure that after exiting enclave
 	# mode in-enclave memory can't be accessed.
@@ -421,17 +487,20 @@ sgx_ocall:
 	movq %gs:SGX_EXIT_TARGET, %rbx
 	movq $EEXIT, %rax
 	ENCLU
+.Locall_about_to_eexit_end:
 
 .Lreturn_from_ocall:
 	# PAL convention:
 	# RDI - return value
 	# RSI - external event (if there is any)
 
-	movq $0, %gs:SGX_OCALL_PREPARED
-
 	# restore the stack
 	movq $0, %rsp
+.Lreturn_from_ocall_rsp_is_zero:
 	xchgq %rsp, %gs:SGX_STACK
+.Lreturn_from_ocall_rsp_is_set:
+
+	movq $0, %gs:SGX_OCALL_PREPARED
 
 	## sgx_context_t::rax = %rdi
 	movq %rdi, (%rsp) # return value

--- a/Pal/src/host/Linux-SGX/enclave_entry.S
+++ b/Pal/src/host/Linux-SGX/enclave_entry.S
@@ -213,10 +213,54 @@ enclave_entry:
 	movq SGX_GPR_RSP(%rbx), %rsi
 	movq %gs:SGX_STACK, %rax
 	cmpq $0, %rax
-	je 1f
+	je .Lsetup_exception_handler
 	movq %rax, %rsi
-1:
 
+	cmpq $0, %gs:SGX_OCALL_PREPARED
+	jne 1f
+	FAIL_LOOP
+1:
+	movq SGX_GPR_RIP(%rbx), %rax
+	leaq .Locall_about_to_eexit_begin(%rip), %r11
+	cmpq %r11, %rax
+	jb 1f
+	leaq .Locall_about_to_eexit_end(%rip), %r11
+	cmpq %r11, %rax
+	jae 1f
+	/*
+	 * We're about to eexit for ocall in
+	 * [.Locall_about_to_eexit_begin, .Locall_about_to_eexit_end)
+	 * the stack points to untrusted area, but we're still within enclave.
+	 * Skip eexit as if ocall returned PAL_ERROR_INTERRUPTED.
+	 */
+	movq $0, SGX_GPR_RAX(%rbx)
+	movq $-PAL_ERROR_INTERRUPTED, SGX_GPR_RDI(%rbx) # return value for .Lreturn_from_ocall
+	movq %rdi, SGX_GPR_RSI(%rbx) # external event for .Lreturn_from_ocall
+	movq .Lreturn_from_ocall_prepared_is_cleared(%rip), %rax
+	movq %rax, SGX_GPR_RIP(%rbx)
+	movq %rsi, SGX_GPR_RSP(%rbx)
+	movq $0, %gs:SGX_STACK
+	movq $0, %gs:SGX_OCALL_PREPARED
+	jmp .Leexit_exception
+
+1:
+	/*
+	 * We're right after eenter from ocall, but not establish stack yet.
+	 * establish stack within enclave for __restore_sgx_context[_retry]
+	 */
+	# we know that ocall actually successfully completed. don't abort ocall.
+	# ocall_marker_clear()
+	movq $0, %gs:SGX_OCALL_MARKER
+	# Just let _DkHandleExternalEvent handles pending external events which
+	# we recorded above.
+	movq .Lreturn_from_ocall_prepared_is_cleared(%rip), %rax
+	movq %rax, SGX_GPR_RIP(%rbx)
+	movq %rsi, SGX_GPR_RSP(%rbx)
+	movq $0, %gs:SGX_STACK
+	movq $0, %gs:SGX_OCALL_PREPARED
+	jmp .Leexit_exception
+
+.Lsetup_exception_handler:
 	movq %gs:SGX_SIG_STACK_LOW, %rax
 	cmpq %rax, %rsi
 	jbe .Lout_of_signal_stack
@@ -302,73 +346,7 @@ enclave_entry:
 
 	# FP registers are saved on entry of _DkExceptionHandler()
 
-	movq %gs:SGX_STACK, %rax
-	cmpq $0, %rax
-	je 2f
-	cmpq $0, %gs:SGX_OCALL_PREPARED
-	jne 1f
-	FAIL_LOOP
-1:
-	movq SGX_CONTEXT_RIP(%rsi), %rax
-	leaq .Locall_about_to_eexit_begin(%rip), %rax
-	jb 1f
-	leaq .Locall_about_to_eexit_end(%rip), %rax
-	jae 1f
-	/*
-	 * We're about to eexit for ocall,
-	 * [.Locall_about_to_eexit_begin, .Locall_about_to_eexit_end)
-	 * the stack points to untrusted area, but we're still within enclave.
-	 * We do the following in C code so that ocall is interrupted.
-	 * ocall_marker_clear()
-	 * ocall_marker_check()
-	 */
-	movq $0, %rax
-	xchgq %rax, %gs:SGX_OCALL_MARKER
-	movq $-PAL_ERROR_INTERRUPTED, %rsi
-	movq %rsi, SGX_GPR_RAX(%rbx)
-	movq $0, %rsi
-	movq %rsi, SGX_GPR_RDX(%rbx)
-	movq OCALL_MARKER_RBX(%rax), %rsi
-	movq %rsi, SGX_GPR_RBX(%rbx)
-	movq OCALL_MARKER_RBP(%rax), %rsi
-	movq %rsi, SGX_GPR_RBP(%rbx)
-	movq OCALL_MARKER_R12(%rax), %rsi
-	movq %rsi, SGX_GPR_R12(%rbx)
-	movq OCALL_MARKER_R13(%rax), %rsi
-	movq %rsi, SGX_GPR_R13(%rbx)
-	movq OCALL_MARKER_R14(%rax), %rsi
-	movq %rsi, SGX_GPR_R14(%rbx)
-	movq OCALL_MARKER_R15(%rax), %rsi
-	movq %rsi, SGX_GPR_R15(%rbx)
-	movq OCALL_MARKER_RSP(%rax), %rsi
-	movq %rsi, SGX_GPR_RSP(%rbx)
-	movq OCALL_MARKER_RIP(%rax), %rsi
-	movq %rsi, SGX_GPR_RIP(%rbx)
-	jmp 2f
-1:
-	/*
-	 * We're aright after eenter, but not establish stack set.
-	 * establish stack within enclave for __restore_sgx_context[_retry]
-	 */
-	# we know that ocall actually successfully completed. don't abort ocall.
-	# ocall_marker_clear()
-	movq $0, %rax
-	xchgq %rax, %gs:SGX_OCALL_MARKER
-
-	# trick to %rsp to point to trusted area
-	movq %gs:SGX_STACK, %rax
-	movq %rax, SGX_CONTEXT_RSP(%rsi)
-
-	# If we're at .Lreturn_from_ocall_rsp_is_set, the situation is unstable.
-	# emulate xchgq %rsp, %gs:SGX_STACK
-	movq SGX_CONTEXT_RIP(%rsi), %rax
-	leaq .Lreturn_from_ocall_rsp_is_zero(%rip), %rax
-	jne 2f
-	leaq .Lreturn_from_ocall_rsp_is_set(%rip), %rax
-	movq $0, %gs:SGX_STACK
-	movq %rax, SGX_CONTEXT_RIP(%rsi)
-2:
-
+.Leexit_exception:
 	# clear the registers
 	xorq %rdi, %rdi
 	xorq %rsi, %rsi
@@ -379,6 +357,9 @@ enclave_entry:
 	movq $EEXIT, %rax
 	ENCLU
 
+	# TODO: merge. caution. fixup the check with .Locall_about_to_eexit_begin,
+	# and .Locall_about_to_eexit_end
+	# https://github.com/oscarlab/graphene/pull/626/commits/71b54115880907e2eb7f94d416185126dfa85abd
 
 	.global sgx_ocall
 	.type sgx_ocall, @function
@@ -496,14 +477,12 @@ sgx_ocall:
 
 	# restore the stack
 	movq $0, %rsp
-.Lreturn_from_ocall_rsp_is_zero:
 	xchgq %rsp, %gs:SGX_STACK
-.Lreturn_from_ocall_rsp_is_set:
-
 	movq $0, %gs:SGX_OCALL_PREPARED
+.Lreturn_from_ocall_prepared_is_cleared:
 
 	## sgx_context_t::rax = %rdi
-	movq %rdi, (%rsp) # return value
+	movq %rdi, SGX_CONTEXT_RAX(%rsp) # return value
 
 	# restore FSBASE if necessary
 	movq %gs:SGX_FSBASE, %rbx

--- a/Pal/src/host/Linux-SGX/enclave_entry.S
+++ b/Pal/src/host/Linux-SGX/enclave_entry.S
@@ -10,6 +10,32 @@
 	jmp .Lfail_loop\@
 .endm
 
+# If this enclave thread has not been initialized yet, we should not
+# try to call an event handler yet.
+.macro FAIL_LOOP_IF_NOT_READY_FOR_EXCEPTIONS
+	cmpq $0, %gs:SGX_READY_FOR_EXCEPTIONS
+	jne 1f
+	FAIL_LOOP
+1:
+.endm
+
+.macro WRFSBASE_RBX
+	.byte 0xf3, 0x48, 0x0f, 0xae, 0xd3 /* WRFSBASE %RBX */
+.endm
+
+.macro SGX_TLS_FLAGS_SET_EXECUTING_BIT reg
+	movq %gs:SGX_SELF, \reg
+	lock btsq $SGX_TLS_FLAGS_EVENT_EXECUTING_BIT, SGX_FLAGS(\reg)
+.endm
+
+.macro SGX_TLS_FLAGS_CLEAR_EXECUTING_BIT reg
+	movq %gs:SGX_SELF, \reg
+	lock btrq $SGX_TLS_FLAGS_EVENT_EXECUTING_BIT, SGX_FLAGS(\reg)
+.endm
+
+	.extern ecall_table
+	.extern enclave_ecall_pal_main
+
 	.global enclave_entry
 	.type enclave_entry, @function
 
@@ -104,7 +130,8 @@ enclave_entry:
 
 	movq %rdi, %rsi
 	xorq %rdi, %rdi
-	movl SGX_GPR_EXITINFO(%rbx), %edi
+	movl $0, %edi
+	xchgl %edi, SGX_GPR_EXITINFO(%rbx) ## don't carry this info for next resume
 	testl $0x80000000, %edi
 	jnz .Lhandle_exception
 
@@ -112,7 +139,7 @@ enclave_entry:
 	# use external event - only the first 8 bits count
 	andl $0xff, %edi
 	cmpl $0, %edi
-	jne .Lhandle_exception
+	jne .Lhandle_exception_raise
 
 	# clear the registers
 	xorq %rdi, %rdi
@@ -122,14 +149,6 @@ enclave_entry:
 	movq %rdx, %rbx
 	movq $EEXIT, %rax
 	ENCLU
-
-.Lhandle_exception:
-	# If this enclave thread has not been initialized yet, we should not
-	# try to call an event handler yet.
-	cmpq $0, %gs:SGX_READY_FOR_EXCEPTIONS
-	jne 1f
-	FAIL_LOOP
-1:
 
 	## There is a race between host signal delivery and restoring %rsp
 	## in this entry code. We must be careful to setup %rsp.
@@ -159,6 +178,31 @@ enclave_entry:
 	## SGX_STACK (which was updated with the last known good in-enclave
 	## %rsp during Leexit).
 
+.Lhandle_exception_raise:
+	FAIL_LOOP_IF_NOT_READY_FOR_EXCEPTIONS
+
+	SGX_TLS_FLAGS_SET_EXECUTING_BIT %rax
+	jnc .Lhandle_exception__
+
+	cmpq $PAL_EVENT_QUIT, %rdi
+	je .Lpend_async_event
+	cmpq $PAL_EVENT_SUSPEND, %rdi
+	je .Lpend_async_event
+	cmpq $PAL_EVENT_RESUME, %rdi
+	je .Lpend_async_event
+	jmp .Lhandle_exception__
+
+.Lpend_async_event:
+	# %rdi = $PAL_EVENT_QUIT or $PAL_EVENT_SUSPEND or $PAL_EVENT_RESUME
+	lock btsq %rdi, SGX_PENDING_ASYNC_EVENT(%rax)
+	lock btsq $SGX_TLS_FLAGS_ASYNC_EVENT_PENDING_BIT, SGX_FLAGS(%rax)
+	jmp .Lhandle_exception__
+
+.Lhandle_exception:
+	FAIL_LOOP_IF_NOT_READY_FOR_EXCEPTIONS
+
+	SGX_TLS_FLAGS_SET_EXECUTING_BIT %rax
+.Lhandle_exception__:
 	# %rbx SGX_GPR base address from TLS
 	movq SGX_GPR_RSP(%rbx), %rsi
 	movq %gs:SGX_STACK, %rax
@@ -432,10 +476,69 @@ __restore_sgx_context:
 	popq %r15
 	popfq
 
+	/* void to clobber red zone */
+	subq $(REDZONE_SIZE + 8), -13 * 8(%rsp)
+	movq -13 * 8(%rsp), %rsp
+	retq $REDZONE_SIZE
+
+	# void __restore_sgx_context_retry (sgx_context_t *uc)
+	# __attribute__((noreturn))
+	.global __restore_sgx_context_retry
+	.type __restore_sgx_context_retry, @function
+__restore_sgx_context_retry:
+	movq %rdi, %rsp
+
+	popq %rax
+	popq %rcx
+	popq %rdx
+	popq %rbx
+	addq $8, %rsp /* don't popq RSP yet */
+	popq %rbp
+	popq %rsi
+	popq %rdi
+	popq %r8
+	popq %r9
+	popq %r10
+	popq %r11
+	popq %r12
+	popq %r13
+
+	/* store saved %rip at -REDZONE-8(%saved rsp) */
+	## there is sgx_context_t + xsave area + 8 bytes + redzone
+	## is allocated on the stack. So it doesn't clobber saved
+	## registers.
+	##
+	## see the definition of sgx_context_t
+	## currently %rsp is pointing to %r14
+	movq -10 * 8(%rsp), %r14 # %r14 = saved %rsp
+	movq 3 * 8(%rsp), %r15	 # %r15 = saved %rip
+	movq %r15, - REDZONE_SIZE - 8(%r14)
+
+	popq %r14
+
+	SGX_TLS_FLAGS_CLEAR_EXECUTING_BIT %r15
+	/* There is a window from here to movq below where stack
+	 * can grow. */
+	lock btrq $SGX_TLS_FLAGS_ASYNC_EVENT_PENDING_BIT, SGX_FLAGS(%r15)
+	jc .Ltry_again
+
+	popq %r15
+	popfq
+
 	/* avoid to clobber red zone */
 	subq $(REDZONE_SIZE + 8), -13 * 8(%rsp)
 	movq -13 * 8(%rsp), %rsp
 	retq $REDZONE_SIZE
+
+.Ltry_again:
+	lock btsq $SGX_TLS_FLAGS_EVENT_EXECUTING_BIT, SGX_FLAGS(%r15)
+	## XXX TODO. check if the stack
+	## what if %rsp was on signal stack.
+	## just substracting %rsp doesn't work. check %rsp is
+	## in signal stack.
+	subq $15 * 8, %rsp 	# revert popq
+	movq %rsp, %rdi
+	callq _DkExceptionHandlerMore
 
 	# void save_xregs(uint64_t xsave_area)
 	.global save_xregs

--- a/Pal/src/host/Linux-SGX/enclave_entry.S
+++ b/Pal/src/host/Linux-SGX/enclave_entry.S
@@ -159,17 +159,49 @@ enclave_entry:
 	## SGX_STACK (which was updated with the last known good in-enclave
 	## %rsp during Leexit).
 
+	# %rbx SGX_GPR base address from TLS
 	movq SGX_GPR_RSP(%rbx), %rsi
 	movq %gs:SGX_STACK, %rax
 	cmpq $0, %rax
 	je 1f
 	movq %rax, %rsi
 1:
-	subq $(SGX_CONTEXT_SIZE + REDZONE_SIZE), %rsi
+
+	movq %gs:SGX_SIG_STACK_LOW, %rax
+	cmpq %rax, %rsi
+	jbe .Lout_of_signal_stack
+	movq %gs:SGX_SIG_STACK_HIGH, %rax
+	cmpq %rax, %rsi
+	ja .Lout_of_signal_stack
+	jmp .Lon_signal_stack
+
+.Lout_of_signal_stack:
+	movq %gs:SGX_SIG_STACK_HIGH, %rsi
+        /* staring from new stack. there is no red zone used.
+         * offset it below calculation */
+	addq $REDZONE_SIZE, %rsi
+
+	/* 8 is to avoid redzone clobber */
+#define STACK_PADDING_SIZE	(PAL_FP_XSTATE_MAGIC2_SIZE + 8)
+#define STACK_FRAME_SUB \
+	(SGX_CONTEXT_SIZE + REDZONE_SIZE + STACK_PADDING_SIZE)
+.Lon_signal_stack:
+	movq xsave_size@GOTPCREL(%rip), %rax
+	movl (%rax), %eax
+	addq $STACK_FRAME_SUB, %rax
+	subq %rax, %rsi
+	# Align xsave area to 64 bytes after sgx_context_t
+	# SGX_CONTEXT_SIZE = sizeof(sgx_context_t) = 144
+	# PAL_XSTATE_ALIGN = 64
+	# SGX_CONTEXT_XSTATE_ALIGN_SUB=SGX_CONTEXT_SIZE % PAL_XSTATE_ALIGN = 16
+	# unfortunatley gas doesn't understand
+	# $(SGX_CONTEXT_SIZE % PAL_XSTATE_ALIGN)
+	andq $~(PAL_XSTATE_ALIGN - 1), %rsi
+	subq $SGX_CONTEXT_XSTATE_ALIGN_SUB, %rsi
 
 	# we have exitinfo in RDI, swap with the one on GPR
 	# and dump into the context
-	xchgq %rdi, SGX_GPR_RDI(%rbx)
+	xchgq %rdi, SGX_GPR_RDI(%rbx) # 1st argument for _DkExceptionHandler()
 	movq %rdi, SGX_CONTEXT_RDI(%rsi)
 
 	# dump the rest of context
@@ -210,11 +242,15 @@ enclave_entry:
 	movq %rdi, SGX_CONTEXT_RIP(%rsi)
 
 	movq %rsi, SGX_GPR_RSP(%rbx)
-	movq %rsi, SGX_GPR_RSI(%rbx)
+	movq %rsi, SGX_GPR_RSI(%rbx) ## 2nd argument for _DkExceptionHandler()
+
+	/* TODO: save EXINFO in MISC region */
 
 	# new RIP is the exception handler
 	leaq _DkExceptionHandler(%rip), %rdi
 	movq %rdi, SGX_GPR_RIP(%rbx)
+
+	# FP registers are saved on entry of _DkExceptionHandler()
 
 	# clear the registers
 	xorq %rdi, %rdi
@@ -230,8 +266,55 @@ enclave_entry:
 	.type sgx_ocall, @function
 
 sgx_ocall:
+	##
+	## input:
+	## %rdi: code
+	## %rsi: void * ms
+	##
+	## sgx_context_t:
+	##   rax = 0: place holder
+	##   rcx
+	##   ...
+	##   rflags
+	##   rip
+	## xsave area
+	##   xregs
+	## (padding)
+	## ---
+	## previous rbp
+	## previous rip: pushed by callq
+	##
+
 	pushq %rbp
 	movq %rsp, %rbp
+
+	## switch to signal stack if not yet.
+	movq %gs:SGX_SIG_STACK_LOW, %rax
+	cmpq %rax, %rsp
+	jbe .Lout_of_signal_stack_ocall
+	movq %gs:SGX_SIG_STACK_HIGH, %rax
+	cmpq %rax, %rsp
+	ja .Lout_of_signal_stack_ocall
+	jmp .Lon_signal_stack_ocall
+
+.Lout_of_signal_stack_ocall:
+	movq %gs:SGX_SIG_STACK_HIGH, %rsp
+
+.Lon_signal_stack_ocall:
+
+	movq xsave_size@GOTPCREL(%rip), %rax
+	movl (%rax), %eax
+	addq $STACK_PADDING_SIZE, %rax
+	subq %rax, %rsp
+	andq $~(PAL_XSTATE_ALIGN - 1), %rsp
+
+	pushq %rdx
+	pushq %rdi
+	movq %rsp, %rdi
+	addq $2 * 8, %rdi	/* adjust pushq %rdx; pushq %rdi above */
+	callq save_xregs
+	popq %rdi
+	popq %rdx
 
 	movq 8(%rbp), %rax
 	pushq %rax	# previous RIP
@@ -253,18 +336,16 @@ sgx_ocall:
 	pushq %rbx
 	pushq %rdx
 	pushq %rcx
-	# no RAX
-
-	movq %rsp, %rbp
-	subq $XSAVE_SIZE,  %rsp
-	andq $XSAVE_ALIGN, %rsp
-	fxsave (%rsp)
-
-	pushq %rbp
+	pushq $0        # place holder for RAX
 
 	movq $1, %gs:SGX_OCALL_PREPARED
 
 .Leexit:
+	movq %rdi, %rbx
+	movq SYNTHETIC_STATE@GOTPCREL(%rip), %rdi
+	callq restore_xregs
+	movq %rbx, %rdi
+
 	xorq %rdx, %rdx
 	xorq %r8, %r8
 	xorq %r9, %r9
@@ -296,7 +377,12 @@ sgx_ocall:
 
 	movq $0, %gs:SGX_OCALL_PREPARED
 
-	movq %rdi, %rax
+	# restore the stack
+	movq $0, %rsp
+	xchgq %rsp, %gs:SGX_STACK
+
+	## sgx_context_t::rax = %rdi
+	movq %rdi, (%rsp) # return value
 
 	# restore FSBASE if necessary
 	movq %gs:SGX_FSBASE, %rbx
@@ -304,28 +390,26 @@ sgx_ocall:
 	je .Lno_fsbase
 	.byte 0xf3, 0x48, 0x0f, 0xae, 0xd3 /* WRFSBASE %RBX */
 .Lno_fsbase:
-
-	# restore the stack
-	movq $0, %rsp
-	xchgq %rsp, %gs:SGX_STACK
-
-	popq %rbp
-	fxrstor (%rsp)
-	movq %rbp, %rsp
-
-	cmpq $0, %rsi
-	je .Lno_external_event
-	pushq %rax
-	movq %rsi, %rdi
-	movq %rsp, %rsi
+	movq %rsi, %rdi	## %rdi = PAL_NUM event <- RSI
+	movq %rsp, %rsi	## %rsi = sgx_context_t * uc
+	movq %rsp, %rdx
+	addq $SGX_CONTEXT_SIZE, %rdx ## %rdx = PAL_XREGS_STATE * xregs_state
 	callq _DkHandleExternalEvent
-	popq %rax
-.Lno_external_event:
+	## NOTREACHED
 
+	# void __restore_sgx_context (sgx_context_t *uc)
+	# __attribute__((noreturn))
+	.global __restore_sgx_context
+	.type __restore_sgx_context, @function
+__restore_sgx_context:
+	movq %rdi, %rsp
+
+	popq %rax
 	popq %rcx
 	popq %rdx
 	popq %rbx
-	addq $16, %rsp	# skip RSP and RBP
+	addq $8, %rsp /* don't popq RSP yet */
+	popq %rbp
 	popq %rsi
 	popq %rdi
 	popq %r8
@@ -334,12 +418,24 @@ sgx_ocall:
 	popq %r11
 	popq %r12
 	popq %r13
+
+	/* store saved %rip at -REDZONE-8(%saved rsp).
+	 * notice sizeof(sgx_context_t) = 144 > 128 = REDZONE_SIZE.
+	 */
+	## see the definition of sgx_context_t
+	## currently %rsp is pointing to %r14
+	movq -10 * 8(%rsp), %r14 # %r14 = saved %rsp
+	movq 3 * 8(%rsp), %r15	 # %r15 = saved %rip
+	movq %r15, - REDZONE_SIZE - 8(%r14)
+
 	popq %r14
 	popq %r15
 	popfq
-	addq $8, %rsp	# skip RIP
-	popq %rbp
-	retq
+
+	/* avoid to clobber red zone */
+	subq $(REDZONE_SIZE + 8), -13 * 8(%rsp)
+	movq -13 * 8(%rsp), %rsp
+	retq $REDZONE_SIZE
 
 	# void save_xregs(uint64_t xsave_area)
 	.global save_xregs

--- a/Pal/src/host/Linux-SGX/enclave_entry.S
+++ b/Pal/src/host/Linux-SGX/enclave_entry.S
@@ -130,6 +130,15 @@ enclave_entry:
 	# PAL convention:
 	# RDI - external event
 
+    # It is assumed that synchronous exception doesn't happen during
+    # .Lhandle_resume. the host OS doesn't inject async signal nestedly
+	# as it masks async signals on signal handler.
+	# If malicious host OS inject exception nestedly, stop execution.
+	cmpq $1, %rax
+	je 1f
+	FAIL_LOOP
+1:
+
 	# get some information from GPR
 	movq %gs:SGX_GPR, %rbx
 

--- a/Pal/src/host/Linux-SGX/enclave_ocalls.h
+++ b/Pal/src/host/Linux-SGX/enclave_ocalls.h
@@ -5,6 +5,9 @@
  * This is for enclave to make ocalls to untrusted runtime.
  */
 
+#ifndef ENCLAVE_OCALLS_H
+#define ENCLAVE_OCALLS_H
+
 #include "pal_linux.h"
 
 #include <asm/stat.h>
@@ -103,3 +106,35 @@ int ocall_rename (const char * oldpath, const char * newpath);
 int ocall_delete (const char * pathname);
 
 int ocall_load_debug (const char * command);
+
+/* callee saved registers */
+struct ocall_marker_buf {
+    uint64_t rbx;
+    uint64_t rbp;
+    uint64_t r12;
+    uint64_t r13;
+    uint64_t r14;
+    uint64_t r15;
+    uint64_t rsp;
+    uint64_t rip;
+};
+
+struct ocall_marker_ret {
+    int64_t ret;                    /* %rax */
+    struct ocall_marker_buf * prev; /* %rdx */
+};
+
+struct ocall_marker_ret ocall_marker_save(struct ocall_marker_buf * marker);
+
+static inline struct ocall_marker_buf * ocall_marker_clear(void)
+{
+    struct ocall_marker_buf * prev = NULL;
+    __asm__ volatile (
+        "xchgq %0, %%gs:%c1\n"
+        : "+r"(prev)
+        : "i"(offsetof(struct enclave_tls, ocall_marker))
+        : "memory");
+    return prev;
+}
+
+#endif /* ENCLAVE_OCALLS_H */

--- a/Pal/src/host/Linux-SGX/pal_linux.h
+++ b/Pal/src/host/Linux-SGX/pal_linux.h
@@ -113,6 +113,7 @@ void init_xsave_size(uint64_t xfrm);
 void save_xregs(PAL_XREGS_STATE * xsave_area);
 void restore_xregs(const PAL_XREGS_STATE * xsave_area);
 int init_trusted_files (void);
+void __restore_sgx_context (sgx_context_t *uc) __attribute__((noreturn));
 
 /* Function: load_trusted_file
  * checks if the file to be opened is trusted or allowed,

--- a/Pal/src/host/Linux-SGX/pal_linux.h
+++ b/Pal/src/host/Linux-SGX/pal_linux.h
@@ -105,6 +105,11 @@ extern char __text_start, __text_end, __data_start, __data_end;
 typedef struct { char bytes[32]; } sgx_checksum_t;
 typedef struct { char bytes[16]; } sgx_stub_t;
 
+extern uint64_t xsave_features;
+extern uint32_t xsave_size;
+#define SYNTHETIC_STATE_SIZE   (512 + 64)  // 512 for legacy regs, 64 for xsave header
+extern const uint32_t SYNTHETIC_STATE[];
+void init_xsave_size(uint64_t xfrm);
 int init_trusted_files (void);
 
 /* Function: load_trusted_file

--- a/Pal/src/host/Linux-SGX/pal_linux.h
+++ b/Pal/src/host/Linux-SGX/pal_linux.h
@@ -110,6 +110,8 @@ extern uint32_t xsave_size;
 #define SYNTHETIC_STATE_SIZE   (512 + 64)  // 512 for legacy regs, 64 for xsave header
 extern const uint32_t SYNTHETIC_STATE[];
 void init_xsave_size(uint64_t xfrm);
+void save_xregs(PAL_XREGS_STATE * xsave_area);
+void restore_xregs(const PAL_XREGS_STATE * xsave_area);
 int init_trusted_files (void);
 
 /* Function: load_trusted_file

--- a/Pal/src/host/Linux-SGX/pal_linux.h
+++ b/Pal/src/host/Linux-SGX/pal_linux.h
@@ -114,6 +114,7 @@ void save_xregs(PAL_XREGS_STATE * xsave_area);
 void restore_xregs(const PAL_XREGS_STATE * xsave_area);
 int init_trusted_files (void);
 void __restore_sgx_context (sgx_context_t *uc) __attribute__((noreturn));
+void __restore_sgx_context_retry (sgx_context_t *uc) __attribute__((noreturn));
 
 /* Function: load_trusted_file
  * checks if the file to be opened is trusted or allowed,

--- a/Pal/src/host/Linux-SGX/pal_linux_defs.h
+++ b/Pal/src/host/Linux-SGX/pal_linux_defs.h
@@ -8,6 +8,7 @@
 #define SSAFRAMENUM         (2)
 #define MEMORY_GAP          (PRESET_PAGESIZE)
 #define ENCLAVE_STACK_SIZE  (PRESET_PAGESIZE * 16)
+#define ENCLAVE_SIG_STACK_SIZE  (PRESET_PAGESIZE * 16)
 #define DEAFULT_HEAP_MIN    (0x10000)
 #define TRACE_ECALL         (1)
 #define TRACE_OCALL         (1)

--- a/Pal/src/host/Linux-SGX/sgx_arch.h
+++ b/Pal/src/host/Linux-SGX/sgx_arch.h
@@ -44,6 +44,9 @@ typedef struct {
 
 #define SGX_XFRM_LEGACY          0x03ULL
 #define SGX_XFRM_AVX             0x06ULL
+#define SGX_XFRM_MPX             0x18ULL
+#define SGX_XFRM_AVX512          0xE6ULL
+#define SGX_XFRM_RESERVED        (~(SGX_XFRM_LEGACY | SGX_XFRM_AVX))
 
 #define SGX_MISCSELECT_EXINFO    0x01UL
 

--- a/Pal/src/host/Linux-SGX/sgx_arch.h
+++ b/Pal/src/host/Linux-SGX/sgx_arch.h
@@ -275,8 +275,6 @@ typedef uint8_t sgx_arch_key128_t[16] __attribute__((aligned(16)));
 #define KEYPOLICY_MRENCLAVE     1
 #define KEYPOLICY_MRSIGNER      2
 
-#define XSAVE_SIZE  512
-
 #define STACK_ALIGN 0xfffffffffffffff0
 #define XSAVE_ALIGN 0xffffffffffffffc0
 

--- a/Pal/src/host/Linux-SGX/sgx_arch.h
+++ b/Pal/src/host/Linux-SGX/sgx_arch.h
@@ -279,4 +279,6 @@ typedef uint8_t sgx_arch_key128_t[16] __attribute__((aligned(16)));
 
 #define RETURN_FROM_OCALL 0xffffffffffffffff
 
+#define REDZONE_SIZE    128
+
 #endif /* SGX_ARCH_H */

--- a/Pal/src/host/Linux-SGX/sgx_exception.c
+++ b/Pal/src/host/Linux-SGX/sgx_exception.c
@@ -211,6 +211,8 @@ static void _DkTerminateSighandler (int signum, siginfo_t * info,
         uc->uc_mcontext.gregs[REG_RDI] = -PAL_ERROR_INTERRUPTED;
         uc->uc_mcontext.gregs[REG_RSI] = get_event_num(signum);
     } else {
+        SGX_DBG(DBG_E, "sgx_raise signum %d event %d\n",
+                signum, get_event_num(signum));
         sgx_raise(get_event_num(signum));
     }
 }
@@ -244,6 +246,7 @@ static void _DkResumeSighandler (int signum, siginfo_t * info,
     }
 
     int event = get_event_num(signum);
+    SGX_DBG(DBG_E, "sgx_raise signum %d event %d\n", signum, event);
     sgx_raise(event);
 }
 

--- a/Pal/src/host/Linux-SGX/sgx_exception.c
+++ b/Pal/src/host/Linux-SGX/sgx_exception.c
@@ -88,7 +88,11 @@ int set_sighandler (int * sigs, int nsig, void * handler)
     action.sa_restorer = restore_rt;
 #endif
 
+    /* during enclave handling exception,
+     * don't inject async exception nestedly. */
     __sigemptyset((__sigset_t *) &action.sa_mask);
+    __sigaddset((__sigset_t *) &action.sa_mask, SIGTERM);
+    __sigaddset((__sigset_t *) &action.sa_mask, SIGINT);
     __sigaddset((__sigset_t *) &action.sa_mask, SIGCONT);
 
     for (int i = 0 ; i < nsig ; i++) {

--- a/Pal/src/host/Linux-SGX/sgx_main.c
+++ b/Pal/src/host/Linux-SGX/sgx_main.c
@@ -421,6 +421,8 @@ int initialize_enclave (struct pal_enclave * enclave)
 
             for (int t = 0 ; t < enclave->thread_num ; t++) {
                 struct enclave_tls * gs = data + pagesize * t;
+                gs->self = (struct enclave_tls *)(
+                    tls_area->addr + pagesize * t + enclave_secs.baseaddr);
                 gs->enclave_size = enclave->size;
                 gs->tcs_offset = tcs_area->addr + pagesize * t;
                 gs->initial_stack_offset =

--- a/Pal/src/host/Linux-SGX/sgx_tls.h
+++ b/Pal/src/host/Linux-SGX/sgx_tls.h
@@ -11,6 +11,18 @@ struct enclave_tls {
     uint64_t initial_stack_offset;
     uint64_t sig_stack_low;
     uint64_t sig_stack_high;
+#define SGX_TLS_FLAGS_ASYNC_EVENT_PENDING_BIT   (0)
+#define SGX_TLS_FLAGS_EVENT_EXECUTING_BIT       (1)
+#define SGX_TLS_FLAGS_ASYNC_ENVET_PENDING       (1UL << SGX_TLS_FLAGS_ASYNC_ENVET_PENDING_BIT)
+#define SGX_TLS_FLAGS_EVENT_EXECUTING           (1UL << SGX_TLS_FLAGS_ENVET_EXECUTING_BIT)
+    uint64_t flags;
+#define PAL_EVENT_MASK(event)   (1UL << (event))
+#define PAL_ASYNC_EVENT_MASK                    \
+    (PAL_EVENT_MASK(PAL_EVENT_QUIT) |           \
+     PAL_EVENT_MASK(PAL_EVENT_SUSPEND) |        \
+     PAL_EVENT_MASK(PAL_EVENT_RESUME))
+    uint64_t pending_async_event;
+    struct atomic_int event_nest;
     void *   aep;
     void *   ssa;
     sgx_arch_gpr_t * gpr;

--- a/Pal/src/host/Linux-SGX/sgx_tls.h
+++ b/Pal/src/host/Linux-SGX/sgx_tls.h
@@ -5,6 +5,7 @@
 #define __SGX_TLS_H__
 
 struct enclave_tls {
+    struct enclave_tls * self;
     uint64_t enclave_size;
     uint64_t tcs_offset;
     uint64_t initial_stack_offset;
@@ -42,6 +43,14 @@ extern uint64_t dummy_debug_variable;
         __asm__ ("movq %q0, %%gs:%c1":: "r" (value),                \
              "i" (offsetof(struct enclave_tls, member)));           \
     } while (0)
+
+static inline struct enclave_tls * get_enclave_tls(void)
+{
+        struct enclave_tls * __self;
+        __asm__ ("movq %%gs:%c1, %q0": "=r" (__self)
+             : "i" (offsetof(struct enclave_tls, self)));
+        return __self;
+}
 # endif
 
 #endif /* __SGX_TLS_H__ */

--- a/Pal/src/host/Linux-SGX/sgx_tls.h
+++ b/Pal/src/host/Linux-SGX/sgx_tls.h
@@ -8,6 +8,8 @@ struct enclave_tls {
     uint64_t enclave_size;
     uint64_t tcs_offset;
     uint64_t initial_stack_offset;
+    uint64_t sig_stack_low;
+    uint64_t sig_stack_high;
     void *   aep;
     void *   ssa;
     sgx_arch_gpr_t * gpr;

--- a/Pal/src/host/Linux-SGX/sgx_tls.h
+++ b/Pal/src/host/Linux-SGX/sgx_tls.h
@@ -23,6 +23,7 @@ struct enclave_tls {
      PAL_EVENT_MASK(PAL_EVENT_RESUME))
     uint64_t pending_async_event;
     struct atomic_int event_nest;
+    struct ocall_marker_buf * ocall_marker;
     void *   aep;
     void *   ssa;
     sgx_arch_gpr_t * gpr;

--- a/Pal/src/host/Linux-SGX/signer/pal-sgx-sign
+++ b/Pal/src/host/Linux-SGX/signer/pal-sgx-sign
@@ -22,6 +22,7 @@ SSAFRAMESIZE = PAGESIZE
 SSAFRAMENUM = 2
 
 ENCLAVE_STACK_SIZE = PAGESIZE * 16
+ENCLAVE_SIG_STACK_SIZE = PAGESIZE * 16
 DEFAULT_ENCLAVE_SIZE = '256M'
 DEFAULT_THREAD_NUM = 4
 ENCLAVE_HEAP_MIN = 0x10000
@@ -344,6 +345,9 @@ def get_memory_areas(manifest, attr, args):
 
     for t in range(attr['thread_num']):
         areas.append(MemoryArea('stack', size=ENCLAVE_STACK_SIZE,
+                                flags=PAGEINFO_R|PAGEINFO_W|PAGEINFO_REG))
+    for t in range(attr['thread_num']):
+        areas.append(MemoryArea('sig_stack', size=ENCLAVE_SIG_STACK_SIZE,
                                 flags=PAGEINFO_R|PAGEINFO_W|PAGEINFO_REG))
 
     areas.append(MemoryArea('pal', file=args['libpal'], flags=PAGEINFO_REG))

--- a/Pal/src/host/Linux/db_exception.c
+++ b/Pal/src/host/Linux/db_exception.c
@@ -137,8 +137,10 @@ static void _DkGenericEventTrigger (PAL_IDX event_num, PAL_EVENT_HANDLER upcall,
     PAL_EVENT event;
     event.event_num = event_num;
 
-    if (uc)
+    if (uc) {
         memcpy(&event.context, uc->uc_mcontext.gregs, sizeof(PAL_CONTEXT));
+        event.context.fpregs = (PAL_XREGS_STATE*)uc->uc_mcontext.fpregs;
+    }
 
     event.uc = uc;
 
@@ -363,5 +365,8 @@ void _DkExceptionReturn (void * event)
     if (e->uc) {
         /* copy the context back to ucontext */
         memcpy(e->uc->uc_mcontext.gregs, &e->context, sizeof(PAL_CONTEXT));
+        if (e->context.fpregs == NULL) {
+            e->uc->uc_mcontext.fpregs = NULL;
+        }
     }
 }


### PR DESCRIPTION
This PR is early preview for feedback and to avoid duplicated effort like #625 #626 

also related to issue #632 

Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md).

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [x] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes (reasons and measures)
This patch series is to clean up host signal handling by Linux-SGX PAL.
- use dedicated stack for host signal to avoid stack overflow when using stack application uses
- save/restore/initialize FP registers
- don't nest host signal as host signal is actually handled out of host signal context.
  If already signal is being served, record it and serve it after that. i.e. looping serving host signals.
- replace eframe hack with more clean way
  unwinding all pal call frame when host signal causes resource leak.
  Instead, make ocall atomic regarding to host signal.

## How to test this PR? (if applicable)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/632)
<!-- Reviewable:end -->
