### PR TITLE
[LibOS] work around of mmap-file.c in regression

### DIFF
--- a/LibOS/shim/test/regression/mmap-file.c
+++ b/LibOS/shim/test/regression/mmap-file.c
@@ -6,7 +6,7 @@
 #include <sys/wait.h>
 #include <unistd.h>
 
-const char* message;
+static const char* message;
 
 void SIGBUS_handler(int sig) {
     puts(message);
@@ -79,6 +79,8 @@ int main(int argc, const char** argv) {
     }
 
     message = pid == 0 ? "mmap test 5 passed\n" : "mmap test 8 passed\n";
+    /* need a barrier to assign message before SIGBUS due to a[4096] */
+    asm volatile ("nop" ::: "memory");
     a[4096] = 0xff;
 
     if (signal(SIGBUS, SIG_DFL) == SIG_ERR) {


### PR DESCRIPTION
It has undefined behavior and causes test failure.
Add some work around.
TODO: remove undefined behavior and update test case.

<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->


## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/996)
<!-- Reviewable:end -->
