### PR TITLE
stack trampoline instead of switch_stack in the middle of function

### DIFF
--- a/LibOS/shim/include/shim_internal.h
+++ b/LibOS/shim/include/shim_internal.h
@@ -759,20 +759,6 @@ bool test_user_string (const char * addr);
 int object_wait_with_retry(PAL_HANDLE handle);
 
 #ifdef __x86_64__
-#define SWITCH_STACK(stack_top)                                         \
-    ({                                                                  \
-        void * _rsp, * _rbp;                                            \
-        void * _stack = (stack_top);                                    \
-        __asm__ volatile ("movq %%rsp, %0" : "=r"(_rsp) :: "memory");   \
-        __asm__ volatile ("movq %%rbp, %0" : "=r"(_rbp) :: "memory");   \
-        _rsp = _stack - (_rbp - _rsp);                                  \
-        _rbp = _stack;                                                  \
-        __asm__ volatile ("movq %0, %%rsp" :: "r"(_rsp) : "memory");    \
-        __asm__ volatile ("movq %0, %%rbp" :: "r"(_rbp) : "memory");    \
-        __asm__ volatile ("movq %%rbp, %0" : "=r"(_stack) :: "memory"); \
-        _stack;                                                         \
-    })
-
 #define __SWITCH_STACK(stack_top, func, arg)                    \
     do {                                                        \
         /* 16 Bytes align of stack */                           \

--- a/LibOS/shim/include/shim_internal.h
+++ b/LibOS/shim/include/shim_internal.h
@@ -773,6 +773,19 @@ int object_wait_with_retry(PAL_HANDLE handle);
         _stack;                                                         \
     })
 
+#define __SWITCH_STACK(stack_top, func, arg)                    \
+    do {                                                        \
+        /* 16 Bytes align of stack */                           \
+        uintptr_t __stack_top = (uintptr_t)(stack_top);         \
+        __stack_top &= ~0xf;                                    \
+        __stack_top -= 8;                                       \
+        __asm__ volatile (                                      \
+            "movq %0, %%rbp\n"                                  \
+            "movq %0, %%rsp\n"                                  \
+            "jmpq *%1\n"                                        \
+            ::"r"(__stack_top), "r"(func), "D"(arg): "memory"); \
+    } while (0)
+
 static_always_inline void * current_stack(void)
 {
     void * _rsp;

--- a/LibOS/shim/include/shim_utils.h
+++ b/LibOS/shim/include/shim_utils.h
@@ -210,9 +210,9 @@ int check_elf_object (struct shim_handle * file);
 int load_elf_object (struct shim_handle * file, void * addr, size_t mapped);
 int load_elf_interp (struct shim_handle * exec);
 int free_elf_interp (void);
-void execute_elf_object (struct shim_handle * exec,
-                         int * argcp, const char ** argp,
-                         elf_auxv_t * auxp);
+noreturn void execute_elf_object (struct shim_handle * exec,
+                                  int * argcp, const char ** argp,
+                                  elf_auxv_t * auxp);
 int remove_loaded_libraries (void);
 
 /* gdb debugging support */

--- a/LibOS/shim/src/elf/shim_rtld.c
+++ b/LibOS/shim/src/elf/shim_rtld.c
@@ -1554,9 +1554,9 @@ int register_library (const char * name, unsigned long load_address)
     return 0;
 }
 
