### PR TITLE
[Pal/{Linux, Linux-SGX}] block async signal during vfork

### DIFF
--- a/Pal/src/host/Linux-SGX/sgx_internal.h
+++ b/Pal/src/host/Linux-SGX/sgx_internal.h
@@ -132,5 +132,7 @@ void sgx_edbgwr (void * addr, uint64_t data);
 
 int sgx_init_child_process (struct pal_sec * pal_sec);
 int sgx_signal_setup (void);
+int block_signals (bool block, const int * sigs, int nsig);
+int block_async_signals (bool block);
 
 #endif

--- a/Pal/src/host/Linux-SGX/sgx_process.c
+++ b/Pal/src/host/Linux-SGX/sgx_process.c
@@ -105,11 +105,27 @@ int sgx_create_process (const char * uri, int nargs, const char ** args,
     memcpy(argv + 1, args, sizeof(const char *) * nargs);
     argv[nargs + 1] = NULL;
 
+    /* Child's signal handler may mess with parent's memory during vfork(),
+     * so block signals
+     */
+    ret = block_async_signals(true);
+    if (ret < 0) {
+        ret = -ret;
+        goto out;
+    }
+
     ret = vfork_exec(proc_fds[0][0], proc_fds[1], argv);
     if (IS_ERR(ret))
         goto out;
 
     child = ret;
+
+    /* children unblock async signals by sgx_signal_setup() */
+    ret = block_async_signals(false);
+    if (ret < 0) {
+        ret = -ret;
+        goto out;
+    }
 
     for (int i = 0 ; i < 3 ; i++)
         INLINE_SYSCALL(close, 1, proc_fds[0][i]);

--- a/Pal/src/host/Linux/db_process.c
+++ b/Pal/src/host/Linux/db_process.c
@@ -299,6 +299,13 @@ int _DkProcessCreate (PAL_HANDLE * handle, const char * uri, const char ** args)
     proc_args->process_create_time = before_create;
 #endif
 
+    /* Child's signal handler may mess with parent's memory during vfork(),
+     * so block signals
+     */
+    ret = block_async_signals(true);
+    if (ret < 0)
+        goto out;
+
     ret = child_process(&param);
     if (IS_ERR(ret)) {
         ret = -PAL_ERROR_DENIED;
@@ -307,6 +314,11 @@ int _DkProcessCreate (PAL_HANDLE * handle, const char * uri, const char ** args)
 
     proc_args->pal_sec.process_id = ret;
     child_handle->process.pid = ret;
+
+    /* children unblock async signals by signal_setup() */
+    ret = block_async_signals(false);
+    if (ret < 0)
+        goto out;
 
     /* step 4: send parameters over the process handle */
 

--- a/Pal/src/host/Linux/pal_linux.h
+++ b/Pal/src/host/Linux/pal_linux.h
@@ -163,6 +163,8 @@ void init_child_process (PAL_HANDLE * parent, PAL_HANDLE * exec,
 
 void cpuid (unsigned int leaf, unsigned int subleaf,
             unsigned int words[]);
+int block_signals (bool block, const int * sigs, int nsig);
+int block_async_signals (bool block);
 void signal_setup (void);
 
 unsigned long _DkSystemTimeQueryEarly (void);


### PR DESCRIPTION
<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [x] Linux PAL
- [x] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->
To avoid vfork child from corrupting parent memory, block async signal
before vfork().

This PR depends on #768 


## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/770)
<!-- Reviewable:end -->
