### PR TITLE
[LibOS] getcwd() return string length including last NUL

### DIFF
--- a/LibOS/shim/src/sys/shim_getcwd.c
+++ b/LibOS/shim/src/sys/shim_getcwd.c
@@ -61,7 +61,7 @@ int shim_do_getcwd (char * buf, size_t len)
     } else if (plen + 1 > len) {
         ret = -ERANGE;
     } else {
-        ret = plen;
+        ret = plen + 1;
         memcpy(buf, path, plen + 1);
     }
     return ret;


### PR DESCRIPTION
getcwd() system call should return string length including
last NUL. off-by-one bug.

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->


## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/710)
<!-- Reviewable:end -->
