### PR TITLE
[Pal] fix libos preload handling

### DIFF
--- a/LibOS/shim/test/benchmark/manifest.template
+++ b/LibOS/shim/test/benchmark/manifest.template
@@ -1,4 +1,5 @@
 loader.preload = file:../../src/libsysdb.so
+loader.libos = libsysdb
 loader.env.LD_LIBRARY_PATH = /lib
 loader.debug_type = none
 loader.syscall_symbol = syscalldb

--- a/LibOS/shim/test/inline/manifest.template
+++ b/LibOS/shim/test/inline/manifest.template
@@ -1,2 +1,3 @@
 loader.preload = file:../../src/libsysdb_debug.so
+loader.libos = libsysdb
 loader.debug_type = inline

--- a/LibOS/shim/test/native/exec_fork.manifest.template
+++ b/LibOS/shim/test/native/exec_fork.manifest.template
@@ -1,4 +1,5 @@
 loader.preload = file:$(SHIMPATH)
+loader.libos = libsysdb
 loader.env.LD_LIBRARY_PATH = /lib
 loader.debug_type = inline
 loader.syscall_symbol = syscalldb

--- a/LibOS/shim/test/native/ls.manifest.template
+++ b/LibOS/shim/test/native/ls.manifest.template
@@ -1,4 +1,5 @@
 loader.preload = file:$(SHIMPATH)
+loader.libos = libsysdb
 loader.exec = file:/bin/ls
 loader.env.LD_LIBRARY_PATH = /lib:/lib/x86_64-linux-gnu
 loader.debug_type = none

--- a/LibOS/shim/test/native/manifest.template
+++ b/LibOS/shim/test/native/manifest.template
@@ -1,4 +1,5 @@
 loader.preload = file:$(SHIMPATH)
+loader.libos = libsysdb
 loader.env.LD_LIBRARY_PATH = /lib
 loader.debug_type = inline
 loader.syscall_symbol = syscalldb

--- a/LibOS/shim/test/native/script.manifest.template
+++ b/LibOS/shim/test/native/script.manifest.template
@@ -1,4 +1,5 @@
 loader.preload = file:$(SHIMPATH)
+loader.libos = libsysdb
 loader.env.LD_LIBRARY_PATH = /lib
 loader.debug_type = inline
 loader.syscall_symbol = syscalldb

--- a/LibOS/shim/test/native/static.manifest.template
+++ b/LibOS/shim/test/native/static.manifest.template
@@ -1,4 +1,5 @@
 loader.preload = file:$(SHIMPATH)
+loader.libos = libsysdb
 loader.env.LD_LIBRARY_PATH = /lib
 loader.debug_type = inline
 

--- a/LibOS/shim/test/regression/exec_victim.manifest.template
+++ b/LibOS/shim/test/regression/exec_victim.manifest.template
@@ -1,4 +1,5 @@
 loader.preload = file:$(SHIMPATH)
+loader.libos = libsysdb
 loader.env.LD_LIBRARY_PATH = /lib
 loader.debug_type = none
 loader.syscall_symbol = syscalldb

--- a/LibOS/shim/test/regression/futex.manifest.template
+++ b/LibOS/shim/test/regression/futex.manifest.template
@@ -1,4 +1,5 @@
 loader.preload = file:../../src/libsysdb.so
+loader.libos = libsysdb
 loader.env.LD_LIBRARY_PATH = /lib
 loader.debug_type = none
 loader.syscall_symbol = syscalldb

--- a/LibOS/shim/test/regression/getdents.manifest.template
+++ b/LibOS/shim/test/regression/getdents.manifest.template
@@ -1,4 +1,5 @@
 loader.preload = file:$(SHIMPATH)
+loader.libos = libsysdb
 loader.env.LD_LIBRARY_PATH = /lib
 loader.debug_type = inline
 

