### PR TITLE
Makefile: don't include .manifest.sgx.d when cleaning as wildcard

### DIFF
--- a/LibOS/shim/test/native/Makefile
+++ b/LibOS/shim/test/native/Makefile
@@ -29,7 +29,7 @@ $(c_executables): %: %.c
 $(cxx_executables): %: %.cpp
 	$(call cmd,cxxsingle)
 
-include $(wildcard *.d)
+include $(filter-out %.manifest.sgx.d,$(wildcard *.d))
 else
 .IGNORE: $(c_executables) $(cxx_executables)
 $(c_executables) $(cxx_executables):

--- a/Pal/regression/Makefile
+++ b/Pal/regression/Makefile
@@ -89,6 +89,11 @@ $(graphene_lib): .lib/host_endian.h
 
 Process2.manifest.sgx: Bootstrap.manifest.sgx
 
+# File.manifest.template includes ../regression/File
+# make doesn't understand that ../regression/File is same to File
+../regression/File: | File
+	@true
+
 else
 .IGNORE: $(preloads) $(executables)
 $(preloads) $(executables):

--- a/Pal/regression/Makefile
+++ b/Pal/regression/Makefile
@@ -89,11 +89,6 @@ $(graphene_lib): .lib/host_endian.h
 
 Process2.manifest.sgx: Bootstrap.manifest.sgx
 
-# File.manifest.template includes ../regression/File
-# make doesn't understand that ../regression/File is same to File
-../regression/File: | File
-	@true
-
 else
 .IGNORE: $(preloads) $(executables)
 $(preloads) $(executables):

--- a/Pal/regression/Makefile
+++ b/Pal/regression/Makefile
@@ -73,7 +73,7 @@ $(executables): LDLIBS = $(LDLIBS-executables)
 $(executables): %: %.c $(LDLIBS-executables)
 	$(call cmd,csingle)
 
-include $(wildcard *.d)
+include $(filter-out %.manifest.sgx.d,$(wildcard *.d))
 ifeq ($(filter clean,$(MAKECMDGOALS)),)
 ifeq ($(SGX), 1)
 include $(addsuffix .manifest.sgx.d,$(executables))
@@ -88,6 +88,11 @@ $(graphene_lib): .lib/host_endian.h
 	$(MAKE) -C ../lib target=$(abspath .lib)/
 
 Process2.manifest.sgx: Bootstrap.manifest.sgx
+
+# File.manifest.template includes ../regression/File
+# make doesn't understand that ../regression/File is same to File
+../regression/File: | File
+	@true
 
 else
 .IGNORE: $(preloads) $(executables)


### PR DESCRIPTION
Since Make tries to update those .manifest.sgx.d as dependency,
but it isn't wanted when cleaning.

<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->


## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1011)
<!-- Reviewable:end -->
