### PR TITLE
[LibOS/regression] Add OpenMP simple for-loop test

### DIFF
--- a/Jenkinsfiles/ubuntu-16.04.dockerfile
+++ b/Jenkinsfiles/ubuntu-16.04.dockerfile
@@ -20,6 +20,7 @@ RUN apt-get update \
        python3-minimal \
        texinfo \
        wget \
+       libomp-dev \
 
 # Add the user UID:1001, GID:1001, home at /leeroy
     && groupadd -r leeroy -g 1001 \

--- a/LibOS/shim/test/regression/00_openmp.py
+++ b/LibOS/shim/test/regression/00_openmp.py
@@ -1,0 +1,20 @@
+import os, sys, mmap
+from regression import Regression
+
+loader = sys.argv[1]
+sgx = os.environ.get('SGX_RUN') == '1'
+
+# This test is only meaningful on SGX PAL because only SGX catches raw syscalls
+# and redirects to Graphene's LibOS. If we will add seccomp to Linux PAL, then
+# we should allow this test on Linux PAL as well.
+if not sgx:
+    sys.exit(0)
+
+# Running OpenMP
+regression = Regression(loader, "openmp")
+
+regression.add_check(name="OpenMP simple for loop",
+    check=lambda res: "first: 0, last: 9" in res[0].out)
+
+rv = regression.run_checks()
+if rv: sys.exit(rv)

--- a/LibOS/shim/test/regression/Makefile
+++ b/LibOS/shim/test/regression/Makefile
@@ -1,4 +1,4 @@
-special_executables = bootstrap_static bootstrap_pie shared_object
+special_executables = bootstrap_static bootstrap_pie shared_object openmp
 c_executables = $(filter-out $(special_executables),$(patsubst %.c,%,$(wildcard *.c)))
 cxx_executables = $(patsubst %.cpp,%,$(wildcard *.cpp))
 manifests = $(patsubst %.manifest.template,%.manifest,$(wildcard *.manifest.template)) manifest
@@ -43,6 +43,11 @@ shared_object: %: %.c
 	$(shell echo $@ | sed 's/^[^\.]*//g' | sed 's/\./ -l/g')
 
 syscall: CFLAGS += -I$(PALDIR)/../include -I$(PALDIR)/host/$(PAL_HOST)
+
+openmp: %: %.c
+	@echo [ $@ ]
+	@$(CC) $(CFLAGS) -o $@ -fopenmp $< \
+	$(shell echo $@ | sed 's/^[^\.]*//g' | sed 's/\./ -l/g')
 
 else
 .IGNORE: $(special_executables) $(c_executables) $(cxx_executables)

--- a/LibOS/shim/test/regression/openmp.c
+++ b/LibOS/shim/test/regression/openmp.c
@@ -1,0 +1,15 @@
+/* build with: gcc -fopenmp openmp-test.c -o openmp-test */
+#include <stdio.h>
+#include <stdlib.h>
+#include <omp.h>
+
+int v[10];
+
+int main(void) {
+#pragma omp parallel for
+    for (int i=0; i<10; i++)
+        v[i] = i;
+
+    printf("first: %d, last: %d\n", v[0], v[9]);
+    return 0;
+}

--- a/LibOS/shim/test/regression/openmp.manifest.template
+++ b/LibOS/shim/test/regression/openmp.manifest.template
@@ -1,0 +1,24 @@
+loader.preload = file:../../src/libsysdb.so
+loader.env.LD_LIBRARY_PATH = /lib:/usrlib
+loader.debug_type = none
+loader.syscall_symbol = syscalldb
+
+fs.mount.lib.type = chroot
+fs.mount.lib.path = /lib
+fs.mount.lib.uri = file:../../../../Runtime
+
+fs.mount.bin.type = chroot
+fs.mount.bin.path = /bin
+fs.mount.bin.uri = file:/bin
+
+fs.mount.usrlib.type = chroot
+fs.mount.usrlib.path = /usrlib
+fs.mount.usrlib.uri = file:/usr/lib/x86_64-linux-gnu
+
+sgx.thread_num = 32
+
+sgx.trusted_files.ld = file:../../../../Runtime/ld-linux-x86-64.so.2
+sgx.trusted_files.libc = file:../../../../Runtime/libc.so.6
+sgx.trusted_files.libpthread = file:../../../../Runtime/libpthread.so.0
+sgx.trusted_files.libdl = file:../../../../Runtime/libdl.so.2
+sgx.trusted_files.libgomp = file:/usr/lib/x86_64-linux-gnu/libgomp.so.1


### PR DESCRIPTION
## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->

Previously, OpenMP apps failed to run under Graphene-SGX because it did
not support raw system calls (used inside of OpenMP lib, in particular
the futex() syscall). Since recently, Graphene-SGX has support for raw
syscall execution. This commit adds a test showing that OpenMP works.

Fixes #567.

## How to test this PR? <!-- (if applicable) -->

This PR adds LibOS regression test `openmp`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/749)
<!-- Reviewable:end -->
