### PR TITLE
Remove modelines from all source files

### DIFF
--- a/LibOS/shim/include/shim_checkpoint.h
+++ b/LibOS/shim/include/shim_checkpoint.h
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/LibOS/shim/include/shim_defs.h
+++ b/LibOS/shim/include/shim_defs.h
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #ifndef _SHIM_DEFS_H_
 #define _SHIM_DEFS_H_
 

--- a/LibOS/shim/include/shim_fs.h
+++ b/LibOS/shim/include/shim_fs.h
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/LibOS/shim/include/shim_handle.h
+++ b/LibOS/shim/include/shim_handle.h
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/LibOS/shim/include/shim_internal.h
+++ b/LibOS/shim/include/shim_internal.h
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/LibOS/shim/include/shim_ipc.h
+++ b/LibOS/shim/include/shim_ipc.h
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/LibOS/shim/include/shim_ipc_ns.h
+++ b/LibOS/shim/include/shim_ipc_ns.h
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/LibOS/shim/include/shim_profile.h
+++ b/LibOS/shim/include/shim_profile.h
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/LibOS/shim/include/shim_signal.h
+++ b/LibOS/shim/include/shim_signal.h
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #ifndef _SHIM_SIGNAL_H_
 #define _SHIM_SIGNAL_H_
 

--- a/LibOS/shim/include/shim_sysv.h
+++ b/LibOS/shim/include/shim_sysv.h
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/LibOS/shim/include/shim_table.h
+++ b/LibOS/shim/include/shim_table.h
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #ifndef _SHIM_TABLE_H_
 #define _SHIM_TABLE_H_
 

--- a/LibOS/shim/include/shim_thread.h
+++ b/LibOS/shim/include/shim_thread.h
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #ifndef _SHIM_THREAD_H_
 #define _SHIM_THREAD_H_
 

--- a/LibOS/shim/include/shim_tls.h
+++ b/LibOS/shim/include/shim_tls.h
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #ifndef _SHIM_TLS_H_
 #define _SHIM_TLS_H_
 

--- a/LibOS/shim/include/shim_types.h
+++ b/LibOS/shim/include/shim_types.h
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #ifndef _SHIM_TYPES_H_
 #define _SHIM_TYPES_H_
 

--- a/LibOS/shim/include/shim_unistd.h
+++ b/LibOS/shim/include/shim_unistd.h
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #ifndef _SHIM_UNISTD_H_
 #define _SHIM_UNISTD_H_
 

--- a/LibOS/shim/include/shim_unistd_defs.h
+++ b/LibOS/shim/include/shim_unistd_defs.h
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #ifndef _SHIM_UNISTD_DEFS_H_
 #define _SHIM_UNISTD_DEFS_H_
 

--- a/LibOS/shim/include/shim_utils.h
+++ b/LibOS/shim/include/shim_utils.h
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/LibOS/shim/include/shim_vma.h
+++ b/LibOS/shim/include/shim_vma.h
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/LibOS/shim/src/bookkeep/shim_handle.c
+++ b/LibOS/shim/src/bookkeep/shim_handle.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/LibOS/shim/src/bookkeep/shim_signal.c
+++ b/LibOS/shim/src/bookkeep/shim_signal.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/LibOS/shim/src/bookkeep/shim_thread.c
+++ b/LibOS/shim/src/bookkeep/shim_thread.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/LibOS/shim/src/bookkeep/shim_vma.c
+++ b/LibOS/shim/src/bookkeep/shim_vma.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/LibOS/shim/src/elf/dl-machine-x86_64.h
+++ b/LibOS/shim/src/elf/dl-machine-x86_64.h
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/LibOS/shim/src/elf/do-rel.h
+++ b/LibOS/shim/src/elf/do-rel.h
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/LibOS/shim/src/elf/ldsodefs.h
+++ b/LibOS/shim/src/elf/ldsodefs.h
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #ifndef __LDSODEFS_H__
 #define __LDSODEFS_H__
 

--- a/LibOS/shim/src/elf/rel.h
+++ b/LibOS/shim/src/elf/rel.h
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #include "elf.h"
 
 #ifndef VERSYMIDX

--- a/LibOS/shim/src/elf/shim_rtld.c
+++ b/LibOS/shim/src/elf/shim_rtld.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/LibOS/shim/src/fs/chroot/fs.c
+++ b/LibOS/shim/src/fs/chroot/fs.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/LibOS/shim/src/fs/dev/fs.c
+++ b/LibOS/shim/src/fs/dev/fs.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/LibOS/shim/src/fs/pipe/fs.c
+++ b/LibOS/shim/src/fs/pipe/fs.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/LibOS/shim/src/fs/proc/fs.c
+++ b/LibOS/shim/src/fs/proc/fs.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/LibOS/shim/src/fs/proc/info.c
+++ b/LibOS/shim/src/fs/proc/info.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #include <shim_internal.h>
 #include <shim_fs.h>
 

--- a/LibOS/shim/src/fs/proc/ipc-thread.c
+++ b/LibOS/shim/src/fs/proc/ipc-thread.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #include <shim_internal.h>
 #include <shim_table.h>
 #include <shim_thread.h>

--- a/LibOS/shim/src/fs/proc/thread.c
+++ b/LibOS/shim/src/fs/proc/thread.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #include <shim_internal.h>
 #include <shim_table.h>
 #include <shim_thread.h>

--- a/LibOS/shim/src/fs/shim_dcache.c
+++ b/LibOS/shim/src/fs/shim_dcache.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University,
    2017 University of North Carolina at Chapel Hill and Fortanix, Inc.
    This file is part of Graphene Library OS.

--- a/LibOS/shim/src/fs/shim_fs.c
+++ b/LibOS/shim/src/fs/shim_fs.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/LibOS/shim/src/fs/shim_namei.c
+++ b/LibOS/shim/src/fs/shim_namei.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2017, University of North Carolina at Chapel Hill
    and Fortanix, Inc.
    This file is part of Graphene Library OS.

