### PR TITLE
[LibOS] Fix handle leak in epoll_ctl (issue #765)

### DIFF
--- a/LibOS/shim/src/sys/shim_epoll.c
+++ b/LibOS/shim/src/sys/shim_epoll.c
@@ -256,10 +256,12 @@ int shim_do_epoll_ctl (int epfd, int op, int fd,
                     lock(&hdl->lock);
                     LISTP_DEL(epoll_fd, &hdl->epolls, back);
                     unlock(&hdl->lock);
-                    put_handle(epoll_hdl);
 
                     debug("delete handle %p from epoll handle %p\n",
                           hdl, epoll);
+
+                    put_handle(epoll_hdl);
+                    put_handle(hdl);
 
                     LISTP_DEL(epoll_fd, &epoll->fds, list);
                     epoll->nfds--;


### PR DESCRIPTION
<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [X] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->
- Fixes #765 
- Added a `put_handle(hdl)` line in the `shim_do_epoll_ctl`  function (in the 'delete' section of the case statement to ensure proper bookkeeping of handle usage)
- Moved line `put_handle(epoll_hdl)` for better code readability 

## How to test this PR? <!-- (if applicable) -->
I tested it on my (non-open-source app), can be checked by code review, would need an elaborate event based communication app to test (currently not covered by regression tests).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/797)
<!-- Reviewable:end -->
