### PR TITLE
[PAL] Fix assertion on DF_SYMBOLIC

### DIFF
--- a/Pal/src/dynamic_link.h
+++ b/Pal/src/dynamic_link.h
@@ -156,7 +156,7 @@ elf_get_dynamic_info (ElfW(Dyn) *dyn, ElfW(Dyn) **l_info, ElfW(Addr) l_addr)
     assert (!l_info[VERSYMIDX (DT_FLAGS_1)]
             || l_info[VERSYMIDX (DT_FLAGS_1)]->d_un.d_val == DF_1_NOW);
     assert (!l_info[DT_FLAGS]
-            || l_info[DT_FLAGS]->d_un.d_val == DF_BIND_NOW);
+            || (l_info[DT_FLAGS]->d_un.d_val & ~DF_SYMBOLIC) == DF_BIND_NOW);
     /* Flags must not be set for ld.so.  */
     assert (!l_info[DT_RUNPATH]);
     assert (!l_info[DT_RPATH]);


### PR DESCRIPTION
The legacy use of DT_SYMBOLIC has been superseded by the DF_SYMBOLIC flag.
Thus, a newer gcc compiler (e.g, 7.4.0) may use a DT_FLAGS entry with
DF_SYMBOLIC flag to relfect using -Bsymbolic. This behavior should be
allowed.

Signed-off-by: Jia Zhang <zhang.jia@linux.alibaba.com>

<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [x] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->


## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/904)
<!-- Reviewable:end -->
