### PR TITLE
[GLIBC] Fix the Makefile rules for building GLIBC

### DIFF
--- a/LibOS/Makefile
+++ b/LibOS/Makefile
@@ -48,7 +48,7 @@ $(BUILD_DIR)/Build.success: $(BUILD_DIR)/Makefile
 
 $(GLIBC_TARGET): $(BUILD_DIR)/Build.success
 
-$(BUILD_DIR)/Makefile: $(addprefix $(GLIBC_SRC)/,configure elf/Versions nptl/Versions dlfcn/Versions)
+$(BUILD_DIR)/Makefile: $(GLIBC_SRC)/configure
 ifeq ($(DEBUG),1)
 	./buildglibc.py --quiet --debug
 else
@@ -78,21 +78,24 @@ ifneq ($(filter %.gold,$(shell readlink -f /usr/bin/ld)),)
 GLIBC_PATCHES += glibc-ld.gold.patch
 endif
 
-$(GLIBC_SRC)/configure: $(GLIBC_PATCHES) Makefile
-	[ -f $(GLIBC_SRC).tar.gz ] || \
-	for MIRROR in $(GLIBC_MIRRORS); do \
-		wget --timeout=10 $${MIRROR}glibc/$(GLIBC_SRC).tar.gz \
-		&& break; \
-	done
+$(GLIBC_SRC)/configure: $(GLIBC_PATCHES) $(GLIBC_SRC).tar.gz
 	[ "`sha256sum $(GLIBC_SRC).tar.gz`" = "$(GLIBC_CHECKSUM)  $(GLIBC_SRC).tar.gz" ] || \
 		(echo "*** $(GLIBC_SRC).tar.gz has a wrong checksum ***"; exit 255)
+	rm -rf $(GLIBC_SRC)
 	tar -xzf $(GLIBC_SRC).tar.gz
 	cd $(GLIBC_SRC) && \
 	for p in $(GLIBC_PATCHES); do \
 		echo applying $$p; \
-		patch -p1 < ../$$p; \
+		patch -p1 < ../$$p || exit 255; \
 	done
+	touch $@
 endif
+
+$(GLIBC_SRC).tar.gz:
+	for MIRROR in $(GLIBC_MIRRORS); do \
+		wget --timeout=10 $${MIRROR}glibc/$(GLIBC_SRC).tar.gz \
+		&& break; \
+	done
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->

(1) Removing unnecessary dependencies
(2) Need to abort if one of the patches isn't applied properly
(3) Preventing repeated patching and building (fix #725)
(4) Clean up and repatch the GLIBC source when the dependencies are updated

## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/726)
<!-- Reviewable:end -->
