### PR TITLE
Tune the run time of Apache and Lighttpd tests

### DIFF
--- a/Jenkinsfiles/Linux
+++ b/Jenkinsfiles/Linux
@@ -53,14 +53,14 @@ pipeline {
                             make
                             make start-graphene-server &
                             sleep 1
-                            ./benchmark-http.sh `hostname -I|tr -d '[:space:]'`:8000
+                            LOOP=1 CONCURRENCY_LIST="1 32" ./benchmark-http.sh `hostname -I|tr -d '[:space:]'`:8000
                             '''
                         sh '''
                             cd LibOS/shim/test/apps/apache
                             make
                             make start-graphene-server &
                             sleep 1
-                            ./benchmark-http.sh `hostname -I|tr -d '[:space:]'`:8001
+                            LOOP=1 CONCURRENCY_LIST="1 32" ./benchmark-http.sh `hostname -I|tr -d '[:space:]'`:8001
                             '''
                     }
                 }

--- a/Jenkinsfiles/Linux-18.04
+++ b/Jenkinsfiles/Linux-18.04
@@ -52,14 +52,14 @@ pipeline {
                             make
                             make start-graphene-server &
                             sleep 1
-                            ./benchmark-http.sh `hostname -I|tr -d '[:space:]'`:8000
+                            LOOP=1 CONCURRENCY_LIST="1 32" ./benchmark-http.sh `hostname -I|tr -d '[:space:]'`:8000
                             '''
                         sh '''
                             cd LibOS/shim/test/apps/apache
                             make
                             make start-graphene-server &
                             sleep 1
-                            ./benchmark-http.sh `hostname -I|tr -d '[:space:]'`:8001
+                            LOOP=1 CONCURRENCY_LIST="1 32" ./benchmark-http.sh `hostname -I|tr -d '[:space:]'`:8001
                             '''
                     }
                 }

--- a/Jenkinsfiles/Linux-Debug
+++ b/Jenkinsfiles/Linux-Debug
@@ -53,14 +53,14 @@ pipeline {
                             make
                             make start-graphene-server &
                             sleep 1
-                            ./benchmark-http.sh `hostname -I|tr -d '[:space:]'`:8000
+                            LOOP=1 CONCURRENCY_LIST="1 32" ./benchmark-http.sh `hostname -I|tr -d '[:space:]'`:8000
                             '''
                         sh '''
                             cd LibOS/shim/test/apps/apache
                             make
                             make start-graphene-server &
                             sleep 1
-                            ./benchmark-http.sh `hostname -I|tr -d '[:space:]'`:8001
+                            LOOP=1 CONCURRENCY_LIST="1 32" ./benchmark-http.sh `hostname -I|tr -d '[:space:]'`:8001
                             '''
                     }
                 }

--- a/Jenkinsfiles/Linux-Debug-18.04
+++ b/Jenkinsfiles/Linux-Debug-18.04
@@ -52,14 +52,14 @@ pipeline {
                             make
                             make start-graphene-server &
                             sleep 1
-                            ./benchmark-http.sh `hostname -I|tr -d '[:space:]'`:8000
+                            LOOP=1 CONCURRENCY_LIST="1 32" ./benchmark-http.sh `hostname -I|tr -d '[:space:]'`:8000
                             '''
                         sh '''
                             cd LibOS/shim/test/apps/apache
                             make
                             make start-graphene-server &
                             sleep 1
-                            ./benchmark-http.sh `hostname -I|tr -d '[:space:]'`:8001
+                            LOOP=1 CONCURRENCY_LIST="1 32" ./benchmark-http.sh `hostname -I|tr -d '[:space:]'`:8001
                             '''
                     }
                 }

--- a/Jenkinsfiles/Linux-SGX
+++ b/Jenkinsfiles/Linux-SGX
@@ -86,7 +86,7 @@ pipeline {
                             make SGX_RUN=1
                             make SGX_RUN=1 start-graphene-server &
                             sleep 10
-                            ./benchmark-http.sh `hostname -I|tr -d '[:space:]'`:8000
+                            LOOP=1 CONCURRENCY_LIST="1 32" ./benchmark-http.sh `hostname -I|tr -d '[:space:]'`:8000
                             '''
                             /*
                         sh '''
@@ -94,7 +94,8 @@ pipeline {
                             make SGX=1
                             make SGX_RUN=1
                             make SGX_RUN=1 start-graphene-server &
-                            sleep 15 && ./benchmark-http.sh `hostname -I|tr -d '[:space:]'`:8001
+                            sleep 15
+                            LOOP=1 CONCURRENCY_LIST="1 32" ./benchmark-http.sh `hostname -I|tr -d '[:space:]'`:8001
                             '''
                             */
                     }

--- a/Jenkinsfiles/Linux-SGX-18.04
+++ b/Jenkinsfiles/Linux-SGX-18.04
@@ -86,7 +86,7 @@ pipeline {
                             make SGX_RUN=1
                             make SGX_RUN=1 start-graphene-server &
                             sleep 10
-                            ./benchmark-http.sh `hostname -I|tr -d '[:space:]'`:8000
+                            LOOP=1 CONCURRENCY_LIST="1 32" ./benchmark-http.sh `hostname -I|tr -d '[:space:]'`:8000
                             '''
                             /*
                         sh '''
@@ -94,7 +94,8 @@ pipeline {
                             make SGX=1
                             make SGX_RUN=1
                             make SGX_RUN=1 start-graphene-server &
-                            sleep 15 && ./benchmark-http.sh `hostname -I|tr -d '[:space:]'`:8001
+                            sleep 15
+                            LOOP=1 CONCURRENCY_LIST="1 32" ./benchmark-http.sh `hostname -I|tr -d '[:space:]'`:8001
                             '''
                             */
                     }


### PR DESCRIPTION
<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [x] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->

This PR uses the variables introduced in https://github.com/oscarlab/graphene-tests/pull/15 to reduce the run time of Apache and Lighttpd in Jenkins.

## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/864)
<!-- Reviewable:end -->
