### PR TITLE
[Pal/Linux-SGX] Fix incorrect "0x%p" format string for GDB plugin

### DIFF
--- a/Pal/src/host/Linux-SGX/db_rtld.c
+++ b/Pal/src/host/Linux-SGX/db_rtld.c
@@ -158,8 +158,8 @@ void setup_pal_map (struct link_map * pal_map)
 
     char buffer[BUFFER_LENGTH];
     snprintf(buffer, BUFFER_LENGTH,
-             "add-symbol-file %s 0x%p -readnow -s .rodata 0x%p "
-             "-s .dynamic 0x%p -s .data 0x%p -s .bss 0x%p",
+             "add-symbol-file %s %p -readnow -s .rodata %p "
+             "-s .dynamic %p -s .data %p -s .bss %p",
              pal_map->l_name,
              &section_text, &section_rodata, &section_dynamic,
              &section_data, &section_bss);


### PR DESCRIPTION
## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [x] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->

Previously, setup_pal_map() instructed GDB to load symbols for the PAL shared library using incorrectly formatted string with "0x%p". This led to addresses of the form "0x0xdeadbeef" which could not be parsed by GDB. This commit fixes this via "%p" and thus enables SGX-GDB again.

## How to test this PR? <!-- (if applicable) -->

Run any executable with SGX-GDB (e.g. `GDB=1 SGX=1 ./pal_loader helloworld`)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/906)
<!-- Reviewable:end -->
