### PR TITLE
[LibOS, Pal] add .file directive to .S file to make debug easier

### DIFF
--- a/LibOS/shim/src/start.S
+++ b/LibOS/shim/src/start.S
@@ -16,6 +16,7 @@
    ...
    NULL
  */
+    .file "start.S"
     .text
     .globl shim_start
     .type shim_start,@function

--- a/LibOS/shim/src/syscallas.S
+++ b/LibOS/shim/src/syscallas.S
@@ -24,6 +24,7 @@
 
 #include "asm-offsets.h"
 
+        .file "syscallas.S"
         .global syscalldb
         .type syscalldb, @function
         .extern shim_table, debug_unsupp

--- a/LibOS/shim/src/vdso/vdso-data.S
+++ b/LibOS/shim/src/vdso/vdso-data.S
@@ -1,3 +1,4 @@
+	.file "vdso-data.S"
 	.section .rodata
 
 	.global vdso_so

--- a/LibOS/shim/src/vdso/vdso-note.S
+++ b/LibOS/shim/src/vdso/vdso-note.S
@@ -1,3 +1,4 @@
+	.file "vdso-note.S"
 	/* This .note section informs dynamic linker about vDSO */
 	.section .note.Linux, "a", @note
 

--- a/Pal/src/host/Linux-SGX/enclave_entry.S
+++ b/Pal/src/host/Linux-SGX/enclave_entry.S
@@ -1,6 +1,8 @@
 #include "sgx_arch.h"
 #include "asm-offsets.h"
 
+	.file "enclave_entry.S"
+
 # In some cases, like bogus parameters passed to enclave_entry, it's tricky to
 # return cleanly (passing the correct return address to EEXIT, OCALL_EXIT can
 # be interrupted, etc.). Since those cases should only ever happen with a

--- a/Pal/src/host/Linux-SGX/sgx_entry.S
+++ b/Pal/src/host/Linux-SGX/sgx_entry.S
@@ -3,6 +3,8 @@
 
 #include "asm-offsets.h"
 
+	.file "sgx_entry.S"
+
 	.extern tcs_base
 
 	.global sgx_ecall

--- a/Pal/src/host/Linux/clone-x86_64.S
+++ b/Pal/src/host/Linux/clone-x86_64.S
@@ -30,6 +30,8 @@
 
 #include "sysdep-x86_64.h"
 
+	.file "clone-x86_64.S"
+
 #define CLONE_VM	0x00000100
 #define CLONE_THREAD	0x00010000
 

--- a/Pal/src/host/Linux/gettimeofday-x86_64.S
+++ b/Pal/src/host/Linux/gettimeofday-x86_64.S
@@ -26,6 +26,8 @@
 
 #include "sysdep-x86_64.h"
 
+	.file "gettimeofday-x86_64.S"
+
 /* For the calculation see asm/vsyscall.h.  */
 #define VSYSCALL_ADDR_vgettimeofday	0xffffffffff600000
 

--- a/Pal/src/user_start.S
+++ b/Pal/src/user_start.S
@@ -17,6 +17,7 @@
 						NULL
 */
 
+	.file "user_start.S"
 	.text
 	.globl _start
 	.type _start,@function


### PR DESCRIPTION
gas includes dwarf info about compilation unit into .o compiled
from .S. Hoever, without .file directive, gnu linker drops dwarf
compilation unit info about .S. from .so (libpal.so libsysdb.so).
As result gdb fails to open .S when debugging .S file.
Add .file directive to .S files to make debug .S easier.

My ld version is
> $ ld --version
> GNU ld (GNU Binutils for Ubuntu) 2.30

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [x] Linux PAL
- [x] SGX PAL
- [ ] FreeBSD PAL
- [x] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->


## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/899)
<!-- Reviewable:end -->
