### PR TITLE
[Pal/Linux-SGX] clear %rflang when setting up _DkExceptionHandler

### DIFF
--- a/Pal/src/host/Linux-SGX/enclave_entry.S
+++ b/Pal/src/host/Linux-SGX/enclave_entry.S
@@ -233,6 +233,9 @@ enclave_entry:
 	andq $STACK_ALIGN, %rsi
 	movq %rsi, SGX_GPR_RSP(%rbx)
 
+	# clear rflags to conform the ABI which requires RFLAGS.DF = 0
+	movq $0, SGX_GPR_RFLAGS(%rbx)
+
 	# new RIP is the exception handler
 	leaq _DkExceptionHandler(%rip), %rdi
 	movq %rdi, SGX_GPR_RIP(%rbx)


### PR DESCRIPTION
This is follow up of https://github.com/oscarlab/graphene/pull/643
Clear rflags when setting up exception handler.

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [x] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes (reasons and measures)


## How to test this PR? (if applicable)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/669)
<!-- Reviewable:end -->
