### PR TITLE
[LibOS] remove PARALLELMFLAGS hack of buildglibc.py

### DIFF
--- a/LibOS/Makefile
+++ b/LibOS/Makefile
@@ -43,7 +43,7 @@ ifeq ($(findstring x86_64,$(SYS))$(findstring linux,$(SYS)),x86_64linux)
 
 $(BUILD_DIR)/Build.success: $(BUILD_DIR)/Makefile
 	@echo "Building glibc, may take a while to finish. Warning messages may show up. If this process terminates with failures, see \"$(BUILD_DIR)/build.log\" for more information."
-	($(MAKE) -C $(BUILD_DIR) 2>&1 >> build.log) && touch $@
+	($(MAKE) PARALLELMFLAGS='-j `nproc`' -C $(BUILD_DIR) 2>&1 >> build.log) && touch $@
 #  2>&1 | tee -a build.log)
 
 $(GLIBC_TARGET): $(BUILD_DIR)/Build.success

--- a/LibOS/buildglibc.py
+++ b/LibOS/buildglibc.py
@@ -1,12 +1,9 @@
 #!/usr/bin/env python3
 
-import sys, os, string, subprocess, shutil, fileinput, multiprocessing, re, resource
-
-def replaceAll(fd,searchExp,replaceExp):
-    for line in fileinput.input(fd, inplace=1):
-        if searchExp in line:
-            line = line.replace(searchExp,replaceExp)
-        sys.stdout.write(line)
+import os
+import shutil
+import subprocess
+import sys
 
 def prependText(filename, text) :
     data = ""
@@ -108,11 +105,3 @@ if True:
     commandStr = r'CFLAGS="{2}" {3} {0}/configure --prefix={1} {4} | tee configure.out'.format(glibc, installDir, cflags, extra_defs, extra_flags)
     print(commandStr)
     commandOutput = subprocess.call(commandStr, shell=True)
-
-    ##    Enable parallel builds
-    numCPUs = multiprocessing.cpu_count()
-    ##    Don't use up all the cores!
-    numCPUs = numCPUs - 1
-    if numCPUs == 0:
-        numCPUs = 1
-    replaceAll('Makefile', r'# PARALLELMFLAGS = -j4', r'PARALLELMFLAGS = -j{0}'.format(numCPUs))


### PR DESCRIPTION
remove replacing logic of PARALLELMFLAGS in buildglibc.py
instead use $(MAKE) PARALLELMFLAGS="-j `nproc`"

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->


## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/913)
<!-- Reviewable:end -->
