### PR TITLE
[PAL/Linux] Clean up -Wsign-compare flags

### DIFF
--- a/Pal/src/host/Linux/Makefile
+++ b/Pal/src/host/Linux/Makefile
@@ -24,7 +24,7 @@ all: $(host_files)
 
 ifeq ($(DEBUG),1)
 CC += -gdwarf-2 -g3
-CFLAGS += -DDEBUG -Wsign-compare
+CFLAGS += -DDEBUG
 export DEBUG
 endif
 

--- a/Pal/src/host/Linux/Makefile.am
+++ b/Pal/src/host/Linux/Makefile.am
@@ -5,7 +5,7 @@ SEC_DIR = security/$(PAL_HOST)
 CFLAGS	= -Wall -fPIC -O2 -std=c11 -U_FORTIFY_SOURCE \
 	  -fno-stack-protector -fno-builtin
 
-EXTRAFLAGS = -Wextra -Wno-sign-compare $(call cc-option,-Wnull-dereference)
+EXTRAFLAGS = -Wextra $(call cc-option,-Wnull-dereference)
 
 CFLAGS += $(EXTRAFLAGS)
 


### PR DESCRIPTION
<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [X] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->
Just a cleanup, nothing really changes (the flag was removed and then re-added in the Makefiles before this PR).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/800)
<!-- Reviewable:end -->
