### PR TITLE
[Pal, LibOS] Remove passing of ELF aux vectors from PAL to LibOS

### DIFF
--- a/LibOS/shim/include/shim_defs.h
+++ b/LibOS/shim/include/shim_defs.h
@@ -37,4 +37,8 @@
 #define MIGRATE_SYSV_SEM            0
 #define MIGRATE_SYSV_MSG            1
 
+/* ELF aux vectors  */
+#define REQUIRED_ELF_AUXV           7   /* number of LibOS-supported vectors */
+#define REQUIRED_ELF_AUXV_SPACE     16  /* extra memory space (in bytes) */
+
 #endif /* _SHIM_DEFS_H_ */

--- a/LibOS/shim/include/shim_thread.h
+++ b/LibOS/shim/include/shim_thread.h
@@ -349,6 +349,6 @@ bool check_on_stack (struct shim_thread * cur_thread, void * mem)
 
 int init_stack (const char ** argv, const char ** envp,
                 int ** argcpp, const char *** argpp,
-                int nauxv, elf_auxv_t ** auxpp);
+                elf_auxv_t ** auxpp);
 
 #endif /* _SHIM_THREAD_H_ */

--- a/LibOS/shim/include/shim_utils.h
+++ b/LibOS/shim/include/shim_utils.h
@@ -215,7 +215,7 @@ int load_elf_interp (struct shim_handle * exec);
 int free_elf_interp (void);
 void execute_elf_object (struct shim_handle * exec,
                          int * argcp, const char ** argp,
-                         int nauxv, elf_auxv_t * auxp);
+                         elf_auxv_t * auxp);
 int remove_loaded_libraries (void);
 
 /* gdb debugging support */

--- a/LibOS/shim/src/sys/shim_exec.c
+++ b/LibOS/shim/src/sys/shim_exec.c
@@ -70,8 +70,6 @@ static int           new_argc;
 static int *         new_argcp;
 static elf_auxv_t *  new_auxp;
 
-#define REQUIRED_ELF_AUXV       6
-
 int init_brk_from_executable (struct shim_handle * exec);
 
 int shim_do_execve_rtld (struct shim_handle * hdl, const char ** argv,
@@ -112,8 +110,7 @@ int shim_do_execve_rtld (struct shim_handle * hdl, const char ** argv,
     for (const char ** a = argv ; *a ; a++, new_argc++);
 
     new_argcp = &new_argc;
-    if ((ret = init_stack(argv, envp, &new_argcp, &new_argp,
-                          REQUIRED_ELF_AUXV, &new_auxp)) < 0)
+    if ((ret = init_stack(argv, envp, &new_argcp, &new_argp, &new_auxp)) < 0)
         return ret;
 
     SAVE_PROFILE_INTERVAL(alloc_new_stack_for_exec);
@@ -197,9 +194,7 @@ retry_dump_vmas:
 #endif
 
     debug("execve: start execution\n");
-    execute_elf_object(cur_thread->exec, new_argcp, new_argp,
-                       REQUIRED_ELF_AUXV, new_auxp);
-
+    execute_elf_object(cur_thread->exec, new_argcp, new_argp, new_auxp);
     return 0;
 }
 

--- a/Pal/src/db_rtld.c
+++ b/Pal/src/db_rtld.c
@@ -1331,7 +1331,7 @@ void start_execution (const char * first_argument, const char ** arguments,
     ncookies++; /* for NULL-end */
 
     int cookiesz = sizeof(unsigned long int) * ncookies
-                      + sizeof(ElfW(auxv_t)) * 6 + 16
+                      + sizeof(ElfW(auxv_t)) * 1  /* only AT_NULL */
                       + sizeof(void *) * 4 + 16;
 
     unsigned long int * cookies = __alloca(cookiesz);
@@ -1349,26 +1349,12 @@ void start_execution (const char * first_argument, const char ** arguments,
         cookies[cnt++] = (unsigned long int) environs[i];
     cookies[cnt++] = 0;
 
+    /* NOTE: LibOS implements its own ELF aux vectors. Any info from host's
+     * aux vectors must be passed in PAL_CONTROL. Here we pass an empty list
+     * of aux vectors for sanity. */
     ElfW(auxv_t) * auxv = (ElfW(auxv_t) *) &cookies[cnt];
-    /* random 16 bytes follows auxp */
-    ElfW(Addr) random = (ElfW(Addr))&auxv[7];
-    int ret = DkRandomBitsRead((PAL_PTR)random, 16);
-    if (ret < 0)
-        INIT_FAIL(-ret, "start_execution: DkRandomBitsRead failed\n");
-
-    auxv[0].a_type = AT_PHDR;
-    auxv[0].a_un.a_val = exec_map ? (unsigned long) exec_map->l_phdr  : 0;
-    auxv[1].a_type = AT_PHNUM;
-    auxv[1].a_un.a_val = exec_map ? exec_map->l_phnum : 0;
-    auxv[2].a_type = AT_PAGESZ;
-    auxv[2].a_un.a_val = __pal_control.pagesize;
-    auxv[3].a_type = AT_ENTRY;
-    auxv[3].a_un.a_val = exec_map ? exec_map->l_entry : 0;
-    auxv[4].a_type = AT_BASE;
-    auxv[4].a_un.a_val = exec_map ? exec_map->l_addr  : 0;
-    auxv[5].a_type = AT_RANDOM;
-    auxv[5].a_un.a_val = random;
-    auxv[6].a_type = AT_NULL;
+    auxv[0].a_type = AT_NULL;
+    auxv[0].a_un.a_val = 0;
 
 #if PROFILING == 1
     __pal_control.startup_time = _DkSystemTimeQuery() - pal_state.start_time;


### PR DESCRIPTION
## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [x] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->

Previously, PAL initialized a subset of ELF aux vectors on binary start
and passed them to LibOS. However, LibOS initializes ELF aux vectors on
its own, without consulting PAL's ones. This commit removes the ELF auxv
logic from PAL and simplifies logic in LibOS.

Closes #736 and #738.

## How to test this PR? <!-- (if applicable) -->

NA

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/740)
<!-- Reviewable:end -->
