### PR TITLE
Fix integer overflow checks

### DIFF
--- a/LibOS/shim/src/sys/shim_brk.c
+++ b/LibOS/shim/src/sys/shim_brk.c
@@ -95,8 +95,8 @@ int init_brk_region (void * brk_region)
                 int ret = DkRandomBitsRead(&rand, sizeof(rand));
                 if (ret < 0)
                     return -convert_pal_errno(-ret);
-                rand %= MIN((uint32_t) 0x2000000,
-                            (uint32_t) (PAL_CB(user_address.end) - brk_region - brk_max_size));
+                rand %= MIN((size_t)0x2000000,
+                            (size_t)(PAL_CB(user_address.end) - brk_region - brk_max_size));
                 rand = ALIGN_DOWN(rand);
 
                 if (brk_region + rand + brk_max_size >= PAL_CB(user_address.end))


### PR DESCRIPTION
<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [X] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->
This PR fixes a few broken integer overflow checks which were introduced in #741. There were basically two problems: signed overflows inside the checks (which are UB) and using `a + b < 0` to check for an overflow (which misses a lot of cases).
Both can be solved using gcc builtins (and this is probably the only way to implement those checks correctly).

Quoting https://gcc.gnu.org/onlinedocs/gcc/Integer-Overflow-Builtins.html#Integer-Overflow-Builtins:
> These built-in functions promote the first two operands into infinite precision signed type and perform addition on those promoted operands. The result is then cast to the type the third pointer argument points to and stored there. If the stored result is equal to the infinite precision result, the built-in functions return false, otherwise they return true. As the addition is performed in infinite signed precision, these built-in functions have fully defined behavior for all argument values.
>
> The first built-in function allows arbitrary integral types for operands and the result type must be pointer to some integral type other than enumerated or boolean type, the rest of the built-in functions have explicit integer types.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/764)
<!-- Reviewable:end -->
