### PR TITLE
Fix warnings in LibOS with -Wsign-compare

### DIFF
--- a/LibOS/shim/include/elf.h
+++ b/LibOS/shim/include/elf.h
@@ -757,7 +757,7 @@ typedef struct
    range.  Be compatible.  */
 #define DT_AUXILIARY    0x7ffffffd      /* Shared object to load before self */
 #define DT_FILTER       0x7fffffff      /* Shared object to get values from */
-#define DT_EXTRATAGIDX(tag)	((Elf32_Word)-((Elf32_Sword) (tag) <<1>>1)-1)
+#define DT_EXTRATAGIDX(tag)	(DT_FILTER - ((tag) & DT_FILTER))
 #define DT_EXTRANUM	3
 
 /* Values of `d_un.d_val' in the DT_FLAGS entry.  */

--- a/LibOS/shim/include/shim_checkpoint.h
+++ b/LibOS/shim/include/shim_checkpoint.h
@@ -170,7 +170,7 @@ enum {
     ({                                                              \
         ptr_t _off = store->offset;                                 \
         if (store->offset + (size) > store->bound) {                \
-            int new_bound = store->bound * 2;                       \
+            ptr_t new_bound = store->bound * 2;                     \
                                                                     \
             while (store->offset + (size) > new_bound)              \
                 new_bound *= 2;                                     \
@@ -441,7 +441,7 @@ struct newproc_response {
 int do_migration (struct newproc_cp_header * hdr, void ** cpptr);
 
 int restore_checkpoint (struct cp_header * cphdr, struct mem_header * memhdr,
-                        ptr_t base, int type);
+                        ptr_t base, ptr_t type);
 
 int do_migrate_process (int (*migrate) (struct shim_cp_store *,
                                         struct shim_thread *,

--- a/LibOS/shim/include/shim_handle.h
+++ b/LibOS/shim/include/shim_handle.h
@@ -84,12 +84,12 @@ struct shim_file_handle {
     struct shim_file_data * data;
 
     enum shim_file_type type;
-    uint64_t		size;
-    uint64_t 		marker;
+    off_t               size;
+    off_t               marker;
 
     enum { FILEBUF_MAP, FILEBUF_NONE } buf_type;
-    uint64_t 		mapsize;
-    uint64_t 		mapoffset;
+    size_t              mapsize;
+    off_t               mapoffset;
     void *              mapbuf;
 };
 
@@ -105,16 +105,16 @@ struct shim_dev_ops {
     int (*close) (struct shim_handle * hdl);
 
     /* read: the content from the file opened as handle */
-    int (*read) (struct shim_handle * hdl, void * buf, size_t count);
+    ssize_t (*read) (struct shim_handle * hdl, void * buf, size_t count);
 
     /* write: the content from the file opened as handle */
-    int (*write) (struct shim_handle * hdl, const void * buf, size_t count);
+    ssize_t (*write) (struct shim_handle * hdl, const void * buf, size_t count);
 
     /* flush: flush out user buffer */
     int (*flush) (struct shim_handle * hdl);
 
     /* seek: the content from the file opened as handle */
-    int (*seek) (struct shim_handle * hdl, off_t offset, int wence);
+    off_t (*seek) (struct shim_handle * hdl, off_t offset, int wence);
 
     int (*truncate) (struct shim_handle * hdl, uint64_t len);
 
@@ -290,7 +290,7 @@ struct shim_futex_handle {
 struct shim_str_data {
     REFTYPE ref_count;
     char * str;
-    size_t len;
+    off_t len;
     size_t buf_size;
     bool dirty;
     int (*update) (struct shim_handle * hdl);
@@ -425,7 +425,7 @@ int walk_handle_map (int (*callback) (struct shim_fd_handle *,
 int init_handle (void);
 int init_important_handles (void);
 
-ssize_t get_file_size (struct shim_handle * file);
+off_t get_file_size (struct shim_handle * file);
 
 int do_handle_read (struct shim_handle * hdl, void * buf, int count);
 int do_handle_write (struct shim_handle * hdl, const void * buf, int count);

--- a/LibOS/shim/include/shim_internal.h
+++ b/LibOS/shim/include/shim_internal.h
@@ -257,7 +257,7 @@ static inline uint64_t get_cur_preempt (void) {
     r shim_##name (PROTO_ARGS_##n (args)) {                         \
         SHIM_ARG_TYPE ret =  __shim_##name (CAST_ARGS_##n (args));  \
         if (POINTER_TYPE(r)) {                                      \
-            if ((unsigned long) ret >= -4095L) return (r) 0;        \
+            if ((uint64_t) ret >= (uint64_t) -4095L) return (r) 0;  \
         } else {                                                    \
             if ((int) ret < 0) return (r) -1;                       \
         }                                                           \

--- a/LibOS/shim/include/shim_ipc.h
+++ b/LibOS/shim/include/shim_ipc.h
@@ -100,7 +100,7 @@ struct shim_ipc_port {
 
     bool                update, recent;
     struct {
-        unsigned int    type;
+        IDTYPE          type;
         IDTYPE          vmid;
     }                   info, private;
 };
@@ -373,7 +373,7 @@ int ipc_sysv_msgsnd_callback (IPC_CALLBACK_ARGS);
 struct shim_ipc_sysv_msgrcv {
     IDTYPE msgid;
     long msgtype;
-    int size;
+    size_t size;
     int flags;
 } __attribute__((packed));
 
@@ -413,22 +413,22 @@ struct shim_ipc_sysv_semctl {
     IDTYPE semid;
     int semnum;
     int cmd;
-    int valsize;
+    size_t valsize;
     unsigned char vals[];
 } __attribute__((packed));
 
 int ipc_sysv_semctl_send (IDTYPE semid, int semnum, int cmd, void * vals,
-                          int valsize);
+                          size_t valsize);
 int ipc_sysv_semctl_callback (IPC_CALLBACK_ARGS);
 
 /* SYSV_SEMRET */
 struct shim_ipc_sysv_semret {
-    int valsize;
+    size_t valsize;
     unsigned char vals[];
 } __attribute__((packed));
 
 int ipc_sysv_semret_send (struct shim_ipc_port * port, IDTYPE dest,
-                          void * vals, int valsize, unsigned long seq);
+                          void * vals, size_t valsize, unsigned long seq);
 int ipc_sysv_semret_callback (IPC_CALLBACK_ARGS);
 
 /* SYSV_SEMMOV */
@@ -503,18 +503,18 @@ enum {
 #define IPC_PORT_IFPOLL    (IPC_PORT_SERVER|IPC_PORT_LISTEN)
 
 /* general-purpose routines */
-void add_ipc_port_by_id (IDTYPE vmid, PAL_HANDLE hdl, int type,
+void add_ipc_port_by_id (IDTYPE vmid, PAL_HANDLE hdl, IDTYPE type,
                          port_fini fini,
                          struct shim_ipc_port ** portptr);
-void add_ipc_port (struct shim_ipc_port * port, IDTYPE vmid, int type,
+void add_ipc_port (struct shim_ipc_port * port, IDTYPE vmid, IDTYPE type,
                    port_fini fini);
-void del_ipc_port_by_id (IDTYPE vm_pid, int type);
-void del_ipc_port (struct shim_ipc_port * port, int type);
+void del_ipc_port_by_id (IDTYPE vm_pid, IDTYPE type);
+void del_ipc_port (struct shim_ipc_port * port, IDTYPE type);
 void del_ipc_port_fini (struct shim_ipc_port * port, unsigned int exitcode);
-struct shim_ipc_port * lookup_ipc_port (IDTYPE vmid, int type);
+struct shim_ipc_port * lookup_ipc_port (IDTYPE vmid, IDTYPE type);
 void get_ipc_port (struct shim_ipc_port * port);
 void put_ipc_port (struct shim_ipc_port * port);
-void del_all_ipc_ports (int type);
+void del_all_ipc_ports (IDTYPE type);
 
 struct shim_ipc_info * get_new_ipc_info (IDTYPE vmid, const char * uri,
                                          size_t len);

--- a/LibOS/shim/include/shim_sysv.h
+++ b/LibOS/shim/include/shim_sysv.h
@@ -147,10 +147,10 @@ void put_msg_handle (struct shim_msg_handle * msgq);
 int recover_msg_ownership (struct shim_msg_handle * msgq);
 
 int add_sysv_msg (struct shim_msg_handle * msgq,
-                  long type, int size, const void * data,
+                  long type, size_t size, const void * data,
                   struct sysv_client * src);
 int get_sysv_msg (struct shim_msg_handle * msgq,
-                  long type, int size, void * data, int flags,
+                  long type, size_t size, void * data, int flags,
                   struct sysv_client * src);
 
 int store_all_msg_persist (void);

--- a/LibOS/shim/include/shim_table.h
+++ b/LibOS/shim/include/shim_table.h
@@ -421,7 +421,7 @@ int shim_do_mkdir (const char * pathname, int mode);
 int shim_do_rmdir (const char * pathname);
 int shim_do_creat (const char * path, mode_t mode);
 int shim_do_unlink (const char * file);
-int shim_do_readlink (const char * file, char * buf, int bufsize);
+int shim_do_readlink (const char * file, char * buf, size_t bufsize);
 int shim_do_chmod (const char * filename, mode_t mode);
 int shim_do_fchmod (int fd, mode_t mode);
 int shim_do_chown (const char * filename, uid_t user, gid_t group);
@@ -495,9 +495,9 @@ int shim_do_accept4 (int sockfd, struct sockaddr * addr, socklen_t * addrlen,
 int shim_do_dup3 (int oldfd, int newfd, int flags);
 int shim_do_epoll_create1 (int flags);
 int shim_do_pipe2 (int * fildes, int flags);
-int shim_do_recvmmsg (int sockfd, struct mmsghdr * msg, int vlen, int flags,
-                      struct __kernel_timespec * timeout);
-int shim_do_sendmmsg (int sockfd, struct mmsghdr * msg, int vlen, int flags);
+ssize_t shim_do_recvmmsg (int sockfd, struct mmsghdr * msg, size_t vlen, int flags,
+                          struct __kernel_timespec * timeout);
+ssize_t shim_do_sendmmsg (int sockfd, struct mmsghdr * msg, size_t vlen, int flags);
 
 /* libos call implementation */
 long shim_do_sandbox_create (int flags, const char * fs_sb,
@@ -613,7 +613,7 @@ int shim_creat (const char * path, mode_t mode);
 int shim_link (const char * oldname, const char * newname);
 int shim_unlink (const char * file);
 int shim_symlink (const char * old, const char * new);
-int shim_readlink (const char * file, char * buf, int bufsize);
+int shim_readlink (const char * file, char * buf, size_t bufsize);
 int shim_chmod (const char * filename, mode_t mode);
 int shim_fchmod (int fd, mode_t mode);
 int shim_chown (const char * filename, uid_t user, gid_t group);
@@ -866,9 +866,9 @@ int shim_pwritev (unsigned long fd, const struct iovec * vec,
 int shim_rt_tgsigqueueinfo (pid_t tgid, pid_t pid, int sig, siginfo_t * uinfo);
 int shim_perf_event_open (struct perf_event_attr * attr_uptr, pid_t pid,
                           int cpu, int group_fd, int flags);
-int shim_recvmmsg (int sockfd, struct mmsghdr * msg, int vlen, int flags,
-                   struct __kernel_timespec * timeout);
-int shim_sendmmsg (int sockfd, struct mmsghdr * msg, int vlen, int flags);
+ssize_t shim_recvmmsg (int sockfd, struct mmsghdr * msg, size_t vlen, int flags,
+                       struct __kernel_timespec * timeout);
+ssize_t shim_sendmmsg (int sockfd, struct mmsghdr * msg, size_t vlen, int flags);
 
 /* libos call wrappers */
 long shim_sandbox_create (int flags, const char * fs_sb, struct net_sb * net_sb);

--- a/LibOS/shim/include/shim_vma.h
+++ b/LibOS/shim/include/shim_vma.h
@@ -43,10 +43,10 @@ struct shim_handle;
  */
 struct shim_vma_val {
     void *                  addr;
-    uint64_t                length;
+    size_t                  length;
     int                     prot;
     int                     flags;
-    uint64_t                offset;
+    off_t                   offset;
     struct shim_handle *    file;
     char                    comment[VMA_COMMENT_LEN];
 };
@@ -54,7 +54,7 @@ struct shim_vma_val {
 static inline
 void free_vma_val_array (struct shim_vma_val * vmas, size_t count)
 {
-    for (int i = 0 ; i < count ; i++) {
+    for (size_t i = 0 ; i < count ; i++) {
         /* need to release the file handle */
         if (vmas[i].file)
             put_handle(vmas[i].file);
@@ -112,23 +112,20 @@ static inline PAL_FLG PAL_PROT (int prot, int flags)
 int init_vma (void);
 
 /* Bookkeeping mmap() system call */
-int bkeep_mmap (void * addr, uint64_t length,
-                int prot, int flags,
-                struct shim_handle * file, uint64_t offset,
-                const char * comment);
+int bkeep_mmap (void * addr, size_t length, int prot, int flags,
+                struct shim_handle * file, off_t offset, const char * comment);
 
 /* Bookkeeping munmap() system call */
-int bkeep_munmap (void * addr, uint64_t length, int flags);
+int bkeep_munmap (void * addr, size_t length, int flags);
 
 /* Bookkeeping mprotect() system call */
-int bkeep_mprotect (void * addr, uint64_t length, int prot, int flags);
+int bkeep_mprotect (void * addr, size_t length, int prot, int flags);
 
 /* Looking up VMA that contains [addr, length) */
 int lookup_vma (void * addr, struct shim_vma_val * vma);
 
 /* Looking up VMA that overlaps with [addr, length) */
-int lookup_overlap_vma (void * addr, uint64_t length,
-                        struct shim_vma_val * vma);
+int lookup_overlap_vma (void * addr, size_t length, struct shim_vma_val * vma);
 
 /* True if [addr, addr+length) is found in one VMA (valid memory region) */
 bool is_in_one_vma (void * addr, size_t length);
@@ -139,23 +136,20 @@ bool is_in_one_vma (void * addr, size_t length);
  *
  * Note: the first argument is "top_addr" because the search is top-down.
  */
-void * bkeep_unmapped (void * top_addr, void * bottom_addr, uint64_t length,
-                       int prot, int flags, struct shim_handle * file,
-                       uint64_t offset, const char * comment);
+void * bkeep_unmapped (void * top_addr, void * bottom_addr, size_t length, int prot, int flags,
+                       struct shim_handle * file, off_t offset, const char * comment);
 
 static inline void *
-bkeep_unmapped_any (uint64_t length, int prot, int flags,
-                    struct shim_handle * file, uint64_t offset,
-                    const char * comment)
+bkeep_unmapped_any (size_t length, int prot, int flags, struct shim_handle * file,
+                    off_t offset, const char * comment)
 {
     return bkeep_unmapped(PAL_CB(user_address.end),
                           PAL_CB(user_address.start),
                           length, prot, flags, file, offset, comment);
 }
 
-void * bkeep_unmapped_heap (uint64_t length, int prot, int flags,
-                            struct shim_handle * file, uint64_t offset,
-                            const char * comment);
+void * bkeep_unmapped_heap (size_t length, int prot, int flags, struct shim_handle * file,
+                            off_t offset, const char * comment);
 
 /*
  * Dumping all *non-internal* VMAs into a user-allocated buffer ("max_count" is

--- a/LibOS/shim/src/Makefile
+++ b/LibOS/shim/src/Makefile
@@ -16,7 +16,7 @@ CFLAGS	= -Wall -fPIC -std=c11 -Winline -Wwrite-strings \
 	  -fno-stack-protector -fno-builtin -Wno-inline \
 	  -I../include -I../../../Pal/lib -I../../../Pal/include/pal
 
-EXTRAFLAGS = -Wextra -Wno-unused-parameter -Wno-sign-compare
+EXTRAFLAGS = -Wextra -Wno-unused-parameter
 
 CFLAGS += $(EXTRAFLAGS)
 

--- a/LibOS/shim/src/bookkeep/shim_handle.c
+++ b/LibOS/shim/src/bookkeep/shim_handle.c
@@ -69,7 +69,7 @@ static inline int init_tty_handle (struct shim_handle * hdl, bool write)
     hdl->dentry = dent;
     hdl->flags = O_RDWR|O_APPEND|0100000;
 
-    int size;
+    size_t size;
     char * path = dentry_get_path(dent, true, &size);
     if (path)
         qstrsetstr(&hdl->path, path, size);
@@ -99,7 +99,7 @@ static inline int init_exec_handle (struct shim_thread * thread)
                       &exec->dentry, fs);
         set_handle_fs(exec, fs);
         if (exec->dentry) {
-            int len;
+            size_t len;
             const char * path = dentry_get_path(exec->dentry, true, &len);
             qstrsetstr(&exec->path, path, len);
         }
@@ -558,7 +558,7 @@ void put_handle (struct shim_handle * hdl)
     }
 }
 
-ssize_t get_file_size (struct shim_handle * hdl)
+off_t get_file_size (struct shim_handle * hdl)
 {
     if (!hdl->fs || !hdl->fs->fs_ops)
         return -EINVAL;

--- a/LibOS/shim/src/bookkeep/shim_signal.c
+++ b/LibOS/shim/src/bookkeep/shim_signal.c
@@ -270,7 +270,7 @@ static void memfault_upcall (PAL_PTR event, PAL_NUM arg, PAL_CONTEXT * context)
         if (vma.file && vma.file->type == TYPE_FILE) {
             /* DEP 3/3/17: If the mapping exceeds end of a file (but is in the VMA)
              * then return a SIGBUS. */
-            uint64_t eof_in_vma = (uint64_t) vma.addr + vma.offset + vma.file->info.file.size;
+            uintptr_t eof_in_vma = (uintptr_t) vma.addr + vma.offset + vma.file->info.file.size;
             if (arg > eof_in_vma) {
                 signo = SIGBUS;
                 code = BUS_ADRERR;

--- a/LibOS/shim/src/bookkeep/shim_thread.c
+++ b/LibOS/shim/src/bookkeep/shim_thread.c
@@ -413,7 +413,7 @@ void add_thread (struct shim_thread * thread)
 
 void del_thread (struct shim_thread * thread)
 {
-    debug("del_thread(%p, %d, %ld)\n", thread, thread ? thread->tid : -1,
+    debug("del_thread(%p, %d, %ld)\n", thread, thread ? (int) thread->tid : -1,
           atomic_read(&thread->ref_count));
 
     if (is_internal(thread) || LIST_EMPTY(thread, list)) {

--- a/LibOS/shim/src/bookkeep/shim_vma.c
+++ b/LibOS/shim/src/bookkeep/shim_vma.c
@@ -47,7 +47,7 @@ struct shim_vma {
     void *                  end;
     int                     prot;
     int                     flags;
-    uint64_t                offset;
+    off_t                   offset;
     struct shim_handle *    file;
     char                    comment[VMA_COMMENT_LEN];
 };
@@ -60,9 +60,9 @@ static struct shim_vma * reserved_vmas[RESERVED_VMAS];
 static struct shim_vma early_vmas[RESERVED_VMAS];
 
 static void * __bkeep_unmapped (void * top_addr, void * bottom_addr,
-                                uint64_t length, int prot, int flags,
+                                size_t length, int prot, int flags,
                                 struct shim_handle * file,
-                                uint64_t offset, const char * comment);
+                                off_t offset, const char * comment);
 
 /*
  * Because the default system_malloc() must create VMA(s), we need
@@ -262,7 +262,7 @@ static void * current_heap_top;
 
 static int __bkeep_mmap (struct shim_vma * prev,
                          void * start, void * end, int prot, int flags,
-                         struct shim_handle * file, uint64_t offset,
+                         struct shim_handle * file, off_t offset,
                          const char * comment);
 
 static int __bkeep_munmap (struct shim_vma ** prev,
@@ -349,9 +349,9 @@ int init_vma (void)
      * This is a simplified version of the mmap_base() logic in the Linux
      * kernel: https://elixir.bootlin.com/linux/v4.8/ident/mmap_base
      */
-    uint64_t addr_rand_size =
+    size_t addr_rand_size =
         (PAL_CB(user_address.end) - PAL_CB(user_address.start)) * 5 / 6;
-    uint64_t rand;
+    size_t rand;
     ret = DkRandomBitsRead(&rand, sizeof(rand));
     if (ret < 0)
         return -convert_pal_errno(-ret);
@@ -443,7 +443,7 @@ __set_vma_comment (struct shim_vma * vma, const char * comment)
         return;
     }
 
-    uint64_t len = strlen(comment);
+    size_t len = strlen(comment);
 
     if (len > VMA_COMMENT_LEN - 1)
         len = VMA_COMMENT_LEN - 1;
@@ -465,7 +465,7 @@ __set_vma_comment (struct shim_vma * vma, const char * comment)
  */
 static int __bkeep_mmap (struct shim_vma * prev,
                          void * start, void * end, int prot, int flags,
-                         struct shim_handle * file, uint64_t offset,
+                         struct shim_handle * file, off_t offset,
                          const char * comment)
 {
     int ret = 0;
@@ -492,9 +492,8 @@ static int __bkeep_mmap (struct shim_vma * prev,
     return 0;
 }
 
-int bkeep_mmap (void * addr, uint64_t length, int prot, int flags,
-                struct shim_handle * file, uint64_t offset,
-                const char * comment)
+int bkeep_mmap (void * addr, size_t length, int prot, int flags,
+                struct shim_handle * file, off_t offset, const char * comment)
 {
     if (!addr || !length)
         return -EINVAL;
@@ -678,7 +677,7 @@ cont:
     return 0;
 }
 
-int bkeep_munmap (void * addr, uint64_t length, int flags)
+int bkeep_munmap (void * addr, size_t length, int flags)
 {
     if (!length)
         return -EINVAL;
@@ -789,7 +788,7 @@ cont:
     return 0;
 }
 
-int bkeep_mprotect (void * addr, uint64_t length, int prot, int flags)
+int bkeep_mprotect (void * addr, size_t length, int prot, int flags)
 {
     if (!addr || !length)
         return -EINVAL;
@@ -813,13 +812,13 @@ int bkeep_mprotect (void * addr, uint64_t length, int prot, int flags)
  * added to the VMA list.
  */
 static void * __bkeep_unmapped (void * top_addr, void * bottom_addr,
-                                uint64_t length, int prot, int flags,
+                                size_t length, int prot, int flags,
                                 struct shim_handle * file,
-                                uint64_t offset, const char * comment)
+                                off_t offset, const char * comment)
 {
     assert(top_addr > bottom_addr);
 
-    if (!length || length > top_addr - bottom_addr)
+    if (!length || length > (uintptr_t) top_addr - (uintptr_t) bottom_addr)
         return NULL;
 
     struct shim_vma * prev = NULL;
@@ -834,7 +833,7 @@ static void * __bkeep_unmapped (void * top_addr, void * bottom_addr,
         assert(start <= end);
 
         /* Check if there is enough space between prev and cur */
-        if (length <= end - start) {
+        if (length <= (uintptr_t) end - (uintptr_t) start) {
             /* create a new VMA at the top of the range */
             __bkeep_mmap(prev, end - length, end, prot, flags,
                          file, offset, comment);
@@ -856,9 +855,9 @@ static void * __bkeep_unmapped (void * top_addr, void * bottom_addr,
     return NULL;
 }
 
-void * bkeep_unmapped (void * top_addr, void * bottom_addr, uint64_t length,
+void * bkeep_unmapped (void * top_addr, void * bottom_addr, size_t length,
                        int prot, int flags, struct shim_handle * file,
-                       uint64_t offset, const char * comment)
+                       off_t offset, const char * comment)
 {
     lock(&vma_list_lock);
     void * addr = __bkeep_unmapped(top_addr, bottom_addr, length, prot, flags,
@@ -869,9 +868,9 @@ void * bkeep_unmapped (void * top_addr, void * bottom_addr, uint64_t length,
     return addr;
 }
 
-void * bkeep_unmapped_heap (uint64_t length, int prot, int flags,
+void * bkeep_unmapped_heap (size_t length, int prot, int flags,
                             struct shim_handle * file,
-                            uint64_t offset, const char * comment)
+                            off_t offset, const char * comment)
 {
     lock(&vma_list_lock);
 
@@ -968,8 +967,7 @@ int lookup_vma (void * addr, struct shim_vma_val * res)
     return 0;
 }
 
-int lookup_overlap_vma (void * addr, uint64_t length,
-                        struct shim_vma_val * res)
+int lookup_overlap_vma (void * addr, size_t length, struct shim_vma_val * res)
 {
     struct shim_vma * tmp, * vma = NULL;
 
@@ -1013,7 +1011,7 @@ int dump_all_vmas (struct shim_vma_val * vmas, size_t max_count)
 {
     struct shim_vma_val * val = vmas;
     struct shim_vma * vma;
-    int cnt = 0;
+    size_t cnt = 0;
     lock(&vma_list_lock);
 
     LISTP_FOR_EACH_ENTRY(vma, &vma_list, list) {
@@ -1024,7 +1022,7 @@ int dump_all_vmas (struct shim_vma_val * vmas, size_t max_count)
 
         if (cnt == max_count) {
             cnt = -EOVERFLOW;
-            for (int i = 0 ; i < max_count ; i++)
+            for (size_t i = 0 ; i < max_count ; i++)
                 if (vmas[i].file)
                     put_handle(vmas[i].file);
             break;
@@ -1070,8 +1068,8 @@ BEGIN_CP_FUNC(vma)
 #endif
             goto no_mem;
 
-        void *   send_addr = vma->addr;
-        uint64_t send_size = vma->length;
+        void * send_addr = vma->addr;
+        size_t send_size = vma->length;
         if (vma->file) {
             /*
              * Chia-Che 8/13/2017:
@@ -1088,9 +1086,9 @@ BEGIN_CP_FUNC(vma)
              * (3) Data in the last file-backed page is valid before or after
              *     forking. Has to be included in process migration.
              */
-            int64_t file_len = get_file_size(vma->file);
+            off_t file_len = get_file_size(vma->file);
             if (file_len >= 0 &&
-                vma->offset + vma->length > file_len) {
+                (off_t) (vma->offset + vma->length) > file_len) {
                 send_size = file_len > vma->offset ?
                             file_len - vma->offset : 0;
                 send_size = ALIGN_UP(send_size);

--- a/LibOS/shim/src/elf/do-rel.h
+++ b/LibOS/shim/src/elf/do-rel.h
@@ -55,7 +55,7 @@
    relocations; they should be set up to call _dl_runtime_resolve, rather
    than fully resolved now.  */
 static void __attribute__((unused))
-elf_dynamic_do_rel (struct link_map * l, ElfW(Addr) reladdr, int relsize)
+elf_dynamic_do_rel (struct link_map * l, ElfW(Addr) reladdr, size_t relsize)
 {
     if (!l->l_info[DT_SYMTAB])
         return;
@@ -65,7 +65,7 @@ elf_dynamic_do_rel (struct link_map * l, ElfW(Addr) reladdr, int relsize)
     ElfW(Rel) * end = (void *) (reladdr + relsize);
     ElfW(Word) nrelative = l->l_info[RELCOUNT_IDX] == NULL
                            ? 0 : l->l_info[RELCOUNT_IDX]->d_un.d_val;
-    int nrelsize = relsize / sizeof (ElfW(Rel));
+    size_t nrelsize = relsize / sizeof (ElfW(Rel));
 
     r = r + (nrelative < nrelsize ? nrelative : nrelsize);
     for (; r < end; ++r) {

--- a/LibOS/shim/src/elf/rel.h
+++ b/LibOS/shim/src/elf/rel.h
@@ -8,6 +8,12 @@
 # define DT_THISPROCNUM 0
 #endif
 
+#if __ELF_NATIVE_CLASS == 32
+typedef Elf32_Word  d_tag_utype, d_val_utype;
+#elif __ELF_NATIVE_CLASS == 64
+typedef Elf64_Xword d_tag_utype, d_val_utype;
+#endif
+
 #define IN_RANGE(l, addr)   \
         ((ElfW(Addr)) (addr) >= (l)->l_map_start && (ElfW(Addr)) (addr) < (l)->l_map_end)
 
@@ -24,11 +30,6 @@ static inline
 void __attribute__ ((unused, always_inline))
 elf_get_dynamic_info (struct link_map * l)
 {
-#if __ELF_NATIVE_CLASS == 32
-    typedef Elf32_Word d_tag_utype;
-#elif __ELF_NATIVE_CLASS == 64
-    typedef Elf64_Xword d_tag_utype;
-#endif
     ElfW(Dyn) * dyn = l->l_ld;
 
     if (dyn == NULL)
@@ -136,8 +137,8 @@ elf_get_dynamic_info (struct link_map * l)
    We will keep it for now */
 
 static void
-_elf_dynamic_do_reloc(struct link_map * l, int dt_reloc, int dt_reloc_sz,
-                      void (*do_reloc) (struct link_map *, ElfW(Addr), int))
+_elf_dynamic_do_reloc(struct link_map * l, d_val_utype dt_reloc, d_val_utype dt_reloc_sz,
+                      void (*do_reloc) (struct link_map *, ElfW(Addr), size_t))
 {
     struct { ElfW(Addr) start, size; } ranges[3];
 
@@ -157,8 +158,8 @@ _elf_dynamic_do_reloc(struct link_map * l, int dt_reloc, int dt_reloc_sz,
 /* Now this part is for our x86s machines */
 
 static void __attribute__((unused))
-_elf_dynamic_do_reloc(struct link_map * l, int dt_reloc, int dt_reloc_sz,
-                      void (*do_reloc) (struct link_map *, ElfW(Addr), int))
+_elf_dynamic_do_reloc(struct link_map * l, d_val_utype dt_reloc, d_val_utype dt_reloc_sz,
+                      void (*do_reloc) (struct link_map *, ElfW(Addr), size_t))
 {
     struct { ElfW(Addr) start, size; } ranges[2];
     ranges[0].size = ranges[1].size = 0;

--- a/LibOS/shim/src/fs/proc/info.c
+++ b/LibOS/shim/src/fs/proc/info.c
@@ -54,7 +54,7 @@ retry:
     if (!str)
         return -ENOMEM;
 
-    for (int i = 0 ; i < sizeof(meminfo) / sizeof(meminfo[0]) ; i++) {
+    for (size_t i = 0 ; i < sizeof(meminfo) / sizeof(meminfo[0]) ; i++) {
         int ret = snprintf(str + len, max - len, meminfo[i].fmt,
                            meminfo[i].val);
 
@@ -111,10 +111,10 @@ retry:
     if (!str)
         return -ENOMEM;
 
-    for (int n = 0 ; n < pal_control.cpu_info.cpu_num ; n++) {
+    for (size_t n = 0 ; n < pal_control.cpu_info.cpu_num ; n++) {
         cpuinfo[0].val = n;
         cpuinfo[6].val = n;
-        for (int i = 0 ; i < sizeof(cpuinfo) / sizeof(cpuinfo[0]) ; i++) {
+        for (size_t i = 0 ; i < sizeof(cpuinfo) / sizeof(cpuinfo[0]) ; i++) {
             int ret = snprintf(str + len, max - len, cpuinfo[i].fmt,
                                cpuinfo[i].val);
 

--- a/LibOS/shim/src/fs/shim_fs.c
+++ b/LibOS/shim/src/fs/shim_fs.c
@@ -525,7 +525,7 @@ int walk_mounts (int (*walk) (struct shim_mount * mount, void * arg),
 struct shim_mount * find_mount_from_uri (const char * uri)
 {
     struct shim_mount * mount, * found = NULL;
-    int longest_path = 0;
+    size_t longest_path = 0;
 
     lock(&mount_list_lock);
     LISTP_FOR_EACH_ENTRY(mount, &mount_list, list) {

--- a/LibOS/shim/src/fs/shim_namei.c
+++ b/LibOS/shim/src/fs/shim_namei.c
@@ -71,7 +71,7 @@ static inline int __lookup_flags (int flags)
  * Returns 0 on success, negative on failure.
  */
 /* Assume caller has acquired dcache_lock */
-int permission (struct shim_dentry * dent, int mask, bool force) {
+int permission (struct shim_dentry * dent, mode_t mask, bool force) {
 
     mode_t mode = 0;
 
@@ -494,7 +494,7 @@ int open_namei (struct shim_handle * hdl, struct shim_dentry * start,
                 struct shim_dentry ** dent)
 {
     int lookup_flags = __lookup_flags(flags);
-    int acc_mode = ACC_MODE(flags & O_ACCMODE);
+    mode_t acc_mode = ACC_MODE(flags & O_ACCMODE);
     int err = 0, newly_created = 0;
     struct shim_dentry *mydent = NULL;
 
@@ -586,7 +586,7 @@ int dentry_open (struct shim_handle * hdl, struct shim_dentry * dent,
                  int flags)
 {
     int ret = 0;
-    int size;
+    size_t size;
     char *path;
     struct shim_mount * fs = dent->fs;
 

--- a/LibOS/shim/src/fs/str/fs.c
+++ b/LibOS/shim/src/fs/str/fs.c
@@ -87,10 +87,9 @@ int str_close (struct shim_handle * hdl)
     return 0;
 }
 
-int str_read (struct shim_handle * hdl, void * buf,
-              size_t count)
+ssize_t str_read (struct shim_handle * hdl, void * buf, size_t count)
 {
-    int ret = 0;
+    ssize_t ret = 0;
 
     if (!(hdl->acc_mode && MAY_READ)) {
         ret = -EACCES;
@@ -113,8 +112,8 @@ int str_read (struct shim_handle * hdl, void * buf,
     if (!strhdl->ptr)
         strhdl->ptr = data->str;
 
-    int offset = strhdl->ptr - data->str;
-    int remain = data->len - offset;
+    off_t  offset = strhdl->ptr - data->str;
+    size_t remain = data->len - offset;
 
     if (count >= remain) {
         memcpy(buf, strhdl->ptr, remain);
@@ -133,8 +132,7 @@ out:
     return ret;
 }
 
-int str_write (struct shim_handle * hdl, const void * buf,
-               size_t count)
+ssize_t str_write (struct shim_handle * hdl, const void * buf, size_t count)
 {
     if (!(hdl->acc_mode && MAY_WRITE))
         return -EACCES;
@@ -183,8 +181,7 @@ int str_write (struct shim_handle * hdl, const void * buf,
     return count;
 }
 
-int str_seek (struct shim_handle * hdl, off_t offset,
-              int whence)
+off_t str_seek (struct shim_handle * hdl, off_t offset, int whence)
 {
     struct shim_str_handle * strhdl = &hdl->info.str;
 

--- a/LibOS/shim/src/ipc/shim_ipc_child.c
+++ b/LibOS/shim/src/ipc/shim_ipc_child.c
@@ -281,8 +281,8 @@ int ipc_cld_profile_send (void)
         return -ESRCH;
 
     unsigned long time = GET_PROFILE_INTERVAL();
-    int nsending = 0;
-    for (int i = 0 ; i < N_PROFILE ; i++)
+    size_t nsending = 0;
+    for (size_t i = 0 ; i < N_PROFILE ; i++)
         switch (PROFILES[i].type) {
             case OCCURENCE:
                 if (atomic_read(&PROFILES[i].val.occurence.count))
@@ -305,8 +305,8 @@ int ipc_cld_profile_send (void)
     struct shim_ipc_cld_profile * msgin =
                 (struct shim_ipc_cld_profile *) &msg->msg;
 
-    int nsent = 0;
-    for (int i = 0 ; i < N_PROFILE && nsent < nsending ; i++)
+    size_t nsent = 0;
+    for (size_t i = 0 ; i < N_PROFILE && nsent < nsending ; i++)
         switch (PROFILES[i].type) {
             case OCCURENCE: {
                 unsigned long count =

--- a/LibOS/shim/src/ipc/shim_ipc_helper.c
+++ b/LibOS/shim/src/ipc/shim_ipc_helper.c
@@ -76,7 +76,7 @@ static struct shim_ipc_port * broadcast_port;
 
 //#define DEBUG_REF
 
-static int init_ipc_port (struct shim_ipc_info * info, PAL_HANDLE hdl, int type)
+static int init_ipc_port (struct shim_ipc_info * info, PAL_HANDLE hdl, IDTYPE type)
 {
     if (!info)
         return 0;
@@ -233,7 +233,7 @@ static inline void restart_ipc_helper (bool need_create)
 }
 
 static bool __add_ipc_port (struct shim_ipc_port * port, IDTYPE vmid,
-                            int type, port_fini fini)
+                            IDTYPE type, port_fini fini)
 {
     bool need_restart = false;
     assert(vmid != cur_process.vmid);
@@ -289,7 +289,7 @@ static bool __add_ipc_port (struct shim_ipc_port * port, IDTYPE vmid,
     }
 }
 
-void add_ipc_port (struct shim_ipc_port * port, IDTYPE vmid, int type,
+void add_ipc_port (struct shim_ipc_port * port, IDTYPE vmid, IDTYPE type,
                    port_fini fini)
 {
     debug("adding port %p (handle %p) for process %u (type=%04x)\n",
@@ -325,7 +325,7 @@ static struct shim_ipc_port * __get_new_ipc_port (PAL_HANDLE hdl)
     return port;
 }
 
-void add_ipc_port_by_id (IDTYPE vmid, PAL_HANDLE hdl, int type,
+void add_ipc_port_by_id (IDTYPE vmid, PAL_HANDLE hdl, IDTYPE type,
                          port_fini fini, struct shim_ipc_port ** portptr)
 {
     debug("adding port (handle %p) for process %u (type %04x)\n",
@@ -374,7 +374,7 @@ out:
     unlock(&ipc_helper_lock);
 }
 
-static bool __del_ipc_port (struct shim_ipc_port * port, int type)
+static bool __del_ipc_port (struct shim_ipc_port * port, IDTYPE type)
 {
     debug("deleting port %p (handle %p) for process %u\n",
           port, port->pal_handle, port->info.vmid);
@@ -435,7 +435,7 @@ out:
     return need_restart;
 }
 
-void del_ipc_port (struct shim_ipc_port * port, int type)
+void del_ipc_port (struct shim_ipc_port * port, IDTYPE type)
 {
     lock(&ipc_helper_lock);
 
@@ -453,7 +453,7 @@ void del_ipc_port (struct shim_ipc_port * port, int type)
     unlock(&ipc_helper_lock);
 }
 
-void del_ipc_port_by_id (IDTYPE vmid, int type)
+void del_ipc_port_by_id (IDTYPE vmid, IDTYPE type)
 {
     LISTP_TYPE(shim_ipc_port) * head = &ipc_port_pool[PID_HASH(vmid)];
     struct shim_ipc_port * port, *n;
@@ -509,7 +509,7 @@ void del_ipc_port_fini (struct shim_ipc_port * port, unsigned int exitcode)
         (fini[i])(port, vmid, exitcode);
 }
 
-static struct shim_ipc_port * __lookup_ipc_port (IDTYPE vmid, int type)
+static struct shim_ipc_port * __lookup_ipc_port (IDTYPE vmid, IDTYPE type)
 {
     LISTP_TYPE(shim_ipc_port) * head = &ipc_port_pool[PID_HASH(vmid)];
     struct shim_ipc_port * tmp;
@@ -525,7 +525,7 @@ static struct shim_ipc_port * __lookup_ipc_port (IDTYPE vmid, int type)
     return NULL;
 }
 
-struct shim_ipc_port * lookup_ipc_port (IDTYPE vmid, int type)
+struct shim_ipc_port * lookup_ipc_port (IDTYPE vmid, IDTYPE type)
 {
     lock(&ipc_helper_lock);
     struct shim_ipc_port * port = __lookup_ipc_port(vmid, type);
@@ -559,7 +559,7 @@ void put_ipc_port (struct shim_ipc_port * port)
     }
 }
 
-void del_all_ipc_ports (int type)
+void del_all_ipc_ports (IDTYPE type)
 {
     struct shim_ipc_port * pobj, * n;
     bool need_restart = false;
@@ -895,8 +895,8 @@ update_status:
         if (pobj->private.type & IPC_PORT_SERVER) {
             PAL_HANDLE cli = DkStreamWaitForClient(polled);
             if (cli) {
-                int type = (pobj->private.type & ~IPC_PORT_SERVER) |
-                           IPC_PORT_LISTEN;
+                IDTYPE type = (pobj->private.type & ~IPC_PORT_SERVER) |
+                              IPC_PORT_LISTEN;
                 add_ipc_port_by_id(pobj->private.vmid, cli, type,
                                    NULL, NULL);
             } else {

--- a/LibOS/shim/src/ipc/shim_ipc_nsimpl.h
+++ b/LibOS/shim/src/ipc/shim_ipc_nsimpl.h
@@ -65,7 +65,7 @@ DEFINE_LIST(range);
 struct range {
     LIST_TYPE(range)    hlist;
     LIST_TYPE(range)    list;
-    int                 offset;
+    IDTYPE              offset;
     struct shim_ipc_info *  owner;
     LEASETYPE           lease;
     struct idx_bitmap * used;
@@ -73,7 +73,7 @@ struct range {
 };
 
 struct range_bitmap {
-    int                 map_size;
+    IDTYPE              map_size;
     unsigned char       map[];
 };
 
@@ -123,17 +123,17 @@ void CONCAT3(debug_print, NS, ranges) (void)
         return;
     }
 
-    for (int i = 0 ; i < range_map->map_size ; i++) {
+    for (IDTYPE i = 0 ; i < range_map->map_size ; i++) {
         unsigned char map = range_map->map[i];
 
         if (!map)
             continue;
 
-        for (int j = 0 ; j < BITS ; map >>= 1, j++) {
+        for (IDTYPE j = 0 ; j < BITS ; map >>= 1, j++) {
             if (!(map & 1))
                 continue;
 
-            int off = i * BITS + j;
+            IDTYPE off = i * BITS + j;
             LISTP_TYPE(range) * head = range_table + RANGE_HASH(off);
             struct range * tmp, * r = NULL;
 
@@ -154,7 +154,7 @@ void CONCAT3(debug_print, NS, ranges) (void)
             if (!r->subranges)
                 continue;
 
-            for (int k = 0 ; k < RANGE_SIZE ; k++) {
+            for (IDTYPE k = 0 ; k < RANGE_SIZE ; k++) {
                 struct subrange * s = r->subranges->map[j];
                 if (!s)
                     continue;
@@ -172,9 +172,9 @@ void CONCAT3(debug_print, NS, ranges) (void)
 
 #define INIT_RANGE_MAP_SIZE     32
 
-static int __extend_range_bitmap (int expected)
+static int __extend_range_bitmap (IDTYPE expected)
 {
-    int size = INIT_RANGE_MAP_SIZE;
+    IDTYPE size = INIT_RANGE_MAP_SIZE;
 
     if (range_map)
         size = range_map->map_size;
@@ -201,11 +201,11 @@ static int __extend_range_bitmap (int expected)
     return 0;
 }
 
-static int __set_range_bitmap (int off, bool unset)
+static int __set_range_bitmap (IDTYPE off, bool unset)
 {
-    int i = off / BITS;
-    int j = off - i * BITS;
-    unsigned char * m = range_map->map + i;
+    IDTYPE i = off / BITS;
+    IDTYPE j = off - i * BITS;
+    unsigned char* m = range_map->map + i;
     unsigned char f = 1U << j;
     if (unset) {
         if (!((*m) & f))
@@ -219,16 +219,16 @@ static int __set_range_bitmap (int off, bool unset)
     return 0;
 }
 
-static bool __check_range_bitmap (int off)
+static bool __check_range_bitmap (IDTYPE off)
 {
-    int i = off / BITS;
-    int j = off - i * BITS;
-    unsigned char * m = range_map->map + i;
+    IDTYPE i = off / BITS;
+    IDTYPE j = off - i * BITS;
+    unsigned char* m = range_map->map + i;
     unsigned char f = 1U << j;
     return (*m) && ((*m) & f);
 }
 
-static struct range * __get_range (int off)
+static struct range * __get_range (IDTYPE off)
 {
     LISTP_TYPE(range) * head = range_table + RANGE_HASH(off);
 
@@ -247,7 +247,7 @@ static struct range * __get_range (int off)
     return NULL;
 }
 
-static int __add_range (struct range * r, int off, IDTYPE owner,
+static int __add_range (struct range * r, IDTYPE off, IDTYPE owner,
                         const char * uri, LEASETYPE lease)
 {
     LISTP_TYPE(range) * head = range_table + RANGE_HASH(off);
@@ -329,7 +329,7 @@ static int __add_range (struct range * r, int off, IDTYPE owner,
 int CONCAT3(add, NS, range) (IDTYPE base, IDTYPE owner,
                              const char * uri, LEASETYPE lease)
 {
-    int off = (base - 1) / RANGE_SIZE;
+    IDTYPE off = (base - 1) / RANGE_SIZE;
     int ret;
 
     struct range * r = malloc(sizeof(struct range));
@@ -357,8 +357,9 @@ static void CONCAT3(__del, NS, subrange) (struct subrange ** ptr)
 int CONCAT3(add, NS, subrange) (IDTYPE idx, IDTYPE owner,
                                 const char * uri, LEASETYPE * lease)
 {
-    int off = (idx - 1) / RANGE_SIZE, err = 0;
+    IDTYPE off = (idx - 1) / RANGE_SIZE;
     IDTYPE base = off * RANGE_SIZE + 1;
+    int err = 0;
     struct subrange * s = malloc(sizeof(struct subrange));
     if (!s)
         return -ENOMEM;
@@ -429,7 +430,7 @@ int CONCAT3(alloc, NS, range) (IDTYPE owner, const char * uri,
     int ret = 0;
     lock(&range_map_lock);
     r->owner = NULL;
-    int i = 0, j = 0;
+    IDTYPE i = 0, j = 0;
 
     if (range_map)
         for (i = 0 ; i < range_map->map_size ; i++) {
@@ -467,7 +468,7 @@ int CONCAT3(get, NS, range) (IDTYPE idx,
                              struct CONCAT2(NS, range) * range,
                              struct shim_ipc_info ** info)
 {
-    int off = (idx - 1) / RANGE_SIZE;
+    IDTYPE off = (idx - 1) / RANGE_SIZE;
 
     lock(&range_map_lock);
 
@@ -516,7 +517,7 @@ int CONCAT3(get, NS, range) (IDTYPE idx,
 
 int CONCAT3(del, NS, range) (IDTYPE idx)
 {
-    int off = (idx - 1) / RANGE_SIZE;
+    IDTYPE off = (idx - 1) / RANGE_SIZE;
     int ret = -ESRCH;
 
     lock(&range_map_lock);
@@ -526,7 +527,7 @@ int CONCAT3(del, NS, range) (IDTYPE idx)
         goto failed;
 
     if (r->subranges) {
-        for (int i = 0 ; i < RANGE_SIZE ; i++)
+        for (IDTYPE i = 0 ; i < RANGE_SIZE ; i++)
             if (r->subranges->map[i]) {
                 ret = -EBUSY;
                 goto failed;
@@ -568,7 +569,7 @@ failed:
 
 int CONCAT3(del, NS, subrange) (IDTYPE idx)
 {
-    int off = (idx - 1) / RANGE_SIZE;
+    IDTYPE off = (idx - 1) / RANGE_SIZE;
     IDTYPE base = off * RANGE_SIZE + 1;
     int ret = -ESRCH;
 
@@ -590,7 +591,7 @@ failed:
 
 int CONCAT3(renew, NS, range) (IDTYPE idx, LEASETYPE * lease)
 {
-    int off = (idx - 1) / RANGE_SIZE;
+    IDTYPE off = (idx - 1) / RANGE_SIZE;
 
     lock(&range_map_lock);
 
@@ -609,7 +610,7 @@ int CONCAT3(renew, NS, range) (IDTYPE idx, LEASETYPE * lease)
 
 int CONCAT3(renew, NS, subrange) (IDTYPE idx, LEASETYPE * lease)
 {
-    int off = (idx - 1) / RANGE_SIZE;
+    IDTYPE off = (idx - 1) / RANGE_SIZE;
     IDTYPE base = off * RANGE_SIZE + 1;
 
     lock(&range_map_lock);
@@ -654,8 +655,8 @@ IDTYPE CONCAT2(allocate, NS) (IDTYPE min, IDTYPE max)
                 continue;
         }
 
-        int i = (idx - base) / BITS;
-        int j = (idx - base) - i * BITS;
+        IDTYPE i = (idx - base) / BITS;
+        IDTYPE j = (idx - base) - i * BITS;
         unsigned char * m = r->used->map + i;
         unsigned char f = 1U << j;
 
@@ -682,7 +683,7 @@ out:
 
 void CONCAT2(release, NS) (IDTYPE idx)
 {
-    int off = (idx - 1) / RANGE_SIZE;
+    IDTYPE off = (idx - 1) / RANGE_SIZE;
     IDTYPE base = off * RANGE_SIZE + 1;
 
     lock(&range_map_lock);
@@ -700,8 +701,8 @@ void CONCAT2(release, NS) (IDTYPE idx)
     if (idx < base || idx >= base + RANGE_SIZE)
         goto out;
 
-    int i = (idx - base) / BITS;
-    int j = (idx - base) - i * BITS;
+    IDTYPE i = (idx - base) / BITS;
+    IDTYPE j = (idx - base) - i * BITS;
     unsigned char * m = r->used->map + i;
     unsigned char f = 1U << j;
     if ((*m) & f) {
@@ -936,7 +937,7 @@ static int connect_owner (IDTYPE idx, struct shim_ipc_port ** portptr,
     if (range.port)
         goto success;
 
-    int type = IPC_PORT_OWN|IPC_PORT_LISTEN;
+    IDTYPE type = IPC_PORT_OWN|IPC_PORT_LISTEN;
 
     if (!range.port) {
         PAL_HANDLE pal_handle = DkStreamOpen(qstrgetstr(&range.uri),

--- a/LibOS/shim/src/ipc/shim_ipc_pid.c
+++ b/LibOS/shim/src/ipc/shim_ipc_pid.c
@@ -330,18 +330,20 @@ retry:
     LISTP_FOR_EACH_ENTRY(r, list, list) {
         struct subrange * s = NULL;
         struct shim_ipc_info * p;
-        int off, idx;
+        IDTYPE off, idx;
         IDTYPE base;
         IDTYPE pids[RANGE_SIZE];
         struct pid_status * range_status;
 
+#define UNDEF_IDX   ((IDTYPE) -1)
+
 next_range:
-        idx = -1;
+        idx = UNDEF_IDX;
         off = r->offset;
         base = off * RANGE_SIZE + 1;
 
 next_sub:
-        if (idx == -1) {
+        if (idx == UNDEF_IDX) {
             p = r->owner;
         } else {
             if (idx >= RANGE_SIZE)
@@ -362,7 +364,7 @@ next_sub:
         }
 
         if (!p->port) {
-            int type = IPC_PORT_PIDOWN|IPC_PORT_LISTEN;
+            IDTYPE type = IPC_PORT_PIDOWN|IPC_PORT_LISTEN;
             IDTYPE owner = p->vmid;
             char * uri = qstrtostr(&p->uri, true);
             struct shim_ipc_port * port = NULL;
@@ -386,7 +388,7 @@ next_sub:
             if (!port)
                 continue;
 
-            if (idx == -1) {
+            if (idx == UNDEF_IDX) {
             } else {
                 if (!r->subranges)
                     continue;
@@ -404,7 +406,7 @@ next_sub:
             p->port = port;
         }
 
-        if (idx == -1) {
+        if (idx == UNDEF_IDX) {
             for (int i = 0 ; i < RANGE_SIZE ; i++)
                 pids[i] = base + i;
         } else {
@@ -412,7 +414,7 @@ next_sub:
         }
 
         ret = ipc_pid_getstatus_send(p->port, p->vmid,
-                                     idx == -1 ? RANGE_SIZE : 1, pids,
+                                     idx == UNDEF_IDX ? RANGE_SIZE : 1, pids,
                                      &range_status);
 
         if (ret > 0) {
@@ -512,7 +514,7 @@ int ipc_pid_getmeta_callback (IPC_CALLBACK_ARGS)
 
     struct shim_thread * thread = lookup_thread(msgin->pid);
     void * data = NULL;
-    int datasize = 0;
+    size_t datasize = 0;
 
     if (!thread) {
         ret = -ESRCH;

--- a/LibOS/shim/src/ipc/shim_ipc_sysv.c
+++ b/LibOS/shim/src/ipc/shim_ipc_sysv.c
@@ -565,7 +565,7 @@ DEFINE_PROFILE_INTERVAL(ipc_sysv_semctl_send, ipc);
 DEFINE_PROFILE_INTERVAL(ipc_sysv_semctl_callback, ipc);
 
 int ipc_sysv_semctl_send (IDTYPE semid, int semnum, int cmd, void * vals,
-                          int valsize)
+                          size_t valsize)
 {
     BEGIN_PROFILE_INTERVAL();
     IDTYPE owner;
@@ -619,7 +619,7 @@ int ipc_sysv_semctl_callback (IPC_CALLBACK_ARGS)
     }
 
     void * vals = NULL;
-    int valsize;
+    size_t valsize;
     switch(msgin->cmd) {
         case GETALL: {
             unsigned short * allsems = __alloca(sizeof(unsigned short) *
@@ -698,7 +698,7 @@ DEFINE_PROFILE_INTERVAL(ipc_sysv_semret_send, ipc);
 DEFINE_PROFILE_INTERVAL(ipc_sysv_semret_callback, ipc);
 
 int ipc_sysv_semret_send (struct shim_ipc_port * port, IDTYPE dest, void * vals,
-                          int valsize, unsigned long seq)
+                          size_t valsize, unsigned long seq)
 {
     BEGIN_PROFILE_INTERVAL();
     int ret = 0;
@@ -742,7 +742,7 @@ int ipc_sysv_semret_callback (IPC_CALLBACK_ARGS)
                 case GETPID:
                 case GETVAL:
                 case GETZCNT: {
-                    int retvalsize = semret->valsize;
+                    size_t retvalsize = semret->valsize;
                     if (retvalsize > semctl->valsize)
                         retvalsize = semctl->valsize;
                     memcpy(vals, semret->vals, retvalsize);

--- a/LibOS/shim/src/shim_checkpoint.c
+++ b/LibOS/shim/src/shim_checkpoint.c
@@ -561,7 +561,7 @@ static int restore_gipc (PAL_HANDLE gipc, struct gipc_header * hdr, ptr_t base,
 }
 
 int restore_checkpoint (struct cp_header * cphdr, struct mem_header * memhdr,
-                        ptr_t base, int type)
+                        ptr_t base, ptr_t type)
 {
     ptr_t cpoffset = cphdr->offset;
     ptr_t * offset = &cpoffset;
@@ -896,7 +896,7 @@ int do_migrate_process (int (*migrate) (struct shim_cp_store *,
     int ret = 0;
     struct shim_process * new_process = NULL;
     struct newproc_header hdr;
-    int bytes;
+    size_t bytes;
     memset(&hdr, 0, sizeof(hdr));
 
 #ifdef PROFILE
@@ -1213,7 +1213,7 @@ int do_migration (struct newproc_cp_header * hdr, void ** cpptr)
         SAVE_PROFILE_INTERVAL(child_load_memory_by_gipc);
         DkStreamDelete(gipc_store, 0);
     } else {
-        int total_bytes = 0;
+        size_t total_bytes = 0;
         while (total_bytes < size) {
             int bytes = DkStreamRead(PAL_CB(parent_process), 0,
                                      size - total_bytes,
@@ -1230,7 +1230,7 @@ int do_migration (struct newproc_cp_header * hdr, void ** cpptr)
         }
 
         SAVE_PROFILE_INTERVAL(child_load_checkpoint_on_pipe);
-        debug("%d bytes read on stream\n", total_bytes);
+        debug("%lu bytes read on stream\n", total_bytes);
     }
 
     /* Receive socket or RPC handles from the parent process. */

--- a/LibOS/shim/src/shim_init.c
+++ b/LibOS/shim/src/shim_init.c
@@ -544,7 +544,7 @@ static void set_profile_enabled (const char ** envp)
     if (!(*p))
         return;
 
-    for (int i = 0 ; i < N_PROFILE ; i++)
+    for (size_t i = 0 ; i < N_PROFILE ; i++)
          PROFILES[i].disabled = true;
 
     const char * str = (*p) + 16;
@@ -553,8 +553,8 @@ static void set_profile_enabled (const char ** envp)
         const char * next = str;
         for ( ; (*next) && (*next) != ',' ; next++);
         if (next > str) {
-            int len = next - str;
-            for (int i = 0 ; i < N_PROFILE ; i++) {
+            size_t len = next - str;
+            for (size_t i = 0 ; i < N_PROFILE ; i++) {
                 struct shim_profile * profile = &PROFILES[i];
                 if (!memcmp(profile->name, str, len) && !profile->name[len]) {
                     profile->disabled = false;
@@ -568,7 +568,7 @@ static void set_profile_enabled (const char ** envp)
 
     while (enabled) {
         enabled = false;
-        for (int i = 0 ; i < N_PROFILE ; i++) {
+        for (size_t i = 0 ; i < N_PROFILE ; i++) {
             struct shim_profile * profile = &PROFILES[i];
             if (!profile->disabled || profile->root == &profile_)
                 continue;
@@ -580,7 +580,7 @@ static void set_profile_enabled (const char ** envp)
         }
     }
 
-    for (int i = 0 ; i < N_PROFILE ; i++) {
+    for (size_t i = 0 ; i < N_PROFILE ; i++) {
         struct shim_profile * profile = &PROFILES[i];
         if (profile->type == CATEGORY || profile->disabled)
             continue;
@@ -835,7 +835,7 @@ static int create_unique (int (*mkname) (char *, size_t, void *),
 static int name_pipe (char * uri, size_t size, void * id)
 {
     IDTYPE pipeid;
-    int len;
+    size_t len;
     int ret = DkRandomBitsRead(&pipeid, sizeof(pipeid));
     if (ret < 0)
         return -convert_pal_errno(-ret);
@@ -863,7 +863,7 @@ static int pipe_addr (char * uri, size_t size, const void * id,
                       struct shim_qstr * qstr)
 {
     IDTYPE pipeid = *((IDTYPE *) id);
-    int len;
+    size_t len;
     if ((len = snprintf(uri, size, "pipe:%u", pipeid)) == size)
         return -ERANGE;
     if (qstr)
@@ -886,7 +886,7 @@ static int name_path (char * path, size_t size, void * id)
 {
     unsigned int suffix;
     int prefix_len = strlen(path);
-    int len;
+    size_t len;
     int ret = DkRandomBitsRead(&suffix, sizeof(suffix));
     if (ret < 0)
         return -convert_pal_errno(-ret);
@@ -972,7 +972,7 @@ static int open_pal_handle (const char * uri, void * obj)
 static int output_path (char * path, size_t size, const void * id,
                         struct shim_qstr * qstr)
 {
-    int len = strlen(path);
+    size_t len = strlen(path);
     if (qstr)
         qstrsetstr(qstr, path, len);
     return len;
@@ -984,7 +984,7 @@ int create_dir (const char * prefix, char * path, size_t size,
     unsigned int suffix;
 
     if (prefix) {
-        int len = strlen(prefix);
+        size_t len = strlen(prefix);
         if (len >= size)
             return -ERANGE;
         memcpy(path, prefix, len + 1);
@@ -1000,7 +1000,7 @@ int create_file (const char * prefix, char * path, size_t size,
     unsigned int suffix;
 
     if (prefix) {
-        int len = strlen(prefix);
+        size_t len = strlen(prefix);
         if (len >= size)
             return -ERANGE;
         memcpy(path, prefix, len + 1);
@@ -1016,7 +1016,7 @@ int create_handle (const char * prefix, char * uri, size_t size,
     unsigned int suffix;
 
     if (prefix) {
-        int len = strlen(prefix);
+        size_t len = strlen(prefix);
         if (len >= size)
             return -ERANGE;
         memcpy(uri, prefix, len + 1);
@@ -1034,7 +1034,7 @@ void check_stack_hook (void)
     __asm__ volatile ("movq %%rsp, %0" : "=r"(rsp) :: "memory");
 
     if (rsp <= cur_thread->stack_top && rsp > cur_thread->stack) {
-        if (rsp - cur_thread->stack < PAL_CB(pagesize))
+        if ((uintptr_t) rsp - (uintptr_t) cur_thread->stack < PAL_CB(pagesize))
             SYS_PRINTF("*** stack is almost drained (RSP = %p, stack = %p-%p) ***\n",
                        rsp, cur_thread->stack, cur_thread->stack_top);
     } else {
@@ -1049,7 +1049,7 @@ static void print_profile_result (PAL_HANDLE hdl, struct shim_profile * root,
 {
     unsigned long total_interval_time = 0;
     unsigned long total_interval_count = 0;
-    for (int i = 0 ; i < N_PROFILE ; i++) {
+    for (size_t i = 0 ; i < N_PROFILE ; i++) {
         struct shim_profile * profile = &PROFILES[i];
         if (profile->root != root || profile->disabled)
             continue;
@@ -1089,7 +1089,7 @@ static void print_profile_result (PAL_HANDLE hdl, struct shim_profile * root,
         }
     }
     if (total_interval_count) {
-        __SYS_FPRINTF(hdl, "                - (%11.11u) total: %u times, %lu msec\n",
+        __SYS_FPRINTF(hdl, "                - (%11.11lu) total: %lu times, %lu msec\n",
                       total_interval_time, total_interval_count,
                       total_interval_time / total_interval_count);
     }

--- a/LibOS/shim/src/shim_malloc.c
+++ b/LibOS/shim/src/shim_malloc.c
@@ -138,10 +138,9 @@ void * malloc (size_t size)
 #endif
 {
 #ifdef PROFILE
-    int i;
     int level = -1;
 
-    for (i = 0 ; i < SLAB_LEVEL ; i++)
+    for (size_t i = 0 ; i < SLAB_LEVEL ; i++)
         if (size < slab_levels[i]) {
             level = i;
             break;

--- a/LibOS/shim/src/shim_parser.c
+++ b/LibOS/shim/src/shim_parser.c
@@ -562,7 +562,7 @@ void parse_syscall_after (int sysno, const char * name, int nr, ...)
         }
 
     if (is_pointer(ret_type)) {
-        if (ret_ptr < -4095L)
+        if ((uint64_t) ret_ptr < (uint64_t) -4095L)
             PRINTF(") = 0x%08lx\n", ret_ptr);
         else
             PRINTF(") = %ld\n", (long) ret_ptr);
@@ -648,7 +648,7 @@ static void parse_clone_flags (const char * type, va_list * ap)
 #undef FLG
 
     bool printed = false;
-    for (int i = 0 ; i < sizeof(all_flags) / sizeof(all_flags[0]) ; i++)
+    for (size_t i = 0 ; i < sizeof(all_flags) / sizeof(all_flags[0]) ; i++)
         if (flags & all_flags[i].flag) {
             if (printed)
                 PUTCH('|');
@@ -861,7 +861,7 @@ static void parse_sigmask (const char * type, va_list * ap)
 
     PUTS("[");
 
-    for (int signum = 1 ; signum <= sizeof(sigset) * 8 ; signum++)
+    for (size_t signum = 1 ; signum <= sizeof(sigset) * 8 ; signum++)
         if (__sigismember(sigset, signum)) {
             PUTS(signal_name(signum));
             PUTS(",");

--- a/LibOS/shim/src/shim_syscalls.c
+++ b/LibOS/shim/src/shim_syscalls.c
@@ -451,7 +451,7 @@ SHIM_SYSCALL_PASSTHROUGH (symlink, 2, int, const char *, old, const char *, new)
 
 /* readlink: sys/shim_stat.c */
 DEFINE_SHIM_SYSCALL (readlink, 3, shim_do_readlink, int, const char *, path,
-                     char *, buf, int, bufsize)
+                     char *, buf, size_t, bufsize)
 
 DEFINE_SHIM_SYSCALL (chmod, 2, shim_do_chmod, int, const char *, filename,
                      mode_t, mode)
@@ -1127,8 +1127,8 @@ SHIM_SYSCALL_PASSTHROUGH (perf_event_open, 5, int, struct perf_event_attr *,
                           attr_uptr, pid_t, pid, int, cpu, int, group_fd,
                           int, flags)
 
-DEFINE_SHIM_SYSCALL (recvmmsg, 5, shim_do_recvmmsg, int, int, fd,
-                     struct mmsghdr *, msg, int, vlen, int, flags,
+DEFINE_SHIM_SYSCALL (recvmmsg, 5, shim_do_recvmmsg, ssize_t, int, fd,
+                     struct mmsghdr *, msg, size_t, vlen, int, flags,
                      struct __kernel_timespec *, timeout)
 
 SHIM_SYSCALL_PASSTHROUGH (fanotify_init, 2, int, int, flags, int, event_f_flags)
@@ -1153,8 +1153,8 @@ SHIM_SYSCALL_PASSTHROUGH (clock_adjtime, 2, int, clockid_t, which_clock,
 
 SHIM_SYSCALL_PASSTHROUGH (syncfs, 1, int, int, fd)
 
-DEFINE_SHIM_SYSCALL (sendmmsg, 4, shim_do_sendmmsg, int, int, fd,
-                     struct mmsghdr *, msg, int, vlen, int, flags)
+DEFINE_SHIM_SYSCALL (sendmmsg, 4, shim_do_sendmmsg, ssize_t, int, fd,
+                     struct mmsghdr *, msg, size_t, vlen, int, flags)
 
 SHIM_SYSCALL_PASSTHROUGH (setns, 2, int, int, fd, int, nstype)
 

--- a/LibOS/shim/src/sys/shim_brk.c
+++ b/LibOS/shim/src/sys/shim_brk.c
@@ -95,7 +95,8 @@ int init_brk_region (void * brk_region)
                 int ret = DkRandomBitsRead(&rand, sizeof(rand));
                 if (ret < 0)
                     return -convert_pal_errno(-ret);
-                rand %= MIN(0x2000000, PAL_CB(user_address.end) - brk_region - brk_max_size);
+                rand %= MIN((uint32_t) 0x2000000,
+                            (uint32_t) (PAL_CB(user_address.end) - brk_region - brk_max_size));
                 rand = ALIGN_DOWN(rand);
 
                 if (brk_region + rand + brk_max_size >= PAL_CB(user_address.end))

--- a/LibOS/shim/src/sys/shim_exec.c
+++ b/LibOS/shim/src/sys/shim_exec.c
@@ -336,7 +336,7 @@ err:
         return -EACCES;
     }
 
-    int pathlen;
+    size_t pathlen;
     char *path = dentry_get_path(dent, true, &pathlen);
     qstrsetstr(&exec->path, path, pathlen);
 

--- a/LibOS/shim/src/sys/shim_futex.c
+++ b/LibOS/shim/src/sys/shim_futex.c
@@ -162,7 +162,7 @@ int shim_do_futex (int * uaddr, int op, int val, void * utime,
             }
 
         {
-            uint32_t bitset = (futex_op == FUTEX_WAIT_BITSET) ? val3 :
+            uint32_t bitset = (futex_op == FUTEX_WAIT_BITSET) ? (uint32_t) val3 :
                               0xffffffff;
 
             debug("FUTEX_WAIT: %p (val = %d) vs %d mask = %08x, timeout ptr %p\n",
@@ -198,7 +198,7 @@ int shim_do_futex (int * uaddr, int op, int val, void * utime,
         case FUTEX_WAKE_BITSET: {
             struct futex_waiter * waiter, * wtmp;
             int nwaken = 0;
-            uint32_t bitset = (futex_op == FUTEX_WAKE_BITSET) ? val3 :
+            uint32_t bitset = (futex_op == FUTEX_WAKE_BITSET) ? (uint32_t) val3 :
                               0xffffffff;
 
             debug("FUTEX_WAKE: %p (val = %d) count = %d mask = %08x\n",

--- a/LibOS/shim/src/sys/shim_getcwd.c
+++ b/LibOS/shim/src/sys/shim_getcwd.c
@@ -49,7 +49,7 @@ int shim_do_getcwd (char * buf, size_t len)
 
     struct shim_dentry * cwd = thread->cwd;
 
-    int plen;
+    size_t plen;
     const char * path = dentry_get_path(cwd, true, &plen);
 
     int ret;

--- a/LibOS/shim/src/sys/shim_getpid.c
+++ b/LibOS/shim/src/sys/shim_getpid.c
@@ -109,7 +109,7 @@ int shim_do_setpgid (pid_t pid, pid_t pgid)
     if (!thread)
         return -ESRCH;
 
-    thread->pgid = pgid ? : thread->tgid;
+    thread->pgid = (IDTYPE) pgid ? : thread->tgid;
 
     return 0;
 }

--- a/LibOS/shim/src/sys/shim_msgget.c
+++ b/LibOS/shim/src/sys/shim_msgget.c
@@ -284,7 +284,7 @@ int shim_do_msgget (key_t key, int msgflg)
         if (msgq) {
             msgid = msgq->msqid;
             put_msg_handle(msgq);
-            return (msgflg & IPC_EXCL) ? -EEXIST : msgid;
+            return (msgflg & IPC_EXCL) ? -EEXIST : (int) msgid;
         }
     }
 
@@ -494,7 +494,7 @@ static int __load_msg_qobjs (struct shim_msg_handle * msgq,
                              struct msg_type * mtype,
                              struct msg_item * msg, void * data)
 {
-    int copysize = MSG_ITEM_DATA_SIZE(msg->size);
+    size_t copysize = MSG_ITEM_DATA_SIZE(msg->size);
     memcpy(data, msg->data, copysize);
     mtype->msgs = msg->next;
     __free_msg_qobj(msgq, msg);
@@ -502,7 +502,7 @@ static int __load_msg_qobjs (struct shim_msg_handle * msgq,
     while (copysize < msg->size) {
         assert(mtype->msgs);
         struct msg_ext_item * ext = (struct msg_ext_item *) mtype->msgs;
-        int sz = MSG_EXT_ITEM_DATA_SIZE(msg->size - copysize);
+        size_t sz = MSG_EXT_ITEM_DATA_SIZE(msg->size - copysize);
         memcpy(data + copysize, ext->data, sz);
         copysize += sz;
         mtype->msgs = ext->next;
@@ -519,7 +519,7 @@ static int __load_msg_qobjs (struct shim_msg_handle * msgq,
 
 static int __store_msg_qobjs (struct shim_msg_handle * msgq,
                               struct msg_type * mtype,
-                              int size, const void * data)
+                              size_t size, const void * data)
 {
     struct msg_item * newmsg = __get_msg_qobj(msgq);
     if (!newmsg)
@@ -529,7 +529,7 @@ static int __store_msg_qobjs (struct shim_msg_handle * msgq,
 
     newmsg->next = NULL;
     newmsg->size = size;
-    int copysize = MSG_ITEM_DATA_SIZE(size);
+    size_t copysize = MSG_ITEM_DATA_SIZE(size);
     memcpy(newmsg->data, data, copysize);
 
     if (mtype->msg_tail) {
@@ -545,7 +545,7 @@ static int __store_msg_qobjs (struct shim_msg_handle * msgq,
         if (!ext)
             goto eagain;
 
-        int sz = MSG_EXT_ITEM_DATA_SIZE(size - copysize);
+        size_t sz = MSG_EXT_ITEM_DATA_SIZE(size - copysize);
         memcpy(ext->data, data + copysize, sz);
         ext->next = NULL;
         mtype->msg_tail->next = ext;
@@ -582,7 +582,7 @@ static struct sysv_balance_policy msg_policy  = {
 DEFINE_PROFILE_INTERVAL(add_sysv_msg, sysv_msg);
 
 int add_sysv_msg (struct shim_msg_handle * msgq,
-                  long type, int size, const void * data,
+                  long type, size_t size, const void * data,
                   struct sysv_client * src)
 {
     BEGIN_PROFILE_INTERVAL();
@@ -666,7 +666,7 @@ static int __add_msg_req (struct shim_msg_handle * msgq,
 DEFINE_PROFILE_INTERVAL(get_sysv_msg, sysv_msg);
 
 int get_sysv_msg (struct shim_msg_handle * msgq,
-                  long type, int size, void * data, int flags,
+                  long type, size_t size, void * data, int flags,
                   struct sysv_client * src)
 {
     BEGIN_PROFILE_INTERVAL();
@@ -870,8 +870,8 @@ static int __load_msg_persist (struct shim_msg_handle * msgq, bool readmsg)
 
     struct msg_handle_backup mback;
 
-    int bytes = DkStreamRead(file, 0, sizeof(struct msg_handle_backup),
-                             &mback, NULL, 0);
+    size_t bytes = DkStreamRead(file, 0, sizeof(struct msg_handle_backup),
+                                &mback, NULL, 0);
 
     if (bytes < sizeof(struct msg_handle_backup)) {
         ret = bytes ? -EFAULT : -PAL_ERRNO;

--- a/LibOS/shim/src/sys/shim_poll.c
+++ b/LibOS/shim/src/sys/shim_poll.c
@@ -392,7 +392,7 @@ int shim_do_poll (struct pollfd * fds, nfds_t nfds, int timeout)
     struct poll_handle * polls =
             __try_alloca(cur, sizeof(struct poll_handle) * nfds);
 
-    for (int i = 0 ; i < nfds ; i++) {
+    for (size_t i = 0 ; i < nfds ; i++) {
         polls[i].fd = fds[i].fd;
         polls[i].flags = 0;
         if (fds[i].events & (POLLIN|POLLRDNORM))
@@ -409,7 +409,7 @@ int shim_do_poll (struct pollfd * fds, nfds_t nfds, int timeout)
 
     ret = 0;
 
-    for (int i = 0 ; i < nfds ; i++) {
+    for (size_t i = 0 ; i < nfds ; i++) {
         fds[i].revents = 0;
 
         if (polls[i].flags & RET_R)

--- a/LibOS/shim/src/sys/shim_sandbox.c
+++ b/LibOS/shim/src/sys/shim_sandbox.c
@@ -65,7 +65,7 @@ static int isolate_fs (struct config_store * cfg, const char * path)
         return -ENOTDIR;
     }
 
-    int dpath_len = 0;
+    size_t dpath_len = 0;
     char * dpath = dentry_get_path(dent, true, &dpath_len);
     bool root_created = false;
     char t[CONFIG_MAX], u[CONFIG_MAX];
@@ -97,21 +97,21 @@ static int isolate_fs (struct config_store * cfg, const char * path)
         bool is_chroot = false;
 
         /* Skip FS that are not chroot */
-        strcpy_static(kp, ".type", k + CONFIG_MAX - kp);
+        strcpy_static(kp, ".type", (size_t) ((k + CONFIG_MAX) - kp));
         if (get_config(cfg, k, t, CONFIG_MAX) <= 0)
             continue;
         if (strpartcmp_static(t, "chroot"))
             is_chroot = true;
 
-        strcpy_static(kp, ".uri", k + CONFIG_MAX - kp);
+        strcpy_static(kp, ".uri",  (size_t) ((k + CONFIG_MAX) - kp));
         if ((ulen = get_config(cfg, k, u, CONFIG_MAX)) <= 0)
             continue;
 
-        strcpy_static(kp, ".path", k + CONFIG_MAX - kp);
+        strcpy_static(kp, ".path", (size_t) ((k + CONFIG_MAX) - kp));
         if ((plen = get_config(cfg, k, p, CONFIG_MAX)) <= 0)
             continue;
 
-        if (plen >= dpath_len) {
+        if ((size_t) plen >= dpath_len) {
             if (!memcmp(p, dpath, dpath_len)) {
                 if (!p[dpath_len]) {
                     root_created = true;
@@ -129,9 +129,9 @@ remove:
                     continue;
                 }
                 set_config(cfg, k, NULL);
-                strcpy_static(kp, ".type", k + CONFIG_MAX - kp);
+                strcpy_static(kp, ".type", (size_t) ((k + CONFIG_MAX) - kp));
                 set_config(cfg, k, NULL);
-                strcpy_static(kp, ".uri", k + CONFIG_MAX - kp);
+                strcpy_static(kp, ".uri",  (size_t) ((k + CONFIG_MAX) - kp));
                 set_config(cfg, k, NULL);
                 debug("deleted file rule: %s => %s\n", p, u);
             }
@@ -150,7 +150,7 @@ remove:
 
             append_uri(u, ulen, dpath + plen, dpath_len - plen);
             set_config(cfg, k, dpath);
-            strcpy_static(kp, "uri", k + CONFIG_MAX - kp);
+            strcpy_static(kp, "uri", (size_t) ((k + CONFIG_MAX) - kp));
             set_config(cfg, k, u);
             root_created = true;
             debug("added file rule: %s => %s\n", dpath, u);

--- a/LibOS/shim/src/sys/shim_sched.c
+++ b/LibOS/shim/src/sys/shim_sched.c
@@ -44,9 +44,9 @@ int shim_do_sched_getaffinity (pid_t pid, size_t len,
 
     /* Linux kernel bitmap is based on long. So according to its
      * implementation, round up the result to sizeof(long) */
-    int bitmask_long_count = (ncpus + sizeof(long) * 8 - 1) /
-        (sizeof(long) * 8);
-    int bitmask_size_in_bytes = bitmask_long_count * sizeof(long);
+    size_t bitmask_long_count = (ncpus + sizeof(long) * 8 - 1) /
+                                (sizeof(long) * 8);
+    size_t bitmask_size_in_bytes = bitmask_long_count * sizeof(long);
     if (len < bitmask_size_in_bytes)
         return -EINVAL;
     /* Linux kernel also rejects non-natural size */

--- a/LibOS/shim/src/sys/shim_semget.c
+++ b/LibOS/shim/src/sys/shim_semget.c
@@ -244,7 +244,7 @@ int shim_do_semget (key_t key, int nsems, int semflg)
         if (sem) {
             semid = sem->semid;
             put_sem_handle(sem);
-            return (semflg & IPC_EXCL) ? -EEXIST : semid;
+            return (semflg & IPC_EXCL) ? -EEXIST : (int) semid;
         }
     }
 
@@ -354,9 +354,9 @@ static int __do_semop (int semid, struct sembuf * sops, unsigned int nsops,
 {
     int ret;
     struct shim_sem_handle * sem;
-    int nsems = 0;
+    size_t nsems = 0;
 
-    for (int i = 0 ; i < nsops ; i++)
+    for (size_t i = 0 ; i < nsops ; i++)
         if (sops[i].sem_num >= nsems)
             nsems = sops[i].sem_num + 1;
 

--- a/LibOS/shim/src/sys/shim_sigaction.c
+++ b/LibOS/shim/src/sys/shim_sigaction.c
@@ -528,14 +528,14 @@ int shim_do_kill (pid_t pid, int sig)
        specified by pid. */
     else if (pid > 0) {
         ret = do_kill_proc(cur->tid, pid, sig, true);
-        send_to_self = (pid == cur->tgid);
+        send_to_self = ((IDTYPE) pid == cur->tgid);
     }
 
     /* If pid is less than -1, then sig is sent to every process in the
        process group whose id is -pid */
     else {
         ret = do_kill_pgroup(cur->tid, -pid, sig, true);
-        send_to_self = (-pid == cur->pgid);
+        send_to_self = ((IDTYPE) -pid == cur->pgid);
     }
 
     if (send_to_self) {
@@ -594,7 +594,7 @@ int shim_do_tkill (pid_t tid, int sig)
 
     struct shim_thread * cur = get_cur_thread();
 
-    if (tid == cur->tid) {
+    if ((IDTYPE) tid == cur->tid) {
         if (sig) {
             siginfo_t info;
             memset(&info, 0, sizeof(siginfo_t));
@@ -620,7 +620,7 @@ int shim_do_tgkill (pid_t tgid, pid_t tid, int sig)
 
     struct shim_thread * cur = get_cur_thread();
 
-    if (tid == cur->tid) {
+    if ((IDTYPE) tid == cur->tid) {
         if (sig) {
             siginfo_t info;
             memset(&info, 0, sizeof(siginfo_t));

--- a/LibOS/shim/src/sys/shim_stat.c
+++ b/LibOS/shim/src/sys/shim_stat.c
@@ -108,7 +108,7 @@ out:
     return ret;
 }
 
-int shim_do_readlink (const char * file, char * buf, int bufsize)
+int shim_do_readlink (const char * file, char * buf, size_t bufsize)
 {
     if (!file || test_user_string(file))
         return -EFAULT;

--- a/LibOS/shim/src/sys/shim_wait.c
+++ b/LibOS/shim/src/sys/shim_wait.c
@@ -109,7 +109,7 @@ block:
             pid = -cur->pgid;
 
         LISTP_FOR_EACH_ENTRY(thread, &cur->exited_children, siblings)
-            if (thread->pgid == -pid)
+            if (thread->pgid == (IDTYPE) -pid)
                 goto found_child;
 
         if (!(option & WNOHANG))

--- a/LibOS/shim/src/utils/printf.c
+++ b/LibOS/shim/src/utils/printf.c
@@ -34,7 +34,7 @@ struct debugbuf {
 static inline int
 debug_fputs (void * f, const char * buf, int len)
 {
-    if (DkStreamWrite(debug_handle, 0, len, (void *) buf, NULL) == len)
+    if (DkStreamWrite(debug_handle, 0, len, (void *) buf, NULL) == (PAL_NUM) len)
         return 0;
     else
         return -1;

--- a/Pal/lib/slabmgr.h
+++ b/Pal/lib/slabmgr.h
@@ -140,7 +140,7 @@ struct slab_debug {
 
 // User buffer sizes on each level (not counting mandatory header
 // (SLAB_HDR_SIZE)).
-static const int slab_levels[SLAB_LEVEL] = { SLAB_LEVEL_SIZES };
+static const size_t slab_levels[SLAB_LEVEL] = { SLAB_LEVEL_SIZES };
 
 DEFINE_LISTP(slab_obj);
 DEFINE_LISTP(slab_area);
@@ -344,7 +344,7 @@ static inline int enlarge_slab_mgr (SLAB_MGR mgr, int level)
     return 0;
 }
 
-static inline void * slab_alloc (SLAB_MGR mgr, int size)
+static inline void * slab_alloc (SLAB_MGR mgr, size_t size)
 {
     SLAB_OBJ mobj;
     int i;
@@ -400,7 +400,7 @@ static inline void * slab_alloc (SLAB_MGR mgr, int size)
 }
 
 #ifdef SLAB_DEBUG
-static inline void * slab_alloc_debug (SLAB_MGR mgr, int size,
+static inline void * slab_alloc_debug (SLAB_MGR mgr, size_t size,
                                        const char * file, int line)
 {
     void * mem = slab_alloc(mgr, size);


### PR DESCRIPTION
Signed-off-by: Chia-Che Tsai <chiache@tamu.edu>

<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->

Enabling -WSign-compare as the compile option in `LibOS/shim/src` and fixing all the related warnings.

## How to test this PR? <!-- (if applicable) -->

Just run the regression tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/741)
<!-- Reviewable:end -->
