### PR TITLE
[Pal/Linux-SGX] gdb wrapper: use add-auto-load-safe-path

### DIFF
--- a/Pal/src/host/Linux-SGX/debugger/gdb
+++ b/Pal/src/host/Linux-SGX/debugger/gdb
@@ -7,4 +7,4 @@ if [ -z "$INSIDE_EMACS" ]; then
 	set -x
 fi
 
-LD_PRELOAD=$GDB_SO gdb -iex "set auto-load safe-path $GDB_SCRIPT" "$@"
+LD_PRELOAD=$GDB_SO gdb -iex "add-auto-load-safe-path $GDB_SCRIPT" "$@"


### PR DESCRIPTION
## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [x] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->

Previously, the GDB wrapper of Graphene-SGX used "set auto-load safe-path GDB_SCRIPT". This contradicts newer GDB versions which have a libpthread-2.27.so-gdb.py script in a different system dir. Thus, our wrapper overwrote the native GDB safe-path and broke GDB. This commit ensures that our wrapper only adds paths to safe-path.

## How to test this PR? <!-- (if applicable) -->

Try GDB on any executable under Ubuntu 18.04 (where PIE executables are default): `cd LibOS/shim/test/native && GDB=1 SGX=1 ./pal_loader helloworld`. GDB should not complain (without this PR, it says something like `warning: File "/usr/share/gdb/auto-load/lib/x86_64-linux-gnu/libpthread-2.27.so-gdb.py" auto-loading has been declined by your auto-load safe-path set to "graphene/Pal/src/host/Linux-SGX/debugger/pal-gdb.py".`).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1004)
<!-- Reviewable:end -->
