### PR TITLE
[LibOS] remove duplicaated unused migrated_shim_addr

### DIFF
--- a/LibOS/shim/src/elf/shim_rtld.c
+++ b/LibOS/shim/src/elf/shim_rtld.c
@@ -1469,9 +1469,6 @@ int remove_loaded_libraries (void)
     return 0;
 }
 
-void * __load_address;
-void * migrated_shim_addr __attribute_migratable = &__load_address;
-
 int init_internal_map (void)
 {
     __load_elf_object(NULL, &__load_address, OBJECT_INTERNAL, NULL);

--- a/LibOS/shim/src/shim_init.c
+++ b/LibOS/shim/src/shim_init.c
@@ -168,7 +168,6 @@ long int glibc_option (const char * opt)
 
 void * migrated_memory_start;
 void * migrated_memory_end;
-void * migrated_shim_addr;
 
 const char ** initial_envp __attribute_migratable;
 


### PR DESCRIPTION
remove duplicated unused migrated_shim_addr because it's unused.
remove definition of __load_address because it's defined by linker script.

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->


## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/739)
<!-- Reviewable:end -->
