### PR TITLE
[SGX] Add DCAP support

### DIFF
--- a/Documentation/building.rst
+++ b/Documentation/building.rst
@@ -86,11 +86,17 @@ Prerequisites
 
 2. Install the Intel SGX SDK and driver
 
-   The Intel SGX Linux SDK is required to compile and run Graphene on SGX.
-   Download and install it from the official Intel GitHub repositories:
+   The Intel SGX Linux SDK and the Intel SGX driver are required to compile and
+   run Graphene on SGX. Download and install them from the official Intel
+   GitHub repositories:
 
-   - <https://github.com/01org/linux-sgx>
-   - <https://github.com/01org/linux-sgx-driver>
+   - https://github.com/01org/linux-sgx
+   - https://github.com/01org/linux-sgx-driver
+
+   Alternatively, if you want to use the DCAP versions of the SDK and driver,
+   download and install it from:
+
+   - https://github.com/intel/SGXDataCenterAttestationPrimitives
 
 3. Build and install the Graphene SGX driver
    A Graphene-specific Linux driver must also be installed before running

--- a/Documentation/oldwiki/Introduction-to-Graphene-SGX.rst
+++ b/Documentation/oldwiki/Introduction-to-Graphene-SGX.rst
@@ -94,7 +94,9 @@ Prerequisites for Untrusted Host
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 To run the applications on Intel SGX with Graphene-SGX, the host must have an SGX-enabled CPU, with
 Intel SGX SDK and the SGX driver installed. Please download and install the SDK and the driver from:
-<https://github.com/01org/linux-sgx> and <https://github.com/01org/linux-sgx-driver>.
+https://github.com/01org/linux-sgx and https://github.com/01org/linux-sgx-driver. If you want
+to use the DCAP SDK and driver, please download and install from:
+https://github.com/intel/SGXDataCenterAttestationPrimitives.
 
 A Graphene SGX driver (gsgx) also needs to be installed on the untrusted host. Simply run the
 following commands to build the driver::

--- a/Documentation/quickstart.rst
+++ b/Documentation/quickstart.rst
@@ -34,19 +34,22 @@ SGX Quick Start
 
 Before you run any applications in Graphene-SGX, please make sure that Intel SGX
 SDK and the SGX driver are installed on your system. We recommend using Intel
-SGX SDK and the SGX driver no older than version 2.1.
+SGX SDK and the SGX driver no older than version 1.9 (or the DCAP SGX SDK and
+the driver version 1.4/1.5).
 
 If Intel SGX SDK and the SGX driver are not installed, please follow the READMEs
-in <https://github.com/01org/linux-sgx> and
-<https://github.com/01org/linux-sgx-driver> to download and install them.
+in https://github.com/01org/linux-sgx and
+https://github.com/01org/linux-sgx-driver to download and install them.
+If you want to use the DCAP SDK and driver, please follow the README in
+https://github.com/intel/SGXDataCenterAttestationPrimitives.
 
 1. Ensure That Intel SGX is Enabled on Your Platform::
 
-      lsmod | grep isgx
+      lsmod | grep sgx
       ps ax | grep [a]esm_service
 
-The first command should list :command:`isgx` and the second command should list
-the process status of :command:`aesm_service`.
+The first command should list :command:`isgx` (or :command:`sgx`) and the
+second command should list the process status of :command:`aesm_service`.
 
 2. Clone the Repository and Set the Home Directory of Graphene::
 

