### PR TITLE
[SGX] Switch from requiring AVX making it optional by default.

### DIFF
--- a/Pal/regression/AvxDisable.manifest.template
+++ b/Pal/regression/AvxDisable.manifest.template
@@ -1,3 +1,3 @@
-sgx.enable_avx = 0
-sgx.enable_avx512 = 0
+sgx.require_avx = 0
+sgx.require_avx512 = 0
 sgx.allowed_files.res = file:avxRes

--- a/Pal/regression/test_pal.py
+++ b/Pal/regression/test_pal.py
@@ -133,7 +133,7 @@ class TC_01_Bootstrap(RegressionTestCase):
     @unittest.skipUnless(HAS_SGX, 'this test requires SGX')
     def test_120_8gb_enclave(self):
         manifest = self.get_manifest('Bootstrap6')
-        stdout, stderr = self.run_binary([manifest], timeout=240)
+        stdout, stderr = self.run_binary([manifest], timeout=360)
         self.assertIn('Loaded Manifest: file:' + manifest, stderr)
         self.assertIn('Executable Range OK', stderr)
 

--- a/Pal/src/host/Linux-SGX/sgx_framework.c
+++ b/Pal/src/host/Linux-SGX/sgx_framework.c
@@ -153,6 +153,12 @@ int create_enclave(sgx_arch_secs_t * secs,
     secs->miscselect = token->miscselect_mask;
     memcpy(&secs->attributes, &token->attributes,
            sizeof(sgx_arch_attributes_t));
+
+    // Enable AVX and AVX512
+    // [2019-09-18] TODO(dep): This alone is not enough to get the fully optional behavior we will want.
+    // Leave this here for future work in another PR
+    // secs->attributes.xfrm |= SGX_XFRM_AVX;
+
     /* Do not initialize secs->mrsigner and secs->mrenclave here as they are
      * not used by ECREATE to populate the internal SECS. SECS's mrenclave is
      * computed dynamically and SECS's mrsigner is populated based on the

--- a/Pal/src/host/Linux-SGX/signer/pal-sgx-sign
+++ b/Pal/src/host/Linux-SGX/signer/pal-sgx-sign
@@ -151,7 +151,6 @@ def get_enclave_attributes(manifest):
     default_attributes = {
         'FLAG_DEBUG',
         'XFRM_LEGACY',
-        'XFRM_AVX',
     }
 
     if ARCHITECTURE == 'amd64':
@@ -159,8 +158,8 @@ def get_enclave_attributes(manifest):
 
     manifest_options = {
         'debug'          : 'FLAG_DEBUG',
-        'enable_avx'     : 'XFRM_AVX',
-        'enable_avx512'  : 'XFRM_AVX512',
+        'require_avx'    : 'XFRM_AVX',
+        'require_avx512' : 'XFRM_AVX512',
         'enable_mpx'     : 'XFRM_MPX',
         'support_exinfo' : 'MISC_EXINFO',
     }


### PR DESCRIPTION
<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [X] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->

Our current signer always signs SGX manifests in such a way that it requires AVX, even if the application doesn't use AVX.  This creates problems on some SGX v2 systems (NUCs) that don't support AVX.

Change the default behavior for AVX to be off by default.

In a future PR, we will change this behavior to enabled, but not required, by default.

## How to test this PR? <!-- (if applicable) -->

Run a Jenkins pipeline on such a node.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/999)
<!-- Reviewable:end -->
