### PR TITLE
[LibOS] Fix int type cast bug in chroot FS

### DIFF
--- a/LibOS/shim/src/fs/chroot/fs.c
+++ b/LibOS/shim/src/fs/chroot/fs.c
@@ -464,7 +464,7 @@ static int chroot_open (struct shim_handle * hdl, struct shim_dentry * dent,
         return ret;
 
     struct shim_file_handle * file = &hdl->info.file;
-    int size = atomic_read(&data->size);
+    uint64_t size = atomic_read(&data->size);
 
     /* initialize hdl, does not need a lock because no one is sharing */
     hdl->type       = TYPE_FILE;
@@ -494,7 +494,7 @@ static int chroot_creat (struct shim_handle * hdl, struct shim_dentry * dir,
         return 0;
 
     struct shim_file_handle * file = &hdl->info.file;
-    int size = atomic_read(&data->size);
+    uint64_t size = atomic_read(&data->size);
 
     /* initialize hdl, does not need a lock because no one is sharing */
     hdl->type       = TYPE_FILE;
@@ -617,7 +617,7 @@ static int chroot_flush (struct shim_handle * hdl)
     if (file->buf_type == FILEBUF_MAP) {
         lock(&hdl->lock);
         void * mapbuf = file->mapbuf;
-        int mapsize = file->mapsize;
+        uint64_t mapsize = file->mapsize;
         file->mapoffset = 0;
         file->mapbuf = NULL;
         unlock(&hdl->lock);
@@ -901,7 +901,7 @@ static int chroot_seek (struct shim_handle * hdl, off_t offset, int wence)
     lock(&hdl->lock);
 
     int marker = file->marker;
-    int size = file->size;
+    uint64_t size = file->size;
 
     if (check_version(hdl)) {
         struct shim_file_data * data = FILE_HANDLE_DATA(hdl);

--- a/LibOS/shim/src/fs/chroot/fs.c
+++ b/LibOS/shim/src/fs/chroot/fs.c
@@ -900,7 +900,7 @@ static int chroot_seek (struct shim_handle * hdl, off_t offset, int wence)
     struct shim_file_handle * file = &hdl->info.file;
     lock(&hdl->lock);
 
-    int marker = file->marker;
+    uint64_t marker = file->marker;
     uint64_t size = file->size;
 
     if (check_version(hdl)) {


### PR DESCRIPTION
## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->

Chroot FS implementation contained several bugs pertaining to
greater-int-type cast to smaller-int-type (uint64_t -> int). For files
more than 2GB, this resulted in negative length passed to other LibOS
functions, resulting in pointer arithmetic overflows and sefaults.

Note that this commit fixes one particular bug regarding type casts.
More changes are required to weed out such bugs from LibOS code.

## How to test this PR? <!-- (if applicable) -->

This bug was triggered on a complicated Python3 setup with huge files. No simple test was constructed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/737)
<!-- Reviewable:end -->
