### PR TITLE
[Pal, LibOS] fix vprintf signature

### DIFF
--- a/LibOS/shim/include/shim_internal.h
+++ b/LibOS/shim/include/shim_internal.h
@@ -71,7 +71,7 @@ extern PAL_HANDLE debug_handle;
 void debug_printf (const char * fmt, ...) __attribute__((format (printf, 1, 2)));
 void debug_puts (const char * str);
 void debug_putch (int ch);
-void debug_vprintf (const char * fmt, va_list * ap) __attribute__((format (printf, 1, 0)));
+void debug_vprintf (const char * fmt, va_list ap) __attribute__((format (printf, 1, 0)));
 
 #define VMID_PREFIX     "[P%05u] "
 #define TID_PREFIX      "[%-6u] "
@@ -86,7 +86,7 @@ void debug_vprintf (const char * fmt, va_list * ap) __attribute__((format (print
 #define SYSPRINT_BUFFER_SIZE    256
 
 void handle_printf (PAL_HANDLE hdl, const char * fmt, ...) __attribute__((format (printf, 2, 3)));
-void handle_vprintf (PAL_HANDLE hdl, const char * fmt, va_list * ap) __attribute__((format (printf, 2, 0)));
+void handle_vprintf (PAL_HANDLE hdl, const char * fmt, va_list ap) __attribute__((format (printf, 2, 0)));
 
 #define __SYS_PRINTF(fmt, ...)                                              \
     do {                                                                    \

--- a/LibOS/shim/src/fs/proc/thread.c
+++ b/LibOS/shim/src/fs/proc/thread.c
@@ -534,7 +534,7 @@ retry_dump_vmas:
         };
         char pr = (vma->flags & MAP_PRIVATE) ? 'p' : 's';
 
-#define ADDR_FMT(addr) ((addr) > 0xffffffff ? "%lx" : "%08x")
+#define ADDR_FMT(addr) ((addr) > 0xffffffff ? "%lx" : "%08lx")
 #define EMIT(fmt ...)                                                   \
         do {                                                            \
             offset += snprintf(buffer + offset, buffer_size - offset,   \
@@ -553,7 +553,7 @@ retry_emit_vma:
             EMIT(ADDR_FMT(start), start);
             EMIT("-");
             EMIT(ADDR_FMT(end),   end);
-            EMIT(" %c%c%c%c %08lx %02d:%02d %u %s\n", pt[0], pt[1], pt[2], pr,
+            EMIT(" %c%c%c%c %08lx %02d:%02d %lu %s\n", pt[0], pt[1], pt[2], pr,
                  vma->offset, dev_major, dev_minor, ino, name);
         } else {
             EMIT(ADDR_FMT(start), start);

--- a/LibOS/shim/src/shim_checkpoint.c
+++ b/LibOS/shim/src/shim_checkpoint.c
@@ -1047,7 +1047,7 @@ int do_migrate_process (int (*migrate) (struct shim_cp_store *,
 
     if (cpstore.use_gipc) {
         snprintf(hdr.checkpoint.gipc.uri, sizeof(hdr.checkpoint.gipc.uri),
-                 "gipc:%lld", gipc_key);
+                 "gipc:%ld", gipc_key);
 
         if (cpstore.gipc_nentries) {
             hdr.checkpoint.gipc.entoffset =

--- a/LibOS/shim/src/shim_init.c
+++ b/LibOS/shim/src/shim_init.c
@@ -65,7 +65,7 @@ void warn (const char *format, ...)
 {
     va_list args;
     va_start (args, format);
-    __SYS_VPRINTF(format, &args);
+    __SYS_VPRINTF(format, args);
     va_end (args);
 }
 

--- a/LibOS/shim/src/utils/printf.c
+++ b/LibOS/shim/src/utils/printf.c
@@ -105,7 +105,7 @@ void debug_putch (int ch)
     debug_fputch(NULL, ch, shim_get_tls()->debug_buf);
 }
 
-void debug_vprintf (const char * fmt, va_list * ap)
+void debug_vprintf (const char * fmt, va_list ap)
 {
     vfprintfmt((void *) debug_fputch, NULL, shim_get_tls()->debug_buf,
                fmt, ap);
@@ -115,7 +115,7 @@ void debug_printf (const char * fmt, ...)
 {
     va_list ap;
     va_start(ap, fmt);
-    debug_vprintf(fmt, &ap);
+    debug_vprintf(fmt, ap);
     va_end(ap);
 }
 
@@ -169,7 +169,7 @@ sys_fputch (void * f, int ch, void * b)
 }
 
 static void
-sys_vfprintf (PAL_HANDLE hdl, const char * fmt, va_list * ap)
+sys_vfprintf (PAL_HANDLE hdl, const char * fmt, va_list ap)
 {
     vfprintfmt((void *) &sys_fputch, hdl, NULL, fmt, ap);
 }
@@ -178,11 +178,11 @@ void handle_printf (PAL_HANDLE hdl, const char * fmt, ...)
 {
     va_list ap;
     va_start(ap, fmt);
-    sys_vfprintf(hdl, fmt, &ap);
+    sys_vfprintf(hdl, fmt, ap);
     va_end(ap);
 }
 
-void handle_vprintf (PAL_HANDLE hdl, const char * fmt, va_list * ap)
+void handle_vprintf (PAL_HANDLE hdl, const char * fmt, va_list ap)
 {
     sys_vfprintf(hdl, fmt, ap);
 }

--- a/Pal/lib/api.h
+++ b/Pal/lib/api.h
@@ -145,12 +145,12 @@ void *calloc(size_t nmemb, size_t size);
 
 /* Libc printf functions. stdio.h/stdarg.h. */
 void fprintfmt (int (*_fputch)(void *, int, void *), void * f, void * putdat,
-                const char * fmt, ...);
+                const char * fmt, ...) __attribute__((format(printf, 4, 5)));
 
 void vfprintfmt (int (*_fputch)(void *, int, void *), void * f, void * putdat,
-                 const char * fmt, va_list *ap);
+                 const char * fmt, va_list ap) __attribute__((format(printf, 4, 0)));
 
-int snprintf (char * buf, int n, const char * fmt, ...);
+int snprintf (char * buf, int n, const char * fmt, ...) __attribute__((format(printf, 3, 4)));
 
 /* Miscelleneous */
 

--- a/Pal/lib/assert.h
+++ b/Pal/lib/assert.h
@@ -18,7 +18,7 @@
  * terminates the process.
  */
 
-void warn (const char *format, ...);
+void warn (const char *format, ...) __attribute__((format(printf, 1, 2)));
 noreturn void __abort(void);
 
 # define assert(test)                                                   \
@@ -26,8 +26,8 @@ noreturn void __abort(void);
         long _val = (long)(test);                                       \
         (!(_val))                                                       \
             ? ({                                                        \
-                    warn("assert failed " __FILE__ ":%d " #test " (value:%x)\n", \
-                         __LINE__, _val);                               \
+                    warn("assert failed " __FILE__ ":%d %s (value:%lx)\n", \
+                         __LINE__, #test, _val);                        \
                     __abort(); })                                       \
             : (void)0;                                                  \
     })

--- a/Pal/lib/stdlib/printfmt.c
+++ b/Pal/lib/stdlib/printfmt.c
@@ -43,42 +43,42 @@ printnum(int (*_fputch)(void *, int, void *), void * f, void * putdat,
 // depending on the lflag parameter.
 #if !defined(__i386__)
 inline unsigned long long
-getuint(va_list *ap, int lflag)
+getuint(va_list ap, int lflag)
 #else
 inline unsigned long
-getuint(va_list *ap, int lflag)
+getuint(va_list ap, int lflag)
 #endif
 {
 #if !defined(__i386__)
 	if (lflag >= 2)
-		return va_arg(*ap, unsigned long long);
+		return va_arg(ap, unsigned long long);
 	else
 #endif
 	if (lflag)
-		return va_arg(*ap, unsigned long);
+		return va_arg(ap, unsigned long);
 	else
-		return va_arg(*ap, unsigned int);
+		return va_arg(ap, unsigned int);
 }
 
 // Same as getuint but signed - can't use getuint
 // because of sign extension
 #if !defined(__i386__)
 inline long long
-getint(va_list *ap, int lflag)
+getint(va_list ap, int lflag)
 #else
 inline long
-getint(va_list *ap, int lflag)
+getint(va_list ap, int lflag)
 #endif
 {
 #if !defined(__i386__)
 	if (lflag >= 2)
-		return va_arg(*ap, long long);
+		return va_arg(ap, long long);
 	else
 #endif
 	if (lflag)
-		return va_arg(*ap, long);
+		return va_arg(ap, long);
 	else
-		return va_arg(*ap, int);
+		return va_arg(ap, int);
 }
 
 // Main function to format and print a string.
@@ -87,7 +87,7 @@ void fprintfmt(int (*_fputch)(void *, int, void *), void * f, void * putdat,
 
 void
 vfprintfmt(int (*_fputch)(void *, int, void *), void * f, void * putdat,
-			  const char * fmt, va_list *ap)
+			  const char * fmt, va_list ap)
 {
 	register const char *p;
 	register int ch;
@@ -145,7 +145,7 @@ vfprintfmt(int (*_fputch)(void *, int, void *), void * f, void * putdat,
 			goto process_precision;
 
 		case '*':
-			precision = va_arg(*ap, int);
+			precision = va_arg(ap, int);
 			goto process_precision;
 
 		case '.':
@@ -169,13 +169,13 @@ vfprintfmt(int (*_fputch)(void *, int, void *), void * f, void * putdat,
 
 		// character
 		case 'c':
-			if ((*_fputch) (f, va_arg(*ap, int), putdat) == -1)
+			if ((*_fputch) (f, va_arg(ap, int), putdat) == -1)
 				return;
 			break;
 
 		// string
 		case 's':
-			if ((p = va_arg(*ap, char *)) == NULL)
+			if ((p = va_arg(ap, char *)) == NULL)
 				p = "(null)";
 			if (width > 0 && padc != '-')
 				for (width -= strnlen(p, precision); width > 0; width--)
@@ -235,10 +235,10 @@ vfprintfmt(int (*_fputch)(void *, int, void *), void * f, void * putdat,
 				return;
 #if !defined(__i386__)
 			num = (unsigned long long)
-				(uintptr_t) va_arg(*ap, void *);
+				(uintptr_t) va_arg(ap, void *);
 #else
 			num = (unsigned long)
-				(uintptr_t) va_arg(*ap, void *);
+				(uintptr_t) va_arg(ap, void *);
 #endif
 			base = 16;
 			goto number;
@@ -280,7 +280,7 @@ fprintfmt(int (*_fputch)(void *, int, void *), void * f, void * putdat,
 	va_list ap;
 
 	va_start(ap, fmt);
-	vfprintfmt(_fputch, f, putdat, fmt, &ap);
+	vfprintfmt(_fputch, f, putdat, fmt, ap);
 	va_end(ap);
 }
 
@@ -302,7 +302,7 @@ sprintputch(void * f, int ch, struct sprintbuf * b)
 }
 
 static int
-vsprintf(char * buf, int n, const char * fmt, va_list *ap)
+vsprintf(char * buf, int n, const char * fmt, va_list ap)
 {
 	struct sprintbuf b = { 0, n, buf };
 
@@ -326,7 +326,7 @@ snprintf(char * buf, int n, const char * fmt, ...)
 	int rc;
 
 	va_start(ap, fmt);
-	rc = vsprintf(buf, n, fmt, &ap);
+	rc = vsprintf(buf, n, fmt, ap);
 	va_end(ap);
 
 	return rc;

--- a/Pal/regression/Ipc.c
+++ b/Pal/regression/Ipc.c
@@ -200,7 +200,7 @@ int main (int argc, char ** argv, char ** envp)
         PAL_HANDLE ipc1 = DkCreatePhysicalMemoryChannel(&key1);
 
         if (ipc1) {
-            snprintf(gipc_uri, 20, "gipc:%lld", key1);
+            snprintf(gipc_uri, 20, "gipc:%ld", key1);
             pal_printf("Create Physical Memory Store OK\n");
 
             void * mem1 =
@@ -237,7 +237,7 @@ int main (int argc, char ** argv, char ** envp)
         PAL_HANDLE ipc2 = DkCreatePhysicalMemoryChannel(&key2);
 
         if (ipc2) {
-            snprintf(gipc_uri, 20, "gipc:%lld", key2);
+            snprintf(gipc_uri, 20, "gipc:%ld", key2);
             pal_printf("Create Physical Memory Store OK\n");
 
             void * mem2 =
@@ -272,7 +272,7 @@ int main (int argc, char ** argv, char ** envp)
         PAL_HANDLE ipc3 = DkCreatePhysicalMemoryChannel(&key3);
 
         if (ipc3) {
-            snprintf(gipc_uri, 20, "gipc:%lld", key3);
+            snprintf(gipc_uri, 20, "gipc:%ld", key3);
             pal_printf("Create Physical Memory Store OK\n");
 
             void * mem3 = NULL;
@@ -310,7 +310,7 @@ int main (int argc, char ** argv, char ** envp)
         PAL_HANDLE ipc4 = DkCreatePhysicalMemoryChannel(&key4);
 
         if (ipc4) {
-            snprintf(gipc_uri, 20, "gipc:%lld", key4);
+            snprintf(gipc_uri, 20, "gipc:%ld", key4);
             pal_printf("Create Physical Memory Store OK\n");
 
             void * mem4 = NULL;
@@ -344,7 +344,7 @@ int main (int argc, char ** argv, char ** envp)
         PAL_HANDLE ipc5 = DkCreatePhysicalMemoryChannel(&key5);
 
         if (ipc5) {
-            snprintf(gipc_uri, 20, "gipc:%lld", key5);
+            snprintf(gipc_uri, 20, "gipc:%ld", key5);
             pal_printf("Create Physical Memory Store OK\n");
 
             void * mem5 =

--- a/Pal/src/db_exception.c
+++ b/Pal/src/db_exception.c
@@ -93,7 +93,7 @@ void warn (const char *format, ...)
 {
     va_list args;
     va_start (args, format);
-    vprintf(format, &args);
+    vprintf(format, args);
     va_end (args);
 }
 

--- a/Pal/src/host/Linux-SGX/db_rtld.c
+++ b/Pal/src/host/Linux-SGX/db_rtld.c
@@ -111,7 +111,7 @@ void _DkDebugAddMap (struct link_map * map)
     char buffer[BUFFER_LENGTH], * ptr = buffer;
 
     snprintf(ptr, BUFFER_LENGTH - (ptr - buffer),
-             "add-symbol-file %s 0x%016llx -readnow", map->l_name, text_addr);
+             "add-symbol-file %s 0x%016lx -readnow", map->l_name, text_addr);
     ptr += strlen(ptr);
 
     for (ElfW(Shdr) * s = shdr ; s < shdrend ; s++) {
@@ -125,7 +125,7 @@ void _DkDebugAddMap (struct link_map * map)
             continue;
 
         snprintf(ptr, BUFFER_LENGTH - (ptr - buffer),
-                 " -s %s 0x%016llx", shstrtab + s->sh_name,
+                 " -s %s 0x%016lx", shstrtab + s->sh_name,
                  map->l_addr + s->sh_addr);
         ptr += strlen(ptr);
     }
@@ -158,8 +158,8 @@ void setup_pal_map (struct link_map * pal_map)
 
     char buffer[BUFFER_LENGTH];
     snprintf(buffer, BUFFER_LENGTH,
-             "add-symbol-file %s 0x%016llx -readnow -s .rodata 0x%016llx "
-             "-s .dynamic 0x%016llx -s .data 0x%016llx -s .bss 0x%016llx",
+             "add-symbol-file %s 0x%p -readnow -s .rodata 0x%p "
+             "-s .dynamic 0x%p -s .data 0x%p -s .bss 0x%p",
              pal_map->l_name,
              &section_text, &section_rodata, &section_dynamic,
              &section_data, &section_bss);

--- a/Pal/src/host/Linux-SGX/sgx_graphene.c
+++ b/Pal/src/host/Linux-SGX/sgx_graphene.c
@@ -103,7 +103,7 @@ fputch(void * f, int ch, struct printbuf * b)
 }
 
 static int
-vprintf(const char * fmt, va_list *ap)
+vprintf(const char * fmt, va_list ap)
 {
     struct printbuf b;
 
@@ -122,7 +122,7 @@ pal_printf(const char * fmt, ...)
     int cnt;
 
     va_start(ap, fmt);
-    cnt = vprintf(fmt, &ap);
+    cnt = vprintf(fmt, ap);
     va_end(ap);
 
     return cnt;

--- a/Pal/src/host/Linux-SGX/sgx_internal.h
+++ b/Pal/src/host/Linux-SGX/sgx_internal.h
@@ -36,8 +36,8 @@
 #define ERRNO INTERNAL_SYSCALL_ERRNO
 #define ERRNO_P INTERNAL_SYSCALL_ERRNO_P
 
-int printf(const char * fmt, ...);
-int snprintf(char * str, int size, const char * fmt, ...);
+int printf(const char * fmt, ...) __attribute__((format(printf, 1, 2)));
+int snprintf(char * str, int size, const char * fmt, ...) __attribute__((format(printf, 3, 4)));
 
 /* constants and macros to help rounding addresses to page
    boundaries */

--- a/Pal/src/pal_internal.h
+++ b/Pal/src/pal_internal.h
@@ -405,7 +405,7 @@ void free (void * mem);
 void _DkPrintConsole (const void * buf, int size);
 int printf  (const char  *fmt, ...) __attribute__((format (printf, 1, 2)));
 #include <stdarg.h>
-int vprintf(const char * fmt, va_list *ap) __attribute__((format (printf, 1, 0)));
+int vprintf(const char * fmt, va_list ap) __attribute__((format (printf, 1, 0)));
 void write_log (int nstrs, ...);
 
 static inline void log_stream (const char * uri)

--- a/Pal/src/printf.c
+++ b/Pal/src/printf.c
@@ -48,7 +48,7 @@ fputch(void * f, int ch, struct printbuf * b)
 }
 
 int
-vprintf(const char * fmt, va_list *ap)
+vprintf(const char * fmt, va_list ap)
 {
     struct printbuf b;
 
@@ -67,7 +67,7 @@ printf(const char * fmt, ...)
     int cnt;
 
     va_start(ap, fmt);
-    cnt = vprintf(fmt, &ap);
+    cnt = vprintf(fmt, ap);
     va_end(ap);
 
     return cnt;

--- a/Pal/src/security/Linux/internal.h
+++ b/Pal/src/security/Linux/internal.h
@@ -23,7 +23,7 @@
 #define ERRNO INTERNAL_SYSCALL_ERRNO
 #define ERRNO_P INTERNAL_SYSCALL_ERRNO_P
 
-int printf (const char * fmt, ...);
+int printf (const char * fmt, ...) __attribute__ ((format(printf, 1, 2)));
 void * malloc (size_t size);
 void free (void * mem);
 

--- a/Pal/src/security/Linux/printf.c
+++ b/Pal/src/security/Linux/printf.c
@@ -43,7 +43,7 @@ fputch(int fd, int ch, struct printbuf *b)
 }
 
 static int
-vprintf(const char *fmt, va_list *ap)
+vprintf(const char *fmt, va_list ap)
 {
 	struct printbuf b;
 
@@ -62,7 +62,7 @@ printf(const char *fmt, ...)
 	int cnt;
 
 	va_start(ap, fmt);
-	cnt = vprintf(fmt, &ap);
+	cnt = vprintf(fmt, ap);
 	va_end(ap);
 
 	return cnt;

--- a/Pal/test/Ipc.c
+++ b/Pal/test/Ipc.c
@@ -30,7 +30,7 @@ int main(int argc, char ** argv)
             return 0;
         }
 
-        snprintf(uri, 20, "gipc:%lld", key);
+        snprintf(uri, 20, "gipc:%ld", key);
 
         PAL_HANDLE phdl = DkProcessCreate("file:Ipc", args);
 

--- a/Pal/test/Pipe.c
+++ b/Pal/test/Pipe.c
@@ -16,7 +16,7 @@ int main (int argc, char ** argv)
     }
     pipeid = pipeid % 1024;
 
-    snprintf(uri, 40, "pipe.srv:%d", pipeid);
+    snprintf(uri, 40, "pipe.srv:%ld", pipeid);
 
     PAL_HANDLE srv = DkStreamOpen(uri, 0, 0,
                                   PAL_CREATE_TRY|PAL_CREATE_ALWAYS, 0);
@@ -26,7 +26,7 @@ int main (int argc, char ** argv)
         return -1;
     }
 
-    snprintf(uri, 40, "pipe:%d", pipeid);
+    snprintf(uri, 40, "pipe:%ld", pipeid);
 
     PAL_HANDLE cli = DkStreamOpen(uri, PAL_ACCESS_RDWR, 0,
                                   PAL_CREATE_TRY|PAL_CREATE_ALWAYS, 0);


### PR DESCRIPTION
Normally vprintf takes va_list, not va_list *.
Adjust its signature and add function attribute.

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [x] Linux PAL
- [x] SGX PAL
- [ ] FreeBSD PAL
- [x] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->


## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/780)
<!-- Reviewable:end -->
