### PR TITLE
[LibOS] Disable the warning when GIPC is not supported

### DIFF
--- a/LibOS/shim/include/shim_defs.h
+++ b/LibOS/shim/include/shim_defs.h
@@ -65,4 +65,6 @@
 #define REQUIRED_ELF_AUXV           8   /* number of LibOS-supported vectors */
 #define REQUIRED_ELF_AUXV_SPACE     16  /* extra memory space (in bytes) */
 
+#define WARN_NO_GIPC                0   /* warn if GIPC is not supported for process creation */
+
 #endif /* _SHIM_DEFS_H_ */

--- a/LibOS/shim/src/shim_checkpoint.c
+++ b/LibOS/shim/src/shim_checkpoint.c
@@ -907,7 +907,9 @@ DEFINE_PROFILE_INTERVAL(migrate_send_pal_handles, migrate_proc);
 DEFINE_PROFILE_INTERVAL(migrate_free_checkpoint,  migrate_proc);
 DEFINE_PROFILE_INTERVAL(migrate_wait_response,    migrate_proc);
 
+#if WARN_NO_GIPC == 1
 static bool warn_no_gipc __attribute_migratable = true;
+#endif
 
 /*
  * Create a new process and migrate the process states to the new process.
@@ -968,11 +970,13 @@ int do_migrate_process (int (*migrate) (struct shim_cp_store *,
         use_gipc = true;
         SAVE_PROFILE_INTERVAL(migrate_create_gipc);
     } else {
+#if WARN_NO_GIPC == 1
         if (warn_no_gipc) {
             warn_no_gipc = false;
             SYS_PRINTF("WARNING: no physical memory support, process creation "
                        "may be slow.\n");
         }
+#endif
     }
 
     /* Create process and IPC bookkeepings */


### PR DESCRIPTION
<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->

This PR removes the warning ``WARNING: no physical memory support, process creation may be slow`` when GIPC (Bulk IPC feature) is not supported. This warning message has caused quite a few confusing for the users.

## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/935)
<!-- Reviewable:end -->
