### PR TITLE
[Pal, LibOS] pass AT_RANDOM

### DIFF
--- a/LibOS/shim/src/shim_init.c
+++ b/LibOS/shim/src/shim_init.c
@@ -342,6 +342,11 @@ copy_envp:
             memcpy(new_auxp, *auxpp, nauxv * sizeof(elf_auxv_t));
     }
 
+    /* reserve at least 16 bytes on the stack to accommodate AT_RANDOM bytes
+     * later
+     */
+    ALLOCATE_TOP(16);
+
     /* x86_64 ABI requires 16 bytes alignment on stack on every function
        call. */
     size_t move_size = stack_bottom - stack;


### PR DESCRIPTION
glibc start up routine tries to read AT_RANDOM address and segv.
This patch teaches LibOS AT_RANDOM and initialize 16 bytes area with
random value.

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [x] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes (reasons and measures)


## How to test this PR? (if applicable)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/684)
<!-- Reviewable:end -->
