### PR TITLE
[Pal/Linux-SGX] correct variable type of proc_args

### DIFF
--- a/Pal/src/host/Linux-SGX/sgx_process.c
+++ b/Pal/src/host/Linux-SGX/sgx_process.c
@@ -39,11 +39,11 @@
 
 struct proc_args {
     PAL_SEC_STR     exec_name;
-    unsigned int    instance_id;
-    unsigned int    parent_process_id;
-    unsigned int    proc_fds[3];
+    PAL_NUM         instance_id;
+    PAL_IDX         parent_process_id;
+    int             proc_fds[3];
     PAL_SEC_STR     pipe_prefix;
-    unsigned int    mcast_port;
+    PAL_IDX         mcast_port;
 };
 
 int sgx_create_process (const char * uri, int nargs, const char ** args,


### PR DESCRIPTION
struct proc_args should have correct type instead of unsigned int.

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [x] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->


## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/766)
<!-- Reviewable:end -->
