### PR TITLE
[Pal/Linux-SGX] Fix comparing manifest file suffix

### DIFF
--- a/Pal/src/host/Linux-SGX/sgx_main.c
+++ b/Pal/src/host/Linux-SGX/sgx_main.c
@@ -1014,9 +1014,11 @@ int main (int argc, char ** argv, char ** envp)
         goto out;
     }
 
-    if (strcmp_static(sgx_manifest + len - strlen(".manifest"), ".manifest")) {
+    if (len >= static_strlen(".manifest") &&
+        strcmp_static(sgx_manifest + len - static_strlen(".manifest"), ".manifest")) {
         strcpy_static(sgx_manifest + len, ".sgx", sizeof(sgx_manifest) - len);
-    } else if (!strcmp_static(sgx_manifest + len - strlen(".manifest.sgx"),
+    } else if (len < static_strlen(".manifest.sgx") ||
+               !strcmp_static(sgx_manifest + len - static_strlen(".manifest.sgx"),
                               ".manifest.sgx")) {
         strcpy_static(sgx_manifest + len, ".manifest.sgx", sizeof(sgx_manifest) - len);
     }


### PR DESCRIPTION
If the basename length of manifest file is not long enough,
a buffer underflow aceess occurs.

Signed-off-by: Jia Zhang \<zhang.jia@linux.alibaba.com\>

<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [x] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->
Bug fix

## How to test this PR? <!-- (if applicable) -->
cd LibOS/shim/test/native
cp helloworld h
cp helloworld.manifest.sgx h.manifest.sgx
./pal_loader SGX h

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1005)
<!-- Reviewable:end -->