### PR TITLE
[LibOS] shim_parser.c: Additionally specify string as "const char*"

### DIFF
--- a/LibOS/shim/src/shim_parser.c
+++ b/LibOS/shim/src/shim_parser.c
@@ -441,7 +441,7 @@ static inline void parse_integer_arg(va_list ap) {
 static inline void parse_syscall_args(va_list ap) {
     const char* arg_type = va_arg(ap, const char*);
 
-    if (strcmp_static(arg_type, "const char *"))
+    if (strcmp_static(arg_type, "const char *") || strcmp_static(arg_type, "const char*"))
         parse_string_arg(ap);
     else if (is_pointer(arg_type))
         parse_pointer_arg(ap);
@@ -452,7 +452,7 @@ static inline void parse_syscall_args(va_list ap) {
 static inline void skip_syscall_args(va_list ap) {
     const char* arg_type = va_arg(ap, const char*);
 
-    if (strcmp_static(arg_type, "const char *"))
+    if (strcmp_static(arg_type, "const char *") || strcmp_static(arg_type, "const char*"))
         va_arg(ap, const char*);
     else if (is_pointer(arg_type))
         va_arg(ap, void*);


### PR DESCRIPTION

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->

The parser logic checks the arguments of syscalls and prints strings in debug output. Previously, our code base only contained "const char *" as strings. Recently, we started migration to "const char*" (no-space) style. This broke the parser logic, so this commit adds an additional check on what it means for a C type to be a string.

## How to test this PR? <!-- (if applicable) -->

All tests should run. One can try any application that does something like `open("somefile", O_RDONLY)`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1002)
<!-- Reviewable:end -->
