### PR TITLE
Fix return code on exit due to signal

### DIFF
--- a/LibOS/shim/test/regression/Makefile
+++ b/LibOS/shim/test/regression/Makefile
@@ -20,6 +20,7 @@ CFLAGS-shared_object = -fPIC -pie
 CFLAGS-syscall += -I$(PALDIR)/../include -I$(PALDIR)/host/$(PAL_HOST)
 CFLAGS-openmp = -fopenmp
 CFLAGS-multi_pthread = -pthread
+CFLAGS-exit_group = -pthread
 
 %: %.c
 	$(call cmd,csingle)

--- a/LibOS/shim/test/regression/abort.c
+++ b/LibOS/shim/test/regression/abort.c
@@ -1,0 +1,8 @@
+#include <stdlib.h>
+
+/* Test if the correct error code is propagated on a signal-induced exit. This should report 134
+ * (128 + 6 where 6 is SIGABRT) as its return code. */
+
+int main(int argc, char* arvg[]) {
+    abort();
+}

--- a/LibOS/shim/test/regression/exit_group.c
+++ b/LibOS/shim/test/regression/exit_group.c
@@ -1,0 +1,33 @@
+#include <linux/unistd.h>
+#include <pthread.h>
+#include <stdatomic.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#define THREAD_NUM 4
+
+atomic_int counter = 1;
+
+pthread_barrier_t barrier;
+
+/* Test the process exit logic in Graphene. Multiple threads race to execute
+ * exit()/exit_group(). Expected return code is 0 .. 4, depending on which thread wins. */
+
+void* inc(void* arg) {
+    int a = counter++;
+    pthread_barrier_wait(&barrier);
+    exit(a);
+}
+
+int main(int argc, char** argv) {
+    pthread_t thread[THREAD_NUM];
+    pthread_barrier_init(&barrier, NULL, THREAD_NUM + 1);
+
+    for (int j = 0; j < THREAD_NUM; j++) {
+        pthread_create(&thread[j], NULL, inc, NULL);
+    }
+
+    pthread_barrier_wait(&barrier);
+    return 0;
+}

--- a/LibOS/shim/test/regression/exit_group.manifest.template
+++ b/LibOS/shim/test/regression/exit_group.manifest.template
@@ -1,0 +1,15 @@
+loader.preload = file:../../src/libsysdb.so
+loader.env.LD_LIBRARY_PATH = /lib
+loader.debug_type = none
+loader.syscall_symbol = syscalldb
+
+fs.mount.lib.type = chroot
+fs.mount.lib.path = /lib
+fs.mount.lib.uri = file:../../../../Runtime
+
+sgx.trusted_files.ld = file:../../../../Runtime/ld-linux-x86-64.so.2
+sgx.trusted_files.libc = file:../../../../Runtime/libc.so.6
+sgx.trusted_files.libpthread = file:../../../../Runtime/libpthread.so.0
+
+# Test uses 5 threads plus Graphene has up to two internal threads.
+sgx.thread_num = 7

--- a/LibOS/shim/test/regression/test_libos.py
+++ b/LibOS/shim/test/regression/test_libos.py
@@ -118,6 +118,18 @@ class TC_00_Bootstrap(RegressionTestCase):
         with self.expect_returncode(113):
             self.run_binary(['exit'])
 
+    @unittest.skipIf(HAS_SGX,
+        'Exposes a rare memory corruption on SGX PAL. Disable for now.')
+    def test_401_exit_group(self):
+        try:
+            self.run_binary(['exit_group'])
+        except subprocess.CalledProcessError as e:
+            self.assertTrue(1 <= e.returncode and e.returncode <= 4)
+
+    def test_401_signalexit(self):
+        with self.expect_returncode(134):
+            self.run_binary(['abort'])
+
     def test_500_init_fail(self):
         try:
             self.run_binary(['init_fail'])


### PR DESCRIPTION
<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->

Exit due to signal produced a return code of 0. This correctly propagates the return code on exiting from a signal.

Closes #841.

## How to test this PR? <!-- (if applicable) -->

Test case is provided.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1034)
<!-- Reviewable:end -->
