### PR TITLE
Clean up asserts

### DIFF
--- a/LibOS/shim/include/shim_ipc.h
+++ b/LibOS/shim/include/shim_ipc.h
@@ -479,7 +479,8 @@ static_always_inline size_t get_ipc_msg_size(size_t payload) {
 }
 
 static_always_inline size_t get_ipc_msg_duplex_size(size_t payload) {
-    assert(sizeof(struct shim_ipc_msg_duplex) >= sizeof(struct shim_ipc_msg));
+    static_assert(sizeof(struct shim_ipc_msg_duplex) >= sizeof(struct shim_ipc_msg),
+                  "Incorrect shim_ipc_msg_duplex size");
     return get_ipc_msg_size(payload) +
            (sizeof(struct shim_ipc_msg_duplex) - sizeof(struct shim_ipc_msg));
 }

--- a/LibOS/shim/src/bookkeep/shim_handle.c
+++ b/LibOS/shim/src/bookkeep/shim_handle.c
@@ -49,6 +49,7 @@ static inline int init_tty_handle(struct shim_handle* hdl, bool write) {
     struct shim_dentry* dent = NULL;
     int ret;
     struct shim_thread* cur_thread = get_cur_thread();
+    __UNUSED(cur_thread);
 
     /* XXX: Try getting the root FS from current thread? */
     assert(cur_thread);
@@ -697,6 +698,7 @@ done:
 }
 
 BEGIN_CP_FUNC(handle) {
+    __UNUSED(size);
     assert(size == sizeof(struct shim_handle));
 
     struct shim_handle* hdl     = (struct shim_handle*)obj;
@@ -781,6 +783,7 @@ BEGIN_RS_FUNC(handle) {
 END_RS_FUNC(handle)
 
 BEGIN_CP_FUNC(fd_handle) {
+    __UNUSED(size);
     assert(size == sizeof(struct shim_fd_handle));
 
     struct shim_fd_handle* fdhdl     = (struct shim_fd_handle*)obj;
@@ -798,6 +801,7 @@ BEGIN_CP_FUNC(fd_handle) {
 END_CP_FUNC_NO_RS(fd_handle)
 
 BEGIN_CP_FUNC(handle_map) {
+    __UNUSED(size);
     assert(size >= sizeof(struct shim_handle_map));
 
     struct shim_handle_map* handle_map     = (struct shim_handle_map*)obj;

--- a/LibOS/shim/src/bookkeep/shim_thread.c
+++ b/LibOS/shim/src/bookkeep/shim_thread.c
@@ -601,6 +601,7 @@ void switch_dummy_thread (struct shim_thread * thread)
 
 BEGIN_CP_FUNC(thread)
 {
+    __UNUSED(size);
     assert(size == sizeof(struct shim_thread));
 
     struct shim_thread * thread = (struct shim_thread *) obj;
@@ -698,6 +699,7 @@ END_RS_FUNC(thread)
 
 BEGIN_CP_FUNC(running_thread)
 {
+    __UNUSED(size);
     __UNUSED(objp);
     assert(size == sizeof(struct shim_thread));
 

--- a/LibOS/shim/src/bookkeep/shim_vma.c
+++ b/LibOS/shim/src/bookkeep/shim_vma.c
@@ -233,6 +233,7 @@ __insert_vma (struct shim_vma * vma, struct shim_vma * prev)
             LISTP_NEXT_ENTRY(prev, &vma_list, list) :
             LISTP_FIRST_ENTRY(&vma_list, struct shim_vma, list);
 
+    __UNUSED(next);
     assert(!next || vma->end <= next->start);
 
     if (prev)
@@ -249,6 +250,7 @@ __insert_vma (struct shim_vma * vma, struct shim_vma * prev)
 static inline void
 __remove_vma (struct shim_vma * vma, struct shim_vma * prev)
 {
+    __UNUSED(prev);
     assert(vma != prev);
     LISTP_DEL(vma, &vma_list, list);
 }
@@ -1040,6 +1042,7 @@ int dump_all_vmas (struct shim_vma_val * vmas, size_t max_count)
 
 BEGIN_CP_FUNC(vma)
 {
+    __UNUSED(size);
     assert(size == sizeof(struct shim_vma_val));
 
     struct shim_vma_val * vma = (struct shim_vma_val *) obj;

--- a/LibOS/shim/src/fs/chroot/fs.c
+++ b/LibOS/shim/src/fs/chroot/fs.c
@@ -672,7 +672,7 @@ static inline int __map_buffer (struct shim_handle * hdl, size_t size)
         return -PAL_ERRNO;
     }
 
-    assert((void *) mapped == mapbuf);
+    assert((void*)mapped == mapbuf);
 
     file->mapbuf    = mapbuf;
     file->mapoffset = mapoff;

--- a/LibOS/shim/src/fs/proc/ipc-thread.c
+++ b/LibOS/shim/src/fs/proc/ipc-thread.c
@@ -98,7 +98,7 @@ do_ipc:
 
     if (dentptr) {
         /* XXX: Not sure how to handle this case yet */
-        assert(0);
+        __abort();
         ret = path_lookupat(NULL, (char*)ipc_data, 0, &dent, NULL);
         if (ret < 0)
             goto out;

--- a/LibOS/shim/src/fs/shim_dcache.c
+++ b/LibOS/shim/src/fs/shim_dcache.c
@@ -127,7 +127,7 @@ static void free_dentry (struct shim_dentry *dent) {
  */
 void put_dentry (struct shim_dentry * dent) {
     int count = REF_DEC(dent->ref_count);
-    assert (count >= 0);
+    assert(count >= 0);
     // We don't expect this to commonly free a dentry, and may represent a
     // reference counting bug.
     if (count == 0) {
@@ -258,7 +258,7 @@ __lookup_dcache (struct shim_dentry * start, const char * name, int namelen,
         //continue;
 
         // Check for memory corruption
-        assert(0 == (dent->state & DENTRY_INVALID_FLAGS));
+        assert((dent->state & DENTRY_INVALID_FLAGS) == 0);
 
         /* Compare the hash first */
         if (dent->rel_path.hash != hash)
@@ -328,6 +328,7 @@ bool dentry_is_ancestor(struct shim_dentry* anc, struct shim_dentry* dent) {
 
 BEGIN_CP_FUNC(dentry)
 {
+    __UNUSED(size);
     assert(size == sizeof(struct shim_dentry));
 
     struct shim_dentry * dent = (struct shim_dentry *) obj;

--- a/LibOS/shim/src/fs/shim_fs.c
+++ b/LibOS/shim/src/fs/shim_fs.c
@@ -292,7 +292,7 @@ int __mount_fs (struct shim_mount * mount, struct shim_dentry * dent)
         ret = mount->d_ops->lookup(mount_root);
         if (ret < 0) {
             /* Try getting rid of ESKIPPED case */
-            assert (ret != -ESKIPPED);
+            assert(ret != -ESKIPPED);
             put_dentry(mount_root);
             return ret;
         }
@@ -554,6 +554,7 @@ struct shim_mount * find_mount_from_uri (const char * uri)
 
 BEGIN_CP_FUNC(mount)
 {
+    __UNUSED(size);
     assert(size == sizeof(struct shim_mount));
 
     struct shim_mount * mount = (struct shim_mount *) obj;

--- a/LibOS/shim/src/fs/shim_namei.c
+++ b/LibOS/shim/src/fs/shim_namei.c
@@ -188,9 +188,9 @@ int lookup_dentry (struct shim_dentry * parent, const char * name, int namelen, 
     if (do_fs_lookup) {
         // This doesn't make any sense if there isn't a low-level
         // lookup function.
-        assert (dent->fs);
-        assert (dent->fs->d_ops);
-        assert (dent->fs->d_ops->lookup);
+        assert(dent->fs);
+        assert(dent->fs->d_ops);
+        assert(dent->fs->d_ops->lookup);
         err = dent->fs->d_ops->lookup(dent);
 
         /* XXX: On an error, it seems like we should probably destroy
@@ -741,7 +741,7 @@ int list_directory_dentry (struct shim_dentry *dent) {
         return 0;
     }
 
-    assert (dent->state & DENTRY_ISDIRECTORY);
+    assert(dent->state & DENTRY_ISDIRECTORY);
 
     struct shim_dirent * dirent = NULL;
 
@@ -790,8 +790,8 @@ int list_directory_handle (struct shim_dentry * dent, struct shim_handle * hdl)
     int nchildren = dent->nchildren, count = 0;
     struct shim_dentry * child;
 
-    assert(hdl->dir_info.buf == (void *)-1);
-    assert(hdl->dir_info.ptr == (void *)-1);
+    assert(hdl->dir_info.buf == (void*)-1);
+    assert(hdl->dir_info.ptr == (void*)-1);
 
     // Handle the case where the handle is on a rmdir-ed directory
     // Handle is already locked by caller, so these values shouldn't change

--- a/LibOS/shim/src/ipc/shim_ipc.c
+++ b/LibOS/shim/src/ipc/shim_ipc.c
@@ -491,6 +491,7 @@ out:
 }
 
 BEGIN_CP_FUNC(ipc_info) {
+    __UNUSED(size);
     assert(size == sizeof(struct shim_ipc_info));
 
     struct shim_ipc_info* info     = (struct shim_ipc_info*)obj;
@@ -530,6 +531,7 @@ BEGIN_CP_FUNC(ipc_info) {
 END_CP_FUNC_NO_RS(ipc_info)
 
 BEGIN_CP_FUNC(process) {
+    __UNUSED(size);
     assert(size == sizeof(struct shim_process));
 
     struct shim_process* process     = (struct shim_process*)obj;

--- a/LibOS/shim/src/ipc/shim_ipc_helper.c
+++ b/LibOS/shim/src/ipc/shim_ipc_helper.c
@@ -338,7 +338,7 @@ void add_ipc_port_by_id(IDTYPE vmid, PAL_HANDLE hdl, IDTYPE type,
     if (portptr)
         *portptr = NULL;
 
-    assert(hdl && PAL_GET_TYPE(hdl));
+    assert(hdl);
     lock(&ipc_helper_lock);
 
     /* check if port with this PAL handle already exists, then we only

--- a/LibOS/shim/src/ipc/shim_ipc_helper.c
+++ b/LibOS/shim/src/ipc/shim_ipc_helper.c
@@ -271,6 +271,7 @@ static void __add_ipc_port(struct shim_ipc_port* port, IDTYPE vmid,
     /* find empty slot in fini callbacks and register callback */
     if (fini) {
         bool found_empty_slot = false;
+        __UNUSED(found_empty_slot);
         for (int i = 0; i < MAX_IPC_PORT_FINI_CB; i++)
             if (!port->fini[i] || port->fini[i] == fini) {
                 port->fini[i] = fini;

--- a/LibOS/shim/src/shim_checkpoint.c
+++ b/LibOS/shim/src/shim_checkpoint.c
@@ -674,7 +674,7 @@ int init_from_checkpoint_file (const char * filename,
     int ret;
 
     /* XXX: Not sure what to do here yet */
-    assert(0);
+    __abort();
     ret = path_lookupat(NULL, filename, LOOKUP_ACCESS|LOOKUP_DIRECTORY, &dir, NULL);
     if (ret < 0)
         return ret;

--- a/LibOS/shim/src/shim_syscalls.c
+++ b/LibOS/shim/src/shim_syscalls.c
@@ -578,8 +578,10 @@ SHIM_SYSCALL_PASSTHROUGH(prctl, 5, int, int, option, unsigned long, arg2, unsign
 DEFINE_SHIM_SYSCALL(arch_prctl, 2, shim_do_arch_prctl, void*, int, code, void*, addr)
 
 void* shim_do_arch_prctl(int code, void* addr) {
-    /* We only support set fs.  Die loudly if we see anything else. */
-    assert(code == ARCH_SET_FS || code == ARCH_GET_FS);
+    if (code != ARCH_SET_FS && code != ARCH_GET_FS) {
+        debug("Not supported flag (0x%x) passed to arch_prctl\n", code);
+        return (void*)-ENOSYS;
+    }
 
     switch (code) {
         case ARCH_SET_FS:

--- a/LibOS/shim/src/sys/shim_brk.c
+++ b/LibOS/shim/src/sys/shim_brk.c
@@ -310,7 +310,7 @@ BEGIN_RS_FUNC(brk)
 
         void * ptr = DkVirtualMemoryAlloc(alloc_addr, alloc_size, 0,
                                           PAL_PROT_READ|PAL_PROT_WRITE);
-
+        __UNUSED(ptr);
         assert(ptr == alloc_addr);
         ADD_PROFILE_OCCURENCE(brk, alloc_size);
         INC_PROFILE_OCCURENCE(brk_migrate_count);

--- a/LibOS/shim/src/sys/shim_epoll.c
+++ b/LibOS/shim/src/sys/shim_epoll.c
@@ -391,6 +391,7 @@ struct shim_mount epoll_builtin_fs = {
 };
 
 BEGIN_CP_FUNC(epoll_fd) {
+    __UNUSED(size);
     assert(size == sizeof(LISTP_TYPE(shim_epoll_fd)));
 
     LISTP_TYPE(shim_epoll_fd)* old_list = (LISTP_TYPE(shim_epoll_fd)*)obj;

--- a/LibOS/shim/src/sys/shim_exit.c
+++ b/LibOS/shim/src/sys/shim_exit.c
@@ -199,6 +199,7 @@ noreturn int shim_do_exit (int error_code)
 {
     INC_PROFILE_OCCURENCE(syscall_use_ipc);
     struct shim_thread * cur_thread = get_cur_thread();
+    __UNUSED(cur_thread);
     assert(!is_internal(cur_thread));
 
     if (debug_handle)

--- a/LibOS/shim/src/sys/shim_mmap.c
+++ b/LibOS/shim/src/sys/shim_mmap.c
@@ -113,6 +113,7 @@ void* shim_do_mmap(void* addr, size_t length, int prot, int flags, int fd, off_t
 
     // Approximate check only, to help root out bugs.
     void* cur_stack = current_stack();
+    __UNUSED(cur_stack);
     assert(cur_stack < addr || cur_stack > addr + length);
 
     /* addr needs to be kept for bkeep_munmap() below */

--- a/LibOS/shim/src/sys/shim_open.c
+++ b/LibOS/shim/src/sys/shim_open.c
@@ -45,7 +45,7 @@ int do_handle_read (struct shim_handle * hdl, void * buf, int count)
         return -EACCES;
 
     struct shim_mount * fs = hdl->fs;
-    assert (fs && fs->fs_ops);
+    assert(fs && fs->fs_ops);
 
     if (!fs->fs_ops->read)
         return -EBADF;
@@ -76,7 +76,7 @@ int do_handle_write (struct shim_handle * hdl, const void * buf, int count)
         return -EACCES;
 
     struct shim_mount * fs = hdl->fs;
-    assert (fs && fs->fs_ops);
+    assert(fs && fs->fs_ops);
 
     if (!fs->fs_ops->write)
         return -EBADF;

--- a/LibOS/shim/test/regression/large_dir_read.c
+++ b/LibOS/shim/test/regression/large_dir_read.c
@@ -49,7 +49,7 @@ int main(int argc, char* argv[]) {
     }
 
     if (mkdir(tmp_name, S_IRWXU | S_IRWXG | S_IRWXO) < 0 || chdir(tmp_name) < 0) {
-        err(1, "mkdir & chdr");
+        err(1, "mkdir & chdir");
     }
 
     for (i = 0; i < FILES_NO; i++) {

--- a/LibOS/shim/test/regression/proc_cpuinfo.c
+++ b/LibOS/shim/test/regression/proc_cpuinfo.c
@@ -1,4 +1,3 @@
-#include <assert.h>
 #include <stdio.h>
 #include <string.h>
 

--- a/Pal/lib/api.h
+++ b/Pal/lib/api.h
@@ -17,6 +17,7 @@
 #ifndef API_H
 #define API_H
 
+#include <assert.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
@@ -159,7 +160,7 @@ void *calloc(size_t nmemb, size_t size);
         (void) (_d == &_d2);                                                    \
                                                                                 \
         /* Double check sizes. */                                               \
-        _Static_assert(sizeof(*_s) == sizeof(*_d), "sizes don't match");        \
+        static_assert(sizeof(*_s) == sizeof(*_d), "sizes don't match");         \
                                                                                 \
         memcpy(*_d, *_s, sizeof(*_d));                                          \
     } while (0)

--- a/Pal/lib/assert.h
+++ b/Pal/lib/assert.h
@@ -11,11 +11,7 @@
 
 #include <stdnoreturn.h>
 
-#define COMPILE_TIME_ASSERT(pred) \
-    switch (0) {                  \
-        case 0:                   \
-        case (pred):;             \
-    }
+#define static_assert _Static_assert
 
 /* All environments should implement warn, which prints a non-optional debug
  * message. All environments should also implement __abort, which
@@ -25,14 +21,20 @@
 void warn(const char* format, ...) __attribute__((format(printf, 1, 2)));
 noreturn void __abort(void);
 
-#define assert(test)                                                                       \
-    ({                                                                                     \
-        long _val = (long)(test);                                                          \
-        (!(_val)) ? ({                                                                     \
-            warn("assert failed " __FILE__ ":%d %s (value:%lx)\n", __LINE__, #test, _val); \
-            __abort();                                                                     \
-        })                                                                                 \
-                  : (void)0;                                                               \
+/* TODO(mkow): We should actually use the standard `NDEBUG`, but that would require changes in the
+ * build system.
+ */
+#ifdef DEBUG
+#define assert(expr)                                                     \
+    ({                                                                   \
+        (!(expr)) ? ({                                                   \
+            warn("assert failed " __FILE__ ":%d %s\n", __LINE__, #expr); \
+            __abort();                                                   \
+        })                                                               \
+                  : (void)0;                                             \
     })
-
+#else
+#define assert(expr) ((void)0)
 #endif
+
+#endif  /* ASSERT_H */

--- a/Pal/lib/hex.h
+++ b/Pal/lib/hex.h
@@ -18,6 +18,7 @@
 #ifndef HEX_H
 #define HEX_H
 
+#include <api.h>
 #include <assert.h>
 #include <stddef.h>
 #include <stdint.h>
@@ -36,6 +37,7 @@ static inline __attribute__((always_inline))
 char * __bytes2hexstr(void * hex, size_t size, char *str, size_t len)
 {
     static char * ch = "0123456789abcdef";
+    __UNUSED(len);
     assert(len >= size * 2 + 1);
 
     for (size_t i = 0 ; i < size ; i++) {
@@ -63,13 +65,13 @@ int8_t hex2dec(char c) {
         return -1;
 }
 
-    /*
+/*
  * BYTES2HEXSTR converts an array into a hexadecimal string and fills into a
  * given buffer. The buffer size is given as an extra argument.
  */
-#define BYTES2HEXSTR(array, str, len) ({             \
-            COMPILE_TIME_ASSERT(IS_ARRAY(array));    \
-            __bytes2hexstr((array), sizeof(array), str, len);})
+#define BYTES2HEXSTR(array, str, len) ({                        \
+    static_assert(IS_ARRAY(array), "`array` must be an array"); \
+    __bytes2hexstr((array), sizeof(array), str, len);})
 
 /*
  * ALLOCA_BYTES2HEXSTR uses __alloca to allocate a buffer on the current frame

--- a/Pal/lib/slabmgr.h
+++ b/Pal/lib/slabmgr.h
@@ -419,7 +419,8 @@ static inline size_t slab_get_buf_size(const void* ptr) {
 
 #ifdef SLAB_CANARY
     const unsigned long* m = (const unsigned long*)(ptr + slab_levels[level]);
-    assert((*m) == SLAB_CANARY_STRING);
+    __UNUSED(m);
+    assert(*m == SLAB_CANARY_STRING);
 #endif
 
     return slab_levels[level];
@@ -454,7 +455,8 @@ static inline void slab_free(SLAB_MGR mgr, void* obj) {
 
 #ifdef SLAB_CANARY
     unsigned long* m = (unsigned long*)(obj + slab_levels[level]);
-    assert((*m) == SLAB_CANARY_STRING);
+    __UNUSED(m);
+    assert(*m == SLAB_CANARY_STRING);
 #endif
 
     SLAB_OBJ mobj = RAW_TO_OBJ(obj, SLAB_OBJ_TYPE);

--- a/Pal/regression/test_pal.py
+++ b/Pal/regression/test_pal.py
@@ -271,13 +271,12 @@ class TC_20_SingleProcess(RegressionTestCase):
         self.assertEqual(file_exist[200:240], file_nonexist[0:40])
 
         # File Attribute Query
-        self.assertIn(
-            'Query: type = 1, size = {}'.format(len(file_exist)), stderr)
+        self.assertIn('Query: type = ', stderr)
+        self.assertIn(', size = {}'.format(len(file_exist)), stderr)
 
         # File Attribute Query by Handle
-        self.assertIn(
-            'Query by Handle: type = 1, size = {}'.format(len(file_exist)),
-            stderr)
+        self.assertIn('Query by Handle: type = ', stderr)
+        self.assertIn(', size = {}'.format(len(file_exist)), stderr)
 
         # File Mapping
         self.assertIn(
@@ -335,10 +334,10 @@ class TC_20_SingleProcess(RegressionTestCase):
             self.assertIn('Read Directory: {}'.format(p.name), stderr)
 
         # Directory Attribute Query
-        self.assertIn('Query: type = 7', stderr)
+        self.assertIn('Query: type = ', stderr)
 
         # Directory Attribute Query by Handle
-        self.assertIn('Query by Handle: type = 7', stderr)
+        self.assertIn('Query by Handle: type = ', stderr)
 
         # Directory Deletion
         self.assertFalse(pathlib.Path('dir_delete.tmp').exists())

--- a/Pal/src/db_object.c
+++ b/Pal/src/db_object.c
@@ -33,10 +33,13 @@
 int _DkObjectClose (PAL_HANDLE objectHandle)
 {
     const struct handle_ops * ops = HANDLE_OPS(objectHandle);
+    if (!ops)
+        return -PAL_ERROR_BADHANDLE;
+
     int ret = 0;
 
     /* if the operation 'close' is defined, call the function. */
-    if (ops && ops->close)
+    if (ops->close)
         ret = ops->close(objectHandle);
 
     /*
@@ -56,7 +59,7 @@ void DkObjectClose (PAL_HANDLE objectHandle)
 {
     ENTER_PAL_CALL(DkObjectClose);
 
-    if (!objectHandle || UNKNOWN_HANDLE(objectHandle)) {
+    if (!objectHandle) {
         _DkRaiseFailure(PAL_ERROR_INVAL);
         LEAVE_PAL_CALL();
     }
@@ -64,7 +67,6 @@ void DkObjectClose (PAL_HANDLE objectHandle)
     UNTRACE_HEAP(objectHandle);
 
     int ret = _DkObjectClose(objectHandle);
-
     if (ret < 0)
         _DkRaiseFailure(-ret);
 

--- a/Pal/src/db_rtld.c
+++ b/Pal/src/db_rtld.c
@@ -39,14 +39,6 @@ struct link_map * exec_map = NULL;
 
 struct link_map * lookup_symbol (const char *undef_name, ElfW(Sym) **ref);
 
-#ifdef assert
-/* This function can be used as a breakpoint to debug assertion */
-void __attribute_noinline __assert (void)
-{
-    BREAK();
-}
-#endif
-
 /* This macro is used as a callback from the ELF_DYNAMIC_RELOCATE code.  */
 static struct link_map * resolve_map (const char **strtab, ElfW(Sym) ** ref)
 {
@@ -108,7 +100,7 @@ void setup_elf_hash (struct link_map *map)
         Elf32_Word bitmask_nwords = *hash32++;
 
         /* Must be a power of two.  */
-        assert ((bitmask_nwords & (bitmask_nwords - 1)) == 0);
+        assert((bitmask_nwords & (bitmask_nwords - 1)) == 0);
         map->l_gnu_bitmask_idxbits = bitmask_nwords - 1;
         map->l_gnu_shift = *hash32++;
 

--- a/Pal/src/host/FreeBSD/db_object.c
+++ b/Pal/src/host/FreeBSD/db_object.c
@@ -99,6 +99,9 @@ static int _DkObjectWaitOne (PAL_HANDLE handle, int timeout)
 
     const struct handle_ops * ops = HANDLE_OPS(handle);
 
+    if (!ops)
+        return -PAL_ERROR_BADHANDLE;
+
     if (!ops->wait)
         return -PAL_ERROR_NOTSUPPORT;
 

--- a/Pal/src/host/Linux-SGX/db_files.c
+++ b/Pal/src/host/Linux-SGX/db_files.c
@@ -24,6 +24,7 @@
 #include <linux/types.h>
 
 #include "api.h"
+#include "assert.h"
 #include "pal.h"
 #include "pal_debug.h"
 #include "pal_defs.h"
@@ -124,8 +125,8 @@ static int64_t file_read(PAL_HANDLE handle, uint64_t offset, uint64_t count, voi
     if (offset >= total)
         return 0;
 
-    _Static_assert((TRUSTED_STUB_SIZE & (TRUSTED_STUB_SIZE - 1)) == 0,
-                   "TRUSTED_STUB_SIZE must be a power of two");
+    static_assert((TRUSTED_STUB_SIZE & (TRUSTED_STUB_SIZE - 1)) == 0,
+                  "TRUSTED_STUB_SIZE must be a power of two");
 
     uint64_t end       = (offset + count > total) ? total : offset + count;
     uint64_t map_start = offset & ~(TRUSTED_STUB_SIZE - 1);
@@ -235,8 +236,8 @@ static int file_map(PAL_HANDLE handle, void** addr, int prot, uint64_t offset, u
     uint64_t map_start, map_end;
 
     if (stubs) {
-        _Static_assert((TRUSTED_STUB_SIZE & (TRUSTED_STUB_SIZE - 1)) == 0,
-                       "TRUSTED_STUB_SIZE must be a power of two");
+        static_assert((TRUSTED_STUB_SIZE & (TRUSTED_STUB_SIZE - 1)) == 0,
+                      "TRUSTED_STUB_SIZE must be a power of two");
         map_start = offset & ~(TRUSTED_STUB_SIZE - 1);
         map_end   = (end + TRUSTED_STUB_SIZE - 1) & ~(TRUSTED_STUB_SIZE - 1);
     } else {

--- a/Pal/src/host/Linux-SGX/db_main.c
+++ b/Pal/src/host/Linux-SGX/db_main.c
@@ -502,7 +502,10 @@ int _DkGetCPUInfo (PAL_CPU_INFO * ci)
     vendor_id[VENDOR_ID_SIZE - 1] = '\0';
     ci->cpu_vendor = vendor_id;
     // Must be an Intel CPU
-    assert(!memcmp(vendor_id, "GenuineIntel", 12));
+    if (memcmp(vendor_id, "GenuineIntel", 12)) {
+      free(vendor_id);
+      return -PAL_ERROR_INVAL;
+    }
 
     const size_t BRAND_SIZE = 49;
     char* brand = malloc(BRAND_SIZE);

--- a/Pal/src/host/Linux-SGX/db_misc.c
+++ b/Pal/src/host/Linux-SGX/db_misc.c
@@ -36,7 +36,8 @@
 unsigned long _DkSystemTimeQuery(void) {
     unsigned long microsec;
     int ret = ocall_gettime(&microsec);
-    assert(!ret);
+    if (ret)
+        return -PAL_ERROR_DENIED;
     return microsec;
 }
 

--- a/Pal/src/host/Linux-SGX/db_object.c
+++ b/Pal/src/host/Linux-SGX/db_object.c
@@ -91,7 +91,10 @@ static int _DkObjectWaitOne(PAL_HANDLE handle, int64_t timeout_us) {
 
     const struct handle_ops * ops = HANDLE_OPS(handle);
 
-    if (!ops || !ops->wait)
+    if (!ops)
+        return -PAL_ERROR_BADHANDLE;
+
+    if (!ops->wait)
         return -PAL_ERROR_NOTSUPPORT;
 
     return ops->wait(handle, timeout_us);

--- a/Pal/src/host/Linux-SGX/debugger/sgx_gdb.c
+++ b/Pal/src/host/Linux-SGX/debugger/sgx_gdb.c
@@ -182,7 +182,8 @@ static int update_thread_tids(struct enclave_dbginfo* ei) {
     void* src = (void*)DBGINFO_ADDR + offsetof(struct enclave_dbginfo, thread_tids);
     void* dst = (void*)ei + offsetof(struct enclave_dbginfo, thread_tids);
 
-    assert((sizeof(ei->thread_tids) % sizeof(long)) == 0);
+    static_assert((sizeof(ei->thread_tids) % sizeof(long)) == 0,
+                  "Unsupported ei->thread_tids size");
 
     for (int off = 0; off < sizeof(ei->thread_tids); off += sizeof(long)) {
         errno = 0;
@@ -337,7 +338,7 @@ static int open_memdevice(pid_t tid, int* memdev, struct enclave_dbginfo** ei) {
         }
     }
 
-    assert(sizeof(eib) % sizeof(long) == 0);
+    static_assert(sizeof(eib) % sizeof(long) == 0, "Unsupported eib size");
 
     for (int off = 0; off < sizeof(eib); off += sizeof(long)) {
         errno = 0;

--- a/Pal/src/host/Linux-SGX/enclave_untrusted.c
+++ b/Pal/src/host/Linux-SGX/enclave_untrusted.c
@@ -15,7 +15,6 @@
    along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
 
 #include <api.h>
-#include <assert.h>
 #include <pal_error.h>
 #include <pal_internal.h>
 #include <pal_security.h>

--- a/Pal/src/host/Linux-SGX/sgx_arch.h
+++ b/Pal/src/host/Linux-SGX/sgx_arch.h
@@ -21,6 +21,7 @@
 
 #ifndef __ASSEMBLER__
 
+#include "assert.h"
 #include <stdint.h>
 
 typedef uint8_t sgx_arch_key_t [384];
@@ -126,11 +127,11 @@ typedef struct {
 } sgx_context_t;
 
 // Required by _restore_sgx_context, see enclave_entry.S.
-_Static_assert(offsetof(sgx_context_t, rip) - offsetof(sgx_context_t, rflags) ==
-               sizeof(((sgx_context_t) {0}).rflags),
-               "rip must be directly after rflags in sgx_context_t");
-_Static_assert(offsetof(sgx_context_t, rflags) - offsetof(sgx_context_t, rdi) <= RED_ZONE_SIZE,
-               "rdi needs to be within red zone distance from rflags");
+static_assert(offsetof(sgx_context_t, rip) - offsetof(sgx_context_t, rflags) ==
+              sizeof(((sgx_context_t) {0}).rflags),
+              "rip must be directly after rflags in sgx_context_t");
+static_assert(offsetof(sgx_context_t, rflags) - offsetof(sgx_context_t, rdi) <= RED_ZONE_SIZE,
+              "rdi needs to be within red zone distance from rflags");
 
 typedef struct {
     uint32_t vector:8;

--- a/Pal/src/host/Linux-SGX/sgx_tls.h
+++ b/Pal/src/host/Linux-SGX/sgx_tls.h
@@ -45,8 +45,8 @@ extern uint64_t dummy_debug_variable;
     ({                                                              \
         struct enclave_tls * tmp;                                   \
         uint64_t val;                                               \
-        _Static_assert(sizeof(tmp->member) == 8,                    \
-                       "sgx_tls member should have 8-byte type");   \
+        static_assert(sizeof(tmp->member) == 8,                     \
+                      "sgx_tls member should have 8-byte type");    \
         __asm__ ("movq %%gs:%c1, %q0": "=r" (val)                   \
              : "i" (offsetof(struct enclave_tls, member)));         \
         (__typeof(tmp->member)) val;                                \
@@ -54,10 +54,10 @@ extern uint64_t dummy_debug_variable;
 #  define SET_ENCLAVE_TLS(member, value)                            \
     do {                                                            \
         struct enclave_tls * tmp;                                   \
-        _Static_assert(sizeof(tmp->member) == 8,                    \
-                       "sgx_tls member should have 8-byte type");   \
-        _Static_assert(sizeof(value) == 8,                          \
-                       "only 8-byte type can be set to sgx_tls");  \
+        static_assert(sizeof(tmp->member) == 8,                     \
+                      "sgx_tls member should have 8-byte type");    \
+        static_assert(sizeof(value) == 8,                           \
+                      "only 8-byte type can be set to sgx_tls");    \
         __asm__ ("movq %q0, %%gs:%c1":: "r" (value),                \
              "i" (offsetof(struct enclave_tls, member)));           \
     } while (0)

--- a/Pal/src/host/Linux/db_exception.c
+++ b/Pal/src/host/Linux/db_exception.c
@@ -299,10 +299,12 @@ static void _DkTerminateSighandler (int signum, siginfo_t * info,
 static void _DkPipeSighandler (int signum, siginfo_t * info,
                                struct ucontext * uc)
 {
-    assert(signum == SIGPIPE);
+    __UNUSED(signum);
     __UNUSED(info);
+    assert(signum == SIGPIPE);
 
     uintptr_t rip = uc->uc_mcontext.gregs[REG_RIP];
+    __UNUSED(rip);
     assert(ADDR_IN_PAL(rip)); // This signal can only happens inside PAL
     return;
 }

--- a/Pal/src/host/Linux/db_object.c
+++ b/Pal/src/host/Linux/db_object.c
@@ -112,7 +112,10 @@ static int _DkObjectWaitOne(PAL_HANDLE handle, int64_t timeout_us) {
 
     const struct handle_ops * ops = HANDLE_OPS(handle);
 
-    if (!ops || !ops->wait)
+    if (!ops)
+        return -PAL_ERROR_BADHANDLE;
+
+    if (!ops->wait)
         return -PAL_ERROR_NOTSUPPORT;
 
     return ops->wait(handle, timeout_us);

--- a/Pal/src/pal.h
+++ b/Pal/src/pal.h
@@ -63,11 +63,8 @@ static inline void init_handle_hdr(PAL_HDR *hdr, int pal_type) {
     hdr->flags = 0;
 }
 
-# define SET_HANDLE_TYPE(handle, t) \
-    init_handle_hdr(HANDLE_HDR(handle), pal_type_##t)
-
-# define IS_HANDLE_TYPE(handle, t)              \
-    (HANDLE_HDR(handle)->type == pal_type_##t)
+# define SET_HANDLE_TYPE(handle, t) init_handle_hdr(HANDLE_HDR(handle), pal_type_##t)
+# define IS_HANDLE_TYPE(handle, t) (HANDLE_HDR(handle)->type == pal_type_##t)
 
 #else
 typedef union pal_handle
@@ -128,7 +125,6 @@ typedef struct {
 
 /********** PAL TYPE DEFINITIONS **********/
 enum {
-    pal_type_none = 0,
     pal_type_file,
     pal_type_pipe,
     pal_type_pipesrv,
@@ -150,10 +146,10 @@ enum {
 };
 
 
-/* PAL identifier poison value */
-#define PAL_IDX_POISON          ((PAL_IDX) -1)
+#define PAL_IDX_POISON          ((PAL_IDX)-1) /* PAL identifier poison value */
 #define PAL_GET_TYPE(h)         (HANDLE_HDR(h)->type)
 #define PAL_CHECK_TYPE(h, t)    (PAL_GET_TYPE(h) == pal_type_##t)
+#define UNKNOWN_HANDLE(handle)  (PAL_GET_TYPE(handle) >= PAL_HANDLE_TYPE_BOUND)
 
 typedef struct { PAL_PTR start, end; }  PAL_PTR_RANGE;
 

--- a/Pal/src/pal_debug.h
+++ b/Pal/src/pal_debug.h
@@ -24,7 +24,6 @@
 #define PAL_DEBUG_H
 
 #include "pal.h"
-#include <assert.h>
 
 int pal_printf (const char *fmt, ...) __attribute__((format(printf, 1, 2)));
 

--- a/Pal/src/pal_internal.h
+++ b/Pal/src/pal_internal.h
@@ -127,7 +127,7 @@ extern const struct handle_ops * pal_handle_ops [];
 static inline const struct handle_ops * HANDLE_OPS (PAL_HANDLE handle)
 {
     int _type = PAL_GET_TYPE(handle);
-    if (_type <= 0 || _type >= PAL_HANDLE_TYPE_BOUND)
+    if (_type >= PAL_HANDLE_TYPE_BOUND)
         return NULL;
     return pal_handle_ops[_type];
 }
@@ -162,9 +162,6 @@ static inline uint64_t hash64 (uint64_t key)
    deciding the actual size of the handle */
 extern PAL_HANDLE _h;
 #define HANDLE_SIZE(type)  (sizeof(*_h))
-
-#define UNKNOWN_HANDLE(handle)     \
-    (PAL_GET_TYPE(handle) == 0 || PAL_GET_TYPE(handle) >= PAL_HANDLE_TYPE_BOUND)
 
 static inline int handle_size (PAL_HANDLE handle)
 {


### PR DESCRIPTION
## Affected components

- [ ] README and global configuration
- [X] Linux PAL
- [X] SGX PAL
- [X] FreeBSD PAL
- [X] Common PAL code
- [X] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->

Various assert-related clean-ups:
* Make assert() a no-op in non-debug builds,
* Use static_assert for compile-time asserts,
* Fix assert() implementation (previous version didn't work for expressions with types larger than long, it also always printed `(value:0)`),
* Clean up calls to asserts.

When working on them, I also noticed that `PAL_HANDLE` type is used inconsistently, so I cleaned it up. And two typos fixed as a bonus (`extern struct hadnle_ops udppacket_ops;` and `mkdir & chdr`).

Fixes #1018.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1048)
<!-- Reviewable:end -->
