### PR TITLE
[Pal] add noreturn to _DkThreadExit/pal_main/start_execution

### DIFF
--- a/Pal/src/db_main.c
+++ b/Pal/src/db_main.c
@@ -26,6 +26,7 @@
 #include "pal_internal.h"
 #include "pal_debug.h"
 #include "pal_error.h"
+#include "pal_rtld.h"
 #include "api.h"
 
 #include <sysdeps/generic/ldsodefs.h>
@@ -216,11 +217,8 @@ static int loader_filter (const char * key, int len)
             key[4] == 'e' && key[5] == 'r' && key[6] == '.') ? 0 : 1;
 }
 
-void start_execution (const char * first_argument, const char ** arguments,
-                      const char ** environments);
-
 /* 'pal_main' must be called by the host-specific bootloader */
-void pal_main (
+noreturn void pal_main (
         PAL_NUM    instance_id,      /* current instance id */
         PAL_HANDLE manifest_handle,  /* manifest handle if opened */
         PAL_HANDLE exec_handle,      /* executable handle if opened */

--- a/Pal/src/db_rtld.c
+++ b/Pal/src/db_rtld.c
@@ -1299,8 +1299,8 @@ void * stack_before_call __attribute_unused = NULL;
 #endif
 #endif /* !CALL_ENTRY */
 
-void start_execution (const char * first_argument, const char ** arguments,
-                      const char ** environs)
+noreturn void start_execution (const char * first_argument,
+                               const char ** arguments, const char ** environs)
 {
     /* First we will try to run all the preloaded libraries which come with
        entry points */

--- a/Pal/src/host/FreeBSD/db_threading.c
+++ b/Pal/src/host/FreeBSD/db_threading.c
@@ -113,7 +113,7 @@ void _DkThreadYieldExecution (void)
 }
 
 /* _DkThreadExit for internal use: Thread exiting */
-void _DkThreadExit (void)
+noreturn void _DkThreadExit (void)
 {
     INLINE_SYSCALL(exit, 1, 0);
 }

--- a/Pal/src/host/Linux-SGX/db_threading.c
+++ b/Pal/src/host/Linux-SGX/db_threading.c
@@ -138,7 +138,7 @@ void _DkThreadYieldExecution (void)
 }
 
 /* _DkThreadExit for internal use: Thread exiting */
-void _DkThreadExit (void)
+noreturn void _DkThreadExit (void)
 {
     ocall_exit(0);
 }

--- a/Pal/src/host/Linux-SGX/enclave_ocalls.c
+++ b/Pal/src/host/Linux-SGX/enclave_ocalls.c
@@ -11,7 +11,7 @@
 #include <api.h>
 #include <asm/errno.h>
 
-int ocall_exit(int exitcode)
+noreturn void ocall_exit(int exitcode)
 {
     int64_t code = exitcode;
     // There are two reasons for this loop:
@@ -21,7 +21,6 @@ int ocall_exit(int exitcode)
     while (true) {
         sgx_ocall(OCALL_EXIT, (void *) code);
     }
-    return 0;
 }
 
 int ocall_print_string (const char * str, unsigned int length)

--- a/Pal/src/host/Linux-SGX/enclave_ocalls.h
+++ b/Pal/src/host/Linux-SGX/enclave_ocalls.h
@@ -8,7 +8,7 @@
 #include <linux/socket.h>
 #include <linux/poll.h>
 
-int ocall_exit (int exitcode);
+noreturn void ocall_exit (int exitcode);
 
 int ocall_print_string (const char * str, unsigned int length);
 

--- a/Pal/src/host/Linux/db_main.c
+++ b/Pal/src/host/Linux/db_main.c
@@ -306,7 +306,6 @@ done_init:
         printf("Executable not found\n");
         printf("USAGE: %s [executable|manifest] args ...\n", pal_name);
         _DkProcessExit(0);
-        return;
     }
 
     signal_setup();

--- a/Pal/src/host/Linux/db_threading.c
+++ b/Pal/src/host/Linux/db_threading.c
@@ -167,7 +167,7 @@ void _DkThreadYieldExecution (void)
 }
 
 /* _DkThreadExit for internal use: Thread exiting */
-void _DkThreadExit (void)
+noreturn void _DkThreadExit (void)
 {
     PAL_TCB* tcb = get_tcb();
     PAL_HANDLE handle = tcb->handle;
@@ -191,6 +191,9 @@ void _DkThreadExit (void)
     }
 
     INLINE_SYSCALL(exit, 1, 0);
+    while (true) {
+        /* nothing */
+    }
 }
 
 int _DkThreadResume (PAL_HANDLE threadHandle)

--- a/Pal/src/host/Linux/pal_linux.h
+++ b/Pal/src/host/Linux/pal_linux.h
@@ -192,6 +192,7 @@ typedef struct pal_tcb {
     void *            param;
 } PAL_TCB;
 
+noreturn void pal_linux_main (void * args);
 int pal_thread_init (void * tcbptr);
 
 static inline PAL_TCB * get_tcb (void)

--- a/Pal/src/host/Skeleton/db_threading.c
+++ b/Pal/src/host/Skeleton/db_threading.c
@@ -49,9 +49,12 @@ void _DkThreadYieldExecution (void)
 }
 
 /* _DkThreadExit for internal use: Thread exiting */
-void _DkThreadExit (void)
+noreturn void _DkThreadExit (void)
 {
     /* need to be implemented */
+    while (true) {
+        /* nothing */
+    }
 }
 
 int _DkThreadResume (PAL_HANDLE threadHandle)

--- a/Pal/src/pal_internal.h
+++ b/Pal/src/pal_internal.h
@@ -249,7 +249,7 @@ extern PAL_CONTROL __pal_control;
             (((unsigned long)(addr)) & pal_state.alloc_mask))
 
 /* Main initialization function */
-void pal_main (
+noreturn void pal_main (
         PAL_NUM    instance_id,      /* current instance id */
         PAL_HANDLE manifest_handle,  /* manifest handle if opened */
         PAL_HANDLE exec_handle,      /* executable handle if opened */
@@ -296,7 +296,7 @@ PAL_HANDLE _DkBroadcastStreamOpen (void);
 /* DkProcess and DkThread calls */
 int _DkThreadCreate (PAL_HANDLE * handle, int (*callback) (void *),
                      const void * param);
-void _DkThreadExit (void);
+noreturn void _DkThreadExit (void);
 int _DkThreadDelayExecution (unsigned long * duration);
 void _DkThreadYieldExecution (void);
 int _DkThreadResume (PAL_HANDLE threadHandle);

--- a/Pal/src/pal_rtld.h
+++ b/Pal/src/pal_rtld.h
@@ -180,5 +180,7 @@ do_lookup_map (ElfW(Sym) * ref, const char * undef_name,
 void _DkDebugAddMap (struct link_map * map);
 void _DkDebugDelMap (struct link_map * map);
 
+noreturn void start_execution (const char * first_argument,
+                               const char ** arguments, const char ** environs);
 
 #endif /* PAL_RTLD_H */


### PR DESCRIPTION
This patch add noreturn to _DkThreadExit/pal_main/start_execution
and minor code adjustment for it.

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [x] Linux PAL
- [x] SGX PAL
- [x] FreeBSD PAL
- [x] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->


## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/757)
<!-- Reviewable:end -->
