### PR TITLE
[LibOS/PAL] Return proper exit code on abnormal process termination

### DIFF
--- a/LibOS/shim/include/shim_internal.h
+++ b/LibOS/shim/include/shim_internal.h
@@ -145,7 +145,7 @@ static inline PAL_HANDLE __open_shim_stdio (void)
     return shim_stdio;
 }
 
-int shim_terminate (void);
+int shim_terminate (int err);
 
 /* assertions */
 #define USE_PAUSE       0
@@ -163,7 +163,7 @@ static inline void do_pause (void);
     do {                                                                    \
         __sys_printf("bug() " __FILE__ ":%d\n", __LINE__);                  \
         pause();                                                            \
-        shim_terminate();                                                   \
+        shim_terminate(-ENOTRECOVERABLE);                                   \
     } while (0)
 
 #if USE_ASSERT == 1
@@ -749,7 +749,8 @@ static inline bool memory_migrated(void * mem)
 extern void * __load_address, * __load_address_end;
 extern void * __code_address, * __code_address_end;
 
-int shim_clean (void);
+/* cleanup and terminate process, preserve exit code if err == 0 */
+int shim_clean (int err);
 
 unsigned long parse_int (const char * str);
 

--- a/LibOS/shim/src/ipc/shim_ipc_helper.c
+++ b/LibOS/shim/src/ipc/shim_ipc_helper.c
@@ -1034,7 +1034,7 @@ end:
     barrier();
     if (ipc_helper_state == HELPER_HANDEDOVER) {
         debug("ipc helper thread is the last thread, process exiting\n");
-        shim_terminate(); // Same as shim_clean(), but this is the official termination function
+        shim_terminate(0); // Same as shim_clean(), but this is the official termination function
     }
 
     lock(ipc_helper_lock);

--- a/LibOS/shim/src/sys/shim_exec.c
+++ b/LibOS/shim/src/sys/shim_exec.c
@@ -182,7 +182,7 @@ retry_dump_vmas:
     SAVE_PROFILE_INTERVAL(unmap_all_vmas_for_exec);
 
     if ((ret = load_elf_object(cur_thread->exec, NULL, 0)) < 0)
-        shim_terminate();
+        shim_terminate(ret);
 
     init_brk_from_executable(cur_thread->exec);
     load_elf_interp(cur_thread->exec);

--- a/LibOS/shim/src/sys/shim_exit.c
+++ b/LibOS/shim/src/sys/shim_exit.c
@@ -159,7 +159,7 @@ int try_process_exit (int error_code, int term_signal)
          */
         put_thread(ipc_thread); /* free resources of the thread */
     if (!ret)
-        shim_clean();
+        shim_clean(ret);
     else
         DkThreadExit();
 

--- a/LibOS/shim/test/regression/00_bootstrap.py
+++ b/LibOS/shim/test/regression/00_bootstrap.py
@@ -41,10 +41,20 @@ regression.add_check(name="Shared Object",
 rv = regression.run_checks()
 if rv: sys.exit(rv)
 
+# Exit test
 regression = Regression(loader, "exit")
 
 regression.add_check(name="Exit Code Propagation",
     check=lambda res: 113 == res[0].code)
+
+rv = regression.run_checks()
+if rv: sys.exit(rv)
+
+# Early abort test
+regression = Regression(loader, "init_fail")
+
+regression.add_check(name="Early abort",
+    check=lambda res: res[0].code != 42 and res[0].code != 0)
 
 rv = regression.run_checks()
 if rv: sys.exit(rv)

--- a/LibOS/shim/test/regression/init_fail.c
+++ b/LibOS/shim/test/regression/init_fail.c
@@ -1,0 +1,7 @@
+#include <stdio.h>
+
+int main()
+{
+    printf("Hello world\n");
+    return 42;
+}

--- a/LibOS/shim/test/regression/init_fail.manifest.template
+++ b/LibOS/shim/test/regression/init_fail.manifest.template
@@ -1,0 +1,16 @@
+loader.preload = file:$(SHIMPATH)
+loader.env.LD_LIBRARY_PATH = /lib
+loader.debug_type = none
+
+fs.mount.lib.type = chroot
+fs.mount.lib.path = /lib
+fs.mount.lib.uri = file:$(LIBCDIR)
+
+# purposefully force mount failure to cause early shim abort
+fs.mount.test.type = chroot
+fs.mount.test.path = /test
+fs.mount.test.uri = file:I_DONT_EXIST
+
+sgx.trusted_files.ld = file:$(LIBCDIR)/ld-linux-x86-64.so.2
+sgx.trusted_files.libc = file:$(LIBCDIR)/libc.so.6
+

--- a/Pal/src/db_exception.c
+++ b/Pal/src/db_exception.c
@@ -32,6 +32,8 @@
 #include "list.h"
 #include "pal_debug.h"
 
+#include <errno.h>
+
 #define INIT_EVENT_HANDLER      { .lock = LOCK_INIT }
 
 struct pal_event_handler {
@@ -87,7 +89,7 @@ void DkExceptionReturn (PAL_PTR event)
 
 /* This does not return */
 void __abort(void) {
-    _DkProcessExit(1);
+    _DkProcessExit(-ENOTRECOVERABLE);
 }
 
 void warn (const char *format, ...)

--- a/Pal/src/slab.c
+++ b/Pal/src/slab.c
@@ -127,7 +127,7 @@ void * malloc (size_t size)
          * condition and must terminate the current process.
          */
         printf("******** Out-of-memory in PAL ********\n");
-        _DkProcessExit(-1);
+        _DkProcessExit(-ENOMEM);
     }
 
 #if PROFILING == 1


### PR DESCRIPTION
<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [x] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes (reasons and measures)
Return proper process exit code when shim initialization fails (it's currently always 0).
Also fix PAL exit code on abnormal termination.
Fixes #666

## How to test this PR? (if applicable)
The new `init_fail` regression test should pass.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/676)
<!-- Reviewable:end -->
