### PR TITLE
[LibOS/regression] Add futex-timeout test

### DIFF
--- a/LibOS/shim/test/regression/30_futex.py
+++ b/LibOS/shim/test/regression/30_futex.py
@@ -11,3 +11,12 @@ regression.add_check(name="Futex Wake Test",
 
 rv = regression.run_checks()
 if rv: sys.exit(rv)
+
+# Running futex-timeout
+regression = Regression(loader, "futex-timeout")
+
+regression.add_check(name="Futex Timeout Test",
+    check=lambda res: "futex correctly timed out" in res[0].out)
+
+rv = regression.run_checks()
+if rv: sys.exit(rv)

--- a/LibOS/shim/test/regression/futex-timeout.c
+++ b/LibOS/shim/test/regression/futex-timeout.c
@@ -1,0 +1,24 @@
+#include <unistd.h>
+#include <stdio.h>
+#include <sys/syscall.h>
+#include <linux/futex.h>
+#include <sys/time.h>
+#include <errno.h>
+
+int main (int argc, const char** argv) {
+    int myfutex = 0;
+    int ret;
+
+    struct timespec t = {
+        .tv_sec = 1,
+        .tv_nsec = 0
+    };
+
+    puts("invoke futex syscall with 1-second timeout");
+    ret = syscall(SYS_futex, &myfutex, FUTEX_WAIT, 0, &t, NULL, 0);
+    if (ret == -1 && errno == ETIMEDOUT) {
+        puts("futex correctly timed out");
+    }
+
+    return 0;
+}


### PR DESCRIPTION
## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes (reasons and measures)

Before PR #554, futex() syscall incorrectly failed if user-supplied timeout expired (also see PR #438). This patch adds test on futex() with timeout.

## How to test this PR? (if applicable)

Run LibOS regression tests and ensure `Futex Timeout Test` succeeds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/650)
<!-- Reviewable:end -->
