### PR TITLE
IPC helper cleanup and ensuing killXX bug fixes

### DIFF
--- a/Jenkinsfiles/Linux-SGX
+++ b/Jenkinsfiles/Linux-SGX
@@ -40,7 +40,7 @@ pipeline {
                                 make SGX_RUN=1 KEEP_LOG=1 regression
                                 '''
                         }
-                        timeout(time: 5, unit: 'MINUTES') {
+                        timeout(time: 15, unit: 'MINUTES') {
                             sh '''
                                 cd LibOS/shim/test/regression
                                 make SGX=1

--- a/LibOS/shim/include/shim_defs.h
+++ b/LibOS/shim/include/shim_defs.h
@@ -13,6 +13,33 @@
  */
 #define CPSTORE_DERANDOMIZATION     0
 
+/* This macro disables current vfork implementation and aliases it to fork.
+ *
+ * Rationale:
+ * Current vfork() implementation is broken and works only in simple cases.
+ * The implementation creates a new thread in the same process and runs it
+ * in place of the previous (parent) thread which called vfork(). When the
+ * "pseudo-process" new thread reaches execve(), it silently dies and
+ * switches execution back to the suspended parent thread (as per vfork
+ * semantics). Because execve() emulation creates a new host-OS process,
+ * this vfork implementation works in simple benign cases.
+ *
+ * However, this co-existence of the "pseudo-process" thread with threads
+ * of the parent process leads to bugs elsewhere in Graphene. In general,
+ * the rest of Graphene is not aware of such situation when two processes
+ * co-exist in the same Graphene instance and share memory. If the new
+ * "pseudo-process" thread makes syscalls in-between vfork() and execve()
+ * or abnormally dies or receives a signal, Graphene may hang or segfault
+ * or end up with inconsistent internal state.
+ *
+ * Therefore, instead of trying to support Linux semantics for vfork() --
+ * which requires adding corner-cases in signal handling and syscalls --
+ * we simply redirect vfork() as fork(). We assume that performance hit is
+ * negligible (Graphene has to migrate internal state anyway which is slow)
+ * and apps do not rely on insane Linux-specific semantics of vfork().
+ * */
+#define ALIAS_VFORK_AS_FORK 1
+
 #define DEFAULT_HEAP_MIN_SIZE       (256 * 1024 * 1024) /* 256MB */
 #define DEFAULT_MEM_MAX_NPAGES      (1024 * 1024)       /* 4GB */
 #define DEFAULT_BRK_MAX_SIZE        (256 * 1024)        /* 256KB */

--- a/LibOS/shim/include/shim_ipc.h
+++ b/LibOS/shim/include/shim_ipc.h
@@ -195,9 +195,8 @@ struct shim_ipc_pid_kill {
     int signum;
 } __attribute__((packed));
 
-int ipc_pid_kill_send (IDTYPE sender, IDTYPE id, enum kill_type type,
-                       int signum);
-int ipc_pid_kill_callback (IPC_CALLBACK_ARGS);
+int ipc_pid_kill_send(IDTYPE sender, IDTYPE target, enum kill_type type, int signum);
+int ipc_pid_kill_callback(struct shim_ipc_msg* msg, struct shim_ipc_port* port);
 
 struct pid_status {
     IDTYPE pid, tgid, pgid;

--- a/LibOS/shim/include/shim_ipc.h
+++ b/LibOS/shim/include/shim_ipc.h
@@ -454,7 +454,7 @@ struct shim_ipc_info* create_ipc_info_cur_process(bool is_self_ipc_info);
 int get_ipc_info_cur_process(struct shim_ipc_info** pinfo);
 
 enum {
-    LISTEN=0,   /* listening */
+    LISTEN,     /* listening */
     SERVER,     /* connect as a server */
     KEEPALIVE,  /* keep the connetion alive */
     DIRCLD,     /* direct child */
@@ -487,7 +487,7 @@ struct shim_ipc_info* create_ipc_info(IDTYPE vmid, const char* uri, size_t len);
 void get_ipc_info(struct shim_ipc_info* port);
 void put_ipc_info(struct shim_ipc_info* port);
 
-struct shim_ipc_info* create_ipc_info_in_list(IDTYPE vmid, const char* uri);
+struct shim_ipc_info* create_ipc_info_in_list(IDTYPE vmid, const char* uri, size_t len);
 void put_ipc_info_in_list(struct shim_ipc_info* info);
 struct shim_ipc_info* lookup_ipc_info(IDTYPE vmid);
 
@@ -497,6 +497,7 @@ static_always_inline size_t get_ipc_msg_size(size_t payload) {
 }
 
 static_always_inline size_t get_ipc_msg_duplex_size(size_t payload) {
+    assert(sizeof(struct shim_ipc_msg_duplex) >= sizeof(struct shim_ipc_msg));
     return get_ipc_msg_size(payload) +
         (sizeof(struct shim_ipc_msg_duplex) - sizeof(struct shim_ipc_msg));
 }

--- a/LibOS/shim/include/shim_ipc.h
+++ b/LibOS/shim/include/shim_ipc.h
@@ -447,10 +447,10 @@ int ipc_sysv_semreply_callback (IPC_CALLBACK_ARGS);
 int init_ipc(void);
 int init_ipc_helper(void);
 
-struct shim_process* create_process(void);
+struct shim_process* create_process(bool dup_cur_process);
 void free_process(struct shim_process* process);
 
-struct shim_ipc_info* create_ipc_info_cur_process(void);
+struct shim_ipc_info* create_ipc_info_cur_process(bool is_self_ipc_info);
 int get_ipc_info_cur_process(struct shim_ipc_info** pinfo);
 
 enum {
@@ -515,8 +515,6 @@ int send_response_ipc_message(struct shim_ipc_port* port, IDTYPE dest, int ret, 
 void ipc_port_with_child_fini(struct shim_ipc_port* port, IDTYPE vmid, unsigned int exitcode);
 
 struct shim_thread* terminate_ipc_helper(void);
-
-#define IPC_FORCE_RECONNECT     ((void*)-1)
 
 int prepare_ns_leaders(void);
 

--- a/LibOS/shim/include/shim_signal.h
+++ b/LibOS/shim/include/shim_signal.h
@@ -149,7 +149,6 @@ int do_kill_thread (IDTYPE sender, IDTYPE tgid, IDTYPE tid, int sig,
 int do_kill_proc (IDTYPE sender, IDTYPE tgid, int sig, bool use_ipc);
 int do_kill_pgroup (IDTYPE sender, IDTYPE pgid, int sig, bool use_ipc);
 
-int broadcast_signal (IDTYPE sender, int sig);
 int kill_all_threads (struct shim_thread * cur, IDTYPE sender, int sig);
 
 #endif /* _SHIM_SIGNAL_H_ */

--- a/LibOS/shim/include/shim_thread.h
+++ b/LibOS/shim/include/shim_thread.h
@@ -37,7 +37,7 @@ struct shim_thread {
     struct shim_thread * parent;
     /* thread leader */
     struct shim_thread * leader;
-    /* dummy thread */
+    /* dummy thread: stores blocked parent thread for vfork */
     struct shim_thread * dummy;
     /* child handles; protected by thread->lock */
     LISTP_TYPE(shim_thread) children;
@@ -264,7 +264,10 @@ void add_simple_thread (struct shim_simple_thread * thread);
 void del_simple_thread (struct shim_simple_thread * thread);
 
 int check_last_thread (struct shim_thread * self);
+
+#ifndef ALIAS_VFORK_AS_FORK
 void switch_dummy_thread (struct shim_thread * thread);
+#endif
 
 int walk_thread_list (int (*callback) (struct shim_thread *, void *, bool *),
                       void * arg);

--- a/LibOS/shim/include/shim_utils.h
+++ b/LibOS/shim/include/shim_utils.h
@@ -223,7 +223,7 @@ void clean_link_map_list (void);
 /* create unique files/pipes */
 #define PIPE_URI_SIZE   40
 int create_pipe (IDTYPE * pipeid, char * uri, size_t size, PAL_HANDLE * hdl,
-                 struct shim_qstr * qstr);
+                 struct shim_qstr * qstr, bool use_vmid_for_name);
 int create_dir (const char * prefix, char * path, size_t size,
                 struct shim_handle ** hdl);
 int create_file (const char * prefix, char * path, size_t size,

--- a/LibOS/shim/src/bookkeep/shim_signal.c
+++ b/LibOS/shim/src/bookkeep/shim_signal.c
@@ -747,16 +747,20 @@ void append_signal (struct shim_thread * thread, int sig, siginfo_t * info,
     }
 }
 
+#define __WCOREDUMP_BIT 0x80
+
 static void sighandler_kill (int sig, siginfo_t * info, void * ucontext)
 {
+    int sig_without_coredump_bit = sig & ~(__WCOREDUMP_BIT);
+
     __UNUSED(ucontext);
-    debug("killed by %s\n", signal_name(sig));
+    debug("killed by %s\n", signal_name(sig_without_coredump_bit));
 
     if (!info->si_pid)
         switch(sig) {
             case SIGTERM:
             case SIGINT:
-                shim_do_kill(-1, sig);
+                shim_do_kill(-1, sig_without_coredump_bit);
                 break;
         }
 
@@ -764,10 +768,11 @@ static void sighandler_kill (int sig, siginfo_t * info, void * ucontext)
     DkThreadExit();
 }
 
-/* We don't currently implement core dumps, but put a wrapper
- * in case we do in the future */
 static void sighandler_core (int sig, siginfo_t * info, void * ucontext)
 {
+    /* NOTE: This implementation only indicates the core dump for wait4()
+     *       and friends. No actual core-dump file is created. */
+    sig = __WCOREDUMP_BIT | sig;
     sighandler_kill(sig, info, ucontext);
 }
 
@@ -775,24 +780,33 @@ static void (*default_sighandler[NUM_SIGS]) (int, siginfo_t *, void *) =
     {
         /* SIGHUP */    &sighandler_kill,
         /* SIGINT */    &sighandler_kill,
-        /* SIGQUIT */   &sighandler_kill,
-        /* SIGILL */    &sighandler_kill,
+        /* SIGQUIT */   &sighandler_core,
+        /* SIGILL */    &sighandler_core,
         /* SIGTRAP */   &sighandler_core,
-        /* SIGABRT */   &sighandler_kill,
-        /* SIGBUS */    &sighandler_kill,
-        /* SIGFPE */    &sighandler_kill,
+        /* SIGABRT */   &sighandler_core,
+        /* SIGBUS */    &sighandler_core,
+        /* SIGFPE */    &sighandler_core,
         /* SIGKILL */   &sighandler_kill,
-        /* SIGUSR1 */   NULL,
-        /* SIGSEGV */   &sighandler_kill,
-        /* SIGUSR2 */   NULL,
+        /* SIGUSR1 */   &sighandler_kill,
+        /* SIGSEGV */   &sighandler_core,
+        /* SIGUSR2 */   &sighandler_kill,
         /* SIGPIPE */   &sighandler_kill,
         /* SIGALRM */   &sighandler_kill,
         /* SIGTERM */   &sighandler_kill,
-        /* SIGSTKFLT */ NULL,
+        /* SIGSTKFLT */ &sighandler_kill,
         /* SIGCHLD */   NULL,
         /* SIGCONT */   NULL,
         /* SIGSTOP */   NULL,
         /* SIGTSTP */   NULL,
         /* SIGTTIN */   NULL,
         /* SIGTTOU */   NULL,
+        /* SIGURG  */   NULL,
+        /* SIGXCPU */   &sighandler_core,
+        /* SIGXFSZ */   &sighandler_core,
+        /* SIGVTALRM */ &sighandler_kill,
+        /* SIGPROF   */ &sighandler_kill,
+        /* SIGWINCH  */ NULL,
+        /* SIGIO   */   &sighandler_kill,
+        /* SIGPWR  */   &sighandler_kill,
+        /* SIGSYS  */   &sighandler_core
     };

--- a/LibOS/shim/src/bookkeep/shim_thread.c
+++ b/LibOS/shim/src/bookkeep/shim_thread.c
@@ -656,6 +656,8 @@ BEGIN_RS_FUNC(thread)
     struct shim_thread * thread = (void *) (base + GET_CP_FUNC_ENTRY());
     __UNUSED(offset);
 
+    thread->vmid = cur_process.vmid;
+
     CP_REBASE(thread->children);
     CP_REBASE(thread->siblings);
     CP_REBASE(thread->exited_children);
@@ -738,6 +740,8 @@ BEGIN_RS_FUNC(running_thread)
     struct shim_thread * thread = (void *) (base + GET_CP_FUNC_ENTRY());
     struct shim_thread * cur_thread = get_cur_thread();
     thread->in_vm = true;
+
+    thread->vmid = cur_process.vmid;
 
     if (!thread->user_tcb)
         CP_REBASE(thread->tcb);

--- a/LibOS/shim/src/bookkeep/shim_thread.c
+++ b/LibOS/shim/src/bookkeep/shim_thread.c
@@ -564,6 +564,7 @@ out:
     return ret;
 }
 
+#ifndef ALIAS_VFORK_AS_FORK
 void switch_dummy_thread (struct shim_thread * thread)
 {
     struct shim_thread * real_thread = thread->dummy;
@@ -596,6 +597,7 @@ void switch_dummy_thread (struct shim_thread * thread)
                        "a"(child)
                      : "memory");
 }
+#endif
 
 BEGIN_CP_FUNC(thread)
 {

--- a/LibOS/shim/src/bookkeep/shim_thread.c
+++ b/LibOS/shim/src/bookkeep/shim_thread.c
@@ -658,8 +658,6 @@ BEGIN_RS_FUNC(thread)
     struct shim_thread * thread = (void *) (base + GET_CP_FUNC_ENTRY());
     __UNUSED(offset);
 
-    thread->vmid = cur_process.vmid;
-
     CP_REBASE(thread->children);
     CP_REBASE(thread->siblings);
     CP_REBASE(thread->exited_children);

--- a/LibOS/shim/src/elf/shim_rtld.c
+++ b/LibOS/shim/src/elf/shim_rtld.c
@@ -875,31 +875,14 @@ static int __check_elf_header (void * fbp, size_t len)
         [EI_CLASS] = ELFW(CLASS),
         [EI_DATA] = byteorder,
         [EI_VERSION] = EV_CURRENT,
-        [EI_OSABI] = ELFOSABI_SYSV,
-        [EI_ABIVERSION] = 0
+        [EI_OSABI] = 0,
     };
 
     /* See whether the ELF header is what we expect.  */
-    if (__builtin_expect (memcmp (ehdr->e_ident, expected, EI_ABIVERSION) !=
-                          0, 0)) {
+    if (__builtin_expect(memcmp(ehdr->e_ident, expected, EI_OSABI) != 0 ||
+        (ehdr->e_ident[EI_OSABI] != ELFOSABI_SYSV &&
+         ehdr->e_ident[EI_OSABI] != ELFOSABI_LINUX), 0)) {
         errstring = "ELF file with invalid header";
-        goto verify_failed;
-    }
-
-    /* Check whether the ELF header use the right endian */
-    if (ehdr->e_ident[EI_DATA] != byteorder) {
-        if (__BYTE_ORDER == __BIG_ENDIAN) {
-            errstring = "ELF file data encoding not big-endian";
-            goto verify_failed;
-        } else {
-            errstring = "ELF file data encoding not little-endian";
-            goto verify_failed;
-        }
-    }
-
-    /* checking the header is of the right version */
-    if (ehdr->e_ident[EI_VERSION] != EV_CURRENT) {
-        errstring = "ELF file version ident does not match current one";
         goto verify_failed;
     }
 
@@ -907,11 +890,6 @@ static int __check_elf_header (void * fbp, size_t len)
                EI_NIDENT - EI_PAD) != 0) {
        errstring = "nonzero padding in e_ident";
        goto verify_failed;
-    }
-
-    if (__builtin_expect (ehdr->e_version, EV_CURRENT) != EV_CURRENT) {
-        errstring = "ELF file version does not match current one";
-        goto verify_failed;
     }
 
     /* Now we check if the host match the elf machine profile */

--- a/LibOS/shim/src/ipc/shim_ipc.c
+++ b/LibOS/shim/src/ipc/shim_ipc.c
@@ -17,7 +17,9 @@
 /*
  * shim_ipc.c
  *
- * This file contains codes to maintain generic bookkeeping of IPC.
+ * This file contains codes to maintain generic bookkeeping of IPC: operations
+ * on shim_ipc_msg (one-way IPC messages), shim_ipc_msg_duplex (IPC messages
+ * with acknowledgement), shim_ipc_info (IPC ports of process), shim_process.
  */
 
 #include <shim_internal.h>
@@ -35,25 +37,29 @@
 
 #define IPC_INFO_MGR_ALLOC  32
 #define PAGE_SIZE           allocsize
-
 #define OBJ_TYPE struct shim_ipc_info
 #include "memmgr.h"
-
 static MEM_MGR ipc_info_mgr;
 
 struct shim_lock ipc_info_lock;
 
 struct shim_process cur_process;
 
+#define CLIENT_HASH_LEN     6
+#define CLIENT_HASH_NUM     (1 << CLIENT_HASH_LEN)
+#define CLIENT_HASH_MASK    (CLIENT_HASH_NUM - 1)
+#define CLIENT_HASH(vmid)   ((vmid) & CLIENT_HASH_MASK)
+DEFINE_LISTP(shim_ipc_info);
+static LISTP_TYPE(shim_ipc_info) info_hlist[CLIENT_HASH_NUM];
+
 DEFINE_PROFILE_CATEGORY(ipc, );
 DEFINE_PROFILE_OCCURENCE(syscall_use_ipc, ipc);
 
-int init_ipc_ports (void);
-int init_ns_pid    (void);
-int init_ns_sysv   (void);
+int init_ipc_ports(void);
+int init_ns_pid(void);
+int init_ns_sysv(void);
 
-int init_ipc (void)
-{
+int init_ipc(void) {
     int ret = 0;
 
     create_lock(&ipc_info_lock);
@@ -63,18 +69,15 @@ int init_ipc (void)
 
     if ((ret = init_ipc_ports()) < 0)
         return ret;
-
     if ((ret = init_ns_pid()) < 0)
         return ret;
-
     if ((ret = init_ns_sysv()) < 0)
         return ret;
 
     return 0;
 }
 
-int prepare_ns_leaders (void)
-{
+int prepare_ns_leaders(void) {
     int ret = 0;
     if ((ret = prepare_pid_leader()) < 0)
         return ret;
@@ -83,18 +86,14 @@ int prepare_ns_leaders (void)
     return 0;
 }
 
-static struct shim_ipc_info * __get_new_ipc_info (IDTYPE vmid, const char * uri,
-                                                  size_t len)
-{
-    struct shim_ipc_info * info =
-                get_mem_obj_from_mgr_enlarge(ipc_info_mgr,
-                                             size_align_up(IPC_INFO_MGR_ALLOC));
+static struct shim_ipc_info* __create_ipc_info(IDTYPE vmid, const char* uri, size_t len) {
+    struct shim_ipc_info* info =
+        get_mem_obj_from_mgr_enlarge(ipc_info_mgr, size_align_up(IPC_INFO_MGR_ALLOC));
     if (!info)
         return NULL;
 
     memset(info, 0, sizeof(struct shim_ipc_info));
-    if (vmid)
-        info->vmid = vmid;
+    info->vmid = vmid;
     if (uri)
         qstrsetstr(&info->uri, uri, len);
     REF_SET(info->ref_count, 1);
@@ -102,257 +101,168 @@ static struct shim_ipc_info * __get_new_ipc_info (IDTYPE vmid, const char * uri,
     return info;
 }
 
-struct shim_ipc_info * get_new_ipc_info (IDTYPE vmid, const char * uri,
-                                         size_t len)
-{
+static void __free_ipc_info(struct shim_ipc_info* info) {
+    if (info->pal_handle) {
+        DkObjectClose(info->pal_handle);
+        info->pal_handle = NULL;
+    }
+    if (info->port)
+        put_ipc_port(info->port);
+    qstrfree(&info->uri);
+    free_mem_obj_to_mgr(ipc_info_mgr, info);
+}
+
+static void __get_ipc_info(struct shim_ipc_info* info) {
+    REF_INC(info->ref_count);
+}
+
+static void __put_ipc_info(struct shim_ipc_info* info) {
+    int ref_count = REF_DEC(info->ref_count);
+    if (!ref_count)
+        __free_ipc_info(info);
+}
+
+void get_ipc_info(struct shim_ipc_info* info) {
+    /* no need to grab ipc_info_lock because __get_ipc_info() is atomic */
+    __get_ipc_info(info);
+}
+
+void put_ipc_info(struct shim_ipc_info* info) {
+    /* this is atomic so we don't grab lock in common case of ref_count > 0 */
+    int ref_count = REF_DEC(info->ref_count);
+
+    if (!ref_count) {
+        lock(&ipc_info_lock);
+        __free_ipc_info(info);
+        unlock(&ipc_info_lock);
+    }
+}
+
+struct shim_ipc_info* create_ipc_info(IDTYPE vmid, const char* uri, size_t len) {
     lock(&ipc_info_lock);
-    struct shim_ipc_info * info = __get_new_ipc_info(vmid, uri, len);
+    struct shim_ipc_info* info = __create_ipc_info(vmid, uri, len);
     unlock(&ipc_info_lock);
     return info;
 }
 
-static void __get_ipc_info (struct shim_ipc_info * info)
-{
-    REF_INC(info->ref_count);
-}
-
-void get_ipc_info (struct shim_ipc_info * info)
-{
-    __get_ipc_info(info);
-}
-
-static void unset_ipc_info (struct shim_ipc_info * info)
-{
-    qstrfree(&info->uri);
-
-    if (info->port)
-        put_ipc_port(info->port);
-
-    if (info->pal_handle)
-        DkObjectClose(info->pal_handle);
-}
-
-static void __put_ipc_info (struct shim_ipc_info * info)
-{
-    int ref_count = REF_DEC(info->ref_count);
-
-    if (ref_count)
-        return;
-
-    unset_ipc_info(info);
-    free_mem_obj_to_mgr(ipc_info_mgr, info);
-}
-
-void put_ipc_info (struct shim_ipc_info * info)
-{
-    int ref_count = REF_DEC(info->ref_count);
-
-    if (ref_count)
-        return;
-
-    unset_ipc_info(info);
-    lock(&ipc_info_lock);
-    free_mem_obj_to_mgr(ipc_info_mgr, info);
-    unlock(&ipc_info_lock);
-}
-
-#define CLIENT_HASH_LEN     6
-#define CLIENT_HASH_NUM     (1 << CLIENT_HASH_LEN)
-#define CLIENT_HASH_MASK    (CLIENT_HASH_NUM - 1)
-#define CLIENT_HASH(vmid)   ((vmid) & CLIENT_HASH_MASK)
-
-/* Links to shim_ipc_info->hlist */
-DEFINE_LISTP(shim_ipc_info);
-static LISTP_TYPE(shim_ipc_info) client_table [CLIENT_HASH_NUM];
-
-struct shim_ipc_info *
-lookup_and_alloc_client (IDTYPE vmid, const char * uri)
-{
-    struct shim_ipc_info * p;
-    LISTP_TYPE(shim_ipc_info) *head = client_table + CLIENT_HASH(vmid);
-    size_t len = strlen(uri);
-
+struct shim_ipc_info* create_ipc_info_in_list(IDTYPE vmid, const char* uri) {
     assert(vmid);
 
+    struct shim_ipc_info* info;
+    size_t len = strlen(uri);
+
     lock(&ipc_info_lock);
-    LISTP_FOR_EACH_ENTRY(p, head, hlist)
-        if (p->vmid == vmid && !qstrcmpstr(&p->uri, uri, len)) {
-            get_ipc_info(p);
+
+    /* check if info with this vmid and uri already exists and return it */
+    LISTP_TYPE(shim_ipc_info)* info_bucket = &info_hlist[CLIENT_HASH(vmid)];
+    LISTP_FOR_EACH_ENTRY(info, info_bucket, hlist)
+        if (info->vmid == vmid && !qstrcmpstr(&info->uri, uri, len)) {
+            get_ipc_info(info);
             unlock(&ipc_info_lock);
-            return p;
+            return info;
         }
 
-    p = __get_new_ipc_info(vmid, uri, len);
-    if (p) {
-        LISTP_ADD(p, head, hlist);
-        get_ipc_info(p);
+    /* otherwise create new info and return it */
+    info = __create_ipc_info(vmid, uri, len);
+    if (info) {
+        LISTP_ADD(info, info_bucket, hlist);
+        get_ipc_info(info);
     }
+
     unlock(&ipc_info_lock);
-    return p;
+    return info;
 }
 
-void put_client (struct shim_ipc_info * info)
-{
+void put_ipc_info_in_list(struct shim_ipc_info* info) {
+    LISTP_TYPE(shim_ipc_info)* info_bucket = &info_hlist[CLIENT_HASH(info->vmid)];
+
     lock(&ipc_info_lock);
-    /* Look up the hash */
-    LISTP_TYPE(shim_ipc_info) *head = client_table + CLIENT_HASH(info->vmid);
     __put_ipc_info(info);
     if (REF_GET(info->ref_count) == 1) {
-        LISTP_DEL_INIT(info, head, hlist);
+        LISTP_DEL_INIT(info, info_bucket, hlist);
         __put_ipc_info(info);
     }
     unlock(&ipc_info_lock);
 }
 
-struct shim_ipc_info * discover_client (struct shim_ipc_port * port,
-                                        IDTYPE vmid)
-{
-    struct shim_ipc_info * p;
-    LISTP_TYPE(shim_ipc_info) * head = client_table + CLIENT_HASH(vmid);
-
+struct shim_ipc_info* lookup_ipc_info(IDTYPE vmid) {
     assert(vmid);
-
     lock(&ipc_info_lock);
-    LISTP_FOR_EACH_ENTRY(p, head, hlist)
-        if (p->vmid == vmid && !qstrempty(&p->uri)) {
-            __get_ipc_info(p);
+
+    struct shim_ipc_info* info;
+    LISTP_TYPE(shim_ipc_info)* info_bucket = &info_hlist[CLIENT_HASH(vmid)];
+    LISTP_FOR_EACH_ENTRY(info, info_bucket, hlist)
+        if (info->vmid == vmid && !qstrempty(&info->uri)) {
+            __get_ipc_info(info);
             unlock(&ipc_info_lock);
-            return p;
+            return info;
         }
+
     unlock(&ipc_info_lock);
-    return NULL;
-
-    if (!ipc_finduri_send(port, vmid, &p))
-        return p;
-
     return NULL;
 }
 
-struct shim_process * create_new_process (bool inherit_parent)
-{
-    struct shim_process * new_process = calloc(1, sizeof(struct shim_process));
+struct shim_process* create_process(void) {
+    struct shim_process* new_process = calloc(1, sizeof(struct shim_process));
     if (!new_process)
         return NULL;
 
-    new_process->parent = get_new_ipc_info(cur_process.vmid, NULL, 0);
-
-    if (!inherit_parent)
-        return new_process;
+    new_process->parent = create_ipc_info(cur_process.vmid, NULL, 0);
 
     lock(&cur_process.lock);
 
     if (cur_process.self)
         qstrcopy(&new_process->parent->uri, &cur_process.self->uri);
-
-    for (int i = 0 ; i < TOTAL_NS ; i++)
+    for (int i = 0; i < TOTAL_NS; i++) {
         if (cur_process.ns[i])
-            new_process->ns[i] =
-                get_new_ipc_info(cur_process.ns[i]->vmid,
-                                 qstrgetstr(&cur_process.ns[i]->uri),
-                                 cur_process.ns[i]->uri.len);
+            new_process->ns[i] = create_ipc_info(cur_process.ns[i]->vmid,
+                                                 qstrgetstr(&cur_process.ns[i]->uri),
+                                                 cur_process.ns[i]->uri.len);
+    }
 
     unlock(&cur_process.lock);
     return new_process;
 }
 
-void destroy_process (struct shim_process * proc)
-{
-    if (proc->self)
-        put_ipc_info(proc->self);
-
-    if (proc->parent)
-        put_ipc_info(proc->parent);
-
-    for (int i = 0 ; i < TOTAL_NS ; i++)
-        if (proc->ns[i])
-            put_ipc_info(proc->ns[i]);
-
-    free(proc);
+void free_process(struct shim_process* process) {
+    if (process->self)
+        put_ipc_info(process->self);
+    if (process->parent)
+        put_ipc_info(process->parent);
+    for (int i = 0; i < TOTAL_NS; i++)
+        if (process->ns[i])
+            put_ipc_info(process->ns[i]);
+    free(process);
 }
 
-int __init_ipc_msg (struct shim_ipc_msg * msg, int code, int size, IDTYPE dest)
-{
+void init_ipc_msg(struct shim_ipc_msg* msg, int code, size_t size, IDTYPE dest) {
     msg->code = code;
-    msg->size = IPC_MSG_SIZE(size);
+    msg->size = get_ipc_msg_size(size);
     msg->src = cur_process.vmid;
     msg->dst = dest;
     msg->seq = 0;
-    return 0;
 }
 
-struct shim_ipc_msg * create_ipc_msg (int code, int size, IDTYPE dest)
-{
-    struct shim_ipc_msg * msg = malloc(IPC_MSG_SIZE(size));
-
-    if (msg && __init_ipc_msg(msg, code, size, dest)) {
-        free(msg);
-        msg = NULL;
-    }
-
-    return msg;
-}
-
-int __init_ipc_msg_duplex (struct shim_ipc_msg_obj * msg, int code, int size,
-                           IDTYPE dest)
-{
-    __init_ipc_msg(&msg->msg, code, size, dest);
+void init_ipc_msg_duplex(struct shim_ipc_msg_duplex* msg, int code, size_t size, IDTYPE dest) {
+    init_ipc_msg(&msg->msg, code, size, dest);
     msg->thread = NULL;
     INIT_LIST_HEAD(msg, list);
     msg->retval = 0;
     msg->private = NULL;
-    return 0;
 }
 
-struct shim_ipc_msg_obj *
-create_ipc_msg_duplex (int code, int size, IDTYPE dest)
-{
-    struct shim_ipc_msg_obj * msg = malloc(IPC_MSGOBJ_SIZE(size));
-
-    if (msg && __init_ipc_msg_duplex(msg, code, size, dest)) {
-        free(msg);
-        msg = NULL;
-    }
-
-    return msg;
-}
-
-int __init_ipc_resp_msg (struct shim_ipc_msg * resp, int ret,
-                         unsigned long seq)
-{
-    struct shim_ipc_resp * resp_in = (struct shim_ipc_resp *) resp->msg;
-    resp->seq = seq;
-    resp_in->retval = ret;
-    return 0;
-}
-
-struct shim_ipc_msg *
-create_ipc_resp_msg (int ret, IDTYPE dest, unsigned long seq)
-{
-    struct shim_ipc_msg * resp =
-            create_ipc_msg(IPC_RESP, sizeof(struct shim_ipc_resp), dest);
-
-    if (resp && __init_ipc_resp_msg(resp, ret, seq)) {
-        free(resp);
-        resp = NULL;
-    }
-
-    return resp;
-}
-
-int send_ipc_message (struct shim_ipc_msg * msg, struct shim_ipc_port * port)
-{
+int send_ipc_message(struct shim_ipc_msg* msg, struct shim_ipc_port* port) {
     assert(msg->size >= IPC_MSG_MINIMAL_SIZE);
+
     msg->src = cur_process.vmid;
+    debug("Sending ipc message to port %p (handle %p)\n", port, port->pal_handle);
 
-    debug("send ipc message to port %p (handle %p)\n", port,
-          port->pal_handle);
-
+    /* TODO: Handle benign EINTR case? */
+    /* TODO: Add while-loop to send all msg */
     int ret = DkStreamWrite(port->pal_handle, 0, msg->size, msg, NULL);
 
     if (ret == 0 && PAL_NATIVE_ERRNO) {
-        debug("port %p (handle %p) is removed at sending\n", port,
-              port->pal_handle);
-
+        debug("Port %p (handle %p) was removed during sending\n", port, port->pal_handle);
         del_ipc_port_fini(port, -ECHILD);
         return -PAL_ERRNO;
     }
@@ -360,57 +270,11 @@ int send_ipc_message (struct shim_ipc_msg * msg, struct shim_ipc_port * port)
     return 0;
 }
 
-int close_ipc_message_duplex (struct shim_ipc_msg_obj * msg,
-                              struct shim_ipc_port * port)
-{
-    if (port) {
-        // Check if the message is pending on the port for response. If so,
-        // remove the message from the list.
-        lock(&port->msgs_lock);
-        if (!LIST_EMPTY(msg, list))
-            LISTP_DEL_INIT(msg, &port->msgs, list);
-        unlock(&port->msgs_lock);
-    }
+struct shim_ipc_msg_duplex* pop_ipc_msg_duplex(struct shim_ipc_port* port, unsigned long seq) {
+    struct shim_ipc_msg_duplex* found = NULL;
 
-    if (msg->thread) {
-        put_thread(msg->thread);
-        msg->thread = NULL;
-    }
-
-    return 0;
-}
-
-static struct atomic_int ipc_seq_counter;
-
-int send_ipc_message_duplex (struct shim_ipc_msg_obj * msg,
-                             struct shim_ipc_port * port, bool save,
-                             void * private_data)
-{
-    msg->msg.seq = atomic_inc_return(&ipc_seq_counter);
-
-    if (save) {
-        lock(&port->msgs_lock);
-        msg->private = private_data;
-        LISTP_ADD_TAIL(msg, &port->msgs, list);
-        unlock(&port->msgs_lock);
-    }
-
-    int ret = send_ipc_message(&msg->msg, port);
-
-    if (ret < 0) {
-        if (save)
-            close_ipc_message_duplex(msg, port);
-        return ret;
-    }
-
-    return 0;
-}
-
-struct shim_ipc_msg_obj * find_ipc_msg_duplex (struct shim_ipc_port * port,
-                                               unsigned long seq)
-{
-    struct shim_ipc_msg_obj * tmp, * found = NULL;
     lock(&port->msgs_lock);
+    struct shim_ipc_msg_duplex* tmp;
     LISTP_FOR_EACH_ENTRY(tmp, &port->msgs, list)
         if (tmp->msg.seq == seq) {
             found = tmp;
@@ -418,262 +282,197 @@ struct shim_ipc_msg_obj * find_ipc_msg_duplex (struct shim_ipc_port * port,
             break;
         }
     unlock(&port->msgs_lock);
+
     return found;
 }
 
-/* for convenience */
-int do_ipc_duplex (struct shim_ipc_msg_obj * msg,
-                   struct shim_ipc_port * port, unsigned long * seq,
-                   void * private_data)
-{
+int send_ipc_message_duplex(struct shim_ipc_msg_duplex* msg, struct shim_ipc_port* port,
+                  unsigned long* seq, void* private_data) {
     int ret = 0;
+
     struct shim_thread * thread = get_cur_thread();
     assert(thread);
 
+    /* prepare thread which sends the message for waiting for response
+     * (this also acquires reference to the thread) */
     if (!msg->thread)
         thread_setwait(&msg->thread, thread);
 
-    ret = send_ipc_message_duplex(msg, port, true, private_data);
+    static struct atomic_int ipc_seq_counter;
+    msg->msg.seq = atomic_inc_return(&ipc_seq_counter);
 
-    if (seq)
-        *seq = (ret < 0) ? 0 : msg->msg.seq;
+    /* save the message to list of port msgs together with its private data */
+    lock(&port->msgs_lock);
+    msg->private = private_data;
+    LISTP_ADD_TAIL(msg, &port->msgs, list);
+    unlock(&port->msgs_lock);
 
+    ret = send_ipc_message(&msg->msg, port);
     if (ret < 0)
         goto out;
 
-    debug("wait for response (seq = %lu)\n", msg->msg.seq);
-    thread_sleep(NO_TIMEOUT);
+    if (seq)
+        *seq = msg->msg.seq;
 
+    debug("Start waiting for response (seq = %lu)\n", msg->msg.seq);
+
+    /* force thread which sends the message to wait for response;
+     * ignore unrelated interrupts but fail on actual errors */
+    do {
+        ret = thread_sleep(NO_TIMEOUT);
+        if (ret < 0 && ret != -EINTR && ret != -EAGAIN)
+            goto out;
+    } while (ret != 0);
+
+    debug("Finished waiting for response (seq = %lu, ret = %d)\n",
+          msg->msg.seq, msg->retval);
     ret = msg->retval;
 out:
-    close_ipc_message_duplex(msg, port);
+    lock(&port->msgs_lock);
+    if (!LIST_EMPTY(msg, list))
+        LISTP_DEL_INIT(msg, &port->msgs, list);
+    unlock(&port->msgs_lock);
+
+    if (msg->thread) {
+        /* put reference to the thread acquired earlier */
+        put_thread(msg->thread);
+        msg->thread = NULL;
+    }
+
     return ret;
 }
 
-struct shim_ipc_info * create_ipc_port (IDTYPE vmid, bool listen)
-{
-    struct shim_ipc_info * proc = get_new_ipc_info(vmid, NULL, 0);
-    if (!proc)
+/* must be called with cur_process.lock taken */
+struct shim_ipc_info* create_ipc_info_cur_process(void) {
+    struct shim_ipc_info* info = create_ipc_info(cur_process.vmid, NULL, 0);
+    if (!info)
         return NULL;
 
     char uri[PIPE_URI_SIZE];
-    if (create_pipe(NULL, uri, PIPE_URI_SIZE, &proc->pal_handle,
-                    &proc->uri) < 0) {
-        put_ipc_info(proc);
+    if (create_pipe(NULL, uri, PIPE_URI_SIZE, &info->pal_handle,
+                    &info->uri) < 0) {
+        put_ipc_info(info);
         return NULL;
     }
 
-    if (listen)
-        add_ipc_port_by_id(0, proc->pal_handle, IPC_PORT_SERVER,
-                           NULL, &proc->port);
-    return proc;
+    add_ipc_port_by_id(0, info->pal_handle, IPC_PORT_SERVER,
+            NULL, &info->port);
+
+    return info;
 }
 
-int create_ipc_location (struct shim_ipc_info ** info)
-{
+int get_ipc_info_cur_process(struct shim_ipc_info** info) {
     lock(&cur_process.lock);
-    int ret = -EACCES;
 
-    if (cur_process.self)
-        goto success;
+    if (!cur_process.self) {
+        cur_process.self = create_ipc_info_cur_process();
+        if (!cur_process.self) {
+            unlock(&cur_process.lock);
+            return -EACCES;
+        }
+    }
 
-    cur_process.self = create_ipc_port(cur_process.vmid, true);
-    if (!cur_process.self)
-        goto out;
-
-success:
     get_ipc_info(cur_process.self);
     *info = cur_process.self;
-    ret = 0;
-out:
+
     unlock(&cur_process.lock);
-    return ret;
-}
-
-DEFINE_PROFILE_INTERVAL(ipc_finduri_send, ipc);
-DEFINE_PROFILE_INTERVAL(ipc_finduri_callback, ipc);
-
-int ipc_finduri_send (struct shim_ipc_port * port, IDTYPE dest,
-                      struct shim_ipc_info ** info)
-{
-    BEGIN_PROFILE_INTERVAL();
-    int ret;
-    struct shim_ipc_msg_obj * msg = create_ipc_msg_duplex_on_stack(
-                                        IPC_FINDURI, 0, dest);
-
-    debug("ipc send to %u: IPC_FINDURI\n", dest);
-
-    ret = do_ipc_duplex(msg, port, NULL, info);
-    SAVE_PROFILE_INTERVAL(ipc_finduri_send);
-    return ret;
-}
-
-int ipc_finduri_callback (IPC_CALLBACK_ARGS)
-{
-    BEGIN_PROFILE_INTERVAL();
-    int ret = 0;
-
-    debug("ipc callback from %u: IPC_FINDURI\n", msg->src);
-
-    struct shim_ipc_info * info;
-
-    if ((ret = create_ipc_location(&info)) < 0)
-        goto out;
-
-    ret = ipc_telluri_send(port, msg->src, info);
-out:
-    SAVE_PROFILE_INTERVAL(ipc_finduri_callback);
-    return ret;
-}
-
-DEFINE_PROFILE_INTERVAL(ipc_telluri_send, ipc);
-DEFINE_PROFILE_INTERVAL(ipc_telluri_callback, ipc);
-
-int ipc_telluri_send (struct shim_ipc_port * port, IDTYPE dest,
-                      struct shim_ipc_info * info)
-{
-    BEGIN_PROFILE_INTERVAL();
-    int ret;
-    struct shim_ipc_msg * msg = create_ipc_msg_on_stack(
-                                        IPC_TELLURI,
-                                        info->uri.len, dest);
-    struct shim_ipc_telluri * msgin =
-                (struct shim_ipc_telluri *) &msg->msg;
-
-    if (qstrempty(&info->uri)) {
-        ret = -ENOENT;
-        return ret;
-    }
-
-    memcpy(msgin->uri, qstrgetstr(&info->uri), info->uri.len + 1);
-
-    debug("ipc send to %u: IPC_TELLURI(%s)\n", dest,
-          qstrgetstr(&info->uri));
-
-    ret = send_ipc_message(msg, port);
-    SAVE_PROFILE_INTERVAL(ipc_telluri_send);
-    return ret;
-}
-
-int ipc_telluri_callback (IPC_CALLBACK_ARGS)
-{
-    BEGIN_PROFILE_INTERVAL();
-    int ret = 0;
-    struct shim_ipc_telluri * msgin =
-                (struct shim_ipc_telluri *) &msg->msg;
-
-    debug("ipc callback from %u: IPC_TELLURI(%s)\n", msg->src, msgin->uri);
-
-    struct shim_ipc_info * info =
-            lookup_and_alloc_client(msg->src, msgin->uri);
-
-    struct shim_ipc_msg_obj * obj = find_ipc_msg_duplex(port, msg->seq);
-
-    if (obj) {
-        if (info) {
-            if (obj->private)
-                *(struct shim_ipc_info **) obj->private = info;
-            obj->retval = 0;
-        } else {
-            obj->retval = -ENOMEM;
-        }
-
-        if (obj->thread)
-            thread_wakeup(obj->thread);
-    }
-
-    SAVE_PROFILE_INTERVAL(ipc_telluri_callback);
-    return ret;
+    return 0;
 }
 
 DEFINE_PROFILE_INTERVAL(ipc_checkpoint_send, ipc);
 DEFINE_PROFILE_INTERVAL(ipc_checkpoint_callback, ipc);
 
-int ipc_checkpoint_send (const char * cpdir, IDTYPE cpsession)
-{
+/* Graphene's checkpoint() syscall broadcasts a msg to all processes
+ * asking to checkpoint their state and save in process-unique file in
+ * directory cpdir under session cpsession. */
+int ipc_checkpoint_send(const char* cpdir, IDTYPE cpsession) {
     BEGIN_PROFILE_INTERVAL();
     int ret;
-    int len = strlen(cpdir);
+    size_t len = strlen(cpdir);
 
-    struct shim_ipc_msg * msg = create_ipc_msg_on_stack(
-                                        IPC_CHECKPOINT,
-                                        sizeof(struct shim_ipc_checkpoint)
-                                        + len, 0);
-    struct shim_ipc_checkpoint * msgin =
-                    (struct shim_ipc_checkpoint *) &msg->msg;
+    size_t total_msg_size = get_ipc_msg_size(sizeof(struct shim_ipc_checkpoint) + len);
+    struct shim_ipc_msg* msg = __alloca(total_msg_size);
+    init_ipc_msg(msg, IPC_CHECKPOINT, total_msg_size, 0);
 
+    struct shim_ipc_checkpoint* msgin = (struct shim_ipc_checkpoint *) &msg->msg;
     msgin->cpsession = cpsession;
     memcpy(&msgin->cpdir, cpdir, len + 1);
 
-    debug("ipc broadcast to all: IPC_CHECKPOINT(%u, %s)\n",
-          cpsession, cpdir);
+    debug("IPC broadcast to all: IPC_CHECKPOINT(%u, %s)\n", cpsession, cpdir);
 
+    /* broadcast to all including myself (so I can also checkpoint) */
     ret = broadcast_ipc(msg, IPC_PORT_DIRCLD|IPC_PORT_DIRPRT, /*exclude_port*/ NULL);
     SAVE_PROFILE_INTERVAL(ipc_checkpoint_send);
     return ret;
 }
 
-int ipc_checkpoint_callback (IPC_CALLBACK_ARGS)
-{
+/* This process is asked to create a checkpoint, so it:
+ * - sends a Graphene-specific SIGCP signal to all its threads (for
+ *   all to stop and join the checkpoint for consistent state),
+ * - broadcasts checkpoint msg further to other processes. */
+int ipc_checkpoint_callback(struct shim_ipc_msg* msg, struct shim_ipc_port* port) {
     BEGIN_PROFILE_INTERVAL();
     int ret = 0;
-    struct shim_ipc_checkpoint * msgin =
-                (struct shim_ipc_checkpoint *) msg->msg;
+    struct shim_ipc_checkpoint* msgin = (struct shim_ipc_checkpoint *) msg->msg;
 
-    debug("ipc callback form %u: IPC_CHECKPOINT(%u, %s)\n", msg->src,
-          msgin->cpsession, msgin->cpdir);
+    debug("IPC callback from %u: IPC_CHECKPOINT(%u, %s)\n",
+          msg->src, msgin->cpsession, msgin->cpdir);
 
     ret = create_checkpoint(msgin->cpdir, &msgin->cpsession);
     if (ret < 0)
         goto out;
 
     kill_all_threads(NULL, msgin->cpsession, SIGCP);
-    broadcast_ipc(msg, IPC_PORT_DIRPRT|IPC_PORT_DIRCLD, port);
+    broadcast_ipc(msg, IPC_PORT_DIRCLD|IPC_PORT_DIRPRT, port);
 out:
     SAVE_PROFILE_INTERVAL(ipc_checkpoint_callback);
     return ret;
 }
 
-BEGIN_CP_FUNC(ipc_info)
-{
+BEGIN_CP_FUNC(ipc_info) {
     assert(size == sizeof(struct shim_ipc_info));
 
-    struct shim_ipc_info * port = (struct shim_ipc_info *) obj;
-    struct shim_ipc_info * new_port = NULL;
+    struct shim_ipc_info* info = (struct shim_ipc_info *) obj;
+    struct shim_ipc_info* new_info = NULL;
 
     ptr_t off = GET_FROM_CP_MAP(obj);
 
     if (!off) {
         off = ADD_CP_OFFSET(sizeof(struct shim_ipc_info));
+        ADD_TO_CP_MAP(obj, off);
 
-        new_port = (struct shim_ipc_info *) (base + off);
-        memcpy(new_port, port, sizeof(struct shim_ipc_info));
-        REF_SET(new_port->ref_count, 0);
+        new_info = (struct shim_ipc_info *) (base + off);
+        memcpy(new_info, info, sizeof(struct shim_ipc_info));
+        REF_SET(new_info->ref_count, 0);
 
-        DO_CP_IN_MEMBER(qstr, new_port, uri);
+        /* call qstr-specific checkpointing function for new_info->uri */
+        DO_CP_IN_MEMBER(qstr, new_info, uri);
 
-        if (port->pal_handle &&
-            port->pal_handle != IPC_FORCE_RECONNECT) {
-            struct shim_palhdl_entry * entry;
-            DO_CP(palhdl, port->pal_handle, &entry);
-            entry->uri = &new_port->uri;
-            entry->phandle = &new_port->pal_handle;
+        if (info->pal_handle && info->pal_handle != IPC_FORCE_RECONNECT) {
+            struct shim_palhdl_entry* entry;
+            /* call palhdl-specific checkpointing function to checkpoint
+             * info->pal_handle and return created object in entry */
+            DO_CP(palhdl, info->pal_handle, &entry);
+            /* info's PAL handle will be re-opened with new URI during
+             * palhdl restore (see checkpoint.c) */
+            entry->uri = &new_info->uri;
+            entry->phandle = &new_info->pal_handle;
         }
     } else {
-        new_port = (struct shim_ipc_info *) (base + off);
+        /* already checkpointed */
+        new_info = (struct shim_ipc_info *) (base + off);
     }
 
-    if (new_port && objp)
-        *objp = (void *) new_port;
+    if (new_info && objp)
+        *objp = (void *) new_info;
 }
 END_CP_FUNC_NO_RS(ipc_info)
 
-BEGIN_CP_FUNC(process)
-{
+BEGIN_CP_FUNC(process) {
     assert(size == sizeof(struct shim_process));
 
-    struct shim_process * proc = (struct shim_process *) obj;
-    struct shim_process * new_proc = NULL;
+    struct shim_process* process = (struct shim_process *) obj;
+    struct shim_process* new_process = NULL;
 
     ptr_t off = GET_FROM_CP_MAP(obj);
 
@@ -681,57 +480,55 @@ BEGIN_CP_FUNC(process)
         off = ADD_CP_OFFSET(sizeof(struct shim_process));
         ADD_TO_CP_MAP(obj, off);
 
-        new_proc = (struct shim_process *) (base + off);
-        memcpy(new_proc, proc, sizeof(struct shim_process));
+        new_process = (struct shim_process *) (base + off);
+        memcpy(new_process, process, sizeof(struct shim_process));
 
-        if (proc->self)
-            DO_CP_MEMBER(ipc_info, proc, new_proc, self);
-
-        if (proc->parent)
-            DO_CP_MEMBER(ipc_info, proc, new_proc, parent);
-
-        for (int i = 0 ; i < TOTAL_NS ; i++)
-            if (proc->ns[i])
-                DO_CP_MEMBER(ipc_info, proc, new_proc, ns[i]);
+        /* call ipc_info-specific checkpointing functions
+         * for new_process's self, parent, and ns infos */
+        if (process->self)
+            DO_CP_MEMBER(ipc_info, process, new_process, self);
+        if (process->parent)
+            DO_CP_MEMBER(ipc_info, process, new_process, parent);
+        for (int i = 0; i < TOTAL_NS; i++)
+            if (process->ns[i])
+                DO_CP_MEMBER(ipc_info, process, new_process, ns[i]);
 
         ADD_CP_FUNC_ENTRY(off);
     } else {
-        new_proc = (struct shim_process *) (base + off);
+        /* already checkpointed */
+        new_process = (struct shim_process *) (base + off);
     }
 
     if (objp)
-        *objp = (void *) new_proc;
+        *objp = (void *) new_process;
 }
 END_CP_FUNC(process)
 
-BEGIN_RS_FUNC(process)
-{
+BEGIN_RS_FUNC(process) {
     __UNUSED(offset);
-    struct shim_process * proc = (void *) (base + GET_CP_FUNC_ENTRY());
+    struct shim_process* process = (void *) (base + GET_CP_FUNC_ENTRY());
 
-    CP_REBASE(proc->self);
-    CP_REBASE(proc->parent);
-    CP_REBASE(proc->ns);
+    CP_REBASE(process->self);
+    CP_REBASE(process->parent);
+    CP_REBASE(process->ns);
 
-    if (proc->self) {
-        proc->self->vmid = cur_process.vmid;
-        get_ipc_info(proc->self);
+    if (process->self) {
+        process->self->vmid = cur_process.vmid;
+        get_ipc_info(process->self);
     }
+    if (process->parent)
+        get_ipc_info(process->parent);
+    for (int i = 0; i < TOTAL_NS; i++)
+        if (process->ns[i])
+            get_ipc_info(process->ns[i]);
 
-    if (proc->parent)
-        get_ipc_info(proc->parent);
-
-    for (int i = 0 ; i < TOTAL_NS ; i++)
-        if (proc->ns[i])
-            get_ipc_info(proc->ns[i]);
-
-    proc->vmid = cur_process.vmid;
-    memcpy(&cur_process, proc, sizeof(struct shim_process));
+    process->vmid = cur_process.vmid;
+    memcpy(&cur_process, process, sizeof(struct shim_process));
     create_lock(&cur_process.lock);
 
-    DEBUG_RS("vmid=%u,uri=%s,parent=%u(%s)", proc->vmid,
-             proc->self ? qstrgetstr(&proc->self->uri) : "",
-             proc->parent ? proc->parent->vmid : 0,
-             proc->parent ? qstrgetstr(&proc->parent->uri) : "");
+    DEBUG_RS("vmid=%u,uri=%s,parent=%u(%s)", process->vmid,
+             process->self ? qstrgetstr(&process->self->uri) : "",
+             process->parent ? process->parent->vmid : 0,
+             process->parent ? qstrgetstr(&process->parent->uri) : "");
 }
 END_RS_FUNC(process)

--- a/LibOS/shim/src/ipc/shim_ipc_child.c
+++ b/LibOS/shim/src/ipc/shim_ipc_child.c
@@ -191,7 +191,7 @@ int ipc_cld_exit_send (IDTYPE ppid, IDTYPE tid, unsigned int exitcode, unsigned 
 
     debug("ipc broadcast: IPC_CLD_EXIT(%u, %u, %d)\n", ppid, tid, exitcode);
 
-    ret = broadcast_ipc(msg, NULL, 0, IPC_PORT_DIRPRT|IPC_PORT_DIRCLD);
+    ret = broadcast_ipc(msg, IPC_PORT_DIRPRT|IPC_PORT_DIRCLD, /*exclude_port*/ NULL);
     SAVE_PROFILE_INTERVAL(ipc_cld_exit_send);
     return ret;
 }

--- a/LibOS/shim/src/ipc/shim_ipc_child.c
+++ b/LibOS/shim/src/ipc/shim_ipc_child.c
@@ -15,7 +15,7 @@
    along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
 
 /*
- * shim_ipc_helper.c
+ * shim_ipc_child.c
  *
  * This file contains functions and callbacks to handle IPC between parent
  * processes and their children.
@@ -30,55 +30,7 @@
 
 #include <pal.h>
 #include <pal_error.h>
-
 #include <errno.h>
-
-static int ipc_thread_exit (IDTYPE vmid, IDTYPE tid, unsigned int exitcode,
-                            unsigned int term_signal, unsigned long exit_time)
-{
-    assert(vmid != cur_process.vmid);
-
-#ifdef PROFILE
-    if (!exit_time)
-        exit_time = GET_PROFILE_INTERVAL();
-#else
-    __UNUSED(exit_time);
-#endif
-
-    struct shim_thread * thread = __lookup_thread(tid);
-
-    if (thread) {
-        int ret = 0;
-        //assert(thread->vmid == vmid && !thread->in_vm);
-        thread->exit_code = -exitcode;
-        thread->term_signal = term_signal;
-#ifdef PROFILE
-        thread->exit_time = exit_time;
-#endif
-        ret = thread_exit(thread, false);
-        put_thread(thread);
-        return ret;
-    }
-
-    struct shim_simple_thread * sthread = __lookup_simple_thread(tid);
-
-    if (!sthread) {
-        sthread = get_new_simple_thread();
-        sthread->vmid = vmid;
-        sthread->tid = tid;
-        add_simple_thread(sthread);
-    }
-
-    sthread->is_alive = 0;
-    sthread->exit_code = -exitcode;
-    sthread->term_signal = term_signal;
-#ifdef PROFILE
-    sthread->exit_time = exit_time;
-#endif
-    DkEventSet(sthread->exit_event);
-    put_simple_thread(sthread);
-    return 0;
-}
 
 struct thread_info {
     IDTYPE vmid;
@@ -86,193 +38,228 @@ struct thread_info {
     unsigned int term_signal;
 };
 
-static int child_sthread_exit (struct shim_simple_thread * thread, void * arg,
-                               bool * unlocked)
-{
-    __UNUSED(unlocked); // Used by other callbacks
-    struct thread_info * info = (struct thread_info *) arg;
+/* walk_simple_thread_list callback; exit each simple thread of child process vmid. */
+static int child_sthread_exit(struct shim_simple_thread* thread, void* arg, bool* unlocked) {
+    __UNUSED(unlocked); /* FYI: notifies about unlocked thread_list_lock */
+
+    struct thread_info* info = (struct thread_info *) arg;
+    int found_exiting_thread = 0;
+
+    lock(&thread->lock);
     if (thread->vmid == info->vmid) {
+        found_exiting_thread = 1;
+
         if (thread->is_alive) {
             thread->exit_code = -info->exitcode;
             thread->term_signal = info->term_signal;
             thread->is_alive = false;
+
+            /* arrange exit event for subsequent wait4(thread->tid) */
             DkEventSet(thread->exit_event);
         }
-        return 1;
     }
-    return 0;
+    unlock(&thread->lock);
+    return found_exiting_thread;
 }
 
-static int child_thread_exit (struct shim_thread * thread, void * arg,
-                              bool * unlocked)
-{
-    __UNUSED(unlocked); // Used by other callbacks
-    struct thread_info * info = (struct thread_info *) arg;
+/* walk_thread_list callback; exit each thread of child process vmid. */
+static int child_thread_exit(struct shim_thread* thread, void* arg, bool* unlocked) {
+    __UNUSED(unlocked); /* FYI: notifies about unlocked thread_list_lock */
+
+    struct thread_info* info = (struct thread_info *) arg;
+    int found_exiting_thread = 0;
+
+    lock(&thread->lock);
     if (thread->vmid == info->vmid) {
+        found_exiting_thread = 1;
+
         if (thread->is_alive) {
             thread->exit_code = -info->exitcode;
             thread->term_signal = info->term_signal;
+            unlock(&thread->lock);
+
+            /* remote thread is "virtually" exited: SIGCHLD is generated for
+             * the parent thread and exit events are arranged for subsequent
+             * wait4(). */
             thread_exit(thread, false);
+            goto out;
         }
-        return 1;
     }
-    return 0;
+    unlock(&thread->lock);
+
+out:
+    return found_exiting_thread;
 }
 
-int remove_child_thread (IDTYPE vmid, unsigned int exitcode, unsigned int term_signal)
-{
-    struct thread_info info = { .vmid = vmid, .exitcode = exitcode, .term_signal = term_signal };
-    int nkilled = 0, ret;
+/* IPC helper thread invokes this fini function when main IPC port for
+ * communication with child process is disconnected/removed by host OS.
+ *
+ * Similarly to benign case of receiving an explicit IPC_CLD_EXIT message
+ * from exiting remote thread (see ipc_cld_exit_callback()), we want to
+ * delete all remote threads associated with disconnected child process.
+ */
+void ipc_port_with_child_fini(struct shim_ipc_port* port, IDTYPE vmid, unsigned int exitcode) {
+    __UNUSED(port);
 
+    /* NOTE: IPC port may be closed by host OS because the child process
+     *       exited on host OS (and so host OS closed all its sockets).
+     *       This may happen before arrival of the "expected" IPC_CLD_EXIT
+     *       message from child process. Ideally, we would inspect whether
+     *       we previously sent SIGINT/SIGTERM/SIGKILL to this child and
+     *       use the corresponding termination signal. For now, we simply
+     *       report that child process was killed by SIGKILL. */
+    struct thread_info info = { .vmid = vmid, .exitcode = exitcode, .term_signal = SIGKILL };
+
+    /* message cannot come from our own threads (from ourselves as process) */
     assert(vmid != cur_process.vmid);
 
+    int ret;
+    int exited_threads_cnt = 0;
+
     if ((ret = walk_thread_list(&child_thread_exit, &info)) > 0)
-        nkilled += ret;
-
+        exited_threads_cnt += ret;
     if ((ret = walk_simple_thread_list(&child_sthread_exit, &info)) > 0)
-        nkilled += ret;
+        exited_threads_cnt += ret;
 
-    if (!nkilled)
-        debug("child port closed, no thread exited\n");
-
-    return 0;
-}
-
-void ipc_child_exit (struct shim_ipc_port * port, IDTYPE vmid,
-                     unsigned int exitcode)
-{
-    debug("ipc port %p of process %u closed suggests child exiting\n",
-          port, vmid);
-
-    /*
-     * Chia-Che 12/12/2017:
-     * Can't assume there is a termination signal. this callback
-     * is only called when the child process is not responding, and
-     * under this circumstance can only assume the child process
-     * has encountered severe failure, hence SIGKILL.
-     */
-    remove_child_thread(vmid, exitcode, SIGKILL);
-}
-
-static struct shim_ipc_port * get_parent_port (IDTYPE * dest)
-{
-    struct shim_ipc_port * port = NULL;
-    lock(&cur_process.lock);
-    if (cur_process.parent && (port = cur_process.parent->port)) {
-        get_ipc_port(port);
-        *dest = cur_process.parent->vmid;
-    }
-    unlock(&cur_process.lock);
-    return port;
+    debug("Child process %u got disconnected: assume that child exited and "
+          "force %d of its threads to exit\n", vmid & 0xFFFF, exited_threads_cnt);
 }
 
 DEFINE_PROFILE_INTERVAL(ipc_cld_exit_turnaround, ipc);
 DEFINE_PROFILE_INTERVAL(ipc_cld_exit_send, ipc);
 DEFINE_PROFILE_INTERVAL(ipc_cld_exit_callback, ipc);
 
-int ipc_cld_exit_send (IDTYPE ppid, IDTYPE tid, unsigned int exitcode, unsigned int term_signal)
-{
+/* The exiting thread of this process calls this function to broadcast
+ * IPC_CLD_EXIT notification to its parent process (technically, to all
+ * processes of type DIRPRT or DIRCLD but the only interesting case is
+ * the notification of parent). */
+int ipc_cld_exit_send(IDTYPE ppid, IDTYPE tid, unsigned int exitcode, unsigned int term_signal) {
     __attribute__((unused)) unsigned long send_time = GET_PROFILE_INTERVAL();
     BEGIN_PROFILE_INTERVAL_SET(send_time);
-    int ret = 0;
 
     size_t total_msg_size = get_ipc_msg_size(sizeof(struct shim_ipc_cld_exit));
     struct shim_ipc_msg* msg = __alloca(total_msg_size);
     init_ipc_msg(msg, IPC_CLD_EXIT, total_msg_size, 0);
 
-    struct shim_ipc_cld_exit * msgin =
-                (struct shim_ipc_cld_exit *) &msg->msg;
-    msgin->ppid = ppid;
-    msgin->tid = tid;
-    msgin->exitcode = exitcode;
+    struct shim_ipc_cld_exit* msgin = (struct shim_ipc_cld_exit *) &msg->msg;
+    msgin->ppid        = ppid;
+    msgin->tid         = tid;
+    msgin->exitcode    = exitcode;
     msgin->term_signal = term_signal;
 #ifdef PROFILE
-    msgin->time = send_time;
+    msgin->time        = send_time;
 #endif
 
-    debug("ipc broadcast: IPC_CLD_EXIT(%u, %u, %d)\n", ppid, tid, exitcode);
+    debug("IPC broadcast: IPC_CLD_EXIT(%u, %u, %d, %u)\n",
+          ppid, tid, exitcode, term_signal);
 
-    ret = broadcast_ipc(msg, IPC_PORT_DIRPRT|IPC_PORT_DIRCLD, /*exclude_port*/ NULL);
+    int ret = broadcast_ipc(msg, IPC_PORT_DIRPRT|IPC_PORT_DIRCLD, /*exclude_port*/ NULL);
     SAVE_PROFILE_INTERVAL(ipc_cld_exit_send);
     return ret;
 }
 
-int ipc_cld_exit_callback (IPC_CALLBACK_ARGS)
-{
-    // XXX: Should we close/free port?
+/* IPC helper thread invokes this callback on an IPC_CLD_EXIT mesage received
+ * from a specific thread msgin->tid of the exiting child process with vmid
+ * msg->src. The thread of the exiting child process informs about its exit
+ * code in msgin->exit_code and its terminating signal in msgin->term_signal.
+ *
+ * The callback finds this remote thread of the child process among our
+ * process's threads/simple threads (recall that parent process maintains
+ * remote child threads in its thread list, marking them as in_vm == false).
+ * The remote thread is "virtually" exited: SIGCHLD is generated for the
+ * parent thread and exit events are arranged for subsequent wait4().
+ */
+int ipc_cld_exit_callback(struct shim_ipc_msg* msg, struct shim_ipc_port* port) {
     __UNUSED(port);
+    int ret = 0;
 
-    struct shim_ipc_cld_exit * msgin =
-                (struct shim_ipc_cld_exit *) &msg->msg;
+    struct shim_ipc_cld_exit* msgin = (struct shim_ipc_cld_exit *) &msg->msg;
 
 #ifdef PROFILE
     unsigned long time = msgin->time;
-#else
-    unsigned long time = 0;
+    if (!time)
+        time = GET_PROFILE_INTERVAL();
 #endif
     BEGIN_PROFILE_INTERVAL_SET(time);
     SAVE_PROFILE_INTERVAL(ipc_cld_exit_turnaround);
 
-    debug("ipc callback from %u: IPC_CLD_EXIT(%u, %u, %d)\n",
-          msg->src, msgin->ppid, msgin->tid, msgin->exitcode);
+    debug("IPC callback from %u: IPC_CLD_EXIT(%u, %u, %d, %u)\n",
+          msg->src & 0xFFFF, msgin->ppid, msgin->tid, msgin->exitcode, msgin->term_signal);
 
-    // XXX: Assert that we are the msgin->ppid?
+    /* message cannot come from our own threads (from ourselves as process) */
+    assert(msg->src != cur_process.vmid);
 
-    int ret = ipc_thread_exit(msg->src, msgin->tid,
-                              msgin->exitcode, msgin->term_signal,
-                              time);
+    /* First try to find remote thread who sent this message among normal
+     * threads. In the common case, we (as parent process) keep remote child
+     * threads in the thread list. But sometimes the message can arrive twice
+     * or very late, such that the corresponding remote thread was already
+     * exited and deleted; in such cases, we fall back to simple threads. */
+    struct shim_thread* thread = lookup_thread(msgin->tid);
+    if (thread) {
+        lock(&thread->lock);
+        thread->exit_code   = -msgin->exitcode;
+        thread->term_signal = msgin->term_signal;
+#ifdef PROFILE
+        thread->exit_time = time;
+#endif
+        unlock(&thread->lock);
+
+        /* Remote thread is "virtually" exited: SIGCHLD is generated for the
+         * parent thread and exit events are arranged for subsequent wait4(). */
+        ret = thread_exit(thread, /*send_ipc*/ false);
+        put_thread(thread);
+    } else {
+        /* Uncommon case: remote child thread was already exited and deleted
+         * (probably because the same message was already received earlier).
+         * Find or create a simple thread for a sole purpose of arranging
+         * exit events for subsequent wait4(). */
+        struct shim_simple_thread* sthread = lookup_simple_thread(msgin->tid);
+
+        if (!sthread) {
+            sthread = get_new_simple_thread();
+            sthread->vmid = msg->src;
+            sthread->tid  = msgin->tid;
+            add_simple_thread(sthread);
+        }
+
+        lock(&sthread->lock);
+        sthread->is_alive    = false;
+        sthread->exit_code   = -msgin->exitcode;
+        sthread->term_signal = msgin->term_signal;
+#ifdef PROFILE
+        sthread->exit_time = time;
+#endif
+        unlock(&sthread->lock);
+
+        DkEventSet(sthread->exit_event); /* for wait4(msgin->tid) */
+        put_simple_thread(sthread);
+    }
+
     SAVE_PROFILE_INTERVAL(ipc_cld_exit_callback);
     return ret;
-}
-
-DEFINE_PROFILE_INTERVAL(ipc_cld_join_send, ipc);
-DEFINE_PROFILE_INTERVAL(ipc_cld_join_callback, ipc);
-
-int ipc_cld_join_send (IDTYPE dest)
-{
-    BEGIN_PROFILE_INTERVAL();
-    struct shim_ipc_port * port = dest ?
-                                  lookup_ipc_port(dest, IPC_PORT_DIRPRT) :
-                                  get_parent_port(&dest);
-    if (!port)
-        return -ESRCH;
-
-    size_t total_msg_size = get_ipc_msg_size(0);
-    struct shim_ipc_msg* msg = __alloca(total_msg_size);
-    init_ipc_msg(msg, IPC_CLD_JOIN, total_msg_size, dest);
-
-    debug("ipc send to %u: IPC_CLD_JOIN\n", dest);
-
-    int ret = send_ipc_message(msg, port);
-
-    add_ipc_port(port, dest, IPC_PORT_DIRPRT, NULL);
-    put_ipc_port(port);
-    SAVE_PROFILE_INTERVAL(ipc_cld_join_send);
-    return ret;
-}
-
-int ipc_cld_join_callback (IPC_CALLBACK_ARGS)
-{
-    BEGIN_PROFILE_INTERVAL();
-    debug("ipc callback from %u: IPC_CLD_JOIN\n", msg->src);
-    add_ipc_port(port, msg->src, IPC_PORT_DIRCLD, NULL);
-    SAVE_PROFILE_INTERVAL(ipc_cld_join_callback);
-    return 0;
 }
 
 DEFINE_PROFILE_INTERVAL(ipc_send_profile, ipc);
 
 #ifdef PROFILE
-int ipc_cld_profile_send (void)
-{
-    IDTYPE dest;
-    struct shim_ipc_port * port = get_parent_port(&dest);
-    if (!port)
+int ipc_cld_profile_send(void) {
+    struct shim_ipc_port* port = NULL;
+    IDTYPE dest = (IDTYPE) -1;
+
+    /* port and dest are initialized to parent process */
+    lock(&cur_process.lock);
+    if (cur_process.parent && (port = cur_process.parent->port)) {
+        get_ipc_port(port);
+        dest = cur_process.parent->vmid;
+    }
+    unlock(&cur_process.lock);
+
+    if (!port || (dest == (IDTYPE) -1))
         return -ESRCH;
 
     unsigned long time = GET_PROFILE_INTERVAL();
     size_t nsending = 0;
-    for (size_t i = 0 ; i < N_PROFILE ; i++)
+    for (size_t i = 0; i < N_PROFILE; i++)
         switch (PROFILES[i].type) {
             case OCCURENCE:
                 if (atomic_read(&PROFILES[i].val.occurence.count))
@@ -286,38 +273,34 @@ int ipc_cld_profile_send (void)
                 break;
         }
 
-
     size_t total_msg_size = get_ipc_msg_size(sizeof(struct shim_ipc_cld_profile) +
                                              sizeof(struct profile_val) * nsending);
     struct shim_ipc_msg* msg = __alloca(total_msg_size);
     init_ipc_msg(msg, IPC_CLD_PROFILE, total_msg_size, dest);
 
-    struct shim_ipc_cld_profile * msgin =
-                (struct shim_ipc_cld_profile *) &msg->msg;
+    struct shim_ipc_cld_profile* msgin = (struct shim_ipc_cld_profile *) &msg->msg;
 
     size_t nsent = 0;
-    for (size_t i = 0 ; i < N_PROFILE && nsent < nsending ; i++)
+    for (size_t i = 0; i < N_PROFILE && nsent < nsending; i++)
         switch (PROFILES[i].type) {
             case OCCURENCE: {
-                unsigned long count =
-                    atomic_read(&PROFILES[i].val.occurence.count);
+                unsigned long count = atomic_read(&PROFILES[i].val.occurence.count);
                 if (count) {
                     msgin->profile[nsent].idx = i + 1;
                     msgin->profile[nsent].val.occurence.count = count;
-                    debug("send %s: %lu times\n", PROFILES[i].name, count);
+                    debug("Send %s: %lu times\n", PROFILES[i].name, count);
                     nsent++;
                 }
                 break;
             }
             case INTERVAL: {
-                unsigned long count =
-                    atomic_read(&PROFILES[i].val.interval.count);
+                unsigned long count = atomic_read(&PROFILES[i].val.interval.count);
                 if (count) {
                     msgin->profile[nsent].idx = i + 1;
                     msgin->profile[nsent].val.interval.count = count;
                     msgin->profile[nsent].val.interval.time =
                         atomic_read(&PROFILES[i].val.interval.time);
-                    debug("send %s: %lu times, %lu msec\n", PROFILES[i].name,
+                    debug("Send %s: %lu times, %lu msec\n", PROFILES[i].name,
                           count, msgin->profile[nsent].val.interval.time);
                     nsent++;
                 }
@@ -330,34 +313,32 @@ int ipc_cld_profile_send (void)
     msgin->time = time;
     msgin->nprofile = nsent;
 
-    debug("ipc send to %u: IPC_CLD_PROFILE\n", dest);
-
+    debug("IPC send to %u: IPC_CLD_PROFILE\n", dest & 0xFFFF);
     int ret = send_ipc_message(msg, port);
+
     put_ipc_port(port);
     return ret;
 }
 
-int ipc_cld_profile_callback (IPC_CALLBACK_ARGS)
-{
-    struct shim_ipc_cld_profile * msgin =
-                (struct shim_ipc_cld_profile *) &msg->msg;
+int ipc_cld_profile_callback(struct shim_ipc_msg* msg, struct shim_ipc_port* port) {
+    debug("IPC callback from %u: IPC_CLD_PROFILE\n", msg->src & 0xFFFF);
 
-    debug("ipc callback from %u: IPC_CLD_PROFILE\n", msg->src);
+    struct shim_ipc_cld_profile* msgin = (struct shim_ipc_cld_profile *) &msg->msg;
 
-    for (int i = 0 ; i < msgin->nprofile ; i++) {
+    for (int i = 0; i < msgin->nprofile; i++) {
         int idx = msgin->profile[i].idx;
         if (idx == 0)
             break;
         idx--;
         switch (PROFILES[idx].type) {
             case OCCURENCE:
-                debug("receive %s: %u times\n", PROFILES[idx].name,
+                debug("Receive %s: %u times\n", PROFILES[idx].name,
                       msgin->profile[i].val.occurence.count);
                 atomic_add(msgin->profile[i].val.occurence.count,
                            &PROFILES[idx].val.occurence.count);
                 break;
             case INTERVAL:
-                debug("receive %s: %u times, %lu msec\n", PROFILES[idx].name,
+                debug("Receive %s: %u times, %lu msec\n", PROFILES[idx].name,
                       msgin->profile[i].val.interval.count,
                       msgin->profile[i].val.interval.time);
                 atomic_add(msgin->profile[i].val.interval.count,

--- a/LibOS/shim/src/ipc/shim_ipc_child.c
+++ b/LibOS/shim/src/ipc/shim_ipc_child.c
@@ -176,9 +176,10 @@ int ipc_cld_exit_send (IDTYPE ppid, IDTYPE tid, unsigned int exitcode, unsigned 
     BEGIN_PROFILE_INTERVAL_SET(send_time);
     int ret = 0;
 
-    struct shim_ipc_msg * msg =
-            create_ipc_msg_on_stack(IPC_CLD_EXIT,
-                                    sizeof(struct shim_ipc_cld_exit), 0);
+    size_t total_msg_size = get_ipc_msg_size(sizeof(struct shim_ipc_cld_exit));
+    struct shim_ipc_msg* msg = __alloca(total_msg_size);
+    init_ipc_msg(msg, IPC_CLD_EXIT, total_msg_size, 0);
+
     struct shim_ipc_cld_exit * msgin =
                 (struct shim_ipc_cld_exit *) &msg->msg;
     msgin->ppid = ppid;
@@ -236,8 +237,9 @@ int ipc_cld_join_send (IDTYPE dest)
     if (!port)
         return -ESRCH;
 
-    struct shim_ipc_msg * msg =
-                create_ipc_msg_on_stack(IPC_CLD_JOIN, 0, dest);
+    size_t total_msg_size = get_ipc_msg_size(0);
+    struct shim_ipc_msg* msg = __alloca(total_msg_size);
+    init_ipc_msg(msg, IPC_CLD_JOIN, total_msg_size, dest);
 
     debug("ipc send to %u: IPC_CLD_JOIN\n", dest);
 
@@ -285,11 +287,11 @@ int ipc_cld_profile_send (void)
         }
 
 
-    struct shim_ipc_msg * msg = create_ipc_msg_on_stack(
-                                        IPC_CLD_PROFILE,
-                                        sizeof(struct shim_ipc_cld_profile) +
-                                        sizeof(struct profile_val) *
-                                        nsending, dest);
+    size_t total_msg_size = get_ipc_msg_size(sizeof(struct shim_ipc_cld_profile) +
+                                             sizeof(struct profile_val) * nsending);
+    struct shim_ipc_msg* msg = __alloca(total_msg_size);
+    init_ipc_msg(msg, IPC_CLD_PROFILE, total_msg_size, dest);
+
     struct shim_ipc_cld_profile * msgin =
                 (struct shim_ipc_cld_profile *) &msg->msg;
 

--- a/LibOS/shim/src/ipc/shim_ipc_helper.c
+++ b/LibOS/shim/src/ipc/shim_ipc_helper.c
@@ -61,7 +61,7 @@ static ipc_callback ipc_callbacks[IPC_CODE_NUM] = {
 
     /* parents and children */
     /* CLD_EXIT         */  &ipc_cld_exit_callback,
-    /* CLD_JOIN         */  &ipc_cld_join_callback,
+
 #ifdef PROFILE
     /* CLD_PROFILE      */  &ipc_cld_profile_callback,
 #endif

--- a/LibOS/shim/src/ipc/shim_ipc_helper.c
+++ b/LibOS/shim/src/ipc/shim_ipc_helper.c
@@ -44,8 +44,7 @@ static MEM_MGR port_mgr;
 DEFINE_LISTP(shim_ipc_port);
 static LISTP_TYPE(shim_ipc_port) port_list;
 
-/* can be read without ipc_helper_lock but always written with lock held */
-static enum {  HELPER_NOTALIVE, HELPER_ALIVE } ipc_helper_state;
+static enum { HELPER_NOTALIVE, HELPER_ALIVE } ipc_helper_state;
 
 static struct shim_thread* ipc_helper_thread;
 static struct shim_lock    ipc_helper_lock;
@@ -95,7 +94,7 @@ static int init_self_ipc_port(void) {
 
     if (!cur_process.self) {
         /* very first process or clone/fork case: create IPC port from scratch */
-        cur_process.self = create_ipc_info_cur_process(/*is_self_ipc_info*/ true);
+        cur_process.self = create_ipc_info_cur_process(/*is_self_ipc_info=*/true);
         if (!cur_process.self) {
             unlock(&cur_process.lock);
             return -EACCES;
@@ -107,7 +106,7 @@ static int init_self_ipc_port(void) {
         add_ipc_port_by_id(cur_process.self->vmid,
                            cur_process.self->pal_handle,
                            IPC_PORT_SERVER,
-                           /* fini callback */ NULL,
+                           /*fini=*/NULL,
                            &cur_process.self->port);
     }
 
@@ -135,7 +134,7 @@ static int init_parent_ipc_port(void) {
     add_ipc_port_by_id(cur_process.parent->vmid,
                        cur_process.parent->pal_handle,
                        IPC_PORT_DIRPRT | IPC_PORT_LISTEN,
-                       /* fini callback */ NULL,
+                       /*fini=*/NULL,
                        &cur_process.parent->port);
 
     unlock(&cur_process.lock);
@@ -170,7 +169,7 @@ static int init_ns_ipc_port(int ns_idx) {
     add_ipc_port_by_id(cur_process.ns[ns_idx]->vmid,
                        cur_process.ns[ns_idx]->pal_handle,
                        type | IPC_PORT_LISTEN,
-                       /* fini callback */ NULL,
+                       /*fini=*/NULL,
                        &cur_process.ns[ns_idx]->port);
 
     unlock(&cur_process.lock);
@@ -271,11 +270,14 @@ static void __add_ipc_port(struct shim_ipc_port* port, IDTYPE vmid,
 
     /* find empty slot in fini callbacks and register callback */
     if (fini) {
+        bool found_empty_slot = false;
         for (int i = 0; i < MAX_IPC_PORT_FINI_CB; i++)
             if (!port->fini[i] || port->fini[i] == fini) {
                 port->fini[i] = fini;
+                found_empty_slot = true;
                 break;
             }
+        assert(found_empty_slot);
     }
 
     /* add to port list if not there already */
@@ -305,7 +307,7 @@ static void __del_ipc_port(struct shim_ipc_port* port) {
         msg->retval = -ECONNRESET;
         if (msg->thread) {
             debug("Deleted pending message on port %p, wake up blocking thread %d\n",
-                    port, msg->thread->tid);
+                  port, msg->thread->tid);
             thread_wakeup(msg->thread);
         }
     }
@@ -384,8 +386,10 @@ void del_ipc_port_fini(struct shim_ipc_port* port, unsigned int exitcode) {
     unlock(&ipc_helper_lock);
 
     for (int i = 0; i < MAX_IPC_PORT_FINI_CB; i++)
-        if (port->fini[i])
+        if (port->fini[i]) {
             (port->fini[i])(port, port->vmid, exitcode);
+            port->fini[i] = NULL;
+        }
 
     __put_ipc_port(port);
 }
@@ -410,7 +414,7 @@ struct shim_ipc_port* lookup_ipc_port(IDTYPE vmid, IDTYPE type) {
     struct shim_ipc_port* tmp;
     LISTP_FOR_EACH_ENTRY(tmp, &port_list, list) {
         if (tmp->vmid == vmid && (tmp->type & type)) {
-            debug("found port %p (handle %p) for process %u (type %04x)\n",
+            debug("Found port %p (handle %p) for process %u (type %04x)\n",
                   tmp, tmp->pal_handle, tmp->vmid & 0xFFFF, tmp->type);
             port = tmp;
             __get_ipc_port(port);
@@ -422,34 +426,36 @@ struct shim_ipc_port* lookup_ipc_port(IDTYPE vmid, IDTYPE type) {
     return port;
 }
 
+#define PORTS_ON_STACK_CNT 32
+
 int broadcast_ipc(struct shim_ipc_msg* msg, int target_type, struct shim_ipc_port* exclude_port) {
     int ret;
     struct shim_ipc_port* port;
     struct shim_ipc_port** target_ports;
-    int target_ports_cnt = 0;
+    size_t target_ports_cnt = 0;
 
     assert(target_type);
     lock(&ipc_helper_lock);
 
     /* Collect all ports with appropriate types. In common case, stack-allocated
-     * array of 32 ports is enough. If there are more ports, we will allocate
-     * a bigger array on the heap and collect all ports again. */
-    struct shim_ipc_port* target_ports_stack[32];
+     * array of PORTS_ON_STACK_CNT ports is enough. If there are more ports, we
+     * will allocate a bigger array on the heap and collect all ports again. */
+    struct shim_ipc_port* target_ports_stack[PORTS_ON_STACK_CNT];
     LISTP_FOR_EACH_ENTRY(port, &port_list, list) {
         if (port == exclude_port)
             continue;
         if (port->type & target_type) {
-            if (target_ports_cnt < 32)
+            if (target_ports_cnt < PORTS_ON_STACK_CNT)
                 target_ports_stack[target_ports_cnt] = port;
             target_ports_cnt++;
         }
     }
     target_ports = target_ports_stack;
 
-    if (target_ports_cnt > 32) {
-        /* Rare case when there are more than 32 ports. Allocate big-enough
-         * array on the heap and collect all ports again. */
-        int cnt = 0;
+    if (target_ports_cnt > PORTS_ON_STACK_CNT) {
+        /* Rare case when there are more than PORTS_ON_STACK_CNT ports. Allocate
+         * big-enough array on the heap and collect all ports again. */
+        size_t cnt = 0;
         struct shim_ipc_port** target_ports_heap =
             malloc(sizeof(struct shim_ipc_port *) * target_ports_cnt);
 
@@ -463,13 +469,13 @@ int broadcast_ipc(struct shim_ipc_msg* msg, int target_type, struct shim_ipc_por
         assert(cnt == target_ports_cnt);
     }
 
+    for (size_t i = 0; i < target_ports_cnt; i++)
+        __get_ipc_port(target_ports[i]);
+
     unlock(&ipc_helper_lock);
 
-    for (int i = 0; i < target_ports_cnt; i++)
-        get_ipc_port(target_ports[i]);
-
     /* send msg to each collected port (note that ports cannot be freed in meantime) */
-    for (int i = 0; i < target_ports_cnt; i++) {
+    for (size_t i = 0; i < target_ports_cnt; i++) {
         port = target_ports[i];
 
         debug("Broadcast to port %p (handle %p) for process %u (type %x, target %x)\n",
@@ -479,14 +485,14 @@ int broadcast_ipc(struct shim_ipc_msg* msg, int target_type, struct shim_ipc_por
         ret = send_ipc_message(msg, port);
         if (ret < 0) {
             debug("Broadcast to port %p (handle %p) for process %u failed (errno = %d)!\n",
-                    port, port->pal_handle, port->vmid & 0xFFFF, ret);
+                  port, port->pal_handle, port->vmid & 0xFFFF, ret);
             goto out;
         }
     }
 
     ret = 0;
 out:
-    for (int i = 0; i < target_ports_cnt; i++)
+    for (size_t i = 0; i < target_ports_cnt; i++)
         put_ipc_port(target_ports[i]);
     if (target_ports != target_ports_stack)
         free(target_ports);
@@ -503,7 +509,7 @@ static int ipc_resp_callback(struct shim_ipc_msg* msg, struct shim_ipc_port* por
     /* find a corresponding request msg for this response msg */
     struct shim_ipc_msg_duplex* req_msg = pop_ipc_msg_duplex(port, msg->seq);
 
-    /* if some thread waits for response, wake it up with response retval */
+    /* if some thread is waiting for response, wake it with response retval */
     if (req_msg) {
         req_msg->retval = resp->retval;
         if (req_msg->thread)
@@ -514,7 +520,7 @@ static int ipc_resp_callback(struct shim_ipc_msg* msg, struct shim_ipc_port* por
     return resp->retval;
 }
 
-int send_response_ipc_message(struct shim_ipc_port* port, IDTYPE dest, int ret, uint64_t seq) {
+int send_response_ipc_message(struct shim_ipc_port* port, IDTYPE dest, int ret, unsigned long seq) {
     ret = (ret == RESPONSE_CALLBACK) ? 0 : ret;
 
     /* create IPC_RESP msg to send to dest, with sequence number seq, and in-body retval ret */
@@ -523,7 +529,7 @@ int send_response_ipc_message(struct shim_ipc_port* port, IDTYPE dest, int ret, 
     init_ipc_msg(resp_msg, IPC_RESP, total_msg_size, dest);
     resp_msg->seq = seq;
 
-    struct shim_ipc_resp* resp = (struct shim_ipc_resp *) resp_msg->msg;
+    struct shim_ipc_resp* resp = (struct shim_ipc_resp *)resp_msg->msg;
     resp->retval = ret;
 
     debug("IPC send to %u: IPC_RESP(%d)\n", resp_msg->dst & 0xFFFF, ret);
@@ -532,12 +538,12 @@ int send_response_ipc_message(struct shim_ipc_port* port, IDTYPE dest, int ret, 
 
 static int receive_ipc_message(struct shim_ipc_port* port) {
     int ret;
-    int readahead = IPC_MSG_MINIMAL_SIZE * 2;
-    int bufsize = IPC_MSG_MINIMAL_SIZE + readahead;
+    size_t readahead = IPC_MSG_MINIMAL_SIZE * 2;
+    size_t bufsize = IPC_MSG_MINIMAL_SIZE + readahead;
 
     struct shim_ipc_msg* msg = malloc(bufsize);
-    int expected_size = IPC_MSG_MINIMAL_SIZE;
-    int bytes = 0;
+    size_t expected_size = IPC_MSG_MINIMAL_SIZE;
+    size_t bytes = 0;
 
     do {
         while (bytes < expected_size) {
@@ -551,8 +557,8 @@ static int receive_ipc_message(struct shim_ipc_port* port) {
                 msg = tmp_buf;
             }
 
-            int read = DkStreamRead(port->pal_handle, /*offset*/ 0, expected_size - bytes + readahead,
-                                     (void *) msg + bytes, NULL, 0);
+            size_t read = DkStreamRead(port->pal_handle, /*offset=*/0, expected_size - bytes + readahead,
+                                       (void *) msg + bytes, NULL, 0);
 
             if (!read) {
                 if (PAL_ERRNO == EINTR || PAL_ERRNO == EAGAIN || PAL_ERRNO == EWOULDBLOCK)
@@ -578,13 +584,13 @@ static int receive_ipc_message(struct shim_ipc_port* port) {
         if (msg->src != cur_process.vmid) {
             if (msg->code < IPC_CODE_NUM && ipc_callbacks[msg->code]) {
                 /* invoke callback to this msg */
-                ret = (*ipc_callbacks[msg->code]) (msg, port);
+                ret = (*ipc_callbacks[msg->code])(msg, port);
                 if ((ret < 0 || ret == RESPONSE_CALLBACK) && msg->seq) {
                     /* send IPC_RESP message to sender of this msg */
                     ret = send_response_ipc_message(port, msg->src, ret, msg->seq);
                     if (ret < 0) {
                         debug("Sending IPC_RESP msg on port %p (handle %p) to %u failed\n",
-                                port, port->pal_handle, msg->src & 0xFFFF);
+                              port, port->pal_handle, msg->src & 0xFFFF);
                         ret = -PAL_ERRNO;
                         goto out;
                     }
@@ -597,7 +603,7 @@ static int receive_ipc_message(struct shim_ipc_port* port) {
         if (bytes > 0) {
             /* we may have started reading the next message, move this message
              * to beginning of msg buffer and reset expected size */
-            memmove(msg, (void *) msg + expected_size, bytes);
+            memmove(msg, (void *)msg + expected_size, bytes);
             expected_size = IPC_MSG_MINIMAL_SIZE;
             if (bytes >= IPC_MSG_MINIMAL_SIZE)
                 expected_size = msg->size;
@@ -642,7 +648,7 @@ noreturn static void shim_ipc_helper(void* dummy) {
     /* Initialize two lists:
      * - object_list collects IPC port objects and is the main handled list
      * - palhandle_list collects corresponding PAL handles of IPC port objects
-     *   and is needed for DkObjectsWaitAny(.., <arrya-of-PAL-handles>, ..)
+     *   and is needed for DkObjectsWaitAny(.., <array-of-PAL-handles>, ..)
      *   interface; palhandle_list always contains at least install_new_event
      *
      * We allocate these two lists on the heap so they do not overflow the
@@ -658,7 +664,15 @@ noreturn static void shim_ipc_helper(void* dummy) {
     PAL_HANDLE install_new_event_hdl = event_handle(&install_new_event);
     palhandle_list[0] = install_new_event_hdl;
 
-    while (ipc_helper_state == HELPER_ALIVE) {
+    while (true) {
+        lock(&ipc_helper_lock);
+        if (ipc_helper_state != HELPER_ALIVE) {
+            ipc_helper_thread = NULL;
+            unlock(&ipc_helper_lock);
+            break;
+        }
+        unlock(&ipc_helper_lock);
+
         struct shim_ipc_port* polled_port = NULL;
 
         if (polled == install_new_event_hdl) {
@@ -702,22 +716,20 @@ noreturn static void shim_ipc_helper(void* dummy) {
 
                     if (attr.disconnected) {
                         debug("Port %p (handle %p) disconnected\n",
-                                polled_port, polled_port->pal_handle);
+                              polled_port, polled_port->pal_handle);
                         del_ipc_port_fini(polled_port, -ECONNRESET);
                     }
                 } else {
                     debug("Port %p (handle %p) was removed during attr querying\n",
-                            polled_port, polled_port->pal_handle);
+                          polled_port, polled_port->pal_handle);
                     del_ipc_port_fini(polled_port, -PAL_ERRNO);
                 }
             }
         }
 
         /* done handling ports; put their references so they can be freed */
-        for (size_t i = 0; i < object_list_size; i++) {
-            struct shim_ipc_port* port = object_list[i];
-            put_ipc_port(port);
-        }
+        for (size_t i = 0; i < object_list_size; i++)
+            put_ipc_port(object_list[i]);
 
         lock(&ipc_helper_lock);
 
@@ -729,14 +741,14 @@ noreturn static void shim_ipc_helper(void* dummy) {
             /* get port reference so it is not freed while we wait on/handle it */
             __get_ipc_port(port);
 
-            /* grow object_list and palhandle_list to accomodate more objects */
             if (object_list_size == object_list_maxsize) {
+                /* grow object_list and palhandle_list to accomodate more objects */
                 struct shim_ipc_port** tmp_array = malloc(
                         sizeof(struct shim_ipc_port *) * (object_list_maxsize * 2));
                 PAL_HANDLE* tmp_pal_array = malloc(
                         sizeof(PAL_HANDLE) * (1 + object_list_maxsize * 2));
                 memcpy(tmp_array, object_list,
-                        sizeof(struct shim_ipc_port *) * (object_list_maxsize));
+                        sizeof(struct shim_ipc_port *) * (object_list_size));
                 memcpy(tmp_pal_array, palhandle_list,
                         sizeof(PAL_HANDLE) * (1 + object_list_size));
                 object_list_maxsize *= 2;
@@ -759,23 +771,15 @@ noreturn static void shim_ipc_helper(void* dummy) {
 
         /* wait on collected ports' PAL handles + install_new_event_hdl */
         polled = DkObjectsWaitAny(object_list_size + 1, palhandle_list, NO_TIMEOUT);
-        /* ensure that while loop breaks on ipc_helper_state change */
-        COMPILER_BARRIER();
     }
 
     /* IPC thread exits; put acquired port references so they can be freed */
-    for (size_t i = 0; i < object_list_size; i++) {
-        struct shim_ipc_port* port = object_list[i];
-        put_ipc_port(port);
-    }
+    for (size_t i = 0; i < object_list_size; i++)
+        put_ipc_port(object_list[i]);
 
     free(object_list);
     free(palhandle_list);
 
-    lock(&ipc_helper_lock);
-    ipc_helper_state = HELPER_NOTALIVE;
-    ipc_helper_thread = NULL;
-    unlock(&ipc_helper_lock);
     put_thread(self);
     debug("IPC helper thread terminated\n");
 
@@ -799,6 +803,7 @@ static void shim_ipc_helper_prepare(void* arg) {
     void* stack = allocate_stack(IPC_HELPER_STACK_SIZE, allocsize, false);
 
     if (notme || !stack) {
+        free(stack);
         put_thread(self);
         DkThreadExit();
         return;
@@ -827,10 +832,11 @@ static int create_ipc_helper(void) {
     PAL_HANDLE handle = thread_create(shim_ipc_helper_prepare, new);
 
     if (!handle) {
+        int ret = -PAL_ERRNO;  /* put_thread() may overwrite errno */
         ipc_helper_thread = NULL;
         ipc_helper_state = HELPER_NOTALIVE;
         put_thread(new);
-        return -PAL_ERRNO;
+        return ret;
     }
 
     new->pal_handle = handle;

--- a/LibOS/shim/src/ipc/shim_ipc_helper.c
+++ b/LibOS/shim/src/ipc/shim_ipc_helper.c
@@ -17,7 +17,7 @@
 /*
  * shim_ipc_helper.c
  *
- * This file contains codes to create a IPC helper thread inside library OS
+ * This file contains code to create an IPC helper thread inside library OS
  * and maintain bookkeeping of IPC ports.
  */
 
@@ -33,638 +33,29 @@
 #include <pal_error.h>
 #include <list.h>
 
+#define IPC_HELPER_STACK_SIZE (allocsize * 4)
+
 #define PORT_MGR_ALLOC  32
 #define PAGE_SIZE       allocsize
-
 #define OBJ_TYPE struct shim_ipc_port
 #include "memmgr.h"
-
 static MEM_MGR port_mgr;
-/* This points to a list of shim_ipc_port objects (by the list field) */
+
 DEFINE_LISTP(shim_ipc_port);
-static LISTP_TYPE(shim_ipc_port) pobj_list;
+static LISTP_TYPE(shim_ipc_port) port_list;
 
-#define PID_HASH_LEN   6
-#define PID_HASH_NUM   (1 << PID_HASH_LEN)
-#define PID_HASH_MASK  (PID_HASH_NUM - 1)
-#define PID_HASH(pid)  ((pid) & PID_HASH_MASK)
+/* can be read without ipc_helper_lock but always written with lock held */
+static enum {  HELPER_NOTALIVE, HELPER_ALIVE } ipc_helper_state;
 
-/* This points to a list of shim_ipc_port objects (by the hlist field) */
-static LISTP_TYPE(shim_ipc_port) ipc_port_pool [PID_HASH_NUM];
+static struct shim_thread* ipc_helper_thread;
+static struct shim_lock    ipc_helper_lock;
 
-/* This variable can be read without the ipc_helper_lock held, but
- * should be modified with the ipc_helper_lock held (and in some cases,
- * the value should be re-checked after acquiring the lock.
- * For reads in a loop without the lock, some caution should be taken to
- * use compiler barriers to ensure that a stale value isn't cached.
- */
-static enum {
-    HELPER_UNINITIALIZED, HELPER_DELAYED, HELPER_NOTALIVE,
-    HELPER_ALIVE, HELPER_HANDEDOVER,
-} ipc_helper_state;
+static AEVENTTYPE install_new_event;
 
-static struct shim_thread *  ipc_helper_thread;
-static bool                  ipc_helper_update;
-static AEVENTTYPE            ipc_helper_event;
+static int create_ipc_helper(void);
+static int ipc_resp_callback(struct shim_ipc_msg* msg, struct shim_ipc_port* port);
 
-#define IN_HELPER() \
-    (ipc_helper_thread && ipc_helper_thread == get_cur_thread())
-
-static struct shim_lock ipc_helper_lock;
-
-static struct shim_ipc_port * broadcast_port;
-
-//#define DEBUG_REF
-
-static int init_ipc_port (struct shim_ipc_info * info, PAL_HANDLE hdl, IDTYPE type)
-{
-    if (!info)
-        return 0;
-
-    if (info->pal_handle == IPC_FORCE_RECONNECT) {
-        info->pal_handle = NULL;
-        if (!hdl && !qstrempty(&info->uri)) {
-            debug("try reconnect port %s\n", qstrgetstr(&info->uri));
-
-            hdl = DkStreamOpen(qstrgetstr(&info->uri),
-                               0, 0, 0, 0);
-            if (!hdl)
-                return -PAL_ERRNO;
-        }
-        info->pal_handle = hdl;
-    }
-
-    if (!info->pal_handle)
-        info->pal_handle = hdl;
-
-    if (info->pal_handle)
-        add_ipc_port_by_id(info->vmid == cur_process.vmid ? 0 : info->vmid,
-                           info->pal_handle, type, NULL, &info->port);
-    return 0;
-}
-
-static void ipc_broadcast_exit (struct shim_ipc_port * port, IDTYPE vmid,
-                                unsigned exitcode)
-{
-    // Arguments for compatibility
-    __UNUSED(vmid);
-    __UNUSED(exitcode);
-    if (port == broadcast_port) {
-        MASTER_LOCK();
-        broadcast_port = NULL;
-        put_ipc_port(port);
-        MASTER_UNLOCK();
-    }
-}
-
-int init_ipc_ports (void)
-{
-    int ret = 0;
-
-    if (!(port_mgr = create_mem_mgr(init_align_up(PORT_MGR_ALLOC))))
-        return -ENOMEM;
-
-    if ((ret = init_ipc_port(cur_process.self, NULL, IPC_PORT_SERVER)) < 0)
-        return ret;
-
-    if (PAL_CB(parent_process) &&
-        (ret = init_ipc_port(cur_process.parent, PAL_CB(parent_process),
-                             IPC_PORT_DIRPRT|IPC_PORT_LISTEN)) < 0)
-        return ret;
-
-    if ((ret = init_ipc_port(cur_process.ns[PID_NS], NULL,
-                             IPC_PORT_PIDLDR|IPC_PORT_LISTEN)) < 0)
-        return ret;
-
-    if ((ret = init_ipc_port(cur_process.ns[SYSV_NS], NULL,
-                             IPC_PORT_SYSVLDR|IPC_PORT_LISTEN)) < 0)
-        return ret;
-
-    if (PAL_CB(broadcast_stream))
-        add_ipc_port_by_id(0, PAL_CB(broadcast_stream), IPC_PORT_LISTEN,
-                           &ipc_broadcast_exit, &broadcast_port);
-
-    return 0;
-}
-
-
-static int create_ipc_helper (void);
-
-/* This function should be called as part of init, before locks or atomics are
- * required */
-int init_ipc_helper (void)
-{
-    bool need_helper = (ipc_helper_state == HELPER_DELAYED);
-    ipc_helper_state = HELPER_NOTALIVE;
-    create_lock(&ipc_helper_lock);
-    create_event(&ipc_helper_event);
-    if (need_helper) {
-        /*
-         * we are enabling multi-threading, must turn on threading
-         * before grabbing any lock
-         */
-        enable_locking();
-
-        /* Go ahead and lock the ipc helper lock here, for consistency */
-        lock(&ipc_helper_lock);
-        create_ipc_helper();
-        unlock(&ipc_helper_lock);
-    }
-    return 0;
-}
-
-static void __get_ipc_port (struct shim_ipc_port * pobj)
-{
-#ifdef DEBUG_REF
-    int ref_count = REF_INC(pobj->ref_count);
-
-    debug("get ipc_port %p (handle %p, ref_count = %d)\n", pobj,
-          pobj->pal_handle, ref_count);
-#else
-    REF_INC(pobj->ref_count);
-#endif
-}
-
-static void __free_ipc_port (struct shim_ipc_port * pobj)
-{
-    if (pobj->pal_handle) {
-        DkObjectClose(pobj->pal_handle);
-        pobj->pal_handle = NULL;
-    }
-
-    destroy_lock(&pobj->msgs_lock);
-    free_mem_obj_to_mgr(port_mgr, pobj);
-}
-
-static void __put_ipc_port (struct shim_ipc_port * pobj)
-{
-    int ref_count = REF_DEC(pobj->ref_count);
-
-#ifdef DEBUG_REF
-    debug("put ipc port %p (handle %p, ref_count = %d)\n", pobj,
-          pobj->pal_handle, ref_count);
-#endif
-
-    if (!ref_count)
-        __free_ipc_port(pobj);
-}
-
-/* This should be called with the ipc_helper_lock held */
-static inline void restart_ipc_helper (bool need_create)
-{
-    switch (ipc_helper_state) {
-        case HELPER_UNINITIALIZED:
-            ipc_helper_state = HELPER_DELAYED;
-        case HELPER_DELAYED:
-            return;
-        case HELPER_NOTALIVE:
-            if (need_create)
-                create_ipc_helper();
-            return;
-        case HELPER_ALIVE:
-            if (IN_HELPER()) {
-                ipc_helper_update = true;
-                return;
-            }
-            debug("set ipc helper restart\n");
-            set_event(&ipc_helper_event, 1);
-            return;
-        case HELPER_HANDEDOVER:
-            ipc_helper_update = true;
-            return;
-    }
-}
-
-static bool __add_ipc_port (struct shim_ipc_port * port, IDTYPE vmid,
-                            IDTYPE type, port_fini fini)
-{
-    bool need_restart = false;
-    assert(vmid != cur_process.vmid);
-
-    if (vmid && !port->info.vmid) {
-        port->info.vmid = vmid;
-        port->update = true;
-    }
-
-    if (port->info.vmid && LIST_EMPTY(port, hlist)) {
-        LISTP_TYPE(shim_ipc_port) * head = &ipc_port_pool[PID_HASH(vmid)];
-        __get_ipc_port(port);
-        LISTP_ADD(port, head, hlist);
-    }
-
-    if (!(port->info.type & IPC_PORT_IFPOLL) && (type & IPC_PORT_IFPOLL))
-        need_restart = true;
-
-    if ((port->info.type & type) != type) {
-        port->info.type |= type;
-        port->update = true;
-    }
-
-    if (fini && (type & ~IPC_PORT_IFPOLL)) {
-        port_fini * cb = port->fini;
-        for ( ; cb < port->fini + MAX_IPC_PORT_FINI_CB ; cb++)
-            if (!*cb || *cb == fini)
-                break;
-
-        assert(cb < port->fini + MAX_IPC_PORT_FINI_CB);
-        *cb = fini;
-    }
-
-    if (need_restart) {
-        if (LIST_EMPTY(port, list)) {
-            __get_ipc_port(port);
-            LISTP_ADD(port, &pobj_list, list);
-            port->recent = true;
-        } else {
-            if (!port->recent) {
-                LISTP_DEL_INIT(port, &pobj_list, list);
-                LISTP_ADD(port, &pobj_list, list);
-                port->recent = true;
-            }
-        }
-        return true;
-    } else {
-        if (LIST_EMPTY(port, list)) {
-            __get_ipc_port(port);
-            LISTP_ADD_TAIL(port, &pobj_list, list);
-        }
-        return false;
-    }
-}
-
-void add_ipc_port (struct shim_ipc_port * port, IDTYPE vmid, IDTYPE type,
-                   port_fini fini)
-{
-    debug("adding port %p (handle %p) for process %u (type=%04x)\n",
-          port, port->pal_handle, port->info.vmid, type);
-
-    lock(&ipc_helper_lock);
-    bool need_restart = __add_ipc_port(port, vmid, type, fini);
-    if (need_restart)
-        restart_ipc_helper(true);
-
-    unlock(&ipc_helper_lock);
-}
-
-static struct shim_ipc_port * __get_new_ipc_port (PAL_HANDLE hdl)
-{
-    struct shim_ipc_port * port =
-                get_mem_obj_from_mgr_enlarge(port_mgr,
-                                             size_align_up(PORT_MGR_ALLOC));
-
-    if (!port) {
-        debug("failed to allocate shim_ipc_port\n");
-        return NULL;
-    }
-
-    memset(port, 0, sizeof(struct shim_ipc_port));
-    port->pal_handle = hdl;
-    port->update = true;
-    INIT_LIST_HEAD(port, hlist);
-    INIT_LIST_HEAD(port, list);
-    INIT_LISTP(&port->msgs);
-    REF_SET(port->ref_count, 1);
-    create_lock(&port->msgs_lock);
-    return port;
-}
-
-void add_ipc_port_by_id (IDTYPE vmid, PAL_HANDLE hdl, IDTYPE type,
-                         port_fini fini, struct shim_ipc_port ** portptr)
-{
-    debug("adding port (handle %p) for process %u (type %04x)\n",
-          hdl, vmid, type);
-
-    assert(!!hdl && PAL_GET_TYPE(hdl));
-    lock(&ipc_helper_lock);
-
-    LISTP_TYPE(shim_ipc_port) * head = vmid ? &ipc_port_pool[PID_HASH(vmid)] : NULL;
-    struct shim_ipc_port * tmp, * port = NULL;
-
-    if (vmid)
-        LISTP_FOR_EACH_ENTRY(tmp, head, hlist)
-            if (tmp->info.vmid == vmid && tmp->pal_handle == hdl) {
-                port = tmp;
-                __get_ipc_port(port);
-                break;
-            }
-
-    if (!port)
-        LISTP_FOR_EACH_ENTRY(tmp, &pobj_list, list)
-            if (tmp->pal_handle == hdl) {
-                port = tmp;
-                __get_ipc_port(port);
-                break;
-            }
-
-    if (!port && !(port = __get_new_ipc_port(hdl))) {
-        *portptr = NULL;
-        goto out;
-    }
-
-    bool need_restart = __add_ipc_port(port, vmid, type, fini);
-    assert(!LIST_EMPTY(port, list));
-    assert(!vmid || !LIST_EMPTY(port, hlist));
-
-    if (portptr)
-        *portptr = port;
-    else
-        __put_ipc_port(port);
-
-    if (need_restart)
-        restart_ipc_helper(true);
-
-out:
-    unlock(&ipc_helper_lock);
-}
-
-static bool __del_ipc_port (struct shim_ipc_port * port, IDTYPE type)
-{
-    debug("deleting port %p (handle %p) for process %u\n",
-          port, port->pal_handle, port->info.vmid);
-
-    __get_ipc_port(port); // Prevent the object from being freed during deletion
-    assert(!LIST_EMPTY(port, list)); // Never delete a port twice
-
-    bool need_restart = false;
-    type = type ? (type & port->info.type) : port->info.type;
-
-    if ((type & IPC_PORT_KEEPALIVE) ^
-        (port->info.type & IPC_PORT_KEEPALIVE))
-        need_restart = true;
-
-    /* if the port still have other usage, we will not remove the port */
-    if (port->info.type & ~(type|IPC_PORT_IFPOLL|IPC_PORT_KEEPALIVE)) {
-        debug("masking port %p (handle %p): type %x->%x\n",
-              port, port->pal_handle, port->info.type, port->info.type & ~type);
-        port->info.type &= ~type;
-        goto out;
-    }
-
-    // Prevent further usage of the PAL handle
-    DkStreamDelete(port->pal_handle, 0);
-
-    if (port->info.type & IPC_PORT_IFPOLL)
-        need_restart = true;
-
-    // Officially delete the port
-    LISTP_DEL_INIT(port, &pobj_list, list);
-    port->info.type &= IPC_PORT_IFPOLL;
-    __put_ipc_port(port);
-
-    if (!LIST_EMPTY(port, hlist)) {
-        // Re-fetch head pointer
-        LISTP_TYPE(shim_ipc_port) * head = &ipc_port_pool[PID_HASH(port->info.vmid)];
-        LISTP_DEL_INIT(port, head, hlist);
-        __put_ipc_port(port);
-    }
-
-    // Need to check if there are any pending messages on the port, which means
-    // some threads might be blocking for responses.
-    lock(&port->msgs_lock);
-    struct shim_ipc_msg_obj * msg, * n;
-    LISTP_FOR_EACH_ENTRY_SAFE(msg, n, &port->msgs, list) {
-        LISTP_DEL_INIT(msg, &port->msgs, list);
-        msg->retval = -ECONNRESET;
-        if (msg->thread) {
-            debug("wake up thread %d\n", msg->thread->tid);
-            thread_wakeup(msg->thread);
-        }
-    }
-    unlock(&port->msgs_lock);
-
-out:
-    port->update = true;
-    __put_ipc_port(port); // Free the object if ref_count is 0
-    return need_restart;
-}
-
-void del_ipc_port (struct shim_ipc_port * port, IDTYPE type)
-{
-    lock(&ipc_helper_lock);
-
-    // If the port is already deleted, don't delete it again.
-    if (LIST_EMPTY(port, list)) {
-        unlock(&ipc_helper_lock);
-        return;
-    }
-
-    bool need_restart = __del_ipc_port(port, type);
-
-    if (need_restart)
-        restart_ipc_helper(false);
-
-    unlock(&ipc_helper_lock);
-}
-
-void del_ipc_port_by_id (IDTYPE vmid, IDTYPE type)
-{
-    LISTP_TYPE(shim_ipc_port) * head = &ipc_port_pool[PID_HASH(vmid)];
-    struct shim_ipc_port * port, *n;
-    bool need_restart = false;
-
-    lock(&ipc_helper_lock);
-
-    LISTP_FOR_EACH_ENTRY_SAFE(port, n, head, hlist) {
-        if (LIST_EMPTY(port, list))
-            continue;
-
-        debug("port %p (handle %p) for process %u in list %p\n",
-              port, port->pal_handle, port->info.vmid, head);
-
-        if (port->info.vmid == vmid && __del_ipc_port(port, type))
-            need_restart = true;
-    }
-
-    if (need_restart)
-        restart_ipc_helper(false);
-
-    unlock(&ipc_helper_lock);
-}
-
-void del_ipc_port_fini (struct shim_ipc_port * port, unsigned int exitcode)
-{
-    port_fini fini[MAX_IPC_PORT_FINI_CB];
-    int nfini = 0;
-    assert(REF_GET(port->ref_count) > 0);
-    lock(&ipc_helper_lock);
-
-    // If the port is already deleted, don't delete it again.
-    if (LIST_EMPTY(port, list)) {
-        unlock(&ipc_helper_lock);
-        return;
-    }
-
-    IDTYPE vmid = port->info.vmid;
-    for (int i = 0 ; i < MAX_IPC_PORT_FINI_CB ; i++)
-        if (port->fini[i]) {
-            fini[nfini++] = port->fini[i];
-            port->fini[i] = NULL;
-        }
-
-    bool need_restart = __del_ipc_port(port, 0);
-
-    if (need_restart)
-        restart_ipc_helper(false);
-
-    unlock(&ipc_helper_lock);
-
-    for (int i = 0 ; i < nfini ; i++)
-        (fini[i])(port, vmid, exitcode);
-}
-
-static struct shim_ipc_port * __lookup_ipc_port (IDTYPE vmid, IDTYPE type)
-{
-    LISTP_TYPE(shim_ipc_port) * head = &ipc_port_pool[PID_HASH(vmid)];
-    struct shim_ipc_port * tmp;
-
-    LISTP_FOR_EACH_ENTRY(tmp, head, hlist)
-        if (tmp->info.vmid == vmid && (!type || tmp->info.type & type)) {
-            debug("found port %p (handle %p) for process %u (type %04x)\n",
-                  tmp, tmp->pal_handle, tmp->info.vmid, tmp->info.type);
-            __get_ipc_port(tmp);
-            return tmp;
-        }
-
-    return NULL;
-}
-
-struct shim_ipc_port * lookup_ipc_port (IDTYPE vmid, IDTYPE type)
-{
-    lock(&ipc_helper_lock);
-    struct shim_ipc_port * port = __lookup_ipc_port(vmid, type);
-    if (port) {
-        assert(!LIST_EMPTY(port, list));
-        assert(!vmid || !LIST_EMPTY(port, hlist));
-    }
-    unlock(&ipc_helper_lock);
-    return port;
-}
-
-void get_ipc_port (struct shim_ipc_port * port)
-{
-    // No need to grab ipc_helper_lock because __get_ipc_port() is atomic.
-    __get_ipc_port(port);
-}
-
-void put_ipc_port (struct shim_ipc_port * port)
-{
-    int ref_count = REF_DEC(port->ref_count);
-
-#ifdef DEBUG_REF
-    debug("put ipc port %p (handle %p, ref_count = %d)\n", port,
-          port->pal_handle, ref_count);
-#endif
-
-    if (!ref_count) {
-        lock(&ipc_helper_lock); // Need to grab the lock
-        __free_ipc_port(port);
-        unlock(&ipc_helper_lock);
-    }
-}
-
-void del_all_ipc_ports (IDTYPE type)
-{
-    struct shim_ipc_port * pobj, * n;
-    bool need_restart = false;
-
-    lock(&ipc_helper_lock);
-
-    LISTP_FOR_EACH_ENTRY_SAFE(pobj, n, &pobj_list, list) {
-        if (__del_ipc_port(pobj, type))
-            need_restart = true;
-    }
-
-    if (need_restart)
-        restart_ipc_helper(false);
-
-    unlock(&ipc_helper_lock);
-}
-
-int broadcast_ipc (struct shim_ipc_msg * msg, struct shim_ipc_port ** exclude,
-                   int exsize, int target_type)
-{
-    struct shim_ipc_port ** exend = exclude + exsize, ** ex;
-    struct shim_ipc_port * pobj;
-
-    if (!target_type && broadcast_port) {
-        for (ex = exclude ; ex < exend && *ex != broadcast_port ; ex++);
-        if (ex != exend)
-            return 0;
-
-        debug("send to broadcast stream\n");
-        int ret = send_ipc_message(msg, broadcast_port);
-        if (!ret)
-            return 0;
-    }
-
-    lock(&ipc_helper_lock);
-
-    int ntargets = 0;
-    LISTP_FOR_EACH_ENTRY(pobj, &pobj_list, list) {
-        debug("found port %p (handle %p) for process %u (type %04x)\n", pobj,
-              pobj->pal_handle, pobj->info.vmid, pobj->info.type);
-        if (pobj->info.type & target_type)
-            ntargets++;
-    }
-
-    struct shim_ipc_port ** targets = __alloca(sizeof(struct shim_ipc_port *)
-                                               * ntargets);
-    int i = 0;
-    LISTP_FOR_EACH_ENTRY(pobj, &pobj_list, list)
-        if (pobj->info.type & target_type) {
-            get_ipc_port(pobj);
-            targets[i++] = pobj;
-        }
-
-    unlock(&ipc_helper_lock);
-
-    for (i = 0 ; i < ntargets ; i++) {
-        pobj = targets[i];
-
-        debug("broadcast to port %p (handle %p) for process %u "
-              "(type %x, target %x)\n",
-              pobj, pobj->pal_handle, pobj->info.vmid,
-              pobj->info.type, target_type);
-
-        if (exsize) {
-            for (ex = exclude ; ex < exend && *ex != pobj ; ex++);
-            if (ex != exend)
-                continue;
-        }
-
-        msg->dst = pobj->info.vmid;
-
-        /* has to be assigned, so shim_send_ipc_message will not try
-           to grab ipc_helper_lock */
-        send_ipc_message(msg, pobj);
-        put_ipc_port(pobj);
-    }
-
-    return 0;
-}
-
-static int ipc_resp_callback (IPC_CALLBACK_ARGS)
-{
-    struct shim_ipc_resp * msgin = (struct shim_ipc_resp *) &msg->msg;
-
-    debug("ipc callback from %u: IPC_RESP(%d)\n", msg->src, msgin->retval);
-
-    if (!msg->seq)
-        return msgin->retval;
-
-    struct shim_ipc_msg_obj * obj = find_ipc_msg_duplex(port, msg->seq);
-
-    if (obj) {
-        obj->retval = msgin->retval;
-        if (obj->thread)
-            thread_wakeup(obj->thread);
-        return 0;
-    }
-
-    return msgin->retval;
-}
-
-static ipc_callback ipc_callbacks [IPC_CODE_NUM] = {
+static ipc_callback ipc_callbacks[IPC_CODE_NUM] = {
     /* RESP             */  &ipc_resp_callback,
     /* FINDURI          */  &ipc_finduri_callback,
     /* TELLURI          */  &ipc_telluri_callback,
@@ -701,331 +92,634 @@ static ipc_callback ipc_callbacks [IPC_CODE_NUM] = {
     /* SYSV_SEMMOV      */  &ipc_sysv_semmov_callback,
 };
 
-int __response_ipc_message (struct shim_ipc_port * port, IDTYPE dest,
-                            int ret, unsigned long seq)
-{
-    struct shim_ipc_msg * resp = create_ipc_resp_msg_on_stack(ret, dest, seq);
+static int init_ipc_port(struct shim_ipc_info* info, PAL_HANDLE hdl, IDTYPE type) {
+    if (!info)
+        return 0;
 
-    ret = (ret == RESPONSE_CALLBACK) ? 0 : ret;
-    debug("ipc send to %u: IPC_RESP(%d)\n", resp->dst, ret);
+    if (info->pal_handle == IPC_FORCE_RECONNECT) {
+        info->pal_handle = NULL;
+        if (!hdl && !qstrempty(&info->uri)) {
+            debug("Reconnecting IPC port %s\n", qstrgetstr(&info->uri));
+            hdl = DkStreamOpen(qstrgetstr(&info->uri), 0, 0, 0, 0);
+            if (!hdl)
+                return -PAL_ERRNO;
+        }
+        info->pal_handle = hdl;
+    }
 
-    struct shim_ipc_resp * msgin = (struct shim_ipc_resp *) &resp->msg;
-    msgin->retval = ret;
-    return send_ipc_message(resp, port);
+    if (!info->pal_handle)
+        info->pal_handle = hdl;
+
+    if (info->pal_handle)
+        add_ipc_port_by_id(info->vmid == cur_process.vmid ? 0 : info->vmid,
+                           info->pal_handle, type, NULL, &info->port);
+    return 0;
 }
 
-/* not only ipc helper thread can receive messsage, anyone can
-   receive message if they have acquired (locked) the port */
-int receive_ipc_message (struct shim_ipc_port * port, unsigned long seq,
-                         struct shim_ipc_msg ** msgptr)
-{
-    int readahead = IPC_MSG_READAHEAD;
-    int bufsize = IPC_MSG_MINIMAL_SIZE + readahead;
-    struct shim_ipc_msg * msg = __alloca(bufsize);
-    int expected_size;
-    int bytes = 0, ret = 0;
+int init_ipc_ports(void) {
+    int ret = 0;
 
-    do {
-        expected_size = IPC_MSG_MINIMAL_SIZE;
-        while (bytes < expected_size) {
-retry_read:
-            if (expected_size + readahead > bufsize) {
-                while (expected_size + readahead > bufsize)
-                    bufsize *= 2;
-                void * new_buff = __alloca(bufsize);
-                memcpy(new_buff, msg, bytes);
-                msg = new_buff;
-            }
+    if (!(port_mgr = create_mem_mgr(init_align_up(PORT_MGR_ALLOC))))
+        return -ENOMEM;
 
-            if (!(ret = DkStreamRead(port->pal_handle, 0,
-                                     expected_size - bytes + readahead,
-                                     (void *) msg + bytes, NULL, 0)))
+    if ((ret = init_ipc_port(cur_process.self, NULL, IPC_PORT_SERVER)) < 0)
+        return ret;
+    if (PAL_CB(parent_process) &&
+        (ret = init_ipc_port(cur_process.parent, PAL_CB(parent_process),
+                             IPC_PORT_DIRPRT|IPC_PORT_LISTEN)) < 0)
+        return ret;
+    if ((ret = init_ipc_port(cur_process.ns[PID_NS], NULL,
+                             IPC_PORT_PIDLDR|IPC_PORT_LISTEN)) < 0)
+        return ret;
+    if ((ret = init_ipc_port(cur_process.ns[SYSV_NS], NULL,
+                             IPC_PORT_SYSVLDR|IPC_PORT_LISTEN)) < 0)
+        return ret;
+
+    return 0;
+}
+
+
+int init_ipc_helper(void) {
+    /* early enough in init, can write global vars without the lock */
+    ipc_helper_state = HELPER_NOTALIVE;
+    create_lock(&ipc_helper_lock);
+    create_event(&install_new_event);
+
+    /* some IPC ports were already added before this point, so spawn IPC
+     * helper thread (and enable locking mechanisms if not done already
+     * since we are going in multi-threaded mode) */
+    enable_locking();
+    lock(&ipc_helper_lock);
+    create_ipc_helper();
+    unlock(&ipc_helper_lock);
+
+    return 0;
+}
+
+static struct shim_ipc_port* __create_ipc_port(PAL_HANDLE hdl) {
+    struct shim_ipc_port* port =
+        get_mem_obj_from_mgr_enlarge(port_mgr, size_align_up(PORT_MGR_ALLOC));
+    if (!port)
+        return NULL;
+
+    memset(port, 0, sizeof(struct shim_ipc_port));
+    port->pal_handle = hdl;
+    INIT_LIST_HEAD(port, list);
+    INIT_LISTP(&port->msgs);
+    REF_SET(port->ref_count, 0);
+    create_lock(&port->msgs_lock);
+    return port;
+}
+
+static void __free_ipc_port(struct shim_ipc_port* port) {
+    if (port->pal_handle) {
+        DkObjectClose(port->pal_handle);
+        port->pal_handle = NULL;
+    }
+
+    destroy_lock(&port->msgs_lock);
+    free_mem_obj_to_mgr(port_mgr, port);
+}
+
+static void __get_ipc_port(struct shim_ipc_port* port) {
+    REF_INC(port->ref_count);
+}
+
+static void __put_ipc_port(struct shim_ipc_port* port) {
+    int ref_count = REF_DEC(port->ref_count);
+    if (!ref_count)
+        __free_ipc_port(port);
+}
+
+void get_ipc_port(struct shim_ipc_port* port) {
+    /* no need to grab ipc_helper_lock because __get_ipc_port() is atomic */
+    __get_ipc_port(port);
+}
+
+void put_ipc_port(struct shim_ipc_port* port) {
+    /* this is atomic so we don't grab lock in common case of ref_count > 0 */
+    int ref_count = REF_DEC(port->ref_count);
+
+    if (!ref_count) {
+        lock(&ipc_helper_lock);
+        __free_ipc_port(port);
+        unlock(&ipc_helper_lock);
+    }
+}
+
+static void __add_ipc_port(struct shim_ipc_port* port, IDTYPE vmid,
+                           IDTYPE type, port_fini fini) {
+    assert(vmid != cur_process.vmid); /* no sense in IPCing myself */
+
+    port->type |= type;
+    if (vmid && !port->vmid)
+        port->vmid = vmid;
+
+    /* find empty slot in fini callbacks and register callback */
+    if (fini) {
+        for (int i = 0; i < MAX_IPC_PORT_FINI_CB; i++)
+            if (!port->fini[i] || port->fini[i] == fini) {
+                port->fini[i] = fini;
                 break;
-
-            bytes += ret;
-        }
-
-        if (!bytes) {
-            if (PAL_NATIVE_ERRNO) {
-                debug("port %p (handle %p) is removed at reading\n",
-                      port, port->pal_handle);
-                del_ipc_port_fini(port, -ECHILD);
-                ret = -PAL_ERRNO;
             }
+    }
 
+    /* add to port list if not there already */
+    if (LIST_EMPTY(port, list)) {
+        __get_ipc_port(port);
+        LISTP_ADD(port, &port_list, list);
+    }
+
+    /* wake up IPC helper thread so that it picks up added port */
+    if (ipc_helper_state == HELPER_ALIVE)
+        set_event(&install_new_event, 1);
+}
+
+static void __del_ipc_port(struct shim_ipc_port* port) {
+    debug("Deleting port %p (handle %p) of process %u\n",
+          port, port->pal_handle, port->vmid & 0xFFFF);
+
+    DkStreamDelete(port->pal_handle, 0);
+    LISTP_DEL_INIT(port, &port_list, list);
+
+    /* Check for pending messages on port (threads might be blocking for responses) */
+    lock(&port->msgs_lock);
+    struct shim_ipc_msg_obj* msg;
+    struct shim_ipc_msg_obj* tmp;
+    LISTP_FOR_EACH_ENTRY_SAFE(msg, tmp, &port->msgs, list) {
+        LISTP_DEL_INIT(msg, &port->msgs, list);
+        msg->retval = -ECONNRESET;
+        if (msg->thread) {
+            debug("Deleted pending message on port %p, wake up blocking thread %d\n",
+                    port, msg->thread->tid);
+            thread_wakeup(msg->thread);
+        }
+    }
+    unlock(&port->msgs_lock);
+
+    __put_ipc_port(port);
+
+    /* wake up IPC helper thread so that it forgets about deleted port */
+    if (ipc_helper_state == HELPER_ALIVE)
+        set_event(&install_new_event, 1);
+}
+
+void add_ipc_port(struct shim_ipc_port* port, IDTYPE vmid, IDTYPE type, port_fini fini) {
+    debug("Adding port %p (handle %p) for process %u (type=%04x)\n",
+          port, port->pal_handle, port->vmid & 0xFFFF, type);
+
+    lock(&ipc_helper_lock);
+    __add_ipc_port(port, vmid, type, fini);
+    unlock(&ipc_helper_lock);
+}
+
+void add_ipc_port_by_id(IDTYPE vmid, PAL_HANDLE hdl, IDTYPE type,
+                        port_fini fini, struct shim_ipc_port** portptr) {
+    debug("Adding port (handle %p) for process %u (type %04x)\n",
+            hdl, vmid & 0xFFFF, type);
+
+    struct shim_ipc_port* port = NULL;
+    if (portptr)
+        *portptr = NULL;
+
+    assert(hdl && PAL_GET_TYPE(hdl));
+    lock(&ipc_helper_lock);
+
+    /* check if port with this PAL handle already exists, then we only
+     * need to update its vmid, type, and fini callback */
+    struct shim_ipc_port* tmp;
+    LISTP_FOR_EACH_ENTRY(tmp, &port_list, list)
+        if (tmp->pal_handle == hdl) {
+            port = tmp;
             break;
         }
 
-        debug("receive a message from port %p (handle %p): "
-              "code=%d size=%d src=%u dst=%u seq=%lx\n",
-              port, port->pal_handle,
-              msg->code, msg->size, msg->src, msg->dst, msg->seq);
-
-        expected_size = msg->size;
-        if (bytes < expected_size)
-            goto retry_read;
-
-        if (msgptr && (!seq || msg->seq == seq)) {
-            struct shim_ipc_msg * retmsg;
-            if (*msgptr) {
-                if (msg->size > (*msgptr)->size)
-                    msg->size = (*msgptr)->size;
-                retmsg = *msgptr;
-            } else {
-                *msgptr = retmsg = malloc(msg->size);
-            }
-
-            memcpy(retmsg, msg, msg->size);
-            return 0;
+    if (!port) {
+        /* port does not yet exist, create it */
+        port = __create_ipc_port(hdl);
+        if (!port) {
+            debug("Failed to create IPC port for handle %p\n", hdl);
+            goto out;
         }
+    }
 
-        /* skip if the message comes from myself (it's possible because
-           of the broadcast channel */
-        if (msg->src == cur_process.vmid)
-            goto next;
+    /* add/update port */
+    __add_ipc_port(port, vmid, type, fini);
 
-        ipc_callback callback = ipc_callbacks[msg->code];
+    if (portptr) {
+        __get_ipc_port(port);
+        *portptr = port;
+    }
 
-        if (callback) {
-            ret = (*callback) (msg, port);
-            if ((ret < 0 || ret == RESPONSE_CALLBACK) && msg->seq)
-                /* only helper thread sends back response */
-                ret = __response_ipc_message(port, msg->src, ret, msg->seq);
+out:
+    unlock(&ipc_helper_lock);
+}
+
+void del_ipc_port_fini(struct shim_ipc_port* port, unsigned int exitcode) {
+    lock(&ipc_helper_lock);
+
+    if (LIST_EMPTY(port, list)) {
+        unlock(&ipc_helper_lock);
+        return;
+    }
+
+    /* prevent __del_ipc_port() from freeing port since we need it for fini callbacks */
+    __get_ipc_port(port);
+    __del_ipc_port(port);
+
+    unlock(&ipc_helper_lock);
+
+    for (int i = 0; i < MAX_IPC_PORT_FINI_CB; i++)
+        if (port->fini[i])
+            (port->fini[i])(port, port->vmid, exitcode);
+
+    __put_ipc_port(port);
+}
+
+void del_all_ipc_ports(void) {
+    lock(&ipc_helper_lock);
+
+    struct shim_ipc_port* port;
+    struct shim_ipc_port* tmp;
+    LISTP_FOR_EACH_ENTRY_SAFE(port, tmp, &port_list, list)
+        __del_ipc_port(port);
+
+    unlock(&ipc_helper_lock);
+}
+
+struct shim_ipc_port* lookup_ipc_port(IDTYPE vmid, IDTYPE type) {
+    struct shim_ipc_port* port = NULL;
+
+    assert(vmid && type);
+    lock(&ipc_helper_lock);
+
+    struct shim_ipc_port* tmp;
+    LISTP_FOR_EACH_ENTRY(tmp, &port_list, list) {
+        if (tmp->vmid == vmid && (tmp->type & type)) {
+            debug("found port %p (handle %p) for process %u (type %04x)\n",
+                  tmp, tmp->pal_handle, tmp->vmid & 0xFFFF, tmp->type);
+            port = tmp;
+            __get_ipc_port(port);
+            break;
         }
+    }
 
-next:
-        if ((bytes -= expected_size) > 0)
-            memmove(msg, (void *) msg + expected_size, bytes);
+    unlock(&ipc_helper_lock);
+    return port;
+}
 
-    } while (bytes > 0 || (seq && msg->seq != seq));
+int broadcast_ipc(struct shim_ipc_msg* msg, int target_type, struct shim_ipc_port* exclude_port) {
+    int ret;
+    struct shim_ipc_port* port;
+    struct shim_ipc_port** target_ports;
+    int target_ports_cnt = 0;
 
-    if (msgptr)
-        *msgptr = NULL;
+    assert(target_type);
+    lock(&ipc_helper_lock);
 
+    /* Collect all ports with appropriate types. In common case, stack-allocated
+     * array of 32 ports is enough. If there are more ports, we will allocate
+     * a bigger array on the heap and collect all ports again. */
+    struct shim_ipc_port* target_ports_stack[32];
+    LISTP_FOR_EACH_ENTRY(port, &port_list, list) {
+        if (port == exclude_port)
+            continue;
+        if (port->type & target_type) {
+            if (target_ports_cnt < 32)
+                target_ports_stack[target_ports_cnt] = port;
+            target_ports_cnt++;
+        }
+    }
+    target_ports = target_ports_stack;
+
+    if (target_ports_cnt > 32) {
+        /* Rare case when there are more than 32 ports. Allocate big-enough
+         * array on the heap and collect all ports again. */
+        int cnt = 0;
+        struct shim_ipc_port** target_ports_heap =
+            malloc(sizeof(struct shim_ipc_port *) * target_ports_cnt);
+
+        LISTP_FOR_EACH_ENTRY(port, &port_list, list) {
+            if (port == exclude_port)
+                continue;
+            if (port->type & target_type)
+                target_ports_heap[cnt++] = port;
+        }
+        target_ports = target_ports_heap;
+        assert(cnt == target_ports_cnt);
+    }
+
+    unlock(&ipc_helper_lock);
+
+    for (int i = 0; i < target_ports_cnt; i++)
+        get_ipc_port(target_ports[i]);
+
+    /* send msg to each collected port (note that ports cannot be freed in meantime) */
+    for (int i = 0; i < target_ports_cnt; i++) {
+        port = target_ports[i];
+
+        debug("Broadcast to port %p (handle %p) for process %u (type %x, target %x)\n",
+              port, port->pal_handle, port->vmid & 0xFFFF, port->type, target_type);
+
+        msg->dst = port->vmid;
+        ret = send_ipc_message(msg, port);
+        if (ret < 0) {
+            debug("Broadcast to port %p (handle %p) for process %u failed (errno = %d)!\n",
+                    port, port->pal_handle, port->vmid & 0xFFFF, ret);
+            goto out;
+        }
+    }
+
+    ret = 0;
+out:
+    for (int i = 0; i < target_ports_cnt; i++)
+        put_ipc_port(target_ports[i]);
+    if (target_ports != target_ports_stack)
+        free(target_ports);
     return ret;
 }
 
-#define IPC_HELPER_STACK_SIZE       (allocsize * 4)
-#define IPC_HELPER_LIST_INIT_SIZE   32
+static int ipc_resp_callback(struct shim_ipc_msg* msg, struct shim_ipc_port* port) {
+    struct shim_ipc_resp* resp = (struct shim_ipc_resp*) &msg->msg;
+    debug("IPC callback from %u: IPC_RESP(%d)\n", msg->src & 0xFFFF, resp->retval);
 
-noreturn static void shim_ipc_helper_end(struct shim_thread * self)
-{
-    /* Put our handle map reference */
-    if (self->handle_map)
-        put_handle_map(self->handle_map);
+    if (!msg->seq)
+        return resp->retval;
 
-    /* Another thread may be calling shim_clean(). Lower the chances of our
-     * IPC helper thread and another thread competing on shim_clean/shim_terminate
-     * (which is benign due to protection via ipc_helper_lock) by adding a barrier
-     * to ensure reading the latest IPC helper state. */
-    COMPILER_BARRIER();
-    if (ipc_helper_state == HELPER_HANDEDOVER) {
-        debug("ipc helper thread is the last thread, process exiting\n");
-        shim_terminate(0); // Same as shim_clean(), but this is the official termination function
+    /* find a corresponding request msg for this response msg */
+    struct shim_ipc_msg_obj* req_msg = find_ipc_msg_duplex(port, msg->seq);
+
+    /* if some thread waits for response, wake it up with response retval */
+    if (req_msg) {
+        req_msg->retval = resp->retval;
+        if (req_msg->thread)
+            thread_wakeup(req_msg->thread);
+        return 0;
     }
+
+    return resp->retval;
+}
+
+int send_response_ipc_message(struct shim_ipc_port* port, IDTYPE dest, int ret, uint64_t seq) {
+    ret = (ret == RESPONSE_CALLBACK) ? 0 : ret;
+
+    /* create IPC_RESP msg to send to dest, with sequence number seq, and in-body retval ret */
+    struct shim_ipc_msg* resp_msg = create_ipc_resp_msg_on_stack(ret, dest, seq);
+    debug("IPC send to %u: IPC_RESP(%d)\n", resp_msg->dst & 0xFFFF, ret);
+    return send_ipc_message(resp_msg, port);
+}
+
+static int receive_ipc_message(struct shim_ipc_port* port) {
+    int ret;
+    int readahead = IPC_MSG_MINIMAL_SIZE * 2;
+    int bufsize = IPC_MSG_MINIMAL_SIZE + readahead;
+
+    struct shim_ipc_msg* msg = malloc(bufsize);
+    int expected_size = IPC_MSG_MINIMAL_SIZE;
+    int bytes = 0;
+
+    do {
+        while (bytes < expected_size) {
+            /* grow msg buffer to accomodate bigger messages */
+            if (expected_size + readahead > bufsize) {
+                while (expected_size + readahead > bufsize)
+                    bufsize *= 2;
+                void* tmp_buf = malloc(bufsize);
+                memcpy(tmp_buf, msg, bytes);
+                free(msg);
+                msg = tmp_buf;
+            }
+
+            int read = DkStreamRead(port->pal_handle, /*offset*/ 0, expected_size - bytes + readahead,
+                                     (void *) msg + bytes, NULL, 0);
+
+            if (read == 0) {
+                /* TODO: Handle benign EINTR case? */
+                debug("Port %p (handle %p) closed while receiving IPC message\n", port, port->pal_handle);
+                del_ipc_port_fini(port, -ECHILD);
+                ret = -PAL_ERRNO;
+                goto out;
+            }
+
+            bytes += read;
+
+            /* extract actual msg size from msg header and continue reading msg body */
+            if (bytes >= IPC_MSG_MINIMAL_SIZE)
+                expected_size = msg->size;
+        }
+
+        debug("Received IPC message from port %p (handle %p): code=%d size=%d src=%u dst=%u seq=%lx\n",
+              port, port->pal_handle, msg->code, msg->size, msg->src & 0xFFFF, msg->dst & 0xFFFF, msg->seq);
+
+        /* skip messages coming from myself (in case of broadcast) */
+        if (msg->src != cur_process.vmid) {
+            if (msg->code < IPC_CODE_NUM && ipc_callbacks[msg->code]) {
+                /* invoke callback to this msg */
+                ret = (*ipc_callbacks[msg->code]) (msg, port);
+                if ((ret < 0 || ret == RESPONSE_CALLBACK) && msg->seq) {
+                    /* send IPC_RESP message to sender of this msg */
+                    ret = send_response_ipc_message(port, msg->src, ret, msg->seq);
+                    if (ret < 0) {
+                        debug("Sending IPC_RESP msg on port %p (handle %p) to %u failed\n",
+                                port, port->pal_handle, msg->src & 0xFFFF);
+                        ret = -PAL_ERRNO;
+                        goto out;
+                    }
+                }
+            }
+        }
+
+        bytes -= expected_size; /* one message was received and handled */
+
+        if (bytes > 0) {
+            /* we may have started reading the next message, move this message
+             * to beginning of msg buffer and reset expected size */
+            memmove(msg, (void *) msg + expected_size, bytes);
+            expected_size = IPC_MSG_MINIMAL_SIZE;
+            if (bytes >= IPC_MSG_MINIMAL_SIZE)
+                expected_size = msg->size;
+        }
+    } while (bytes > 0);
+
+    ret = 0;
+out:
+    free(msg);
+    return ret;
+}
+
+/* Main routine of the IPC helper thread. IPC helper thread is spawned when
+ * the first IPC port is added and is terminated only when the whole Graphene
+ * application terminates. IPC helper thread runs in an endless loop and waits
+ * on port events (either the addition/removal of ports or actual port events:
+ * acceptance of new client or receiving/sending messages). In particular,
+ * IPC helper thread calls receive_ipc_message() if a message arrives on port.
+ *
+ * Other threads add and remove IPC ports via add_ipc_xxx() and del_ipc_xxx()
+ * functions. These ports are added to port_list which the IPC helper thread
+ * consults before each new DkObjectsWaitAny().
+ *
+ * Note that ports are copied from global port_list to local object_list. This
+ * is because ports may be removed from port_list by other threads while IPC
+ * helper thread is waiting on DkObjectsWaitAny(). For this reason IPC thread
+ * also get references to all current ports and puts them after handling all
+ * ports in object_list.
+ *
+ * Previous implementation went to great lengths to keep changes to the list of
+ * current ports to a minimum (instead of repopulating the list before each wait
+ * like in current code). Unfortunately, this resulted in undue complexity.
+ * Current implementation should perform fine for usual case of <100 IPC ports
+ * and with IPC helper thread always running in background on its own core.
+ */
+noreturn static void shim_ipc_helper(void* dummy) {
+    __UNUSED(dummy);
+    struct shim_thread* self = get_cur_thread();
+
+    PAL_HANDLE polled = NULL;
+
+    /* Initialize two lists:
+     * - object_list collects IPC port objects and is the main handled list
+     * - palhandle_list collects corresponding PAL handles of IPC port objects
+     *   and is needed for DkObjectsWaitAny(.., <arrya-of-PAL-handles>, ..)
+     *   interface; palhandle_list always contains at least install_new_event
+     *
+     * We allocate these two lists on the heap so they do not overflow the
+     * limited PAL stack. We grow them at runtime if needed.
+     */
+    size_t object_list_size = 0;
+    size_t object_list_maxsize = 32;
+    struct shim_ipc_port** object_list =
+            malloc(sizeof(struct shim_ipc_port *) * object_list_maxsize);
+    PAL_HANDLE* palhandle_list =
+            malloc(sizeof(PAL_HANDLE) * (1 + object_list_maxsize));
+
+    PAL_HANDLE install_new_event_hdl = event_handle(&install_new_event);
+    palhandle_list[0] = install_new_event_hdl;
+
+    while (ipc_helper_state == HELPER_ALIVE) {
+        struct shim_ipc_port* polled_port = NULL;
+
+        if (polled == install_new_event_hdl) {
+            /* some thread wants to install new event; this event is found
+             * in object_list below, so just re-init install_new_event */
+            debug("New IPC event was requested (port was added/removed)\n");
+            clear_event(&install_new_event);
+        } else {
+            /* it is not install_new_event handle, so must be one of ports */
+            for (size_t i = 0; i < object_list_size; i++)
+                if (polled == object_list[i]->pal_handle) {
+                    polled_port = object_list[i];
+                    break;
+                }
+        }
+
+        if (polled_port) {
+            if (polled_port->type & IPC_PORT_SERVER) {
+                /* if polled port is server port, accept a client,
+                 * create client port, and add it to port list */
+                PAL_HANDLE client = DkStreamWaitForClient(polled_port->pal_handle);
+                if (client) {
+                    /* type of client port is the same as original server port
+                     * but with LISTEN (for remote client) and without SERVER
+                     * (this port doesn't wait for new clients) */
+                    IDTYPE client_type = (polled_port->type & ~IPC_PORT_SERVER) | IPC_PORT_LISTEN;
+                    add_ipc_port_by_id(polled_port->vmid, client, client_type, NULL, NULL);
+                } else {
+                    debug("Port %p (handle %p) was removed during accepting client\n",
+                            polled_port, polled_port->pal_handle);
+                    del_ipc_port_fini(polled_port, -ECHILD);
+                }
+            } else {
+                PAL_STREAM_ATTR attr;
+                if (DkStreamAttributesQueryByHandle(polled_port->pal_handle, &attr)) {
+                    /* can read on this port, so receive messages */
+                    if (attr.readable) {
+                        /* TODO: IPC helper thread does not handle failures currently */
+                        receive_ipc_message(polled_port);
+                    }
+
+                    if (attr.disconnected) {
+                        debug("Port %p (handle %p) disconnected\n",
+                                polled_port, polled_port->pal_handle);
+                        del_ipc_port_fini(polled_port, -ECONNRESET);
+                    }
+                } else {
+                    debug("Port %p (handle %p) was removed during attr querying\n",
+                            polled_port, polled_port->pal_handle);
+                    del_ipc_port_fini(polled_port, -PAL_ERRNO);
+                }
+            }
+        }
+
+        /* done handling ports; put their references so they can be freed */
+        for (size_t i = 0; i < object_list_size; i++) {
+            struct shim_ipc_port* port = object_list[i];
+            put_ipc_port(port);
+        }
+
+        lock(&ipc_helper_lock);
+
+        /* iterate through all ports to repopulate object_list */
+        object_list_size = 0;
+        struct shim_ipc_port* port;
+        struct shim_ipc_port* tmp;
+        LISTP_FOR_EACH_ENTRY_SAFE(port, tmp, &port_list, list) {
+            /* get port reference so it is not freed while we wait on/handle it */
+            __get_ipc_port(port);
+
+            /* grow object_list and palhandle_list to accomodate more objects */
+            if (object_list_size == object_list_maxsize) {
+                struct shim_ipc_port** tmp_array = malloc(
+                        sizeof(struct shim_ipc_port *) * (object_list_maxsize * 2));
+                PAL_HANDLE* tmp_pal_array = malloc(
+                        sizeof(PAL_HANDLE) * (1 + object_list_maxsize * 2));
+                memcpy(tmp_array, object_list,
+                        sizeof(struct shim_ipc_port *) * (object_list_maxsize));
+                memcpy(tmp_pal_array, palhandle_list,
+                        sizeof(PAL_HANDLE) * (1 + object_list_size));
+                object_list_maxsize *= 2;
+                free(object_list);
+                free(palhandle_list);
+                object_list    = tmp_array;
+                palhandle_list = tmp_pal_array;
+            }
+
+            /* re-add this port to object_list and palhandle_list */
+            object_list[object_list_size]        = port;
+            palhandle_list[object_list_size + 1] = port->pal_handle;
+            object_list_size++;
+
+            debug("Listening to process %u on port %p (handle %p, type %04x)\n",
+                  port->vmid & 0xFFFF, port, port->pal_handle, port->type);
+        }
+
+        unlock(&ipc_helper_lock);
+
+        /* wait on collected ports' PAL handles + install_new_event_hdl */
+        polled = DkObjectsWaitAny(object_list_size + 1, palhandle_list, NO_TIMEOUT);
+        /* ensure that while loop breaks on ipc_helper_state change */
+        COMPILER_BARRIER();
+    }
+
+    /* IPC thread exits; put acquired port references so they can be freed */
+    for (size_t i = 0; i < object_list_size; i++) {
+        struct shim_ipc_port* port = object_list[i];
+        put_ipc_port(port);
+    }
+
+    free(object_list);
+    free(palhandle_list);
 
     lock(&ipc_helper_lock);
     ipc_helper_state = HELPER_NOTALIVE;
     ipc_helper_thread = NULL;
     unlock(&ipc_helper_lock);
     put_thread(self);
-    debug("ipc helper thread terminated\n");
+    debug("IPC helper thread terminated\n");
 
     DkThreadExit();
 }
 
-noreturn static void __shim_ipc_helper (void * dummy)
-{
-    __UNUSED(dummy);
-    struct shim_thread * self = get_cur_thread();
-    void * stack = self->stack;
-
-    int port_num = 0, port_size = IPC_HELPER_LIST_INIT_SIZE;
-    struct shim_ipc_port ** local_pobjs = stack, * pobj;
-    PAL_HANDLE * local_ports;
-    PAL_HANDLE ipc_event_handle = event_handle(&ipc_helper_event);
-
-    int nalive = 0;
-    PAL_HANDLE polled = NULL;
-    int count = -1;
-
-    local_ports = (PAL_HANDLE *) (local_pobjs + port_size);
-    local_ports[0] = ipc_event_handle;
-
-    goto update_status;
-
-    /* The compiler should be careful not to cache the ipc_helper_state or
-     * else ths loop could fail to terminate on update.  Use a compiler
-     * barrier to force a re-read after sleeping. */
-    while ((ipc_helper_state == HELPER_ALIVE) ||
-           nalive) {
-        /* do a global poll on all the ports */
-        polled = DkObjectsWaitAny(port_num + 1, local_ports, NO_TIMEOUT);
-        COMPILER_BARRIER();
-
-        if (!polled)
-            continue;
-
-        /* before we locking pobj list, at least we can look at the returned
-           port if it is the ipc helper event */
-        if (polled == ipc_event_handle) {
-            clear_event(&ipc_helper_event);
-update_status:
-            COMPILER_BARRIER();
-            if (ipc_helper_state == HELPER_NOTALIVE)
-                goto end;
-            else
-                goto update_list;
-        }
-
-        pobj = NULL;
-        count = -1;
-        for (int i = 0 ; i < port_num ; i++)
-            if (polled == local_pobjs[i]->pal_handle) {
-                pobj = local_pobjs[i];
-                count = i;
-                break;
-            }
-
-        if (!pobj)
-            continue;
-
-        /* if the polled port is a server port, accept a client and add it
-           to the port list */
-        if (pobj->private.type & IPC_PORT_SERVER) {
-            PAL_HANDLE cli = DkStreamWaitForClient(polled);
-            if (cli) {
-                IDTYPE type = (pobj->private.type & ~IPC_PORT_SERVER) |
-                              IPC_PORT_LISTEN;
-                add_ipc_port_by_id(pobj->private.vmid, cli, type,
-                                   NULL, NULL);
-            } else {
-                debug("port %p (handle %p) is removed at accepting\n",
-                      pobj, polled);
-                del_ipc_port_fini(pobj, -ECHILD);
-            }
-            polled = NULL;
-            count = -1;
-            goto update_list;
-        }
-
-        PAL_STREAM_ATTR attr;
-        if (!DkStreamAttributesQueryByHandle(polled, &attr)) {
-            debug("port %p (handle %p) is removed at querying\n",
-                  pobj, polled);
-            del_ipc_port_fini(pobj, -PAL_ERRNO);
-            goto update_list;
-        }
-
-        if (attr.readable)
-            receive_ipc_message(pobj, 0, NULL);
-
-        if (attr.disconnected) {
-            debug("port %p (handle %p) is disconnected\n",
-                  pobj, polled);
-            del_ipc_port_fini(pobj, -ECONNRESET);
-            goto update_list;
-        }
-
-        if (!ipc_helper_update)
-            continue;
-update_list:
-        ipc_helper_update = false;
-        lock(&ipc_helper_lock);
-
-        int compact = 0;
-        /* first walk though all the polling ports and remove the one
-           being deleted. */
-        for (int i = 0 ; i < port_num ; i++) {
-            struct shim_ipc_port * pobj = local_pobjs[i];
-
-            // If the port is removed from the list or intended to be deleted,
-            // remove the port from the polling array
-            if (LIST_EMPTY(pobj, list)) {
-                if (polled == pobj->pal_handle) {
-                    polled = NULL;
-                    count = -1;
-                }
-                local_pobjs[i] = NULL;
-                if (pobj->private.type & IPC_PORT_KEEPALIVE)
-                    nalive--;
-                __put_ipc_port(pobj);
-                compact++;
-                continue;
-            }
-
-            if (pobj->update) {
-                if (pobj->info.type & IPC_PORT_KEEPALIVE) {
-                    if (!(pobj->private.type & IPC_PORT_KEEPALIVE))
-                        nalive--;
-                } else {
-                    if (pobj->private.type & IPC_PORT_KEEPALIVE)
-                        nalive++;
-                }
-                pobj->private = pobj->info;
-                pobj->update = false;
-            }
-
-            if (compact) {
-                if (polled == pobj->pal_handle)
-                    count -= compact;
-                local_pobjs[i - compact] = pobj;
-                local_ports[i - compact + 1] = pobj->pal_handle;
-            }
-        }
-        port_num -= compact;
-
-        LISTP_FOR_EACH_ENTRY(pobj, &pobj_list, list) {
-            /* we only update among recently updated ports */
-            if (!pobj->recent)
-                break;
-
-            if (pobj->update) {
-                pobj->private = pobj->info;
-                pobj->update = false;
-            }
-
-            assert(pobj->private.type & IPC_PORT_IFPOLL);
-
-            if (port_num == port_size) {
-                port_size *= 2;
-                memmove(local_pobjs + port_size,
-                        local_ports,
-                        (port_num + 1) * sizeof(PAL_HANDLE));
-                local_ports = (PAL_HANDLE *) (local_pobjs + port_size);
-            }
-
-            pobj->recent = false;
-            __get_ipc_port(pobj);
-            local_pobjs[port_num] = pobj;
-            local_ports[port_num + 1] = pobj->pal_handle;
-            port_num++;
-
-            if (pobj->private.type & IPC_PORT_KEEPALIVE)
-                nalive++;
-
-            debug("listen to process %u on port %p (handle %p, type %04x)\n",
-                  pobj->private.vmid,
-                  pobj,
-                  pobj->pal_handle,
-                  pobj->private.type);
-        }
-
-        unlock(&ipc_helper_lock);
-    }
-
-    for (int i = 0 ; i < port_num ; i++) {
-        struct shim_ipc_port * pobj = local_pobjs[i];
-        __put_ipc_port(pobj);
-    }
-
-end:
-    shim_ipc_helper_end(self);
-}
-
-static void shim_ipc_helper (void * arg)
-{
-    /* set ipc helper thread */
+static void shim_ipc_helper_prepare(void* arg) {
     struct shim_thread * self = (struct shim_thread *) arg;
     if (!arg)
         return;
@@ -1033,40 +727,30 @@ static void shim_ipc_helper (void * arg)
     __libc_tcb_t tcb;
     allocate_tls(&tcb, false, self);
     debug_setbuf(&tcb.shim_tcb, true);
-    debug("set tcb to %p\n", &tcb);
+    debug("Set tcb to %p\n", &tcb);
 
     lock(&ipc_helper_lock);
     bool notme = (self != ipc_helper_thread);
     unlock(&ipc_helper_lock);
 
-    if (notme) {
+    void* stack = allocate_stack(IPC_HELPER_STACK_SIZE, allocsize, false);
+
+    if (notme || !stack) {
         put_thread(self);
         DkThreadExit();
         return;
     }
 
-    debug("ipc helper thread started\n");
+    debug("IPC helper thread started\n");
 
-    void * stack = allocate_stack(IPC_HELPER_STACK_SIZE, allocsize, false);
-
-    if (!stack) {
-        shim_ipc_helper_end(self);
-        return;
-    }
-
+    /* swap stack to be sure we don't drain the small stack PAL provides */
     self->stack_top = stack + IPC_HELPER_STACK_SIZE;
     self->stack = stack;
-    __SWITCH_STACK(self->stack_top, __shim_ipc_helper, NULL);
+    __SWITCH_STACK(self->stack_top, shim_ipc_helper, NULL);
 }
 
-/* This function shoudl be called with the ipc_helper_lock held */
-static int create_ipc_helper (void)
-{
-    int ret = 0;
-
-    /* If we are holding the lock, no barrier is needed here, as
-     * the lock (and new function) form an implicit barrier, and
-     * any "recent" changes should have come from this thread */
+/* this should be called with the ipc_helper_lock held */
+static int create_ipc_helper(void) {
     if (ipc_helper_state == HELPER_ALIVE)
         return 0;
 
@@ -1077,95 +761,50 @@ static int create_ipc_helper (void)
     ipc_helper_thread = new;
     ipc_helper_state = HELPER_ALIVE;
 
-    PAL_HANDLE handle = thread_create(shim_ipc_helper, new);
+    PAL_HANDLE handle = thread_create(shim_ipc_helper_prepare, new);
 
     if (!handle) {
-        ret = -PAL_ERRNO;
         ipc_helper_thread = NULL;
         ipc_helper_state = HELPER_NOTALIVE;
         put_thread(new);
-        return ret;
+        return -PAL_ERRNO;
     }
 
     new->pal_handle = handle;
     return 0;
 }
 
-/*
- * on success, the reference to the helper thread is returned with
- * reference count incremented.
- * The caller is responsible to wait for the IPC helper thread to exit
- * and release the final reference to free related resources.
- * It's problematic for the thread itself to release its resources which it's
- * using. For example stack.
- * So defer releasing it after its exit and make the releasing the caller
- * responsibility.
+/* On success, the reference to ipc helper thread is returned with refcount
+ * incremented. It is the responsibility of caller to wait for ipc helper's
+ * exit and then release the final reference to free related resources (it is
+ * problematic for the thread itself to release its own resources e.g. stack).
  */
-int exit_with_ipc_helper (bool handover, struct shim_thread ** ret)
-{
-    *ret = NULL;
-    if (IN_HELPER() || ipc_helper_state != HELPER_ALIVE)
-        return 0;
+struct shim_thread* terminate_ipc_helper(void) {
+    if (ipc_helper_state != HELPER_ALIVE)
+        return NULL;
+
+    /* NOTE: Graphene doesn't have an abstraction of a queue of pending signals
+     * between communicating processes (instead all communication is done over
+     * streams). Thus, app code like this (found in e.g. Lmbench's bw_unix):
+     *     kill(child, SIGKILL);
+     *     exit(0);
+     * results in a data race between the SIGKILL message sent over IPC stream
+     * and the parent process exiting. In the worst case, the parent will exit
+     * before the SIGKILL message goes through the host-OS stream, the host OS
+     * will close the stream, and the message will never be seen by child. To
+     * prevent such cases, we simply wait for a bit before exiting.
+     * */
+    debug("Waiting for 0.5s for all in-flight IPC messages to reach their destinations\n");
+    DkThreadDelayExecution(500);
 
     lock(&ipc_helper_lock);
-    if (handover) {
-        handover = false;
-        struct shim_ipc_port * pobj;
-        LISTP_FOR_EACH_ENTRY(pobj, &pobj_list, list)
-            if (pobj->info.type & IPC_PORT_KEEPALIVE) {
-                handover = true;
-                break;
-            }
-    }
-
-    int new_state = HELPER_NOTALIVE;
-    if (handover) {
-        debug("handing over to ipc helper\n");
-        new_state = HELPER_HANDEDOVER;
-    } else {
-        debug("exiting ipc helper\n");
-    }
-
-    ipc_helper_state = new_state;
-    if (ipc_helper_thread != NULL) {
-        get_thread(ipc_helper_thread);
-        *ret = ipc_helper_thread;
-    }
-    unlock(&ipc_helper_lock);
-
-    set_event(&ipc_helper_event, 1);
-
-    if (new_state != HELPER_NOTALIVE) {
-        return -EAGAIN;
-    } else {
-        /* We could get here via a signal handler invoked during
-         * receive_ipc_message. Let that complete so that whoever
-         * generated the signal doesn't hang waiting for IPC_RESP. */
-        int loops = 0;
-        while (ipc_helper_thread != NULL && loops++ < 2000) {
-            COMPILER_BARRIER();
-            DkThreadDelayExecution(1000);
-        }
-        if (ipc_helper_thread != NULL) {
-            debug("timed out waiting for ipc helper to exit\n");
-        }
-        return 0;
-    }
-}
-
-int terminate_ipc_helper (void)
-{
-    lock(&ipc_helper_lock);
-
-    struct shim_thread * thread = ipc_helper_thread;
-    if (!thread) {
-        unlock(&ipc_helper_lock);
-        return -ESRCH;
-    }
-
-    debug("terminating ipc helper\n");
+    struct shim_thread* ret = ipc_helper_thread;
+    if (ret)
+        get_thread(ret);
     ipc_helper_state = HELPER_NOTALIVE;
-    set_event(&ipc_helper_event, 1);
     unlock(&ipc_helper_lock);
-    return 0;
+
+    /* force wake up of ipc helper thread so that it exits */
+    set_event(&install_new_event, 1);
+    return ret;
 }

--- a/LibOS/shim/src/ipc/shim_ipc_nsimpl.h
+++ b/LibOS/shim/src/ipc/shim_ipc_nsimpl.h
@@ -770,7 +770,8 @@ static void __discover_ns (bool block, bool need_locate)
     if (NS_LEADER) {
         if (NS_LEADER->vmid == cur_process.vmid) {
             if (need_locate && qstrempty(&NS_LEADER->uri)) {
-                struct shim_ipc_info * info = create_ipc_info_cur_process();
+                bool is_self_ipc_info = false; /* not cur_process.self but cur_process.ns */
+                struct shim_ipc_info * info = create_ipc_info_cur_process(is_self_ipc_info);
                 if (info) {
                     put_ipc_info(NS_LEADER);
                     NS_LEADER = info;
@@ -816,7 +817,8 @@ static void __discover_ns (bool block, bool need_locate)
         goto out;
     }
 
-    if (!(NS_LEADER = create_ipc_info_cur_process()))
+    bool is_self_ipc_info = false; /* not cur_process.self but cur_process.ns */
+    if (!(NS_LEADER = create_ipc_info_cur_process(is_self_ipc_info)))
         goto out;
 
     // Finally, set the IPC port as a leadership port

--- a/LibOS/shim/src/ipc/shim_ipc_nsimpl.h
+++ b/LibOS/shim/src/ipc/shim_ipc_nsimpl.h
@@ -266,7 +266,7 @@ static int __add_range (struct range * r, IDTYPE off, IDTYPE owner,
     r->subranges = NULL;
 
     if (owner) {
-        r->owner = create_ipc_info_in_list(owner, uri);
+        r->owner = create_ipc_info_in_list(owner, uri, strlen(uri));
         if (!r->owner)
             return -ENOMEM;
     }
@@ -367,7 +367,7 @@ int CONCAT3(add, NS, subrange) (IDTYPE idx, IDTYPE owner,
     assert(owner);
     lock(&range_map_lock);
 
-    s->owner = create_ipc_info_in_list(owner, uri);
+    s->owner = create_ipc_info_in_list(owner, uri, strlen(uri));
     if (!s->owner) {
         err = -ENOMEM;
         goto failed;

--- a/LibOS/shim/src/ipc/shim_ipc_nsimpl.h
+++ b/LibOS/shim/src/ipc/shim_ipc_nsimpl.h
@@ -1204,7 +1204,7 @@ int NS_SEND(offer) (struct shim_ipc_port * port, IDTYPE dest, IDTYPE base,
     msg->seq     = seq;
 
     debug("ipc send to %u: " NS_CODE_STR(OFFER) "(%u, %u, %lu)\n",
-          port->info.vmid, base, size, lease);
+          port->vmid, base, size, lease);
     ret = send_ipc_message(msg, port);
     SAVE_PROFILE_INTERVAL(NS_SEND(offer));
     return ret;

--- a/LibOS/shim/src/ipc/shim_ipc_nsimpl.h
+++ b/LibOS/shim/src/ipc/shim_ipc_nsimpl.h
@@ -266,7 +266,7 @@ static int __add_range (struct range * r, IDTYPE off, IDTYPE owner,
     r->subranges = NULL;
 
     if (owner) {
-        r->owner = lookup_and_alloc_client(owner, uri);
+        r->owner = create_ipc_info_in_list(owner, uri);
         if (!r->owner)
             return -ENOMEM;
     }
@@ -291,7 +291,7 @@ static int __add_range (struct range * r, IDTYPE off, IDTYPE owner,
                 }
 
                 if (tmp->owner)
-                    put_client(tmp->owner);
+                    put_ipc_info_in_list(tmp->owner);
 
                 r->used = tmp->used;
                 r->subranges = tmp->subranges;
@@ -367,7 +367,7 @@ int CONCAT3(add, NS, subrange) (IDTYPE idx, IDTYPE owner,
     assert(owner);
     lock(&range_map_lock);
 
-    s->owner = lookup_and_alloc_client(owner, uri);
+    s->owner = create_ipc_info_in_list(owner, uri);
     if (!s->owner) {
         err = -ENOMEM;
         goto failed;
@@ -770,8 +770,7 @@ static void __discover_ns (bool block, bool need_locate)
     if (NS_LEADER) {
         if (NS_LEADER->vmid == cur_process.vmid) {
             if (need_locate && qstrempty(&NS_LEADER->uri)) {
-                struct shim_ipc_info * info = create_ipc_port(cur_process.vmid,
-                                                              true);
+                struct shim_ipc_info * info = create_ipc_info_cur_process();
                 if (info) {
                     put_ipc_info(NS_LEADER);
                     NS_LEADER = info;
@@ -810,14 +809,14 @@ static void __discover_ns (bool block, bool need_locate)
 
     // If all other ways failed, the current process becomes the leader
     if (!need_locate) {
-        NS_LEADER = get_new_ipc_info(cur_process.vmid, NULL, 0);
+        NS_LEADER = create_ipc_info(cur_process.vmid, NULL, 0);
         goto out;
     }
 
     if (NS_LEADER)
         put_ipc_info(NS_LEADER);
 
-    if (!(NS_LEADER = create_ipc_port(cur_process.vmid, true)))
+    if (!(NS_LEADER = create_ipc_info_cur_process()))
         goto out;
 
     // Finally, set the IPC port as a leadership port
@@ -995,17 +994,19 @@ int NS_SEND(findns) (bool block)
     unlock(&cur_process.lock);
 
     if (block) {
-        struct shim_ipc_msg_obj * msg =
-            create_ipc_msg_duplex_on_stack(NS_CODE(FINDNS), 0, dest);
+        size_t total_msg_size = get_ipc_msg_duplex_size(0);
+        struct shim_ipc_msg_duplex* msg = __alloca(total_msg_size);
+        init_ipc_msg_duplex(msg, NS_CODE(FINDNS), total_msg_size, dest);
 
         debug("ipc send to %u: " NS_CODE_STR(FINDNS) "\n", dest);
 
-        ret = do_ipc_duplex(msg, port, NULL, NULL);
+        ret = send_ipc_message_duplex(msg, port, NULL, NULL);
         goto out_port;
     }
 
-    struct shim_ipc_msg * msg =
-            create_ipc_msg_on_stack(NS_CODE(FINDNS), 0, dest);
+    size_t total_msg_size = get_ipc_msg_size(0);
+    struct shim_ipc_msg* msg = __alloca(total_msg_size);
+    init_ipc_msg(msg, NS_CODE(FINDNS), total_msg_size, dest);
 
     debug("ipc send to %u: " NS_CODE_STR(FINDNS) "\n", dest);
 
@@ -1057,10 +1058,10 @@ int NS_SEND(tellns) (struct shim_ipc_port * port, IDTYPE dest,
                      struct shim_ipc_info * leader, unsigned long seq)
 {
     BEGIN_PROFILE_INTERVAL();
-    struct shim_ipc_msg * msg =
-        create_ipc_msg_on_stack(NS_CODE(TELLNS),
-                                leader->uri.len + sizeof(NS_MSG_TYPE(tellns)),
-                                dest);
+    size_t total_msg_size = get_ipc_msg_size(leader->uri.len + sizeof(NS_MSG_TYPE(tellns)));
+    struct shim_ipc_msg* msg = __alloca(total_msg_size);
+    init_ipc_msg(msg, NS_CODE(TELLNS), total_msg_size, dest);
+
     NS_MSG_TYPE(tellns) * msgin = (void *) &msg->msg;
     msgin->vmid = leader->vmid;
     memcpy(msgin->uri, qstrgetstr(&leader->uri), leader->uri.len + 1);
@@ -1089,7 +1090,7 @@ int NS_CALLBACK(tellns) (IPC_CALLBACK_ARGS)
         NS_LEADER->vmid = msgin->vmid;
         qstrsetstr(&NS_LEADER->uri, msgin->uri, strlen(msgin->uri));
     } else {
-        NS_LEADER = get_new_ipc_info(msgin->vmid, msgin->uri,
+        NS_LEADER = create_ipc_info(msgin->vmid, msgin->uri,
                                       strlen(msgin->uri));
         if (!NS_LEADER) {
             ret = -ENOMEM;
@@ -1109,7 +1110,7 @@ int NS_CALLBACK(tellns) (IPC_CALLBACK_ARGS)
         free(query);
     }
 
-    struct shim_ipc_msg_obj * obj = find_ipc_msg_duplex(port, msg->seq);
+    struct shim_ipc_msg_duplex * obj = pop_ipc_msg_duplex(port, msg->seq);
     if (obj && obj->thread)
         thread_wakeup(obj->thread);
 
@@ -1133,7 +1134,7 @@ int NS_SEND(lease) (LEASETYPE * lease)
     if ((ret = connect_ns(&leader, &port)) < 0)
         goto out;
 
-    if ((ret = create_ipc_location(&self)) < 0)
+    if ((ret = get_ipc_info_cur_process(&self)) < 0)
         goto out;
 
     if (leader == cur_process.vmid) {
@@ -1145,10 +1146,10 @@ int NS_SEND(lease) (LEASETYPE * lease)
     }
 
     int len = self->uri.len;
-    struct shim_ipc_msg_obj * msg = create_ipc_msg_duplex_on_stack(
-                                        NS_CODE(LEASE),
-                                        len + sizeof(NS_MSG_TYPE(lease)),
-                                        leader);
+    size_t total_msg_size = get_ipc_msg_duplex_size(len + sizeof(NS_MSG_TYPE(lease)));
+    struct shim_ipc_msg_duplex* msg = __alloca(total_msg_size);
+    init_ipc_msg_duplex(msg, NS_CODE(LEASE), total_msg_size, leader);
+
     NS_MSG_TYPE(lease) * msgin = (void *) &msg->msg.msg;
     assert(!qstrempty(&self->uri));
     memcpy(msgin->uri, qstrgetstr(&self->uri), len + 1);
@@ -1157,7 +1158,7 @@ int NS_SEND(lease) (LEASETYPE * lease)
     debug("ipc send to %u: " NS_CODE_STR(LEASE) "(%s)\n", leader,
           msgin->uri);
 
-    ret = do_ipc_duplex(msg, port, NULL, lease);
+    ret = send_ipc_message_duplex(msg, port, NULL, lease);
 out:
     if (port)
         put_ipc_port(port);
@@ -1195,8 +1196,10 @@ int NS_SEND(offer) (struct shim_ipc_port * port, IDTYPE dest, IDTYPE base,
 {
     BEGIN_PROFILE_INTERVAL();
     int ret = 0;
-    struct shim_ipc_msg * msg = create_ipc_msg_on_stack(NS_CODE(OFFER),
-                                        sizeof(NS_MSG_TYPE(offer)), dest);
+    size_t total_msg_size = get_ipc_msg_size(sizeof(NS_MSG_TYPE(offer)));
+    struct shim_ipc_msg* msg = __alloca(total_msg_size);
+    init_ipc_msg(msg, NS_CODE(OFFER), total_msg_size, dest);
+
     NS_MSG_TYPE(offer) * msgin = (void *) &msg->msg;
     msgin->base  = base;
     msgin->size  = size;
@@ -1218,7 +1221,7 @@ int NS_CALLBACK(offer) (IPC_CALLBACK_ARGS)
     debug("ipc callback from %u: " NS_CODE_STR(OFFER) "(%u, %u, %lu)\n",
           msg->src, msgin->base, msgin->size, msgin->lease);
 
-    struct shim_ipc_msg_obj * obj = find_ipc_msg_duplex(port, msg->seq);
+    struct shim_ipc_msg_duplex * obj = pop_ipc_msg_duplex(port, msg->seq);
 
     switch (msgin->size) {
         case RANGE_SIZE:
@@ -1265,9 +1268,10 @@ int NS_SEND(renew) (IDTYPE base, IDTYPE size)
     if ((ret = connect_ns(&leader, &port)) < 0)
         goto out;
 
-    struct shim_ipc_msg * msg =
-            create_ipc_msg_on_stack(NS_CODE(RENEW),
-                                    sizeof(NS_MSG_TYPE(renew)), leader);
+    size_t total_msg_size = get_ipc_msg_size(sizeof(NS_MSG_TYPE(renew)));
+    struct shim_ipc_msg* msg = __alloca(total_msg_size);
+    init_ipc_msg(msg, NS_CODE(RENEW), total_msg_size, leader);
+
     NS_MSG_TYPE(renew) * msgin = (void *) &msg->msg;
     msgin->base = base;
     msgin->size = size;
@@ -1339,10 +1343,10 @@ int NS_SEND(sublease) (IDTYPE tenant, IDTYPE idx, const char * uri,
     }
 
     int len = strlen(uri);
-    struct shim_ipc_msg_obj * msg = create_ipc_msg_duplex_on_stack(
-                                            NS_CODE(SUBLEASE),
-                                            len + sizeof(NS_MSG_TYPE(sublease)),
-                                            leader);
+    size_t total_msg_size = get_ipc_msg_duplex_size(len + sizeof(NS_MSG_TYPE(sublease)));
+    struct shim_ipc_msg_duplex* msg = __alloca(total_msg_size);
+    init_ipc_msg_duplex(msg, NS_CODE(SUBLEASE), total_msg_size, leader);
+
     NS_MSG_TYPE(sublease) * msgin = (void *) &msg->msg.msg;
     msgin->tenant = tenant;
     msgin->idx = idx;
@@ -1351,7 +1355,7 @@ int NS_SEND(sublease) (IDTYPE tenant, IDTYPE idx, const char * uri,
     debug("ipc send to %u: " NS_CODE_STR(SUBLEASE) "(%u, %u, %s)\n",
           leader, tenant, idx, msgin->uri);
 
-    ret = do_ipc_duplex(msg, port, NULL, lease);
+    ret = send_ipc_message_duplex(msg, port, NULL, lease);
 out:
     if (port)
         put_ipc_port(port);
@@ -1399,17 +1403,16 @@ int NS_SEND(query) (IDTYPE idx)
         goto out;
     }
 
-    struct shim_ipc_msg_obj * msg = create_ipc_msg_duplex_on_stack(
-                                            NS_CODE(QUERY),
-                                            sizeof(NS_MSG_TYPE(query)),
-                                            leader);
+    size_t total_msg_size = get_ipc_msg_duplex_size(sizeof(NS_MSG_TYPE(query)));
+    struct shim_ipc_msg_duplex* msg = __alloca(total_msg_size);
+    init_ipc_msg_duplex(msg, NS_CODE(QUERY), total_msg_size, leader);
 
     NS_MSG_TYPE(query) * msgin = (void *) &msg->msg.msg;
     msgin->idx = idx;
 
     debug("ipc send to %u: " NS_CODE_STR(QUERY) "(%u)\n", leader, idx);
 
-    ret = do_ipc_duplex(msg, port, NULL, NULL);
+    ret = send_ipc_message_duplex(msg, port, NULL, NULL);
 out:
     if (port)
         put_ipc_port(port);
@@ -1471,12 +1474,13 @@ int NS_SEND(queryall) (void)
     if (cur_process.vmid == leader)
         goto out;
 
-    struct shim_ipc_msg_obj * msg = create_ipc_msg_duplex_on_stack(
-                                            NS_CODE(QUERYALL), 0, leader);
+    size_t total_msg_size = get_ipc_msg_duplex_size(0);
+    struct shim_ipc_msg_duplex* msg = __alloca(total_msg_size);
+    init_ipc_msg_duplex(msg, NS_CODE(QUERYALL), total_msg_size, leader);
 
     debug("ipc send to %u: " NS_CODE_STR(QUERYALL) "\n", leader);
 
-    ret = do_ipc_duplex(msg, port, NULL, NULL);
+    ret = send_ipc_message_duplex(msg, port, NULL, NULL);
     put_ipc_port(port);
 out:
     SAVE_PROFILE_INTERVAL(NS_SEND(queryall));
@@ -1587,9 +1591,9 @@ int NS_SEND(answer) (struct shim_ipc_port * port, IDTYPE dest,
     for (int i = 0 ; i < nowners ; i++)
         total_ownerdatasz += ownerdatasz[i];
 
-    struct shim_ipc_msg * msg =
-            create_ipc_msg_on_stack(NS_CODE(ANSWER),
-                                    owner_offset + total_ownerdatasz, dest);
+    size_t total_msg_size = get_ipc_msg_size(owner_offset + total_ownerdatasz);
+    struct shim_ipc_msg* msg = __alloca(total_msg_size);
+    init_ipc_msg(msg, NS_CODE(ANSWER), total_msg_size, dest);
 
     NS_MSG_TYPE(answer) * msgin = (void *) &msg->msg;
     msgin->nanswers = nanswers;
@@ -1646,7 +1650,7 @@ int NS_CALLBACK(answer) (IPC_CALLBACK_ARGS)
         }
     }
 
-    struct shim_ipc_msg_obj * obj = find_ipc_msg_duplex(port, msg->seq);
+    struct shim_ipc_msg_duplex * obj = pop_ipc_msg_duplex(port, msg->seq);
     if (obj && obj->thread)
         thread_wakeup(obj->thread);
 
@@ -1746,17 +1750,17 @@ int NS_SEND(findkey) (NS_KEY * key)
         goto out;
     }
 
-    struct shim_ipc_msg_obj * msg = create_ipc_msg_duplex_on_stack(
-                                        NS_CODE(FINDKEY),
-                                        sizeof(NS_MSG_TYPE(findkey)),
-                                        dest);
+    size_t total_msg_size = get_ipc_msg_duplex_size(sizeof(NS_MSG_TYPE(findkey)));
+    struct shim_ipc_msg_duplex* msg = __alloca(total_msg_size);
+    init_ipc_msg_duplex(msg, NS_CODE(FINDKEY), total_msg_size, dest);
+
     NS_MSG_TYPE(findkey) * msgin = (void *) &msg->msg.msg;
     KEY_COPY(&msgin->key, key);
 
     debug("ipc send to %u: " NS_CODE_STR(FINDKEY) "(%lu)\n",
           dest, KEY_HASH(key));
 
-    ret = do_ipc_duplex(msg, port, NULL, NULL);
+    ret = send_ipc_message_duplex(msg, port, NULL, NULL);
     put_ipc_port(port);
 
     if (!ret)
@@ -1809,10 +1813,10 @@ int NS_SEND(tellkey) (struct shim_ipc_port * port, IDTYPE dest, NS_KEY * key,
     }
 
     if (owned) {
-        struct shim_ipc_msg * msg = create_ipc_msg_on_stack(
-                                        NS_CODE(TELLKEY),
-                                        sizeof(NS_MSG_TYPE(tellkey)),
-                                        dest);
+        size_t total_msg_size = get_ipc_msg_size(sizeof(NS_MSG_TYPE(tellkey)));
+        struct shim_ipc_msg* msg = __alloca(total_msg_size);
+        init_ipc_msg(msg, NS_CODE(TELLKEY), total_msg_size, dest);
+
         NS_MSG_TYPE(tellkey) * msgin = (void *) &msg->msg;
         KEY_COPY(&msgin->key, key);
         msgin->id = id;
@@ -1825,10 +1829,10 @@ int NS_SEND(tellkey) (struct shim_ipc_port * port, IDTYPE dest, NS_KEY * key,
         goto out;
     }
 
-    struct shim_ipc_msg_obj * msg = create_ipc_msg_duplex_on_stack(
-                                        NS_CODE(TELLKEY),
-                                        sizeof(NS_MSG_TYPE(tellkey)),
-                                        dest);
+    size_t total_msg_size = get_ipc_msg_duplex_size(sizeof(NS_MSG_TYPE(tellkey)));
+    struct shim_ipc_msg_duplex* msg = __alloca(total_msg_size);
+    init_ipc_msg_duplex(msg, NS_CODE(TELLKEY), total_msg_size, dest);
+
     NS_MSG_TYPE(tellkey) * msgin = (void *) &msg->msg.msg;
     KEY_COPY(&msgin->key, key);
     msgin->id = id;
@@ -1836,7 +1840,7 @@ int NS_SEND(tellkey) (struct shim_ipc_port * port, IDTYPE dest, NS_KEY * key,
     debug("ipc send to %u: IPC_SYSV_TELLKEY(%lu, %u)\n", dest,
           KEY_HASH(key), id);
 
-    ret = do_ipc_duplex(msg, port, NULL, NULL);
+    ret = send_ipc_message_duplex(msg, port, NULL, NULL);
     put_ipc_port(port);
 out:
     SAVE_PROFILE_INTERVAL(NS_SEND(tellkey));
@@ -1854,7 +1858,7 @@ int NS_CALLBACK(tellkey) (IPC_CALLBACK_ARGS)
 
     ret = CONCAT2(NS, add_key)(&msgin->key, msgin->id);
 
-    struct shim_ipc_msg_obj * obj = find_ipc_msg_duplex(port, msg->seq);
+    struct shim_ipc_msg_duplex * obj = pop_ipc_msg_duplex(port, msg->seq);
     if (!obj) {
         ret = RESPONSE_CALLBACK;
         goto out;

--- a/LibOS/shim/src/ipc/shim_ipc_pid.c
+++ b/LibOS/shim/src/ipc/shim_ipc_pid.c
@@ -87,7 +87,7 @@ int broadcast_signal (IDTYPE sender, int signum)
     debug("ipc send to %u: IPC_PID_KILL(%u, %d, %u, %d)\n", 0,
           sender, KILL_ALL, 0, signum);
 
-    ret = broadcast_ipc(msg, NULL, 0, IPC_PORT_DIRCLD|IPC_PORT_DIRPRT);
+    ret = broadcast_ipc(msg, IPC_PORT_DIRCLD|IPC_PORT_DIRPRT, /*exclude_port*/ NULL);
     SAVE_PROFILE_INTERVAL(ipc_pid_kill_send);
     return ret;
 }
@@ -152,7 +152,7 @@ int ipc_pid_kill_callback (IPC_CALLBACK_ARGS)
                                  true);
             break;
         case KILL_ALL:
-            broadcast_ipc(msg, &port, 1, IPC_PORT_DIRPRT|IPC_PORT_DIRCLD);
+            broadcast_ipc(msg, IPC_PORT_DIRPRT|IPC_PORT_DIRCLD, port);
             kill_all_threads(NULL, msgin->sender, msgin->signum);
             break;
     }

--- a/LibOS/shim/src/ipc/shim_ipc_pid.c
+++ b/LibOS/shim/src/ipc/shim_ipc_pid.c
@@ -68,57 +68,50 @@ int init_ns_pid (void)
     return 0;
 }
 
-int broadcast_signal (IDTYPE sender, int signum)
-{
+int ipc_pid_kill_send(IDTYPE sender, IDTYPE target, enum kill_type type, int signum) {
     BEGIN_PROFILE_INTERVAL();
     int ret;
+
+    if (!signum) {
+        /* if sig is 0, then no signal is sent, but error checking on kill()
+         * is still performed (used to check for existence of processes) */
+        ret = 0;
+        goto out;
+    }
+
+    IDTYPE dest;
+    struct shim_ipc_port* port;
+    if (type == KILL_ALL) {
+        dest = 0;
+        port = NULL;
+    } else {
+        ret = connect_owner(target, &port, &dest);
+        if (ret < 0)
+            goto out;
+    }
 
     size_t total_msg_size = get_ipc_msg_size(sizeof(struct shim_ipc_pid_kill));
     struct shim_ipc_msg* msg = __alloca(total_msg_size);
-    init_ipc_msg(msg, IPC_PID_KILL, total_msg_size, 0);
-    struct shim_ipc_pid_kill * msgin =
-                    (struct shim_ipc_pid_kill *) &msg->msg;
+    init_ipc_msg(msg, IPC_PID_KILL, total_msg_size, dest);
 
+    struct shim_ipc_pid_kill* msgin = (struct shim_ipc_pid_kill *) &msg->msg;
     msgin->sender = sender;
-    msgin->id     = 0;
-    msgin->type   = KILL_ALL;
-    msgin->signum = signum;
-
-    debug("ipc send to %u: IPC_PID_KILL(%u, %d, %u, %d)\n", 0,
-          sender, KILL_ALL, 0, signum);
-
-    ret = broadcast_ipc(msg, IPC_PORT_DIRCLD|IPC_PORT_DIRPRT, /*exclude_port*/ NULL);
-    SAVE_PROFILE_INTERVAL(ipc_pid_kill_send);
-    return ret;
-}
-
-int ipc_pid_kill_send (IDTYPE sender, IDTYPE id, enum kill_type type,
-                       int signum)
-{
-    BEGIN_PROFILE_INTERVAL();
-    IDTYPE dest;
-    struct shim_ipc_port * port = NULL;
-    int ret;
-
-    if ((ret = connect_owner(id, &port, &dest)) < 0)
-        goto out;
-
-    size_t total_msg_size = get_ipc_msg_duplex_size(sizeof(struct shim_ipc_pid_kill));
-    struct shim_ipc_msg_duplex* msg = __alloca(total_msg_size);
-    init_ipc_msg_duplex(msg, IPC_PID_KILL, total_msg_size, dest);
-
-    struct shim_ipc_pid_kill * msgin =
-                    (struct shim_ipc_pid_kill *) &msg->msg.msg;
-    msgin->sender = sender;
-    msgin->id     = id;
     msgin->type   = type;
+    msgin->id     = target;
     msgin->signum = signum;
 
-    debug("ipc send to %u: IPC_PID_KILL(%u, %d, %u, %d)\n", dest,
-          sender, type, id, signum);
+    if (type == KILL_ALL) {
+        debug("IPC broadcast: IPC_PID_KILL(%u, %d, %u, %d)\n",
+              sender, type, target, signum);
+        ret = broadcast_ipc(msg, IPC_PORT_DIRCLD|IPC_PORT_DIRPRT, /*exclude_port*/ NULL);
+    }
+    else {
+        debug("IPC send to %u: IPC_PID_KILL(%u, %d, %u, %d)\n",
+              dest & 0xFFFF, sender, type, target, signum);
+        ret = send_ipc_message(msg, port);
+        put_ipc_port(port);
+    }
 
-    ret = send_ipc_message_duplex(msg, port, NULL, NULL);
-    put_ipc_port(port);
 out:
     SAVE_PROFILE_INTERVAL(ipc_pid_kill_send);
     return ret;
@@ -127,37 +120,33 @@ out:
 DEFINE_PROFILE_INTERVAL(ipc_pid_kill_send, ipc);
 DEFINE_PROFILE_INTERVAL(ipc_pid_kill_callback, ipc);
 
-int ipc_pid_kill_callback (IPC_CALLBACK_ARGS)
-{
+int ipc_pid_kill_callback(struct shim_ipc_msg* msg, struct shim_ipc_port* port) {
     BEGIN_PROFILE_INTERVAL();
-    struct shim_ipc_pid_kill * msgin =
-            (struct shim_ipc_pid_kill *) msg->msg;
+    struct shim_ipc_pid_kill* msgin = (struct shim_ipc_pid_kill *) msg->msg;
 
-    debug("ipc callback from %u: IPC_PID_KILL(%u, %u, %d)\n",
-          msg->src, msgin->sender, msgin->id, msgin->signum);
+    debug("IPC callback from %u: IPC_PID_KILL(%u, %d, %u, %d)\n",
+          msg->src & 0xFFFF, msgin->sender, msgin->type, msgin->id, msgin->signum);
 
     int ret = 0;
 
     switch (msgin->type) {
         case KILL_THREAD:
-            ret = do_kill_thread(msgin->sender, 0, msgin->id, msgin->signum,
-                                 true);
+            ret = do_kill_thread(msgin->sender, 0, msgin->id, msgin->signum, true);
             break;
         case KILL_PROCESS:
             ret = do_kill_proc(msgin->sender, msgin->id, msgin->signum, true);
             break;
         case KILL_PGROUP:
-            ret = do_kill_pgroup(msgin->sender, msgin->id, msgin->signum,
-                                 true);
+            ret = do_kill_pgroup(msgin->sender, msgin->id, msgin->signum, true);
             break;
         case KILL_ALL:
-            broadcast_ipc(msg, IPC_PORT_DIRPRT|IPC_PORT_DIRCLD, port);
+            broadcast_ipc(msg, IPC_PORT_DIRCLD|IPC_PORT_DIRPRT, port);
             kill_all_threads(NULL, msgin->sender, msgin->signum);
             break;
     }
 
     SAVE_PROFILE_INTERVAL(ipc_pid_kill_callback);
-    return ret < 0 ? ret : RESPONSE_CALLBACK;
+    return ret;
 }
 
 DEFINE_PROFILE_INTERVAL(ipc_pid_getstatus_send, ipc);

--- a/LibOS/shim/src/ipc/shim_ipc_pid.c
+++ b/LibOS/shim/src/ipc/shim_ipc_pid.c
@@ -94,7 +94,7 @@ int ipc_pid_kill_send(IDTYPE sender, IDTYPE target, enum kill_type type, int sig
     struct shim_ipc_msg* msg = __alloca(total_msg_size);
     init_ipc_msg(msg, IPC_PID_KILL, total_msg_size, dest);
 
-    struct shim_ipc_pid_kill* msgin = (struct shim_ipc_pid_kill *) &msg->msg;
+    struct shim_ipc_pid_kill* msgin = (struct shim_ipc_pid_kill *)&msg->msg;
     msgin->sender = sender;
     msgin->type   = type;
     msgin->id     = target;
@@ -103,9 +103,8 @@ int ipc_pid_kill_send(IDTYPE sender, IDTYPE target, enum kill_type type, int sig
     if (type == KILL_ALL) {
         debug("IPC broadcast: IPC_PID_KILL(%u, %d, %u, %d)\n",
               sender, type, target, signum);
-        ret = broadcast_ipc(msg, IPC_PORT_DIRCLD|IPC_PORT_DIRPRT, /*exclude_port*/ NULL);
-    }
-    else {
+        ret = broadcast_ipc(msg, IPC_PORT_DIRCLD|IPC_PORT_DIRPRT, /*exclude_port=*/NULL);
+    } else {
         debug("IPC send to %u: IPC_PID_KILL(%u, %d, %u, %d)\n",
               dest & 0xFFFF, sender, type, target, signum);
         ret = send_ipc_message(msg, port);

--- a/LibOS/shim/src/ipc/shim_ipc_sysv.c
+++ b/LibOS/shim/src/ipc/shim_ipc_sysv.c
@@ -71,10 +71,10 @@ int ipc_sysv_delres_send (struct shim_ipc_port * port, IDTYPE dest,
     }
 
     if (!owned) {
-        struct shim_ipc_msg * msg = create_ipc_msg_on_stack(
-                        IPC_SYSV_DELRES,
-                        sizeof(struct shim_ipc_sysv_delres),
-                        dest);
+        size_t total_msg_size = get_ipc_msg_size(sizeof(struct shim_ipc_sysv_delres));
+        struct shim_ipc_msg* msg = __alloca(total_msg_size);
+        init_ipc_msg(msg, IPC_SYSV_DELRES, total_msg_size, dest);
+
         struct shim_ipc_sysv_delres * msgin = (struct shim_ipc_sysv_delres *)
             &msg->msg;
         msgin->resid = resid;
@@ -87,10 +87,10 @@ int ipc_sysv_delres_send (struct shim_ipc_port * port, IDTYPE dest,
         goto out;
     }
 
-    struct shim_ipc_msg_obj * msg = create_ipc_msg_duplex_on_stack(
-                                        IPC_SYSV_DELRES,
-                                        sizeof(struct shim_ipc_sysv_delres),
-                                        dest);
+    size_t total_msg_size = get_ipc_msg_duplex_size(sizeof(struct shim_ipc_sysv_delres));
+    struct shim_ipc_msg_duplex* msg = __alloca(total_msg_size);
+    init_ipc_msg_duplex(msg, IPC_SYSV_DELRES, total_msg_size, dest);
+
     struct shim_ipc_sysv_delres * msgin = (struct shim_ipc_sysv_delres *)
                                           &msg->msg.msg;
     msgin->resid = resid;
@@ -99,7 +99,7 @@ int ipc_sysv_delres_send (struct shim_ipc_port * port, IDTYPE dest,
     debug("ipc send to %u: IPC_SYSV_DELRES(%u, %s)\n", dest, resid,
           SYSV_TYPE_STR(type));
 
-    ret = do_ipc_duplex(msg, port, NULL, NULL);
+    ret = send_ipc_message_duplex(msg, port, NULL, NULL);
     put_ipc_port(port);
 out:
     SAVE_PROFILE_INTERVAL(ipc_sysv_delres_send);
@@ -160,10 +160,9 @@ int ipc_sysv_movres_send (struct sysv_client * client, IDTYPE owner,
     int ret = 0;
     int len = strlen(uri);
 
-    struct shim_ipc_msg * msg = create_ipc_msg_on_stack(
-                                        IPC_SYSV_MOVRES,
-                                        sizeof(struct shim_ipc_sysv_movres) +
-                                        len, client->vmid);
+    size_t total_msg_size = get_ipc_msg_size(sizeof(struct shim_ipc_sysv_movres) + len);
+    struct shim_ipc_msg* msg = __alloca(total_msg_size);
+    init_ipc_msg(msg, IPC_SYSV_MOVRES, total_msg_size, client->vmid);
     struct shim_ipc_sysv_movres * msgin = (struct shim_ipc_sysv_movres *)
                                           &msg->msg;
     msgin->resid = resid;
@@ -191,7 +190,7 @@ int ipc_sysv_movres_callback (IPC_CALLBACK_ARGS)
     debug("ipc callback from %u: IPC_SYSV_MOVRES(%u, %s, %u, %s)\n", msg->src,
           msgin->resid, SYSV_TYPE_STR(msgin->type), msgin->owner, msgin->uri);
 
-    struct shim_ipc_msg_obj * obj = find_ipc_msg_duplex(port, msg->seq);
+    struct shim_ipc_msg_duplex * obj = pop_ipc_msg_duplex(port, msg->seq);
     if (!obj)
         goto out;
 
@@ -233,10 +232,9 @@ int ipc_sysv_msgsnd_send (struct shim_ipc_port * port, IDTYPE dest,
         owned = false;
     }
 
-    struct shim_ipc_msg * msg = create_ipc_msg_on_stack(
-                                    IPC_SYSV_MSGSND,
-                                    sizeof(struct shim_ipc_sysv_msgsnd) +
-                                    size, dest);
+    size_t total_msg_size = get_ipc_msg_size(sizeof(struct shim_ipc_sysv_msgsnd) + size);
+    struct shim_ipc_msg* msg = __alloca(total_msg_size);
+    init_ipc_msg(msg, IPC_SYSV_MSGSND, total_msg_size, dest);
     struct shim_ipc_sysv_msgsnd * msgin =
                                (struct shim_ipc_sysv_msgsnd *) &msg->msg;
     msgin->msgid = msgid;
@@ -269,7 +267,7 @@ int ipc_sysv_msgsnd_callback (IPC_CALLBACK_ARGS)
     size_t size = msg->size - sizeof(*msg) - sizeof(*msgin);
 
     if (msg->seq) {
-        struct shim_ipc_msg_obj * obj = find_ipc_msg_duplex(port, msg->seq);
+        struct shim_ipc_msg_duplex * obj = pop_ipc_msg_duplex(port, msg->seq);
         void * priv = obj ? obj->private : NULL;
 
         if (priv) {
@@ -329,10 +327,10 @@ int ipc_sysv_msgrcv_send (IDTYPE msgid, long msgtype, int flags, void * buf,
 
     assert(port);
 
-    struct shim_ipc_msg_obj * msg = create_ipc_msg_duplex_on_stack(
-                                        IPC_SYSV_MSGRCV,
-                                        sizeof(struct shim_ipc_sysv_msgrcv),
-                                        true);
+    size_t total_msg_size = get_ipc_msg_duplex_size(sizeof(struct shim_ipc_sysv_msgrcv));
+    struct shim_ipc_msg_duplex* msg = __alloca(total_msg_size);
+    init_ipc_msg_duplex(msg, IPC_SYSV_MSGRCV, total_msg_size, owner);
+
     struct shim_ipc_sysv_msgrcv * msgin =
                 (struct shim_ipc_sysv_msgrcv *) &msg->msg.msg;
     msgin->msgid = msgid;
@@ -343,7 +341,7 @@ int ipc_sysv_msgrcv_send (IDTYPE msgid, long msgtype, int flags, void * buf,
     debug("ipc send to %u: IPC_SYSV_MSGRCV(%u, %ld)\n", owner,
           msgid, msgtype);
 
-    ret = do_ipc_duplex(msg, port, NULL, buf);
+    ret = send_ipc_message_duplex(msg, port, NULL, buf);
     put_ipc_port(port);
 out:
     SAVE_PROFILE_INTERVAL(ipc_sysv_msgrcv_send);
@@ -396,11 +394,10 @@ int ipc_sysv_msgmov_send (struct shim_ipc_port * port, IDTYPE dest,
                           struct sysv_score * scores, int nscores)
 {
     BEGIN_PROFILE_INTERVAL();
-    struct shim_ipc_msg * msg =
-            create_ipc_msg_on_stack(IPC_SYSV_MSGMOV,
-                                    sizeof(struct shim_ipc_sysv_msgmov) +
-                                    sizeof(struct sysv_score) * nscores,
-                                    dest);
+    size_t total_msg_size = get_ipc_msg_size(sizeof(struct shim_ipc_sysv_msgmov) +
+                                             sizeof(struct sysv_score) * nscores);
+    struct shim_ipc_msg* msg = __alloca(total_msg_size);
+    init_ipc_msg(msg, IPC_SYSV_MSGMOV, total_msg_size, dest);
     struct shim_ipc_sysv_msgmov * msgin =
                             (struct shim_ipc_sysv_msgmov *) &msg->msg;
 
@@ -450,7 +447,7 @@ int ipc_sysv_msgmov_callback (IPC_CALLBACK_ARGS)
     ret = recover_msg_ownership(msgq);
 
     struct shim_ipc_info * info;
-    if (!create_ipc_location(&info)) {
+    if (!get_ipc_info_cur_process(&info)) {
         add_sysv_subrange(msgin->msgid, info->vmid, qstrgetstr(&info->uri),
                           &msgin->lease);
         put_ipc_info(info);
@@ -491,11 +488,10 @@ int ipc_sysv_semop_send (IDTYPE semid, struct sembuf * sops, int nsops,
     assert(port);
 
     if (!waitforreply) {
-        struct shim_ipc_msg * msg = create_ipc_msg_on_stack(
-                                        IPC_SYSV_SEMOP,
-                                        sizeof(struct shim_ipc_sysv_semop) +
-                                        sizeof(struct sembuf) * nsops,
-                                        owner);
+        size_t total_msg_size = get_ipc_msg_size(sizeof(struct shim_ipc_sysv_semop) +
+                                                 sizeof(struct sembuf) * nsops);
+        struct shim_ipc_msg* msg = __alloca(total_msg_size);
+        init_ipc_msg(msg, IPC_SYSV_SEMOP, total_msg_size, owner);
         struct shim_ipc_sysv_semop * msgin =
                 (struct shim_ipc_sysv_semop *) &msg->msg;
 
@@ -514,11 +510,11 @@ int ipc_sysv_semop_send (IDTYPE semid, struct sembuf * sops, int nsops,
         goto out;
     }
 
-    struct shim_ipc_msg_obj * msg = create_ipc_msg_duplex_on_stack(
-                                        IPC_SYSV_SEMOP,
-                                        sizeof(struct shim_ipc_sysv_semop) +
-                                        sizeof(struct sembuf) * nsops,
-                                        owner);
+    size_t total_msg_size = get_ipc_msg_duplex_size(sizeof(struct shim_ipc_sysv_semop) +
+                                                 sizeof(struct sembuf) * nsops);
+    struct shim_ipc_msg_duplex* msg = __alloca(total_msg_size);
+    init_ipc_msg_duplex(msg, IPC_SYSV_SEMOP, total_msg_size, owner);
+
     struct shim_ipc_sysv_semop * msgin =
             (struct shim_ipc_sysv_semop *) &msg->msg.msg;
     msgin->semid   = semid;
@@ -530,7 +526,7 @@ int ipc_sysv_semop_send (IDTYPE semid, struct sembuf * sops, int nsops,
     debug("ipc send to %u: IPC_SYSV_SEMOP(%u, %ld, %u)\n", owner, semid,
           timeout, nsops);
 
-    ret = do_ipc_duplex(msg, port, seq, NULL);
+    ret = send_ipc_message_duplex(msg, port, seq, NULL);
     put_ipc_port(port);
 out:
     SAVE_PROFILE_INTERVAL(ipc_sysv_semop_send);
@@ -581,14 +577,12 @@ int ipc_sysv_semctl_send (IDTYPE semid, int semnum, int cmd, void * vals,
 
     int ctlvalsize = (cmd == SETALL || cmd == SETVAL) ? valsize : 0;
 
-    struct shim_ipc_msg_obj * msg = create_ipc_msg_duplex_on_stack(
-                                        IPC_SYSV_SEMCTL,
-                                        sizeof(struct shim_ipc_sysv_semctl) +
-                                        ctlvalsize,
-                                        owner);
+    size_t total_msg_size = get_ipc_msg_duplex_size(sizeof(struct shim_ipc_sysv_semctl) + ctlvalsize);
+    struct shim_ipc_msg_duplex* msg = __alloca(total_msg_size);
+    init_ipc_msg_duplex(msg, IPC_SYSV_SEMCTL, total_msg_size, owner);
+
     struct shim_ipc_sysv_semctl * msgin =
                 (struct shim_ipc_sysv_semctl *) &msg->msg.msg;
-
     msgin->semid   = semid;
     msgin->semnum  = semnum;
     msgin->cmd     = cmd;
@@ -599,7 +593,7 @@ int ipc_sysv_semctl_send (IDTYPE semid, int semnum, int cmd, void * vals,
     debug("ipc send to %u: IPC_SYSV_SEMCTL(%u, %d, %d)\n", owner, semid,
           semnum, cmd);
 
-    ret = do_ipc_duplex(msg, port, NULL, vals);
+    ret = send_ipc_message_duplex(msg, port, NULL, vals);
     put_ipc_port(port);
 out:
     SAVE_PROFILE_INTERVAL(ipc_sysv_semctl_send);
@@ -706,11 +700,10 @@ int ipc_sysv_semret_send (struct shim_ipc_port * port, IDTYPE dest, void * vals,
 {
     BEGIN_PROFILE_INTERVAL();
     int ret = 0;
-    struct shim_ipc_msg * msg = create_ipc_msg_on_stack(
-                                        IPC_SYSV_SEMRET,
-                                        sizeof(struct shim_ipc_sysv_semret) +
-                                        valsize,
-                                        dest);
+    size_t total_msg_size = get_ipc_msg_size(sizeof(struct shim_ipc_sysv_semret) + valsize);
+    struct shim_ipc_msg* msg = __alloca(total_msg_size);
+    init_ipc_msg(msg, IPC_SYSV_SEMRET, total_msg_size, dest);
+
     struct shim_ipc_sysv_semret * msgin =
                 (struct shim_ipc_sysv_semret *) &msg->msg;
     msgin->valsize = valsize;
@@ -732,7 +725,7 @@ int ipc_sysv_semret_callback (IPC_CALLBACK_ARGS)
 
     debug("ipc callback from %u: IPC_SYSV_SEMRET\n", msg->src);
 
-    struct shim_ipc_msg_obj * obj = find_ipc_msg_duplex(port, msg->seq);
+    struct shim_ipc_msg_duplex * obj = pop_ipc_msg_duplex(port, msg->seq);
     if (obj) {
         struct shim_ipc_sysv_semctl * semctl =
                                 (struct shim_ipc_sysv_semctl *) &obj->msg.msg;
@@ -773,13 +766,13 @@ int ipc_sysv_semmov_send (struct shim_ipc_port * port, IDTYPE dest,
                           struct sysv_score * scores, int nscores)
 {
     BEGIN_PROFILE_INTERVAL();
-    struct shim_ipc_msg * msg =
-            create_ipc_msg_on_stack(IPC_SYSV_SEMMOV,
-                                    sizeof(struct shim_ipc_sysv_semmov) +
-                                    sizeof(struct sem_backup) * nsems +
-                                    sizeof(struct sem_client_backup) * nsrcs +
-                                    sizeof(struct sysv_score) * nscores,
-                                    dest);
+    size_t total_msg_size = get_ipc_msg_size(sizeof(struct shim_ipc_sysv_semmov) +
+                                             sizeof(struct sem_backup) * nsems +
+                                             sizeof(struct sem_client_backup) * nsrcs +
+                                             sizeof(struct sysv_score) * nscores);
+    struct shim_ipc_msg* msg = __alloca(total_msg_size);
+    init_ipc_msg(msg, IPC_SYSV_SEMMOV, total_msg_size, dest);
+
     struct shim_ipc_sysv_semmov * msgin =
                             (struct shim_ipc_sysv_semmov *) &msg->msg;
     msgin->semid   = semid;
@@ -843,7 +836,7 @@ int ipc_sysv_semmov_callback (IPC_CALLBACK_ARGS)
                                 msgin->nsrcs);
 
     struct shim_ipc_info * info;
-    if (!create_ipc_location(&info)) {
+    if (!get_ipc_info_cur_process(&info)) {
         add_sysv_subrange(msgin->semid, info->vmid, qstrgetstr(&info->uri),
                           &msgin->lease);
         put_ipc_info(info);
@@ -877,17 +870,17 @@ int ipc_sysv_semquery_send (IDTYPE semid, int * nsems,
     }
 
     assert(port);
-    struct shim_ipc_msg_obj * msg = create_ipc_msg_duplex_on_stack(
-                                        IPC_SYSV_SEMQUERY,
-                                        sizeof(struct shim_ipc_sysv_semquery),
-                                        dest);
+    size_t total_msg_size = get_ipc_msg_duplex_size(sizeof(struct shim_ipc_sysv_semquery));
+    struct shim_ipc_msg_duplex* msg = __alloca(total_msg_size);
+    init_ipc_msg_duplex(msg, IPC_SYSV_SEMQUERY, total_msg_size, dest);
+
     struct shim_ipc_sysv_semquery * msgin =
                 (struct shim_ipc_sysv_semquery *) &msg->msg.msg;
     msgin->semid = semid;
 
     debug("ipc send to %u: IPC_SYSV_SEMQUERY(%u)\n", dest, semid);
 
-    ret = do_ipc_duplex(msg, port, NULL, host_sem_ids);
+    ret = send_ipc_message_duplex(msg, port, NULL, host_sem_ids);
     put_ipc_port(port);
     if (ret >= 0) {
         *nsems = ret;
@@ -930,11 +923,11 @@ int ipc_sysv_semreply_send (struct shim_ipc_port * port, IDTYPE dest,
 {
     BEGIN_PROFILE_INTERVAL();
     int ret = 0;
-    struct shim_ipc_msg * msg = create_ipc_msg_on_stack(
-                                        IPC_SYSV_SEMREPLY,
-                                        sizeof(struct shim_ipc_sysv_semreply)
-                                        + sizeof(PAL_NUM) * nsems,
-                                        dest);
+    size_t total_msg_size = get_ipc_msg_size(sizeof(struct shim_ipc_sysv_semreply) +
+                                             sizeof(PAL_NUM) * nsems);
+    struct shim_ipc_msg* msg = __alloca(total_msg_size);
+    init_ipc_msg(msg, IPC_SYSV_SEMREPLY, total_msg_size, dest);
+
     struct shim_ipc_sysv_semreply * msgin =
                     (struct shim_ipc_sysv_semreply *) &msg->msg;
     msgin->semid = semid;
@@ -960,7 +953,7 @@ int ipc_sysv_semreply_callback (IPC_CALLBACK_ARGS)
     debug("ipc callback from %u: IPC_SYSV_SEMREPLY(%u, %d)\n", msg->src,
           msgin->semid, msgin->nsems);
 
-    struct shim_ipc_msg_obj * obj = find_ipc_msg_duplex(port, msg->seq);
+    struct shim_ipc_msg_duplex * obj = pop_ipc_msg_duplex(port, msg->seq);
     if (!obj)
         goto out;
 

--- a/LibOS/shim/src/shim_async.c
+++ b/LibOS/shim/src/shim_async.c
@@ -276,11 +276,12 @@ static int create_async_helper(void) {
     if (async_helper_state == HELPER_ALIVE)
         return 0;
 
-    enable_locking();
-
     struct shim_thread* new = get_new_internal_thread();
     if (!new)
         return -ENOMEM;
+
+    async_helper_thread = new;
+    async_helper_state = HELPER_ALIVE;
 
     PAL_HANDLE handle = thread_create(shim_async_helper, new);
 
@@ -292,8 +293,6 @@ static int create_async_helper(void) {
     }
 
     new->pal_handle = handle;
-    async_helper_thread = new;
-    async_helper_state = HELPER_ALIVE;
     return 0;
 }
 

--- a/LibOS/shim/src/shim_async.c
+++ b/LibOS/shim/src/shim_async.c
@@ -130,6 +130,10 @@ int init_async(void) {
     async_helper_state = HELPER_NOTALIVE;
     create_lock(&async_helper_lock);
     create_event(&install_new_event);
+
+    /* enable locking mechanisms since we are going in multi-threaded mode */
+    enable_locking();
+
     return 0;
 }
 

--- a/LibOS/shim/src/shim_checkpoint.c
+++ b/LibOS/shim/src/shim_checkpoint.c
@@ -1145,7 +1145,7 @@ int do_migrate_process (int (*migrate) (struct shim_cp_store *,
     /* Listen on the RPC stream to the new process */
     add_ipc_port_by_id(res.child_vmid, proc,
                        IPC_PORT_DIRCLD|IPC_PORT_LISTEN|IPC_PORT_KEEPALIVE,
-                       &ipc_child_exit,
+                       &ipc_port_with_child_fini,
                        NULL);
 
     free_process(new_process);

--- a/LibOS/shim/src/shim_checkpoint.c
+++ b/LibOS/shim/src/shim_checkpoint.c
@@ -1131,7 +1131,7 @@ int do_migrate_process (int (*migrate) (struct shim_cp_store *,
          * current process, so notify the leader regarding subleasing of TID
          * (child must create self-pipe with convention of pipe:child-vmid) */
         char new_process_self_uri[256];
-        snprintf(new_process_self_uri, 256, "pipe:%u", res.child_vmid);
+        snprintf(new_process_self_uri, sizeof(new_process_self_uri), "pipe:%u", res.child_vmid);
         ipc_pid_sublease_send(res.child_vmid, thread->tid, new_process_self_uri, NULL);
 
         /* listen on the new IPC port to the new child process */

--- a/LibOS/shim/src/shim_init.c
+++ b/LibOS/shim/src/shim_init.c
@@ -844,9 +844,9 @@ static int name_pipe_rand (char * uri, size_t size, void * id)
     if (ret < 0)
         return -convert_pal_errno(-ret);
     debug("creating pipe: pipe.srv:%u\n", pipeid);
-    if ((len = snprintf(uri, size, "pipe.srv:%u", pipeid)) == size)
+    if ((len = snprintf(uri, size, "pipe.srv:%u", pipeid)) >= size)
         return -ERANGE;
-    *((IDTYPE *) id) = pipeid;
+    *((IDTYPE *)id) = pipeid;
     return len;
 }
 
@@ -855,9 +855,9 @@ static int name_pipe_vmid (char * uri, size_t size, void * id)
     IDTYPE pipeid = cur_process.vmid;
     size_t len;
     debug("creating pipe: pipe.srv:%u\n", pipeid);
-    if ((len = snprintf(uri, size, "pipe.srv:%u", pipeid)) == size)
+    if ((len = snprintf(uri, size, "pipe.srv:%u", pipeid)) >= size)
         return -ERANGE;
-    *((IDTYPE *) id) = pipeid;
+    *((IDTYPE *)id) = pipeid;
     return len;
 }
 

--- a/LibOS/shim/src/shim_init.c
+++ b/LibOS/shim/src/shim_init.c
@@ -836,13 +836,24 @@ static int create_unique (int (*mkname) (char *, size_t, void *),
     }
 }
 
-static int name_pipe (char * uri, size_t size, void * id)
+static int name_pipe_rand (char * uri, size_t size, void * id)
 {
     IDTYPE pipeid;
     size_t len;
     int ret = DkRandomBitsRead(&pipeid, sizeof(pipeid));
     if (ret < 0)
         return -convert_pal_errno(-ret);
+    debug("creating pipe: pipe.srv:%u\n", pipeid);
+    if ((len = snprintf(uri, size, "pipe.srv:%u", pipeid)) == size)
+        return -ERANGE;
+    *((IDTYPE *) id) = pipeid;
+    return len;
+}
+
+static int name_pipe_vmid (char * uri, size_t size, void * id)
+{
+    IDTYPE pipeid = cur_process.vmid;
+    size_t len;
     debug("creating pipe: pipe.srv:%u\n", pipeid);
     if ((len = snprintf(uri, size, "pipe.srv:%u", pipeid)) == size)
         return -ERANGE;
@@ -876,10 +887,15 @@ static int pipe_addr (char * uri, size_t size, const void * id,
 }
 
 int create_pipe (IDTYPE * id, char * uri, size_t size, PAL_HANDLE * hdl,
-                 struct shim_qstr * qstr)
+                 struct shim_qstr * qstr, bool use_vmid_for_name)
 {
     IDTYPE pipeid;
-    int ret = create_unique(&name_pipe, &open_pipe, &pipe_addr,
+    int ret;
+    if (use_vmid_for_name)
+        ret = create_unique(&name_pipe_vmid, &open_pipe, &pipe_addr,
+                            uri, size, &pipeid, hdl, qstr);
+    else
+        ret = create_unique(&name_pipe_rand, &open_pipe, &pipe_addr,
                             uri, size, &pipeid, hdl, qstr);
     if (ret > 0 && id)
         *id = pipeid;

--- a/LibOS/shim/src/shim_init.c
+++ b/LibOS/shim/src/shim_init.c
@@ -1157,7 +1157,7 @@ int shim_clean (int err)
     }
 #endif
 
-    del_all_ipc_ports(0);
+    del_all_ipc_ports();
 
     if (shim_stdio && shim_stdio != (PAL_HANDLE) -1)
         DkObjectClose(shim_stdio);

--- a/LibOS/shim/src/sys/shim_exit.c
+++ b/LibOS/shim/src/sys/shim_exit.c
@@ -147,19 +147,15 @@ int try_process_exit (int error_code, int term_signal)
          */
         put_thread(async_thread); /* free resources of the thread */
 
-    struct shim_thread * ipc_thread;
-    int ret = exit_with_ipc_helper(true, &ipc_thread);
+    struct shim_thread * ipc_thread = terminate_ipc_helper();
     if (ipc_thread)
         /* TODO: wait for the thread to exit in host.
          * This is tracked by the following issue.
          * https://github.com/oscarlab/graphene/issues/440
          */
         put_thread(ipc_thread); /* free resources of the thread */
-    if (!ret)
-        shim_clean(ret);
-    else
-        DkThreadExit();
 
+    shim_clean(0);
     return 0;
 }
 

--- a/LibOS/shim/src/sys/shim_exit.c
+++ b/LibOS/shim/src/sys/shim_exit.c
@@ -129,6 +129,7 @@ int thread_exit(struct shim_thread * self, bool send_ipc)
     return 0;
 }
 
+/* note that term_signal argument may contain WCOREDUMP bit (0x80) */
 int try_process_exit (int error_code, int term_signal)
 {
     struct shim_thread * cur_thread = get_cur_thread();

--- a/LibOS/shim/src/sys/shim_exit.c
+++ b/LibOS/shim/src/sys/shim_exit.c
@@ -173,11 +173,13 @@ noreturn int shim_do_exit_group (int error_code)
     if (debug_handle)
         sysparser_printf("---- shim_exit_group (returning %d)\n", error_code);
 
+#ifndef ALIAS_VFORK_AS_FORK
     if (cur_thread->dummy) {
         cur_thread->term_signal = 0;
         thread_exit(cur_thread, true);
         switch_dummy_thread(cur_thread);
     }
+#endif
 
     debug("now kill other threads in the process\n");
     do_kill_proc(cur_thread->tgid, cur_thread->tgid, SIGKILL, false);
@@ -202,11 +204,13 @@ noreturn int shim_do_exit (int error_code)
     if (debug_handle)
         sysparser_printf("---- shim_exit (returning %d)\n", error_code);
 
+#ifndef ALIAS_VFORK_AS_FORK
     if (cur_thread->dummy) {
         cur_thread->term_signal = 0;
         thread_exit(cur_thread, true);
         switch_dummy_thread(cur_thread);
     }
+#endif
 
     try_process_exit(error_code, 0);
 

--- a/LibOS/shim/src/sys/shim_msgget.c
+++ b/LibOS/shim/src/sys/shim_msgget.c
@@ -998,7 +998,7 @@ static int msg_balance_migrate (struct shim_handle * hdl,
     if ((ret = __store_msg_persist(msgq)) < 0)
         return 0;
 
-    struct shim_ipc_info * info = discover_client(src->port, src->vmid);
+    struct shim_ipc_info * info = lookup_ipc_info(src->vmid);
     if (!info)
         goto failed;
 

--- a/LibOS/shim/src/sys/shim_msgget.c
+++ b/LibOS/shim/src/sys/shim_msgget.c
@@ -844,7 +844,7 @@ static int __store_msg_persist (struct shim_msg_handle * msgq)
                 struct sysv_client * c = &req->dest;
                 struct msg_req * next = req->next;
 
-                __response_ipc_message(c->port, c->vmid, -EIDRM, c->seq);
+                send_response_ipc_message(c->port, c->vmid, -EIDRM, c->seq);
 
                 put_ipc_port(c->port);
                 __free_msg_qobj(msgq, req);

--- a/LibOS/shim/src/sys/shim_pipe.c
+++ b/LibOS/shim/src/sys/shim_pipe.c
@@ -41,7 +41,7 @@ int create_pipes (IDTYPE * pipeid, PAL_HANDLE * srv, PAL_HANDLE * cli,
     char uri[PIPE_URI_SIZE];
 
     if ((ret = create_pipe(pipeid, uri, PIPE_URI_SIZE, &hdl0,
-                           qstr, /*use_vmid_for_name*/ false)) < 0) {
+                           qstr, /*use_vmid_for_name=*/false)) < 0) {
         debug("pipe creation failure\n");
         return ret;
     }

--- a/LibOS/shim/src/sys/shim_pipe.c
+++ b/LibOS/shim/src/sys/shim_pipe.c
@@ -41,7 +41,7 @@ int create_pipes (IDTYPE * pipeid, PAL_HANDLE * srv, PAL_HANDLE * cli,
     char uri[PIPE_URI_SIZE];
 
     if ((ret = create_pipe(pipeid, uri, PIPE_URI_SIZE, &hdl0,
-                           qstr)) < 0) {
+                           qstr, /*use_vmid_for_name*/ false)) < 0) {
         debug("pipe creation failure\n");
         return ret;
     }

--- a/LibOS/shim/src/sys/shim_sandbox.c
+++ b/LibOS/shim/src/sys/shim_sandbox.c
@@ -366,7 +366,7 @@ long shim_do_sandbox_create (int flags, const char * fs_sb,
     }
 
     if (flags & SANDBOX_RPC)
-        del_all_ipc_ports(0);
+        del_all_ipc_ports();
 
     if ((ret = free_config(root_config)) < 0)
         goto err;

--- a/LibOS/shim/src/sys/shim_semget.c
+++ b/LibOS/shim/src/sys/shim_semget.c
@@ -574,7 +574,7 @@ send_result:
             init_ipc_msg(resp_msg, IPC_RESP, total_msg_size, sops->client.vmid);
             resp_msg->seq = sops->client.seq;
 
-            struct shim_ipc_resp* resp = (struct shim_ipc_resp *) resp_msg->msg;
+            struct shim_ipc_resp* resp = (struct shim_ipc_resp *)resp_msg->msg;
             resp->retval = sops->stat.completed ? 0 : -EAGAIN;
 
             send_ipc_message(resp_msg, sops->client.port);
@@ -797,7 +797,7 @@ unowned:
             init_ipc_msg(resp_msg, IPC_RESP, total_msg_size, client->vmid);
             resp_msg->seq = client->seq;
 
-            struct shim_ipc_resp* resp = (struct shim_ipc_resp *) resp_msg->msg;
+            struct shim_ipc_resp* resp = (struct shim_ipc_resp *)resp_msg->msg;
             resp->retval = ret;
 
             ret = send_ipc_message(resp_msg, client->port);

--- a/LibOS/shim/src/sys/shim_sigaction.c
+++ b/LibOS/shim/src/sys/shim_sigaction.c
@@ -535,7 +535,7 @@ int shim_do_kill (pid_t pid, int sig)
     /* If pid equals -1, then sig is sent to every process for which the
        calling process has permission to send */
     else if (pid == -1) {
-        ipc_pid_kill_send(cur->tid, /*target*/ 0, KILL_ALL, sig);
+        ipc_pid_kill_send(cur->tid, /*target=*/0, KILL_ALL, sig);
         kill_all_threads(cur, cur->tid, sig);
         send_to_self = true;
     }

--- a/LibOS/shim/src/sys/shim_sigaction.c
+++ b/LibOS/shim/src/sys/shim_sigaction.c
@@ -489,8 +489,6 @@ static int __kill_all_threads (struct shim_thread * thread, void * arg,
     return srched;
 }
 
-int broadcast_signal (IDTYPE sender, int sig);
-
 int kill_all_threads (struct shim_thread * cur, IDTYPE sender, int sig)
 {
     struct walk_arg arg;
@@ -524,7 +522,7 @@ int shim_do_kill (pid_t pid, int sig)
     /* If pid equals -1, then sig is sent to every process for which the
        calling process has permission to send */
     else if (pid == -1) {
-        broadcast_signal(cur->tid, sig);
+        ipc_pid_kill_send(cur->tid, /*target*/ 0, KILL_ALL, sig);
         kill_all_threads(cur, cur->tid, sig);
         send_to_self = true;
     }

--- a/LibOS/shim/src/sys/shim_vfork.c
+++ b/LibOS/shim/src/sys/shim_vfork.c
@@ -35,13 +35,13 @@
 #include <linux/futex.h>
 #include <errno.h>
 
-struct vfork_args {
-    PAL_HANDLE create_event;
-    struct shim_thread * thread;
-};
-
 int shim_do_vfork (void)
 {
+#ifdef ALIAS_VFORK_AS_FORK
+    debug("vfork() is an alias to fork() in Graphene, calling fork() now\n");
+    return shim_do_fork();
+#else
+    /* NOTE: leaving this old implementation for historical reference */
     INC_PROFILE_OCCURENCE(syscall_use_ipc);
 
     /* DEP 7/7/12 - Why r13?
@@ -114,4 +114,5 @@ int shim_do_vfork (void)
 
     /* here we return immediately, no letting the hooks mes up our stack */
     return 0;
+#endif
 }

--- a/LibOS/shim/test/regression/00_bootstrap.py
+++ b/LibOS/shim/test/regression/00_bootstrap.py
@@ -40,6 +40,16 @@ regression.add_check(name="2 page child binary",
 rv = regression.run_checks()
 if rv: sys.exit(rv)
 
+# Running Fork and Exec
+regression = Regression(loader, "fork_and_exec")
+
+regression.add_check(name="Fork and exec 2 page child binary",
+    check=lambda res: "child exited with status: 0" in res[0].out and \
+                      "test completed successfully" in res[0].out)
+
+rv = regression.run_checks()
+if rv: sys.exit(rv)
+
 # Running execve with invalid pointers in arguments
 regression = Regression(loader, "exec_invalid_args")
 

--- a/LibOS/shim/test/regression/00_bootstrap.py
+++ b/LibOS/shim/test/regression/00_bootstrap.py
@@ -40,10 +40,20 @@ regression.add_check(name="2 page child binary",
 rv = regression.run_checks()
 if rv: sys.exit(rv)
 
-# Running Fork and Exec
+# Running fork and exec
 regression = Regression(loader, "fork_and_exec")
 
-regression.add_check(name="Fork and exec 2 page child binary",
+regression.add_check(name="fork and exec 2 page child binary",
+    check=lambda res: "child exited with status: 0" in res[0].out and \
+                      "test completed successfully" in res[0].out)
+
+rv = regression.run_checks()
+if rv: sys.exit(rv)
+
+# Running vfork and exec
+regression = Regression(loader, "vfork_and_exec")
+
+regression.add_check(name="vfork and exec 2 page child binary",
     check=lambda res: "child exited with status: 0" in res[0].out and \
                       "test completed successfully" in res[0].out)
 

--- a/LibOS/shim/test/regression/80_udp.py
+++ b/LibOS/shim/test/regression/80_udp.py
@@ -4,7 +4,7 @@ from regression import Regression
 loader = sys.argv[1]
 
 # Running udp
-regression = Regression(loader, "udp", None)
+regression = Regression(loader, "udp", None, 50000)
 
 regression.add_check(name="udp",
     check=lambda res:

--- a/LibOS/shim/test/regression/fork_and_exec.c
+++ b/LibOS/shim/test/regression/fork_and_exec.c
@@ -1,0 +1,46 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <errno.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+
+int main(int argc, const char** argv, const char** envp) {
+    pid_t child_pid;
+
+    /* duplicate STDOUT into newfd and pass it as exec_victim argument
+     * (it will be inherited by exec_victim) */
+    int newfd = dup(1);
+    char fd_argv[4];
+    snprintf(fd_argv, 4, "%d", newfd);
+    char* const new_argv[] = {"./exec_victim", fd_argv, NULL};
+
+    /* set environment variable to test that it is inherited by exec_victim */
+    setenv("IN_EXECVE", "1", 1);
+
+    child_pid = fork();
+
+    if (child_pid == 0) {
+        /* child performs execve(exec_victim) */
+        execv(new_argv[0], new_argv);
+        perror("execve failed");
+        return 1;
+    } else if (child_pid > 0) {
+        /* parent waits for child termination */
+        int status;
+        pid_t pid = wait(&status);
+        if (pid < 0) {
+            perror("wait failed");
+            return 1;
+        }
+        if (WIFEXITED(status))
+            printf("child exited with status: %d\n", WEXITSTATUS(status));
+    } else {
+        /* error */
+        perror("fork failed");
+        return 1;
+    }
+
+    puts("test completed successfully");
+    return 0;
+}

--- a/LibOS/shim/test/regression/vfork_and_exec.c
+++ b/LibOS/shim/test/regression/vfork_and_exec.c
@@ -27,7 +27,7 @@ int main(int argc, const char** argv, const char** envp) {
         return 1;
     }
 
-    child_pid = fork();
+    child_pid = vfork();
 
     if (child_pid == 0) {
         /* child performs execve(exec_victim) */

--- a/Pal/src/host/Linux-SGX/db_main.c
+++ b/Pal/src/host/Linux-SGX/db_main.c
@@ -302,7 +302,7 @@ void pal_linux_main(char * uptr_args, uint64_t args_size,
     rv = init_enclave();
     if (rv) {
         SGX_DBG(DBG_E, "Failed to initialize enclave properties: %d\n", rv);
-        ocall_exit(rv);
+        ocall_exit(rv, /*is_exitgroup=*/true);
     }
 
     if (args_size > MAX_ARGS_SIZE || env_size > MAX_ENV_SIZE) {
@@ -323,7 +323,7 @@ void pal_linux_main(char * uptr_args, uint64_t args_size,
     if (pal_sec.ppid) {
         if ((rv = init_child_process(&parent)) < 0) {
             SGX_DBG(DBG_E, "Failed to initialize child process: %d\n", rv);
-            ocall_exit(rv);
+            ocall_exit(rv, /*is_exitgroup=*/true);
         }
     }
 
@@ -366,7 +366,7 @@ void pal_linux_main(char * uptr_args, uint64_t args_size,
     const char * errstring = NULL;
     if ((rv = read_config(root_config, loader_filter, &errstring)) < 0) {
         SGX_DBG(DBG_E, "Can't read manifest: %s, error code %d\n", errstring, rv);
-        ocall_exit(rv);
+        ocall_exit(rv, /*is_exitgroup=*/true);
     }
 
     pal_state.root_config = root_config;

--- a/Pal/src/host/Linux-SGX/db_process.c
+++ b/Pal/src/host/Linux-SGX/db_process.c
@@ -327,7 +327,7 @@ noreturn void _DkProcessExit (int exitcode)
 #endif
     if (exitcode)
         SGX_DBG(DBG_I, "DkProcessExit: Returning exit code %d\n", exitcode);
-    ocall_exit(exitcode);
+    ocall_exit(exitcode, /*is_exitgroup=*/true);
     while (true) {
         /* nothing */;
     }

--- a/Pal/src/host/Linux-SGX/db_threading.c
+++ b/Pal/src/host/Linux-SGX/db_threading.c
@@ -140,7 +140,7 @@ void _DkThreadYieldExecution (void)
 /* _DkThreadExit for internal use: Thread exiting */
 noreturn void _DkThreadExit (void)
 {
-    ocall_exit(0);
+    ocall_exit(0, /*is_exitgroup=*/false);
 }
 
 int _DkThreadResume (PAL_HANDLE threadHandle)

--- a/Pal/src/host/Linux-SGX/enclave_framework.c
+++ b/Pal/src/host/Linux-SGX/enclave_framework.c
@@ -1236,7 +1236,7 @@ out:
 void restore_sgx_context(sgx_context_t *ctx) {
     if (((uint64_t) ctx) != ctx->rsp - (sizeof(sgx_context_t) + RED_ZONE_SIZE)) {
         SGX_DBG(DBG_E, "Invalid sgx_context_t pointer passed to restore_sgx_context!\n");
-        ocall_exit(1);
+        ocall_exit(1, /*is_exitgroup=*/false);
     }
 
     _restore_sgx_context(ctx);

--- a/Pal/src/host/Linux-SGX/enclave_ocalls.c
+++ b/Pal/src/host/Linux-SGX/enclave_ocalls.c
@@ -11,15 +11,20 @@
 #include <api.h>
 #include <asm/errno.h>
 
-noreturn void ocall_exit(int exitcode)
+noreturn void ocall_exit(int exitcode, int is_exitgroup)
 {
-    int64_t code = exitcode;
+    ms_ocall_exit_t * ms;
+
+    ms = sgx_alloc_on_ustack(sizeof(*ms));
+    ms->ms_exitcode     = exitcode;
+    ms->ms_is_exitgroup = is_exitgroup;
+
     // There are two reasons for this loop:
     //  1. Ocalls can be interuppted.
     //  2. We can't trust the outside to actually exit, so we need to ensure
     //     that we never return even when the outside tries to trick us.
     while (true) {
-        sgx_ocall(OCALL_EXIT, (void *) code);
+        sgx_ocall(OCALL_EXIT, ms);
     }
 }
 

--- a/Pal/src/host/Linux-SGX/enclave_ocalls.h
+++ b/Pal/src/host/Linux-SGX/enclave_ocalls.h
@@ -8,7 +8,7 @@
 #include <linux/socket.h>
 #include <linux/poll.h>
 
-noreturn void ocall_exit (int exitcode);
+noreturn void ocall_exit (int exitcode, int is_exitgroup);
 
 int ocall_print_string (const char * str, unsigned int length);
 

--- a/Pal/src/host/Linux-SGX/enclave_pages.c
+++ b/Pal/src/host/Linux-SGX/enclave_pages.c
@@ -60,7 +60,7 @@ static void assert_vma_list (void)
             if (pal_sec.in_gdb)
                 __asm__ volatile ("int $3" ::: "memory");
 #endif
-            ocall_exit();
+            ocall_exit(1, /*is_exitgroup=*/true);
         }
         last_addr = vma->bottom;
     }

--- a/Pal/src/host/Linux-SGX/ocall_types.h
+++ b/Pal/src/host/Linux-SGX/ocall_types.h
@@ -59,6 +59,11 @@ enum {
 #define OCALL_NO_TIMEOUT   ((int64_t)-1)
 
 typedef struct {
+    int ms_exitcode;
+    int ms_is_exitgroup;
+} ms_ocall_exit_t;
+
+typedef struct {
     const char * ms_str;
     unsigned int ms_length;
 } ms_ocall_print_string_t;


### PR DESCRIPTION
## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->

This PR contains commits which serve to cleanup the IPC (Inter-Process Communication) subsystem of Graphene which contained several intermittent bugs (data races between Graphene processes). Please refer to commit messages.

This PR also updates the https://github.com/oscarlab/graphene-tests submodule, see the corresponding PR https://github.com/oscarlab/graphene-tests/pull/3.

Also, for some preliminary info on the bugs fixed by this PR, see https://github.com/oscarlab/graphene/issues/803. This issue also contains the LTP tests fixed by this PR.

Fixes #803.

## How to test this PR? <!-- (if applicable) -->

All LTP tests must pass, including newly enabled killXX and waitpid05.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/811)
<!-- Reviewable:end -->
