### PR TITLE
[LibOS] fix __path_lookupat(start!=NULL, abspath)

### DIFF
--- a/LibOS/shim/src/bookkeep/shim_handle.c
+++ b/LibOS/shim/src/bookkeep/shim_handle.c
@@ -55,8 +55,7 @@ static inline int init_tty_handle (struct shim_handle * hdl, bool write)
     /* XXX: Try getting the root FS from current thread? */
     assert(cur_thread);
     assert(cur_thread->root);
-    if ((ret = path_lookupat(cur_thread->root, "/dev/tty", LOOKUP_OPEN, &dent,
-                             cur_thread->root->fs)) < 0)
+    if ((ret = path_lookupat(NULL, "/dev/tty", LOOKUP_OPEN, &dent, NULL)) < 0)
         return ret;
 
     int flags = (write ? O_WRONLY : O_RDONLY)|O_APPEND;
@@ -95,8 +94,15 @@ static inline int init_exec_handle (struct shim_thread * thread)
 
     struct shim_mount * fs = find_mount_from_uri(PAL_CB(executable));
     if (fs) {
-        path_lookupat(fs->root, PAL_CB(executable) + fs->uri.len, 0,
-                      &exec->dentry, fs);
+        const char * p = PAL_CB(executable) + fs->uri.len;
+        /*
+         * Lookup for PAL_CB(executable) needs to be done under a given
+         * mount point. which requires a relative path name.
+         * On the other hand, the one in manifest file can be absolute path.
+         */
+        while (*p == '/')
+            p++;
+        path_lookupat(fs->root, p, 0, &exec->dentry, fs);
         set_handle_fs(exec, fs);
         if (exec->dentry) {
             size_t len;

--- a/LibOS/shim/src/fs/shim_fs.c
+++ b/LibOS/shim/src/fs/shim_fs.c
@@ -541,7 +541,7 @@ struct shim_mount * find_mount_from_uri (const char * uri)
             continue;
 
         if (!memcmp(qstrgetstr(&mount->uri), uri, mount->uri.len) &&
-            (uri[mount->uri.len] == '/' || uri[mount->uri.len] == '/')) {
+            uri[mount->uri.len] == '/') {
             if (mount->path.len > longest_path) {
                 longest_path = mount->path.len;
                 found = mount;

--- a/LibOS/shim/src/fs/shim_namei.c
+++ b/LibOS/shim/src/fs/shim_namei.c
@@ -42,7 +42,8 @@
  * Must be a null-terminated string. */
 static inline const char * eat_slashes (const char * string)
 {
-    while (*string == '/' && *string != '\0') string++;
+    while (*string == '/')
+        string++;
     return string;
 }
 


### PR DESCRIPTION
__path_lookupat(start!=NULL, path=absoluate) is wrongly handled to lookup
at start dir. Not root dir. resolution should start root directly of the
thread.

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes (reasons and measures)


## How to test this PR? (if applicable)
ltp test cases with xxxat variants. e.g. openat(), statat() etc.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/671)
<!-- Reviewable:end -->
