### PR TITLE
[PAL] fix pal_loader SGX invocation

### DIFF
--- a/Runtime/pal_loader
+++ b/Runtime/pal_loader
@@ -5,6 +5,7 @@ do
 	case "$1" in
 		"SGX")
 			SGX=1
+			export SGX
 			;;
 		"GDB")
 			GDB=1


### PR DESCRIPTION
<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [x] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->
This fixes regression from #961.

## How to test this PR? <!-- (if applicable) -->
Run `pal_loader SGX` instead of `SGX=1 pal_loader`. Sometime. Someday.
Even better, run that regularly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1052)
<!-- Reviewable:end -->
