### PR TITLE
Force -no-pie when building PAL tests

### DIFF
--- a/Pal/regression/Makefile
+++ b/Pal/regression/Makefile
@@ -1,7 +1,7 @@
 include ../src/Makefile.Host
 
 CC	= gcc
-CFLAGS	= -Wall -O2 -std=c11 -fno-builtin -nostdlib -mavx \
+CFLAGS	= -Wall -O2 -std=c11 -fno-builtin -nostdlib -mavx -no-pie \
 	  -I../include/pal -I../lib
 
 preloads    = $(patsubst %.c,%,$(wildcard *.so.c))
@@ -53,7 +53,7 @@ ifeq ($(findstring x86_64,$(SYS))$(findstring linux,$(SYS)),x86_64linux)
 $(preloads): %.so: %.so.c ../src/user_shared_start.o \
 	$(graphene_lib) $(pal_lib) ../include/pal/pal.h
 	@echo [ $@ ]
-	@$(CC) -shared -fPIC $(CFLAGS) $^ -o $@
+	@$(CC) -shared -fPIC $(filter-out -no-pie,$(CFLAGS)) $^ -o $@
 
 $(executables): %: %.c ../src/user_start.o \
 	$(graphene_lib) $(pal_lib) $(preloads) ../include/pal/pal.h

--- a/Pal/test/Makefile
+++ b/Pal/test/Makefile
@@ -1,7 +1,7 @@
 include ../src/Makefile.Host
 
 CC	= gcc
-CFLAGS	= -Wall -O2 -std=c11 -fno-builtin -nostdlib \
+CFLAGS	= -Wall -O2 -std=c11 -fno-builtin -nostdlib -no-pie \
 	  -I../include/pal -I../lib
 
 .PHONY: default


### PR DESCRIPTION
<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [x] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->

The PAL loader cannot relocate the executables. As a result, a position-independent executable (per the default GCC setting on Ubuntu 18.04) will crash if no other loader (e.g., the GLIBC loader) is involved. Since the PAL tests are only for internal testing purposes, we don't have to add relocation to the PAL loader but to make these tests position-dependent (adding `-no-pie` to CFLAGS).


## How to test this PR? <!-- (if applicable) -->

Run the whole regression test under 18.04 or 16.04.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/901)
<!-- Reviewable:end -->
