### PR TITLE
[Pal, LibOS] Unify handling of ELF auxiliary vectors in LibOS and PAL

### DIFF
--- a/LibOS/shim/include/shim_thread.h
+++ b/LibOS/shim/include/shim_thread.h
@@ -349,6 +349,6 @@ bool check_on_stack (struct shim_thread * cur_thread, void * mem)
 
 int init_stack (const char ** argv, const char ** envp,
                 int ** argcpp, const char *** argpp,
-                int nauxv, elf_auxv_t ** auxpp);
+                elf_auxv_t ** auxpp);
 
 #endif /* _SHIM_THREAD_H_ */

--- a/LibOS/shim/include/shim_utils.h
+++ b/LibOS/shim/include/shim_utils.h
@@ -215,7 +215,7 @@ int load_elf_interp (struct shim_handle * exec);
 int free_elf_interp (void);
 void execute_elf_object (struct shim_handle * exec,
                          int * argcp, const char ** argp,
-                         int nauxv, elf_auxv_t * auxp);
+                         elf_auxv_t * auxp);
 int remove_loaded_libraries (void);
 
 /* gdb debugging support */

--- a/LibOS/shim/src/elf/shim_rtld.c
+++ b/LibOS/shim/src/elf/shim_rtld.c
@@ -1563,12 +1563,13 @@ int register_library (const char * name, unsigned long load_address)
 
 void execute_elf_object (struct shim_handle * exec,
                          int * argcp, const char ** argp,
-                         int nauxv, ElfW(auxv_t) * auxp)
+                         ElfW(auxv_t) * auxp)
 {
     struct link_map * exec_map = __search_map_by_handle(exec);
     assert(exec_map);
     assert((uintptr_t)argcp % 16 == 0);  // Stack should be aligned to 16 on entry point.
     assert((void*)argcp + sizeof(long) == argp || argp == NULL);
+    assert(PAL_SUPPORTED_ELF_AUXV >= 7 && PAL_ADDITIONAL_ELF_AUXV_SPACE >= 16);
 
     /* random 16 bytes follows auxp */
     ElfW(Addr) random = (ElfW(Addr))&auxp[7];

--- a/LibOS/shim/src/shim_init.c
+++ b/LibOS/shim/src/shim_init.c
@@ -286,8 +286,7 @@ void * allocate_stack (size_t size, size_t protect_size, bool user)
 }
 
 static int populate_user_stack (void * stack, size_t stack_size,
-                                int nauxv, elf_auxv_t ** auxpp,
-                                int ** argcpp,
+                                elf_auxv_t ** auxpp, int ** argcpp,
                                 const char *** argvp, const char *** envpp)
 {
     const int argc = **argcpp;
@@ -336,16 +335,15 @@ copy_envp:
     if (!new_envp)
         *(const char **) ALLOCATE_BOTTOM(sizeof(const char *)) = NULL;
 
-    if (nauxv) {
-        new_auxp = ALLOCATE_BOTTOM(sizeof(elf_auxv_t) * nauxv);
-        if (*auxpp)
-            memcpy(new_auxp, *auxpp, nauxv * sizeof(elf_auxv_t));
+    new_auxp = ALLOCATE_BOTTOM(PAL_SUPPORTED_ELF_AUXV * sizeof(elf_auxv_t));
+    if (*auxpp) {
+        /* copy auxv if provided by PAL; otherwise it is inited by LibOS rtld */
+        memcpy(new_auxp, *auxpp, PAL_SUPPORTED_ELF_AUXV * sizeof(elf_auxv_t));
     }
 
-    /* reserve at least 16 bytes on the stack to accommodate AT_RANDOM bytes
-     * later
-     */
-    ALLOCATE_TOP(16);
+    /* reserve additional space on the stack to accommodate additional info
+     * for auxv (e.g., 16B for AT_RANDOM) */
+    ALLOCATE_TOP(PAL_ADDITIONAL_ELF_AUXV_SPACE);
 
     /* x86_64 ABI requires 16 bytes alignment on stack on every function
        call. */
@@ -369,7 +367,7 @@ unsigned long sys_stack_size = 0;
 
 int init_stack (const char ** argv, const char ** envp,
                 int ** argcpp, const char *** argpp,
-                int nauxv, elf_auxv_t ** auxpp)
+                elf_auxv_t ** auxpp)
 {
     if (!sys_stack_size) {
         sys_stack_size = DEFAULT_SYS_STACK_SIZE;
@@ -394,7 +392,7 @@ int init_stack (const char ** argv, const char ** envp,
         envp = initial_envp;
 
     int ret = populate_user_stack(stack, sys_stack_size,
-                                  nauxv, auxpp, argcpp, &argv, &envp);
+                                  auxpp, argcpp, &argv, &envp);
     if (ret < 0)
         return ret;
 
@@ -545,18 +543,6 @@ struct shim_profile profile_root;
         (auxp) = _tmp + sizeof(char *);                             \
     } while (0)
 
-
-static elf_auxv_t* __process_auxv (elf_auxv_t * auxp)
-{
-    elf_auxv_t * av;
-
-    for (av = auxp; av->a_type != AT_NULL; av++)
-        switch (av->a_type) {
-            default: break;
-        }
-
-    return av + 1;
-}
 
 #ifdef PROFILE
 static void set_profile_enabled (const char ** envp)
@@ -713,9 +699,7 @@ noreturn void* shim_init (int argc, void * args)
     const char ** argv, ** envp, ** argp = NULL;
     elf_auxv_t * auxp;
 
-    /* call to figure out where the arguments are */
     FIND_ARG_COMPONENTS(args, argc, argv, envp, auxp);
-    int nauxv = __process_auxv(auxp) - auxp;
 
 #ifdef PROFILE
     set_profile_enabled(envp);
@@ -780,7 +764,7 @@ restore:
     RUN_INIT(init_mount);
     RUN_INIT(init_important_handles);
     RUN_INIT(init_async);
-    RUN_INIT(init_stack, argv, envp, &argcp, &argp, nauxv, &auxp);
+    RUN_INIT(init_stack, argv, envp, &argcp, &argp, &auxp);
     RUN_INIT(init_loader);
     RUN_INIT(init_ipc_helper);
     RUN_INIT(init_signal);
@@ -829,8 +813,7 @@ restore:
         restore_context(&cur_tcb->context);
 
     if (cur_thread->exec)
-        execute_elf_object(cur_thread->exec,
-                           argcp, argp, nauxv, auxp);
+        execute_elf_object(cur_thread->exec, argcp, argp, auxp);
     shim_do_exit(0);
 }
 

--- a/LibOS/shim/src/sys/shim_exec.c
+++ b/LibOS/shim/src/sys/shim_exec.c
@@ -70,8 +70,6 @@ static int           new_argc;
 static int *         new_argcp;
 static elf_auxv_t *  new_auxp;
 
-#define REQUIRED_ELF_AUXV       6
-
 int init_brk_from_executable (struct shim_handle * exec);
 
 int shim_do_execve_rtld (struct shim_handle * hdl, const char ** argv,
@@ -112,8 +110,7 @@ int shim_do_execve_rtld (struct shim_handle * hdl, const char ** argv,
     for (const char ** a = argv ; *a ; a++, new_argc++);
 
     new_argcp = &new_argc;
-    if ((ret = init_stack(argv, envp, &new_argcp, &new_argp,
-                          REQUIRED_ELF_AUXV, &new_auxp)) < 0)
+    if ((ret = init_stack(argv, envp, &new_argcp, &new_argp, &new_auxp)) < 0)
         return ret;
 
     SAVE_PROFILE_INTERVAL(alloc_new_stack_for_exec);
@@ -197,8 +194,7 @@ retry_dump_vmas:
 #endif
 
     debug("execve: start execution\n");
-    execute_elf_object(cur_thread->exec, new_argcp, new_argp,
-                       REQUIRED_ELF_AUXV, new_auxp);
+    execute_elf_object(cur_thread->exec, new_argcp, new_argp, new_auxp);
 
     return 0;
 }

--- a/Pal/src/db_rtld.c
+++ b/Pal/src/db_rtld.c
@@ -1305,6 +1305,8 @@ void * stack_before_call __attribute_unused = NULL;
 void start_execution (const char * first_argument, const char ** arguments,
                       const char ** environs)
 {
+    assert(PAL_SUPPORTED_ELF_AUXV >= 7 && PAL_ADDITIONAL_ELF_AUXV_SPACE >= 16);
+
     /* First we will try to run all the preloaded libraries which come with
        entry points */
     if (exec_map) {
@@ -1331,7 +1333,8 @@ void start_execution (const char * first_argument, const char ** arguments,
     ncookies++; /* for NULL-end */
 
     int cookiesz = sizeof(unsigned long int) * ncookies
-                      + sizeof(ElfW(auxv_t)) * 6 + 16
+                      + sizeof(ElfW(auxv_t)) * PAL_SUPPORTED_ELF_AUXV
+                      + PAL_ADDITIONAL_ELF_AUXV_SPACE
                       + sizeof(void *) * 4 + 16;
 
     unsigned long int * cookies = __alloca(cookiesz);

--- a/Pal/src/pal.h
+++ b/Pal/src/pal.h
@@ -532,4 +532,7 @@ DkCpuIdRetrieve (PAL_IDX leaf, PAL_IDX subleaf, PAL_IDX values[4]);
 # define symbol_version_default(real, name, version)
 #endif
 
+#define PAL_SUPPORTED_ELF_AUXV 7  /* includes AT_NULL marking end of auxv */
+#define PAL_ADDITIONAL_ELF_AUXV_SPACE 16    /* 16B for value in AT_RANDOM */
+
 #endif /* PAL_H */


### PR DESCRIPTION
## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [x] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->

PAL initializes a subset of ELF aux vectors on binary start. LibOS does
the same on execve(). Previously, the two flows were similar but not
unified. This led to subtle memory corruption bugs. This commit unifies
the requirements for the minimum supported number of ELF aux vectors as
well as the minimum additional space to hold their auxiliary data (such
as AT_RANDOM bytes). As a side-effect, it removes nauxv argument.

## How to test this PR? <!-- (if applicable) -->

Run regression tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/736)
<!-- Reviewable:end -->