--- a/LibOS/shim/src/fs/socket/fs.c
+++ b/LibOS/shim/src/fs/socket/fs.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/LibOS/shim/src/fs/str/fs.c
+++ b/LibOS/shim/src/fs/str/fs.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/LibOS/shim/src/ipc/shim_ipc.c
+++ b/LibOS/shim/src/ipc/shim_ipc.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/LibOS/shim/src/ipc/shim_ipc_child.c
+++ b/LibOS/shim/src/ipc/shim_ipc_child.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/LibOS/shim/src/ipc/shim_ipc_helper.c
+++ b/LibOS/shim/src/ipc/shim_ipc_helper.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/LibOS/shim/src/ipc/shim_ipc_nsimpl.h
+++ b/LibOS/shim/src/ipc/shim_ipc_nsimpl.h
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/LibOS/shim/src/ipc/shim_ipc_pid.c
+++ b/LibOS/shim/src/ipc/shim_ipc_pid.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/LibOS/shim/src/ipc/shim_ipc_sysv.c
+++ b/LibOS/shim/src/ipc/shim_ipc_sysv.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/LibOS/shim/src/shim_async.c
+++ b/LibOS/shim/src/shim_async.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/LibOS/shim/src/shim_checkpoint.c
+++ b/LibOS/shim/src/shim_checkpoint.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/LibOS/shim/src/shim_debug.c
+++ b/LibOS/shim/src/shim_debug.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/LibOS/shim/src/shim_init.c
+++ b/LibOS/shim/src/shim_init.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/LibOS/shim/src/shim_malloc.c
+++ b/LibOS/shim/src/shim_malloc.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/LibOS/shim/src/shim_parser.c
+++ b/LibOS/shim/src/shim_parser.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/LibOS/shim/src/shim_syscalls.c
+++ b/LibOS/shim/src/shim_syscalls.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/LibOS/shim/src/shim_table.c
+++ b/LibOS/shim/src/shim_table.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/LibOS/shim/src/start.S
+++ b/LibOS/shim/src/start.S
@@ -1,7 +1,3 @@
-/* -*- mode:c; c-basic-offset:4; tab-width:4; indent-tabs-mode:t; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
-
 /* This is the canonical entry point, usually the first thing in the text
    segment.  The SVR4/i386 ABI (pages 3-31, 3-32) says that when the entry
    point runs, most registers' values are unspecified, except for:

--- a/LibOS/shim/src/sys/shim_access.c
+++ b/LibOS/shim/src/sys/shim_access.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/LibOS/shim/src/sys/shim_alarm.c
+++ b/LibOS/shim/src/sys/shim_alarm.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/LibOS/shim/src/sys/shim_benchmark.c
+++ b/LibOS/shim/src/sys/shim_benchmark.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/LibOS/shim/src/sys/shim_brk.c
+++ b/LibOS/shim/src/sys/shim_brk.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/LibOS/shim/src/sys/shim_clone.c
+++ b/LibOS/shim/src/sys/shim_clone.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/LibOS/shim/src/sys/shim_dup.c
+++ b/LibOS/shim/src/sys/shim_dup.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/LibOS/shim/src/sys/shim_epoll.c
+++ b/LibOS/shim/src/sys/shim_epoll.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/LibOS/shim/src/sys/shim_exec.c
+++ b/LibOS/shim/src/sys/shim_exec.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/LibOS/shim/src/sys/shim_exit.c
+++ b/LibOS/shim/src/sys/shim_exit.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/LibOS/shim/src/sys/shim_fcntl.c
+++ b/LibOS/shim/src/sys/shim_fcntl.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/LibOS/shim/src/sys/shim_fork.c
+++ b/LibOS/shim/src/sys/shim_fork.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/LibOS/shim/src/sys/shim_fs.c
+++ b/LibOS/shim/src/sys/shim_fs.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/LibOS/shim/src/sys/shim_futex.c
+++ b/LibOS/shim/src/sys/shim_futex.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/LibOS/shim/src/sys/shim_getcwd.c
+++ b/LibOS/shim/src/sys/shim_getcwd.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/LibOS/shim/src/sys/shim_getpid.c
+++ b/LibOS/shim/src/sys/shim_getpid.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/LibOS/shim/src/sys/shim_getrlimit.c
+++ b/LibOS/shim/src/sys/shim_getrlimit.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/LibOS/shim/src/sys/shim_ioctl.c
+++ b/LibOS/shim/src/sys/shim_ioctl.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/LibOS/shim/src/sys/shim_migrate.c
+++ b/LibOS/shim/src/sys/shim_migrate.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/LibOS/shim/src/sys/shim_mmap.c
+++ b/LibOS/shim/src/sys/shim_mmap.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/LibOS/shim/src/sys/shim_msgget.c
+++ b/LibOS/shim/src/sys/shim_msgget.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/LibOS/shim/src/sys/shim_open.c
+++ b/LibOS/shim/src/sys/shim_open.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/LibOS/shim/src/sys/shim_pipe.c
+++ b/LibOS/shim/src/sys/shim_pipe.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/LibOS/shim/src/sys/shim_poll.c
+++ b/LibOS/shim/src/sys/shim_poll.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/LibOS/shim/src/sys/shim_sandbox.c
+++ b/LibOS/shim/src/sys/shim_sandbox.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/LibOS/shim/src/sys/shim_sched.c
+++ b/LibOS/shim/src/sys/shim_sched.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/LibOS/shim/src/sys/shim_semget.c
+++ b/LibOS/shim/src/sys/shim_semget.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/LibOS/shim/src/sys/shim_sigaction.c
+++ b/LibOS/shim/src/sys/shim_sigaction.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/LibOS/shim/src/sys/shim_sleep.c
+++ b/LibOS/shim/src/sys/shim_sleep.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/LibOS/shim/src/sys/shim_socket.c
+++ b/LibOS/shim/src/sys/shim_socket.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/LibOS/shim/src/sys/shim_stat.c
+++ b/LibOS/shim/src/sys/shim_stat.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/LibOS/shim/src/sys/shim_time.c
+++ b/LibOS/shim/src/sys/shim_time.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/LibOS/shim/src/sys/shim_uname.c
+++ b/LibOS/shim/src/sys/shim_uname.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/LibOS/shim/src/sys/shim_vfork.c
+++ b/LibOS/shim/src/sys/shim_vfork.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/LibOS/shim/src/sys/shim_wait.c
+++ b/LibOS/shim/src/sys/shim_wait.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/LibOS/shim/src/sys/shim_wrappers.c
+++ b/LibOS/shim/src/sys/shim_wrappers.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/LibOS/shim/src/utils/md5.c
+++ b/LibOS/shim/src/utils/md5.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset:4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /*
  **********************************************************************
  ** md5.c                                                            **

--- a/LibOS/shim/src/utils/printf.c
+++ b/LibOS/shim/src/utils/printf.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/LibOS/shim/src/utils/strobjs.c
+++ b/LibOS/shim/src/utils/strobjs.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/LibOS/shim/test/benchmark/fork_latency.c
+++ b/LibOS/shim/test/benchmark/fork_latency.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #include <stdlib.h>
 #include <stdio.h>
 #include <unistd.h>

--- a/LibOS/shim/test/benchmark/rpc_latency.libos.c
+++ b/LibOS/shim/test/benchmark/rpc_latency.libos.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #include <stdlib.h>
 #include <stdio.h>
 #include <unistd.h>

--- a/LibOS/shim/test/benchmark/rpc_latency2.libos.c
+++ b/LibOS/shim/test/benchmark/rpc_latency2.libos.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #include <stdlib.h>
 #include <stdio.h>
 #include <unistd.h>

--- a/LibOS/shim/test/benchmark/sig_latency.c
+++ b/LibOS/shim/test/benchmark/sig_latency.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #include <stdlib.h>
 #include <stdio.h>
 #include <unistd.h>

--- a/LibOS/shim/test/benchmark/start.c
+++ b/LibOS/shim/test/benchmark/start.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #include <stdlib.h>
 #include <stdio.h>
 #include <sys/time.h>

--- a/LibOS/shim/test/benchmark/test_start.m.c
+++ b/LibOS/shim/test/benchmark/test_start.m.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #include <stdlib.h>
 #include <stdio.h>
 #include <unistd.h>

--- a/LibOS/shim/test/inline/fork.c
+++ b/LibOS/shim/test/inline/fork.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #include <shim_table.h>
 #include <errno.h>
 

--- a/LibOS/shim/test/inline/helloworld.c
+++ b/LibOS/shim/test/inline/helloworld.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #include <shim_table.h>
 
 int main (int argc, char ** argv)

--- a/LibOS/shim/test/inline/vfork.c
+++ b/LibOS/shim/test/inline/vfork.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #include <shim_table.h>
 #include <errno.h>
 

--- a/LibOS/shim/test/native/alarm.c
+++ b/LibOS/shim/test/native/alarm.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #include <unistd.h>
 #include <stdlib.h>
 #include <stdio.h>

--- a/LibOS/shim/test/native/brk.c
+++ b/LibOS/shim/test/native/brk.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>

--- a/LibOS/shim/test/native/clone.c
+++ b/LibOS/shim/test/native/clone.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #define _GNU_SOURCE
 #include <malloc.h>
 #include <unistd.h>

--- a/LibOS/shim/test/native/condvar.pthread.c
+++ b/LibOS/shim/test/native/condvar.pthread.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <pthread.h>

--- a/LibOS/shim/test/native/cpuinfo.c
+++ b/LibOS/shim/test/native/cpuinfo.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #define _GNU_SOURCE
 #include <stdio.h>
 #include <stdlib.h>

--- a/LibOS/shim/test/native/dir.c
+++ b/LibOS/shim/test/native/dir.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #include <unistd.h>
 #include <stdlib.h>
 #include <stdio.h>

--- a/LibOS/shim/test/native/divzero.c
+++ b/LibOS/shim/test/native/divzero.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #include <stdlib.h>
 #include <stdio.h>
 #include <signal.h>

--- a/LibOS/shim/test/native/dup.c
+++ b/LibOS/shim/test/native/dup.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #include <stdio.h>
 #include <unistd.h>
 

--- a/LibOS/shim/test/native/epoll.c
+++ b/LibOS/shim/test/native/epoll.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #include <unistd.h>
 #include <stdlib.h>
 #include <string.h>

--- a/LibOS/shim/test/native/epoll_socket.c
+++ b/LibOS/shim/test/native/epoll_socket.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4;
- * indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
 
 // Copied from
 // https://banu.com/blog/2/how-to-use-epoll-a-complete-example-in-c/epoll-example.c

--- a/LibOS/shim/test/native/errno.c
+++ b/LibOS/shim/test/native/errno.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #include <stdio.h>
 #include <errno.h>
 

--- a/LibOS/shim/test/native/exec_fork.c
+++ b/LibOS/shim/test/native/exec_fork.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #include <stdlib.h>
 #include <errno.h>
 #include <unistd.h>

--- a/LibOS/shim/test/native/file.c
+++ b/LibOS/shim/test/native/file.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #include <stdio.h>
 #include <unistd.h>
 #include <fcntl.h>

--- a/LibOS/shim/test/native/fork.c
+++ b/LibOS/shim/test/native/fork.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/LibOS/shim/test/native/fork_bomb.c
+++ b/LibOS/shim/test/native/fork_bomb.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #include <stdlib.h>
 #include <stdio.h>
 #include <unistd.h>

--- a/LibOS/shim/test/native/fork_exec.c
+++ b/LibOS/shim/test/native/fork_exec.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #include <unistd.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/LibOS/shim/test/native/fs.c
+++ b/LibOS/shim/test/native/fs.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/LibOS/shim/test/native/futextest.pthread.c
+++ b/LibOS/shim/test/native/futextest.pthread.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #include <stdio.h>
 #include <pthread.h>
 #include <unistd.h>

--- a/LibOS/shim/test/native/get_time.m.c
+++ b/LibOS/shim/test/native/get_time.m.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #include <stdlib.h>
 #include <stdio.h>
 #include <unistd.h>

--- a/LibOS/shim/test/native/helloworld.c
+++ b/LibOS/shim/test/native/helloworld.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* a simple helloworld test */
 
 #include <stdio.h>

