### PR TITLE
[PAL] Make PAL_HANDLE flags macros MAX_FDS-aware

### DIFF
--- a/Pal/src/host/FreeBSD/pal_host.h
+++ b/Pal/src/host/FreeBSD/pal_host.h
@@ -169,11 +169,11 @@ typedef union pal_handle
     } event;
 } * PAL_HANDLE;
 
-#define RFD(n)          (00001 << (n))
-#define WFD(n)          (00010 << (n))
-#define WRITABLE(n)     (00100 << (n))
-#define ERROR(n)        (01000 << (n))
-#define HAS_FDS         00077
+#define RFD(n)          (1 << (MAX_FDS*0 + (n)))
+#define WFD(n)          (1 << (MAX_FDS*1 + (n)))
+#define WRITABLE(n)     (1 << (MAX_FDS*2 + (n)))
+#define ERROR(n)        (1 << (MAX_FDS*3 + (n)))
+#define HAS_FDS         ((1 << MAX_FDS*2) - 1)
 
 #define HANDLE_TYPE(handle)  ((handle)->hdr.type)
 struct arch_frame {

--- a/Pal/src/host/Linux-SGX/pal_host.h
+++ b/Pal/src/host/Linux-SGX/pal_host.h
@@ -176,11 +176,11 @@ typedef struct pal_handle
     };
 } * PAL_HANDLE;
 
-#define RFD(n)          (00001 << (n))
-#define WFD(n)          (00010 << (n))
-#define WRITABLE(n)     (00100 << (n))
-#define ERROR(n)        (01000 << (n))
-#define HAS_FDS         00077
+#define RFD(n)          (1 << (MAX_FDS*0 + (n)))
+#define WFD(n)          (1 << (MAX_FDS*1 + (n)))
+#define WRITABLE(n)     (1 << (MAX_FDS*2 + (n)))
+#define ERROR(n)        (1 << (MAX_FDS*3 + (n)))
+#define HAS_FDS         ((1 << MAX_FDS*2) - 1)
 
 #define HANDLE_TYPE(handle)  ((handle)->hdr.type)
 

--- a/Pal/src/host/Linux/pal_host.h
+++ b/Pal/src/host/Linux/pal_host.h
@@ -177,11 +177,11 @@ typedef struct pal_handle
     };
 } * PAL_HANDLE;
 
-#define RFD(n)          (00001 << (n))
-#define WFD(n)          (00010 << (n))
-#define WRITABLE(n)     (00100 << (n))
-#define ERROR(n)        (01000 << (n))
-#define HAS_FDS         00077
+#define RFD(n)          (1 << (MAX_FDS*0 + (n)))
+#define WFD(n)          (1 << (MAX_FDS*1 + (n)))
+#define WRITABLE(n)     (1 << (MAX_FDS*2 + (n)))
+#define ERROR(n)        (1 << (MAX_FDS*3 + (n)))
+#define HAS_FDS         ((1 << MAX_FDS*2) - 1)
 
 #define HANDLE_TYPE(handle)  ((handle)->hdr.type)
 


### PR DESCRIPTION
<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [X] Linux PAL
- [X] SGX PAL
- [X] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->

Previously changing MAX_FDS could silently corrupt macros responsible for manipulating handle's flags bitmap, this PR fixes the issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/808)
<!-- Reviewable:end -->
