### PR TITLE
[LibOS/vDSO] eliminate relocation

### DIFF
--- a/LibOS/shim/src/Makefile
+++ b/LibOS/shim/src/Makefile
@@ -128,7 +128,20 @@ LDFLAGS-vdso/vdso.so.dbg = -nostdlib -shared \
 	-z max-page-size=4096 -z common-page-size=4096 \
 	-T vdso/vdso.lds -soname linux-vdso.so.1
 vdso/vdso.so.dbg: LDFLAGS =
-vdso/vdso.so.dbg: vdso/vdso.lds vdso/vdso.o vdso/vdso-note.o
+vdso/vdso.so.dbg: vdso/vdso.lds vdso/vdso.o vdso/vdso-note.o | vdso-check-no-reloc
+	$(call cmd,ld)
+
+#
+# vdso.so is required to have no relocations.
+# this rule checks it.
+#
+vdso-check-no-reloc: vdso/.vdso.so
+	$(call cmd,check_no_reloc)
+
+# use default linker script to retain relocations if exist.
+LDFLAGS-vdso/.vdso.so = -nostdlib -shared -Bsymbolic
+vdso/.vdso.so: LDFLAGS =
+vdso/.vdso.so: vdso/vdso.o
 	$(call cmd,ld)
 
 OBJCOPYFLAGS-vdso/vdso.so = -S
@@ -136,7 +149,7 @@ vdso/vdso.so: vdso/vdso.so.dbg
 	$(call cmd,objcopy)
 
 vdso/vdso-data.o: vdso/vdso.so
-CLEAN_FILES += vdso/vdso.so.dbg vdso/vdso.so
+CLEAN_FILES += vdso/vdso.so.dbg vdso/vdso.so vdso/.vdso.so
 
 clean:
 	rm -rf $(addsuffix .o,$(objs)) $(shim_target) $(files_to_build) .lib $(CLEAN_FILES)

--- a/LibOS/shim/src/vdso/.gitignore
+++ b/LibOS/shim/src/vdso/.gitignore
@@ -1,2 +1,3 @@
+/.vdso.so
 /vdso-data.c
 /vdso.so.dbg

--- a/LibOS/shim/src/vdso/vdso.c
+++ b/LibOS/shim/src/vdso/vdso.c
@@ -21,43 +21,54 @@
 
 #include <shim_types.h>
 
-int (*__vdso_shim_clock_gettime)(clockid_t clock, struct timespec *t) = NULL;
-int (*__vdso_shim_gettimeofday)(struct timeval *tv, struct timezone *tz) = NULL;
-time_t (*__vdso_shim_time)(time_t *t) = NULL;
-long (*__vdso_shim_getcpu)(unsigned *cpu, struct getcpu_cache *unused) = NULL;
+/*
+ * The symbols below need to be exported for libsysdb to inject those values,
+ * but relocation (.rela.dyn section) isn't wanted in the code generation.
+ */
+#define EXPORT_SYMBOL(name) \
+    extern __typeof__(name) __vdso_ ## name __attribute__((alias(#name)))
 
+static int (*shim_clock_gettime)(clockid_t clock, struct timespec *t) = NULL;
+static int (*shim_gettimeofday)(struct timeval *tv, struct timezone *tz) = NULL;
+static time_t (*shim_time)(time_t *t) = NULL;
+static long (*shim_getcpu)(unsigned *cpu, struct getcpu_cache *unused) = NULL;
+
+EXPORT_SYMBOL(shim_clock_gettime);
+EXPORT_SYMBOL(shim_gettimeofday);
+EXPORT_SYMBOL(shim_time);
+EXPORT_SYMBOL(shim_getcpu);
+
+#define EXPORT_WEAK_SYMBOL(name) \
+    __typeof__(__vdso_ ## name) name __attribute__((weak, alias("__vdso_" #name)))
 
 int __vdso_clock_gettime(clockid_t clock, struct timespec *t)
 {
-    if (__vdso_shim_clock_gettime)
-        return (*__vdso_shim_clock_gettime)(clock, t);
+    if (shim_clock_gettime)
+        return (*shim_clock_gettime)(clock, t);
     return -ENOSYS;
 }
-int clock_gettime(clockid_t clock, struct timespec *t)
-    __attribute__((weak, alias("__vdso_clock_gettime")));
+EXPORT_WEAK_SYMBOL(clock_gettime);
 
 int __vdso_gettimeofday(struct timeval *tv, struct timezone *tz)
 {
-    if (__vdso_shim_gettimeofday)
-        return (*__vdso_shim_gettimeofday)(tv, tz);
+    if (shim_gettimeofday)
+        return (*shim_gettimeofday)(tv, tz);
     return -ENOSYS;
 }
-int gettimeofday(struct timeval *tv, struct timezone *tz)
-    __attribute__((weak, alias("__vdso_gettimeofday")));
+EXPORT_WEAK_SYMBOL(gettimeofday);
 
 time_t __vdso_time(time_t *t)
 {
-    if (__vdso_shim_time)
-        return (*__vdso_shim_time)(t);
+    if (shim_time)
+        return (*shim_time)(t);
     return -ENOSYS;
 }
-time_t time(time_t *t) __attribute__((weak, alias("__vdso_time")));
+EXPORT_WEAK_SYMBOL(time);
 
 long __vdso_getcpu(unsigned *cpu, struct getcpu_cache *unused)
 {
-    if (__vdso_shim_getcpu)
-        return (*__vdso_shim_getcpu)(cpu, unused);
+    if (shim_getcpu)
+        return (*shim_getcpu)(cpu, unused);
     return -ENOSYS;
 }
-long getcpu(unsigned *cpu, struct getcpu_cache *unused)
-    __attribute__((weak, alias("__vdso_getcpu")));
+EXPORT_WEAK_SYMBOL(getcpu);

--- a/Makefile.rules
+++ b/Makefile.rules
@@ -109,3 +109,8 @@ quiet_cmd_ld = [ $@ ]
 # OBJCOPY
 quiet_cmd_objcopy = [ $@ ]
       cmd_objcopy = $(OBJCOPY) $(OBJCOPYFLAGS) $(OBJCOPYFLAGS-$@) $< $@
+
+# check_no_reloc
+# This depends on the output of readelf command.
+quiet_cmd_check_no_reloc = [ $@ ]
+      cmd_check_no_reloc = readelf -r $^ | grep -q 'There are no relocations in this file.'


### PR DESCRIPTION
segv in vDSO because relocation isn't applied when vDSO is mapped.
In fact relocation in the code isn't necessary.
So suppress relocation by the use of GOT entry with static symbol.
plus minor code clean up.

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->


## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/885)
<!-- Reviewable:end -->
