### PR TITLE
[Makefile] Central build config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 !/Runtime/pal_loader
 /Jenkinsfiles/Jenkinsfile-*
 /Jenkinsfiles/JenkinsfileSGX-*
+/build-config.mk
 
 .lib
 *.i

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,8 +109,7 @@ For SGX, one needs to do the following:
 
 ```Bash
 cd Pal/regression
-make SGX=1
-make SGX_RUN=1 regression
+make SGX=1 regression
 ```
 
 If a test fails unexpectedly, one can use the KEEP_LOG=1 option to get the complete output.

--- a/Documentation/manpages/pal_loader.rst
+++ b/Documentation/manpages/pal_loader.rst
@@ -34,9 +34,4 @@ Environment variables
 .. envvar:: SGX
 
    If not empty and not ``0``, enable :term:`SGX`. Could be used instead of
-   :option:`SGX option <SGX>`. This has some unexplained interaction with
-   :envvar:`SGX_RUN`.
-
-.. envvar:: SGX_RUN
-
-   This is a mystery to me. It cannot be set together with :envvar:`SGX`.
+   :option:`SGX option <SGX>`.

--- a/Jenkinsfiles/Linux
+++ b/Jenkinsfiles/Linux
@@ -6,14 +6,15 @@ pipeline {
                 stage('Build') {
                     steps {
                         sh '''
+                            ./build-setup WERROR=1
                             cd LibOS
                             make -j 8 glibc-build/Build.success GLIBC_VERSION=2.19
                             rm -r glibc-build
                             make -j 8 glibc-build/Build.success GLIBC_VERSION=2.23
                             rm -r glibc-build
                             cd ..
-                            make -j 8 WERROR=1
-                            make -j 8 WERROR=1 test
+                            make -j 8
+                            make -j 8 test
                             cd Pal/ipc/linux
                             make
                            '''
@@ -53,7 +54,7 @@ pipeline {
                         timeout(time: 15, unit: 'MINUTES') {
                             sh '''
                                 cd LibOS/shim/test/apps/lmbench
-                                make regression N_RUNS=1 ENOUGH=100
+                                make regression N_RUNS=1 ENOUGH=100 WERROR=
                             '''
                         }
                         sh '''

--- a/Jenkinsfiles/Linux-18.04
+++ b/Jenkinsfiles/Linux-18.04
@@ -48,7 +48,7 @@ pipeline {
                         timeout(time: 15, unit: 'MINUTES') {
                             sh '''
                                 cd LibOS/shim/test/apps/lmbench
-                                make regression N_RUNS=1 ENOUGH=100
+                                make regression N_RUNS=1 ENOUGH=100 WERROR=
                             '''
                         }
                         sh '''

--- a/Jenkinsfiles/Linux-Debug
+++ b/Jenkinsfiles/Linux-Debug
@@ -6,8 +6,9 @@ pipeline {
                 stage('Build') {
                     steps {
                         sh '''
-                            make -j 8 DEBUG=1 WERROR=1
-                            make -j 8 DEBUG=1 WERROR=1 test
+                            ./build-setup DEBUG=1 WERROR=1
+                            make -j 8
+                            make -j 8 test
                            '''
                     }
                 }
@@ -45,7 +46,7 @@ pipeline {
                         timeout(time: 20, unit: 'MINUTES') {
                             sh '''
                                 cd LibOS/shim/test/apps/lmbench
-                                make regression N_RUNS=1 ENOUGH=100
+                                make regression N_RUNS=1 ENOUGH=100 WERROR=
                             '''
                         }
                         sh '''

--- a/Jenkinsfiles/Linux-Debug-18.04
+++ b/Jenkinsfiles/Linux-Debug-18.04
@@ -45,7 +45,7 @@ pipeline {
                         timeout(time: 20, unit: 'MINUTES') {
                             sh '''
                                 cd LibOS/shim/test/apps/lmbench
-                                make regression N_RUNS=1 ENOUGH=100
+                                make regression N_RUNS=1 ENOUGH=100 WERROR=
                             '''
                         }
                         sh '''

--- a/Jenkinsfiles/Linux-SGX
+++ b/Jenkinsfiles/Linux-SGX
@@ -27,7 +27,7 @@ pipeline {
                             make -j 8 SGX=1 WERROR=1 test
                         '''
                         sh '''
-                            make SGX_RUN=1 test
+                            make SGX=1 sgx-tokens
                         '''
                     }
                 }
@@ -36,64 +36,56 @@ pipeline {
                         timeout(time: 15, unit: 'MINUTES') {
                             sh '''
                                 cd Pal/regression
-                                make SGX=1
-                                make SGX_RUN=1
-                                make SGX_RUN=1 KEEP_LOG=1 regression
+                                make SGX=1 all sgx-tokens
+                                make SGX=1 KEEP_LOG=1 regression
                                 '''
                         }
                         timeout(time: 15, unit: 'MINUTES') {
                             sh '''
                                 cd LibOS/shim/test/regression
-                                make SGX=1
-                                make SGX_RUN=1
-                                make SGX_RUN=1 regression
+                                make SGX=1 all sgx-tokens
+                                make SGX=1 regression
                             '''
                         }
                         timeout(time: 5, unit: 'MINUTES') {
                             sh '''
                                 cd LibOS/shim/test/apps/python
-                                make SGX=1
-                                make SGX_RUN=1
-                                make SGX_RUN=1 regression
+                                make SGX=1 all sgx-tokens
+                                make SGX=1 regression
                             '''
                         }
                         timeout(time: 5, unit: 'MINUTES') {
                             sh '''
                                 cd LibOS/shim/test/apps/bash
-                                make SGX=1
-                                make SGX_RUN=1
-                                make SGX_RUN=1 regression
+                                make SGX=1 all sgx-tokens
+                                make SGX=1 regression
                            '''
                         }
                         timeout(time: 10, unit: 'MINUTES') {
                             sh '''
                                 cd LibOS/shim/test/apps/gcc
-                                make SGX=1
-                                make SGX_RUN=1
-                                make SGX_RUN=1 regression
+                                make SGX=1 all sgx-tokens
+                                make SGX=1 regression
                            '''
                         }
                         timeout(time: 15, unit: 'MINUTES') {
                             sh '''
                                 cd LibOS/shim/test/apps/lmbench
-                                make SGX=1
-                                make SGX_RUN=1
-                                make SGX_RUN=1 regression N_RUNS=1 ENOUGH=100
+                                make SGX=1 all sgx-tokens
+                                make SGX=1 regression N_RUNS=1 ENOUGH=100
                             '''
                         }
                         sh '''
                             cd LibOS/shim/test/apps/lighttpd
-                            make SGX=1
-                            make SGX_RUN=1
-                            make SGX_RUN=1 start-graphene-server &
+                            make SGX=1 all sgx-tokens
+                            make SGX=1 start-graphene-server &
                             sleep 10
                             LOOP=1 CONCURRENCY_LIST="1 32" ./benchmark-http.sh 127.0.0.1:8000
                             '''
                         sh '''
                             cd LibOS/shim/test/apps/apache
-                            make SGX=1
-                            make SGX_RUN=1
-                            make SGX_RUN=1 start-graphene-server &
+                            make SGX=1 all sgx-tokens
+                            make SGX=1 start-graphene-server &
                             sleep 15
                             LOOP=1 CONCURRENCY_LIST="1 32" ./benchmark-http.sh 127.0.0.1:8001
                             '''

--- a/Jenkinsfiles/Linux-SGX
+++ b/Jenkinsfiles/Linux-SGX
@@ -23,11 +23,12 @@ pipeline {
                             ISGX_DRIVER_PATH=/opt/intel/linux-sgx-driver ISGX_DRIVER_VERSION=1.9 make
                         '''
                         sh '''
-                            make -j 8 SGX=1 WERROR=1
-                            make -j 8 SGX=1 WERROR=1 test
+                            ./build-setup SGX=1 WERROR=1
+                            make -j 8
+                            make -j 8 test
                         '''
                         sh '''
-                            make SGX=1 sgx-tokens
+                            make sgx-tokens
                         '''
                     }
                 }
@@ -36,56 +37,56 @@ pipeline {
                         timeout(time: 15, unit: 'MINUTES') {
                             sh '''
                                 cd Pal/regression
-                                make SGX=1 all sgx-tokens
-                                make SGX=1 KEEP_LOG=1 regression
+                                make all sgx-tokens
+                                make KEEP_LOG=1 regression
                                 '''
                         }
                         timeout(time: 15, unit: 'MINUTES') {
                             sh '''
                                 cd LibOS/shim/test/regression
-                                make SGX=1 all sgx-tokens
-                                make SGX=1 regression
+                                make all sgx-tokens
+                                make regression
                             '''
                         }
                         timeout(time: 5, unit: 'MINUTES') {
                             sh '''
                                 cd LibOS/shim/test/apps/python
-                                make SGX=1 all sgx-tokens
-                                make SGX=1 regression
+                                make all sgx-tokens
+                                make regression
                             '''
                         }
                         timeout(time: 5, unit: 'MINUTES') {
                             sh '''
                                 cd LibOS/shim/test/apps/bash
-                                make SGX=1 all sgx-tokens
-                                make SGX=1 regression
+                                make all sgx-tokens
+                                make regression
                            '''
                         }
                         timeout(time: 10, unit: 'MINUTES') {
                             sh '''
                                 cd LibOS/shim/test/apps/gcc
-                                make SGX=1 all sgx-tokens
-                                make SGX=1 regression
+                                make all sgx-tokens
+                                make regression
                            '''
                         }
                         timeout(time: 15, unit: 'MINUTES') {
                             sh '''
                                 cd LibOS/shim/test/apps/lmbench
-                                make SGX=1 all sgx-tokens
-                                make SGX=1 regression N_RUNS=1 ENOUGH=100
+                                make all sgx-tokens WERROR=
+                                make regression N_RUNS=1 ENOUGH=100 WERROR=
                             '''
                         }
                         sh '''
                             cd LibOS/shim/test/apps/lighttpd
-                            make SGX=1 all sgx-tokens
-                            make SGX=1 start-graphene-server &
+                            make all sgx-tokens
+                            make start-graphene-server &
                             sleep 10
                             LOOP=1 CONCURRENCY_LIST="1 32" ./benchmark-http.sh 127.0.0.1:8000
                             '''
                         sh '''
                             cd LibOS/shim/test/apps/apache
-                            make SGX=1 all sgx-tokens
-                            make SGX=1 start-graphene-server &
+                            make all sgx-tokens
+                            make start-graphene-server &
                             sleep 15
                             LOOP=1 CONCURRENCY_LIST="1 32" ./benchmark-http.sh 127.0.0.1:8001
                             '''

--- a/Jenkinsfiles/Linux-SGX-18.04
+++ b/Jenkinsfiles/Linux-SGX-18.04
@@ -71,8 +71,8 @@ pipeline {
                         timeout(time: 15, unit: 'MINUTES') {
                             sh '''
                                 cd LibOS/shim/test/apps/lmbench
-                                make SGX=1 all sgx-tokens
-                                make SGX=1 regression N_RUNS=1 ENOUGH=100
+                                make SGX=1 all sgx-tokens WERROR=
+                                make SGX=1 regression N_RUNS=1 ENOUGH=100 WERROR=
                             '''
                         }
                         sh '''

--- a/Jenkinsfiles/Linux-SGX-18.04
+++ b/Jenkinsfiles/Linux-SGX-18.04
@@ -27,7 +27,7 @@ pipeline {
                             make -j 8 SGX=1 WERROR=1 test
                         '''
                         sh '''
-                            make SGX_RUN=1 test
+                            make SGX=1 sgx-tokens
                         '''
                     }
                 }
@@ -36,65 +36,57 @@ pipeline {
                         timeout(time: 15, unit: 'MINUTES') {
                             sh '''
                                 cd Pal/regression
-                                make SGX=1
-                                make SGX_RUN=1
-                                make SGX_RUN=1 KEEP_LOG=1 regression
+                                make SGX=1 all sgx-tokens
+                                make SGX=1 KEEP_LOG=1 regression
                                 '''
                         }
                         timeout(time: 15, unit: 'MINUTES') {
                             sh '''
                                 cd LibOS/shim/test/regression
-                                make SGX=1
-                                make SGX_RUN=1
-                                make SGX_RUN=1 regression
+                                make SGX=1 all sgx-tokens
+                                make SGX=1 regression
                             '''
                         }
                         timeout(time: 5, unit: 'MINUTES') {
                             sh '''
                                 cd LibOS/shim/test/apps/python
-                                make SGX=1
-                                make SGX_RUN=1
-                                make SGX_RUN=1 regression
+                                make SGX=1 all sgx-tokens
+                                make SGX=1 regression
                             '''
       }
       timeout(time: 5, unit: 'MINUTES') {
                             sh '''
                                 cd LibOS/shim/test/apps/bash
-                                make SGX=1
-                                make SGX_RUN=1
-                                make SGX_RUN=1 regression
+                                make SGX=1 all sgx-tokens
+                                make SGX=1 regression
                            '''
       }
                         timeout(time: 10, unit: 'MINUTES') {
                             sh '''
                                 cd LibOS/shim/test/apps/gcc
-                                make SGX=1
-                                make SGX_RUN=1
-                                make SGX_RUN=1 regression
+                                make SGX=1 all sgx-tokens
+                                make SGX=1 regression
                            '''
                         }
                         timeout(time: 15, unit: 'MINUTES') {
                             sh '''
                                 cd LibOS/shim/test/apps/lmbench
-                                make SGX=1
-                                make SGX_RUN=1
-                                make SGX_RUN=1 regression N_RUNS=1 ENOUGH=100
+                                make SGX=1 all sgx-tokens
+                                make SGX=1 regression N_RUNS=1 ENOUGH=100
                             '''
                         }
                         sh '''
                             cd LibOS/shim/test/apps/lighttpd
-                            make SGX=1
-                            make SGX_RUN=1
-                            make SGX_RUN=1 start-graphene-server &
+                            make SGX=1 all sgx-tokens
+                            make SGX=1 start-graphene-server &
                             sleep 10
                             LOOP=1 CONCURRENCY_LIST="1 32" ./benchmark-http.sh 127.0.0.1:8000
                             '''
                             /*
                         sh '''
                             cd LibOS/shim/test/apps/apache
-                            make SGX=1
-                            make SGX_RUN=1
-                            make SGX_RUN=1 start-graphene-server &
+                            make SGX=1 all sgx-tokens
+                            make SGX=1 start-graphene-server &
                             sleep 15
                             LOOP=1 CONCURRENCY_LIST="1 32" ./benchmark-http.sh 127.0.0.1:8001
                             '''

--- a/LibOS/Makefile
+++ b/LibOS/Makefile
@@ -143,3 +143,7 @@ endif
 .PHONY: test
 test:
 	$(MAKE) -C $(SHIM_DIR) test
+
+.PHONY: sgx-tokens
+sgx-tokens:
+	$(MAKE) -C $(SHIM_DIR) sgx-tokens

--- a/LibOS/shim/Makefile
+++ b/LibOS/shim/Makefile
@@ -11,6 +11,10 @@ all:
 test:
 	$(MAKE) -C test
 
+.PHONY: sgx-tokens
+sgx-tokens:
+	$(MAKE) -C test sgx-tokens
+
 .PHONY: clean
 clean:
 	$(MAKE) -C src clean

--- a/LibOS/shim/src/Makefile
+++ b/LibOS/shim/src/Makefile
@@ -1,3 +1,5 @@
+include ../../../build-config.mk
+
 RUNTIME_DIR = $(CURDIR)/../../../Runtime
 
 include ../../../Makefile.configs

--- a/LibOS/shim/test/Makefile
+++ b/LibOS/shim/test/Makefile
@@ -34,6 +34,9 @@ include $(PALDIR)/Makefile.Test
 .PHONY: all
 all: pal_loader $(target) $(if $(level),,build-subdirs) | $(call expand_target,$(exec_target))
 
+.PHONY: sgx-tokens
+sgx-tokens: $(if $(level),,sgx-tokens-subdirs) $(call expand_target_to_token,$(exec_target))
+
 ifeq ($(DEBUG),1)
 CC += -g
 CXX += -g
@@ -88,6 +91,10 @@ clean: $(clean-extra) $(if $(level),,clean-subdirs)
 .PHONY: build-subdirs
 build-subdirs:
 	for f in $(subdirs); do (cd $$f; $(MAKE); cd ..); done
+
+.PHONY: sgx-tokens-subdirs
+sgx-tokens-subdirs:
+	for f in $(subdirs); do (cd $$f; $(MAKE) sgx-tokens; cd ..); done
 
 .PHONY: clean-subdirs
 clean-subdirs:

--- a/LibOS/shim/test/Makefile
+++ b/LibOS/shim/test/Makefile
@@ -1,3 +1,5 @@
+include $(dirname $(lastword $(MAKEFILE_LIST))../../../build-config.mk
+
 subdirs = native
 
 SYS ?= $(shell gcc -dumpmachine)

--- a/LibOS/shim/test/Makefile.Test
+++ b/LibOS/shim/test/Makefile.Test
@@ -33,6 +33,9 @@ include $(PALDIR)/Makefile.Test
 .PHONY: all
 all: pal_loader $(target) | $(call expand_target,$(exec_target))
 
+.PHONY: sgx-tokens
+sgx-tokens: $(call expand_target_to_token,$(exec_target))
+
 ifeq ($(DEBUG),1)
 CC += -g
 CXX += -g

--- a/LibOS/shim/test/benchmark/Makefile
+++ b/LibOS/shim/test/benchmark/Makefile
@@ -1,3 +1,5 @@
+include ../../../../build-config.mk
+
 c_executables = $(patsubst %.c,%,$(wildcard *.c))
 cxx_executables = $(patsubst %.cpp,%,$(wildcard *.cpp))
 

--- a/LibOS/shim/test/inline/Makefile
+++ b/LibOS/shim/test/inline/Makefile
@@ -1,3 +1,5 @@
+include ../../../../build-config.mk
+
 c_executables = $(patsubst %.c,%,$(wildcard *.c))
 cxx_executables = $(patsubst %.cpp,%,$(wildcard *.cpp))
 

--- a/LibOS/shim/test/native/Makefile
+++ b/LibOS/shim/test/native/Makefile
@@ -1,3 +1,5 @@
+include ../../../../build-config.mk
+
 c_executables = $(patsubst %.c,%,$(wildcard *.c))
 cxx_executables = $(patsubst %.cpp,%,$(wildcard *.cpp))
 manifests = $(patsubst %.template,%,$(wildcard *.manifest.template)) manifest

--- a/LibOS/shim/test/regression/Makefile
+++ b/LibOS/shim/test/regression/Makefile
@@ -1,3 +1,5 @@
+include ../../../../build-config.mk
+
 c_executables = $(patsubst %.c,%,$(wildcard *.c))
 cxx_executables = $(patsubst %.cpp,%,$(wildcard *.cpp))
 manifests = $(patsubst %.manifest.template,%.manifest,$(wildcard *.manifest.template)) manifest

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ endif
 SYS ?= $(shell gcc -dumpmachine)
 export SYS
 
-targets = all clean format test sgx-tokens
+targets = all format test sgx-tokens
 
 ifneq ($(filter sgx-tokens,$(MAKECMDGOALS)),)
 ifneq ($(SGX),1)
@@ -20,3 +20,10 @@ $(targets):
 	$(MAKE) -C Pal $@
 	$(MAKE) -C LibOS $@
 	$(MAKE) -C Runtime $@
+
+.PHONY: clean
+clean:
+	$(MAKE) -C Pal clean
+	$(MAKE) -C LibOS clean
+	$(MAKE) -C Runtime clean
+	rm -f build-config.mk

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ targets = all clean format test sgx-tokens
 
 ifneq ($(filter sgx-tokens,$(MAKECMDGOALS)),)
 ifneq ($(SGX),1)
-	$(error "The 'sgx-tokens' target requires SGX=1")
+$(error "The 'sgx-tokens' target requires SGX=1")
 endif
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,13 @@
 SYS ?= $(shell gcc -dumpmachine)
 export SYS
 
-targets = all clean format test
+targets = all clean format test sgx-tokens
+
+ifneq ($(filter sgx-tokens,$(MAKECMDGOALS)),)
+ifneq ($(SGX),1)
+	$(error "The 'sgx-tokens' target requires SGX=1")
+endif
+endif
 
 .PHONY: $(targets)
 $(targets):

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,9 @@
+-include build-config.mk
+
+ifneq ($(BUILD_CONFIGURED),1)
+$(error "Run ./build-setup to configure build before running make!")
+endif
+
 SYS ?= $(shell gcc -dumpmachine)
 export SYS
 

--- a/Pal/Makefile
+++ b/Pal/Makefile
@@ -1,3 +1,4 @@
+include ../build-config.mk
 include src/Makefile.Host
 
 DIRS = src test regression

--- a/Pal/Makefile
+++ b/Pal/Makefile
@@ -18,6 +18,11 @@ test:
 	$(MAKE) -C test
 	$(MAKE) -C regression
 
+.PHONY: sgx-tokens
+sgx-tokens:
+	$(MAKE) -C test sgx-tokens
+	$(MAKE) -C regression sgx-tokens
+
 .PHONY: format
 format:
 	clang-format -i $(shell find . -path ./lib/crypto/mbedtls -prune -o \

--- a/Pal/lib/Makefile
+++ b/Pal/lib/Makefile
@@ -1,3 +1,4 @@
+include ../../build-config.mk
 include ../../Makefile.configs
 include ../../Makefile.rules
 include ../src/Makefile.Host

--- a/Pal/regression/Makefile
+++ b/Pal/regression/Makefile
@@ -1,3 +1,4 @@
+include ../../build-config.mk
 include ../src/Makefile.Host
 
 CC	= gcc

--- a/Pal/regression/Makefile
+++ b/Pal/regression/Makefile
@@ -26,6 +26,9 @@ export PAL_LOADER = $(RUNTIME_DIR)/pal-$(PAL_HOST)
 .PHONY: all
 all: $(call expand_target,$(target)) $(preloads)
 
+.PHONY: sgx-tokens
+sgx-tokens: $(call expand_target_to_token,$(target))
+
 ifeq ($(DEBUG),1)
 CC += -g
 endif
@@ -89,7 +92,7 @@ regression:
 	$(RM) pal-regression.xml
 	$(MAKE) pal-regression.xml
 
-pal-regression.xml: test_pal.py $(call expand_target,$(target))
+pal-regression.xml: test_pal.py $(call expand_target_to_token,$(target))
 	python3 -m pytest --junit-xml $@ -v test_pal.py
 
 .PHONY: clean

--- a/Pal/src/Makefile
+++ b/Pal/src/Makefile
@@ -1,3 +1,5 @@
+include ../../build-config.mk
+
 export PAL_DIR = $(CURDIR)
 export RUNTIME_DIR = $(CURDIR)/../../Runtime
 

--- a/Pal/src/Makefile
+++ b/Pal/src/Makefile
@@ -155,3 +155,7 @@ clean:
 .PHONY: test
 test:
 	$(MAKE) -C $(HOST_DIR) test
+
+.PHONY: sgx-tokens
+sgx-tokens:
+	$(MAKE) -C $(HOST_DIR) sgx-tokens

--- a/Pal/src/Makefile.Host
+++ b/Pal/src/Makefile.Host
@@ -11,11 +11,11 @@ $(error Unsupported platform: $(SYS))
 endif
 endif
 
-# Set SGX=1 to build Graphene for SGX
-ifeq ($(SGX)$(SGX_RUN),11)
-	$(error "Do not use SGX=1 and SGX_RUN=1 at the same time")
+ifeq ($(SGX_RUN),1)
+	$(error "SGX_RUN has been removed. Always set SGX=1 if building for SGX and use the 'sgx-tokens' make target to build launch/EINIT tokens")
 endif
-ifeq ($(SGX)$(SGX_RUN),1)
+
+ifeq ($(SGX),1)
 	PAL_HOST := $(patsubst %-SGX,%,$(PAL_HOST))-SGX
 endif
 

--- a/Pal/src/host/FreeBSD/Makefile
+++ b/Pal/src/host/FreeBSD/Makefile
@@ -1,3 +1,4 @@
+include ../../../../build-config.mk
 include ../../../../Makefile.configs
 include Makefile.am
 

--- a/Pal/src/host/Linux-SGX/Makefile
+++ b/Pal/src/host/Linux-SGX/Makefile
@@ -1,3 +1,4 @@
+include ../../../../build-config.mk
 include ../../../../Makefile.configs
 include Makefile.am
 

--- a/Pal/src/host/Linux-SGX/Makefile.Test
+++ b/Pal/src/host/Linux-SGX/Makefile.Test
@@ -6,14 +6,10 @@ SGX_SIGNER_KEY ?= $(SGX_DIR)/signer/enclave-key.pem
 SGX_SIGN = $(SGX_DIR)/signer/pal-sgx-sign -libpal $(LIBPAL) -key $(SGX_SIGNER_KEY)
 SGX_GET_TOKEN = $(SGX_DIR)/signer/pal-sgx-get-token
 
-ifeq ($(SGX_RUN),1)
-
-expand_target = $(foreach t,$(filter-out manifest,$(1)),$(patsubst %.manifest,%,$(t)).token)
+expand_target_to_token = $(foreach t,$(filter-out manifest,$(1)),$(patsubst %.manifest,%,$(t)).token)
 
 %.token: %.sig
 	$(call cmd,sgx_get_token)
-
-else
 
 expand_target = $(1) $(foreach t,$(filter-out manifest,$(1)), \
 		$(patsubst %.manifest,%,$(t)).manifest.sgx)
@@ -37,7 +33,3 @@ $(SGX_SIGNER_KEY):
 
 %.manifest.sgx.d: manifest
 	$(call cmd,sgx_manifest_dependency)
-
-*.token nothing:
-
-endif

--- a/Pal/src/host/Linux-SGX/sgx_main.c
+++ b/Pal/src/host/Linux-SGX/sgx_main.c
@@ -894,7 +894,7 @@ static int load_enclave (struct pal_enclave * enclave,
     if (IS_ERR(enclave->token)) {
         SGX_DBG(DBG_E, "Cannot open token \'%s\'. Use \'"
                 PAL_FILE("pal-sgx-get-token")
-                "\' on the runtime host or run \'make SGX_RUN=1\' "
+                "\' on the runtime host or run \'make SGX=1 sgx-tokens\' "
                 "in the Graphene source to create the token file.\n",
                 token_uri);
         free(token_uri);

--- a/Pal/src/host/Linux/Makefile
+++ b/Pal/src/host/Linux/Makefile
@@ -1,3 +1,4 @@
+include ../../../../build-config.mk
 include ../../../../Makefile.configs
 include Makefile.am
 

--- a/Pal/src/host/Skeleton/Makefile
+++ b/Pal/src/host/Skeleton/Makefile
@@ -1,3 +1,4 @@
+include ../../../../build-config.mk
 include ../../../../Makefile.configs
 include Makefile.am
 

--- a/Pal/test/Makefile
+++ b/Pal/test/Makefile
@@ -23,6 +23,9 @@ pal_lib = ../../Runtime/libpal-$(PAL_HOST).so
 .PHONY: all
 all:	pal_loader $(call expand_target,$(target))
 
+.PHONY: sgx-tokens
+sgx-tokens: $(call expand_target_to_token,$(target))
+
 ifeq ($(DEBUG),1)
 CC += -g
 endif

--- a/Pal/test/Makefile
+++ b/Pal/test/Makefile
@@ -1,3 +1,4 @@
+include ../../build-config.mk
 include ../src/Makefile.Host
 
 CC	= gcc

--- a/README.rst
+++ b/README.rst
@@ -156,7 +156,7 @@ a |_| few tested applications, such as GCC, Python, and Apache.
 
    - Generate the token from aesmd service, via command::
 
-      make SGX_RUN=1
+      make SGX=1 sgx-tokens
 
    - Run Hello World program with Graphene on SGX::
 
@@ -174,7 +174,7 @@ a |_| few tested applications, such as GCC, Python, and Apache.
 
    - Generate token::
 
-      make SGX_RUN=1
+      make SGX=1 sgx-tokens
 
    - Run python helloworld with Graphene-SGX via::
 

--- a/README.rst
+++ b/README.rst
@@ -71,15 +71,16 @@ To build the system, simply run the following commands in the root of the
 source tree::
 
     git submodule update --init -- Pal/src/host/Linux-SGX/sgx-driver/
+    ./build-setup
     make
 
 Each part of Graphene can be built separately in the subdirectories.
 
-To build Graphene library OS with debug symbols, run ``make DEBUG=1``
-instead of ``make``. To specify custom mirrors for downloading the GLIBC
-source, use ``make GLIBC_MIRRORS=...``.
+To build Graphene library OS with debug symbols, pass ``DEBUG=1`` to
+``build-setup``. To specify custom mirrors for downloading the GLIBC source,
+use ``GLIBC_MIRRORS=...``.
 
-To build with ``-Werror``, run ``make WERROR=1``.
+To build with ``-Werror``, pass ``WERROR=1``.
 
 Build with kernel-level sandboxing (optional)
 ---------------------------------------------
@@ -100,9 +101,8 @@ Prerequisites
       openssl genrsa -3 -out enclave-key.pem 3072
 
    You could either put the generated enclave key to the default path,
-   ``host/Linux-SGX/signer/enclave-key.pem``, or specify the key through
-   environment variable ``SGX_SIGNER_KEY`` when building Graphene with SGX
-   support.
+   ``host/Linux-SGX/signer/enclave-key.pem``, or specify the key through the
+   config variable ``SGX_SIGNER_KEY`` when building Graphene with SGX support.
 
    After signing the enclaves, users may ship the application files with the
    built Graphene Library OS, along with a SGX-specific manifest (.manifest.sgx
@@ -130,14 +130,17 @@ Building Graphene-SGX
 To build Graphene Library OS with Intel SGX support, in the root directory of
 Graphene repo, run following command::
 
-   make SGX=1
+   ./build-setup SGX=1
+   make
 
 To build with debug symbols, run the command::
 
-   make SGX=1 DEBUG=1
+   ./build-setup SGX=1 DEBUG=1
+   make
 
-Using ``make SGX=1`` in the test or regression directory will automatically
-generate the enclave signatures (.sig files).
+After running ``./build-setup SGX=1`` in the top level directory, using
+``make`` in the test or regression directory will automatically generate the
+enclave signatures (.sig files).
 
 Run Built-in Examples in Graphene-SGX
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -150,13 +153,13 @@ a |_| few tested applications, such as GCC, Python, and Apache.
 
    - go to LibOS/shim/test/native, build the enclaves via command::
 
-      make SGX=1
+      make
 
      The command will build enclaves for all the programs in the folder
 
    - Generate the token from aesmd service, via command::
 
-      make SGX=1 sgx-tokens
+      make sgx-tokens
 
    - Run Hello World program with Graphene on SGX::
 
@@ -170,11 +173,11 @@ a |_| few tested applications, such as GCC, Python, and Apache.
 
    - go to LibOS/shim/test/apps/python, build the enclave::
 
-      make SGX=1
+      make
 
    - Generate token::
 
-      make SGX=1 sgx-tokens
+      make sgx-tokens
 
    - Run python helloworld with Graphene-SGX via::
 

--- a/Runtime/Makefile
+++ b/Runtime/Makefile
@@ -10,3 +10,6 @@ format:
 
 .PHONY: test
 test:
+
+.PHONY: sgx-tokens
+sgx-tokens:

--- a/Runtime/Makefile
+++ b/Runtime/Makefile
@@ -1,3 +1,5 @@
+include ../build-config.mk
+
 .PHONY: all
 all:
 

--- a/Runtime/pal_loader
+++ b/Runtime/pal_loader
@@ -16,18 +16,6 @@ do
 	shift
 done
 
-if [ -n "$SGX" ] && [ "$SGX" != "0" ]; then
-	export SGX=1
-	# Sometimes, we end up with a stray SGX_RUN in the environment,
-	# which makes the Makefile.Host unhappy
-	unset SGX_RUN
-	# The interaction of SGX and SGX_RUN is getting pretty unwieldly.
-	# We should kill off SGX_RUN.  Here, we can get in trouble
-	# if the make invocation below gets SGX_RUN via an MAKEFLAGS
-	# from a wrapper makefile (e.g., the regression tests)
-	unset MAKEFLAGS
-fi
-
 RUNTIME_DIR=$(/usr/bin/dirname $(readlink -f ${BASH_SOURCE[0]}))
 PAL_HOST=$(/usr/bin/make --no-print-directory --quiet -f $RUNTIME_DIR/../Pal/src/Makefile.Host print_host 2>&1)
 

--- a/Scripts/regression.py
+++ b/Scripts/regression.py
@@ -5,7 +5,7 @@ import signal
 import subprocess
 import unittest
 
-HAS_SGX = os.environ.get('SGX_RUN') == '1'
+HAS_SGX = os.environ.get('SGX') == '1'
 
 def expectedFailureIf(predicate):
     if predicate:

--- a/build-setup
+++ b/build-setup
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+set -eu -o pipefail
+
+cd "$(readlink -m "${BASH_SOURCE[0]}/..")"
+
+: > build-config.mk.new
+
+while [ "${1:+defined}" == defined ]; do
+    name="${1%%=*}"
+    value="${1#*=}"
+
+    case "$name" in
+        --help|-h)
+            echo "Usage: build-setup VARIABLE=VALUE ..."
+            echo
+            echo "for example for SGX with debug symbols: build-setup SGX=1 DEBUG=1"
+            exit 1
+            ;;
+        SGX_RUN)
+            echo "SGX_RUN has been removed, use SGX=1 and the 'sgx-tokens' Make target instead!"
+            exit 1
+            ;;
+        SGX|DEBUG|WERROR)
+            if [ "$value" != "1" ]; then
+                echo "Please set $name to 1 or don't set it"
+                exit 1
+            fi
+            ;;
+        CC|AS|AR|LD|CXX|OBJCOPY|GLIBC_MIRRORS|SGX_SIGNER_KEY|GLIBC_VERSION)
+            ;;
+        *)
+            echo "Warning: Variable \"$name\" not recognized by build-setup."
+            echo "Will set it anyway, but please double check if it is really what you want."
+            ;;
+    esac
+
+    printf '%s := %s\n' "$name" "$value" >> build-config.mk.new
+    printf 'export %s\n' "$name" >> build-config.mk.new
+
+    shift
+done
+
+echo "BUILD_CONFIGURED := 1" >> build-config.mk.new
+
+mv build-config.mk{.new,}


### PR DESCRIPTION
<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [x] README and global configuration
- [x] Linux PAL
- [x] SGX PAL
- [x] FreeBSD PAL
- [x] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->

Before this change the build config (like SGX=1, DEBUG=1, ...) was
passed via make command lines. Subsequent make invocations needed to get
the same arguments (make SGX=1, make SGX=1 regression, make SGX=1 clean,
...).

With this change the build configuration is set once by calling the new
'build-setup' script. Example:

    $ ./build-setup SGX=1
    $ make
    $ make -C Pal/regression regression
    $ make clean

For now build-setup is a simple shell script which mostly passes the
variable definition 1-to-1 into build-config.mk. In the future this can
be expanded with better error detection, searching for libraries, etc.

Depends on #950 and oscarlab/graphene-tests#38.

## How to test this PR? <!-- (if applicable) -->

See above or Jenkins files for usage examples.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/965)
<!-- Reviewable:end -->
