### PR TITLE
[LibOS] Fix O_CREAT|O_EXCL flags checks in open()

### DIFF
--- a/LibOS/shim/src/fs/shim_namei.c
+++ b/LibOS/shim/src/fs/shim_namei.c
@@ -551,10 +551,13 @@ int open_namei (struct shim_handle * hdl, struct shim_dentry * start,
 
         // Set err back to zero and fall through
         err = 0;
-    } else if (err == 0 && (flags & (O_CREAT|O_EXCL))) {
+    } else if (err == 0 && ((flags & (O_CREAT|O_EXCL)) == (O_CREAT|O_EXCL))) {
         err = -EEXIST;
-    } else if (err < 0)
+    }
+
+    if (err < 0) {
         goto out;
+    }
 
     // Check permission, but only if we didn't create the file.
     // creat/O_CREAT have idiosyncratic semantics about opening a


### PR DESCRIPTION
<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->
open with O_CREAT fails for existing files.
Fixes inappropriate O_CREAT|O_EXCL flags check and missing goto
Fixes #571

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->


## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/821)
<!-- Reviewable:end -->
