### PR TITLE
[Pal/Linux-SGX] pal-sgx-sign: Always output sgx.static_address in .manifest.sgx

### DIFF
--- a/Pal/src/host/Linux-SGX/signer/pal-sgx-sign
+++ b/Pal/src/host/Linux-SGX/signer/pal-sgx-sign
@@ -855,6 +855,7 @@ def main_sign(args):
     else:
         global enclave_heap_min
         enclave_heap_min = 0
+        manifest['sgx.static_address'] = '0'
 
     # Add manifest at the top
     shutil.copy2(args['manifest'], args['output'])


### PR DESCRIPTION
Currently, sgx.static_address is not recorded in generated
.manifest.sgx file if preparing to launch a PIE executable.

Signed-off-by: Jia Zhang <zhang.jia@linux.alibaba.com>

<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->


## How to test this PR? <!-- (if applicable) -->
```
# make SGX=1 all sgx-tokens -j32
# cat helloworld.manifest.sgx|grep static_address
sgx.static_address = 0
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1045)
<!-- Reviewable:end -->
