### PR TITLE
[LibOS] fix test_user_memory() regarding to compiler optimization

### DIFF
--- a/LibOS/shim/include/shim_tls.h
+++ b/LibOS/shim/include/shim_tls.h
@@ -64,6 +64,7 @@ struct shim_tcb {
     struct {
         void * start, * end;
         void * cont_addr;
+        bool has_fault;
     } test_range;
 };
 

--- a/LibOS/shim/src/bookkeep/shim_signal.c
+++ b/LibOS/shim/src/bookkeep/shim_signal.c
@@ -254,6 +254,7 @@ static void memfault_upcall (PAL_PTR event, PAL_NUM arg, PAL_CONTEXT * context)
         && (void *) arg >= tcb->test_range.start
         && (void *) arg <= tcb->test_range.end) {
         assert(context);
+        tcb->test_range.has_fault = true;
         context->rip = (PAL_NUM) tcb->test_range.cont_addr;
         goto ret_exception;
     }
@@ -365,14 +366,15 @@ bool test_user_memory (void * addr, size_t size, bool write)
     assert(tcb && tcb->tp);
     __disable_preempt(tcb);
 
-    bool  has_fault = true;
-
     /* Add the memory region to the watch list. This is not racy because
      * each thread has its own record. */
     assert(!tcb->test_range.cont_addr);
+    tcb->test_range.has_fault = false;
     tcb->test_range.cont_addr = &&ret_fault;
     tcb->test_range.start = addr;
     tcb->test_range.end   = addr + size - 1;
+    /* enforce compiler to store tcb->test_range into memory */
+    __asm__ volatile(""::: "memory");
 
     /* Try to read or write into one byte inside each page */
     void * tmp = addr;
@@ -385,11 +387,14 @@ bool test_user_memory (void * addr, size_t size, bool write)
         tmp = ALIGN_UP(tmp + 1);
     }
 
-    has_fault = false; /* All accesses have passed. Nothing wrong. */
-
 ret_fault:
+    /* enforce compiler to load tcb->test_range.has_fault below */
+    __asm__ volatile("": "=m"(tcb->test_range.has_fault));
+
     /* If any read or write into the target region causes an exception,
      * the control flow will immediately jump to here. */
+    bool has_fault = tcb->test_range.has_fault;
+    tcb->test_range.has_fault = false;
     tcb->test_range.cont_addr = NULL;
     tcb->test_range.start = tcb->test_range.end = NULL;
     __enable_preempt(tcb);
@@ -432,10 +437,11 @@ bool test_user_string (const char * addr)
     assert(tcb && tcb->tp);
     __disable_preempt(tcb);
 
-    bool has_fault = true;
-
     assert(!tcb->test_range.cont_addr);
+    tcb->test_range.has_fault = false;
     tcb->test_range.cont_addr = &&ret_fault;
+    /* enforce compiler to store tcb->test_range into memory */
+    __asm__ volatile(""::: "memory");
 
     do {
         /* Add the memory region to the watch list. This is not racy because
@@ -454,11 +460,14 @@ bool test_user_string (const char * addr)
         next = ALIGN_UP(addr + 1);
     } while (size == maxlen);
 
-    has_fault = false; /* All accesses have passed. Nothing wrong. */
-
 ret_fault:
+    /* enforce compiler to load tcb->test_range.has_fault below */
+    __asm__ volatile("": "=m"(tcb->test_range.has_fault));
+
     /* If any read or write into the target region causes an exception,
      * the control flow will immediately jump to here. */
+    bool has_fault = tcb->test_range.has_fault;
+    tcb->test_range.has_fault = false;
     tcb->test_range.cont_addr = NULL;
     tcb->test_range.start = tcb->test_range.end = NULL;
     __enable_preempt(tcb);


### PR DESCRIPTION
With compiler optimization, test_user_memory() doesn't work as expected.
Add compiler barrier and fixes the function.

<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->


## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1039)
<!-- Reviewable:end -->
