### PR TITLE
[PAL] Fix initialization of variables sock_options in db_sockets.c

### DIFF
--- a/Pal/src/host/Linux-SGX/db_sockets.c
+++ b/Pal/src/host/Linux-SGX/db_sockets.c
@@ -351,6 +351,10 @@ static int tcp_listen (PAL_HANDLE * handle, char * uri, int options)
 #endif
 
     struct sockopt sock_options;
+
+    memset(&sock_options, 0, sizeof(sock_options));
+    sock_options.reuseaddr = 1;  /* sockets are always set as reusable in Graphene */
+
     ret = ocall_sock_listen(bind_addr->sa_family,
                             sock_type(SOCK_STREAM, options), 0,
                             bind_addr, &bind_addrlen,
@@ -386,6 +390,10 @@ static int tcp_accept (PAL_HANDLE handle, PAL_HANDLE * client)
     int ret = 0;
 
     struct sockopt sock_options;
+
+    memset(&sock_options, 0, sizeof(sock_options));
+    sock_options.reuseaddr = 1;  /* sockets are always set as reusable in Graphene */
+
     ret = ocall_sock_accept(handle->sock.fd, &dest_addr, &dest_addrlen,
                             &sock_options);
     if (IS_ERR(ret))
@@ -433,6 +441,10 @@ static int tcp_connect (PAL_HANDLE * handle, char * uri, int options)
 
 
     struct sockopt sock_options;
+
+    memset(&sock_options, 0, sizeof(sock_options));
+    sock_options.reuseaddr = 1;  /* sockets are always set as reusable in Graphene */
+
     ret = ocall_sock_connect(dest_addr->sa_family,
                              sock_type(SOCK_STREAM, options), 0,
                              dest_addr, dest_addrlen,
@@ -562,6 +574,10 @@ static int udp_bind (PAL_HANDLE * handle, char * uri, int options)
 #endif
 
     struct sockopt sock_options;
+
+    memset(&sock_options, 0, sizeof(sock_options));
+    sock_options.reuseaddr = 1;  /* sockets are always set as reusable in Graphene */
+
     ret = ocall_sock_listen(bind_addr->sa_family,
                             sock_type(SOCK_DGRAM, options), 0,
                             bind_addr, &bind_addrlen, &sock_options);
@@ -600,6 +616,10 @@ static int udp_connect (PAL_HANDLE * handle, char * uri, int options)
 #endif
 
     struct sockopt sock_options;
+
+    memset(&sock_options, 0, sizeof(sock_options));
+    sock_options.reuseaddr = 1;  /* sockets are always set as reusable in Graphene */
+
     ret = ocall_sock_connect(dest_addr ? dest_addr->sa_family : AF_INET,
                              sock_type(SOCK_DGRAM, options), 0,
                              dest_addr, dest_addrlen,


### PR DESCRIPTION
(This is a re-submission of #776 which I broke due to incorrect push to the remote repo. This is already rebased to latest master and must be merged.)

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [x] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->

Fixes (only partially) #674: Initializing variable `sock_options `to all zero, except `sock_options.reuseaddr`, which is initialized to 1. This for `tcp_connect`, `tcp_listen`, and `tcp_accept`, `udp_bind`, and `udp_connect `in `Pal/src/host/Linux-SGX/db_sockets.c`

## How to test this PR? <!-- (if applicable) -->

All tests must run.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/892)
<!-- Reviewable:end -->
