### PR TITLE
[Pal/{Linux, Linux-SGX}] remove unused dev_attrcopy()

### DIFF
--- a/Pal/src/host/Linux-SGX/db_devices.c
+++ b/Pal/src/host/Linux-SGX/db_devices.c
@@ -83,9 +83,6 @@ static int parse_device_uri(const char ** uri, char ** type, struct handle_ops *
     return 0;
 }
 
-static inline void
-dev_attrcopy (PAL_STREAM_ATTR * attr, struct stat * stat);
-
 static int64_t char_read (PAL_HANDLE handle, uint64_t offset, uint64_t count,
                           void * buffer);
 static int64_t char_write (PAL_HANDLE handle, uint64_t offset, uint64_t count,
@@ -352,17 +349,6 @@ static int dev_flush (PAL_HANDLE handle)
     }
 
     return 0;
-}
-
-static inline void
-dev_attrcopy (PAL_STREAM_ATTR * attr, struct stat * stat)
-{
-    attr->handle_type = pal_type_dev;
-    /* readable, writable and runnable are decied by euidstataccess */
-    attr->readable = stataccess(stat, ACCESS_R);
-    attr->writable = stataccess(stat, ACCESS_W);
-    attr->runnable = stataccess(stat, ACCESS_X);
-    attr->pending_size = stat->st_size;
 }
 
 /* 'attrquery' operation for device streams */

--- a/Pal/src/host/Linux/db_devices.c
+++ b/Pal/src/host/Linux/db_devices.c
@@ -83,8 +83,6 @@ static int parse_device_uri(const char** uri, char** type, struct handle_ops** o
     return 0;
 }
 
-static inline void dev_attrcopy(PAL_STREAM_ATTR* attr, struct stat* stat);
-
 static int64_t char_read(PAL_HANDLE handle, uint64_t offset, uint64_t count, void* buffer);
 static int64_t char_write(PAL_HANDLE handle, uint64_t offset, uint64_t count, const void* buffer);
 static int term_attrquery(const char* type, const char* uri, PAL_STREAM_ATTR* attr);
@@ -357,15 +355,6 @@ static int dev_flush(PAL_HANDLE handle) {
     }
 
     return 0;
-}
-
-static inline void dev_attrcopy(PAL_STREAM_ATTR* attr, struct stat* stat) {
-    attr->handle_type = pal_type_dev;
-    /* readable, writable and runnable are decied by euidstataccess */
-    attr->readable     = stataccess(stat, ACCESS_R);
-    attr->writable     = stataccess(stat, ACCESS_W);
-    attr->runnable     = stataccess(stat, ACCESS_X);
-    attr->pending_size = stat->st_size;
 }
 
 /* 'attrquery' operation for device streams */


### PR DESCRIPTION
The static function, dev_attrcopy() in db_devices.c is unused.
remove it.

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [x] Linux PAL
- [x] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->


## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/878)
<!-- Reviewable:end -->