--- a/LibOS/shim/test/native/helloworld.pthread.c
+++ b/LibOS/shim/test/native/helloworld.pthread.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* a simple helloworld test, with pthread usage */
 
 #include <stdio.h>

--- a/LibOS/shim/test/native/kill.c
+++ b/LibOS/shim/test/native/kill.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/LibOS/shim/test/native/malloc.c
+++ b/LibOS/shim/test/native/malloc.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #include <stdlib.h>
 #include <stdio.h>
 

--- a/LibOS/shim/test/native/meminfo.c
+++ b/LibOS/shim/test/native/meminfo.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #define _GNU_SOURCE
 #include <stdio.h>
 #include <stdlib.h>

--- a/LibOS/shim/test/native/msg_create.c
+++ b/LibOS/shim/test/native/msg_create.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Test to create 100 message queues and query them from another process*/
 
 #include <stdlib.h>

--- a/LibOS/shim/test/native/msg_create.libos.c
+++ b/LibOS/shim/test/native/msg_create.libos.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Test to create 100 message queues and query them from another process*/
 
 #include <stdlib.h>

--- a/LibOS/shim/test/native/msg_send.c
+++ b/LibOS/shim/test/native/msg_send.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>

--- a/LibOS/shim/test/native/msg_send.libos.c
+++ b/LibOS/shim/test/native/msg_send.libos.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>

--- a/LibOS/shim/test/native/multiproc.c
+++ b/LibOS/shim/test/native/multiproc.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #include <stdlib.h>
 #include <unistd.h>
 #include <sys/wait.h>

