### PR TITLE
[LibOS] replace suspicious && with &

### DIFF
--- a/LibOS/shim/src/fs/str/fs.c
+++ b/LibOS/shim/src/fs/str/fs.c
@@ -76,7 +76,7 @@ int str_dput (struct shim_dentry * dent)
 
 int str_close (struct shim_handle * hdl)
 {
-    if (hdl->flags && (O_WRONLY|O_RDWR)) {
+    if (hdl->flags & (O_WRONLY|O_RDWR)) {
         int ret = str_flush(hdl);
 
         if (ret < 0)
@@ -91,7 +91,7 @@ ssize_t str_read (struct shim_handle * hdl, void * buf, size_t count)
 {
     ssize_t ret = 0;
 
-    if (!(hdl->acc_mode && MAY_READ)) {
+    if (!(hdl->acc_mode & MAY_READ)) {
         ret = -EACCES;
         goto out;
     }
@@ -134,7 +134,7 @@ out:
 
 ssize_t str_write (struct shim_handle * hdl, const void * buf, size_t count)
 {
-    if (!(hdl->acc_mode && MAY_WRITE))
+    if (!(hdl->acc_mode & MAY_WRITE))
         return -EACCES;
 
     struct shim_str_handle * strhdl = &hdl->info.str;


### PR DESCRIPTION
fs/str/fs.c has suspicious && which seems to be & for bit operation.
Replace && with &.
This was found by code inspection. Not by any test.
So someone testing strfs, please test it.

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->


## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/877)
<!-- Reviewable:end -->
