### PR TITLE
use clone(!CLONE_VM) for fork instead of modifying glibc

### DIFF
--- a/LibOS/Makefile
+++ b/LibOS/Makefile
@@ -86,6 +86,11 @@ GLIBC_PATCHES = \
 	glibc-fix-warning.patch \
 	glibc-no-pie.patch
 
+# USE_clone_FOR_fork = true
+ifneq ($(USE_clone_FOR_fork),)
+GLIBC_PATCHES += glibc-arch-fork.patch
+endif
+
 $(GLIBC_SRC)/configure: $(GLIBC_PATCHES) Makefile
 	[ -f $(GLIBC_SRC).tar.gz ] || \
 	for MIRROR in $(GLIBC_MIRRORS); do \

--- a/LibOS/glibc-2.19.patch
+++ b/LibOS/glibc-2.19.patch
@@ -713,33 +713,6 @@ index 89fda5e..f6963f6 100644
  	movl	%fs:CANCELHANDLING, %eax
  	jmp	3b
  END(__pthread_disable_asynccancel)
-diff --git a/nptl/sysdeps/unix/sysv/linux/x86_64/fork.c b/nptl/sysdeps/unix/sysv/linux/x86_64/fork.c
-index a036b92..40a1eaf 100644
---- a/nptl/sysdeps/unix/sysv/linux/x86_64/fork.c
-+++ b/nptl/sysdeps/unix/sysv/linux/x86_64/fork.c
-@@ -21,10 +21,20 @@
- #include <sysdep.h>
- #include <tls.h>
- 
--
--#define ARCH_FORK() \
-+/* In Graphene, we prefer to call fork system call directly than clone */
-+#if USE_clone_FOR_fork
-+# define ARCH_FORK() \
-   INLINE_SYSCALL (clone, 4,						      \
- 		  CLONE_CHILD_SETTID | CLONE_CHILD_CLEARTID | SIGCHLD, 0,     \
- 		  NULL, &THREAD_SELF->tid)
-+#else
-+# define ARCH_FORK() \
-+ ({ unsigned long ret = INLINE_SYSCALL (fork, 0);	\
-+    if (!ret) {						\
-+	pid_t pid = INLINE_SYSCALL (getpid, 0);		\
-+	THREAD_SETMEM (THREAD_SELF, pid, pid);		\
-+	THREAD_SETMEM (THREAD_SELF, tid, pid);		\
-+    } ret; })
-+#endif
- 
- #include "../fork.c"
 diff --git a/nptl/sysdeps/unix/sysv/linux/x86_64/lowlevellock.S b/nptl/sysdeps/unix/sysv/linux/x86_64/lowlevellock.S
 index f2dca07..0ce7c67 100644
 --- a/nptl/sysdeps/unix/sysv/linux/x86_64/lowlevellock.S

--- a/LibOS/glibc-arch-fork.patch
+++ b/LibOS/glibc-arch-fork.patch
@@ -1,0 +1,20 @@
+diff --git a/nptl/sysdeps/unix/sysv/linux/x86_64/fork.c b/nptl/sysdeps/unix/sysv/linux/x86_64/fork.c
+index a036b92..40a1eaf 100644
+--- a/nptl/sysdeps/unix/sysv/linux/x86_64/fork.c
++++ b/nptl/sysdeps/unix/sysv/linux/x86_64/fork.c
+@@ -21,9 +21,12 @@
+ #include <sysdep.h>
+ #include <tls.h>
+ 
+ #define ARCH_FORK() \
+-  INLINE_SYSCALL (clone, 4,						      \
+-		  CLONE_CHILD_SETTID | CLONE_CHILD_CLEARTID | SIGCHLD, 0,     \
+-		  NULL, &THREAD_SELF->tid)
++ ({ unsigned long ret = INLINE_SYSCALL (fork, 0);	\
++    if (!ret) {						\
++	pid_t pid = INLINE_SYSCALL (getpid, 0);		\
++	THREAD_SETMEM (THREAD_SELF, pid, pid);		\
++	THREAD_SETMEM (THREAD_SELF, tid, pid);		\
++    } ret; })
+ 
+ #include "../fork.c"

--- a/LibOS/shim/include/shim_tls.h
+++ b/LibOS/shim/include/shim_tls.h
@@ -93,6 +93,8 @@ typedef struct
 
 #include <stddef.h>
 
