### PR TITLE
[Makefile] introduce Makefile.configs for configuration

### DIFF
--- a/LibOS/shim/src/Makefile
+++ b/LibOS/shim/src/Makefile
@@ -1,11 +1,7 @@
 RUNTIME_DIR = $(CURDIR)/../../../Runtime
 
+include ../../../Makefile.configs
 include ../../../Pal/src/Makefile.Host
-
-CC	= gcc
-AS	= gcc
-AR	= ar rcs
-LD	= ld
 
 OMIT_FRAME_POINTER = no
 

--- a/Makefile.configs
+++ b/Makefile.configs
@@ -1,0 +1,12 @@
+ifeq ($(origin CC),default)
+CC	= gcc
+endif
+ifeq ($(origin AS),default)
+AS	= gcc
+endif
+ifeq ($(origin AR),default)
+AR	= ar rcs
+endif
+ifeq ($(origin LD),default)
+LD	= ld
+endif

--- a/Pal/lib/Makefile
+++ b/Pal/lib/Makefile
@@ -1,7 +1,5 @@
+include ../../Makefile.configs
 include ../src/Makefile.Host
-
-CC	= gcc
-AR	= ar rcs
 
 CFLAGS	= -Wall -fPIC -O2 -std=gnu99 -fgnu89-inline -U_FORTIFY_SOURCE \
 	  $(call cc-option,-Wnull-dereference) \

--- a/Pal/src/Makefile
+++ b/Pal/src/Makefile
@@ -1,6 +1,7 @@
 export PAL_DIR = $(CURDIR)
 export RUNTIME_DIR = $(CURDIR)/../../Runtime
 
+include ../../Makefile.configs
 include ../../Makefile.rules
 include Makefile.Host
 

--- a/Pal/src/host/FreeBSD/Makefile
+++ b/Pal/src/host/FreeBSD/Makefile
@@ -1,3 +1,4 @@
+include ../../../../Makefile.configs
 include Makefile.am
 
 CFLAGS	+= -I. -Iinclude -I../.. -I../../../include -I../../../lib -I../../../ipc/linux \

--- a/Pal/src/host/FreeBSD/Makefile.am
+++ b/Pal/src/host/FreeBSD/Makefile.am
@@ -1,11 +1,6 @@
 # Add host-specific compilation rules here
 HOST_DIR = host/$(PAL_HOST)
 
-CC	= gcc
-AS	= gcc
-AR	= ar rcs
-LD	= ld
-
 CFLAGS	= -Wall -fPIC -O2 -std=gnu99 -fgnu89-inline -U_FORTIFY_SOURCE \
 	  -fno-omit-frame-pointer \
 	  -fno-stack-protector -fno-builtin

--- a/Pal/src/host/Linux-SGX/Makefile
+++ b/Pal/src/host/Linux-SGX/Makefile
@@ -1,3 +1,4 @@
+include ../../../../Makefile.configs
 include Makefile.am
 
 CFLAGS	+= -I. -Iinclude -I../.. -I../../../include -I../../../lib -Isgx-driver

--- a/Pal/src/host/Linux-SGX/Makefile.am
+++ b/Pal/src/host/Linux-SGX/Makefile.am
@@ -1,11 +1,6 @@
 # Add host-specific compilation rules here
 HOST_DIR = host/$(PAL_HOST)
 
-CC	= gcc
-AS	= gcc
-AR	= ar rcs
-LD	= ld
-
 CFLAGS	= -Wall -fPIC -O2 -maes -std=c11 -U_FORTIFY_SOURCE \
 	  -fno-omit-frame-pointer \
 	  -fno-stack-protector -fno-builtin -DIN_ENCLAVE

--- a/Pal/src/host/Linux/Makefile
+++ b/Pal/src/host/Linux/Makefile
@@ -1,3 +1,4 @@
+include ../../../../Makefile.configs
 include Makefile.am
 
 CFLAGS	+= -I. -Iinclude -I../.. -I../../../include -I../../../lib \

--- a/Pal/src/host/Linux/Makefile.am
+++ b/Pal/src/host/Linux/Makefile.am
@@ -2,11 +2,6 @@
 HOST_DIR = host/$(PAL_HOST)
 SEC_DIR = security/$(PAL_HOST)
 
-CC	= gcc
-AS	= gcc
-AR	= ar rcs
-LD	= ld
-
 CFLAGS	= -Wall -fPIC -O2 -std=c11 -U_FORTIFY_SOURCE \
 	  -fno-stack-protector -fno-builtin
 

--- a/Pal/src/host/Skeleton/Makefile
+++ b/Pal/src/host/Skeleton/Makefile
@@ -1,3 +1,4 @@
+include ../../../../Makefile.configs
 include Makefile.am
 
 CFLAGS  += -I. -I../.. -I../../../include -I../../../lib

--- a/Pal/src/host/Skeleton/Makefile.am
+++ b/Pal/src/host/Skeleton/Makefile.am
@@ -1,9 +1,5 @@
 # Add host-specific compilation rules here
 
-CC	= gcc
-AS	= gcc
-AR	= ar rcs
-
 CFLAGS  = -Wall -fPIC -O2 -std=gnu99 -fgnu89-inline -Wall -U_FORTIFY_SOURCE -fno-builtin
 ASFLAGS = -DPIC -DSHARED -fPIC -DASSEMBLER -Wa,--noexecstack -x assembler-with-cpp
 ARFLAGS =

--- a/Pal/src/security/Linux/Makefile
+++ b/Pal/src/security/Linux/Makefile
@@ -1,5 +1,4 @@
-CC	= gcc
-LD	= ld
+include ../../../../Makefile.configs
 
 CFLAGS	= -Wall -fPIC -O2 -std=c11 -Wall -U_FORTIFY_SOURCE \
 	  -fno-stack-protector -fno-builtin \


### PR DESCRIPTION
introduce Makefile.configs as single place to allow override
config variables CC, AS, AR and LD.

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [x] Linux PAL
- [x] SGX PAL
- [x] FreeBSD PAL
- [x] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->


## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/758)
<!-- Reviewable:end -->
