### PR TITLE
[Pal] Change the way argv[0] is handled

### DIFF
--- a/Documentation/oldwiki/Graphene-Manifest-Syntax.md
+++ b/Documentation/oldwiki/Graphene-Manifest-Syntax.md
@@ -35,10 +35,10 @@ libraries must be separated by commas. The libraries must be ELF binaries.
 
     loader.execname=[STRING]
 
-This syntax specifies the executable name that will be passed as the first argument (`argv[0]`)
-to the executable. If the executable name is not specified in the manifest, the PAL will use the
-URI of the executable or the manifest -- depending on whether the executable or the manifest is
-given as the first argument to the PAL loader -- as `argv[0]` when running the executable.
+This syntax specifies an arbitrary string (typically the executable name) that will be passed as
+the first argument (argv[0]) to the executable only if it is run via the manifest
+(e.g. `./app.manifest arg1 arg2 ...`). If the string is not specified in the manifest, the PAL will
+use the path to the manifest itself (standard UNIX convention).
 
 ### Environment Variables
 

--- a/LibOS/shim/test/regression/test_libos.py
+++ b/LibOS/shim/test/regression/test_libos.py
@@ -21,14 +21,14 @@ class TC_00_Bootstrap(RegressionTestCase):
 
         # One Argument Given
         self.assertIn('# of Arguments: 1', stdout)
-        self.assertIn('argv[0] = file:bootstrap', stdout)
+        self.assertIn('argv[0] = bootstrap', stdout)
 
 
     def test_101_basic_bootstrapping_five_arguments(self):
         # Five Arguments Given
         stdout, stderr = self.run_binary(['bootstrap', 'a', 'b', 'c', 'd'])
         self.assertIn('# of Arguments: 5', stdout)
-        self.assertIn('argv[0] = file:bootstrap', stdout)
+        self.assertIn('argv[0] = bootstrap', stdout)
         self.assertIn('argv[1] = a', stdout)
         self.assertIn('argv[2] = b', stdout)
         self.assertIn('argv[3] = c', stdout)
@@ -41,14 +41,14 @@ class TC_00_Bootstrap(RegressionTestCase):
     def test_102_basic_bootstrapping_static(self):
         # bootstrap_static
         stdout, stderr = self.run_binary(['bootstrap_static'])
-        self.assertIn('Hello world (file:bootstrap_static)!', stdout)
+        self.assertIn('Hello world (bootstrap_static)!', stdout)
 
     def test_103_basic_bootstrapping_pie(self):
         # bootstrap_pie
         stdout, stderr = self.run_binary(['bootstrap_pie'])
         self.assertIn('User program started', stdout)
         self.assertIn('Local Address in Executable: 0x', stdout)
-        self.assertIn('argv[0] = file:bootstrap_pie', stdout)
+        self.assertIn('argv[0] = bootstrap_pie', stdout)
 
     def test_110_basic_bootstrapping_cxx(self):
         stdout, stderr = self.run_binary(['bootstrap-c++'])

--- a/Pal/lib/api.h
+++ b/Pal/lib/api.h
@@ -17,6 +17,7 @@
 #ifndef API_H
 #define API_H
 
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <stdarg.h>
@@ -90,6 +91,8 @@ void * memcpy (void *dstpp, const void *srcpp, size_t len);
 void * memmove (void *dstpp, const void *srcpp, size_t len);
 void * memset (void *dstpp, int c, size_t len);
 int memcmp (const void *s1, const void *s2, size_t len);
+
+bool strendswith(const char* haystack, const char* needle);
 
 /* Libc memory allocation functions. stdlib.h. */
 void *malloc(size_t size);

--- a/Pal/lib/string/strendswith.c
+++ b/Pal/lib/string/strendswith.c
@@ -1,0 +1,13 @@
+#include <api.h>
+
+
+bool strendswith(const char* haystack, const char* needle) {
+    size_t haystack_len = strlen(haystack);
+    size_t needle_len = strlen(needle);
+
+    if (haystack_len < needle_len) {
+        return false;
+    }
+
+    return !memcmp(&haystack[haystack_len - needle_len], needle, needle_len);
+}

--- a/Pal/regression/test_pal.py
+++ b/Pal/regression/test_pal.py
@@ -50,7 +50,7 @@ class TC_01_Bootstrap(RegressionTestCase):
 
         # One Argument Given
         self.assertIn('# of Arguments: 1', stderr)
-        self.assertIn('argv[0] = file:Bootstrap', stderr)
+        self.assertIn('argv[0] = Bootstrap', stderr)
 
         # Control Block: Debug Stream (Inline)
         self.assertIn('Written to Debug Stream', stdout)

--- a/Pal/src/db_rtld.c
+++ b/Pal/src/db_rtld.c
@@ -1319,9 +1319,7 @@ void * stack_before_call __attribute_unused = NULL;
 #endif
 #endif /* !CALL_ENTRY */
 
-noreturn void start_execution (const char * first_argument,
-                               const char ** arguments, const char ** environs)
-{
+noreturn void start_execution(const char** arguments, const char** environs) {
     /* First we will try to run all the preloaded libraries which come with
        entry points */
     if (exec_map) {
@@ -1334,15 +1332,13 @@ noreturn void start_execution (const char * first_argument,
 #endif
 
     int narguments = 0;
-    if (first_argument)
-        narguments++;
-    for (const char ** a = arguments; *a ; a++, narguments++);
+    for (const char** a = arguments; *a ; a++, narguments++);
 
     /* Let's count the number of cookies, first we will have argc & argv */
     int ncookies = narguments + 3; /* 1 for argc, argc + 2 for argv */
 
     /* Then we count envp */
-    for (const char ** e = environs; *e; e++)
+    for (const char** e = environs; *e; e++)
         ncookies++;
 
     ncookies++; /* for NULL-end */
@@ -1351,13 +1347,11 @@ noreturn void start_execution (const char * first_argument,
                       + sizeof(ElfW(auxv_t)) * 1  /* only AT_NULL */
                       + sizeof(void *) * 4 + 16;
 
-    unsigned long int * cookies = __alloca(cookiesz);
+    unsigned long int* cookies = __alloca(cookiesz);
     int cnt = 0;
 
     /* Let's copy the cookies */
     cookies[cnt++] = (unsigned long int) narguments;
-    if (first_argument)
-        cookies[cnt++] = (unsigned long int) first_argument;
 
     for (int i = 0 ; arguments[i] ; i++)
         cookies[cnt++] = (unsigned long int) arguments[i];

--- a/Pal/src/pal_rtld.h
+++ b/Pal/src/pal_rtld.h
@@ -180,7 +180,6 @@ do_lookup_map (ElfW(Sym) * ref, const char * undef_name,
 void _DkDebugAddMap (struct link_map * map);
 void _DkDebugDelMap (struct link_map * map);
 
-noreturn void start_execution (const char * first_argument,
-                               const char ** arguments, const char ** environs);
+noreturn void start_execution(const char** arguments, const char** environs);
 
 #endif /* PAL_RTLD_H */


### PR DESCRIPTION
Before argv[0] was treated specialy and was changed to a value
from manifest file. Now this happens only if binary was ran as
a manifest i.e. `./pal_loader path_to_manifest_file`

<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [x] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->


## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/971)
<!-- Reviewable:end -->
