### PR TITLE
[Pal/Linux-SGX gdb] Cleanup of ptrace-ldpreloaded library

### DIFF
--- a/LibOS/shim/src/syscallas.S
+++ b/LibOS/shim/src/syscallas.S
@@ -38,6 +38,12 @@ syscalldb:
 
         # Create shim_regs struct on the stack.
         pushfq
+
+        # Under GDB, single-stepping sets Trap Flag (TP) of EFLAGS,
+        # thus TP=1 is stored on pushfq above. Upon consequent popfq,
+        # TP is 1, resulting in spurious trap. Reset TP here.
+        andq $~0x100, (%rsp)
+
         cld
         pushq %rbp
         pushq %rbx

--- a/Pal/src/host/Linux-SGX/debugger/sgx_gdb.h
+++ b/Pal/src/host/Linux-SGX/debugger/sgx_gdb.h
@@ -1,16 +1,20 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
+#define MAX_DBG_THREADS 64
 
-#define MAX_DBG_THREADS     64
+/* This address is shared between our GDB and Graphene-SGX and must
+ * reside in non-enclave memory. Graphene-SGX puts an enclave_dbginfo
+ * object at this address and periodically updates it. Our GDB
+ * reads the object from this address to update its internal structs
+ * and learn about enclave layout, active threads, etc. */
+#define DBGINFO_ADDR 0x100000000000
 
-struct enclave_dbginfo {
-    int                 pid;
-    unsigned long       base, size;
-    unsigned long       ssaframesize;
-    void *              aep;
-    int                 thread_tids[MAX_DBG_THREADS];
-    void *              tcs_addrs[MAX_DBG_THREADS];
-    unsigned long long  thread_stepping;
+/* This struct is read using PTRACE_PEEKDATA in 8B increments
+ * therefore it is aligned as long. */
+struct __attribute__((aligned(__alignof__(long)))) enclave_dbginfo {
+    int pid;
+    unsigned long base, size;
+    unsigned long ssaframesize;
+    void* aep;
+    int thread_tids[MAX_DBG_THREADS];
+    void* tcs_addrs[MAX_DBG_THREADS];
+    unsigned long long thread_stepping;
 };
-
-#define DBGINFO_ADDR        0x100000000000

--- a/Pal/src/host/Linux-SGX/enclave_entry.S
+++ b/Pal/src/host/Linux-SGX/enclave_entry.S
@@ -361,6 +361,12 @@ sgx_ocall:
 	movq 8(%rbp), %rax
 	pushq %rax	# previous RIP
 	pushfq
+
+	# Under GDB, single-stepping sets Trap Flag (TP) of EFLAGS,
+	# thus TP=1 is stored on pushfq above. Upon consequent popfq,
+	# TP is 1, resulting in spurious trap. Reset TP here.
+	andq $~0x100, (%rsp)
+
 	pushq %r15
 	pushq %r14
 	pushq %r13


### PR DESCRIPTION
## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->

After merging PR #688, GDB stopped working. It seems to be a legit bug in GDB. To circumvent this bug, I ended up refactoring the whole sgx-gdb plugin. The code is hopefully readable now, and the bug is gone.

## How to test this PR? <!-- (if applicable) -->

Debug any executable. E.g., build `LibOS/shim/test/native/sleep` executable and run under GDB:
```c
$ GDB=1 SGX=1 ./pal_loader sleep
(gdb) b sgx_ocall_sleep
(gdb) r
<... GDB hits breakpoint ...>
(gdb) bt
#0  sgx_ocall_sleep (pms=0x7ffe7d2b4400) at sgx_enclave.c:593
#1  0x000055882286f5b9 in sgx_entry ()    // <-- untrusted world
#2  0x000000000bd8b610 in __morestack ()  // <-- bridge between untrusted and enclave
#3  0x000000000bd87bec in ocall_sleep (microsec=0x0, microsec@entry=0xba54b78) at enclave_ocalls.c:995  // <-- enclave world
#4  0x000000000bd82d59 in _DkThreadDelayExecution (duration=duration@entry=0xba54b78) at db_threading.c:114
#5  0x000000000bd788ad in DkThreadDelayExecution (duration=3000000) at db_threading.c:61
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/713)
<!-- Reviewable:end -->
