### PR TITLE
[LibOS] Support C++ programs in SHIM test directories

### DIFF
--- a/LibOS/shim/test/Makefile
+++ b/LibOS/shim/test/Makefile
@@ -17,6 +17,8 @@ CC = gcc
 CXX = g++
 CFLAGS 	= -Wall -std=gnu99
 CFLAGS-debug = $(CFLAGS) -I$(SHIMDIR)/../include -I$(PALDIR)/../include/pal -I$(PALDIR)/../lib
+CXXFLAGS = -Wall -std=c++14
+CXXFLAGS-debug = $(CXXFLAGS) -I$(SHIMDIR)/../include -I$(PALDIR)/../include/pal -I$(PALDIR)/../lib
 LDFLAGS	=
 LDFLAGS-debug = $(LDFLAGS) -L$(SHIMDIR) -L$(PALDIR) -Wl,-rpath-link=$(abspath $(RUNTIME))
 

--- a/LibOS/shim/test/native/Makefile
+++ b/LibOS/shim/test/native/Makefile
@@ -17,7 +17,7 @@ $(c_executables): %: %.c
 
 $(cxx_executables): %: %.cpp
 	@echo [ $@ ]
-	@$(CC) $(CFLAGS) $(if $(findstring .libos,$@),$(CFLAGS-libos),) -o $@ $< \
+	@$(CXX) $(CXXFLAGS) $(if $(findstring .libos,$@),$(CFLAGS-libos),) -o $@ $< \
 	$(shell echo $@ | sed 's/^[^\.]*//g' | sed 's/\./ -l/g')
 
 static: %: %.c

--- a/LibOS/shim/test/regression/00_bootstrap.py
+++ b/LibOS/shim/test/regression/00_bootstrap.py
@@ -23,6 +23,14 @@ regression.add_check(name="Five Arguments Given",
 rv = regression.run_checks()
 if rv: sys.exit(rv)
 
+regression = Regression(loader, "bootstrap-c++")
+
+regression.add_check(name="Basic Bootstrapping (C++)",
+    check=lambda res: "User Program Started" in res[0].out)
+
+rv = regression.run_checks()
+if rv: sys.exit(rv)
+
 # Running Exec
 regression = Regression(loader, "exec")
 

--- a/LibOS/shim/test/regression/Makefile
+++ b/LibOS/shim/test/regression/Makefile
@@ -24,7 +24,7 @@ $(c_executables): %: %.c
 
 $(cxx_executables): %: %.cpp
 	@echo [ $@ ]
-	@$(CC) $(CFLAGS) -o $@ $< \
+	@$(CXX) $(CXXFLAGS) -o $@ $< \
 	$(shell echo $@ | sed 's/^[^\.]*//g' | sed 's/\./ -l/g')
 
 bootstrap_static: %: %.c

--- a/LibOS/shim/test/regression/bootstrap-c++.cpp
+++ b/LibOS/shim/test/regression/bootstrap-c++.cpp
@@ -1,0 +1,7 @@
+#include <iostream>
+
+int main()
+{
+    std::cout << "User Program Started" << std::endl;
+    return 0;
+}

--- a/LibOS/shim/test/regression/manifest.template
+++ b/LibOS/shim/test/regression/manifest.template
@@ -1,11 +1,19 @@
 loader.preload = file:../../src/libsysdb.so
-loader.env.LD_LIBRARY_PATH = /lib
+loader.env.LD_LIBRARY_PATH = /lib:/lib/x86_64-linux-gnu:/usr/lib/x86_64-linux-gnu
 loader.debug_type = none
 loader.syscall_symbol = syscalldb
 
-fs.mount.lib.type = chroot
-fs.mount.lib.path = /lib
-fs.mount.lib.uri = file:../../../../Runtime
+fs.mount.graphene_lib.type = chroot
+fs.mount.graphene_lib.path = /lib
+fs.mount.graphene_lib.uri = file:../../../../Runtime
+
+fs.mount.host_lib.type = chroot
+fs.mount.host_lib.path = /lib/x86_64-linux-gnu
+fs.mount.host_lib.uri = file:/lib/x86_64-linux-gnu
+
+fs.mount.host_usr_lib.type = chroot
+fs.mount.host_usr_lib.path = /usr/lib/x86_64-linux-gnu
+fs.mount.host_usr_lib.uri = file:/usr/lib/x86_64-linux-gnu
 
 fs.mount.bin.type = chroot
 fs.mount.bin.path = /bin
@@ -18,5 +26,11 @@ net.rules.2 = 0.0.0.0:0-65535:127.0.0.1:8000
 
 sgx.trusted_files.ld = file:../../../../Runtime/ld-linux-x86-64.so.2
 sgx.trusted_files.libc = file:../../../../Runtime/libc.so.6
+sgx.trusted_files.libdl = file:../../../../Runtime/libdl.so.2
+sgx.trusted_files.libm = file:../../../../Runtime/libm.so.6
+sgx.trusted_files.libpthread = file:../../../../Runtime/libpthread.so.0
+sgx.trusted_files.libgcc_s = file:/lib/x86_64-linux-gnu/libgcc_s.so.1
+sgx.trusted_files.libstdcxx = file:/usr/lib/x86_64-linux-gnu/libstdc++.so.6
+
 sgx.trusted_files.victim = file:exec_victim
 sgx.trusted_children.victim = file:exec_victim.sig


### PR DESCRIPTION
<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->

Fix the Makefile and manifest template in `LibOS/shim/test/native` and `/shim/test/regression` for C++ program. 


## How to test this PR? <!-- (if applicable) -->

Run the test program:

    cd LibOS/shim/test/regression
    ./pal_loader bootstrap-c++` or `./pal_loader SGX bootstreap-c++`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/801)
<!-- Reviewable:end -->
