### PR TITLE
[LibOS] clone_implementation_wrapper remove nonsense arg

### DIFF
--- a/LibOS/shim/src/sys/shim_clone.c
+++ b/LibOS/shim/src/sys/shim_clone.c
@@ -94,13 +94,12 @@ int clone_implementation_wrapper(struct clone_args * arg)
     //PAL allocated stack. We need to switch the stack to use
     //the user provided stack.
 
-    struct clone_args *pcargs = arg;
     int stack_allocated = 0;
 
-    object_wait_with_retry(pcargs->create_event);
-    DkObjectClose(pcargs->create_event);
+    object_wait_with_retry(arg->create_event);
+    DkObjectClose(arg->create_event);
 
-    struct shim_thread * my_thread = pcargs->thread;
+    struct shim_thread * my_thread = arg->thread;
     assert(my_thread);
     get_thread(my_thread);
 
@@ -121,8 +120,8 @@ int clone_implementation_wrapper(struct clone_args * arg)
     if (my_thread->set_child_tid)
         *(my_thread->set_child_tid) = my_thread->tid;
 
-    void * stack = pcargs->stack;
-    void * return_pc = pcargs->return_pc;
+    void * stack = arg->stack;
+    void * return_pc = arg->return_pc;
 
     struct shim_vma_val vma;
     lookup_vma(ALIGN_DOWN(stack), &vma);
@@ -134,7 +133,7 @@ int clone_implementation_wrapper(struct clone_args * arg)
     set_as_child(arg->parent, my_thread);
 
     /* Don't signal the initialize event until we are actually init-ed */
-    DkEventSet(pcargs->initialize_event);
+    DkEventSet(arg->initialize_event);
 
     /***** From here down, we are switching to the user-provided stack ****/
 


### PR DESCRIPTION
It's non-sense to introduce new variable for same one.
Just remove nonsense variable.

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes (reasons and measures)


## How to test this PR? (if applicable)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/692)
<!-- Reviewable:end -->
