### PR TITLE
[Pal] regression: only enable -mavx for AvxDisable

### DIFF
--- a/Pal/regression/Makefile
+++ b/Pal/regression/Makefile
@@ -1,7 +1,7 @@
 include ../src/Makefile.Host
 
 CC	= gcc
-CFLAGS	= -Wall -O2 -std=c11 -fno-builtin -nostdlib -mavx \
+CFLAGS	= -Wall -O2 -std=c11 -fno-builtin -nostdlib \
 	  -I../include/pal -I../lib -I../src
 
 preloads    = $(patsubst %.c,%,$(wildcard *.so.c))
@@ -49,6 +49,8 @@ manifest: manifest.template
 
 ../src/user_shared_start.o ../src/user_start.o: ../src/user_start.S
 	$(MAKE) -C ../src $(notdir $@)
+
+CFLAGS-AvxDisable += -mavx
 
 ifeq ($(findstring x86_64,$(SYS))$(findstring linux,$(SYS)),x86_64linux)
 LDLIBS-preloads = ../src/user_shared_start.o $(graphene_lib) $(pal_lib)


### PR DESCRIPTION
Other executable doesn't need avx, and it causes failure on platform
that doesn't support avx.

<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->


## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/987)
<!-- Reviewable:end -->
