### PR TITLE
[Pal] Delete '\' removal in read_config

### DIFF
--- a/Pal/lib/graphene/config.c
+++ b/Pal/lib/graphene/config.c
@@ -333,18 +333,12 @@ int read_config(struct config_store* store, int (*filter)(const char* key, int k
         char* val = NULL;
         int vlen;
         if (*ptr == '"') {
-            int shift = 0;
-            val       = (++ptr);
-            for (; RANGE && *ptr != '"'; ptr++) {
-                if (*ptr == '\\') {
-                    shift++;
-                    ptr++;
-                }
-                if (shift)
-                    *(ptr - shift) = *ptr;
+            val = ++ptr;
+            while (RANGE && *ptr != '"') {
+                ptr++;
             }
             CHECK_PTR("stream ended without closing quote");
-            vlen = (ptr - shift) - val;
+            vlen = ptr - val;
         } else {
             val        = ptr;
             char* last = ptr - 1;


### PR DESCRIPTION
If a backslah ('\') was encountered in a quoted ('"') value in a manifest,
it was getting deleted, but since the manifest is mapped read-only it caused
a segfault.
Removed this faulty behavior, now values are passed exactly as seen in
a manifest file, e.g. `loader.env.XXX = "\xY"Z"` passes a environmental
variable `XXX` with a value `"\xY"Z"`

<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [x] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->


## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/974)
<!-- Reviewable:end -->
