### PR TITLE
[Jenkins/Pal] Fix test_000_symbols test on debug SGX pipepine

### DIFF
--- a/Pal/regression/test_pal.py
+++ b/Pal/regression/test_pal.py
@@ -198,7 +198,7 @@ class TC_02_Symbols(RegressionTestCase):
     def test_000_symbols(self):
         stdout, stderr = self.run_binary(['Symbols'])
         found_symbols = dict(line.split(' = ')
-            for line in stderr.strip().split('\n'))
+            for line in stderr.strip().split('\n') if line.startswith('Dk'))
         self.assertCountEqual(found_symbols, self.ALL_SYMBOLS)
         for k, v in found_symbols.items():
             v = ast.literal_eval(v)


### PR DESCRIPTION
Previously, test_000_symbols PAL regression test compared all lines in
stderr against a list of expected values (prefixed with "Dk...").
However, SGX PAL in debug mode outputs additional SGX-related
information in stderr which broke the test. This commit fixes this by
checking only lines which start with "Dk...".

<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [x] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->


## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/876)
<!-- Reviewable:end -->