--- a/LibOS/shim/test/native/multisleep.c
+++ b/LibOS/shim/test/native/multisleep.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #define _GNU_SOURCE
 #include <stdlib.h>
 #include <unistd.h>

--- a/LibOS/shim/test/native/pid_alloc.c
+++ b/LibOS/shim/test/native/pid_alloc.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #include <stdlib.h>
 #include <stdio.h>
 #include <unistd.h>

--- a/LibOS/shim/test/native/pid_kill.c
+++ b/LibOS/shim/test/native/pid_kill.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #include <stdlib.h>
 #include <stdio.h>
 #include <unistd.h>

--- a/LibOS/shim/test/native/pie.c
+++ b/LibOS/shim/test/native/pie.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* a simple helloworld test */
 
 #include <stdio.h>

--- a/LibOS/shim/test/native/pipe.c
+++ b/LibOS/shim/test/native/pipe.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #include <stdlib.h>
 #include <stdio.h>
 #include <unistd.h>

--- a/LibOS/shim/test/native/pipe_latency.c
+++ b/LibOS/shim/test/native/pipe_latency.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #include <stdlib.h>
 #include <stdio.h>
 #include <unistd.h>

--- a/LibOS/shim/test/native/readdir.c
+++ b/LibOS/shim/test/native/readdir.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #include <stdio.h>
 #include <dirent.h>
 #include <fcntl.h>

--- a/LibOS/shim/test/native/rename.c
+++ b/LibOS/shim/test/native/rename.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #include <unistd.h>
 #include <stdlib.h>
 #include <stdio.h>

--- a/LibOS/shim/test/native/sandbox_create.libos.c
+++ b/LibOS/shim/test/native/sandbox_create.libos.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #include <stdlib.h>
 #include <unistd.h>
 #include <stdio.h>

--- a/LibOS/shim/test/native/script.c
+++ b/LibOS/shim/test/native/script.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #include <stdlib.h>
 #include <stdio.h>
 #include <errno.h>

--- a/LibOS/shim/test/native/sem.c
+++ b/LibOS/shim/test/native/sem.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>

--- a/LibOS/shim/test/native/sleep.c
+++ b/LibOS/shim/test/native/sleep.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #include <stdio.h>
 #include <unistd.h>
 

--- a/LibOS/shim/test/native/socketpair.c
+++ b/LibOS/shim/test/native/socketpair.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #include <stdlib.h>
 #include <stdio.h>
 #include <unistd.h>

--- a/LibOS/shim/test/native/sqrt.m.c
+++ b/LibOS/shim/test/native/sqrt.m.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #include <stdio.h>
 #include <math.h>
 

--- a/LibOS/shim/test/native/start.pthread.m.c
+++ b/LibOS/shim/test/native/start.pthread.m.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #include <stdlib.h>
 #include <stdio.h>
 #include <sys/time.h>

--- a/LibOS/shim/test/native/static.c
+++ b/LibOS/shim/test/native/static.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* a simple helloworld test */
 
 #include <stdio.h>

--- a/LibOS/shim/test/native/sync.pthread.c
+++ b/LibOS/shim/test/native/sync.pthread.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #include <pthread.h>
 #include <stdio.h>
 #include <math.h>

--- a/LibOS/shim/test/native/system.c
+++ b/LibOS/shim/test/native/system.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #include <stdlib.h>
 
 int main(int argc, char ** argv)

--- a/LibOS/shim/test/native/tcp.c
+++ b/LibOS/shim/test/native/tcp.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* copied from http://www.daniweb.com/software-development/c/threads/179814 */
 
 #include <unistd.h>

--- a/LibOS/shim/test/native/test_start_pthread_m.m.c
+++ b/LibOS/shim/test/native/test_start_pthread_m.m.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #include <stdlib.h>
 #include <stdio.h>
 #include <unistd.h>

--- a/LibOS/shim/test/native/time.c
+++ b/LibOS/shim/test/native/time.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #include <stdio.h>
 #include <sys/time.h>
 

--- a/LibOS/shim/test/native/vfork.c
+++ b/LibOS/shim/test/native/vfork.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/LibOS/shim/test/native/vfork_exec.c
+++ b/LibOS/shim/test/native/vfork_exec.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/LibOS/shim/test/regression/bootstrap.c
+++ b/LibOS/shim/test/regression/bootstrap.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #include <stdio.h>
 
 int main(int argc, const char ** argv, const char ** envp)

--- a/LibOS/shim/test/regression/bootstrap_pie.c
+++ b/LibOS/shim/test/regression/bootstrap_pie.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #include <stdio.h>
 
 static void * ptr = NULL;

--- a/LibOS/shim/test/regression/bootstrap_static.c
+++ b/LibOS/shim/test/regression/bootstrap_static.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* a simple helloworld test */
 
 #include <stdio.h>

--- a/LibOS/shim/test/regression/epoll_wait_timeout.c
+++ b/LibOS/shim/test/regression/epoll_wait_timeout.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #include <errno.h>
 #include <fcntl.h>
 #include <stdio.h>

--- a/LibOS/shim/test/regression/exec.c
+++ b/LibOS/shim/test/regression/exec.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #include <stdlib.h>
 #include <stdio.h>
 #include <errno.h>

--- a/LibOS/shim/test/regression/exec_victim.c
+++ b/LibOS/shim/test/regression/exec_victim.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #include <stdio.h>
 #include <stdlib.h>
 

--- a/LibOS/shim/test/regression/exit.c
+++ b/LibOS/shim/test/regression/exit.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #include <stdio.h>
 
 int main(int argc, const char ** argv, const char ** envp)

--- a/LibOS/shim/test/regression/futex.c
+++ b/LibOS/shim/test/regression/futex.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #define _GNU_SOURCE
 #include <malloc.h>
 #include <unistd.h>

--- a/LibOS/shim/test/regression/large-mmap.c
+++ b/LibOS/shim/test/regression/large-mmap.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #include <stdio.h>
 #include <unistd.h>
 #include <sys/mman.h>

--- a/LibOS/shim/test/regression/mmap-file.c
+++ b/LibOS/shim/test/regression/mmap-file.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #include <sys/mman.h>
 #include <sys/wait.h>
 #include <sys/types.h>

--- a/LibOS/shim/test/regression/shared_object.c
+++ b/LibOS/shim/test/regression/shared_object.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* a simple helloworld test */
 
 #include <stdio.h>

--- a/LibOS/shim/test/regression/udp.c
+++ b/LibOS/shim/test/regression/udp.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #include <stdlib.h>
 #include <stdio.h>
 #include <unistd.h>

