### PR TITLE
[LibOS] fix clone emulation

### DIFF
--- a/LibOS/shim/src/sys/shim_clone.c
+++ b/LibOS/shim/src/sys/shim_clone.c
@@ -59,7 +59,10 @@ void __attribute__((weak)) syscall_wrapper_after_syscalldb(void)
 static void fixup_child_context(struct shim_context * context)
 {
     if (context->ret_ip == &syscall_wrapper_after_syscalldb) {
-        context->sp += RED_ZONE_SIZE;
+        /*
+         * context->sp is overwritten by child stack:
+         * context->sp += RED_ZONE_SIZE;
+         */
         context->regs->rflags = context->regs->r11;
         context->ret_ip = (void*)context->regs->rcx;
     }
@@ -168,9 +171,9 @@ int clone_implementation_wrapper(struct clone_args * arg)
           stack, return_pc, my_thread->tid);
 
     tcb->context.regs = &regs;
-    tcb->context.sp = stack;
     tcb->context.ret_ip = return_pc;
     fixup_child_context(&tcb->context);
+    tcb->context.sp = stack;
 
     restore_context(&tcb->context);
     return 0;


### PR DESCRIPTION
In child, stack is overwritten by passed argument. 

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes (reasons and measures)


## How to test this PR? (if applicable)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/702)
<!-- Reviewable:end -->
