### PR TITLE
[Pal/Linux] use malloc to allocate PAL thread stack

### DIFF
--- a/Pal/src/host/Linux/db_main.c
+++ b/Pal/src/host/Linux/db_main.c
@@ -236,12 +236,12 @@ void pal_linux_main (void * args)
         INIT_FAIL(PAL_ERROR_NOMEM, "Out of memory");
     SET_HANDLE_TYPE(first_thread, thread);
     first_thread->thread.tid = INLINE_SYSCALL(gettid, 0);
-    first_thread->thread.stack = NULL;
 
-    void * alt_stack = NULL;
-    _DkVirtualMemoryAlloc(&alt_stack, ALT_STACK_SIZE, 0, PAL_PROT_READ|PAL_PROT_WRITE);
+    void * alt_stack = malloc(ALT_STACK_SIZE);
     if (!alt_stack)
         INIT_FAIL(PAL_ERROR_NOMEM, "Out of memory");
+    memset(alt_stack, 0, ALT_STACK_SIZE);
+    first_thread->thread.stack = alt_stack;
 
     // Initialize TCB at the top of the alternative stack.
     PAL_TCB_LINUX * tcb = alt_stack + ALT_STACK_SIZE - sizeof(PAL_TCB_LINUX);


### PR DESCRIPTION
Pal/Linux allocate initial thread for PAL thread by _DkVirtualMemoryAlloc() whose result may overlap with pal_control.user_address. LibOS may corrupts such stack and typicall PAL thread can result in SEGV.
use malloc() to allocate initial stack for PAL thread.
Also fix memory leak of PAL_HANDLE for thread.


<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [x] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->


## How to test this PR? <!-- (if applicable) -->
Pal/regression/Memory
thread suddenly dies(SEGV) in PAL during accessing PAL_TCB_LINUX because PAL_TCB_LINUX(especially PAL_TCB_LINUX.common.self) is overwritten by LibOS.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1024)
<!-- Reviewable:end -->
