### PR TITLE
fix makefile parallelmake of glibc

### DIFF
--- a/LibOS/Makefile
+++ b/LibOS/Makefile
@@ -44,7 +44,7 @@ ifeq ($(findstring x86_64,$(SYS))$(findstring linux,$(SYS)),x86_64linux)
 
 $(BUILD_DIR)/Build.success: $(BUILD_DIR)/Makefile
 	@echo "Building glibc, may take a while to finish. Warning messages may show up. If this process terminates with failures, see \"$(BUILD_DIR)/build.log\" for more information."
-	($(MAKE) PARALLELMFLAGS='-j `nproc`' -C $(BUILD_DIR) 2>&1 >> build.log) && touch $@
+	($(MAKE) -C $(BUILD_DIR) 2>&1 >> build.log) && touch $@
 
 $(GLIBC_TARGET): $(BUILD_DIR)/Build.success
 

--- a/LibOS/shim/Makefile
+++ b/LibOS/shim/Makefile
@@ -5,16 +5,16 @@ export SYS
 
 .PHONY: all
 all:
-	make -C src
+	$(MAKE) -C src
 
 .PHONY: test
 test:
-	make -C test
+	$(MAKE) -C test
 
 .PHONY: clean
 clean:
-	make -C src clean
-	make -C test clean
+	$(MAKE) -C src clean
+	$(MAKE) -C test clean
 
 .PHONY: format
 format:


### PR DESCRIPTION
<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->
fix parallel make warning during glibc building
> make[3]: warning: -jN forced in submake: disabling jobserver mode.


## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/930)
<!-- Reviewable:end -->
