### PR TITLE
[LibOS] Cleanup of shim_fs_hash.c and fix of socket's pipeid

### DIFF
--- a/LibOS/shim/include/shim_fs.h
+++ b/LibOS/shim/include/shim_fs.h
@@ -552,14 +552,9 @@ int __del_dentry_tree(struct shim_dentry * root);
 
 #define MOUNT_HASH(hash) ((hash) & (MOUNT_HASH_SIZE - 1))
 
-HASHTYPE hash_path (const char * path, int size,
-                    const char * sep);
-HASHTYPE hash_parent_path (HASHTYPE hbuf, const char * name,
-                           int * size, const char * sep);
-HASHTYPE rehash_name (HASHTYPE parent_hbuf,
-                      const char * name, int size);
-HASHTYPE rehash_path (HASHTYPE ancester_hbuf,
-                      const char * path, int size, const char * sep);
+HASHTYPE hash_path(const char* path, size_t size);
+HASHTYPE rehash_name(HASHTYPE parent_hbuf, const char* name, size_t size);
+HASHTYPE rehash_path(HASHTYPE ancester_hbuf, const char* path, size_t size);
 
 extern struct shim_fs_ops chroot_fs_ops;
 extern struct shim_d_ops  chroot_d_ops;

--- a/LibOS/shim/include/shim_internal.h
+++ b/LibOS/shim/include/shim_internal.h
@@ -800,4 +800,9 @@ static inline bool access_ok(const volatile void* addr, size_t size) {
 # error "Unsupported architecture"
 #endif /* __x86_64__ */
 
+static inline IDTYPE hashtype_to_idtype(HASHTYPE hash) {
+    assert(sizeof(HASHTYPE) == 8 && sizeof(IDTYPE) == 4);
+    return ((IDTYPE)hash) ^ ((IDTYPE)(hash >> 32));
+}
+
 #endif /* _PAL_INTERNAL_H_ */

--- a/LibOS/shim/include/shim_types.h
+++ b/LibOS/shim/include/shim_types.h
@@ -470,7 +470,7 @@ typedef Elf64_auxv_t elf_auxv_t;
 typedef unsigned int IDTYPE;
 typedef uint16_t FDTYPE;
 typedef unsigned long LEASETYPE;
-typedef unsigned long HASHTYPE;
+typedef uint64_t HASHTYPE;
 
 typedef struct atomic_int REFTYPE;
 

--- a/LibOS/shim/src/fs/chroot/fs.c
+++ b/LibOS/shim/src/fs/chroot/fs.c
@@ -87,7 +87,7 @@ static int chroot_mount (const char * uri, const char * root,
 
     mdata->data_size = data_size;
     mdata->base_type = type;
-    mdata->ino_base = hash_path(uri, uri_len, NULL);
+    mdata->ino_base = hash_path(uri, uri_len);
     mdata->root_uri_len = uri_len;
     memcpy(mdata->root_uri, uri, uri_len + 1);
 
@@ -289,7 +289,7 @@ static void chroot_update_ino (struct shim_dentry * dent)
 
     if (!qstrempty(&dent->rel_path))
         ino = rehash_path(mdata->ino_base, qstrgetstr(&dent->rel_path),
-                          dent->rel_path.len, NULL);
+                          dent->rel_path.len);
 
     dent->ino = ino;
     dent->state |= DENTRY_INO_UPDATED;

--- a/LibOS/shim/src/fs/proc/fs.c
+++ b/LibOS/shim/src/fs/proc/fs.c
@@ -255,8 +255,7 @@ static int proc_readdir (struct shim_dentry * dent,
     const struct proc_ent * tmp = ent->dir->ent;
     const struct proc_ent * end = tmp + ent->dir->size;
 
-    HASHTYPE self_hash = hash_path(rel_path,
-                                   dent->rel_path.len, NULL);
+    HASHTYPE self_hash = hash_path(rel_path, dent->rel_path.len);
     HASHTYPE new_hash;
     struct shim_dirent * buf, * ptr;
     int buf_size = MAX_PATH;

--- a/LibOS/shim/src/fs/shim_dcache.c
+++ b/LibOS/shim/src/fs/shim_dcache.c
@@ -47,8 +47,7 @@ struct shim_dentry * dentry_root = NULL;
 static inline
 HASHTYPE hash_dentry (struct shim_dentry * start, const char * path, int len)
 {
-    return rehash_path(start ? start->rel_path.hash : 0,
-                       path, len, NULL);
+    return rehash_path(start ? start->rel_path.hash : 0, path, len);
 }
 
 static struct shim_dentry * alloc_dentry (void)

--- a/LibOS/shim/src/fs/shim_fs_hash.c
+++ b/LibOS/shim/src/fs/shim_fs_hash.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 
@@ -18,191 +15,53 @@
    along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
 
 /*
- * shim_fs_hash.c
- *
  * This file contains functions to generate hash values for FS paths.
  */
 
 #include <shim_internal.h>
-#include <shim_fs.h>
-#include <shim_utils.h>
 
-#include <pal.h>
-#include <pal_error.h>
+static HASHTYPE __hash(const char* p, size_t len) {
+    HASHTYPE hash = 0;
 
-static inline unsigned int fold_hash(unsigned long hash)
-{
-    hash += hash >> (8*sizeof(int));
-    return hash;
-}
-
-uint64_t hash_one(const char *name, unsigned int len)
-{
-    unsigned long a = 0;
-    unsigned long mask = 0;
-    uint64_t hash = 0;
-
-    //debug ("Hashing %s, len %d seed %llx\n", name, len, hash);
-
-    for (;;) {
-        if (len < sizeof(unsigned long)) {
-            a = 0;
-            while (len) {
-                a += *name;
-                a <<= 8;
-                name++;
-                len--;
-            }
-        } else {
-            a = *((unsigned long *) name);
-            len -= sizeof(unsigned long);
-        }
-        hash += a;
+    for (; len >= sizeof(hash); p += sizeof(hash), len -= sizeof(hash)) {
+        hash += *((HASHTYPE*)p);
         hash *= 9;
-        name += sizeof(unsigned long);
-        if (!len)
-            goto done;
     }
-    mask = ~(~0ul << len*8);
-    hash += mask & a;
-done:
-    hash = fold_hash(hash);
-    //debug("Hash returning %llx\n", hash);
+
+    if (len) {
+        HASHTYPE rest = 0;
+        for (; len > 0; p++, len--) {
+            rest <<= 8;
+            rest += (HASHTYPE)*p;
+        }
+        hash += rest;
+        hash *= 9;
+    }
+
     return hash;
 }
 
-static inline int __check_sep (int c, const char * sep)
-{
-    if (!*sep)
-        return 0;
+HASHTYPE hash_path(const char* path, size_t size) {
+    HASHTYPE digest = 0;
 
-    if (!*(sep + 1))
-        return c == *sep;
+    const char* elem_start = path;
+    const char* c          = path;
 
-    if (!*(sep + 2))
-        return c == *sep || c == *(sep + 1);
-
-    for (const char * t = sep ; *sep ; sep++)
-        if (c == *t)
-            return 1;
-
-    return 0;
-}
-
-static inline uint64_t __hash_path (const char * path,
-                                    int size, const char * sep)
-{
-    uint64_t hash = 0;
-    uint64_t digest = 0;
-
-    const char * next_name = path;
-    const char * c = path;
-    while (c < path + size && *c) {
-        if (__check_sep(*c, sep)) {
-            if (next_name < c) {
-                hash = hash_one(next_name, c - next_name);
-                digest ^= hash;
-            }
-            next_name = c + 1;
+    for (; c < path + size && *c; c++) {
+        if (*c == '/') {
+            digest ^= __hash(elem_start, c - elem_start);
+            elem_start = c + 1;
         }
-        c++;
     }
 
-    if (next_name < c) {
-        hash = hash_one(next_name, c - next_name);
-        digest ^= hash;
-    }
-
+    digest ^= __hash(elem_start, c - elem_start);
     return digest;
 }
 
-HASHTYPE hash_path (const char * path, int size,
-                    const char * sep)
-{
-    return  __hash_path(path, size, sep ? sep : "/");
+HASHTYPE rehash_name(HASHTYPE parent_hbuf, const char* name, size_t size) {
+    return parent_hbuf ^ __hash(name, size);
 }
 
-HASHTYPE hash_parent_path (HASHTYPE hbuf, const char * path,
-                           int * size, const char * sep)
-{
-    if (*size < 0)
-        *size = strlen (path);
-
-    if (*size == 0)
-        goto zero;
-
-    sep = sep ? sep : "/";
-
-    const char * last_name = path + *size;
-    const char * last_frame_end = path + *size;
-    while (last_name > path) {
-        if (__check_sep(*(last_name - 1), sep)) {
-            if (last_name < last_frame_end)
-                break;
-
-            last_frame_end = last_name - 1;
-        }
-        last_name--;
-    }
-
-    const char * parent_end = last_name - 1;
-    while (parent_end > path && !__check_sep(*parent_end, sep))
-        parent_end--;
-
-    if (parent_end <= path)
-        goto zero;
-
-    HASHTYPE hash = 0;
-    hash = hash_one(last_name, last_frame_end - last_name);
-
-    hbuf ^= hash;
-
-    *size = parent_end - path;
-
-    return hbuf;
-
-zero:
-    hbuf = 0;
-    *size = 0;
-    return 0;
-}
-
-HASHTYPE rehash_name (HASHTYPE parent_hbuf,
-                      const char * name, int size)
-{
-    HASHTYPE ret = 0;
-    ret = hash_one(name, size);
-    ret ^= parent_hbuf;
-    return ret;
-}
-
-HASHTYPE rehash_path (HASHTYPE ancestor_hbuf,
-                      const char * path, int size, const char * sep)
-{
-    HASHTYPE ctx = 0;
-    HASHTYPE digest = 0;
-    HASHTYPE hbuf;
-
-    sep = sep ? : "/";
-
-    const char * next_name = path;
-    const char * c = path;
-    while (c < path + size && *c) {
-        if (__check_sep(*c, sep)) {
-            if (next_name < c) {
-                ctx = hash_one(next_name, c - next_name);
-                digest ^= ctx;
-            }
-            next_name = c + 1;
-        }
-        c++;
-    }
-
-    if (next_name < c) {
-        ctx = hash_one(next_name, c - next_name);
-        digest ^= ctx;
-    }
-
-    hbuf = ancestor_hbuf ^ digest;
-    return hbuf;
+HASHTYPE rehash_path(HASHTYPE ancestor_hbuf, const char* path, size_t size) {
+    return ancestor_hbuf ^ hash_path(path, size);
 }

--- a/LibOS/shim/src/sys/shim_socket.c
+++ b/LibOS/shim/src/sys/shim_socket.c
@@ -756,8 +756,13 @@ int shim_do_connect (int sockfd, struct sockaddr * addr, int addrlen)
         char * spath = saddr->sun_path;
         struct shim_dentry * dent;
 
-        if ((ret = path_lookupat(NULL, spath, LOOKUP_CREATE, &dent, NULL)) < 0)
-            goto out;
+        if ((ret = path_lookupat(NULL, spath, LOOKUP_CREATE, &dent, NULL)) < 0) {
+            // DEP 7/3/17: We actually want either 0 or -ENOENT, as the
+            // expected case is that the name is free (and we get the dent to
+            // populate the name)
+            if (ret != -ENOENT || !dent)
+                goto out;
+        }
 
         struct shim_unix_data * data = dent->data;
 

--- a/LibOS/shim/src/sys/shim_socket.c
+++ b/LibOS/shim/src/sys/shim_socket.c
@@ -504,7 +504,7 @@ int shim_do_bind (int sockfd, struct sockaddr * addr, socklen_t addrlen)
 
         struct shim_unix_data * data = malloc(sizeof(struct shim_unix_data));
 
-        data->pipeid = dent->rel_path.hash >> 32;
+        data->pipeid = hashtype_to_idtype(dent->rel_path.hash);
         sock->addr.un.pipeid = data->pipeid;
         sock->addr.un.data = data;
         sock->addr.un.dentry = dent;
@@ -763,7 +763,7 @@ int shim_do_connect (int sockfd, struct sockaddr * addr, int addrlen)
 
         if (!(dent->state & DENTRY_VALID) || dent->state & DENTRY_NEGATIVE) {
             data = malloc(sizeof(struct shim_unix_data));
-            data->pipeid = dent->rel_path.hash >> 32;
+            data->pipeid = hashtype_to_idtype(dent->rel_path.hash);
         } else if (dent->fs != &socket_builtin_fs) {
             ret = -ECONNREFUSED;
             goto out;

--- a/LibOS/shim/test/native/manifest.template
+++ b/LibOS/shim/test/native/manifest.template
@@ -26,5 +26,4 @@ sgx.trusted_files.libdl = file:$(LIBCDIR)/libdl.so.2
 sgx.trusted_files.libm = file:$(LIBCDIR)/libm.so.6
 sgx.trusted_files.libpthread = file:$(LIBCDIR)/libpthread.so.0
 
-sgx.trusted_files.unix_pipe = file:unix.c
 sgx.trusted_files.tcp_c = file:tcp.c

--- a/LibOS/shim/test/regression/80_unix.py
+++ b/LibOS/shim/test/regression/80_unix.py
@@ -1,0 +1,24 @@
+import sys
+from regression import Regression
+
+loader = sys.argv[1]
+
+# Running udp
+regression = Regression(loader, "unix", None)
+
+regression.add_check(name="Unix domain socket",
+    check=lambda res:
+      "Data: This is packet 0" in res[0].out and
+      "Data: This is packet 1" in res[0].out and
+      "Data: This is packet 2" in res[0].out and
+      "Data: This is packet 3" in res[0].out and
+      "Data: This is packet 4" in res[0].out and
+      "Data: This is packet 5" in res[0].out and
+      "Data: This is packet 6" in res[0].out and
+      "Data: This is packet 7" in res[0].out and
+      "Data: This is packet 8" in res[0].out and
+      "Data: This is packet 9" in res[0].out)
+
+rv = regression.run_checks()
+if rv:
+    sys.exit(rv)

--- a/LibOS/shim/test/regression/unix.c
+++ b/LibOS/shim/test/regression/unix.c
@@ -1,7 +1,8 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
-/* copied from http://www.daniweb.com/software-development/c/threads/179814 */
+/* NOTE: Under Graphene, this test must be run only in fork mode.
+ * This is due to Graphene restricting communication via Unix
+ * domain sockets only for processes in same Graphene instance
+ * (i.e. only between parent and its child in this test).
+ */
 
 #include <unistd.h>
 #include <stdlib.h>
@@ -14,21 +15,43 @@
 #include <sys/stat.h>
 #include <sys/wait.h>
 
-#define SRV_IP "127.0.0.1"
-#define PORT 9930
-#define BUFLEN 512
-#define NPACK 10
-
-const char * fname;
-
 enum { SINGLE, PARALLEL } mode = PARALLEL;
 int do_fork = 0;
 
 int pipefds[2];
 
+int server_dummy_socket(void)
+{
+    int create_socket;
+    struct sockaddr_un address;
+
+    if ((create_socket = socket(AF_UNIX,SOCK_STREAM,
+                                0)) > 0)
+        printf("Dummy socket was created\n");
+
+    address.sun_family = AF_UNIX;
+    strncpy(address.sun_path, "dummy", sizeof(address.sun_path));
+
+    if (bind(create_socket,(struct sockaddr *)&address,
+             sizeof(address)) < 0) {
+        perror("bind");
+        close(create_socket);
+        exit(-1);
+    }
+
+    if (listen(create_socket,3) < 0) {
+        perror("listen");
+        close(create_socket);
+        exit(-1);
+    }
+
+    /* do not close this socket to test two sockets in parallel */
+    return 0;
+}
+
 int server(void)
 {
-    int conn,create_socket,new_socket,fd;
+    int create_socket,new_socket;
     socklen_t addrlen;
     int bufsize = 1024;
     char *buffer = malloc(bufsize);
@@ -39,7 +62,7 @@ int server(void)
         printf("The socket was created\n");
 
     address.sun_family = AF_UNIX;
-    memcpy(address.sun_path,"u",10);
+    strncpy(address.sun_path, "u", sizeof(address.sun_path));
 
     if (bind(create_socket,(struct sockaddr *)&address,
              sizeof(address)) < 0) {
@@ -83,17 +106,14 @@ int server(void)
         }
     }
 
-    if ((fd = open(fname,O_RDONLY,0)) < 0) {
-        perror("File Open Failed");
-        close(new_socket);
-        exit(-1);
+    for (int i = 0; i < 10; i++) {
+        sprintf(buffer, "Data: This is packet %d\n", i);
+        if (sendto(new_socket, buffer, strlen(buffer), 0, 0, 0) == -1) {
+            fprintf(stderr, "sendto() failed\n");
+            exit(-1);
+        }
     }
 
-    while((conn = read(fd,buffer,
-                       bufsize)) > 0)
-        sendto(new_socket,buffer,conn,0,0,0);
-
-    printf("Request completed\n");
 
     close(new_socket);
     if (do_fork)
@@ -118,7 +138,7 @@ int client(void)
         printf("The socket was created\n");
 
     address.sun_family = AF_UNIX;
-    memcpy(address.sun_path,"u",10);
+    strncpy(address.sun_path, "u", sizeof(address.sun_path));
 
     if (connect(create_socket,(struct sockaddr *)&address,
                 sizeof(address)) == 0)
@@ -136,13 +156,12 @@ int client(void)
         }
     }
 
-    printf("The contents of file are...\n\n");
-    while((count=recv(create_socket,buffer,bufsize,0))>0)
-        write(1,buffer,count);
+    puts("Receiving:");
+    while ((count = recv(create_socket,buffer,bufsize,0)) > 0) {
+        fwrite(buffer, count, 1, stdout);
+    }
+    puts("Done");
 
-    printf("\nEOF\n");
-
-    buffer[0] = 0;
     close(create_socket);
     if (do_fork)
         exit(0);
@@ -151,11 +170,6 @@ int client(void)
 
 int main(int argc, char ** argv)
 {
-    char fnamebuf[40];
-    strcpy(fnamebuf, "unix");
-    strcat(fnamebuf, ".c");
-    fname = fnamebuf;
-
     if (argc > 1) {
         if (strcmp(argv[1], "client") == 0) {
             mode = SINGLE;
@@ -165,6 +179,7 @@ int main(int argc, char ** argv)
 
         if (strcmp(argv[1], "server") == 0) {
             mode = SINGLE;
+            server_dummy_socket();
             server();
             return 0;
         }
@@ -180,10 +195,12 @@ old:
 
         int pid = fork();
 
-        if (pid == 0)
+        if (pid == 0) {
             client();
-        else
+        } else {
+            server_dummy_socket();
             server();
+        }
     }
 
     return 0;

--- a/Pal/src/host/Linux-SGX/sgx_enclave.c
+++ b/Pal/src/host/Linux-SGX/sgx_enclave.c
@@ -301,7 +301,7 @@ static int sgx_ocall_sock_listen(void * pms)
         goto err_fd;
 
     if (ms->ms_addr) {
-        socklen_t addrlen;
+        socklen_t addrlen = ms->ms_addrlen;
         ret = INLINE_SYSCALL(getsockname, 3, fd, ms->ms_addr, &addrlen);
         if (IS_ERR(ret))
             goto err_fd;
@@ -394,7 +394,7 @@ static int sgx_ocall_sock_connect(void * pms)
     }
 
     if (ms->ms_bind_addr && !ms->ms_bind_addr->sa_family) {
-        socklen_t addrlen;
+        socklen_t addrlen = ms->ms_bind_addrlen;
         ret = INLINE_SYSCALL(getsockname, 3, fd, ms->ms_bind_addr,
                              &addrlen);
         if (IS_ERR(ret))


### PR DESCRIPTION
## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes (reasons and measures)

Fixes #390. Closes #593.

Source code in `shim_fs_hash.c` contained an incorrect casting from `uint64_t` to `uint32_t`. While fixing this issue, the whole code of this file was cleaned up (and other files calling its functions).

Additionally, this PR fixes the issue #390 by replacing this incorrect pattern:
```c
    data->pipeid = dent->rel_path.hash >> 32;
```
with the new helper-function cast:
```c
    data->pipeid = hashtype_to_idtype(dent->rel_path.hash);
```

## How to test this PR? (if applicable)

All tests must succeed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/708)
<!-- Reviewable:end -->
