### PR TITLE
[LibOS] resolve race between creation/deletion async helper

### DIFF
--- a/LibOS/shim/src/shim_async.c
+++ b/LibOS/shim/src/shim_async.c
@@ -173,7 +173,7 @@ static void shim_async_helper(void * arg) {
     PAL_HANDLE install_new_event_hdl = event_handle(&install_new_event);
     object_list[0] = install_new_event_hdl;
 
-    while (async_helper_state == HELPER_ALIVE) {
+    while (true) {
         uint64_t now = DkSystemTimeQuery();
 
         if (polled == install_new_event_hdl) {
@@ -183,6 +183,11 @@ static void shim_async_helper(void * arg) {
         }
 
         lock(&async_helper_lock);
+        if (async_helper_state != HELPER_ALIVE) {
+            async_helper_thread = NULL;
+            unlock(&async_helper_lock);
+            break;
+        }
 
         /* Iterate through all async IO events and alarm/timer events to:
          *   - call callbacks for all triggered events, and
@@ -233,8 +238,6 @@ static void shim_async_helper(void * arg) {
             }
         }
 
-        unlock(&async_helper_lock);
-
         uint64_t sleep_time;
         if (next_expire_time) {
             sleep_time = next_expire_time - now;
@@ -249,20 +252,18 @@ static void shim_async_helper(void * arg) {
         }
 
         if (idle_cycles == MAX_IDLE_CYCLES) {
+            async_helper_state = HELPER_NOTALIVE;
+            async_helper_thread = NULL;
+            unlock(&async_helper_lock);
             debug("Async helper thread has been idle for some time; stopping it\n");
             break;
         }
+        unlock(&async_helper_lock);
 
         /* wait on async IO events + install_new_event + next expiring alarm/timer */
         polled = DkObjectsWaitAny(object_num + 1, object_list, sleep_time);
-        /* ensure that while loop breaks on async_helper_state change */
-        COMPILER_BARRIER();
     }
 
-    lock(&async_helper_lock);
-    async_helper_state = HELPER_NOTALIVE;
-    async_helper_thread = NULL;
-    unlock(&async_helper_lock);
     put_thread(self);
     debug("Async helper thread terminated\n");
     free(object_list);


### PR DESCRIPTION
There is a race between creating async helper thread and the tread
exiting.
When the asyc helper breaks while-loop, install_async_event() thinks
the helper is alive and skip to create_async_helper().
In this case while async events is installed, there is no async
helper thread.
Check the condition for async helper to exit with lock held.

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->


## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/817)
<!-- Reviewable:end -->
