### PR TITLE
[LibOS] allocate one more auxv for AT_NULL

### DIFF
--- a/LibOS/shim/src/elf/shim_rtld.c
+++ b/LibOS/shim/src/elf/shim_rtld.c
@@ -1578,19 +1578,29 @@ void execute_elf_object (struct shim_handle * exec,
         DkThreadExit();
     }
 
-    auxp[0].a_type = AT_PHDR;
-    auxp[0].a_un.a_val = (__typeof(auxp[0].a_un.a_val)) exec_map->l_phdr;
-    auxp[1].a_type = AT_PHNUM;
-    auxp[1].a_un.a_val = exec_map->l_phnum;
-    auxp[2].a_type = AT_PAGESZ;
-    auxp[2].a_un.a_val = allocsize;
-    auxp[3].a_type = AT_ENTRY;
-    auxp[3].a_un.a_val = exec_map->l_entry;
-    auxp[4].a_type = AT_BASE;
-    auxp[4].a_un.a_val = interp_map ? interp_map->l_addr : 0;
-    auxp[5].a_type = AT_RANDOM;
-    auxp[5].a_un.a_val = random;
-    auxp[6].a_type = AT_NULL;
+    int i = 0;
+    auxp[i].a_type = AT_PHDR;
+    auxp[i].a_un.a_val = (__typeof(auxp[0].a_un.a_val)) exec_map->l_phdr;
+    i++;
+    auxp[i].a_type = AT_PHNUM;
+    auxp[i].a_un.a_val = exec_map->l_phnum;
+    i++;
+    auxp[i].a_type = AT_PAGESZ;
+    auxp[i].a_un.a_val = allocsize;
+    i++;
+    auxp[i].a_type = AT_ENTRY;
+    auxp[i].a_un.a_val = exec_map->l_entry;
+    i++;
+    auxp[i].a_type = AT_BASE;
+    auxp[i].a_un.a_val = interp_map ? interp_map->l_addr : 0;
+    i++;
+    auxp[i].a_type = AT_RANDOM;
+    auxp[i].a_un.a_val = random;
+    i++;
+    auxp[i].a_type = AT_NULL;
+    auxp[i].a_un.a_val = 0;
+    i++;
+    assert(i <= nauxv);
 
     ElfW(Addr) entry = interp_map ? interp_map->l_entry : exec_map->l_entry;
 

--- a/LibOS/shim/src/shim_init.c
+++ b/LibOS/shim/src/shim_init.c
@@ -715,7 +715,7 @@ noreturn void* shim_init (int argc, void * args)
 
     /* call to figure out where the arguments are */
     FIND_ARG_COMPONENTS(args, argc, argv, envp, auxp);
-    int nauxv = __process_auxv(auxp) - auxp;
+    int nauxv = (__process_auxv(auxp) - auxp) + 1; /* +1 for last AT_NULL */
 
 #ifdef PROFILE
     set_profile_enabled(envp);

--- a/LibOS/shim/src/sys/shim_exec.c
+++ b/LibOS/shim/src/sys/shim_exec.c
@@ -70,7 +70,7 @@ static int           new_argc;
 static int *         new_argcp;
 static elf_auxv_t *  new_auxp;
 
-#define REQUIRED_ELF_AUXV       6
+#define REQUIRED_ELF_AUXV       7
 
 int init_brk_from_executable (struct shim_handle * exec);
 

--- a/Pal/src/db_rtld.c
+++ b/Pal/src/db_rtld.c
@@ -1369,6 +1369,7 @@ void start_execution (const char * first_argument, const char ** arguments,
     auxv[5].a_type = AT_RANDOM;
     auxv[5].a_un.a_val = random;
     auxv[6].a_type = AT_NULL;
+    auxv[6].a_un.a_val = 0;
 
 #if PROFILING == 1
     __pal_control.startup_time = _DkSystemTimeQuery() - pal_state.start_time;


### PR DESCRIPTION
LibOS should allocate one more auxv entry for AT_NULL.
Allocate one more auxv entry and add assertion to check if
the allocate auxv is enough for future modification.

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [x] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->


## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/738)
<!-- Reviewable:end -->
