### PR TITLE
[Jenkins] Don't update LTP submodule twice

### DIFF
--- a/Jenkinsfiles/Linux
+++ b/Jenkinsfiles/Linux
@@ -25,7 +25,6 @@ pipeline {
                             '''
                         sh '''
                             cd LibOS/shim/test/apps/ltp
-                            git submodule update --init src
                             make
                             ./syscalls.sh
                             '''

--- a/Jenkinsfiles/Linux-Debug
+++ b/Jenkinsfiles/Linux-Debug
@@ -23,7 +23,6 @@ pipeline {
                             '''
                         sh '''
                             cd LibOS/shim/test/apps/ltp
-                            git submodule update --init src
                             make
                             ./syscalls.sh
                             '''


### PR DESCRIPTION
<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [x] README and global configuration
- [ ] Linux PAL
- [x] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->

Jenkins already runs a recursive submodule update. So no need to do this
again manually.

## How to test this PR? <!-- (if applicable) -->

See that the Jenkins jobs still work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/922)
<!-- Reviewable:end -->
