### PR TITLE
[SGX PAL] Bypassing mmap restrictions for enclave creation at address 0

### DIFF
--- a/Pal/src/host/Linux-SGX/sgx_main.c
+++ b/Pal/src/host/Linux-SGX/sgx_main.c
@@ -283,10 +283,12 @@ int initialize_enclave (struct pal_enclave * enclave)
 
     /* Reading sgx.static_address from manifest */
     if (get_config(enclave->config, "sgx.static_address", cfgbuf, CONFIG_MAX) > 0 &&
-        cfgbuf[0] == '1')
+        cfgbuf[0] == '1') {
         enclave->baseaddr = heap_min;
-    else
+        enclave->size -= heap_min;
+    } else {
         enclave->baseaddr = heap_min = 0;
+    }
 
     TRY(read_enclave_token, enclave->token, &enclave_token);
     TRY(read_enclave_sigstruct, enclave->sigfile, &enclave_sigstruct);


### PR DESCRIPTION
<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [x] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes (reasons and measures)

To support position-dependent executables loaded at address 0x400000, we currently require users to change the `sysctl vm.mmap_min_addr` setting to allow enclave creation 0. This step is not only a nuisance for users, but also is known to be a dangerous behavior.

I am preparing a patch to [intel/linux-sgx-driver](https://github.com/intel/linux-sgx-driver) for fixing this issue. This restriction is mainly a byproduct of a requirement in the SGX driver to create a VMA to represent the enclave range. If we want to create the enclave at address 0 without setting `vm.mmap_min_addr=0`, we can relax this requirement to make the VMA not an exact match of the enclave range.

The change for the Graphene-SGX is quite straightforward. We only have to change the `mmap` call to `/dev/isgx` when creating the enclave. The problem is we need to convince the Intel SGX driver team that this PR is useful and will not break backward-compatibility. I created a draft for the PR to submit to the Intel SGX driver repository: https://github.com/chiache/linux-sgx-driver/pull/1. I can really use some advice on increasing the chance of getting merged.


## How to test this PR? (if applicable)

You will have to build with the modified Intel SGX driver: https://github.com/chiache/linux-sgx-driver/pull/1. The PR is currently not backward-compatible.

To test the PR, simply run the existing regressions tests for the Linux-SGX host.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/693)
<!-- Reviewable:end -->
