### PR TITLE
[PAL] Skip the trailing whitespaces in the manifest files

### DIFF
--- a/Pal/lib/graphene/config.c
+++ b/Pal/lib/graphene/config.c
@@ -339,8 +339,11 @@ int read_config (struct config_store * store,
             vlen = (ptr - shift) - val;
         } else {
             val = ptr;
-            for ( ; RANGE && !IS_SKIP(ptr) ; ptr++);
-            vlen = ptr - val;
+            char* last = ptr - 1;
+            for ( ; RANGE && !IS_SKIP(ptr) ; ptr++)
+                if (!IS_SPACE(*ptr)) // Skip the trailing whitespaces
+                    last = ptr;
+            vlen = last + 1 - val;
         }
         ptr++;
 


### PR DESCRIPTION
<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [x] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->

Stripping the trailing whitespaces in manifest files. A few examples:

```
loader.debug_type = inline # none
loader.debug_type = inline <newline>
loader.debug_type = inline<tab>
``` 


## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/875)
<!-- Reviewable:end -->
