### PR TITLE
Assert allocation alignment in PAL internal functions

### DIFF
--- a/Pal/src/db_rtld.c
+++ b/Pal/src/db_rtld.c
@@ -304,7 +304,7 @@ map_elf_object_by_handle (PAL_HANDLE handle, enum object_type type,
         void * mapaddr = NULL;
         /* Remember which part of the address space this object uses.  */
         ret = _DkStreamMap(handle, (void **) &mapaddr,
-                           APPEND_WRITECOPY(c->prot), c->mapoff, maplength);
+                           APPEND_WRITECOPY(c->prot), c->mapoff, ALLOC_ALIGNUP(maplength));
 
         if (__builtin_expect (ret < 0, 0)) {
             print_error("failed to map dynamic segment from shared object",
@@ -313,7 +313,7 @@ map_elf_object_by_handle (PAL_HANDLE handle, enum object_type type,
         }
 
         l->l_map_start = (ElfW(Addr)) mapaddr;
-        l->l_map_end = (ElfW(Addr)) mapaddr + maplength;
+        l->l_map_end = (ElfW(Addr)) mapaddr + ALLOC_ALIGNUP(maplength);
         l->l_addr = l->l_map_start - c->mapstart;
 
         if (has_holes)
@@ -331,7 +331,7 @@ map_elf_object_by_handle (PAL_HANDLE handle, enum object_type type,
 
     /* Remember which part of the address space this object uses.  */
     l->l_map_start = c->mapstart + l->l_addr;
-    l->l_map_end = l->l_map_start + maplength;
+    l->l_map_end = l->l_map_start + ALLOC_ALIGNUP(maplength);
 
     while (c < &loadcmds[nloadcmds]) {
         if (c->mapend > c->mapstart) {

--- a/Pal/src/host/Linux-SGX/db_memory.c
+++ b/Pal/src/host/Linux-SGX/db_memory.c
@@ -68,7 +68,9 @@ int _DkVirtualMemoryAlloc (void ** paddr, uint64_t size, int alloc_type, int pro
     if (!WITHIN_MASK(prot, PAL_PROT_MASK))
         return -PAL_ERROR_INVAL;
 
-    void * addr = *paddr, * mem;
+    void* addr = *paddr;
+    void* mem;
+    assert(ALLOC_ALIGNED(addr) && ALLOC_ALIGNED(size));
 
     if ((alloc_type & PAL_ALLOC_INTERNAL) && addr)
         return -PAL_ERROR_INVAL;
@@ -104,6 +106,7 @@ int _DkVirtualMemoryAlloc (void ** paddr, uint64_t size, int alloc_type, int pro
 
 int _DkVirtualMemoryFree (void * addr, uint64_t size)
 {
+    assert(ALLOC_ALIGNED(addr) && ALLOC_ALIGNED(size));
 
     if (sgx_is_completely_within_enclave(addr, size)) {
         free_pages(addr, size);
@@ -117,6 +120,8 @@ int _DkVirtualMemoryFree (void * addr, uint64_t size)
 
 int _DkVirtualMemoryProtect (void * addr, uint64_t size, int prot)
 {
+    assert(ALLOC_ALIGNED(addr) && ALLOC_ALIGNED(size));
+
     static struct atomic_int at_cnt = {.counter = 0};
 
     if (atomic_cmpxchg(&at_cnt, 0, 1) == 0)

--- a/Pal/src/host/Linux-SGX/enclave_pages.c
+++ b/Pal/src/host/Linux-SGX/enclave_pages.c
@@ -194,9 +194,7 @@ void * get_reserved_pages(void * addr, size_t size)
         return NULL;
     }
 
-    size = ((size + pgsz - 1) & ~(pgsz - 1));
-    addr = (void *)((uintptr_t)addr & ~(pgsz - 1));
-
+    assert(ALLOC_ALIGNED(addr) && ALLOC_ALIGNED(size));
     SGX_DBG(DBG_M, "allocate %ld bytes at %p\n", size, addr);
 
     _DkInternalLock(&heap_vma_lock);
@@ -263,11 +261,7 @@ void free_pages(void * addr, size_t size)
     if (!addr || !size)
         return;
 
-    if ((uintptr_t) addr_top & (pgsz - 1))
-        addr = (void *) (((uintptr_t) addr_top + pgsz + 1) & ~(pgsz - 1));
-
-    if ((uintptr_t) addr & (pgsz - 1))
-        addr = (void *) ((uintptr_t) addr & ~(pgsz - 1));
+    assert(ALLOC_ALIGNED(addr) && ALLOC_ALIGNED(size));
 
     if (addr >= heap_base + heap_size)
         return;

--- a/Pal/src/host/Linux/db_files.c
+++ b/Pal/src/host/Linux/db_files.c
@@ -155,6 +155,8 @@ static int file_map (PAL_HANDLE handle, void ** addr, int prot,
 {
     int fd = handle->file.fd;
     void * mem = *addr;
+    assert(ALLOC_ALIGNED(addr) && ALLOC_ALIGNED(size));
+
     /*
      * work around for fork emulation
      * the first exec image to be loaded has to be at same address

--- a/Pal/src/host/Linux/db_files.c
+++ b/Pal/src/host/Linux/db_files.c
@@ -154,8 +154,8 @@ static int file_map (PAL_HANDLE handle, void ** addr, int prot,
                      uint64_t offset, uint64_t size)
 {
     int fd = handle->file.fd;
-    void * mem = *addr;
-    assert(ALLOC_ALIGNED(addr) && ALLOC_ALIGNED(size));
+    void* mem = *addr;
+    assert(ALLOC_ALIGNED(mem) && ALLOC_ALIGNED(size));
 
     /*
      * work around for fork emulation

--- a/Pal/src/host/Linux/db_main.c
+++ b/Pal/src/host/Linux/db_main.c
@@ -223,6 +223,10 @@ void pal_linux_main (void * args)
     ELF_DYNAMIC_RELOCATE(&pal_map);
 
     linux_state.environ = envp;
+    pal_state.pagesize    = pagesz;
+    pal_state.alloc_align = pagesz;
+    pal_state.alloc_shift = pagesz - 1;
+    pal_state.alloc_mask  = ~(pagesz - 1);
 
     init_slab_mgr(pagesz);
 

--- a/Pal/src/host/Linux/db_main.c
+++ b/Pal/src/host/Linux/db_main.c
@@ -223,6 +223,8 @@ void pal_linux_main (void * args)
     ELF_DYNAMIC_RELOCATE(&pal_map);
 
     linux_state.environ = envp;
+
+    /* Set page alignment early */
     pal_state.pagesize    = pagesz;
     pal_state.alloc_align = pagesz;
     pal_state.alloc_shift = pagesz - 1;

--- a/Pal/src/host/Linux/db_memory.c
+++ b/Pal/src/host/Linux/db_memory.c
@@ -40,7 +40,9 @@ bool _DkCheckMemoryMappable (const void * addr, size_t size)
 int _DkVirtualMemoryAlloc (void ** paddr, size_t size, int alloc_type,
                            int prot)
 {
-    void * addr = *paddr, * mem = addr;
+    void* addr = *paddr;
+    void* mem = addr;
+    assert(ALLOC_ALIGNED(addr) && ALLOC_ALIGNED(size));
 
     int flags = HOST_FLAGS(alloc_type, prot|PAL_PROT_WRITECOPY);
     prot = HOST_PROT(prot);
@@ -57,6 +59,8 @@ int _DkVirtualMemoryAlloc (void ** paddr, size_t size, int alloc_type,
 
 int _DkVirtualMemoryFree (void * addr, size_t size)
 {
+    assert(ALLOC_ALIGNED(addr) && ALLOC_ALIGNED(size));
+
     int ret = INLINE_SYSCALL(munmap, 2, addr, size);
 
     return IS_ERR(ret) ? unix_to_pal_error(ERRNO(ret)) : 0;
@@ -64,6 +68,8 @@ int _DkVirtualMemoryFree (void * addr, size_t size)
 
 int _DkVirtualMemoryProtect (void * addr, size_t size, int prot)
 {
+    assert(ALLOC_ALIGNED(addr) && ALLOC_ALIGNED(size));
+
     int ret = INLINE_SYSCALL(mprotect, 3, addr, size, HOST_PROT(prot));
 
     return IS_ERR(ret) ? unix_to_pal_error(ERRNO(ret)) : 0;


### PR DESCRIPTION
<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [x] Linux PAL
- [x] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->

`_DkVirtualMemoryFree()`, `_DkVirtualMemoryProtect()`, and `_DkVirtualMemoryFree()` should only get aligned addresses and sizes. The same assertion also applies to `get_reserved_pages()` and `free_pages()`.

## How to test this PR? <!-- (if applicable) -->

Regression test. This PR should not affect the program logic.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/938)
<!-- Reviewable:end -->
