### PR TITLE
[LibOS] regression/getsockopt return 0 on success.

### DIFF
--- a/LibOS/shim/test/regression/getsockopt.c
+++ b/LibOS/shim/test/regression/getsockopt.c
@@ -14,7 +14,7 @@ int main(int argc,char **argv) {
   int s = -1;                /* Socket */
   int so_type = -1;    /* Socket type */
   socklen_t optlen;  /* Option length */
-  int rv;
+  int rv = 0;
 
   /*
    * Create a TCP/IP socket to use:


### PR DESCRIPTION
rv is uninitialized. initialize it to 0.

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->


## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/888)
<!-- Reviewable:end -->