--- a/Jenkinsfiles/Linux-SGX-18.04
+++ b/Jenkinsfiles/Linux-SGX-18.04
@@ -31,6 +31,22 @@ pipeline {
                            cd linux-sgx-driver
                            git checkout sgx_driver_1.9
                            make
+
+                           cd /opt/intel
+                           git clone https://github.com/intel/SGXDataCenterAttestationPrimitives.git
+                           cd SGXDataCenterAttestationPrimitives
+                           git checkout DCAP_1.5
+                           # no need to build, we only need the SGX header file (sgx.h)
+                        '''
+                        sh '''
+                            # test the build with the DCAP driver and clean up afterwards
+                            cd Pal/src/host/Linux-SGX/sgx-driver
+                            ISGX_DRIVER_PATH=/opt/intel/SGXDataCenterAttestationPrimitives/driver/linux make
+                            cd ../../../../../
+                            CFLAGS="-DSGX_DCAP" make -j 8 SGX=1 WERROR=1
+                            CFLAGS="-DSGX_DCAP" make -j 8 SGX=1 clean
+                            cd Pal/src/host/Linux-SGX/sgx-driver
+                            make distclean
                         '''
                         sh '''
                             cd Pal/src/host/Linux-SGX/sgx-driver

--- a/Pal/lib/Makefile
+++ b/Pal/lib/Makefile
@@ -3,7 +3,7 @@ include ../../Scripts/Makefile.rules
 include ../src/host/$(PAL_HOST)/Makefile.am
 
 CFLAGS += -I../include/lib -I../include -I../include/pal -I../include/host/$(PAL_HOST) \
-          -Icrypto/mbedtls/include -Icrypto/mbedtls/crypto/include
+          -I../src/host/$(PAL_HOST) -Icrypto/mbedtls/include -Icrypto/mbedtls/crypto/include
 
 CRYPTO_PROVIDER ?= mbedtls
 
@@ -77,7 +77,7 @@ crypto/mbedtls/CMakeLists.txt: crypto/$(MBEDTLS_SRC) crypto/$(MBEDCRYPTO_SRC)
 	mv crypto/mbed-crypto-mbedcrypto-$(MBEDCRYPTO_VERSION) crypto/mbedtls
 	mv crypto/mbedtls/mbed-crypto-mbedcrypto-3.1.0 crypto/mbedtls/crypto
 	mkdir crypto/mbedtls/install
-	cd crypto/mbedtls && ./scripts/config.pl set MBEDTLS_CMAC_C && make SHARED=1 DESTDIR=install install .
+	cd crypto/mbedtls && ./scripts/config.pl set MBEDTLS_CMAC_C && make CFLAGS="" SHARED=1 DESTDIR=install install .
 	$(RM) crypto/mbedtls/include/mbedtls/config.h
 	$(RM) crypto/mbedtls/crypto/include/mbedtls/config.h
 

--- a/Pal/src/host/Linux-SGX/generated-offsets.c
+++ b/Pal/src/host/Linux-SGX/generated-offsets.c
@@ -10,6 +10,13 @@
 #include "sgx_arch.h"
 #include "sgx_tls.h"
 
+/* sgx.h header from the Intel SGX driver assumes that `__packed` macro was defined */
+#ifndef __packed
+#define __packed __attribute__((packed))
+#endif
+#include "sgx.h"
+#undef __packed
+
 #include <generated-offsets-build.h>
 
 void dummy(void)
@@ -169,4 +176,9 @@ void dummy(void)
     OFFSET_T(XSAVE_HEADER_OFFSET, PAL_XREGS_STATE, header);
     DEFINE(PAL_XSTATE_ALIGN, PAL_XSTATE_ALIGN);
     DEFINE(PAL_FP_XSTATE_MAGIC2_SIZE, PAL_FP_XSTATE_MAGIC2_SIZE);
+
+    /* SGX_DCAP */
+#ifdef SGX_DCAP
+    DEFINE(SGX_DCAP, SGX_DCAP);
+#endif
 }

