### PR TITLE
[LibOS] 16-byte align of stack on calling shim_table[]

### DIFF
--- a/LibOS/shim/include/shim_tls.h
+++ b/LibOS/shim/include/shim_tls.h
@@ -37,6 +37,7 @@ struct shim_regs {
     unsigned long           rdi;
     unsigned long           rbx;
     unsigned long           rbp;
+    unsigned long           rflags;
 };
 
 struct shim_context {

--- a/LibOS/shim/src/shim_table.c
+++ b/LibOS/shim/src/shim_table.c
@@ -26,6 +26,14 @@
 #include <shim_table.h>
 #include <shim_internal.h>
 
+/*
+ * 16-byte alignment for calling __shim_xxx
+ * after entering syscalldb. stack = 8 mod 16 (pushq %rip by callq)
+ * On calling __shim_xxx: (8 + sizeof(struct shim_regs)) mod 16 == 0
+ */
+_Static_assert((sizeof(struct shim_regs) % 16) == 8,
+               "stack isn't aligned to 16 byte on calling shim_table[]");
+
 void debug_unsupp (int num){
     debug ("Unsupported system call %d\n", num);
 }

--- a/LibOS/shim/src/syscallas.S
+++ b/LibOS/shim/src/syscallas.S
@@ -34,6 +34,7 @@ syscalldb:
         .cfi_startproc
 
         # DEP 7/9/12: Push a stack pointer so clone can find the return address
+        pushfq
         pushq %rbp
         .cfi_def_cfa_offset 16
         movq %rsp, %rbp
@@ -97,6 +98,7 @@ isdef:
 ret:
         popq %rbx
         popq %rbp
+        popfq
         retq
 
 isundef:


### PR DESCRIPTION
Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes (reasons and measures)


## How to test this PR? (if applicable)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/653)
<!-- Reviewable:end -->
