### PR TITLE
[LibOS] emulate clone(CLONE_VFORK | CLONE_VM | SIGCHLD) as vfork()

### DIFF
--- a/LibOS/shim/src/sys/shim_clone.c
+++ b/LibOS/shim/src/sys/shim_clone.c
@@ -171,6 +171,13 @@ int shim_do_clone (int flags, void * user_stack_addr, int * parent_tidptr,
     int * set_parent_tid = NULL;
     int ret = 0;
 
+    /* special case for vfork. some runtime uses clone() for vfork */
+    if (flags == (CLONE_VFORK | CLONE_VM | SIGCHLD) &&
+        user_stack_addr == NULL && parent_tidptr == NULL &&
+        child_tidptr == NULL && tls == NULL) {
+        return shim_do_vfork();
+    }
+
     assert((flags & ~(CLONE_PARENT_SETTID|CLONE_CHILD_SETTID|
                       CLONE_CHILD_CLEARTID|CLONE_SETTLS|
                       CLONE_VM|CLONE_FILES|


### PR DESCRIPTION
Some runtime uses clone(CLONE_VFORK | CLONE_VM | SIGCHLD) for vfork().
emulate clone(CLONE_VFORK | CLONE_VM | SIGCHLD) as vfork().

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes (reasons and measures)


## How to test this PR? (if applicable)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/645)
<!-- Reviewable:end -->
