### PR TITLE
[LibOS] remove unused struct debugbuf

### DIFF
--- a/LibOS/shim/src/utils/printf.c
+++ b/LibOS/shim/src/utils/printf.c
@@ -26,11 +26,6 @@
 
 PAL_HANDLE debug_handle = NULL;
 
-struct debugbuf {
-    int cnt;
-    char buf[DEBUGBUF_SIZE];
-};
-
 static inline int
 debug_fputs (void * f, const char * buf, int len)
 {


### PR DESCRIPTION
Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->


## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/779)
<!-- Reviewable:end -->
