### PR TITLE
[LibOS] make signal_alarm static

### DIFF
--- a/LibOS/shim/src/sys/shim_alarm.c
+++ b/LibOS/shim/src/sys/shim_alarm.c
@@ -26,7 +26,7 @@
 #include <shim_utils.h>
 #include <shim_signal.h>
 
-void signal_alarm (IDTYPE target, void * arg)
+static void signal_alarm (IDTYPE target, void * arg)
 {
     // Kept for API compatibility wtih signal_itimer
     __UNUSED(arg);


### PR DESCRIPTION
signal_alarm() @ shim_alarm.c is used only locally.
So make it static.

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->


## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/827)
<!-- Reviewable:end -->