--- a/Pal/lib/api.h
+++ b/Pal/lib/api.h
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/lib/assert.h
+++ b/Pal/lib/assert.h
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /*
  * assert.h
  *

--- a/Pal/lib/atomic.h
+++ b/Pal/lib/atomic.h
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #ifndef _SHIM_ATOMIC_H_
 #define _SHIM_ATOMIC_H_
 

--- a/Pal/lib/graphene/config.c
+++ b/Pal/lib/graphene/config.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/lib/graphene/path.c
+++ b/Pal/lib/graphene/path.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/lib/hex.h
+++ b/Pal/lib/hex.h
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 OSCAR lab, Stony Brook University
    2017 University of North Carolina at Chapel Hill
    This file is part of Graphene Library OS.

--- a/Pal/lib/list-test.c
+++ b/Pal/lib/list-test.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2017 University of North Carolina at Chapel Hill and
    Fortanix, Inc.
    This file is part of Graphene Library OS.

--- a/Pal/lib/list.h
+++ b/Pal/lib/list.h
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2017 University of North Carolina at Chapel Hill and
    Fortanix, Inc.
    This file is part of Graphene Library OS.

--- a/Pal/lib/memmgr.h
+++ b/Pal/lib/memmgr.h
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/lib/slabmgr.h
+++ b/Pal/lib/slabmgr.h
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/regression/..Bootstrap.c
+++ b/Pal/regression/..Bootstrap.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #include "pal.h"
 #include "pal_debug.h"
 

--- a/Pal/regression/AtomicMath.c
+++ b/Pal/regression/AtomicMath.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #include "pal.h"
 #include "pal_debug.h"
 #include <atomic.h>

--- a/Pal/regression/Bootstrap.c
+++ b/Pal/regression/Bootstrap.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #include "pal.h"
 #include "pal_debug.h"
 

--- a/Pal/regression/Bootstrap2.c
+++ b/Pal/regression/Bootstrap2.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #include "pal.h"
 #include "pal_debug.h"
 

--- a/Pal/regression/Bootstrap3.c
+++ b/Pal/regression/Bootstrap3.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #include "pal.h"
 #include "pal_debug.h"
 

--- a/Pal/regression/Bootstrap7.c
+++ b/Pal/regression/Bootstrap7.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #include "pal_debug.h"
 
 int main (int argc, char ** argv, char ** envp)

--- a/Pal/regression/Directory.c
+++ b/Pal/regression/Directory.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #include "pal.h"
 #include "pal_debug.h"
 #include "api.h"

--- a/Pal/regression/Exception.c
+++ b/Pal/regression/Exception.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* This Hello World simply print out "Hello World" */
 
 #include <stdatomic.h>

--- a/Pal/regression/Exit.c
+++ b/Pal/regression/Exit.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #include "pal.h"
 #include "pal_debug.h"
 #include "api.h"

--- a/Pal/regression/File.c
+++ b/Pal/regression/File.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #include "pal.h"
 #include "pal_debug.h"
 #include "api.h"

--- a/Pal/regression/Hex.c
+++ b/Pal/regression/Hex.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #include "pal.h"
 #include "pal_debug.h"
 #include "api.h"

--- a/Pal/regression/Ipc.c
+++ b/Pal/regression/Ipc.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #include "pal.h"
 #include "pal_debug.h"
 #include "api.h"

--- a/Pal/regression/Memory.c
+++ b/Pal/regression/Memory.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #include "pal.h"
 #include "pal_debug.h"
 #include "api.h"

--- a/Pal/regression/Misc.c
+++ b/Pal/regression/Misc.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #include "pal.h"
 #include "pal_debug.h"
 #include "api.h"

--- a/Pal/regression/Pipe.c
+++ b/Pal/regression/Pipe.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #include "pal.h"
 #include "pal_debug.h"
 #include "api.h"

--- a/Pal/regression/Preload1.so.c
+++ b/Pal/regression/Preload1.so.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #include "pal.h"
 #include "pal_debug.h"
 

--- a/Pal/regression/Preload2.so.c
+++ b/Pal/regression/Preload2.so.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #include "pal.h"
 #include "pal_debug.h"
 

--- a/Pal/regression/Process.c
+++ b/Pal/regression/Process.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #include "pal.h"
 #include "pal_debug.h"
 #include "api.h"

--- a/Pal/regression/Process2.c
+++ b/Pal/regression/Process2.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #include "pal.h"
 #include "pal_debug.h"
 #include "api.h"

--- a/Pal/regression/Process3.c
+++ b/Pal/regression/Process3.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #include "pal.h"
 #include "pal_debug.h"
 #include "api.h"

--- a/Pal/regression/Semaphore.c
+++ b/Pal/regression/Semaphore.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #include "pal.h"
 #include "pal_debug.h"
 #include "api.h"

--- a/Pal/regression/SendHandle.c
+++ b/Pal/regression/SendHandle.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* This Hello World demostrate a simple multithread program */
 
 #include "pal.h"

--- a/Pal/regression/Socket.c
+++ b/Pal/regression/Socket.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #include "pal.h"
 #include "pal_debug.h"
 #include "api.h"

--- a/Pal/regression/Symbols.c
+++ b/Pal/regression/Symbols.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #include "pal.h"
 #include "pal_debug.h"
 

--- a/Pal/regression/Thread.c
+++ b/Pal/regression/Thread.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* This Hello World demostrate a simple multithread program */
 #include "pal.h"
 #include "pal_debug.h"

