### PR TITLE
[CI] Make sure the right kernel version is installed

### DIFF
--- a/Jenkinsfiles/ubuntu-16.04.dockerfile
+++ b/Jenkinsfiles/ubuntu-16.04.dockerfile
@@ -16,6 +16,7 @@ RUN apt-get update \
        libpcre3-dev \
        libxml2-dev \
        linux-headers-generic \
+       linux-headers-$(uname -r) \
        net-tools \
        python \
        python-protobuf \


### PR DESCRIPTION
<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->

The gipc build test can fail in Jenkins if the correct kernel headers are not installed.  This can get out of date after an upgrade on the host, but the docker image is still wrong.

## How to test this PR? <!-- (if applicable) -->

Going to manually test on waldorf

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/927)
<!-- Reviewable:end -->
