### PR TITLE
[Pal/Linux] block async signal on thread exiting

### DIFF
--- a/Pal/src/host/Linux/db_threading.c
+++ b/Pal/src/host/Linux/db_threading.c
@@ -173,6 +173,7 @@ noreturn void _DkThreadExit (void)
     PAL_TCB_LINUX* tcb = get_tcb_linux();
     PAL_HANDLE handle = tcb->handle;
 
+    block_async_signals(true);
     if (tcb->alt_stack) {
         stack_t ss;
         ss.ss_sp    = NULL;


### PR DESCRIPTION
It frees stack signal and pal tcb, signal handle can't be run correctly.
So block async signal.
If async signal arrive in _DkThreadExit() it can SEGV.
For test Pal/test/Yield can be used. It sometimes hangs with the following message

> *** An unexpected memory fault occurred inside PAL. Exiting the thread. (PID = 19881, TID = 19894, RIP = +0x000102b6) ***

<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [x] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->


## How to test this PR? <!-- (if applicable) -->
Pal/test/Yield

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1038)
<!-- Reviewable:end -->
