### PR TITLE
[Pal/Linux-SGX] return -EINTR instead of -PAL_ERROR_INTERRUPTED

### DIFF
--- a/Pal/src/host/Linux-SGX/enclave_entry.S
+++ b/Pal/src/host/Linux-SGX/enclave_entry.S
@@ -234,7 +234,7 @@ enclave_entry:
 	#
 	# On host async signal we treat these cases as follows:
 	# A. right-before EEXIT(0. - 4. in above sequence):
-	#	 - set PAL_ERROR_INTERRUPTED and forward %rip to exception handler
+	#	 - set EINTR and forward %rip to exception handler
 	# B. during untrusted PAL(5. - 6. in above sequence):
 	#	 - code in _DkTerminateSighandler() must handle this case
 	#	 TODO: fix _DkTerminateSighandler() to not lose the result of successful
@@ -256,11 +256,11 @@ enclave_entry:
 
 	# Case A. We are right-before EEXIT for ocall in between
 	# [.Locall_about_to_eexit_begin, .Locall_about_to_eexit_end)
-	# Skip EEXIT as if ocall returned PAL_ERROR_INTERRUPTED.
+	# Skip EEXIT as if ocall returned EINTR.
 	# If there is registered signal handler for the current exception,
 	# _DkHandleExternalEvent() will be called (and thus we need to save
 	# %rdi = <external event>) before returning from ocall.
-	movq $-PAL_ERROR_INTERRUPTED, %rdi # return value for .Lreturn_from_ocall
+	movq $-EINTR, %rdi # return value for .Lreturn_from_ocall
 	# fallthrough to Case C.
 
 	# This code cannot land in Case B because:

--- a/Pal/src/host/Linux-SGX/generated-offsets.c
+++ b/Pal/src/host/Linux-SGX/generated-offsets.c
@@ -1,6 +1,6 @@
 #include <stddef.h>
+#include <asm/errno.h>
 
-#include "pal_error.h"
 #include "sgx_arch.h"
 #include "sgx_tls.h"
 #include "pal_linux.h"
@@ -130,7 +130,7 @@ void dummy(void)
     /* pal_linux.h */
     DEFINE(PAGESIZE, PRESET_PAGESIZE);
 
-    /* pal_error.h */
-    DEFINE(PAL_ERROR_INTERRUPTED, PAL_ERROR_INTERRUPTED);
+    /* errno */
+    DEFINE(EINTR, EINTR);
 }
 

--- a/Pal/src/host/Linux-SGX/sgx_exception.c
+++ b/Pal/src/host/Linux-SGX/sgx_exception.c
@@ -212,7 +212,7 @@ static void _DkTerminateSighandler (int signum, siginfo_t * info,
 
     if (rip != (unsigned long) async_exit_pointer) {
         uc->uc_mcontext.gregs[REG_RIP] = (uint64_t) sgx_entry_return;
-        uc->uc_mcontext.gregs[REG_RDI] = -PAL_ERROR_INTERRUPTED;
+        uc->uc_mcontext.gregs[REG_RDI] = -EINTR;
         uc->uc_mcontext.gregs[REG_RSI] = get_event_num(signum);
     } else {
         sgx_raise(get_event_num(signum));

--- a/Pal/src/host/Linux-SGX/sgx_main.c
+++ b/Pal/src/host/Linux-SGX/sgx_main.c
@@ -574,12 +574,12 @@ static int mcast_s (int port)
     int fd = INLINE_SYSCALL(socket, 3, AF_INET, SOCK_DGRAM, 0);
 
     if (IS_ERR(fd))
-        return -PAL_ERROR_DENIED;
+        return -ERRNO(fd);
 
     ret = INLINE_SYSCALL(setsockopt, 5, fd, IPPROTO_IP, IP_MULTICAST_IF,
                          &addr.sin_addr.s_addr, sizeof(addr.sin_addr.s_addr));
     if (IS_ERR(ret))
-        return -PAL_ERROR_DENIED;
+        return -ERRNO(ret);
 
     return fd;
 }
@@ -595,7 +595,7 @@ static int mcast_c (int port)
 
     fd = INLINE_SYSCALL(socket, 3, AF_INET, SOCK_DGRAM, 0);
     if (IS_ERR(fd))
-        return -PAL_ERROR_DENIED;
+        return -ERRNO(fd);
 
     int reuse = 1;
     INLINE_SYSCALL(setsockopt, 5, fd, SOL_SOCKET, SO_REUSEADDR,
@@ -603,12 +603,12 @@ static int mcast_c (int port)
 
     ret = INLINE_SYSCALL(bind, 3, fd, &addr, sizeof(addr));
     if (IS_ERR(ret))
-        return -PAL_ERROR_DENIED;
+        return -ERRNO(ret);
 
     ret = INLINE_SYSCALL(setsockopt, 5, fd, IPPROTO_IP, IP_MULTICAST_IF,
                          &addr.sin_addr.s_addr, sizeof(addr.sin_addr.s_addr));
     if (IS_ERR(ret))
-        return -PAL_ERROR_DENIED;
+        return -ERRNO(ret);
 
     inet_pton4(MCAST_GROUP, sizeof(MCAST_GROUP) - 1,
                &addr.sin_addr.s_addr);
@@ -620,7 +620,7 @@ static int mcast_c (int port)
     ret = INLINE_SYSCALL(setsockopt, 5, fd, IPPROTO_IP, IP_ADD_MEMBERSHIP,
                          &group, sizeof(group));
     if (IS_ERR(ret))
-        return -PAL_ERROR_DENIED;
+        return -ERRNO(ret);
 
     return fd;
 }

--- a/Pal/src/host/Linux-SGX/sgx_thread.c
+++ b/Pal/src/host/Linux-SGX/sgx_thread.c
@@ -4,6 +4,7 @@
 
 #include <pthread.h>
 #include <linux/futex.h>
+#include <asm/errno.h>
 #include <asm/signal.h>
 #include <asm/prctl.h>
 
@@ -88,9 +89,9 @@ int interrupt_thread (void * tcs)
     int index = (sgx_arch_tcs_t *) tcs - enclave_tcs;
     struct thread_map * map = &enclave_thread_map[index];
     if (index >= enclave_thread_num)
-        return -PAL_ERROR_INVAL;
+        return -EINVAL;
     if (!map->tid)
-        return -PAL_ERROR_INVAL;
+        return -EINVAL;
     INLINE_SYSCALL(tgkill, 3, PAL_SEC()->pid, map->tid, SIGCONT);
     return 0;
 }


### PR DESCRIPTION
This is a follow up of 4f7841e14.
ocall should return -ERRNO on error. So on signal, it should return -EINTR
instead of -PAL_ERROR_INTERRUPTED.

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->


## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/829)
<!-- Reviewable:end -->
