### PR TITLE
Implement rlimit64, getrlimit, and setrlimit for real

### DIFF
--- a/LibOS/shim/include/shim_handle.h
+++ b/LibOS/shim/include/shim_handle.h
@@ -443,6 +443,4 @@ off_t get_file_size (struct shim_handle * file);
 int do_handle_read (struct shim_handle * hdl, void * buf, int count);
 int do_handle_write (struct shim_handle * hdl, const void * buf, int count);
 
-extern struct __kernel_rlimit __rlim[RLIM_NLIMITS];
-
 #endif /* _SHIM_HANDLE_H_ */

--- a/LibOS/shim/include/shim_internal.h
+++ b/LibOS/shim/include/shim_internal.h
@@ -786,14 +786,18 @@ void get_brk_region (void ** start, void ** end, void ** current);
 int reset_brk (void);
 struct shim_handle;
 int init_brk_from_executable (struct shim_handle * exec);
-int init_brk_region (void * brk_region);
+int init_brk_region(void* brk_region, size_t data_segment_size);
 int init_heap (void);
 int init_internal_map (void);
 int init_loader (void);
 int init_manifest (PAL_HANDLE manifest_handle);
+int init_rlimit(void);
 
 bool test_user_memory (void * addr, size_t size, bool write);
 bool test_user_string (const char * addr);
+
+uint64_t get_rlimit_cur(int resource);
+void set_rlimit_cur(int resource, uint64_t rlim);
 
 int object_wait_with_retry(PAL_HANDLE handle);
 

--- a/LibOS/shim/include/shim_table.h
+++ b/LibOS/shim/include/shim_table.h
@@ -501,6 +501,8 @@ int shim_do_epoll_create1 (int flags);
 int shim_do_pipe2 (int * fildes, int flags);
 ssize_t shim_do_recvmmsg (int sockfd, struct mmsghdr * msg, size_t vlen, int flags,
                           struct __kernel_timespec * timeout);
+int shim_do_prlimit64(pid_t pid, int resource, const struct __kernel_rlimit64* new_rlim,
+                      struct __kernel_rlimit64* old_rlim);
 ssize_t shim_do_sendmmsg (int sockfd, struct mmsghdr * msg, size_t vlen, int flags);
 
 /* libos call implementation */
@@ -872,6 +874,8 @@ int shim_perf_event_open (struct perf_event_attr * attr_uptr, pid_t pid,
                           int cpu, int group_fd, int flags);
 ssize_t shim_recvmmsg (int sockfd, struct mmsghdr * msg, size_t vlen, int flags,
                        struct __kernel_timespec * timeout);
+int shim_prlimit64(pid_t pid, int resource, const struct __kernel_rlimit64* new_rlim,
+                   struct __kernel_rlimit64* old_rlim);
 ssize_t shim_sendmmsg (int sockfd, struct mmsghdr * msg, size_t vlen, int flags);
 
 /* libos call wrappers */

--- a/LibOS/shim/include/shim_vma.h
+++ b/LibOS/shim/include/shim_vma.h
@@ -161,8 +161,4 @@ int dump_all_vmas (struct shim_vma_val * vmas, size_t max_count);
 /* Debugging */
 void debug_print_vma_list (void);
 
-/* Constants */
-extern unsigned long brk_max_size;
-extern unsigned long sys_stack_size;
-
 #endif /* _SHIM_VMA_H_ */

--- a/LibOS/shim/src/fs/proc/thread.c
+++ b/LibOS/shim/src/fs/proc/thread.c
@@ -238,7 +238,7 @@ static int parse_thread_fd (const char * name, const char ** rest,
         if (*p < '0' || *p > '9')
             return -ENOENT;
         fd = fd * 10 + *p - '0';
-        if (fd >= __rlim[RLIMIT_NOFILE].rlim_cur)
+        if ((uint64_t) fd >= get_rlimit_cur(RLIMIT_NOFILE))
             return -ENOENT;
     }
 

--- a/LibOS/shim/src/shim_syscalls.c
+++ b/LibOS/shim/src/shim_syscalls.c
@@ -1141,9 +1141,9 @@ SHIM_SYSCALL_PASSTHROUGH (fanotify_init, 2, int, int, flags, int, event_f_flags)
 SHIM_SYSCALL_PASSTHROUGH (fanotify_mark, 5, int, int, fanotify_fd, int, flags,
                           unsigned long, mask, int, fd, const char  *, pathname)
 
-SHIM_SYSCALL_PASSTHROUGH (prlimit64, 4, int, pid_t, pid, int, resource,
-                          const struct __kernel_rlimit64 *, new_rlim,
-                          struct __kernel_rlimit64 *, old_rlim)
+DEFINE_SHIM_SYSCALL(prlimit64, 4, shim_do_prlimit64, int, pid_t, pid, int, resource,
+                    const struct __kernel_rlimit64*, new_rlim,
+                    struct __kernel_rlimit64*, old_rlim)
 
 SHIM_SYSCALL_PASSTHROUGH (name_to_handle_at, 5, int, int, dfd,
                           const char *, name,

--- a/LibOS/shim/src/sys/shim_fork.c
+++ b/LibOS/shim/src/sys/shim_fork.c
@@ -48,14 +48,13 @@ int migrate_fork (struct shim_cp_store * store,
         DEFINE_MIGRATE(all_mounts, NULL, 0);
         DEFINE_MIGRATE(all_vmas, NULL, 0);
         DEFINE_MIGRATE(running_thread, thread, sizeof(struct shim_thread));
-        DEFINE_MIGRATE(handle_map, thread->handle_map,
-                       sizeof (struct shim_handle_map));
+        DEFINE_MIGRATE(handle_map, thread->handle_map, sizeof(struct shim_handle_map));
+        DEFINE_MIGRATE(migratable, NULL, 0);
         DEFINE_MIGRATE(brk, NULL, 0);
         DEFINE_MIGRATE(loaded_libraries, NULL, 0);
 #ifdef DEBUG
         DEFINE_MIGRATE(gdb_map, NULL, 0);
 #endif
-        DEFINE_MIGRATE(migratable, NULL, 0);
     }
     END_MIGRATION_DEF(fork)
 


### PR DESCRIPTION
<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->

This PR is required by #809 

This PR reimplements `getrlimit`/`setrlimit` and adds `rlimit64`. `rlimit64` is necessary for new versions of glibc since `getrlimit`/`setrlimit` are changed into just wrapper of rlimit64. Specifically, this PR implements some basic functionality of RLIMIT_DATA and RLIMIT_STACK.

## How to test this PR? <!-- (if applicable) -->

Run the `brk01` test in LTP.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/830)
<!-- Reviewable:end -->
