### PR TITLE
[LibOS] Remove `opened` reference counter from `struct shim_handle`

### DIFF
--- a/LibOS/shim/include/shim_handle.h
+++ b/LibOS/shim/include/shim_handle.h
@@ -374,15 +374,12 @@ struct shim_handle {
     int                 flags;
     int                 acc_mode;
     IDTYPE              owner;
-    REFTYPE             opened;
     struct shim_lock    lock;
 };
 
 /* allocating / manage handle */
 struct shim_handle * get_new_handle (void);
 void flush_handle (struct shim_handle * hdl);
-void open_handle (struct shim_handle * hdl);
-void close_handle (struct shim_handle * hdl);
 void get_handle (struct shim_handle * hdl);
 void put_handle (struct shim_handle * hdl);
 

--- a/LibOS/shim/src/shim_checkpoint.c
+++ b/LibOS/shim/src/shim_checkpoint.c
@@ -744,7 +744,7 @@ int restore_from_file (const char * filename, struct newproc_cp_header * hdr,
     }
 
     struct shim_mount * fs = file->fs;
-    open_handle(file);
+    get_handle(file);
     debug("restore %s\n", filename);
 
     struct cp_header cphdr;
@@ -764,7 +764,7 @@ int restore_from_file (const char * filename, struct newproc_cp_header * hdr,
     migrated_memory_start = cpaddr;
     migrated_memory_end = cpaddr + hdr->hdr.size;
 out:
-    close_handle(file);
+    put_handle(file);
     return ret;
 }
 

--- a/LibOS/shim/src/sys/shim_dup.c
+++ b/LibOS/shim/src/sys/shim_dup.c
@@ -57,7 +57,7 @@ int shim_do_dup2 (int oldfd, int newfd)
     struct shim_handle * new_hdl = detach_fd_handle(newfd, NULL, handle_map);
 
     if (new_hdl)
-        close_handle(new_hdl);
+        put_handle(new_hdl);
 
     int vfd = set_new_fd_handle_by_fd(newfd, hdl, 0, handle_map);
     put_handle(hdl);
@@ -74,7 +74,7 @@ int shim_do_dup3 (int oldfd, int newfd, int flags)
     struct shim_handle * new_hdl = detach_fd_handle(newfd, NULL, handle_map);
 
     if (new_hdl)
-        close_handle(new_hdl);
+        put_handle(new_hdl);
 
     int vfd = set_new_fd_handle_by_fd(newfd, hdl, flags, handle_map);
     put_handle(hdl);