--- a/Pal/src/db_events.c
+++ b/Pal/src/db_events.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/db_exception.c
+++ b/Pal/src/db_exception.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/db_ipc.c
+++ b/Pal/src/db_ipc.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/db_main.c
+++ b/Pal/src/db_main.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/db_memory.c
+++ b/Pal/src/db_memory.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/db_misc.c
+++ b/Pal/src/db_misc.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/db_mutex.c
+++ b/Pal/src/db_mutex.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/db_object.c
+++ b/Pal/src/db_object.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/db_process.c
+++ b/Pal/src/db_process.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/db_rtld.c
+++ b/Pal/src/db_rtld.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/db_streams.c
+++ b/Pal/src/db_streams.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/db_threading.c
+++ b/Pal/src/db_threading.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/dl-machine-x86_64.h
+++ b/Pal/src/dl-machine-x86_64.h
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/do-rel.h
+++ b/Pal/src/do-rel.h
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/dynamic_link.h
+++ b/Pal/src/dynamic_link.h
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/host/FreeBSD/db_devices.c
+++ b/Pal/src/host/FreeBSD/db_devices.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/host/FreeBSD/db_events.c
+++ b/Pal/src/host/FreeBSD/db_events.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/host/FreeBSD/db_exception.c
+++ b/Pal/src/host/FreeBSD/db_exception.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/host/FreeBSD/db_exception2.c
+++ b/Pal/src/host/FreeBSD/db_exception2.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/host/FreeBSD/db_files.c
+++ b/Pal/src/host/FreeBSD/db_files.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/host/FreeBSD/db_ipc.c
+++ b/Pal/src/host/FreeBSD/db_ipc.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/host/FreeBSD/db_main.c
+++ b/Pal/src/host/FreeBSD/db_main.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/host/FreeBSD/db_memory.c
+++ b/Pal/src/host/FreeBSD/db_memory.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/host/FreeBSD/db_misc.c
+++ b/Pal/src/host/FreeBSD/db_misc.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/host/FreeBSD/db_mutex.c
+++ b/Pal/src/host/FreeBSD/db_mutex.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/host/FreeBSD/db_object.c
+++ b/Pal/src/host/FreeBSD/db_object.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/host/FreeBSD/db_pipes.c
+++ b/Pal/src/host/FreeBSD/db_pipes.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/host/FreeBSD/db_process.c
+++ b/Pal/src/host/FreeBSD/db_process.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/host/FreeBSD/db_rtld.c
+++ b/Pal/src/host/FreeBSD/db_rtld.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/host/FreeBSD/db_sockets.c
+++ b/Pal/src/host/FreeBSD/db_sockets.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/host/FreeBSD/db_streams.c
+++ b/Pal/src/host/FreeBSD/db_streams.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/host/FreeBSD/db_threading.c
+++ b/Pal/src/host/FreeBSD/db_threading.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/host/FreeBSD/elf-x86_64.h
+++ b/Pal/src/host/FreeBSD/elf-x86_64.h
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/host/FreeBSD/pal_freebsd.h
+++ b/Pal/src/host/FreeBSD/pal_freebsd.h
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/host/FreeBSD/pal_freebsd_defs.h
+++ b/Pal/src/host/FreeBSD/pal_freebsd_defs.h
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #ifndef PAL_FREEBSD_DEFS_H
 #define PAL_FREEBSD_DEFS_H
 