--- a/Pal/src/host/Linux-SGX/sgx_framework.c
+++ b/Pal/src/host/Linux-SGX/sgx_framework.c
@@ -285,6 +285,9 @@ int init_enclave(sgx_arch_secs_t * secs,
                  sgx_arch_enclave_css_t * sigstruct,
                  sgx_arch_token_t * token)
 {
+#ifdef SGX_DCAP
+    __UNUSED(token);
+#endif
     unsigned long enclave_valid_addr =
                 secs->base + secs->size - g_page_size;
 
@@ -298,7 +301,9 @@ int init_enclave(sgx_arch_secs_t * secs,
     struct sgx_enclave_init param = {
         .addr           = enclave_valid_addr,
         .sigstruct      = (uint64_t) sigstruct,
+#ifndef SGX_DCAP
         .einittoken     = (uint64_t) token,
+#endif
     };
     int ret = INLINE_SYSCALL(ioctl, 3, isgx_device, SGX_IOC_ENCLAVE_INIT,
                              &param);

--- a/Pal/src/host/Linux-SGX/signer/pal-sgx-get-token
+++ b/Pal/src/host/Linux-SGX/signer/pal-sgx-get-token
@@ -2,6 +2,7 @@
 # pylint: disable=invalid-name
 
 import argparse
+import array
 import os
 import socket
 import struct
@@ -76,6 +77,9 @@ def read_sigstruct(sig):
 
     return attr
 
+def is_dcap():
+    """ Check if we're dealing with DCAP driver."""
+    return hasattr(offs, 'SGX_DCAP')
 
 def connect_aesmd(attr):
     """Connect with AESMD."""
@@ -118,6 +122,41 @@ def connect_aesmd(attr):
 
     return ret_msg.ret.token
 
+def create_dummy_token(attr):
+    """ Create dummy token with a few fields initialized with real values
+        and others with a placeholder ('\0')"""
+    token = array.array('B', b'\0'*304)
+
+    # format: field_name -> tuple (offset, type_with_size)
+    fields = dict()
+
+    fields['valid'] = (0, "<I")
+    fields['reserved'] = (4, "44B")
+    fields['flags'] = (48, "<Q") # attrs
+    fields['xfrms'] = (56, "<Q") # attrs
+    fields['mrenclave'] = (64, "32B")
+    fields['reserved2'] = (96, "32B")
+    fields['mrsigner'] = (128, "32B")
+    fields['reserved3'] = (160, "32B")
+    fields['cpusvnle'] = (192, "<2Q")
+    fields['isvprodidle'] = (208, "<H")
+    fields['isvsvnle'] = (210, "<H")
+    fields['reserved4'] = (212, "24B")
+    fields['misc_mask'] = (236, "<I")
+    fields['flagmask'] = (240, "<Q") # attrmask
+    fields['xfrmmask'] = (248, "<Q") # attrmask
+    fields['keyid'] = (256, "32B")
+    fields['mac'] = (288, "16B")
+
+    # fields read by create_enclave() in sgx_framework.c
+    actual_fields = ['flags', 'xfrms', 'misc_mask']
+
+    for key in actual_fields:
+        field = fields[key]
+        field_size = struct.Struct(field[1]).size
+        token[field[0]:field[0] + field_size] = array.array('B', attr[key])
+
+    return token
 
 argparser = argparse.ArgumentParser()
 argparser.add_argument('--sig', '-sig', metavar='SIGNATURE',
@@ -148,7 +187,11 @@ def main(args=None):
     print("    signature:   %s..." % attr['signature'].hex()[:32])
     print("    date:        %d-%02d-%02d" % (attr['year'], attr['month'], attr['day']))
 
-    token = connect_aesmd(attr)
+    if is_dcap():
+        token = create_dummy_token(attr)
+    else:
+        token = connect_aesmd(attr)
+
     args.output.write(token)
     return 0
 


### PR DESCRIPTION
<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [x] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->

Corresponding SGX driver PR is https://github.com/oscarlab/graphene-sgx-driver/pull/7.

Closes #881. Fixes #1403. 

I have tested this code on Azure’s Confidential Compute VM Deployment instance (Ubuntu 18.04).
DCAP driver does not have `einittoken` in `struct sgx_enclave_init` ([Link](https://github.com/intel/SGXDataCenterAttestationPrimitives/blob/master/driver/linux/include/uapi/asm/sgx.h)), so related codes must be modified accordingly.

## How to test this PR? <!-- (if applicable) -->

Before running `make` in `$GRAPHENE_DIR/Pal/src/host/Linux-SGX/sgx-driver/`, `sgx_user.h` must be symlinked as follows:
```
cp -r /usr/src/sgx-1.10 ~/
cd ~/sgx-1.10
ln -s include/uapi/asm/sgx.h sgx_user.h
```

Also, input `~/sgx-1.10` when "Enter the Intel SGX driver directory" is prompted in the following step.
Note that graphene driver must be modified to remove `einittoken` from related fields. I will create PR .

```
cd $GRAPHENE_DIR/Pal/src/host/Linux-SGX/sgx-driver/
cat > tmp << 'EOF'
diff --git a/Makefile b/Makefile
index 79b9cb2..0b7994d 100644
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,9 @@
+CFLAGS_MODULE = -DDEBUG -g -O0
+
+ifeq ($(SGX_DCAP),1)
+CFLAGS_MODULE += -DSGX_DCAP
+endif
+
 ifneq ($(KERNELRELEASE),)
 	graphene-sgx-y := \
 		gsgx_ioctl_1_6.o \
@@ -11,7 +17,7 @@ PWD  := $(shell pwd)
 
 .PHONY: default
 default: isgx_version.h linux-sgx-driver
-	$(MAKE) -C $(KDIR) M=$(PWD) CFLAGS_MODULE="-DDEBUG -g -O0" modules
+	$(MAKE) -C $(KDIR) M=$(PWD) CFLAGS_MODULE="$(CFLAGS_MODULE)" modules
 
 .INTERMEDIATE: link-sgx-driver
 link-sgx-driver:
diff --git a/graphene-sgx.h b/graphene-sgx.h
index cc779b6..60796ac 100644
--- a/graphene-sgx.h
+++ b/graphene-sgx.h
@@ -66,7 +66,9 @@ struct gsgx_enclave_add_pages {
 struct gsgx_enclave_init {
 	uint64_t addr;
 	uint64_t sigstruct;
+#ifndef SGX_DCAP
 	uint64_t einittoken;
+#endif
 };
 
 #endif /* SDK_DRIVER_VERSION < KERNEL_VERSION(1, 8, 0) */
diff --git a/gsgx_ioctl_1_7.c b/gsgx_ioctl_1_7.c
index 8803877..0aebce2 100644
--- a/gsgx_ioctl_1_7.c
+++ b/gsgx_ioctl_1_7.c
@@ -75,7 +75,10 @@ static long enclave_init(struct file *filep, void * arg)
 
 	isgx_init.addr = initp->addr;
 	isgx_init.sigstruct = initp->sigstruct;
+
+#ifndef SGX_DCAP
 	isgx_init.einittoken = initp->einittoken;
+#endif
 
 	return KSYM(isgx_ioctl_enclave_init)(filep, SGX_IOC_ENCLAVE_INIT,
 					     (unsigned long) &isgx_init);
diff --git a/load.sh b/load.sh
index f5c8215..a70b6b0 100755
--- a/load.sh
+++ b/load.sh
@@ -1,9 +1,7 @@
 #!/bin/bash
 
-sudo service aesmd stop
 sudo rmmod graphene_sgx
-sudo rmmod isgx
+sudo rmmod intel_sgx
 make || exit -1
-sudo modprobe isgx || exit -1
+sudo modprobe intel_sgx || exit -1
 sudo insmod graphene-sgx.ko || exit -1
-sudo service aesmd start || exit -1
EOF

git apply tmp
make SGX=1 SGX_DCAP=1
sudo ./load.sh

cd $GRAPHENE_DIR/Pal/src/
make SGX=1 SGX_DCAP=1

cd $GRAPHENE_DIR/LibOS/
make SGX=1 SGX_DCAP=1

cd $GRAPHENE_DIR/LibOS/shim/test/native
echo "sgx.debug = 0" >> manifest.template
make SGX=1
make SGX_RUN=1 SGX_DCAP=1
./pal_loader SGX helloworld
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/978)
<!-- Reviewable:end -->
