### PR TITLE
move shim_tls::{sp, ret_ip, syscall_nr} to shim_regs

### DIFF
--- a/LibOS/shim/include/shim_thread.h
+++ b/LibOS/shim/include/shim_thread.h
@@ -313,7 +313,6 @@ struct clone_args {
     PAL_HANDLE initialize_event;
     struct shim_thread * parent, * thread;
     void * stack;
-    void * return_pc;
 };
 
 int clone_implementation_wrapper(struct clone_args * arg);

--- a/LibOS/shim/include/shim_tls.h
+++ b/LibOS/shim/include/shim_tls.h
@@ -20,6 +20,8 @@ struct lock_record {
 #define NUM_LOCK_RECORD_MASK (NUM_LOCK_RECORD - 1)
 
 struct shim_regs {
+    unsigned long           orig_rax;
+    unsigned long           rsp;
     unsigned long           r15;
     unsigned long           r14;
     unsigned long           r13;
@@ -35,12 +37,10 @@ struct shim_regs {
     unsigned long           rbx;
     unsigned long           rbp;
     unsigned long           rflags;
+    unsigned long           rip;
 };
 
 struct shim_context {
-    unsigned long           syscall_nr;
-    void *                  sp;
-    void *                  ret_ip;
     struct shim_regs *      regs;
     struct shim_context *   next;
     uint64_t                enter_time;

--- a/LibOS/shim/src/Makefile
+++ b/LibOS/shim/src/Makefile
@@ -132,7 +132,7 @@ elf/shim_rtld.o: $(wildcard elf/*.h)
 	@echo [ $@ ]
 	@$(AS) $(ASFLAGS) $(defs) -E $< -o $@
 
-syscallas.S: asm-offsets.h
+syscallas.S shim_checkpoint.c: asm-offsets.h
 
 include ../../../Makefile.rules
 

--- a/LibOS/shim/src/bookkeep/shim_thread.c
+++ b/LibOS/shim/src/bookkeep/shim_thread.c
@@ -717,7 +717,7 @@ int resume_wrapper (void * param)
     __libc_tcb_t * libc_tcb = thread->tcb;
     assert(libc_tcb);
     shim_tcb_t * tcb = &libc_tcb->shim_tcb;
-    assert(tcb->context.sp);
+    assert(tcb->context.regs && tcb->context.regs->rsp);
 
     thread->in_vm = thread->is_alive = true;
     allocate_tls(libc_tcb, thread->user_tcb, thread);
@@ -759,7 +759,7 @@ BEGIN_RS_FUNC(running_thread)
 
         if (libc_tcb) {
             shim_tcb_t * tcb = &libc_tcb->shim_tcb;
-            assert(tcb->context.sp);
+            assert(tcb->context.regs && tcb->context.regs->rsp);
             tcb->debug_buf = shim_get_tls()->debug_buf;
             allocate_tls(libc_tcb, thread->user_tcb, thread);
             /* Temporarily disable preemption until the thread resumes. */

--- a/LibOS/shim/src/generated-offsets.c
+++ b/LibOS/shim/src/generated-offsets.c
@@ -8,10 +8,10 @@
 void dummy(void)
 {
     OFFSET_T(SHIM_TCB_OFFSET, __libc_tcb_t, shim_tcb);
-    OFFSET_T(TCB_SYSCALL_NR, shim_tcb_t, context.syscall_nr);
-    OFFSET_T(TCB_SP, shim_tcb_t, context.sp);
-    OFFSET_T(TCB_RET_IP, shim_tcb_t, context.ret_ip);
     OFFSET_T(TCB_REGS, shim_tcb_t, context.regs);
+    OFFSET(SHIM_REGS_RSP, shim_regs, rsp);
+    OFFSET(SHIM_REGS_R15, shim_regs, r15);
+    OFFSET(SHIM_REGS_RIP, shim_regs, rip);
     DEFINE(SHIM_REGS_SIZE, sizeof(struct shim_regs));
 
     /* definitions */

--- a/LibOS/shim/src/shim_init.c
+++ b/LibOS/shim/src/shim_init.c
@@ -799,7 +799,7 @@ restore:
     shim_tcb_t * cur_tcb = shim_get_tls();
     struct shim_thread * cur_thread = (struct shim_thread *) cur_tcb->tp;
 
-    if (cur_tcb->context.sp)
+    if (cur_tcb->context.regs && cur_tcb->context.regs->rsp)
         restore_context(&cur_tcb->context);
 
     if (cur_thread->exec)
@@ -1121,7 +1121,7 @@ int shim_clean (int err)
 
 #ifdef PROFILE
     if (ENTER_TIME) {
-        switch (shim_get_tls()->context.syscall_nr) {
+        switch (shim_get_tls()->context.orig_rax) {
             case __NR_exit_group:
                 SAVE_PROFILE_INTERVAL_SINCE(syscall_exit_group, ENTER_TIME);
                 break;

--- a/LibOS/shim/src/sys/shim_sigaction.c
+++ b/LibOS/shim/src/sys/shim_sigaction.c
@@ -162,7 +162,7 @@ int shim_do_sigaltstack (const stack_t * ss, stack_t * oss)
     if (oss)
         *oss = *cur_ss;
 
-    void * sp = shim_get_tls()->context.sp;
+    void * sp = (void *)shim_get_tls()->context.regs->rsp;
     /* check if thread is currently executing on an active altstack */
     if (!(cur_ss->ss_flags & SS_DISABLE) &&
         sp &&

--- a/LibOS/shim/src/syscallas.S
+++ b/LibOS/shim/src/syscallas.S
@@ -59,11 +59,14 @@ syscalldb:
         pushq %r13
         pushq %r14
         pushq %r15
+        leaq SHIM_REGS_SIZE - SHIM_REGS_R15(%rsp), %rbx
+        pushq %rbx
+        pushq %rax
         # shim_regs struct ends here.
 
         movq %rsp, %rbp
-        .cfi_def_cfa_offset SHIM_REGS_SIZE+8  # +8 for ret_addr
-        .cfi_offset %rbp, -3 * 8    # saved_rbp is at CFA-24 (ret + saved_rflags + saved_rbp)
+        .cfi_def_cfa_offset SHIM_REGS_SIZE
+        .cfi_offset %rbp, -3 * 8    # saved_rbp is at CFA-24 (saved_rflags + saved_rbp)
         .cfi_def_cfa_register %rbp  # %rbp
 
         cmp $LIBOS_SYSCALL_BOUND, %rax
@@ -74,11 +77,6 @@ syscalldb:
         cmp $0, %rbx
         je isundef
 
-        movq %rax, %fs:(SHIM_TCB_OFFSET + TCB_SYSCALL_NR)
-        leaq SHIM_REGS_SIZE+8(%rbp), %rax
-        movq %rax, %fs:(SHIM_TCB_OFFSET + TCB_SP)
-        movq SHIM_REGS_SIZE(%rbp), %rax
-        movq %rax, %fs:(SHIM_TCB_OFFSET + TCB_RET_IP)
         movq %rbp, %fs:(SHIM_TCB_OFFSET + TCB_REGS)
 
         /* Translating x86_64 kernel calling convention to user-space
@@ -87,13 +85,11 @@ syscalldb:
         andq $~0xF, %rsp  # Required by System V AMD64 ABI.
         call *%rbx
 
-        movq $0, %fs:(SHIM_TCB_OFFSET + TCB_SYSCALL_NR)
-        movq $0, %fs:(SHIM_TCB_OFFSET + TCB_SP)
-        movq $0, %fs:(SHIM_TCB_OFFSET + TCB_RET_IP)
         movq $0, %fs:(SHIM_TCB_OFFSET + TCB_REGS)
 
 ret:
         movq %rbp, %rsp
+        addq $2 * 8, %rsp   # skip orig_rax and rsp
         popq %r15
         popq %r14
         popq %r13


### PR DESCRIPTION
<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes (reasons and measures)
move shim_tls::{sp, ret_ip, syscall_nr} to shim_regs as clean up.
Those register values are not tls, but register values.

## How to test this PR? (if applicable)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/704)
<!-- Reviewable:end -->
