### PR TITLE
[Pal/Linux-SGX] fix make SGX=1 clean

### DIFF
--- a/Pal/regression/Makefile
+++ b/Pal/regression/Makefile
@@ -66,8 +66,10 @@ $(executables): %: %.c $(LDLIBS-executables)
 	$(call cmd,csingle)
 
 include $(wildcard *.d)
+ifeq ($(filter clean,$(MAKECMDGOALS)),)
 ifeq ($(SGX), 1)
 include $(addsuffix .manifest.sgx.d,$(executables))
+endif
 endif
 
 .lib/host_endian.h: ../src/host/$(PAL_HOST)/host_endian.h

--- a/Pal/test/Makefile
+++ b/Pal/test/Makefile
@@ -53,8 +53,10 @@ $(executables): %: %.c $(LDLIBS)
 
 $(graphene_lib): .lib/host_endian.h
 	$(MAKE) -C ../lib target=$(abspath .lib)/
+ifeq ($(filter clean,$(MAKECMDGOALS)),)
 ifeq ($(SGX), 1)
 include $(addsuffix .manifest.sgx.d,$(executables))
+endif
 endif
 else
 .IGNORE: $(executables)


### PR DESCRIPTION
when clean, dependency should not be calculated.

<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [x] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->


## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/988)
<!-- Reviewable:end -->
