### PR TITLE
[LibOS] add more #ifndef ALIAS_VFORK_AS_FORK to complete ea234412c907…

### DIFF
--- a/LibOS/shim/include/shim_thread.h
+++ b/LibOS/shim/include/shim_thread.h
@@ -37,8 +37,10 @@ struct shim_thread {
     struct shim_thread * parent;
     /* thread leader */
     struct shim_thread * leader;
+#ifndef ALIAS_VFORK_AS_FORK
     /* dummy thread: stores blocked parent thread for vfork */
     struct shim_thread * dummy;
+#endif
     /* child handles; protected by thread->lock */
     LISTP_TYPE(shim_thread) children;
     /* nodes in child handles; protected by the parent's lock */

--- a/LibOS/shim/src/bookkeep/shim_thread.c
+++ b/LibOS/shim/src/bookkeep/shim_thread.c
@@ -621,7 +621,9 @@ BEGIN_CP_FUNC(thread)
 
         new_thread->in_vm  = false;
         new_thread->parent = NULL;
+#ifndef ALIAS_VFORK_AS_FORK
         new_thread->dummy  = NULL;
+#endif
         new_thread->handle_map = NULL;
         new_thread->root   = NULL;
         new_thread->cwd    = NULL;


### PR DESCRIPTION
…4b148b5be928aa693b94e20915ea

This changeset is follow up of ea234412c9074b148b5be928aa693b94e20915ea.
Add missing #ifndef ALIAS_VFORK_AS_FORK.

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->


## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/842)
<!-- Reviewable:end -->
