### PR TITLE
[LibOS] shim handle corruption caused by ambiguous interpretation 

### DIFF
--- a/LibOS/shim/include/shim_handle.h
+++ b/LibOS/shim/include/shim_handle.h
@@ -349,7 +349,6 @@ struct shim_handle {
         struct shim_dev_handle    dev;
         struct shim_pipe_handle   pipe;
         struct shim_sock_handle   sock;
-        struct shim_dir_handle    dir;
         struct shim_shm_handle    shm;
         struct shim_msg_handle    msg;
         struct shim_sem_handle    sem;
@@ -357,6 +356,8 @@ struct shim_handle {
         struct shim_str_handle    str;
         struct shim_epoll_handle  epoll;
     } info;
+
+    struct shim_dir_handle    dir_info;
 
     int                 flags;
     int                 acc_mode;

--- a/LibOS/shim/src/bookkeep/shim_handle.c
+++ b/LibOS/shim/src/bookkeep/shim_handle.c
@@ -470,7 +470,7 @@ void close_handle (struct shim_handle * hdl)
 
     if (!opened) {
         if (hdl->type == TYPE_DIR) {
-            struct shim_dir_handle * dir = &hdl->info.dir;
+            struct shim_dir_handle * dir = &hdl->dir_info;
 
             if (dir->dot) {
                 put_dentry(dir->dot);

--- a/LibOS/shim/src/fs/shim_namei.c
+++ b/LibOS/shim/src/fs/shim_namei.c
@@ -620,18 +620,18 @@ int dentry_open (struct shim_handle * hdl, struct shim_dentry * dent,
 
         // Set dot and dot dot for some reason
         get_dentry(dent);
-        hdl->info.dir.dot = dent;
+        hdl->dir_info.dot = dent;
 
         if (dent->parent) {
             get_dentry(dent->parent);
-            hdl->info.dir.dotdot = dent->parent;
+            hdl->dir_info.dotdot = dent->parent;
         } else
-            hdl->info.dir.dotdot = NULL;
+            hdl->dir_info.dotdot = NULL;
 
         // Let's defer setting the DENTRY_LISTED flag until we need it
         // Use -1 to indicate that the buf/ptr isn't initialized
-        hdl->info.dir.buf = (void *)-1;
-        hdl->info.dir.ptr = (void *)-1;
+        hdl->dir_info.buf = (void *)-1;
+        hdl->dir_info.ptr = (void *)-1;
     }
     path = dentry_get_path(dent, true, &size);
     if (!path) {
@@ -771,15 +771,15 @@ int list_directory_handle (struct shim_dentry * dent, struct shim_handle * hdl)
     int nchildren = dent->nchildren, count = 0;
     struct shim_dentry * child;
 
-    assert(hdl->info.dir.buf == (void *)-1);
-    assert(hdl->info.dir.ptr == (void *)-1);
+    assert(hdl->dir_info.buf == (void *)-1);
+    assert(hdl->dir_info.ptr == (void *)-1);
 
     // Handle the case where the handle is on a rmdir-ed directory
     // Handle is already locked by caller, so these values shouldn't change
     // after dcache lock is acquired
     if (dent->state & DENTRY_NEGATIVE) {
-        hdl->info.dir.buf = NULL;
-        hdl->info.dir.ptr = NULL;
+        hdl->dir_info.buf = NULL;
+        hdl->dir_info.ptr = NULL;
         return 0;
     }
 
@@ -804,8 +804,8 @@ int list_directory_handle (struct shim_dentry * dent, struct shim_handle * hdl)
     }
     children[count] = NULL;
 
-    hdl->info.dir.buf = children;
-    hdl->info.dir.ptr = children;
+    hdl->dir_info.buf = children;
+    hdl->dir_info.ptr = children;
 
     unlock(&dcache_lock);
 

--- a/LibOS/shim/src/sys/shim_open.c
+++ b/LibOS/shim/src/sys/shim_open.c
@@ -353,7 +353,7 @@ size_t shim_do_getdents (int fd, struct linux_dirent * buf, size_t count)
        updated */
     lock(&hdl->lock);
 
-    struct shim_dir_handle * dirhdl = &hdl->info.dir;
+    struct shim_dir_handle * dirhdl = &hdl->dir_info;
     struct shim_dentry * dent = hdl->dentry;
     struct linux_dirent * b = buf;
     int bytes = 0;
@@ -459,7 +459,7 @@ size_t shim_do_getdents64 (int fd, struct linux_dirent64 * buf, size_t count)
 
     lock(&hdl->lock);
 
-    struct shim_dir_handle * dirhdl = &hdl->info.dir;
+    struct shim_dir_handle * dirhdl = &hdl->dir_info;
     struct shim_dentry * dent = hdl->dentry;
     struct linux_dirent64 * b = buf;
     int bytes = 0;

--- a/LibOS/shim/test/regression/30_stat.py
+++ b/LibOS/shim/test/regression/30_stat.py
@@ -7,10 +7,19 @@ loader = sys.argv[1]
 regression = Regression(loader, "stat_invalid_args")
 
 regression.add_check(name="Stat with invalid arguments",
-    check=lambda res: "stat(invalid-path-ptr) correctly returns error" in res[0].out and \
-                      "stat(invalid-buf-ptr) correctly returns error" in res[0].out and \
-                      "lstat(invalid-path-ptr) correctly returns error" in res[0].out and \
-                      "lstat(invalid-buf-ptr) correctly returns error" in res[0].out)
+    check=lambda res: "stat(invalid-path-ptr) correctly returned error" in res[0].out and \
+                      "stat(invalid-buf-ptr) correctly returned error" in res[0].out and \
+                      "lstat(invalid-path-ptr) correctly returned error" in res[0].out and \
+                      "lstat(invalid-buf-ptr) correctly returned error" in res[0].out)
+
+rv = regression.run_checks()
+if rv: sys.exit(rv)
+
+# Running fstat
+regression = Regression(loader, "fstat_cwd")
+
+regression.add_check(name="Fstat on a directory",
+    check=lambda res: "fstat returned the fd type as S_IFDIR" in res[0].out)
 
 rv = regression.run_checks()
 if rv: sys.exit(rv)

--- a/LibOS/shim/test/regression/fstat_cwd.c
+++ b/LibOS/shim/test/regression/fstat_cwd.c
@@ -1,0 +1,33 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <errno.h>
+
+int main (int argc, char** argv) {
+    int r, fd;
+    struct stat buf;
+
+    fd = open(".", O_DIRECTORY);
+    if (fd == -1) {
+        printf("Opening CWD returned error %d\n", errno);
+        return -1;
+    }
+
+    r = fstat(fd, &buf);
+    if (r == -1) {
+        printf("fstat on directory fd returned error %d\n", errno);
+        return -1;
+    }
+
+    close(fd);
+
+    if (S_ISDIR(buf.st_mode))
+        printf("fstat returned the fd type as S_IFDIR\n");
+
+    return 0;
+}

--- a/LibOS/shim/test/regression/stat_invalid_args.c
+++ b/LibOS/shim/test/regression/stat_invalid_args.c
@@ -18,20 +18,20 @@ int main (int argc, char** argv) {
     /* check stat() */
     r = stat(badpath, goodbuf);
     if (r == -1 && errno == EFAULT)
-        printf("stat(invalid-path-ptr) correctly returns error\n");
+        printf("stat(invalid-path-ptr) correctly returned error\n");
 
     r = stat(goodpath, badbuf);
     if (r == -1 && errno == EFAULT)
-        printf("stat(invalid-buf-ptr) correctly returns error\n");
+        printf("stat(invalid-buf-ptr) correctly returned error\n");
 
     /* check lstat() */
     r = lstat(badpath, goodbuf);
     if (r == -1 && errno == EFAULT)
-        printf("lstat(invalid-path-ptr) correctly returns error\n");
+        printf("lstat(invalid-path-ptr) correctly returned error\n");
 
     r = lstat(goodpath, badbuf);
     if (r == -1 && errno == EFAULT)
-        printf("lstat(invalid-buf-ptr) correctly returns error\n");
+        printf("lstat(invalid-buf-ptr) correctly returned error\n");
 
     return 0;
 }


### PR DESCRIPTION
<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->

This PR is needed for #809.

In LibOS, a `shim_handle` contains a union structure `info` to store the FS-specific information. In [`fs/chroot/fs.c`](https://github.com/oscarlab/graphene/blob/7ac25ca5560523a48226abfb3b70f252387e8df7/LibOS/shim/src/fs/chroot/fs.c),  `handle->info` is exclusively intepreted as a `shim_file_handle`. However, in [`fs/namei.c:598-616`](https://github.com/oscarlab/graphene/blob/7ac25ca5560523a48226abfb3b70f252387e8df7/LibOS/shim/src/fs/shim_namei.c#L598-616), if the dentry being opened represents a directory, the code will treat `handle->info` as a `shim_dir_handle`. As a result, it corrupts the content of `shim_file_handle`, causing unexpected failure at run time.

One symptom of this bug is that if you open a directory (e.g., the current directory) and then use `fstat` to retrieve the metadata of the file directory, you will either get wrong values in the `stat` structure, or get an internal memory fault when closing the file descriptor. The exact behavior of this bug is up to the compiler.

To fix this bug, we need to separate the directory info (`shim_dir_handle`) from the FS-specific `handle->info` field since it is accessed in an FS-generic source file. `handle->info` should only be interpreted by FS implementation and should remain opaque for the virtual file system layer.


## How to test this PR? <!-- (if applicable) -->

A test program `fstat_cwd` is added to the regression directory. Normally, this program should print out as follow:

    fstat returns the fd type as S_IFDIR

However, under the buggy implementation, the program will either get the fd type as something abnormal, or fault at closing the file descriptor:

    $ ./pal_loader fstat_cwd
    Internal memory fault at 0x7fa0000000fa (IP = +0x21cd5, VMID = 3290854439, TID=1)
    [1]    29735 trace trap (core dumped)  ./pal_loader fstat_cwd

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/810)
<!-- Reviewable:end -->