--- a/LibOS/shim/test/regression/init_fail.manifest.template
+++ b/LibOS/shim/test/regression/init_fail.manifest.template
@@ -1,4 +1,5 @@
 loader.preload = file:$(SHIMPATH)
+loader.libos = libsysdb
 loader.env.LD_LIBRARY_PATH = /lib
 loader.debug_type = none
 

--- a/LibOS/shim/test/regression/large-mmap.manifest.template
+++ b/LibOS/shim/test/regression/large-mmap.manifest.template
@@ -1,4 +1,5 @@
 loader.preload = file:../../src/libsysdb.so
+loader.libos = libsysdb
 loader.env.LD_LIBRARY_PATH = /lib
 loader.debug_type = none
 loader.syscall_symbol = syscalldb

--- a/LibOS/shim/test/regression/manifest.template
+++ b/LibOS/shim/test/regression/manifest.template
@@ -1,4 +1,5 @@
 loader.preload = file:../../src/libsysdb.so
+loader.libos = libsysdb
 loader.env.LD_LIBRARY_PATH = /lib:/lib/x86_64-linux-gnu:/usr/lib/x86_64-linux-gnu
 loader.debug_type = none
 loader.syscall_symbol = syscalldb

--- a/LibOS/shim/test/regression/mmap-file.manifest.template
+++ b/LibOS/shim/test/regression/mmap-file.manifest.template
@@ -1,4 +1,5 @@
 loader.preload = file:../../src/libsysdb.so
+loader.libos = libsysdb
 loader.env.LD_LIBRARY_PATH = /lib
 loader.debug_type = none
 loader.syscall_symbol = syscalldb

--- a/LibOS/shim/test/regression/proc-path.manifest.template
+++ b/LibOS/shim/test/regression/proc-path.manifest.template
@@ -1,4 +1,5 @@
 loader.preload = file:../../src/libsysdb.so
+loader.libos = libsysdb
 loader.env.LD_LIBRARY_PATH = /lib
 loader.debug_type = none
 loader.syscall_symbol = syscalldb

--- a/LibOS/shim/test/regression/shared_object.manifest.template
+++ b/LibOS/shim/test/regression/shared_object.manifest.template
@@ -1,4 +1,5 @@
 loader.preload = file:$(SHIMPATH)
+loader.libos = libsysdb
 loader.env.LD_LIBRARY_PATH = /lib
 loader.debug_type = none
 

--- a/Pal/regression/Bootstrap3.manifest.template
+++ b/Pal/regression/Bootstrap3.manifest.template
@@ -1,2 +1,3 @@
 loader.debug_type = inline
 loader.preload = file:Preload1.so,file:Preload2.so
+#loader.libos = ?

--- a/Pal/regression/Bootstrap5.manifest.template
+++ b/Pal/regression/Bootstrap5.manifest.template
@@ -1,2 +1,3 @@
 loader.debug_type = inline
 loader.preload = file:Preload1.so,file:Preload2.so
+#loader.libos = ?

--- a/Pal/regression/Bootstrap6.manifest.template
+++ b/Pal/regression/Bootstrap6.manifest.template
@@ -1,6 +1,7 @@
 loader.exec = file:./Bootstrap
 loader.debug_type = inline
 loader.preload = file:Preload1.so,file:Preload2.so
+#loader.libos = ?
 
 fs.mount.root.uri = file:
 

--- a/Pal/regression/Process3.manifest.template
+++ b/Pal/regression/Process3.manifest.template
@@ -1,2 +1,3 @@
 loader.debug_type = inline
 loader.preload = file:Preload1.so,file:Preload2.so
+#loader.libos = ?

--- a/Pal/src/db_main.c
+++ b/Pal/src/db_main.c
@@ -217,8 +217,8 @@ static int loader_filter (const char * key, int len)
             key[4] == 'e' && key[5] == 'r' && key[6] == '.') ? 0 : 1;
 }
 
