### PR TITLE
[Pal] Fix parsing the key ending at space

### DIFF
--- a/Pal/lib/graphene/config.c
+++ b/Pal/lib/graphene/config.c
@@ -291,6 +291,7 @@ int read_config(struct config_store* store, int (*filter)(const char* key, int k
     GOTO_INVAL(msg)
 
     while (RANGE) {
+        /* Skip the comment lines, empty lines and whitespaces before the key */
         for (; RANGE && (IS_SKIP(ptr) || IS_SPACE(*ptr)); ptr++)
             ;
 
@@ -304,6 +305,7 @@ int read_config(struct config_store* store, int (*filter)(const char* key, int k
         for (; RANGE; ptr++) {
             char* pptr = ptr;
 
+            /* Stop when meeting an invalid character */
             for (; RANGE && IS_VALID(*ptr); ptr++)
                 ;
             CHECK_PTR("stream ended at key");
@@ -317,15 +319,17 @@ int read_config(struct config_store* store, int (*filter)(const char* key, int k
 
         int klen = ptr - key;
 
-        for (; RANGE && IS_SPACE(*ptr); ptr++) {
-            CHECK_PTR("stream ended at key");
-        }
+        /* Skip whitespaces between key portion and equal mark */
+        for (; RANGE && IS_SPACE(*ptr); ptr++)
+            ;
+        CHECK_PTR("stream ended at key portion");
 
         if (*ptr != '=')
             GOTO_INVAL("equal mark expected");
 
         ptr++;
 
+        /* Skip whitespaces between equal mark and value portion */
         for (; RANGE && IS_SPACE(*ptr); ptr++)
             ;
         CHECK_PTR("stream ended at equal mark");


### PR DESCRIPTION
The check should happen *AFTER* walking through the training
spaces before equal mark.

Signed-off-by: Jia Zhang <zhang.jia@linux.alibaba.com>

<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [x] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->
Bug fix

## How to test this PR? <!-- (if applicable) -->
Before the patch applied:
```
# echo -n 'sgx.foo ' >> helloworld.manifest.sgx
# ./pal_loader SGX helloworld
Cannot read manifest: equal mark expected
Invalid manifest: file:helloworld.manifest.sgx
```

After the patch applied:
```
# ./pal_loader SGX helloworld
Cannot read manifest: stream ended at key portion
Invalid manifest: file:helloworld.manifest.sgx
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1016)
<!-- Reviewable:end -->