### PR TITLE
[Pal, Pal/Linux-SGX] make Pal/regression work on Pal/Linux-SGX

### DIFF
--- a/Pal/src/db_main.c
+++ b/Pal/src/db_main.c
@@ -380,9 +380,16 @@ noreturn void pal_main (
         }
     }
 
-    /* must be a ELF */
-    if (exec_handle && check_elf_object(exec_handle) < 0)
-        INIT_FAIL(PAL_ERROR_INVAL, "executable is not a ELF binary");
+    /* must be an ELF */
+    if (exec_handle) {
+        if (exec_loaded_addr) {
+            if (check_elf_magic(exec_loaded_addr, sizeof(ElfW(Ehdr))))
+                INIT_FAIL(PAL_ERROR_INVAL, "executable is not an ELF binary");
+        } else {
+            if (check_elf_object(exec_handle) < 0)
+                INIT_FAIL(PAL_ERROR_INVAL, "executable is not an ELF binary");
+        }
+    }
 
     pal_state.manifest        = manifest_uri;
     pal_state.manifest_handle = manifest_handle;

--- a/Pal/src/db_rtld.c
+++ b/Pal/src/db_rtld.c
@@ -817,6 +817,10 @@ int load_elf_object_by_handle (PAL_HANDLE handle, enum object_type type)
     int len = _DkStreamRead(handle, 0, FILEBUF_SIZE, &fb, NULL, 0);
 
     if ((size_t)len < sizeof(ElfW(Ehdr))) {
+        if (len < 0)
+            ret = len;
+        else
+            ret = -PAL_ERROR_INVAL;
         errstring = "ELF file with a strange size";
         goto verify_failed;
     }
@@ -842,6 +846,7 @@ int load_elf_object_by_handle (PAL_HANDLE handle, enum object_type type)
     if (memcmp(ehdr->e_ident, expected, EI_OSABI) != 0 || (
             ehdr->e_ident[EI_OSABI] != ELFOSABI_SYSV &&
             ehdr->e_ident[EI_OSABI] != ELFOSABI_LINUX)) {
+        ret = -PAL_ERROR_INVAL;
         errstring = "ELF file with invalid header";
         goto verify_failed;
     }
@@ -862,12 +867,14 @@ int load_elf_object_by_handle (PAL_HANDLE handle, enum object_type type)
         ret = _DkStreamRead(handle, ehdr->e_phoff, maplength, phdr, NULL, 0);
 
         if (ret < 0 || (size_t)ret != maplength) {
+            ret = -PAL_ERROR_INVAL;
             errstring = "cannot read file data";
             goto verify_failed;
         }
     }
 
     if (!(map = map_elf_object_by_handle(handle, type, &fb, len, true))) {
+        ret = -PAL_ERROR_INVAL;
         errstring = "unexpected failure";
         goto verify_failed;
     }

--- a/Pal/src/db_rtld.c
+++ b/Pal/src/db_rtld.c
@@ -1251,6 +1251,7 @@ void DkDebugAttachBinary (PAL_STR uri, PAL_PTR start_addr)
         }
 
     _DkDebugAddMap(l);
+    free(l);
 #endif
 }
 

--- a/Pal/src/pal_internal.h
+++ b/Pal/src/pal_internal.h
@@ -360,6 +360,7 @@ int _DkCpuIdRetrieve (unsigned int leaf, unsigned int subleaf, unsigned int valu
 /* function and definition for loading binaries */
 enum object_type { OBJECT_RTLD, OBJECT_EXEC, OBJECT_PRELOAD, OBJECT_EXTERNAL };
 
+int check_elf_magic (const void* header, size_t len);
 int check_elf_object (PAL_HANDLE handle);
 int load_elf_object (const char * uri, enum object_type type);
 int load_elf_object_by_handle (PAL_HANDLE handle, enum object_type type);


### PR DESCRIPTION
<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [x] Linux PAL
- [x] SGX PAL
- [ ] FreeBSD PAL
- [x] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->
Pal/Linux-SGX doesn't properly parse exec file and as a result exec_map isn't initialized correctly. As a result Pal/regression doesn't  work on Pal/Linux-SGX.
To be honest, I don't understand why Pal/regression is working on the current CI.
Fix the logic of parsing to make Pal/regression work on Pal/linux-SGX.
As side effect, several struct link_map initialization are fixed.


## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/845)
<!-- Reviewable:end -->