-void execute_elf_object (struct shim_handle * exec,
-                         int * argcp, const char ** argp,
-                         ElfW(auxv_t) * auxp)
+noreturn void execute_elf_object (struct shim_handle * exec,
+                                  int * argcp, const char ** argp,
+                                  ElfW(auxv_t) * auxp)
 {
     struct link_map * exec_map = __search_map_by_handle(exec);
     assert(exec_map);
@@ -1611,6 +1611,8 @@ void execute_elf_object (struct shim_handle * exec,
 #else
 # error "architecture not supported"
 #endif
+    while (true)
+        /* nothing */;
 }
 
 BEGIN_CP_FUNC(library)

--- a/LibOS/shim/src/ipc/shim_ipc_helper.c
+++ b/LibOS/shim/src/ipc/shim_ipc_helper.c
@@ -805,40 +805,36 @@ next:
 #define IPC_HELPER_STACK_SIZE       (allocsize * 4)
 #define IPC_HELPER_LIST_INIT_SIZE   32
 
-static void shim_ipc_helper (void * arg)
+static void shim_ipc_helper_end(struct shim_thread * self)
 {
-    /* set ipc helper thread */
-    struct shim_thread * self = (struct shim_thread *) arg;
-    if (!arg)
-        return;
+    /* Put our handle map reference */
+    if (self->handle_map)
+        put_handle_map(self->handle_map);
 
-    __libc_tcb_t tcb;
-    allocate_tls(&tcb, false, self);
-    debug_setbuf(&tcb.shim_tcb, true);
-    debug("set tcb to %p\n", &tcb);
-
-    lock(&ipc_helper_lock);
-    bool notme = (self != ipc_helper_thread);
-    unlock(&ipc_helper_lock);
-
-    if (notme) {
-        put_thread(self);
-        DkThreadExit();
-        return;
+    /* Another thread may be calling shim_clean(). Lower the chances of our
+     * IPC helper thread and another thread competing on shim_clean/shim_terminate
+     * (which is benign due to protection via ipc_helper_lock) by adding a barrier
+     * to ensure reading the latest IPC helper state. */
+    COMPILER_BARRIER();
+    if (ipc_helper_state == HELPER_HANDEDOVER) {
+        debug("ipc helper thread is the last thread, process exiting\n");
+        shim_terminate(0); // Same as shim_clean(), but this is the official termination function
     }
 
-    debug("ipc helper thread started\n");
+    lock(&ipc_helper_lock);
+    ipc_helper_state = HELPER_NOTALIVE;
+    ipc_helper_thread = NULL;
+    unlock(&ipc_helper_lock);
+    put_thread(self);
+    debug("ipc helper thread terminated\n");
 
-    void * stack = allocate_stack(IPC_HELPER_STACK_SIZE, allocsize, false);
+    DkThreadExit();
+}
 
-    if (!stack)
-        goto end;
-
-    self->stack_top = stack + IPC_HELPER_STACK_SIZE;
-    self->stack = stack;
-    SWITCH_STACK(stack + IPC_HELPER_STACK_SIZE);
-    self = get_cur_thread();
-    stack = self->stack;
+static void __shim_ipc_helper (void * dummy)
+{
+    struct shim_thread * self = get_cur_thread();
+    void * stack = self->stack;
 
     int port_num = 0, port_size = IPC_HELPER_LIST_INIT_SIZE;
     struct shim_ipc_port ** local_pobjs = stack, * pobj;
@@ -1020,28 +1016,43 @@ update_list:
     }
 
 end:
-    /* DP: Put our handle map reference */
-    if (self->handle_map)
-        put_handle_map(self->handle_map);
+    shim_ipc_helper_end(self);
+}
 
-    /* shim_clean ultimately calls del_all_ipc_ports(), which reacquires the
-     * helper lock.  Err on the side of caution by adding a barrier to ensure
-     * reading the latest ipc helper state.
-     */
-    COMPILER_BARRIER();
-    if (ipc_helper_state == HELPER_HANDEDOVER) {
-        debug("ipc helper thread is the last thread, process exiting\n");
-        shim_terminate(0); // Same as shim_clean(), but this is the official termination function
-    }
+static void shim_ipc_helper (void * arg)
+{
+    /* set ipc helper thread */
+    struct shim_thread * self = (struct shim_thread *) arg;
+    if (!arg)
+        return;
+
+    __libc_tcb_t tcb;
+    allocate_tls(&tcb, false, self);
+    debug_setbuf(&tcb.shim_tcb, true);
+    debug("set tcb to %p\n", &tcb);
 
     lock(&ipc_helper_lock);
-    ipc_helper_state = HELPER_NOTALIVE;
-    ipc_helper_thread = NULL;
+    bool notme = (self != ipc_helper_thread);
     unlock(&ipc_helper_lock);
-    put_thread(self);
-    debug("ipc helper thread terminated\n");
 
-    DkThreadExit();
+    if (notme) {
+        put_thread(self);
+        DkThreadExit();
+        return;
+    }
+
+    debug("ipc helper thread started\n");
+
+    void * stack = allocate_stack(IPC_HELPER_STACK_SIZE, allocsize, false);
+
+    if (!stack) {
+        shim_ipc_helper_end(self);
+        return;
+    }
+
+    self->stack_top = stack + IPC_HELPER_STACK_SIZE;
+    self->stack = stack;
+    __SWITCH_STACK(self->stack_top, __shim_ipc_helper, NULL);
 }
 
 /* This function shoudl be called with the ipc_helper_lock held */

--- a/LibOS/shim/src/ipc/shim_ipc_helper.c
+++ b/LibOS/shim/src/ipc/shim_ipc_helper.c
@@ -805,7 +805,7 @@ next:
 #define IPC_HELPER_STACK_SIZE       (allocsize * 4)
 #define IPC_HELPER_LIST_INIT_SIZE   32
 
-static void shim_ipc_helper_end(struct shim_thread * self)
+noreturn static void shim_ipc_helper_end(struct shim_thread * self)
 {
     /* Put our handle map reference */
     if (self->handle_map)
@@ -831,7 +831,7 @@ static void shim_ipc_helper_end(struct shim_thread * self)
     DkThreadExit();
 }
 
-static void __shim_ipc_helper (void * dummy)
+noreturn static void __shim_ipc_helper (void * dummy)
 {
     struct shim_thread * self = get_cur_thread();
     void * stack = self->stack;

--- a/LibOS/shim/src/sys/shim_exec.c
+++ b/LibOS/shim/src/sys/shim_exec.c
@@ -73,7 +73,7 @@ struct execve_rtld_arg
     elf_auxv_t *  new_auxp;
 };
 
-static void __shim_do_execve_rtld (struct execve_rtld_arg * __arg)
+noreturn static void __shim_do_execve_rtld (struct execve_rtld_arg * __arg)
 {
     struct execve_rtld_arg arg;
     memcpy(&arg, __arg, sizeof(arg));
@@ -169,8 +169,7 @@ retry_dump_vmas:
 
     debug("execve: start execution\n");
     execute_elf_object(cur_thread->exec, new_argcp, new_argp, new_auxp);
-
-    return;
+    /* NOTREACHED */
 
 error:
     debug("execve: failed %d\n", ret);

--- a/Pal/src/db_process.c
+++ b/Pal/src/db_process.c
@@ -63,6 +63,8 @@ noreturn void DkProcessExit (PAL_NUM exitcode)
     ENTER_PAL_CALL(DkProcessExit);
     _DkProcessExit(exitcode);
     _DkRaiseFailure(PAL_ERROR_NOTKILLABLE);
+    while (true)
+        /* nothing */;
     LEAVE_PAL_CALL();
 }
 

--- a/Pal/src/db_threading.c
+++ b/Pal/src/db_threading.c
@@ -81,7 +81,8 @@ noreturn void DkThreadExit (void)
     ENTER_PAL_CALL(DkThreadExit);
     _DkThreadExit();
     _DkRaiseFailure(PAL_ERROR_NOTKILLABLE);
-    while (1) {}
+    while (true)
+        /* nothing */;
     LEAVE_PAL_CALL();
 }
 


### PR DESCRIPTION
<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes (reasons and measures)
stack trampoline instead of changing stack in the middle of function by switch_stack()
The changing stack with extended assembler in the middle of function is fragile.

## How to test this PR? (if applicable)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/648)
<!-- Reviewable:end -->
