### PR TITLE
[LibOS] preserve %rflags on syscalldb

### DIFF
--- a/LibOS/shim/include/shim_tls.h
+++ b/LibOS/shim/include/shim_tls.h
@@ -37,6 +37,7 @@ struct shim_regs {
     unsigned long           rdi;
     unsigned long           rbx;
     unsigned long           rbp;
+    unsigned long           rflags;
 };
 
 struct shim_context {

--- a/LibOS/shim/src/bookkeep/shim_signal.c
+++ b/LibOS/shim/src/bookkeep/shim_signal.c
@@ -117,6 +117,7 @@ void __store_context (shim_tcb_t * tcb, PAL_CONTEXT * pal_context,
 
         if (ct->regs) {
             struct shim_regs * regs = ct->regs;
+            context->uc_mcontext.gregs[REG_EFL] = regs->rflags;
             context->uc_mcontext.gregs[REG_R15] = regs->r15;
             context->uc_mcontext.gregs[REG_R14] = regs->r14;
             context->uc_mcontext.gregs[REG_R13] = regs->r13;

--- a/LibOS/shim/src/shim_checkpoint.c
+++ b/LibOS/shim/src/shim_checkpoint.c
@@ -1289,6 +1289,7 @@ void restore_context (struct shim_context * context)
                      "popq %%rdi\r\n"
                      "popq %%rbx\r\n"
                      "popq %%rbp\r\n"
+                     "popfq\r\n"
                      "popq %%rsp\r\n"
                      "movq $0, %%rax\r\n"
                      "jmp *-128-8(%%rsp)\r\n"

--- a/LibOS/shim/src/syscallas.S
+++ b/LibOS/shim/src/syscallas.S
@@ -34,6 +34,7 @@ syscalldb:
         .cfi_startproc
 
         # Create shim_regs struct on the stack.
+        pushfq
         pushq %rbp
         pushq %rbx
         pushq %rdi
@@ -52,8 +53,8 @@ syscalldb:
 
         movq %rsp, %rbp
         .cfi_def_cfa_offset SHIM_REGS_SIZE+8  # +8 for ret_addr
-        .cfi_offset 6,-16        # saved_rbp is at CFA-16 (ret + saved_rbp)
-        .cfi_def_cfa_register 6  # %rbp
+        .cfi_offset %rbp, -3 * 8    # saved_rbp is at CFA-24 (ret + saved_rflags + saved_rbp)
+        .cfi_def_cfa_register %rbp  # %rbp
 
         cmp $LIBOS_SYSCALL_BOUND, %rax
         jae isundef
@@ -97,6 +98,7 @@ ret:
         popq %rdi
         popq %rbx
         popq %rbp
+        popfq
         retq
 
 isundef:


### PR DESCRIPTION
Linux system call preserves %rflags. So does LibOS.
- add rflags to shim_regs
- save/restore rflags on entry/leaving syscalldb

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes (reasons and measures)


## How to test this PR? (if applicable)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/660)
<!-- Reviewable:end -->
