### PR TITLE
[*/regression] Increase timeout of regression tests

### DIFF
--- a/LibOS/shim/test/regression/Makefile
+++ b/LibOS/shim/test/regression/Makefile
@@ -49,7 +49,7 @@ endif
 PYTHONENV="PYTHONPATH=../../../../Scripts"
 
 ifeq ($(SGX_RUN),1)
-	PYTHONENV += "TIMEOUT=5000"
+	PYTHONENV += "TIMEOUT=20000"
 endif
 
 .PHONY: regression

--- a/Pal/regression/00_Bootstrap.py
+++ b/Pal/regression/00_Bootstrap.py
@@ -157,7 +157,7 @@ if rv: sys.exit(rv)
 
 # Running Bootstrap6.manifest - SGX-specific test
 if sgx:
-    regression = Regression(loader, manifest_file("Bootstrap6"), timeout = 100000)
+    regression = Regression(loader, manifest_file("Bootstrap6"), timeout = 200000)
     regression.add_check(name="8GB Enclave Creation (SGX Only)",
                          check=lambda res: "Loaded Manifest: file:Bootstrap6.manifest.sgx" in res[0].log and
                          "Executable Range OK" in res[0].log)

--- a/Pal/regression/02_Misc.py
+++ b/Pal/regression/02_Misc.py
@@ -3,7 +3,7 @@ from regression import Regression
 
 loader = os.environ['PAL_LOADER']
 
-regression = Regression(loader, "Misc", timeout=5000)
+regression = Regression(loader, "Misc")
 
 regression.add_check(name="Query System Time",
     check=lambda res: "Query System Time OK" in res[0].log)

--- a/Pal/regression/Makefile
+++ b/Pal/regression/Makefile
@@ -76,7 +76,7 @@ endif
 PYTHONENV = "PYTHONPATH=../../Scripts"
 
 ifeq ($(SGX_RUN),1)
-	PYTHONENV += "TIMEOUT=5000"
+	PYTHONENV += "TIMEOUT=20000"
 endif
 
 regression: $(call expand_target,$(target))


### PR DESCRIPTION
## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [x] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes (reasons and measures)

On weaker machines (Intel NUCs and SGX-enabled laptops), SGX regression tests take longer than 5 seconds because Graphene measures/zeroes all enclave memory at startup. Increase the timeout for SGX regression tests to 20 sec.

## How to test this PR? (if applicable)

Regression tests should not fail with timeout on weak machines when running `make SGX_RUN=1 regression`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/649)
<!-- Reviewable:end -->
