### PR TITLE
Tools/gsce: Fix parsing image repo

### DIFF
--- a/Tools/gsce
+++ b/Tools/gsce
@@ -101,7 +101,7 @@ if __name__ == '__main__':
     app_name = image_match.group(1)
 
   # application name may contain '/', remove it
-  app_name = app_name.split('/')[0]
+  app_name = app_name.split('/')[-1]
 
   inspect_cmd = 'sudo docker inspect --format \'{{.Config.Cmd}}\' ' + image_name
   res = subprocess.check_output(inspect_cmd, shell=True).strip()


### PR DESCRIPTION
A canonical image repo looks like "foo.com/hello-world:0.1".
So the parsed app_name should be the last portion.

Signed-off-by: Jia Zhang <zhang.jia@linux.alibaba.com>

<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->


## How to test this PR? <!-- (if applicable) -->

