### PR TITLE
[Pal/Linux-SGX] disallow nested async host exception in enclave_entry

### DIFF
--- a/Pal/src/host/Linux-SGX/enclave_entry.S
+++ b/Pal/src/host/Linux-SGX/enclave_entry.S
@@ -102,6 +102,20 @@ enclave_entry:
 	# PAL convention:
 	# RDI - external event
 
+	# Nested exceptions at the host-OS level are disallowed:
+	# - Synchronous exceptions are assumed to never happen during
+	#   handle_resume;
+	# - Asynchronous signals are not nested by benign host OS because
+	#   we mask asynchronous signals on signal handler.
+	# If malicious host OS injects a nested signal, CSSA != 1 and we
+	# fail execution.
+	# This FAIL_LOOP is assertion only because
+	# currently this is also enforced by EENTER because NSSA == 2
+	cmpq $1, %rax
+	je 1f
+	FAIL_LOOP
+1:
+
 	# get some information from GPR
 	movq %gs:SGX_GPR, %rbx
 

--- a/Pal/src/host/Linux-SGX/sgx_exception.c
+++ b/Pal/src/host/Linux-SGX/sgx_exception.c
@@ -91,7 +91,11 @@ int set_sighandler (int * sigs, int nsig, void * handler)
     action.sa_restorer = __restore_rt;
 #endif
 
+    /* Disallow nested asynchronous signals during enclave exception handling.
+     */
     __sigemptyset((__sigset_t *) &action.sa_mask);
+    __sigaddset((__sigset_t *) &action.sa_mask, SIGTERM);
+    __sigaddset((__sigset_t *) &action.sa_mask, SIGINT);
     __sigaddset((__sigset_t *) &action.sa_mask, SIGCONT);
 
     for (int i = 0 ; i < nsig ; i++) {


### PR DESCRIPTION
The enclave is set as TCS.nssa = 2, one for page fault for host OS,
one for host signal to bounce into enclave. .Lhandle_exception assumes
that TCS.cssa == 1. uRTS can maliciously inject async signal
nestedly. In that case, it should fall into fail loop because the code
assumption was broken. Mask host async signal(SIGINT, SIGTERM and
SIGCONT) on signal.

TCS.nssa = 2 is enough because even if we set TCS.nssa = N > 2 and
allow nested async host signal. But if it nested up to
TCS.cssa = N - 1, the situation is same.
Please remember that .Lhandle_exception is called in signal context to
set up the actual exception handler with specified signal masked and
returns back from signal handler to normal execution. And then the
actual exception handler in enclave is triggered as normal execution
context, not as signal handler without any host signal masked.

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md).

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [x] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes (reasons and measures)


## How to test this PR? (if applicable)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/639)
<!-- Reviewable:end -->
