### PR TITLE
[Pal/Linux-SGX] Instruct GDB to bridge enclave-untrusted stacks

### DIFF
--- a/LibOS/shim/src/syscallas.S
+++ b/LibOS/shim/src/syscallas.S
@@ -101,7 +101,9 @@ ret:
         popq %rdi
         popq %rbx
         popq %rbp
+        .cfi_def_cfa %rsp, 2 * 8  # +8 for ret_addr, +8 for saved_rflags
         popfq
+        .cfi_def_cfa_offset 8     # +8 for ret_addr
         retq
 
 isundef:

--- a/Pal/src/host/Linux-SGX/Makefile
+++ b/Pal/src/host/Linux-SGX/Makefile
@@ -23,6 +23,7 @@ all: $(host_files)
 ifeq ($(DEBUG),1)
 CC += -gdwarf-2 -g3
 CFLAGS += -DDEBUG
+ASFLAGS += -DDEBUG
 export DEBUG
 endif
 

--- a/Pal/src/host/Linux-SGX/enclave_entry.S
+++ b/Pal/src/host/Linux-SGX/enclave_entry.S
@@ -254,6 +254,10 @@ enclave_entry:
 	#     %rdi, %rsi: (optional) arguments to untrusted code.
 .Lclear_and_eexit:
 
+	# CFA is away from RBP by ret_addr + saved_rbp + GPR context except RAX
+	.cfi_def_cfa %rbp, SGX_CONTEXT_SIZE - 8 + 16
+	.cfi_offset %rbp, -16
+
 	# Clear "extended" state (FPU aka x87, SSE, AVX, ...).
 
 	leaq .Lxrstor_init_arg(%rip), %rcx
@@ -321,8 +325,12 @@ enclave_entry:
 	.type sgx_ocall, @function
 
 sgx_ocall:
+	.cfi_startproc
 	pushq %rbp
+	.cfi_adjust_cfa_offset 8
 	movq %rsp, %rbp
+	.cfi_offset %rbp, -16
+	.cfi_def_cfa_register %rbp
 
 	movq 8(%rbp), %rax
 	pushq %rax	# previous RIP
@@ -347,6 +355,10 @@ sgx_ocall:
 	# no RAX
 
 	movq %rsp, %rbp
+
+	# CFA shifted away from RBP=RSP by the size of GPR context except RAX
+	.cfi_adjust_cfa_offset SGX_CONTEXT_SIZE - 8
+
 	subq $XSAVE_SIZE,  %rsp
 	andq $XSAVE_ALIGN, %rsp
 	fxsave (%rsp)
@@ -366,6 +378,7 @@ sgx_ocall:
 
 	movq %gs:SGX_EXIT_TARGET, %rbx
 	jmp .Lclear_and_eexit
+	.cfi_endproc
 
 .Lreturn_from_ocall:
 	# PAL convention:

--- a/Pal/src/host/Linux-SGX/enclave_entry.S
+++ b/Pal/src/host/Linux-SGX/enclave_entry.S
@@ -254,6 +254,19 @@ enclave_entry:
 	#     %rdi, %rsi: (optional) arguments to untrusted code.
 .Lclear_and_eexit:
 
+#ifdef DEBUG
+	# Enclave and untrusted stacks are split (segmented). GDB refuses to
+	# unwind such stacks because it looks like stack frames "jump" back
+	# and forth. Luckily, GDB special-cases stack frames for a function
+	# with hardcoded name "__morestack". Declare this dummy function
+	# to make GDB happy.
+
+	.global __morestack
+	.type __morestack, @function
+__morestack:
+#endif
+
+	.cfi_startproc
 	# CFA is away from RBP by ret_addr + saved_rbp + GPR context except RAX
 	.cfi_def_cfa %rbp, SGX_CONTEXT_SIZE - 8 + 16
 	.cfi_offset %rbp, -16
@@ -280,7 +293,15 @@ enclave_entry:
 	# %rcx is set to AEP by EEXIT
 	xorq %rdx, %rdx
 	# %rsi, %rdi are arguments to the untrusted code
