### PR TITLE
[LibOS/tests,Pal/Linux-SGX] Enable large_dir_read regression test, bugfix subdir check

### DIFF
--- a/LibOS/shim/test/regression/manifest.template
+++ b/LibOS/shim/test/regression/manifest.template
@@ -36,4 +36,3 @@ sgx.trusted_files.victim = file:exec_victim
 sgx.trusted_children.victim = file:exec_victim.sig
 
 sgx.allowed_files.tmp_dir = file:tmp/
-sgx.allowed_files.tmp_longname_file = file:tmp/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa

--- a/LibOS/shim/test/regression/test_libos.py
+++ b/LibOS/shim/test/regression/test_libos.py
@@ -164,6 +164,11 @@ class TC_30_Syscall(RegressionTestCase):
         self.assertIn('getdents64: file2 [0x8]', stdout)
         self.assertIn('getdents64: dir3 [0x4]', stdout)
 
+    def test_021_getdents_large_dir(self):
+        stdout, stderr = self.run_binary(['large_dir_read', 'tmp/large_dir', '3000'])
+
+        self.assertIn('Success!', stdout)
+
     def test_030_fopen(self):
         stdout, stderr = self.run_binary(['fopen_cornercases'])
 


### PR DESCRIPTION
<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [x] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->
Enables (already present) large directory read regression test (LibOS)
Fixes a bug that forbade to open files even though parent directory was in sgx.allowed_files in manifest (Pal/Linux-SGX)

## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/884)
<!-- Reviewable:end -->
