### PR TITLE
libos execve memory leak

### DIFF
--- a/LibOS/shim/include/shim_thread.h
+++ b/LibOS/shim/include/shim_thread.h
@@ -350,6 +350,6 @@ bool check_on_stack (struct shim_thread * cur_thread, void * mem)
 
 int init_stack (const char ** argv, const char ** envp,
                 int ** argcpp, const char *** argpp,
-                elf_auxv_t ** auxpp);
+                elf_auxv_t ** auxpp, size_t reserve);
 
 #endif /* _SHIM_THREAD_H_ */

--- a/LibOS/shim/src/shim_init.c
+++ b/LibOS/shim/src/shim_init.c
@@ -358,7 +358,7 @@ copy_envp:
 
 int init_stack (const char ** argv, const char ** envp,
                 int ** argcpp, const char *** argpp,
-                elf_auxv_t ** auxpp)
+                elf_auxv_t ** auxpp, size_t reserve)
 {
     uint64_t stack_size = get_rlimit_cur(RLIMIT_STACK);
 
@@ -382,7 +382,8 @@ int init_stack (const char ** argv, const char ** envp,
     if (initial_envp)
         envp = initial_envp;
 
-    int ret = populate_user_stack(stack, stack_size, auxpp, argcpp, &argv, &envp);
+    int ret = populate_user_stack(stack, stack_size - reserve,
+                                  auxpp, argcpp, &argv, &envp);
     if (ret < 0)
         return ret;
 
@@ -755,7 +756,7 @@ noreturn void* shim_init (int argc, void * args)
     RUN_INIT(init_mount);
     RUN_INIT(init_important_handles);
     RUN_INIT(init_async);
-    RUN_INIT(init_stack, argv, envp, &argcp, &argp, &auxp);
+    RUN_INIT(init_stack, argv, envp, &argcp, &argp, &auxp, 0);
     RUN_INIT(init_loader);
     RUN_INIT(init_ipc_helper);
     RUN_INIT(init_signal);

--- a/LibOS/shim/src/sys/shim_exec.c
+++ b/LibOS/shim/src/sys/shim_exec.c
@@ -194,8 +194,6 @@ static int shim_do_execve_rtld (struct shim_handle * hdl, const char ** argv,
         return -ENOMEM;
 
     populate_tls(tcb, false);
-    __disable_preempt(&((__libc_tcb_t *) tcb)->shim_tcb); // Temporarily disable preemption
-                                                          // during execve().
     debug("set tcb to %p\n", tcb);
 
     put_handle(cur_thread->exec);
@@ -219,6 +217,8 @@ static int shim_do_execve_rtld (struct shim_handle * hdl, const char ** argv,
     if ((ret = init_stack(argv, envp, &new_argcp, &new_argp, &new_auxp)) < 0)
         return ret;
 
+    __disable_preempt(shim_get_tls()); // Temporarily disable preemption
+                                       // during execve().
     SAVE_PROFILE_INTERVAL(alloc_new_stack_for_exec);
 
     struct execve_rtld_arg arg = {


### PR DESCRIPTION
<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->
__libcc_tcb_t is leaked. It should allocated from stack.
Fixes #897.


## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/898)
<!-- Reviewable:end -->
