### PR TITLE
[Pal/Linux-SGX] eliminate duplicate register clear on sgx_ocall

### DIFF
--- a/Pal/src/host/Linux-SGX/enclave_entry.S
+++ b/Pal/src/host/Linux-SGX/enclave_entry.S
@@ -431,17 +431,6 @@ sgx_ocall:
 
 	pushq %rbp
 
-	xorq %rdx, %rdx
-	xorq %r8, %r8
-	xorq %r9, %r9
-	xorq %r10, %r10
-	xorq %r11, %r11
-	xorq %r12, %r12
-	xorq %r13, %r13
-	xorq %r14, %r14
-	xorq %r15, %r15
-	xorq %rbp, %rbp
-
 .Locall_before_set_ocall_prepared:
 	movq $1, %gs:SGX_OCALL_PREPARED
 .Locall_after_set_ocall_prepared:


### PR DESCRIPTION
%rdx, %rbp, %r8-%r15 is cleared twice unnecessarily on sgx_ocall.
So eliminated the first ones.

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [x] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->


## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/820)
<!-- Reviewable:end -->
