### PR TITLE
[Pal/Linux-SGX] remove sign compare warning with DEBUG=1

### DIFF
--- a/Pal/src/host/Linux-SGX/ecall_types.h
+++ b/Pal/src/host/Linux-SGX/ecall_types.h
@@ -11,8 +11,8 @@ struct pal_sec;
 
 typedef struct {
     char * ms_args;
-    uint64_t ms_args_size;
+    size_t ms_args_size;
     char * ms_env;
-    uint64_t ms_env_size;
+    size_t ms_env_size;
     struct pal_sec * ms_sec_info;
 } ms_ecall_enclave_start_t;

--- a/Pal/src/host/Linux-SGX/enclave_ecalls.c
+++ b/Pal/src/host/Linux-SGX/enclave_ecalls.c
@@ -10,12 +10,6 @@
 
 #define SGX_CAST(type, item) ((type)(item))
 
-void pal_linux_main(char * uptr_args, uint64_t args_size,
-                    char * uptr_env, uint64_t env_size,
-                    struct pal_sec * uptr_sec_info);
-
-void pal_start_thread (void);
-
 extern void * enclave_base, * enclave_top;
 
 static struct atomic_int enclave_start_called = ATOMIC_INIT(0);

--- a/Pal/src/host/Linux-SGX/pal_linux.h
+++ b/Pal/src/host/Linux-SGX/pal_linux.h
@@ -85,6 +85,12 @@ bool stataccess (struct stat * stats, int acc);
 
 #ifdef IN_ENCLAVE
 
+struct pal_sec;
+void pal_linux_main(char * uptr_args, size_t args_size,
+                    char * uptr_env, size_t env_size,
+                    struct pal_sec * uptr_sec_info);
+void pal_start_thread (void);
+
 /* Locking and unlocking of Mutexes */
 int __DkMutexCreate (struct mutex_handle * mut);
 int _DkMutexAtomicCreate (struct mutex_handle * mut);

--- a/Pal/src/host/Linux-SGX/sgx_enclave.c
+++ b/Pal/src/host/Linux-SGX/sgx_enclave.c
@@ -702,7 +702,7 @@ sgx_ocall_fn_t ocall_table[OCALL_NR] = {
 
 #define EDEBUG(code, ms) do {} while (0)
 
-int ecall_enclave_start (char * args, uint64_t args_size, char * env, uint64_t env_size)
+int ecall_enclave_start (char * args, size_t args_size, char * env, size_t env_size)
 {
     ms_ecall_enclave_start_t ms;
     ms.ms_args = args;

--- a/Pal/src/host/Linux-SGX/sgx_enclave.h
+++ b/Pal/src/host/Linux-SGX/sgx_enclave.h
@@ -4,6 +4,6 @@
 #include "pal_linux.h"
 #include "pal_security.h"
 
-int ecall_enclave_start (char * args, uint64_t args_size, char * env, uint64_t env_size);
+int ecall_enclave_start (char * args, size_t args_size, char * env, size_t env_size);
 
 int ecall_thread_start (void);

--- a/Pal/src/host/Linux-SGX/sgx_main.c
+++ b/Pal/src/host/Linux-SGX/sgx_main.c
@@ -640,8 +640,8 @@ finalize:
 static int load_enclave (struct pal_enclave * enclave,
                          const char * manifest_uri,
                          const char * exec_uri,
-                         char * args, uint64_t args_size,
-                         char * env, uint64_t env_size,
+                         char * args, size_t args_size,
+                         char * env, size_t env_size,
                          bool exec_uri_inferred)
 {
     struct pal_sec * pal_sec = &enclave->pal_sec;
@@ -931,14 +931,14 @@ int main (int argc, char ** argv, char ** envp)
      * saves us creating a copy of all argv and envp strings.
      */
     char * args = argv[0];
-    uint64_t args_size = argc > 0 ? (argv[argc - 1] - argv[0]) + strlen(argv[argc - 1]) + 1: 0;
+    size_t args_size = argc > 0 ? (argv[argc - 1] - argv[0]) + strlen(argv[argc - 1]) + 1: 0;
 
     int envc = 0;
     while (envp[envc] != NULL) {
         envc++;
     }
     char * env = envp[0];
-    uint64_t env_size = envc > 0 ? (envp[envc - 1] - envp[0]) + strlen(envp[envc - 1]) + 1: 0;
+    size_t env_size = envc > 0 ? (envp[envc - 1] - envp[0]) + strlen(envp[envc - 1]) + 1: 0;
 
 
     return load_enclave(enclave, manifest_uri, exec_uri,

--- a/Pal/src/host/Linux-SGX/sgx_main.c
+++ b/Pal/src/host/Linux-SGX/sgx_main.c
@@ -669,7 +669,7 @@ static int load_enclave (struct pal_enclave * enclave,
     pal_sec->gid = INLINE_SYSCALL(getgid, 0);
 
 #ifdef DEBUG
-    int env_i = 0;
+    size_t env_i = 0;
     while (env_i < env_size) {
         if (strcmp_static(&env[env_i], "IN_GDB=1")) {
             SGX_DBG(DBG_I, "being GDB'ed!!!\n");


### PR DESCRIPTION
> [ host/Linux-SGX/sgx_main.o ]
> sgx_main.c: In function load_enclave:
> sgx_main.c:673:18: error: comparison between signed and unsigned integer expressions [-Werror=sign-compare]
>      while (env_i < env_size) {
>                   ^
> cc1: all warnings being treated as errors

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [x] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->


## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/723)
<!-- Reviewable:end -->
