### PR TITLE
initialize rflags according to sysv x86-64 abi

### DIFF
--- a/LibOS/shim/src/elf/shim_rtld.c
+++ b/LibOS/shim/src/elf/shim_rtld.c
@@ -1586,13 +1586,15 @@ int execute_elf_object (struct shim_handle * exec,
 
 #if defined(__x86_64__)
     asm volatile (
+                    "pushq $0\r\n"
+                    "popfq\r\n"
                     "movq %%rbx, %%rsp\r\n"
                     "jmp *%%rax\r\n"
                     :
                     : "a"(entry),
                       "b"(argcp),
                       "d"(0)
-                    : "memory");
+                    : "memory", "cc");
 #else
 # error "architecture not supported"
 #endif

--- a/Pal/lib/atomic.h
+++ b/Pal/lib/atomic.h
@@ -117,7 +117,7 @@ static inline int64_t _atomic_add (int64_t i, struct atomic_int * v)
     int64_t increment = i;
     __asm__ __volatile__(
         "lock ; xadd %0, %1"
-        : "=r"(i), "=m"(v->counter) : "0"(i) : "memory" );
+        : "=r"(i), "=m"(v->counter) : "0"(i) : "memory", "cc");
     return i + increment;
 }
 
@@ -138,7 +138,7 @@ static inline void atomic_inc (struct atomic_int * v)
 {
     __asm__ __volatile__(
         "lock ; incl %0"
-        : "=m"(v->counter) : "m"(v->counter) : "memory" );
+        : "=m"(v->counter) : "m"(v->counter) : "memory", "cc");
 }
 
 /* Atomically substracts 1 from v.  Does not return a value. */
@@ -146,7 +146,7 @@ static inline void atomic_dec (struct atomic_int * v)
 {
     __asm__ __volatile__(
         "lock ; decl %0"
-        : "=m"(v->counter) : "m"(v->counter) : "memory" );
+        : "=m"(v->counter) : "m"(v->counter) : "memory", "cc");
 }
 
 /* Atomically substracts 1 from v.  Returns 1 if this causes the 
@@ -164,7 +164,7 @@ static inline int64_t cmpxchg(volatile int64_t *p, int64_t t, int64_t s)
 {
     __asm__ __volatile__ (
         "lock ; cmpxchg %3, %1"
-        : "=a"(t), "=m"(*p) : "a"(t), "r"(s) : "memory" );
+        : "=a"(t), "=m"(*p) : "a"(t), "r"(s) : "memory", "cc");
     return t;
 }
 

--- a/Pal/src/db_rtld.c
+++ b/Pal/src/db_rtld.c
@@ -1284,7 +1284,10 @@ void * stack_before_call __attribute_unused = NULL;
 
 #define CALL_ENTRY(l, cookies)                                          \
     ({  long ret;                                                       \
-        __asm__ volatile("movq %%rsp, stack_before_call(%%rip)\r\n"     \
+        __asm__ volatile(                                               \
+                     "pushq $0\r\n"                                     \
+                     "popfq\r\n"                                        \
+                     "movq %%rsp, stack_before_call(%%rip)\r\n"         \
                      "leaq 1f(%%rip), %%rdx\r\n"                        \
                      "movq %2, %%rsp\r\n"                               \
                      "jmp *%1\r\n"                                      \
@@ -1292,7 +1295,7 @@ void * stack_before_call __attribute_unused = NULL;
                                                                         \
                      : "=a"(ret) : "a"(l->l_entry), "b"(cookies)        \
                      : "rcx", "rdx", "rdi", "rsi", "r8", "r9",          \
-                       "r10", "r11", "memory");                         \
+                       "r10", "r11", "memory", "cc");                   \
         ret; })
 #else
 # error "unsupported architecture"

--- a/Pal/src/host/Linux-SGX/enclave_entry.S
+++ b/Pal/src/host/Linux-SGX/enclave_entry.S
@@ -17,6 +17,9 @@ enclave_entry:
 	# On EENTER/ERESUME, RAX is the current SSA, RBX is the address of TCS,
 	# RCX is the address of AEP. Other registers are not trusted.
 
+	# x86-64 sysv abi requires %rFLAGS.DF = 0 on entry to function call.
+	cld
+
 	# current SSA is in RAX (Trusted)
 	cmpq $0, %rax
 	jne .Lhandle_resume

--- a/Pal/src/host/Linux/db_misc.c
+++ b/Pal/src/host/Linux/db_misc.c
@@ -122,7 +122,7 @@ int _DkRandomBitsRead (void * buffer, int size)
     do {
         unsigned long rand;
         asm volatile (".Lretry: rdrand %%rax\r\n jnc .Lretry\r\n"
-                      : "=a"(rand) :: "memory");
+                      : "=a"(rand) :: "memory", "cc");
 
         if (total_bytes + sizeof(rand) <= size) {
             *(unsigned long *) (buffer + total_bytes) = rand;


### PR DESCRIPTION
Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md).

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [x] SGX PAL
- [ ] FreeBSD PAL
- [x] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes (reasons and measures)
initialize rflags on function entry where necessary according to sysv x86-64 abi.

## How to test this PR? (if applicable)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/643)
<!-- Reviewable:end -->
