### PR TITLE
[LibOS] Fixing LTP test clone03

### DIFF
--- a/LibOS/shim/include/shim_signal.h
+++ b/LibOS/shim/include/shim_signal.h
@@ -136,9 +136,10 @@ int init_signal (void);
 void __store_context (shim_tcb_t * tcb, PAL_CONTEXT * pal_context,
                       struct shim_signal * signal);
 
-void append_signal (struct shim_thread * thread, int sig, siginfo_t * info,
-                    bool wakeup);
-void deliver_signal (siginfo_t * info, PAL_CONTEXT * context);
+// Need to hold thread->lock when calling this function
+void append_signal(struct shim_thread* thread, int sig, siginfo_t* info, bool need_interrupt);
+
+void deliver_signal(siginfo_t* info, PAL_CONTEXT* context);
 
 __sigset_t * get_sig_mask (struct shim_thread * thread);
 __sigset_t * set_sig_mask (struct shim_thread * thread,

--- a/LibOS/shim/src/sys/shim_alarm.c
+++ b/LibOS/shim/src/sys/shim_alarm.c
@@ -37,7 +37,9 @@ static void signal_alarm (IDTYPE target, void * arg)
     if (!thread)
         return;
 
+    lock(&thread->lock);
     append_signal(thread, SIGALRM, NULL, true);
+    unlock(&thread->lock);
 }
 
 int shim_do_alarm (unsigned int seconds)

--- a/LibOS/shim/src/sys/shim_ioctl.c
+++ b/LibOS/shim/src/sys/shim_ioctl.c
@@ -307,7 +307,9 @@ void signal_io (IDTYPE target, void *arg)
     if (!thread)
         return;
 
+    lock(&thread->lock);
     append_signal(thread, SIGIO, NULL, true);
+    unlock(&thread->lock);
 }
 
 int shim_do_ioctl (int fd, int cmd, unsigned long arg)


### PR DESCRIPTION
<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->

This PR fixes #529. Just as @dimakuv investigated, the root cause of this bug is the interruption of `read()` on the pipe between the parent and child processes. The emulation of `read()` is interrupted by the host-level signal sent from the IPC helper in order to deliver the SIGCHLD signal from the terminated child process. The `clone03` test does not expect `read()` to be interrupted because SIGCHLD is set to be ignored by default.

The quick fix presented in this PR is to skip the delivery of a signal if the target thread is set to ignore the said signal. This fix should at least stabilize `clone03` and prevent similar corner cases to happen again. However, this fix does not prevent the target thread from being interrupted by **other** signals (e.g., a SIGINT from the host). We may need a more fundamental fix in the future.


## How to test this PR? <!-- (if applicable) -->

The potential way to reproduce this issue is to run `./pal_loader clone03` in a loop while running the whole regression in parallel. `clone03` should no longer fail under Graphene or Graphene-SGX.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/832)
<!-- Reviewable:end -->