+
+#ifdef DEBUG
+.Lfor_cfa_debug_info:
+	# Leave %rbp pointing to OCALL function on trusted stack.
+#else
+	# In non-debug mode, clear %rbp to not leak trusted stack address.
 	xorq %rbp, %rbp
+#endif
+
 	# %rsp points to untrusted stack
 	xorq %r8, %r8
 	xorq %r9, %r9
@@ -295,6 +316,7 @@ enclave_entry:
 	ENCLU
 
 	ud2 # We should never get here.
+	.cfi_endproc
 
 	# fxsave/xsave area to reset extended state.
 	#
@@ -375,6 +397,13 @@ sgx_ocall:
 
 	movq %gs:SGX_USTACK, %rsp
 	andq $STACK_ALIGN, %rsp
+
+#ifdef DEBUG
+	# Push %rip of some code inside __morestack() on untrusted stack.
+	# At sgx_entry(), GDB deduces saved_rip by looking at CFA-8 = %rsp.
+	leaq .Lfor_cfa_debug_info(%rip), %r8
+	pushq %r8
+#endif
 
 	movq %gs:SGX_EXIT_TARGET, %rbx
 	jmp .Lclear_and_eexit

--- a/Pal/src/host/Linux-SGX/sgx_entry.S
+++ b/Pal/src/host/Linux-SGX/sgx_entry.S
@@ -44,18 +44,23 @@ sgx_raise:
 sgx_entry:
 	# arguments: RDI - code, RSI - ms
 
+	.cfi_startproc
 	leaq ocall_table(%rip), %rbx
 	movq (%rbx,%rdi,8), %rbx
 	movq %rsi, %rdi
 
 	pushq %rbp
+	.cfi_adjust_cfa_offset 8
 	movq %rsp, %rbp
+	.cfi_offset %rbp, -16
+	.cfi_def_cfa_register %rbp
 	andq $~0xF, %rsp  # Required by System V AMD64 ABI.
 
 	callq *%rbx
 
 	movq %rbp, %rsp
 	popq %rbp
+	.cfi_def_cfa %rsp, 8
 
 	movq %rax, %rdi
 	# Not interrupted
@@ -69,6 +74,7 @@ sgx_entry_return:
 	# RDI - return value
 	# RSI - external event
 	jmp .Ldo_ecall
+	.cfi_endproc
 
 /*
  * rdfsbase:


### PR DESCRIPTION
## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [x] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes (reasons and measures)

Before, GDB did not know about enclave stack frames when debugging untrusted OCALL functions. This patch bridges untrusted stack to its corresponding enclave stack by utilizing CFI asm directives and setting RBP to point to the first enclave stack frame.

This functionality is only enabled if Graphene-SGX is built with DEBUG flag. Without DEBUG, RBP is cleared to prevent leakage of the address of enclave stack.

This commit also adds some missing CFI directives to .S files (not related to enclave-untrusted stack bridge).

## How to test this PR? (if applicable)

Build `LibOS/shim/test/native/sleep` executable and run under GDB:
```c
$ GDB=1 SGX=1 ./pal_loader sleep
(gdb) b sgx_ocall_sleep
(gdb) r
<... GDB hits breakpoint ...>
(gdb) bt
#0  sgx_ocall_sleep (pms=0x7ffe7d2b4400) at sgx_enclave.c:593
#1  0x000055882286f5b9 in sgx_entry ()    // <-- untrusted world
#2  0x000000000bd8b610 in __morestack ()  // <-- bridge between untrusted and enclave
#3  0x000000000bd87bec in ocall_sleep (microsec=0x0, microsec@entry=0xba54b78) at enclave_ocalls.c:995  // <-- enclave world
#4  0x000000000bd82d59 in _DkThreadDelayExecution (duration=duration@entry=0xba54b78) at db_threading.c:114
#5  0x000000000bd788ad in DkThreadDelayExecution (duration=3000000) at db_threading.c:61
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/680)
<!-- Reviewable:end -->
