### PR TITLE
Preserve the history of the apps submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/oscarlab/graphene-sgx-driver.git
 [submodule "LibOS/shim/test/apps"]
 	path = LibOS/shim/test/apps
-	url = https://github.com/oscarlab/graphene-tests.git
+	url = https://github.com/oscarlab/graphene-apps.git


### PR DESCRIPTION
<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->

I created a new repository [graphene-apps](https://github.com/oscarlab/graphene-apps) with the cherry-picked history from the original `LibOS/shim/test/apps` repository. `graphene-apps` is also IMO a more accurate naming than `graphene-tests`.


## How to test this PR? <!-- (if applicable) -->

The head of `graphene-apps` is the same as the original `graphene-test` repository, so all regression tests should just work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/763)
<!-- Reviewable:end -->
