### PR TITLE
[Pal/Linux-SGX] set CLOSEXEC on /dev/isgx, /dev/gsgx

### DIFF
--- a/Pal/src/host/Linux-SGX/sgx_framework.c
+++ b/Pal/src/host/Linux-SGX/sgx_framework.c
@@ -15,17 +15,19 @@ void * zero_page;
 
 int open_gsgx(void)
 {
-    gsgx_device = INLINE_SYSCALL(open, 3, GSGX_FILE, O_RDWR, 0);
+    gsgx_device = INLINE_SYSCALL(open, 3, GSGX_FILE, O_RDWR | O_CLOEXEC, 0);
     if (IS_ERR(gsgx_device)) {
         SGX_DBG(DBG_E, "Cannot open device " GSGX_FILE ". Please make sure the"
                 " \'graphene_sgx\' kernel module is loaded.\n");
         return -ERRNO(gsgx_device);
     }
 
-    isgx_device = INLINE_SYSCALL(open, 3, ISGX_FILE, O_RDWR, 0);
+    isgx_device = INLINE_SYSCALL(open, 3, ISGX_FILE, O_RDWR | O_CLOEXEC, 0);
     if (IS_ERR(isgx_device)) {
         SGX_DBG(DBG_E, "Cannot open device " ISGX_FILE ". Please make sure the"
                 " Intel SGX kernel module is loaded.\n");
+        INLINE_SYSCALL(close, 1, gsgx_device);
+        gsgx_device = -1;
         return -ERRNO(isgx_device);
     }
 


### PR DESCRIPTION
On host exec, file descriptors for /dev/isgx and /dev/gsgx are
leaked.
So set CLOSEXEC for them to be closed when emulating fork/exec
by using host exec.

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [x] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->


## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/936)
<!-- Reviewable:end -->
