### PR TITLE
[LibOS] remove warning in exec_invalid_args.c

### DIFF
--- a/LibOS/shim/test/regression/exec_invalid_args.c
+++ b/LibOS/shim/test/regression/exec_invalid_args.c
@@ -5,7 +5,8 @@
 
 int main(int argc, const char** argv, const char** envp) {
     int r;
-    char* badptr = (char*) -1;
+    char** badptr_argv = (char**)-1;
+    char* badptr = (char*)-1;
 
     char* bad_argv[]  = { badptr,  NULL };
     char* good_argv[] = { "DUMMY", NULL };
@@ -17,11 +18,11 @@ int main(int argc, const char** argv, const char** envp) {
     if (r == -1 && errno == EFAULT)
         printf("execve(invalid-path) correctly returned error\n");
 
-    r = execve(argv[0], badptr, good_envp);
+    r = execve(argv[0], badptr_argv, good_envp);
     if (r == -1 && errno == EFAULT)
         printf("execve(invalid-argv-ptr) correctly returned error\n");
 
-    r = execve(argv[0], good_argv, badptr);
+    r = execve(argv[0], good_argv, badptr_argv);
     if (r == -1 && errno == EFAULT)
         printf("execve(invalid-envp-ptr) correctly returned error\n");
 


### PR DESCRIPTION
elimiate the following warnings.

> [ exec_invalid_args ]
> exec_invalid_args.c: In function main:
> exec_invalid_args.c:20:25: warning: passing argument 2 of execve from incompatible pointer type [-Wincompatible-pointer-types]
>      r = execve(argv[0], badptr, good_envp);
>                          ^~~~~~
> In file included from exec_invalid_args.c:4:0:
> /usr/include/unistd.h:554:12: note: expected char * const* but argument is of type char *
>  extern int execve (const char *__path, char *const __argv[],
>             ^~~~~~
> exec_invalid_args.c:24:36: warning: passing argument 3 of execve from incompatible pointer type [-Wincompatible-pointer-types]
>      r = execve(argv[0], good_argv, badptr);
>                                     ^~~~~~
> In file included from exec_invalid_args.c:4:0:
> /usr/include/unistd.h:554:12: note: expected char * const* but argument is of type char *
>  extern int execve (const char *__path, char *const __argv[],

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->


## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/735)
<!-- Reviewable:end -->
