### PR TITLE
Nginx specific network fixes

### DIFF
--- a/LibOS/shim/src/sys/shim_epoll.c
+++ b/LibOS/shim/src/sys/shim_epoll.c
@@ -137,7 +137,6 @@ int delete_from_epoll_handles(struct shim_handle* handle) {
 
         LISTP_DEL(epoll_fd, &handle->epolls, back);
         unlock(&handle->lock);
-        put_handle(handle);
 
         struct shim_handle* epoll_hdl   = epoll_fd->epoll;
         struct shim_epoll_handle* epoll = &epoll_hdl->info.epoll;
@@ -217,6 +216,7 @@ int shim_do_epoll_ctl(int epfd, int op, int fd, struct __kernel_epoll_event* eve
             INIT_LIST_HEAD(epoll_fd, back);
             LISTP_ADD_TAIL(epoll_fd, &hdl->epolls, back);
             unlock(&hdl->lock);
+            put_handle(hdl);
 
             INIT_LIST_HEAD(epoll_fd, list);
             LISTP_ADD_TAIL(epoll_fd, &epoll->fds, list);
@@ -250,7 +250,6 @@ int shim_do_epoll_ctl(int epfd, int op, int fd, struct __kernel_epoll_event* eve
                     debug("delete handle %p from epoll handle %p\n", hdl, epoll);
 
                     put_handle(epoll_hdl);
-                    put_handle(hdl);
 
                     LISTP_DEL(epoll_fd, &epoll->fds, list);
                     epoll->nfds--;

--- a/LibOS/shim/src/sys/shim_socket.c
+++ b/LibOS/shim/src/sys/shim_socket.c
@@ -630,7 +630,7 @@ int shim_do_listen(int sockfd, int backlog) {
     enum shim_sock_state state = sock->sock_state;
     int ret                    = -EINVAL;
 
-    if (state != SOCK_BOUND) {
+    if (state != SOCK_BOUND && state != SOCK_LISTENED) {
         debug("shim_listen: listen on unbound socket\n");
         goto out;
     }


### PR DESCRIPTION
## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->

Two bug fixes here:

*    [LibOS] Do not get/put handles when adding/removing from epoll

Previously, Graphene explicitly incremented refcount of a handle added to/removed from epoll, in epoll_ctl(EPOLL_CTL_ADD/EPOLL_CTL_DEL). However, according to epoll(7), closing a file descriptor causes the FD (handle) to be removed from all epoll sets. In other words, adding/removing a handle to/from epoll must not count towards refcount of the handle. Otherwise the handle remains dangling in the epoll set even if it was close()'d (this particular case led to Nginx segfault). This commit removes get/put of handle during epoll add/remove.

*    [LibOS] Allow repeated listen() on the same socket

Typically, listen() is called only once by the application, to mark the socket as passive for listening for client connections. Thus, LibOS had a state machine that forbade performing repeated listen() syscalls on the same socket. However, at least Nginx issues repeated listen's to adjust the backlog parameter. This commit allows such corner cases.

## How to test this PR? <!-- (if applicable) -->

Nginx must start running, at least under SGX PAL.

*TODO:* Figure out the issue with Nginx under Linux PAL (accept() = -11).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1019)
<!-- Reviewable:end -->
