### PR TITLE
Turn on CPSTORE_DERANDOMIZATION, fixes apache on SGX.

### DIFF
--- a/Jenkinsfiles/Linux-SGX
+++ b/Jenkinsfiles/Linux-SGX
@@ -51,20 +51,20 @@ pipeline {
                         timeout(time: 5, unit: 'MINUTES') {
                             sh '''
                                 cd LibOS/shim/test/apps/python
-                                                  make SGX=1
-                                                  make SGX_RUN=1
+                                make SGX=1
+                                make SGX_RUN=1
                                 make SGX_RUN=1 regression
                             '''
-      }
-      timeout(time: 5, unit: 'MINUTES') {
+                        }
+                        timeout(time: 5, unit: 'MINUTES') {
                             sh '''
                                 cd LibOS/shim/test/apps/bash
                                 make SGX=1
                                 make SGX_RUN=1
                                 make SGX_RUN=1 regression
                            '''
-      }
-                        timeout(time: 5, unit: 'MINUTES') {
+                        }
+                        timeout(time: 10, unit: 'MINUTES') {
                             sh '''
                                 cd LibOS/shim/test/apps/gcc
                                 make SGX=1

--- a/Jenkinsfiles/Linux-SGX
+++ b/Jenkinsfiles/Linux-SGX
@@ -88,7 +88,6 @@ pipeline {
                             sleep 10
                             LOOP=1 CONCURRENCY_LIST="1 32" ./benchmark-http.sh `hostname -I|tr -d '[:space:]'`:8000
                             '''
-                            /*
                         sh '''
                             cd LibOS/shim/test/apps/apache
                             make SGX=1
@@ -97,7 +96,6 @@ pipeline {
                             sleep 15
                             LOOP=1 CONCURRENCY_LIST="1 32" ./benchmark-http.sh `hostname -I|tr -d '[:space:]'`:8001
                             '''
-                            */
                     }
                     post {
                         always {

--- a/Jenkinsfiles/Linux-SGX-18.04
+++ b/Jenkinsfiles/Linux-SGX-18.04
@@ -64,7 +64,7 @@ pipeline {
                                 make SGX_RUN=1 regression
                            '''
       }
-                        timeout(time: 5, unit: 'MINUTES') {
+                        timeout(time: 10, unit: 'MINUTES') {
                             sh '''
                                 cd LibOS/shim/test/apps/gcc
                                 make SGX=1

--- a/LibOS/shim/include/shim_defs.h
+++ b/LibOS/shim/include/shim_defs.h
@@ -11,7 +11,7 @@
  * exact address it was created. Currently this option is disabled
  * to prevent internal fragmentation of virtual memory space.
  */
-#define CPSTORE_DERANDOMIZATION     0
+#define CPSTORE_DERANDOMIZATION     1
 
 /* This macro disables current vfork implementation and aliases it to fork.
  *


### PR DESCRIPTION
<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [X] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->

The Apache test on SGX deterministically hit an ongoing problem with fork - that the cpstore location was creating conflicts.  In the short-term, disable CPSTORE randomization, to reduce the risk of address space conflicts.  In the longer term, we will need to clean up cpstore.

This makes Apache work on Linux-SGX, and probably reduces the likelihood of other heisenbugs.  

This also includes a few whitespace fixes to the Jenkinsfile.

Fixes #826 

## How to test this PR? <!-- (if applicable) -->

Run the SGX Jenkins pipeline.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/859)
<!-- Reviewable:end -->