--- a/LibOS/shim/src/sys/shim_exec.c
+++ b/LibOS/shim/src/sys/shim_exec.c
@@ -43,7 +43,7 @@ static int close_on_exec (struct shim_fd_handle * fd_hdl,
 {
     if (fd_hdl->flags & FD_CLOEXEC) {
         struct shim_handle * hdl = __detach_fd_handle(fd_hdl, NULL, map);
-        close_handle(hdl);
+        put_handle(hdl);
     }
     return 0;
 }

--- a/LibOS/shim/src/sys/shim_fs.c
+++ b/LibOS/shim/src/sys/shim_fs.c
@@ -616,8 +616,6 @@ static int do_rename (struct shim_dentry * old_dent,
     }
 
     struct shim_handle * old_hdl = NULL, * new_hdl = NULL;
-    bool old_opened = false;
-    bool new_opened = false;
 
     if (!(old_hdl = get_new_handle())) {
         ret = -ENOMEM;
@@ -627,8 +625,6 @@ static int do_rename (struct shim_dentry * old_dent,
     if ((ret = dentry_open(old_hdl, old_dent, O_RDONLY)) < 0)
         goto out_hdl;
 
-    old_opened = true;
-
     if (!(new_hdl = get_new_handle())) {
         ret = -ENOMEM;
         goto out_hdl;
@@ -637,7 +633,6 @@ static int do_rename (struct shim_dentry * old_dent,
     if ((ret = dentry_open(new_hdl, new_dent, O_WRONLY|O_CREAT)) < 0)
         goto out_hdl;
 
-    new_opened = true;
     off_t old_offset = 0, new_offset = 0;
 
     if ((ret = handle_copy(old_hdl, &old_offset,
@@ -664,15 +659,9 @@ static int do_rename (struct shim_dentry * old_dent,
 
 out_hdl:
     if (old_hdl) {
-        if (old_opened)
-            close_handle(old_hdl);
-        else
             put_handle(old_hdl);
     }
     if (new_hdl) {
-        if (new_opened)
-            close_handle(new_hdl);
-        else
             put_handle(new_hdl);
     }
 out:

--- a/LibOS/shim/src/sys/shim_migrate.c
+++ b/LibOS/shim/src/sys/shim_migrate.c
@@ -98,7 +98,7 @@ int create_checkpoint (const char * cpdir, IDTYPE * sid)
                           O_CREAT|O_EXCL|O_RDWR, 0600, NULL)) < 0)
         goto err;
 
-    open_handle(cpsession->cpfile);
+    get_handle(cpsession->cpfile);
     MASTER_LOCK();
 
     struct cp_session * s;
@@ -131,7 +131,7 @@ err_locked:
     MASTER_UNLOCK();
 err:
     if (cpsession->cpfile)
-        close_handle(cpsession->cpfile);
+        put_handle(cpsession->cpfile);
 
     DkObjectClose(cpsession->finish_event);
     free(cpsession);
@@ -260,7 +260,7 @@ static int finish_checkpoint (struct cp_session * cpsession)
 
     DkStreamUnmap((void *) cpstore->base, cpstore->bound);
 
-    close_handle(cpstore->cp_file);
+    put_handle(cpstore->cp_file);
     return 0;
 }
 

--- a/LibOS/shim/src/sys/shim_open.c
+++ b/LibOS/shim/src/sys/shim_open.c
@@ -165,7 +165,7 @@ int shim_do_close (int fd)
     if (!handle)
         return -EBADF;
 
-    close_handle(handle);
+    put_handle(handle);
     return 0;
 }
 

--- a/LibOS/shim/src/sys/shim_pipe.c
+++ b/LibOS/shim/src/sys/shim_pipe.c
@@ -114,12 +114,12 @@ int shim_do_pipe2 (int * filedes, int flags)
         if (vfd1 >= 0) {
             struct shim_handle * tmp = detach_fd_handle(vfd1, NULL, NULL);
             if (tmp)
-                close_handle(tmp);
+                put_handle(tmp);
         }
         if (vfd2 >= 0) {
             struct shim_handle * tmp = detach_fd_handle(vfd2, NULL, NULL);
             if (tmp)
-                close_handle(tmp);
+                put_handle(tmp);
         }
         goto out;
     }
@@ -196,12 +196,12 @@ int shim_do_socketpair (int domain, int type, int protocol, int * sv)
         if (vfd1 >= 0) {
             struct shim_handle * tmp = detach_fd_handle(vfd1, NULL, NULL);
             if (tmp)
-                close_handle(tmp);
+                put_handle(tmp);
         }
         if (vfd2 >= 0) {
             struct shim_handle * tmp = detach_fd_handle(vfd2, NULL, NULL);
             if (tmp)
-                close_handle(tmp);
+                put_handle(tmp);
         }
         goto out;
     }


### PR DESCRIPTION
<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->
Inside `struct shim_handle` `opened` reference counter is used incorrectly.
Additionally at this moment it guards the same resource (handle) as `ref_counter`,
making it obsolete.
This patch removes `opened` counter and moves `close_handle` logic into
`put_handle` - there should be no way of closing underlying file if there still exist handle references.
Fixes #910 and partially #903

## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/911)
<!-- Reviewable:end -->
