### PR TITLE
[LibOS] remove warning cast-function-type with gcc-8

### DIFF
--- a/LibOS/shim/include/shim_checkpoint.h
+++ b/LibOS/shim/include/shim_checkpoint.h
@@ -32,12 +32,11 @@
 #include <stdarg.h>
 
 #ifdef __i386__
-typedef uint32_t ptr_t;
-# define hashfunc hash32
-#else
+# error "x86-32 support is heavily broken."
+#endif
+
 typedef uint64_t ptr_t;
 # define hashfunc hash64
-#endif
 
 #define __attribute_migratable __attribute__((section(".migratable")))
 

--- a/LibOS/shim/src/bookkeep/shim_signal.c
+++ b/LibOS/shim/src/bookkeep/shim_signal.c
@@ -613,16 +613,15 @@ __handle_one_signal (shim_tcb_t * tcb, int sig, struct shim_signal * signal)
 
     if (sighdl->action) {
         struct __kernel_sigaction * act = sighdl->action;
-        /* This is a workaround. The truth is that many program will
-           use sa_handler as sa_sigaction, because sa_sigaction is
-           not supported in amd64 */
+        /*
+         * on amd64, sa_handler can be treated as sa_sigaction
+         * because 1-3 arguments are passed by register and
+         * sa_handler simply ignores 2nd and 3rd argument.
+         */
 #ifdef __i386__
-        handler = (void (*) (int, siginfo_t *, void *)) act->_u._sa_handler;
-        if (act->sa_flags & SA_SIGINFO)
-            sa_handler = act->_u._sa_sigaction;
-#else
-        handler = (void (*) (int, siginfo_t *, void *)) act->k_sa_handler;
+# error "x86-32 support is heavily broken."
 #endif
+        handler = (void *)act->k_sa_handler;
         if (act->sa_flags & SA_RESETHAND) {
             sighdl->action = NULL;
             free(act);


### PR DESCRIPTION
gcc-8 complains
> bookkeep/shim_signal.c: In function __handle_one_signal:
> bookkeep/shim_signal.c:622:19: error: cast between incompatible function types from __sighandler_t {aka void (*)(int)} to void (*)(int  siginfo_t *, void *) {aka void (*)(int,  struct siginfo *, void *)} [-Werror=cast-function-type]
>          handler = (void (*) (int, siginfo_t *, void *)) act->k_sa_handler;

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->


## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/762)
<!-- Reviewable:end -->
