### PR TITLE
[Pal] Append ELF binaries to tail of loaded_maps

### DIFF
--- a/Pal/src/db_rtld.c
+++ b/Pal/src/db_rtld.c
@@ -554,12 +554,21 @@ int add_elf_object(void * addr, PAL_HANDLE handle, int type)
     setup_elf_hash(map);
     ELF_DYNAMIC_RELOCATE(map);
 
-    struct link_map * prev = loaded_maps;
-    while (prev->l_next)
-        prev = prev->l_next;
-    map->l_prev = prev;
+    /* append to list (to preserve order of libs specified in
+     * manifest, e.g., loader.preload)
+     */
     map->l_next = NULL;
-    prev->l_next = map;
+    if (!loaded_maps) {
+        map->l_prev = NULL;
+        loaded_maps = map;
+    } else {
+        struct link_map * end = loaded_maps;
+        while (end->l_next)
+            end = end->l_next;
+        end->l_next = map;
+        map->l_prev = end;
+    }
+
     if (type == OBJECT_EXEC)
         exec_map = map;
 
@@ -888,11 +897,21 @@ int load_elf_object_by_handle (PAL_HANDLE handle, enum object_type type)
 done:
 #endif
 
-    if (loaded_maps)
-        loaded_maps->l_prev = map;
-    map->l_next = loaded_maps;
-    map->l_prev = NULL;
-    loaded_maps = map;
+    /* append to list (to preserve order of libs specified in
+     * manifest, e.g., loader.preload)
+     */
+    map->l_next = NULL;
+    if (!loaded_maps) {
+        map->l_prev = NULL;
+        loaded_maps = map;
+    } else {
+        struct link_map * end = loaded_maps;
+        while (end->l_next)
+            end = end->l_next;
+        end->l_next = map;
+        map->l_prev = end;
+    }
+
     if (map->l_type == OBJECT_EXEC)
         exec_map = map;
 
@@ -1359,10 +1378,7 @@ noreturn void start_execution (const char * first_argument,
             pal_state.tail_startup_time += _DkSystemTimeQuery() - before_tail;
 #endif
 
-    struct link_map * l = loaded_maps;
-    /* run entry point in reverse order */
-    for (; l->l_next ; l = l->l_next);
-    for (; l ; l = l->l_prev)
+    for (struct link_map * l = loaded_maps; l ; l = l->l_next)
         if (l->l_type == OBJECT_PRELOAD && l->l_entry)
             CALL_ENTRY(l, cookies);
 


### PR DESCRIPTION
Prior code pushed to the head, but code referencing it iterated in-order, so we add to tail to preserve order. Affects order of `loader.preload` libraries.

Signed-off-by: Alex Merritt <mail@alexmerritt.us>

<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [x] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->

ELF binaries loaded by Pal are placed into the `loaded_maps` list. Current code pushes new libraries as `link_map` structures to head of list. When one requires in-order traversal of the objects (e.g., coming from `loader.preload` key in the manifest file), one must iterate from the end of the list to maintain order.

This patch pushes new libraries to the tail of `loaded_maps` to preserve the order as specified in `loader.preload` from the manifest file.

## How to test this PR? <!-- (if applicable) -->

Execute all existing tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/778)
<!-- Reviewable:end -->
