### PR TITLE
Fix cpuid parsing on a system with hyperthreads

### DIFF
--- a/Pal/src/db_main.c
+++ b/Pal/src/db_main.c
@@ -452,7 +452,9 @@ noreturn void pal_main (
     __pal_control.alloc_align        = pal_state.alloc_align;
     __pal_control.broadcast_stream   = _DkBroadcastStreamOpen();
 
-    _DkGetCPUInfo(&__pal_control.cpu_info);
+    if (_DkGetCPUInfo(&__pal_control.cpu_info) < 0) {
+        goto out_fail;
+    }
     __pal_control.mem_info.mem_total = _DkMemoryQuota();
 
 #if PROFILING == 1
@@ -470,6 +472,7 @@ noreturn void pal_main (
     /* Now we will start the execution */
     start_execution(first_argument, arguments, environments);
 
+ out_fail:
     /* We wish we will never reached here */
     INIT_FAIL(PAL_ERROR_DENIED, "unexpected termination");
 }

--- a/Pal/src/host/Linux-SGX/pal_security.h
+++ b/Pal/src/host/Linux-SGX/pal_security.h
@@ -49,6 +49,9 @@ struct pal_sec {
     PAL_SEC_STR     pipe_prefix;
     PAL_IDX         mcast_port, mcast_srv, mcast_cli;
 
+    /* Need to pass in the number of cores */
+    PAL_NUM         num_cpus;
+
 #ifdef DEBUG
     PAL_BOL         in_gdb;
 #endif

--- a/Pal/src/host/Linux/db_devices.c
+++ b/Pal/src/host/Linux/db_devices.c
@@ -35,8 +35,6 @@
 typedef __kernel_pid_t pid_t;
 #include <asm/errno.h>
 #include <asm/fcntl.h>
-#include <asm/stat.h>
-#include <linux/stat.h>
 
 #define DEVICE_OPS(handle)                                                             \
     ({                                                                                 \

--- a/Pal/src/host/Linux/db_files.c
+++ b/Pal/src/host/Linux/db_files.c
@@ -35,8 +35,6 @@
 typedef __kernel_pid_t pid_t;
 #undef __GLIBC__
 #include <linux/stat.h>
-#include <asm/stat.h>
-#include <asm/fcntl.h>
 #include <asm/errno.h>
 
 /* 'open' operation for file streams */

--- a/Pal/src/host/Linux/db_main.c
+++ b/Pal/src/host/Linux/db_main.c
@@ -383,9 +383,57 @@ static char * cpu_flags[]
           "pbe",    // "pending break event"
         };
 
-void _DkGetCPUInfo (PAL_CPU_INFO * ci)
+/*
+ * Returns the number of online CPUs read from /sys/devices/system/cpu/online, -errno on failure.
+ * Understands complex formats like "1,3-5,6".
+ */
+int get_cpu_count(void) {
+    int fd = INLINE_SYSCALL(open, 3, "/sys/devices/system/cpu/online", O_RDONLY|O_CLOEXEC, 0);
+    if (fd < 0)
+        return unix_to_pal_error(ERRNO(fd));
+
+    char buf[64];
+    int ret = INLINE_SYSCALL(read, 3, fd, buf, sizeof(buf) - 1);
+    INLINE_SYSCALL(close, 1, fd);
+    if (ret < 0) {
+        return unix_to_pal_error(ERRNO(ret));
+    }
+
+    buf[ret] = '\0'; /* ensure null-terminated buf even in partial read */
+
+    char* end;
+    char* ptr = buf;
+    int cpu_count = 0;
+    while (*ptr) {
+        while (*ptr == ' ' || *ptr == '\t' || *ptr == ',')
+            ptr++;
+
+        int firstint = (int)strtol(ptr, &end, 10);
+        if (ptr == end)
+            break;
+
+        if (*end == '\0' || *end == ',') {
+            /* single CPU index, count as one more CPU */
+            cpu_count++;
+        } else if (*end == '-') {
+            /* CPU range, count how many CPUs in range */
+            ptr = end + 1;
+            int secondint = (int)strtol(ptr, &end, 10);
+            if (secondint > firstint)
+                cpu_count += secondint - firstint + 1; // inclusive (e.g., 0-7, or 8-16)
+        }
+        ptr = end;
+    }
+
+    if (cpu_count == 0)
+        return -PAL_ERROR_STREAMNOTEXIST;
+    return cpu_count;
+}
+
+int _DkGetCPUInfo (PAL_CPU_INFO * ci)
 {
     unsigned int words[PAL_CPUID_WORD_NUM];
+    int rv = 0;
 
     const size_t VENDOR_ID_SIZE = 13;
     char* vendor_id = malloc(VENDOR_ID_SIZE);
@@ -408,22 +456,15 @@ void _DkGetCPUInfo (PAL_CPU_INFO * ci)
     brand[BRAND_SIZE - 1] = '\0';
     ci->cpu_brand = brand;
 
-    if (!memcmp(vendor_id, "GenuineIntel", 12)) {
-
-       /* According to SDM: EBX[15:0] is to enumerate processor topology
-        * of the system. However this value is intended for display/diagnostic
-        * purposes. The actual number of logical processors available to
-        * BIOS/OS/App may be different. We use this leaf for now as it's the
-        * best option we have so far to get the cpu number  */
-
-        cpuid(0xb, 1, words);
-        ci->cpu_num  = BIT_EXTRACT_LE(words[PAL_CPUID_WORD_EBX], 0, 16);
-    } else if (!memcmp(vendor_id, "AuthenticAMD", 12)) {
-        cpuid(0x8000008, 0, words);
-        ci->cpu_num  = BIT_EXTRACT_LE(words[PAL_CPUID_WORD_EAX], 0, 8) + 1;
-    } else {
-        ci->cpu_num  = 1;
+    /* we cannot use CPUID(0xb) because it counts even disabled-by-BIOS cores (e.g. HT cores);
+     * instead we extract info on number of online CPUs by parsing sysfs pseudo-files */
+    int cores = get_cpu_count();
+    if (cores < 0) {
+        free(vendor_id);
+        free(brand);
+        return cores;
     }
+    ci->cpu_num = cores;
 
     cpuid(1, 0, words);
     ci->cpu_family   = BIT_EXTRACT_LE(words[PAL_CPUID_WORD_EAX],  8, 12);
@@ -460,4 +501,5 @@ void _DkGetCPUInfo (PAL_CPU_INFO * ci)
 
     flags[flen ? flen - 1 : 0] = 0;
     ci->cpu_flags = flags;
+    return rv;
 }

--- a/Pal/src/host/Linux/db_streams.c
+++ b/Pal/src/host/Linux/db_streams.c
@@ -32,12 +32,10 @@
 
 #include <linux/types.h>
 typedef __kernel_pid_t pid_t;
-#include <linux/stat.h>
 #include <linux/msg.h>
 #include <linux/socket.h>
 #include <linux/wait.h>
 #include <asm/fcntl.h>
-#include <asm/stat.h>
 #include <asm/socket.h>
 #include <asm/poll.h>
 #include <sys/signal.h>

--- a/Pal/src/host/Linux/pal_linux.h
+++ b/Pal/src/host/Linux/pal_linux.h
@@ -30,6 +30,11 @@
 #include <sys/syscall.h>
 #include <sigset.h>
 
+#include <asm/fcntl.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
 #ifdef __x86_64__
 # include "sysdep-x86_64.h"
 #endif
@@ -74,7 +79,7 @@ extern struct pal_linux_state {
 #endif
 } linux_state;
 
-#include <asm/fcntl.h>
+
 #include <asm/mman.h>
 
 #ifdef INLINE_SYSCALL
@@ -153,7 +158,6 @@ int handle_deserialize (PAL_HANDLE * handle, const void * data, int size);
 #define ACCESS_W    2
 #define ACCESS_X    1
 
-struct stat;
 bool stataccess (struct stat * stats, int acc);
 
 void init_child_process (PAL_HANDLE * parent, PAL_HANDLE * exec,

--- a/Pal/src/pal_internal.h
+++ b/Pal/src/pal_internal.h
@@ -269,7 +269,8 @@ PAL_NUM _DkGetProcessId (void);
 PAL_NUM _DkGetHostId (void);
 unsigned long _DkMemoryQuota (void);
 unsigned long _DkMemoryAvailableQuota (void);
-void _DkGetCPUInfo (PAL_CPU_INFO * info);
+// Returns 0 on success, negative PAL code on failure
+int _DkGetCPUInfo (PAL_CPU_INFO * info);
 
 /* Internal DK calls, in case any of the internal routines needs to use them */
 /* DkStream calls */


### PR DESCRIPTION
<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [X] Linux PAL
- [X] SGX PAL
- [X] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->

Add code to figure out whether hyperthreads are enabled, so that one can detect the total number of cores on the system.

## How to test this PR? <!-- (if applicable) -->

Run the Bootstrap PAL regression on a HT system.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/868)
<!-- Reviewable:end -->
