### PR TITLE
add errno EAFNOSUPPORT

### DIFF
--- a/LibOS/shim/src/shim_init.c
+++ b/LibOS/shim/src/shim_init.c
@@ -104,6 +104,7 @@ static int pal_errno_to_unix_errno [PAL_ERROR_NATIVE_COUNT + 1] = {
         /* PAL_ERROR_ZEROSIZE       */  0,
         /* PAL_ERROR_CONNFAILED     */  ECONNRESET,
         /* PAL_ERROR_ADDRNOTEXIST   */  EADDRNOTAVAIL,
+        /* PAL_ERROR_AFNOSUPPORT    */  EAFNOSUPPORT,
     };
 
 long convert_pal_errno (long err)

--- a/Pal/src/host/Linux-SGX/pal_linux_error.h
+++ b/Pal/src/host/Linux-SGX/pal_linux_error.h
@@ -34,8 +34,8 @@ static inline __attribute__((unused)) int unix_to_pal_error(int unix_errno) {
         case ECONNRESET:
         case EPIPE:
             return -PAL_ERROR_CONNFAILED;
-        case EPERM:
-            return -PAL_ERROR_DENIED;
+        case EAFNOSUPPORT:
+            return -PAL_ERROR_AFNOSUPPORT;
         default:
             return -PAL_ERROR_DENIED;
     }

--- a/Pal/src/host/Linux/pal_linux_error.h
+++ b/Pal/src/host/Linux/pal_linux_error.h
@@ -34,6 +34,8 @@ static inline __attribute__((unused)) int unix_to_pal_error(int unix_errno) {
         case ECONNRESET:
         case EPIPE:
             return -PAL_ERROR_CONNFAILED;
+        case EAFNOSUPPORT:
+            return -PAL_ERROR_AFNOSUPPORT;
         default:
             return -PAL_ERROR_DENIED;
     }

--- a/Pal/src/pal_error.c
+++ b/Pal/src/pal_error.c
@@ -48,6 +48,7 @@ static const struct pal_error_description pal_error_list[] = {
     { PAL_ERROR_ZEROSIZE, "Zero size" },
     { PAL_ERROR_CONNFAILED, "Connection failed" },
     { PAL_ERROR_ADDRNOTEXIST, "Resource address does not exist" },
+    { PAL_ERROR_AFNOSUPPORT, "Address family not supported by protocol" },
 
     { PAL_ERROR_CRYPTO_FEATURE_UNAVAILABLE, "[Crypto] Feature not available" },
     { PAL_ERROR_CRYPTO_INVALID_CONTEXT, "[Crypto] Invalid context" },

--- a/Pal/src/pal_error.h
+++ b/Pal/src/pal_error.h
@@ -52,8 +52,9 @@ typedef enum _pal_error_t {
     PAL_ERROR_ZEROSIZE,
     PAL_ERROR_CONNFAILED,
     PAL_ERROR_ADDRNOTEXIST,
+    PAL_ERROR_AFNOSUPPORT,
 
-#define PAL_ERROR_NATIVE_COUNT PAL_ERROR_ADDRNOTEXIST
+#define PAL_ERROR_NATIVE_COUNT PAL_ERROR_AFNOSUPPORT
 #define PAL_ERROR_CRYPTO_START PAL_ERROR_CRYPTO_FEATURE_UNAVAILABLE
 
     /* Crypto error constants and their descriptions are adapted from mbedtls. */


### PR DESCRIPTION
<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [x] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->
When redis runs, it tries to listen on the ipv6 port. If the listen()
returns -1 and the errno is EAFNOSUPPORT, it will try to listen to the
ipv4 port, otherwise it will exit the program. So EAFNOSUPPORT needs to
be handled by Pal.

## How to test this PR? <!-- (if applicable) -->
Run redis on a host that does not support ipv6.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1032)
<!-- Reviewable:end -->
