### PR TITLE
[Pal/Linux-SGX] enclave_entry.S fix stack on exception and ocall

### DIFF
--- a/Pal/src/host/Linux-SGX/enclave_entry.S
+++ b/Pal/src/host/Linux-SGX/enclave_entry.S
@@ -226,8 +226,12 @@ enclave_entry:
 	# Pass pointer to sgx_context_t to _DkExceptionHandler
 	movq %rsi, SGX_GPR_RSI(%rbx)
 
-	# Align the stack for _DkExceptionHandler
+	# x86-64 sysv abi requires 16B alignment of stack before call instruction
+	# which implies a (8 mod 16)B alignment on function entry (due to implicit
+	# push %rip).
+	# Align the stack for _DkExceptionHandler according to this requirement.
 	andq $STACK_ALIGN, %rsi
+	subq $8, %rsi
 	movq %rsi, SGX_GPR_RSP(%rbx)
 
 	# clear rflags to conform the ABI which requires RFLAGS.DF = 0
@@ -396,7 +400,6 @@ sgx_ocall:
 	# mode in-enclave memory can't be accessed.
 
 	movq %gs:SGX_USTACK, %rsp
-	andq $STACK_ALIGN, %rsp
 
 #ifdef DEBUG
 	# Push %rip of some code inside __morestack() on untrusted stack.


### PR DESCRIPTION
Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [x] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes (reasons and measures)


## How to test this PR? (if applicable)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/696)
<!-- Reviewable:end -->
