### PR TITLE
[Pal/Linux-SGX] fix argument for ocall_load_debug()

### DIFF
--- a/Pal/src/host/Linux-SGX/db_rtld.c
+++ b/Pal/src/host/Linux-SGX/db_rtld.c
@@ -158,8 +158,8 @@ void setup_pal_map (struct link_map * pal_map)
 
     char buffer[BUFFER_LENGTH];
     snprintf(buffer, BUFFER_LENGTH,
-             "add-symbol-file %s 0x%p -readnow -s .rodata 0x%p "
-             "-s .dynamic 0x%p -s .data 0x%p -s .bss 0x%p",
+             "add-symbol-file %s %p -readnow -s .rodata %p "
+             "-s .dynamic %p -s .data %p -s .bss %p",
              pal_map->l_name,
              &section_text, &section_rodata, &section_dynamic,
              &section_data, &section_bss);


### PR DESCRIPTION
the loading address should be %p instead of 0x%p which results in
something like 0x0xabcdefg (double leading "0x").
then gdb fails to parse it.
remove redundant 0x so that gdb can parse it.

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [x] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->


## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/900)
<!-- Reviewable:end -->
