### PR TITLE
Enable parallel make in jenkins, fix parallel make for SGX

### DIFF
--- a/Jenkinsfiles/Linux
+++ b/Jenkinsfiles/Linux
@@ -6,7 +6,7 @@ pipeline {
                 stage('Build') {
                     steps {
                         sh '''
-                            make WERROR=1
+                            make -j 8 WERROR=1
                            '''
                     }
                 }

--- a/Jenkinsfiles/Linux-Debug
+++ b/Jenkinsfiles/Linux-Debug
@@ -6,7 +6,7 @@ pipeline {
                 stage('Build') {
                     steps {
                         sh '''
-                            make DEBUG=1 WERROR=1
+                            make -j 8 DEBUG=1 WERROR=1
                            '''
                     }
                 }

--- a/Jenkinsfiles/Linux-SGX
+++ b/Jenkinsfiles/Linux-SGX
@@ -23,7 +23,7 @@ pipeline {
                             ISGX_DRIVER_PATH=/opt/intel/linux-sgx-driver ISGX_DRIVER_VERSION=1.9 make
                         '''
                         sh '''
-                            make SGX=1 WERROR=1
+                            make -j 8 SGX=1 WERROR=1
                         '''
                         sh '''
                             make SGX_RUN=1

--- a/LibOS/Makefile
+++ b/LibOS/Makefile
@@ -97,6 +97,12 @@ $(GLIBC_SRC).tar.gz:
 		&& break; \
 	done
 
+$(GLIBC_SRC)/elf/Versions: $(GLIBC_SRC)/configure
+
+$(GLIBC_SRC)/nptl/Versions: $(GLIBC_SRC)/configure
+
+$(GLIBC_SRC)/dlfcn/Versions: $(GLIBC_SRC)/configure
+
 .PHONY: clean
 clean:
 	$(MAKE) -C $(SHIM_DIR) clean

--- a/Pal/regression/Makefile
+++ b/Pal/regression/Makefile
@@ -43,7 +43,7 @@ manifest_rules = \
 manifest: manifest.template
 	sed $(manifest_rules) $< >$@
 
-%.manifest: %.manifest.template
+%.manifest: %.manifest.template $(executables) $(pal_lib)
 	sed $(manifest_rules) $< >$@
 	(grep -q "#\!" $@ && chmod +x $@) || true
 
@@ -67,6 +67,8 @@ $(executables): %: %.c ../src/user_start.o \
 
 $(graphene_lib): .lib/host_endian.h
 	$(MAKE) -C ../lib target=$(abspath .lib)/
+
+Process2.manifest.sgx: Bootstrap.manifest.sgx
 
 else
 .IGNORE: $(preloads) $(executables)


### PR DESCRIPTION
<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [X] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes (reasons and measures)

Jenkins just does single-process builds; make it go faster with -j.

SGX build doesn't work with parallel builds; fix that too.

## How to test this PR? (if applicable)

make -j

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/700)
<!-- Reviewable:end -->
