### PR TITLE
Follow up to PR #640 (Fix "cld" on entry and small cleanup)

### DIFF
--- a/Pal/src/host/Linux-SGX/enclave_entry.S
+++ b/Pal/src/host/Linux-SGX/enclave_entry.S
@@ -282,7 +282,7 @@ enclave_entry:
 	movq %rsi, SGX_GPR_RSP(%rbx)
 	movq $0, %gs:SGX_STACK
 	movq $0, %gs:SGX_OCALL_PREPARED
-	xorq %r11, %r11
+	andq $(~RFLAGS_DF), SGX_GPR_RFLAGS(%rbx)
 	jmp .Leexit_exception
 
 .Lsetup_exception_handler:
@@ -365,8 +365,8 @@ enclave_entry:
 	subq $8, %rsi
 	movq %rsi, SGX_GPR_RSP(%rbx)
 
-	# clear rflags to conform the ABI which requires RFLAGS.DF = 0
-	movq $0, SGX_GPR_RFLAGS(%rbx)
+	# Clear RFLAGS.DF to conform to the SysV ABI.
+	andq $(~RFLAGS_DF), SGX_GPR_RFLAGS(%rbx)
 
 	# new RIP is the exception handler
 	leaq _DkExceptionHandler(%rip), %rdi

--- a/Pal/src/host/Linux-SGX/sgx_arch.h
+++ b/Pal/src/host/Linux-SGX/sgx_arch.h
@@ -288,4 +288,6 @@ typedef uint8_t sgx_arch_key128_t[16] __attribute__((aligned(16)));
 
 #define RETURN_FROM_OCALL 0xffffffffffffffff
 
+#define RFLAGS_DF (1<<10)
+
 #endif /* SGX_ARCH_H */


### PR DESCRIPTION
<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [x] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->

See commit messages.

BTW: Is there a reason why we use `cld` after EENTER but `movq $0, SGX_GPR_RFLAGS(%rbx)` (i.e. all flag bits) for `_DkExceptionHandler`?

## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/802)
<!-- Reviewable:end -->
