### PR TITLE
[Pal/Linux-SGX] Sanity check the size of specified signature file

### DIFF
--- a/Pal/src/host/Linux-SGX/sgx_framework.c
+++ b/Pal/src/host/Linux-SGX/sgx_framework.c
@@ -70,7 +70,7 @@ int read_enclave_sigstruct(int sigfile, sgx_arch_sigstruct_t * sig)
     if (IS_ERR(ret))
         return -ERRNO(ret);
 
-    if ((size_t)stat.st_size < sizeof(sgx_arch_sigstruct_t)) {
+    if ((size_t)stat.st_size != sizeof(sgx_arch_sigstruct_t)) {
         SGX_DBG(DBG_I, "size of sigstruct size does not match\n");
         return -EINVAL;
     }


### PR DESCRIPTION
The format of enclave signature should strictly match the spec.

Signed-off-by: Jia Zhang <zhang.jia@linux.alibaba.com>

<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [x] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->


## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1042)
<!-- Reviewable:end -->
