### PR TITLE
No longer set SO_LINGER on socket.

### DIFF
--- a/Pal/src/host/Linux/db_sockets.c
+++ b/Pal/src/host/Linux/db_sockets.c
@@ -956,11 +956,6 @@ struct __kernel_linger {
 
 static int socket_close(PAL_HANDLE handle) {
     if (handle->sock.fd != PAL_IDX_POISON) {
-        struct __kernel_linger l;
-        l.l_onoff  = 1;
-        l.l_linger = 0;
-        INLINE_SYSCALL(setsockopt, 5, handle->sock.fd, SOL_SOCKET, SO_LINGER, &l,
-                       sizeof(struct __kernel_linger));
         INLINE_SYSCALL(close, 1, handle->sock.fd);
         handle->sock.fd = PAL_IDX_POISON;
     }


### PR DESCRIPTION
<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [x] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->

For reasons that have long been forgotten, Linux PAL set SO_LINGER with a zero timeout before closing the socket. [Among other things](https://stackoverflow.com/questions/3757289/tcp-option-so-linger-zero-when-its-required), this leads to ab (Apachebench) reporting failed requests when running nginx/lighttpd on Graphene, because the TCP connection is not closed cleanly.

## How to test this PR? <!-- (if applicable) -->

Run ab against nginx/lighttpd. Without this fix, you will likely see failed requests. With this patch, all requests should succeed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1051)
<!-- Reviewable:end -->
