### PR TITLE
[Pal] Fix htonl/htons() byte-order macro to __BYTE_ORDER

### DIFF
--- a/Pal/lib/network/hton.c
+++ b/Pal/lib/network/hton.c
@@ -19,11 +19,14 @@
 #include "api.h"
 #include <host_endian.h>
 
+#define __bswap_16(x) ((uint16_t)(__builtin_bswap32(x) >> 16))
+#define __bswap_32(x) ((uint32_t)__builtin_bswap32(x))
+
 uint32_t __htonl (uint32_t x)
 {
-#if BYTE_ORDER == BIG_ENDIAN
+#if __BYTE_ORDER == __BIG_ENDIAN
     return x;
-#elif BYTE_ORDER == LITTLE_ENDIAN
+#elif __BYTE_ORDER == __LITTLE_ENDIAN
     return __bswap_32 (x);
 #else
 # error "What kind of system is this?"
@@ -37,9 +40,9 @@ uint32_t __ntohl (uint32_t x)
 
 uint16_t __htons (uint16_t x)
 {
-#if BYTE_ORDER == BIG_ENDIAN
+#if __BYTE_ORDER == __BIG_ENDIAN
     return x;
-#elif BYTE_ORDER == LITTLE_ENDIAN
+#elif __BYTE_ORDER == __LITTLE_ENDIAN
     return __bswap_16 (x);
 #else
 # error "What kind of system is this?"

--- a/Pal/src/pal_rtld.h
+++ b/Pal/src/pal_rtld.h
@@ -150,7 +150,7 @@ ELF_PREFERRED_ADDRESS_DATA;
 #elif __BYTE_ORDER == __LITTLE_ENDIAN
 # define byteorder ELFDATA2LSB
 #else
-# error "Unknown BYTE_ORDER " BYTE_ORDER
+# error "Unknown __BYTE_ORDER " __BYTE_ORDER
 # define byteorder ELFDATANONE
 #endif
 


### PR DESCRIPTION
## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [x] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes (reasons and measures)

Previously, `htonl/htons()` used `BYTE_ORDER` macro which for some reason was set to `BIG_ENDIAN`. This PR fixes this issue by changing to the macro `__BYTE_ORDER` used in the rest of the code and correctly set to `LITTLE_ENDIAN` on x86 machines.

Fixes #677.

## How to test this PR? (if applicable)

Not applicable. Trivial change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/679)
<!-- Reviewable:end -->
