### PR TITLE
[LibOS] make rs_running_thread initialize __libc_tcb_t.shim_tcb

### DIFF
--- a/LibOS/shim/include/shim_tls.h
+++ b/LibOS/shim/include/shim_tls.h
@@ -78,15 +78,25 @@ struct shim_tcb {
 
 #ifdef IN_SHIM
 
-typedef struct
+/*
+ * This struct must match the one defined in glibc/nptl/sysdeps/x86_64/tls.h
+ * The first 10 members(from tcb to __unused1) are used by Glibc-internal,
+ * they are NOT used by Graphene.
+ * But Graphene needs to preserve the correct offset of shim_tcb so we have to
+ * duplicate these 10 fields from the original Glibc struct.
+ */
+struct __libc_tcb_t;
+typedef struct __libc_tcb_t __libc_tcb_t;
+struct __libc_tcb_t
 {
-    void *                  tcb, * dtv, * self;
+    __libc_tcb_t *          tcb;
+    void *                  dtv, * self;
     int                     mthreads, gscope;
     uintptr_t               sysinfo, sg, pg;
     unsigned long int       vgetcpu_cache[2];
     int                     __unused1;
     shim_tcb_t              shim_tcb;
-} __libc_tcb_t;
+};
 
 #include <stddef.h>
 

--- a/LibOS/shim/include/shim_tls.h
+++ b/LibOS/shim/include/shim_tls.h
@@ -1,11 +1,7 @@
 #ifndef _SHIM_TLS_H_
 #define _SHIM_TLS_H_
 
-#ifdef __ASSEMBLER__
-
-#define SHIM_TLS_CANARY $xdeadbeef
-
-#else /* !__ASSEMBLER__ */
+#ifndef __ASSEMBLER__
 
 #define SHIM_TLS_CANARY 0xdeadbeef
 

--- a/LibOS/shim/src/bookkeep/shim_thread.c
+++ b/LibOS/shim/src/bookkeep/shim_thread.c
@@ -776,7 +776,7 @@ BEGIN_RS_FUNC(running_thread)
              * user_tcb = false
              * in_vm = false
              */
-            init_tcb(shim_libc_tcb()->tcb);
+            init_tcb(&shim_libc_tcb()->shim_tcb);
             set_cur_thread(thread);
         }
 


### PR DESCRIPTION
rs_running_thread wrongly initialize __libc_tcb_t as shim_tcb.
Correctly initialize __libc_tcb_t.shim_tcb.

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->


## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/771)
<!-- Reviewable:end -->
