### PR TITLE
[Pal/Linux-SGX] ocall_gettime loops ocall_gettime on EINTR

### DIFF
--- a/Pal/src/host/Linux-SGX/enclave_ocalls.c
+++ b/Pal/src/host/Linux-SGX/enclave_ocalls.c
@@ -972,7 +972,9 @@ int ocall_gettime (unsigned long * microsec)
         return -EPERM;
     }
 
-    retval = sgx_ocall(OCALL_GETTIME, ms);
+    do {
+        retval = sgx_ocall(OCALL_GETTIME, ms);
+    } while(retval == -EINTR);
     if (!retval)
         *microsec = ms->ms_microsec;
 


### PR DESCRIPTION
ocall_gettime can return -EINTR. Loop on EINTR case.
So assert(!ret) in _DkSystemTimeQuery() should be correct.

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [x] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->


## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/843)
<!-- Reviewable:end -->
