### PR TITLE
[LibOS] remove abspath check from xxxat() syscalls

### DIFF
--- a/LibOS/shim/src/sys/shim_access.c
+++ b/LibOS/shim/src/sys/shim_access.c
@@ -58,9 +58,6 @@ int shim_do_faccessat (int dfd, const char * filename, mode_t mode)
     if (test_user_string(filename))
         return -EFAULT;
 
-    if (*filename == '/')
-        return shim_do_access(filename, mode);
-
     struct shim_dentry * dir = NULL, * dent = NULL;
     int ret = 0;
 

--- a/LibOS/shim/src/sys/shim_fs.c
+++ b/LibOS/shim/src/sys/shim_fs.c
@@ -84,10 +84,6 @@ int shim_do_unlinkat (int dfd, const char * pathname, int flag)
     if (flag & ~AT_REMOVEDIR)
         return -EINVAL;
 
-    if (*pathname == '/')
-        return (flag & AT_REMOVEDIR) ? shim_do_rmdir(pathname) :
-               shim_do_unlink(pathname);
-
     struct shim_dentry * dir = NULL, * dent = NULL;
     int ret = 0;
 
@@ -141,9 +137,6 @@ int shim_do_mkdirat (int dfd, const char * pathname, int mode)
 
     if (test_user_string(pathname))
         return -EFAULT;
-
-    if (*pathname == '/')
-        return shim_do_mkdir(pathname, mode);
 
     struct shim_dentry * dir = NULL;
     int ret = 0;
@@ -239,9 +232,6 @@ int shim_do_fchmodat (int dfd, const char * filename, mode_t mode)
     if (test_user_string(filename))
         return -EFAULT;
 
-    if (*filename == '/')
-        return shim_do_chmod(filename, mode);
-
     struct shim_dentry * dir = NULL, * dent = NULL;
     int ret = 0;
 
@@ -313,14 +303,14 @@ int shim_do_fchownat (int dfd, const char * filename, uid_t uid, gid_t gid,
                       int flags)
 {
     __UNUSED(flags);
+    __UNUSED(uid);
+    __UNUSED(gid);
+
     if (!filename)
         return -EINVAL;
 
     if (test_user_string(filename))
         return -EFAULT;
-
-    if (*filename == '/')
-        return shim_do_chown(filename, uid, gid);
 
     struct shim_dentry * dir = NULL, * dent = NULL;
     int ret = 0;

--- a/LibOS/shim/src/sys/shim_open.c
+++ b/LibOS/shim/src/sys/shim_open.c
@@ -134,9 +134,6 @@ int shim_do_openat (int dfd, const char * filename, int flags, int mode)
     if (!filename || test_user_string(filename))
         return -EFAULT;
 
-    if (*filename == '/')
-        return shim_do_open(filename, flags, mode);
-
     struct shim_dentry * dir = NULL;
     int ret = 0;
 


### PR DESCRIPTION
This patch is followup of https://github.com/oscarlab/graphene/pull/671
With #671, absolute path check is handled unformly by __path_lookupat().
Now absolute path check in each system call isn't needed, so remove it.

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes (reasons and measures)


## How to test this PR? (if applicable)
LTP test cases for xxxat() syscalls.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/673)
<!-- Reviewable:end -->