--- a/Pal/src/host/FreeBSD/pal_host.h
+++ b/Pal/src/host/FreeBSD/pal_host.h
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/host/FreeBSD/pal_security.h
+++ b/Pal/src/host/FreeBSD/pal_security.h
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/host/FreeBSD/sysdep-x86_64.h
+++ b/Pal/src/host/FreeBSD/sysdep-x86_64.h
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/host/Linux-SGX/db_devices.c
+++ b/Pal/src/host/Linux-SGX/db_devices.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/host/Linux-SGX/db_events.c
+++ b/Pal/src/host/Linux-SGX/db_events.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/host/Linux-SGX/db_exception.c
+++ b/Pal/src/host/Linux-SGX/db_exception.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/host/Linux-SGX/db_files.c
+++ b/Pal/src/host/Linux-SGX/db_files.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/host/Linux-SGX/db_ipc.c
+++ b/Pal/src/host/Linux-SGX/db_ipc.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/host/Linux-SGX/db_main.c
+++ b/Pal/src/host/Linux-SGX/db_main.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/host/Linux-SGX/db_memory.c
+++ b/Pal/src/host/Linux-SGX/db_memory.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/host/Linux-SGX/db_misc.c
+++ b/Pal/src/host/Linux-SGX/db_misc.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/host/Linux-SGX/db_mutex.c
+++ b/Pal/src/host/Linux-SGX/db_mutex.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/host/Linux-SGX/db_object.c
+++ b/Pal/src/host/Linux-SGX/db_object.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/host/Linux-SGX/db_pipes.c
+++ b/Pal/src/host/Linux-SGX/db_pipes.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/host/Linux-SGX/db_process.c
+++ b/Pal/src/host/Linux-SGX/db_process.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/host/Linux-SGX/db_rtld.c
+++ b/Pal/src/host/Linux-SGX/db_rtld.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/host/Linux-SGX/db_sockets.c
+++ b/Pal/src/host/Linux-SGX/db_sockets.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/host/Linux-SGX/db_spinlock.c
+++ b/Pal/src/host/Linux-SGX/db_spinlock.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/host/Linux-SGX/db_streams.c
+++ b/Pal/src/host/Linux-SGX/db_streams.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/host/Linux-SGX/db_threading.c
+++ b/Pal/src/host/Linux-SGX/db_threading.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/host/Linux-SGX/ecall_types.h
+++ b/Pal/src/host/Linux-SGX/ecall_types.h
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 enum {
     ECALL_ENCLAVE_START = 0,
     ECALL_THREAD_START,

--- a/Pal/src/host/Linux-SGX/elf-x86_64.h
+++ b/Pal/src/host/Linux-SGX/elf-x86_64.h
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/host/Linux-SGX/enclave_ecalls.c
+++ b/Pal/src/host/Linux-SGX/enclave_ecalls.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #include "pal_linux.h"
 #include "pal_security.h"
 #include "pal_internal.h"

--- a/Pal/src/host/Linux-SGX/enclave_framework.c
+++ b/Pal/src/host/Linux-SGX/enclave_framework.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #include <pal_linux.h>
 #include <pal_linux_error.h>
 #include <pal_internal.h>

--- a/Pal/src/host/Linux-SGX/enclave_ocalls.c
+++ b/Pal/src/host/Linux-SGX/enclave_ocalls.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /*
  * This is for enclave to make ocalls to untrusted runtime.
  */

--- a/Pal/src/host/Linux-SGX/enclave_ocalls.h
+++ b/Pal/src/host/Linux-SGX/enclave_ocalls.h
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /*
  * This is for enclave to make ocalls to untrusted runtime.
  */

--- a/Pal/src/host/Linux-SGX/enclave_pages.c
+++ b/Pal/src/host/Linux-SGX/enclave_pages.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #include <pal_linux.h>
 #include <pal_internal.h>
 #include <pal_security.h>

--- a/Pal/src/host/Linux-SGX/enclave_pages.h
+++ b/Pal/src/host/Linux-SGX/enclave_pages.h
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 extern void * heap_base;
 void init_pages (void);
 void * get_reserved_pages (void * addr, size_t size);

--- a/Pal/src/host/Linux-SGX/enclave_untrusted.c
+++ b/Pal/src/host/Linux-SGX/enclave_untrusted.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/host/Linux-SGX/linux_types.h
+++ b/Pal/src/host/Linux-SGX/linux_types.h
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #ifndef __LINUX_TYPES_H__
 #define __LINUX_TYPES_H__
 

--- a/Pal/src/host/Linux-SGX/ocall_types.h
+++ b/Pal/src/host/Linux-SGX/ocall_types.h
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /*
  * This is for enclave to make ocalls to untrusted runtime.
  */

--- a/Pal/src/host/Linux-SGX/pal_host.h
+++ b/Pal/src/host/Linux-SGX/pal_host.h
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/host/Linux-SGX/pal_linux.h
+++ b/Pal/src/host/Linux-SGX/pal_linux.h
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/host/Linux-SGX/pal_linux_defs.h
+++ b/Pal/src/host/Linux-SGX/pal_linux_defs.h
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #ifndef PAL_LINUX_DEFS_H
 #define PAL_LINUX_DEFS_H
 

--- a/Pal/src/host/Linux-SGX/pal_security.h
+++ b/Pal/src/host/Linux-SGX/pal_security.h
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/host/Linux-SGX/sgx_api.h
+++ b/Pal/src/host/Linux-SGX/sgx_api.h
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/host/Linux-SGX/sgx_arch.h
+++ b/Pal/src/host/Linux-SGX/sgx_arch.h
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/host/Linux-SGX/sgx_enclave.c
+++ b/Pal/src/host/Linux-SGX/sgx_enclave.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #include "ocall_types.h"
 #include "ecall_types.h"
 #include "sgx_internal.h"

--- a/Pal/src/host/Linux-SGX/sgx_enclave.h
+++ b/Pal/src/host/Linux-SGX/sgx_enclave.h
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #include "pal_linux.h"
 #include "pal_security.h"
 

--- a/Pal/src/host/Linux-SGX/sgx_exception.c
+++ b/Pal/src/host/Linux-SGX/sgx_exception.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/host/Linux-SGX/sgx_framework.c
+++ b/Pal/src/host/Linux-SGX/sgx_framework.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #include <pal_linux.h>
 #include <pal_rtld.h>
 #include "sgx_internal.h"

--- a/Pal/src/host/Linux-SGX/sgx_graphene.c
+++ b/Pal/src/host/Linux-SGX/sgx_graphene.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/host/Linux-SGX/sgx_internal.h
+++ b/Pal/src/host/Linux-SGX/sgx_internal.h
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/host/Linux-SGX/sgx_main.c
+++ b/Pal/src/host/Linux-SGX/sgx_main.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #include <pal_linux.h>
 #include <pal_rtld.h>
 #include "sgx_internal.h"

--- a/Pal/src/host/Linux-SGX/sgx_process.c
+++ b/Pal/src/host/Linux-SGX/sgx_process.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/host/Linux-SGX/sgx_rtld.c
+++ b/Pal/src/host/Linux-SGX/sgx_rtld.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/host/Linux-SGX/sgx_thread.c
+++ b/Pal/src/host/Linux-SGX/sgx_thread.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #include "pal_internal.h"
 #include "sgx_internal.h"
 #include "pal_security.h"

--- a/Pal/src/host/Linux-SGX/sgx_tls.h
+++ b/Pal/src/host/Linux-SGX/sgx_tls.h
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #ifndef __SGX_TLS_H__
 #define __SGX_TLS_H__
 

--- a/Pal/src/host/Linux-SGX/sysdep-x86_64.h
+++ b/Pal/src/host/Linux-SGX/sysdep-x86_64.h
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/host/Linux/db_devices.c
+++ b/Pal/src/host/Linux/db_devices.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil;
- * mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
 
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.

--- a/Pal/src/host/Linux/db_events.c
+++ b/Pal/src/host/Linux/db_events.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/host/Linux/db_exception.c
+++ b/Pal/src/host/Linux/db_exception.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/host/Linux/db_files.c
+++ b/Pal/src/host/Linux/db_files.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/host/Linux/db_ipc.c
+++ b/Pal/src/host/Linux/db_ipc.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/host/Linux/db_main.c
+++ b/Pal/src/host/Linux/db_main.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/host/Linux/db_memory.c
+++ b/Pal/src/host/Linux/db_memory.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/host/Linux/db_misc.c
+++ b/Pal/src/host/Linux/db_misc.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/host/Linux/db_mutex.c
+++ b/Pal/src/host/Linux/db_mutex.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/host/Linux/db_object.c
+++ b/Pal/src/host/Linux/db_object.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/host/Linux/db_pipes.c
+++ b/Pal/src/host/Linux/db_pipes.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/host/Linux/db_process.c
+++ b/Pal/src/host/Linux/db_process.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/host/Linux/db_rtld.c
+++ b/Pal/src/host/Linux/db_rtld.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/host/Linux/db_sockets.c
+++ b/Pal/src/host/Linux/db_sockets.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/host/Linux/db_streams.c
+++ b/Pal/src/host/Linux/db_streams.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/host/Linux/db_threading.c
+++ b/Pal/src/host/Linux/db_threading.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/host/Linux/elf-x86_64.h
+++ b/Pal/src/host/Linux/elf-x86_64.h
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/host/Linux/pal_host.h
+++ b/Pal/src/host/Linux/pal_host.h
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/host/Linux/pal_linux.h
+++ b/Pal/src/host/Linux/pal_linux.h
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/host/Linux/pal_linux_defs.h
+++ b/Pal/src/host/Linux/pal_linux_defs.h
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #ifndef PAL_LINUX_DEFS_H
 #define PAL_LINUX_DEFS_H
 

--- a/Pal/src/host/Linux/pal_security.h
+++ b/Pal/src/host/Linux/pal_security.h
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/host/Linux/sysdep-x86_64.h
+++ b/Pal/src/host/Linux/sysdep-x86_64.h
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/host/Skeleton/db_devices.c
+++ b/Pal/src/host/Skeleton/db_devices.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/host/Skeleton/db_events.c
+++ b/Pal/src/host/Skeleton/db_events.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/host/Skeleton/db_exception.c
+++ b/Pal/src/host/Skeleton/db_exception.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/host/Skeleton/db_files.c
+++ b/Pal/src/host/Skeleton/db_files.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/host/Skeleton/db_ipc.c
+++ b/Pal/src/host/Skeleton/db_ipc.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/host/Skeleton/db_main.c
+++ b/Pal/src/host/Skeleton/db_main.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/host/Skeleton/db_memory.c
+++ b/Pal/src/host/Skeleton/db_memory.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/host/Skeleton/db_misc.c
+++ b/Pal/src/host/Skeleton/db_misc.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/host/Skeleton/db_object.c
+++ b/Pal/src/host/Skeleton/db_object.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/host/Skeleton/db_pipes.c
+++ b/Pal/src/host/Skeleton/db_pipes.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/host/Skeleton/db_process.c
+++ b/Pal/src/host/Skeleton/db_process.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/host/Skeleton/db_rtld.c
+++ b/Pal/src/host/Skeleton/db_rtld.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/host/Skeleton/db_semaphore.c
+++ b/Pal/src/host/Skeleton/db_semaphore.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/host/Skeleton/db_sockets.c
+++ b/Pal/src/host/Skeleton/db_sockets.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/host/Skeleton/db_streams.c
+++ b/Pal/src/host/Skeleton/db_streams.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/host/Skeleton/db_threading.c
+++ b/Pal/src/host/Skeleton/db_threading.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/host/Skeleton/pal_host.h
+++ b/Pal/src/host/Skeleton/pal_host.h
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/pal.h
+++ b/Pal/src/pal.h
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/pal_debug.h
+++ b/Pal/src/pal_debug.h
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/pal_defs.h
+++ b/Pal/src/pal_defs.h
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #ifndef PAL_DEFS_H
 #define PAL_DEFS_H
 

--- a/Pal/src/pal_error.h
+++ b/Pal/src/pal_error.h
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/pal_internal.h
+++ b/Pal/src/pal_internal.h
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/pal_rtld.h
+++ b/Pal/src/pal_rtld.h
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/printf.c
+++ b/Pal/src/printf.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/src/security/Linux/filter.c
+++ b/Pal/src/security/Linux/filter.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 typedef __builtin_va_list __gnuc_va_list;
 
 #include "pal_linux_defs.h"

--- a/Pal/src/security/Linux/internal.h
+++ b/Pal/src/security/Linux/internal.h
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #ifndef __INTERNAL_H__
 #define __INTERNAL_H__
 

--- a/Pal/src/security/Linux/main.c
+++ b/Pal/src/security/Linux/main.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #define _GNU_SOURCE 1
 #ifndef __GNUC__
 #define __GNUC__ 1

--- a/Pal/src/security/Linux/manifest.c
+++ b/Pal/src/security/Linux/manifest.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #define _GNU_SOURCE 1
 #ifndef __GNUC__
 #define __GNUC__ 1

--- a/Pal/src/slab.c
+++ b/Pal/src/slab.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* Copyright (C) 2014 Stony Brook University
    This file is part of Graphene Library OS.
 

--- a/Pal/test/Broadcast.c
+++ b/Pal/test/Broadcast.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* This Hello World demostrate a simple multithread program */
 
 #define DO_BENCH    1

--- a/Pal/test/Cpuid.c
+++ b/Pal/test/Cpuid.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* This Hello World simply print out "Hello World" */
 
 #include "pal.h"

--- a/Pal/test/Event.c
+++ b/Pal/test/Event.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* This Hello World demostrate a simple multithread program */
 
 #include "pal.h"

--- a/Pal/test/Exception.c
+++ b/Pal/test/Exception.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* This Hello World simply print out "Hello World" */
 
 #include "pal.h"

--- a/Pal/test/Failure.c
+++ b/Pal/test/Failure.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* This Hello World simply print out "Hello World" */
 
 #include "pal.h"

--- a/Pal/test/File.c
+++ b/Pal/test/File.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* This Hello World simply print out "Hello World" */
 
 #include "pal.h"

--- a/Pal/test/Fork.c
+++ b/Pal/test/Fork.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* This Hello World simply print out "Hello World" */
 
 #include "pal.h"

--- a/Pal/test/HandleSend.c
+++ b/Pal/test/HandleSend.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* This Hello World demostrate a simple multithread program */
 
 #include "pal.h"

--- a/Pal/test/HelloWorld.c
+++ b/Pal/test/HelloWorld.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* This Hello World simply print out "Hello World" */
 
 #include "pal.h"

--- a/Pal/test/Ipc.c
+++ b/Pal/test/Ipc.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #include "pal.h"
 #include "pal_debug.h"
 #include "api.h"

--- a/Pal/test/Memory.c
+++ b/Pal/test/Memory.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* This Hello World simply print out "Hello World" */
 
 #include "pal.h"

--- a/Pal/test/Pie.c
+++ b/Pal/test/Pie.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* This Hello World simply print out "Hello World" */
 
 #include "pal.h"

--- a/Pal/test/Pipe.c
+++ b/Pal/test/Pipe.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #include "pal.h"
 #include "pal_debug.h"
 #include "api.h"

--- a/Pal/test/Process.c
+++ b/Pal/test/Process.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* This Hello World demostrate a simple multithread program */
 
 #define DO_BENCH    0

--- a/Pal/test/Segment.c
+++ b/Pal/test/Segment.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* This Hello World simply print out "Hello World" */
 
 #include "pal.h"

--- a/Pal/test/Select.c
+++ b/Pal/test/Select.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* This Hello World demostrate a simple multithread program */
 #include "pal.h"
 #include "pal_debug.h"

--- a/Pal/test/Server.c
+++ b/Pal/test/Server.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* The server test program that accept multiple TCP connection at the same
  * time. A port number is taken as argument. If a port is locked up, try
  * another one.

--- a/Pal/test/Sleep.c
+++ b/Pal/test/Sleep.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* This Hello World simply print out "Hello World" */
 
 #include "pal.h"

--- a/Pal/test/Tcp.c
+++ b/Pal/test/Tcp.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #include "pal.h"
 #include "pal_debug.h"
 #include "api.h"

--- a/Pal/test/Thread.c
+++ b/Pal/test/Thread.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* This Hello World demostrate a simple multithread program */
 #include "pal.h"
 #include "pal_debug.h"

--- a/Pal/test/Udp.c
+++ b/Pal/test/Udp.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #include "pal.h"
 #include "pal_debug.h"
 #include "api.h"

--- a/Pal/test/Wait.c
+++ b/Pal/test/Wait.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 /* This Hello World demostrate a simple multithread program */
 
 #include "pal.h"

--- a/Pal/test/Yield.c
+++ b/Pal/test/Yield.c
@@ -1,6 +1,3 @@
-/* -*- mode:c; c-file-style:"k&r"; c-basic-offset: 4; tab-width:4; indent-tabs-mode:nil; mode:auto-fill; fill-column:78; -*- */
-/* vim: set ts=4 sw=4 et tw=78 fo=cqt wm=0: */
-
 #include "pal.h"
 #include "pal_debug.h"
 


### PR DESCRIPTION
<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [x] Linux PAL
- [x] SGX PAL
- [x] FreeBSD PAL
- [x] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->

Fix #304.

This is a resubmission of #324 because the original PR is too stale (since last November).

This PR is to officially retire the Vim modelines and per-file Emac configuration.
For Emacs, we have added [.dir-local.al](.dir-local.al) file. For Vim, we have added a [HACKING.md](HACKING.md) with instruction for how to configure the `vimrc` according to our formatting guidelines. 

## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/743)
<!-- Reviewable:end -->