+void init_tcb (shim_tcb_t * tcb);
+
 static inline bool shim_tls_check_canary(void)
 {
     uint64_t __canary;

--- a/LibOS/shim/src/sys/shim_clone.c
+++ b/LibOS/shim/src/sys/shim_clone.c
@@ -138,11 +138,11 @@ int clone_implementation_wrapper(struct clone_args * arg)
     debug_setbuf(tcb, true);
     debug("set tcb to %p (stack allocated? %d)\n", my_thread->tcb, stack_allocated);
 
-    struct shim_regs regs;
-    regs = *arg->parent->tcb->shim_tcb.context.regs;
-
-    if (my_thread->set_child_tid)
+    struct shim_regs regs = *arg->parent->tcb->shim_tcb.context.regs;
+    if (my_thread->set_child_tid) {
         *(my_thread->set_child_tid) = my_thread->tid;
+        my_thread->set_child_tid = NULL;
+    }
 
     void * stack = arg->stack;
     void * return_pc = arg->return_pc;
@@ -221,6 +221,49 @@ int shim_do_clone (int flags, void * user_stack_addr, int * parent_tidptr,
     if (!(flags & CLONE_SYSVSEM))
         debug("clone without CLONE_SYSVSEM is not yet implemented\n");
 
+    /* currently unsupported flags.
+     * Please update this once you added new flags support.
+     */
+    const int unsupported_flags =
+#ifdef CLONE_PIDFD
+        CLONE_PIDFD |
+#endif
+        CLONE_VFORK | /* vfork is handled above */
+        CLONE_PARENT |
+        CLONE_NEWNS |
+        CLONE_UNTRACED |
+        CLONE_NEWCGROUP |
+        CLONE_NEWUTS |
+        CLONE_NEWIPC |
+        CLONE_NEWUSER |
+        CLONE_NEWPID |
+        CLONE_NEWNET |
+        CLONE_IO;
+    if (flags & unsupported_flags)
+        debug("clone with flags 0x%x is not yet implemented\n",
+            flags & unsupported_flags);
+
+    if ((flags & (CLONE_NEWNS|CLONE_FS)) == (CLONE_NEWNS|CLONE_FS))
+        return -EINVAL;
+    if ((flags & (CLONE_NEWUSER|CLONE_FS)) == (CLONE_NEWUSER|CLONE_FS))
+        return -EINVAL;
+    if ((flags & CLONE_THREAD) && !(flags & CLONE_SIGHAND))
+        return -EINVAL;
+    if ((flags & CLONE_SIGHAND) && !(flags & CLONE_VM))
+        return -EINVAL;
+    if (flags & CLONE_THREAD && (flags & (CLONE_NEWUSER | CLONE_NEWPID)))
+        return -EINVAL;
+#ifdef CLONE_PIDFD
+    if (flags & CLONE_PIDFD) {
+        if (flags & (CLONE_DETACHED | CLONE_PARENT_SETTID | CLONE_THREAD))
+            return -EINVAL;
+        if (test_user_memory(parent_tidptr, sizeof(*parent_tidptr), false))
+            return -EFAULT;
+        if (*parent_tidptr != 0)
+            return -EINVAL;
+    }
+#endif
+
     if (flags & CLONE_PARENT_SETTID) {
         if (!parent_tidptr)
             return -EINVAL;
@@ -286,6 +329,7 @@ int shim_do_clone (int flags, void * user_stack_addr, int * parent_tidptr,
             thread->tcb = tcb = self->tcb;
             old_shim_tcb = __alloca(sizeof(shim_tcb_t));
             memcpy(old_shim_tcb, &tcb->shim_tcb, sizeof(shim_tcb_t));
+            thread->user_tcb = self->user_tcb;
         }
 
         if (user_stack_addr) {
@@ -302,16 +346,17 @@ int shim_do_clone (int flags, void * user_stack_addr, int * parent_tidptr,
         add_thread(thread);
         set_as_child(self, thread);
 
-        if ((ret = do_migrate_process(&migrate_fork, NULL, NULL, thread)) < 0)
-            goto failed;
-
+        ret = do_migrate_process(&migrate_fork, NULL, NULL, thread);
         if (old_shim_tcb)
-            memcpy(&tcb->shim_tcb, old_shim_tcb, sizeof(shim_tcb_t));
+            memcpy(&tcb->shim_tcb, old_shim_tcb, sizeof(tcb->shim_tcb));
+        if (ret < 0)
+            goto failed;
 
         lock(thread->lock);
         handle_map = thread->handle_map;
         thread->handle_map = NULL;
         unlock(thread->lock);
+
         if (handle_map)
             put_handle_map(handle_map);
 


### PR DESCRIPTION
<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes (reasons and measures)
fix shim_do_clone(!CLONE_VM) and use it for fork instead of modifying glibc fork function. 

## How to test this PR? (if applicable)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/690)
<!-- Reviewable:end -->
