### PR TITLE
[Pal] Makefile.Test use := to get directory

### DIFF
--- a/Pal/src/Makefile.Test
+++ b/Pal/src/Makefile.Test
@@ -1,4 +1,4 @@
-DIR = $(dir $(lastword $(MAKEFILE_LIST)))
+DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 expand_target = $(1)
 
 ifeq ($(PAL_HOST),)

--- a/Pal/src/host/Linux-SGX/Makefile.Test
+++ b/Pal/src/host/Linux-SGX/Makefile.Test
@@ -1,4 +1,4 @@
-SGX_DIR = $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+SGX_DIR := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
 RUNTIME_DIR = $(SGX_DIR)/../../../../Runtime
 
 LIBPAL = $(RUNTIME_DIR)/libpal-Linux-SGX.so


### PR DESCRIPTION
Use := to get the directory in which Makefile lives.
Otherwise the directory will be the directly which lastly included.
Not the current one.

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [x] SGX PAL
- [ ] FreeBSD PAL
- [x] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes (reasons and measures)


## How to test this PR? (if applicable)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/656)
<!-- Reviewable:end -->
