### PR TITLE
[LibOS] Makefile.rules: Specify correct path to pal-symbols

### DIFF
--- a/Makefile.rules
+++ b/Makefile.rules
@@ -144,7 +144,7 @@ quiet_cmd_sgx_manifest_dependency = [ $@ ]
 	 echo "") > $@
 
 # pal map
-PAL_SYMBOL_FILE = $(dir $(abspath $(lastword $(MAKEFILE_LIST))))Pal/src/pal-symbols
+PAL_SYMBOL_FILE := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))Pal/src/pal-symbols
 PAL_SYMBOLS = $(shell sed -e 's|$$|;|g' $(PAL_SYMBOL_FILE))
 
 quiet_cmd_pal_map = [ $@ ]


### PR DESCRIPTION
## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->

Previously, Makefile.rules tried to find the absolute path to pal-symbols file using the MAKEFILE_LIST make variable. However, because Makefile.rules is included from other Makefiles, this led to
incorrect path ("graphene/Pal/src/host/Linux/Pal/src/pal-symbols"). This commit switches from MAKEFILE_LIST to PAL_DIR.

## How to test this PR? <!-- (if applicable) -->

Without this PR, doing `make SGX=1` and then `make` (i.e., first build with Linux-SGX PAL, then with Linux PAL) broke with error:
```
sed: can't read /home/dimakuv/graphene/Pal/src/host/Linux/Pal/src/pal-symbols: No such file or directory
```

With this commit, `make SGX=1 && make` must succeed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1009)
<!-- Reviewable:end -->
