### PR TITLE
[LibOS] parser: teach parse_clone_flags() clone signal number

### DIFF
--- a/LibOS/shim/src/shim_parser.c
+++ b/LibOS/shim/src/shim_parser.c
@@ -657,6 +657,16 @@ static void parse_clone_flags (va_list ap)
             flags &= ~all_flags[i].flag;
         }
 
+#define CLONE_SIGNAL_MASK 0xff
+    int exit_signal = flags & CLONE_SIGNAL_MASK;
+    flags &= ~CLONE_SIGNAL_MASK;
+    if (exit_signal) {
+        if (exit_signal >= 0 && exit_signal <= NUM_KNOWN_SIGS)
+            PRINTF("|%s", signal_name(exit_signal));
+        else
+            PRINTF("|[SIG %d]", exit_signal);
+    }
+
     if (flags)
         PRINTF("|0x%x", flags);
 }


### PR DESCRIPTION
show exit signal number for clone as symbol.

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->


## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/887)
<!-- Reviewable:end -->
