### PR TITLE
[Makefile] Don't depend on locale settings when parsing readelf

### DIFF
--- a/Makefile.rules
+++ b/Makefile.rules
@@ -113,4 +113,4 @@ quiet_cmd_objcopy = [ $@ ]
 # check_no_reloc
 # This depends on the output of readelf command.
 quiet_cmd_check_no_reloc = [ $@ ]
-      cmd_check_no_reloc = readelf -r $^ | grep -q 'There are no relocations in this file.'
+      cmd_check_no_reloc = LC_ALL=C readelf -r $^ | grep -q 'There are no relocations in this file.'


### PR DESCRIPTION
<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [x] README and global configuration
- [ ] Linux PAL
- [x] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->

Don't depend on locale settings when parsing readelfs output.

## How to test this PR? <!-- (if applicable) -->

Test with a non English locale and see that the "no reloc" check still works.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/902)
<!-- Reviewable:end -->
