### PR TITLE
clone03 fix followup

### DIFF
--- a/LibOS/shim/src/bookkeep/shim_signal.c
+++ b/LibOS/shim/src/bookkeep/shim_signal.c
@@ -678,7 +678,8 @@ __handle_one_signal(shim_tcb_t* tcb, int sig, struct shim_signal* signal) {
 
 void __handle_signal (shim_tcb_t * tcb, int sig)
 {
-    struct shim_thread * thread = (struct shim_thread *) tcb->tp;
+    struct shim_thread * thread = tcb->tp;
+    assert(thread);
     int begin_sig = 1, end_sig = NUM_KNOWN_SIGS;
 
     if (sig)
@@ -735,6 +736,19 @@ void append_signal(struct shim_thread* thread, int sig, siginfo_t* info, bool ne
     if (!handler) {
         // SIGSTOP and SIGKILL cannot be ignored
         assert(sig != SIGSTOP && sig != SIGKILL);
+        /*
+         * If signal is ignored and unmasked, the signal can be discarded
+         * directly. Otherwise it causes memory leak.
+         *
+         * SIGCHLD can be discarded even if it's masked.
+         * For Linux implementation, please refer to
+         * do_notify_parent() in linux/kernel/signal.c
+         * For standard, please refer to
+         * https://pubs.opengroup.org/onlinepubs/9699919799/functions/_Exit.html
+         */
+        if (!__sigismember(&thread->signal_mask, sig) || sig == SIGCHLD)
+            return;
+
         // If a signal is set to be ignored, append the signal but don't interrupt the thread
         need_interrupt = false;
     }


### PR DESCRIPTION
<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->
    [LibOS] teach append_signal() how to handle SIG_IGN/SIGCHLD
    
    This patch is follow up for #832, "[LibOS] Fixing LTP test clone03".
    When signal is masked ans handler = SIG_IGN, it shouldn't queue
    signal to avoid memory leak.
    If signal is SIGCHLD, it can be discarded even if it's masked.
    
    Reference:
    - Linux implementation: do_notify_parent() @ linux/kernel/signal.c
    - Standards:
      https://pubs.opengroup.org/onlinepubs/9699919799/functions/_Exit.html
    
    With glibc-2.19, kill12 is broken due to the its emulation.
    It may or may not success depending on which, SIGCHLD from parent or
    child nanosleep, is earlier.
    If SIGCHLD is earlyer, it success.
    If child nanosleep is earlier, it hangs.
    With the following changeset, glibc is updated so that the issue
    doesn't exit.
    
    Related:
    glibc patch
    > commit 8c873bf0190740ac1102e13ff7aeb6c08048abfd
    >    Remove signal handling for nanosleep (bug 16364)
    >
    >    Linux 2.6.32 and forward do not show the issue regarding SysV SIGCHLD
    >    vs. SIG_IGN for nanosleep which make it feasible to use it for sleep
    >    implementation without requiring any hacking to handle the spurious
    >    wake up.  The issue is likely being fixed before 2.6 and git
    >    history [1] [2].
    >
    >    This patch simplifies the sleep code to call nanosleep directly by
    >    using the posix default version.  It also removes the early cancellation
    >    tests for zero argument, since nanosleep will handle cancellation
    >    in this case.
    >
    >    [1] https://lkml.org/lkml/2004/11/25/5
    >    [2] https://lkml.org/lkml/2003/11/8/50
    >
    >    Checked on x86_64, ppc64le, and aarch64.
    >
    >    [BZ #16364]
    >    * sysdeps/unix/sysv/linux/sleep.c: Remove file
    >    * sysdeps/posix/sleep.c (__sleep): Simplify cancellation handling.
    
    Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>


## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/869)
<!-- Reviewable:end -->
