### PR TITLE
[Pal/Linux-SGX] get_sockopt() initialize opt with constant

### DIFF
--- a/Pal/src/host/Linux-SGX/sgx_enclave.c
+++ b/Pal/src/host/Linux-SGX/sgx_enclave.c
@@ -274,6 +274,9 @@ static int sock_getopt(int fd, struct sockopt * opt)
 {
     SGX_DBG(DBG_M, "sock_getopt (fd = %d, sockopt addr = %p) is not implemented \
             always returns 0\n", fd, opt);
+    /* initialize *opt with constant */
+    *opt = (struct sockopt){0};
+    opt->reuseaddr = 1;
     return 0;
 }
 


### PR DESCRIPTION
get_sockopt() is expected to initialize it.
For now initialize it with constants to avoid uninitialized value.

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [x] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->


## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/890)
<!-- Reviewable:end -->
