### PR TITLE
Just fix the specific header version within an ubuntu release

### DIFF
--- a/Jenkinsfiles/Linux
+++ b/Jenkinsfiles/Linux
@@ -15,7 +15,7 @@ pipeline {
                             make -j 8 WERROR=1
                             make -j 8 WERROR=1 test
                             cd Pal/ipc/linux
-                            make
+                            make KERNELDIR=/lib/modules/4.4.0-161-generic/build
                            '''
                     }
                 }

--- a/Jenkinsfiles/Linux-18.04
+++ b/Jenkinsfiles/Linux-18.04
@@ -9,8 +9,8 @@ pipeline {
                             make -j 8 WERROR=1
                             make -j 8 WERROR=1 test
                             # We can't build this on 18.04 in our current pipeline
-                            #cd Pal/ipc/linux
-                            #make
+                            cd Pal/ipc/linux
+                            make KERNELDIR=/lib/modules/4.15.0-20-generic/build
                            '''
                     }
                 }

--- a/Jenkinsfiles/ubuntu-16.04.dockerfile
+++ b/Jenkinsfiles/ubuntu-16.04.dockerfile
@@ -15,8 +15,7 @@ RUN apt-get update \
        libexpat1-dev \
        libpcre3-dev \
        libxml2-dev \
-       linux-headers-generic \
-       linux-headers-$(uname -r) \
+       linux-headers-4.4.0-161-generic \
        net-tools \
        python \
        python-protobuf \

--- a/Jenkinsfiles/ubuntu-18.04.dockerfile
+++ b/Jenkinsfiles/ubuntu-18.04.dockerfile
@@ -10,12 +10,13 @@ RUN apt-get update && apt-get install -y \
     bison \
     gettext \
     git \
+    libelf-dev \
     libexpat1 \
     libexpat1-dev \
     libomp-dev \
     libpcre3-dev \
     libxml2-dev \
-    linux-headers-generic \
+    linux-headers-4.15.0-20-generic \
     net-tools \
     python \
     python-protobuf \


### PR DESCRIPTION
<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [X] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->

Fix the specific kernel header version to test graphene IPC build against, at least within one ubuntu release.  In the Jenkins pipelines, the kernel seems to be getting out of sync with the headers, I believe because of an upgrade on a worker node that doesn't flush the cached image.

Switch from testing the build of whatever version is in 'uname -r' to a reasonable, static default of the kernel headers.

## How to test this PR? <!-- (if applicable) -->

Just run the Linux 16.04 and 18.04 pipelines.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/983)
<!-- Reviewable:end -->