-void init_libraries (const char * first_argument, const char ** arguments,
-                     const char ** environments);
+void init_libraries (const char* first_argument, const char** arguments,
+                     const char** environments);
 
 void start_execution (const char * first_argument, const char ** arguments,
                       const char ** environments);

--- a/Pal/src/db_main.c
+++ b/Pal/src/db_main.c
@@ -217,12 +217,6 @@ static int loader_filter (const char * key, int len)
             key[4] == 'e' && key[5] == 'r' && key[6] == '.') ? 0 : 1;
 }
 
-void init_libraries (const char* first_argument, const char** arguments,
-                     const char** environments);
-
-void start_execution (const char * first_argument, const char ** arguments,
-                      const char ** environments);
-
 /* 'pal_main' must be called by the host-specific bootloader */
 noreturn void pal_main (
         PAL_NUM    instance_id,      /* current instance id */

--- a/Pal/src/db_rtld.c
+++ b/Pal/src/db_rtld.c
@@ -1364,7 +1364,7 @@ void call_init (struct link_map* l, const char* first_argument,
 
     /* Invoke constructors. We follow the order in the GNU C Library:
      *  1. if exists, invoke the one constructor named by DT_INIT
-     *  2. if any, all constructors found in DT_INIT_ARRAY, in order
+     *  2. if exists, invoke all constructors in DT_INIT_ARRAY, in order of appearance
      */
 
     if (init)
@@ -1379,7 +1379,7 @@ void call_init (struct link_map* l, const char* first_argument,
 void init_libraries (const char* first_argument, const char** arguments,
                      const char** environs)
 {
-    for (struct link_map* l = loaded_maps; l ; l = l->l_next)
+    for (struct link_map* l = loaded_maps; l; l = l->l_next)
         if (l->l_type == OBJECT_PRELOAD && l->l_entry)
             call_init(l, first_argument, arguments, environs);
 }
@@ -1448,7 +1448,7 @@ noreturn void start_execution (const char * first_argument,
     ssize_t ret = get_config(pal_state.root_config, "loader.libos",
                              libos_str, URI_MAX);
     if (ret > 0)
-        for (struct link_map* l = loaded_maps; l ; l = l->l_next)
+        for (struct link_map* l = loaded_maps; l; l = l->l_next)
             if (l->l_type == OBJECT_PRELOAD && l->l_entry)
                 if (strstr(l->l_name, libos_str))
                     CALL_ENTRY(l, cookies); // Does not return.

--- a/Pal/src/db_rtld.c
+++ b/Pal/src/db_rtld.c
@@ -1444,20 +1444,20 @@ noreturn void start_execution (const char * first_argument,
 
     /* If LibOS is specified and found, invoke ELF entry. */
     char libos_str[URI_MAX];
-    memset(libos_str, 0, URI_MAX);
+    *libos_str = '\0';
     ssize_t ret = get_config(pal_state.root_config, "loader.libos",
                              libos_str, URI_MAX);
     if (ret > 0)
         for (struct link_map* l = loaded_maps; l ; l = l->l_next)
             if (l->l_type == OBJECT_PRELOAD && l->l_entry)
                 if (strstr(l->l_name, libos_str))
-                    CALL_ENTRY(l, cookies);
+                    CALL_ENTRY(l, cookies); // Does not return.
     printf("Warning: loader.libos not defined in manifest file"
             " or cannot find specified lib in loader.preload list.\n");
 
     /* Else, invoke ELF entry in the app. */
     if (exec_map)
-        CALL_ENTRY(exec_map, cookies);
+        CALL_ENTRY(exec_map, cookies); // Does not return.
 
     _DkThreadExit();
 }

--- a/Pal/src/db_rtld.c
+++ b/Pal/src/db_rtld.c
@@ -1320,8 +1320,8 @@ void * stack_before_call __attribute_unused = NULL;
 
 /* Invoke initializers of ELF binary.
    See GNU libc elf/dl-init.c call_init() */
-void call_init (struct link_map *l, const char *first_argument,
-               const char ** arguments, const char ** environs)
+void call_init (struct link_map* l, const char* first_argument,
+                const char** arguments, const char** environs)
 {
     if (l->l_init_called)
         return;
@@ -1333,25 +1333,25 @@ void call_init (struct link_map *l, const char *first_argument,
     /* Set up the arguments */
 
     int argc = 1;
-    for (const char ** a = arguments; *a ; a++, argc++);
+    for (const char** a = arguments; *a ; a++, argc++);
 
-    char **argv = __alloca(argc * sizeof(*argv));
-    argv[0] = (char*) first_argument;
+    char** argv = __alloca(argc * sizeof(*argv));
+    argv[0] = (char*)first_argument;
     for (int i = 1; i < argc; i++)
-        argv[i] = (char*) arguments[i];
+        argv[i] = (char*)arguments[i];
 
-    char** env = (char**) environs;
+    char** env = (char**)environs;
 
     /* Locate constructors: DT_INIT and DT_INIT_ARRAY.
      * One or the other, neither, or both may exist. */
 
-    typedef void (*init_t) (int, char **, char **); /* constructor prototype */
+    typedef void (*init_t)(int, char**, char**); /* constructor prototype */
 
     init_t init = NULL;
-    ElfW(Addr) *init_array = NULL;
+    ElfW(Addr)* init_array = NULL;
     size_t array_n = 0;
 
-    ElfW(Dyn) *dyn = NULL;
+    ElfW(Dyn)* dyn = NULL;
     for (dyn = l->l_ld; dyn < &l->l_ld[l->l_ldnum]; dyn++)
         if (dyn->d_tag == DT_INIT)
             init = (init_t)(l->l_addr + dyn->d_un.d_ptr);
@@ -1371,13 +1371,13 @@ void call_init (struct link_map *l, const char *first_argument,
     if (init_array && array_n > 0)
         for (ElfW(Addr) *a = init_array; a < &init_array[array_n]; a++)
             if (*a != 0UL && *a != ~0UL) /* ignore invalid entries */
-                ((init_t) *a)(argc, argv, env);
+                ((init_t)*a)(argc, argv, env);
 }
 
-void init_libraries (const char * first_argument, const char ** arguments,
-                     const char ** environs)
+void init_libraries (const char* first_argument, const char** arguments,
+                     const char** environs)
 {
-    for (struct link_map *l = loaded_maps; l ; l = l->l_next)
+    for (struct link_map* l = loaded_maps; l ; l = l->l_next)
         if (l->l_type == OBJECT_PRELOAD && l->l_entry)
             call_init(l, first_argument, arguments, environs);
 }
@@ -1446,7 +1446,7 @@ noreturn void start_execution (const char * first_argument,
     ssize_t ret = get_config(pal_state.root_config, "loader.libos",
                              libos_str, URI_MAX);
     if (ret > 0)
-        for (struct link_map *l = loaded_maps; l ; l = l->l_next)
+        for (struct link_map* l = loaded_maps; l ; l = l->l_next)
             if (l->l_type == OBJECT_PRELOAD && l->l_entry)
                 if (strstr(l->l_name, libos_str))
                     CALL_ENTRY(l, cookies);

--- a/Pal/src/db_rtld.c
+++ b/Pal/src/db_rtld.c
@@ -1334,11 +1334,13 @@ void call_init (struct link_map* l, const char* first_argument,
 
     int argc = 1;
     for (const char** a = arguments; *a ; a++, argc++);
+    argc++; /* argv must end with NULL */
 
     char** argv = __alloca(argc * sizeof(*argv));
     argv[0] = (char*)first_argument;
     for (int i = 1; i < argc; i++)
         argv[i] = (char*)arguments[i];
+    argv[argc] = NULL;
 
     char** env = (char**)environs;
 

--- a/Pal/src/db_rtld.c
+++ b/Pal/src/db_rtld.c
@@ -1318,11 +1318,63 @@ void * stack_before_call __attribute_unused = NULL;
 #endif
 #endif /* !CALL_ENTRY */
 
+/* Invoke initializers of ELF binary.
+   See GNU libc elf/dl-init.c call_init() */
+void call_init (struct link_map *l, const char *first_argument,
+               const char ** arguments, const char ** environs)
+{
+    if (l->l_init_called)
+        return;
+    l->l_init_called = true;
+
+    /* Set up the arguments */
+
+    int argc = 1;
+    for (const char ** a = arguments; *a ; a++, argc++);
+
+    char **argv = __alloca(argc * sizeof(*argv));
+    argv[0] = (char*) first_argument;
+    for (int i = 1; i < argc; i++)
+        argv[i] = (char*) arguments[i];
+
+    char** env = (char**) environs;
+
+    /* Find initializers and invoke */
+
+    typedef void (*init_t) (int, char **, char **);
+    init_t init = NULL;
+    ElfW(Addr) *init_array = NULL;
+    size_t array_n = 0;
+
+    ElfW(Dyn) *dyn = NULL;
+    for (dyn = l->l_ld; dyn < &l->l_ld[l->l_ldnum]; dyn++)
+        if (dyn->d_tag == DT_INIT)
+            init = (init_t)(l->l_addr + dyn->d_un.d_ptr);
+        else if (dyn->d_tag == DT_INIT_ARRAY)
+            init_array = (ElfW(Addr)*)(l->l_addr + dyn->d_un.d_ptr);
+        else if (dyn->d_tag == DT_INIT_ARRAYSZ)
+            array_n = dyn->d_un.d_val / sizeof (ElfW(Addr));
+
+    if (init)
+        init(argc, argv, env);
+
+    if (init_array && array_n > 0)
+        for (ElfW(Addr) *a = init_array; a < &init_array[array_n]; a++)
+            if (*a != 0UL && *a != ~0UL)
+                ((init_t) *a)(argc, argv, env);
+}
+
+void init_libraries (const char * first_argument, const char ** arguments,
+                     const char ** environs)
+{
+    for (struct link_map *l = loaded_maps; l ; l = l->l_next)
+        if (l->l_type == OBJECT_PRELOAD && l->l_entry)
+            call_init(l, first_argument, arguments, environs);
+}
+
 noreturn void start_execution (const char * first_argument,
                                const char ** arguments, const char ** environs)
 {
-    /* First we will try to run all the preloaded libraries which come with
-       entry points */
     if (exec_map) {
         __pal_control.executable_range.start = (PAL_PTR) exec_map->l_map_start;
         __pal_control.executable_range.end   = (PAL_PTR) exec_map->l_map_end;
@@ -1378,10 +1430,20 @@ noreturn void start_execution (const char * first_argument,
             pal_state.tail_startup_time += _DkSystemTimeQuery() - before_tail;
 #endif
 
-    for (struct link_map * l = loaded_maps; l ; l = l->l_next)
-        if (l->l_type == OBJECT_PRELOAD && l->l_entry)
-            CALL_ENTRY(l, cookies);
+    /* If LibOS is specified and found, invoke ELF entry. */
+    char libos_str[URI_MAX];
+    memset(libos_str, 0, URI_MAX);
+    ssize_t ret = get_config(pal_state.root_config, "loader.libos",
+                             libos_str, URI_MAX);
+    if (ret > 0)
+        for (struct link_map *l = loaded_maps; l ; l = l->l_next)
+            if (l->l_type == OBJECT_PRELOAD && l->l_entry)
+                if (strstr(l->l_name, libos_str))
+                    CALL_ENTRY(l, cookies);
+    printf("Warning: loader.libos not defined in manifest file"
+            " or cannot find specified lib in loader.preload list.\n");
 
+    /* Else, invoke ELF entry in the app. */
     if (exec_map)
         CALL_ENTRY(exec_map, cookies);
 

--- a/Pal/src/pal_rtld.h
+++ b/Pal/src/pal_rtld.h
@@ -182,6 +182,9 @@ do_lookup_map (ElfW(Sym) * ref, const char * undef_name,
 void _DkDebugAddMap (struct link_map * map);
 void _DkDebugDelMap (struct link_map * map);
 
+void init_libraries (const char* first_argument, const char** arguments,
+                     const char** environments);
+
 noreturn void start_execution (const char * first_argument,
                                const char ** arguments, const char ** environs);
 

--- a/Pal/src/pal_rtld.h
+++ b/Pal/src/pal_rtld.h
@@ -66,6 +66,8 @@ struct link_map {
     ElfW(Half) l_phnum;     /* Number of program header entries.  */
     ElfW(Half) l_ldnum;     /* Number of dynamic segment entries.  */
 
+    bool l_init_called;
+
     /* Start and finish of memory map for this object.  l_map_start
        need not be the same as l_addr.  */
     ElfW(Addr) l_map_start, l_map_end;

--- a/Tools/gen_manifest
+++ b/Tools/gen_manifest
@@ -44,7 +44,7 @@ def gen_manifest(app_name, bin_name, g_path) :
   make_exec(m_path)
   mf.write("#!" + g_path + "/Runtime/pal_loader \n")
   mf.write("loader.preload = file:../../../../../Runtime/libsysdb.so \n")
-  mf.write("loader.libos = {} \n".format(LIBOS_LIB_NAME))
+  mf.write("loader.libos = {}\n".format(LIBOS_LIB_NAME))
 
   # Get Path of Binary
   bin_path = subprocess.check_output(['which', bin_name]).strip()

--- a/Tools/gen_manifest
+++ b/Tools/gen_manifest
@@ -14,6 +14,8 @@ runtime_libs = ['libc',
                 'libresolv',
                 'librt']
 
+LIBOS_LIB_NAME = 'sysdb'
+
 def parse_libs (bin_path) :
   print (bin_path)
   ldd_out = subprocess.check_output(['ldd', bin_path])
@@ -42,6 +44,7 @@ def gen_manifest(app_name, bin_name, g_path) :
   make_exec(m_path)
   mf.write("#!" + g_path + "/Runtime/pal_loader \n")
   mf.write("loader.preload = file:../../../../../Runtime/libsysdb.so \n")
+  mf.write("loader.libos = {} \n".format(LIBOS_LIB_NAME))
 
   # Get Path of Binary
   bin_path = subprocess.check_output(['which', bin_name]).strip()


### PR DESCRIPTION
With this patch, Pal now invokes ELF initializers of preloaded libraries in the order
specified (those in the manifest file in `libos.preload`).

Also fix how CALL_ENTRY is invoked; it should only be invoked on the
LibOS library libsysdb.so. CALL_ENTRY executes the ELF entry point,
which does NOT return to the caller.

In the manifest, user is now required to add `loader.libos` to tell Pal
a substring name of the LibOS library file (retaining it in the
preload list). Adding this allows us to also decouple the actual name of
the LibOS library, and enable it to become position-independent in the
preload list.

For example:

loader.preload = file:libsysdb,file:libfoo.so,file:libbar.so
loader.libos = sysdb

ELF initializers will be invoked in a left-to-right order, with the ELF
entry point invoked on libsysdb.so.

Dependencies between dynamic libraries are NOT understood or caught by
this change set. If one library depends on the state initialized by
another, the user must currently ensure the correct order.

Signed-off-by: Alex Merritt <mail@alexmerritt.us>

<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [x] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [x] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->

See above.

A subsequent PR will allow an easy way to build libs to be used for preloading to LibOS.

Depends on PR #847 and #848  

## How to test this PR? <!-- (if applicable) -->

This change set does not include a test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/849)
<!-- Reviewable:end -->
