### PR TITLE
String handling fixes, part 1

### DIFF
--- a/LibOS/shim/src/bookkeep/shim_signal.c
+++ b/LibOS/shim/src/bookkeep/shim_signal.c
@@ -330,7 +330,7 @@ static bool is_sgx_pal(void) {
 
     if (!atomic_read(&inited)) {
         /* Ensure that is_sgx_pal is updated before initialized */
-        atomic_set(&sgx_pal, strcmp_static(PAL_CB(host_type), "Linux-SGX"));
+        atomic_set(&sgx_pal, !strcmp_static(PAL_CB(host_type), "Linux-SGX"));
         MB();
         atomic_set(&inited, 1);
     }

--- a/LibOS/shim/src/fs/chroot/fs.c
+++ b/LibOS/shim/src/fs/chroot/fs.c
@@ -67,8 +67,7 @@ static int chroot_mount (const char * uri, void ** mount_data)
         type = FILE_UNKNOWN;
         uri += 5;
     } else if (strpartcmp_static(uri, "dev:")) {
-        type = strpartcmp_static(uri + static_strlen("dev"), "tty") ?
-               FILE_DEV : FILE_TTY;
+        type = strpartcmp_static(uri + static_strlen("dev:"), "tty") ? FILE_TTY : FILE_DEV;
         uri += 4;
     } else
         return -EINVAL;

--- a/LibOS/shim/src/fs/chroot/fs.c
+++ b/LibOS/shim/src/fs/chroot/fs.c
@@ -63,11 +63,11 @@ static int chroot_mount (const char * uri, void ** mount_data)
 {
     enum shim_file_type type;
 
-    if (strpartcmp_static(uri, "file:")) {
+    if (strstartswith_static(uri, "file:")) {
         type = FILE_UNKNOWN;
         uri += 5;
-    } else if (strpartcmp_static(uri, "dev:")) {
-        type = strpartcmp_static(uri + static_strlen("dev:"), "tty") ? FILE_TTY : FILE_DEV;
+    } else if (strstartswith_static(uri, "dev:")) {
+        type = strstartswith_static(uri + static_strlen("dev:"), "tty") ? FILE_TTY : FILE_DEV;
         uri += 4;
     } else
         return -EINVAL;
@@ -1017,7 +1017,7 @@ static int chroot_readdir(struct shim_dentry* dent, struct shim_dirent** dirent)
     chroot_update_ino(dent);
 
     const char* uri = qstrgetstr(&data->host_uri);
-    assert(strpartcmp_static(uri, "dir:"));
+    assert(strstartswith_static(uri, "dir:"));
 
     pal_hdl = DkStreamOpen(uri, PAL_ACCESS_RDONLY, 0, 0, 0);
     if (!pal_hdl)

--- a/LibOS/shim/src/fs/dev/fs.c
+++ b/LibOS/shim/src/fs/dev/fs.c
@@ -160,7 +160,7 @@ static int dev_random_hstat(struct shim_handle* hdl, struct stat* stat) {
 }
 
 static int search_dev_driver(const char* name, struct shim_dev_ops* ops) {
-    if (strcmp_static(name, "null") || strcmp_static(name, "tty")) {
+    if (!strcmp_static(name, "null") || !strcmp_static(name, "tty")) {
         if (ops)
             ops->read = &dev_null_read;
     null_dev:
@@ -174,13 +174,13 @@ static int search_dev_driver(const char* name, struct shim_dev_ops* ops) {
         return 0;
     }
 
-    if (strcmp_static(name, "zero")) {
+    if (!strcmp_static(name, "zero")) {
         if (ops)
             ops->read = &dev_zero_read;
         goto null_dev;
     }
 
-    if (strcmp_static(name, "random")) {
+    if (!strcmp_static(name, "random")) {
         if (ops)
             ops->read = &dev_random_read;
     random_dev:
@@ -192,14 +192,14 @@ static int search_dev_driver(const char* name, struct shim_dev_ops* ops) {
         return 0;
     }
 
-    if (strcmp_static(name, "urandom")) {
+    if (!strcmp_static(name, "urandom")) {
         if (ops)
             ops->read = &dev_urandom_read;
         goto random_dev;
     }
 
-    if (strcmp_static(name, "stdin") || strcmp_static(name, "stdout") ||
-        strcmp_static(name, "stderr"))
+    if (!strcmp_static(name, "stdin") || !strcmp_static(name, "stdout") ||
+        !strcmp_static(name, "stderr"))
         return -EISLINK;
 
     return -ENOENT;
@@ -421,18 +421,18 @@ static off_t dev_poll(struct shim_handle* hdl, int poll_type) {
 static int dev_follow_link(struct shim_dentry* dent, struct shim_qstr* link) {
     const char* name = qstrgetstr(&dent->rel_path);
 
-    if (strcmp_static(name, "stdin")) {
+    if (!strcmp_static(name, "stdin")) {
         qstrsetstr(link, "/proc/self/0", static_strlen("/proc/self/0"));
         return 0;
-    } else if (strcmp_static(name, "stdout")) {
+    } else if (!strcmp_static(name, "stdout")) {
         qstrsetstr(link, "/proc/self/1", static_strlen("/proc/self/1"));
         return 0;
-    } else if (strcmp_static(name, "stderr")) {
+    } else if (!strcmp_static(name, "stderr")) {
         qstrsetstr(link, "/proc/self/2", static_strlen("/proc/self/2"));
         return 0;
     }
 
-    if (strcmp_static(name, "null") || strcmp_static(name, "zero"))
+    if (!strcmp_static(name, "null") || !strcmp_static(name, "zero"))
         return -ENOTLINK;
 
     return -ENOENT;

--- a/LibOS/shim/src/fs/proc/thread.c
+++ b/LibOS/shim/src/fs/proc/thread.c
@@ -25,7 +25,7 @@ static int parse_thread_name(const char* name, IDTYPE* pidptr, const char** next
     if (*p == '/')
         p++;
 
-    if (strpartcmp_static(p, "self")) {
+    if (strstartswith_static(p, "self")) {
         p += static_strlen("self");
         if (*p && *p != '/')
             return -ENOENT;

--- a/LibOS/shim/src/shim_init.c
+++ b/LibOS/shim/src/shim_init.c
@@ -163,7 +163,7 @@ long int glibc_option (const char * opt)
 {
     char cfg[CONFIG_MAX];
 
-    if (strcmp_static(opt, "heap_size")) {
+    if (!strcmp_static(opt, "heap_size")) {
         ssize_t ret = get_config(root_config, "glibc.heap_size", cfg, CONFIG_MAX);
         if (ret <= 0) {
             debug("no glibc option: %s (err=%ld)\n", opt, ret);
@@ -727,7 +727,7 @@ noreturn void* shim_init (int argc, void * args)
     debug("shim loaded at %p, ready to initialize\n", &__load_address);
 
     if (argc && argv[0][0] == '-') {
-        if (strcmp_static(argv[0], "-resume") && argc >= 2) {
+        if (!strcmp_static(argv[0], "-resume") && argc >= 2) {
             const char * filename = *(argv + 1);
             argc -= 2;
             argv += 2;

--- a/LibOS/shim/src/shim_init.c
+++ b/LibOS/shim/src/shim_init.c
@@ -409,7 +409,7 @@ int init_stack (const char ** argv, const char ** envp,
 int read_environs (const char ** envp)
 {
     for (const char ** e = envp ; *e ; e++) {
-        if (strpartcmp_static(*e, "LD_LIBRARY_PATH=")) {
+        if (strstartswith_static(*e, "LD_LIBRARY_PATH=")) {
             /* populate library_paths with entries from LD_LIBRARY_PATH envvar */
             const char * s = *e + static_strlen("LD_LIBRARY_PATH=");
             size_t npaths = 2; // One for the first entry, one for the last
@@ -549,7 +549,7 @@ static void set_profile_enabled (const char ** envp)
 {
     const char ** p;
     for (p = envp ; (*p) ; p++)
-        if (strpartcmp_static(*p, "PROFILE_ENABLED="))
+        if (strstartswith_static(*p, "PROFILE_ENABLED="))
             break;
     if (!(*p))
         return;
@@ -969,7 +969,7 @@ static int open_pal_handle (const char * uri, void * obj)
 {
     PAL_HANDLE hdl;
 
-    if (strpartcmp_static(uri, "dev:"))
+    if (strstartswith_static(uri, "dev:"))
         hdl = DkStreamOpen(uri, 0,
                            PAL_SHARE_OWNER_X|PAL_SHARE_OWNER_W|
                            PAL_SHARE_OWNER_R,

--- a/LibOS/shim/src/shim_parser.c
+++ b/LibOS/shim/src/shim_parser.c
@@ -396,8 +396,8 @@ struct parser_table {
 };
 
 static inline int is_pointer(const char* type) {
-    return type[strlen(type) - 1] == '*' || strcmp_static(type, "long") ||
-           strcmp_static(type, "unsigned long");
+    return type[strlen(type) - 1] == '*' || !strcmp_static(type, "long") ||
+           !strcmp_static(type, "unsigned long");
 }
 
 #define PRINTF(fmt, ...)                \
@@ -441,7 +441,7 @@ static inline void parse_integer_arg(va_list ap) {
 static inline void parse_syscall_args(va_list ap) {
     const char* arg_type = va_arg(ap, const char*);
 
-    if (strcmp_static(arg_type, "const char *") || strcmp_static(arg_type, "const char*"))
+    if (!strcmp_static(arg_type, "const char *") || !strcmp_static(arg_type, "const char*"))
         parse_string_arg(ap);
     else if (is_pointer(arg_type))
         parse_pointer_arg(ap);
@@ -452,7 +452,7 @@ static inline void parse_syscall_args(va_list ap) {
 static inline void skip_syscall_args(va_list ap) {
     const char* arg_type = va_arg(ap, const char*);
 
-    if (strcmp_static(arg_type, "const char *") || strcmp_static(arg_type, "const char*"))
+    if (!strcmp_static(arg_type, "const char *") || !strcmp_static(arg_type, "const char*"))
         va_arg(ap, const char*);
     else if (is_pointer(arg_type))
         va_arg(ap, void*);

--- a/LibOS/shim/src/sys/shim_exec.c
+++ b/LibOS/shim/src/sys/shim_exec.c
@@ -468,7 +468,7 @@ err:
     SAVE_PROFILE_INTERVAL(open_file_for_exec);
 
 #if EXECVE_RTLD == 1
-    if (!strcmp_static(PAL_CB(host_type), "Linux-SGX")) {
+    if (strcmp_static(PAL_CB(host_type), "Linux-SGX")) {
         int is_last = check_last_thread(cur_thread) == 0;
         if (is_last) {
             debug("execve() in the same process\n");

--- a/Pal/lib/api.h
+++ b/Pal/lib/api.h
@@ -118,24 +118,23 @@ void *malloc(size_t size);
 void free(void *ptr);
 void *calloc(size_t nmemb, size_t size);
 
-/* Some useful macro */
 /* force failure if str is not a static string */
-#define force_static(str)   ("" str "")
+#define force_literal_cstr(str)   ("" str "")
 
 /* check if the var is exactly the same as the static string */
 #define strcmp_static(var, str) \
-    (!memcmp((var), force_static(str), static_strlen(force_static(str)) + 1))
+    (memcmp(var, force_literal_cstr(str), static_strlen(force_literal_cstr(str)) + 1))
 
 /* check if the var starts with the static string */
 #define strpartcmp_static(var, str) \
-    (!memcmp((var), force_static(str), static_strlen(force_static(str))))
+    (!memcmp(var, force_literal_cstr(str), static_strlen(force_literal_cstr(str))))
 
 /* copy static string and return the address of the null end (null if the dest
  * is not large enough).*/
-#define strcpy_static(var, str, max)                                          \
-    (static_strlen(force_static(str)) + 1 > (max) ? NULL :                    \
-     memcpy((var), force_static(str), static_strlen(force_static(str)) + 1) + \
-     static_strlen(force_static(str)))
+#define strcpy_static(var, str, max)                                                      \
+    (static_strlen(force_literal_cstr(str)) + 1 > (max) ? NULL :                          \
+     memcpy((var), force_literal_cstr(str), static_strlen(force_literal_cstr(str)) + 1) + \
+     static_strlen(force_literal_cstr(str)))
 
 /* Copy a fixed size array. */
 #define COPY_ARRAY(dst, src)                                                    \

--- a/Pal/lib/api.h
+++ b/Pal/lib/api.h
@@ -126,7 +126,7 @@ void *calloc(size_t nmemb, size_t size);
     (memcmp(var, force_literal_cstr(str), static_strlen(force_literal_cstr(str)) + 1))
 
 /* check if the var starts with the static string */
-#define strpartcmp_static(var, str) \
+#define strstartswith_static(var, str) \
     (!memcmp(var, force_literal_cstr(str), static_strlen(force_literal_cstr(str))))
 
 /* copy static string and return the address of the null end (null if the dest

--- a/Pal/src/db_main.c
+++ b/Pal/src/db_main.c
@@ -186,9 +186,9 @@ static void set_debug_type (void)
 
     PAL_HANDLE handle = NULL;
 
-    if (strcmp_static(cfgbuf, "inline")) {
+    if (!strcmp_static(cfgbuf, "inline")) {
         ret = _DkStreamOpen(&handle, "dev:tty", PAL_ACCESS_RDWR, 0, 0, 0);
-    } else if (strcmp_static(cfgbuf, "file")) {
+    } else if (!strcmp_static(cfgbuf, "file")) {
         ret = get_config(pal_state.root_config, "loader.debug_file",
                          cfgbuf, CONFIG_MAX);
         if (ret <= 0)
@@ -198,7 +198,7 @@ static void set_debug_type (void)
                             PAL_ACCESS_RDWR,
                             PAL_SHARE_OWNER_R|PAL_SHARE_OWNER_W,
                             PAL_CREATE_TRY, 0);
-    } else if (strcmp_static(cfgbuf, "none")) {
+    } else if (!strcmp_static(cfgbuf, "none")) {
         ret = 0;
     } else {
         INIT_FAIL(PAL_ERROR_INVAL, "unknown debug type");
@@ -357,11 +357,11 @@ noreturn void pal_main (
         size_t exec_strlen = manifest_strlen - 9;
         int success = 0;
         // Try .manifest
-        if (strcmp_static(&manifest_uri[exec_strlen], ".manifest")) {
+        if (!strcmp_static(&manifest_uri[exec_strlen], ".manifest")) {
             success = 1;
         } else {
             exec_strlen -= 4;
-            if (strcmp_static(&manifest_uri[exec_strlen], ".manifest.sgx")) {
+            if (!strcmp_static(&manifest_uri[exec_strlen], ".manifest.sgx")) {
                 success = 1;
             }
         }

--- a/Pal/src/db_rtld.c
+++ b/Pal/src/db_rtld.c
@@ -1218,7 +1218,7 @@ void DkDebugAttachBinary (PAL_STR uri, PAL_PTR start_addr)
     __UNUSED(uri);
     __UNUSED(start_addr);
 #else
-    if (!strpartcmp_static(uri, "file:"))
+    if (!strstartswith_static(uri, "file:"))
         return;
 
     const char * realname = uri + static_strlen("file:");

--- a/Pal/src/db_streams.c
+++ b/Pal/src/db_streams.c
@@ -82,34 +82,34 @@ static int parse_stream_uri(const char** uri, char** prefix, struct handle_ops**
 
     switch (p - u) {
         case 3:
-            if (strpartcmp_static(u, "dir"))
+            if (strstartswith_static(u, "dir"))
                 hops = &dir_ops;
-            else if (strpartcmp_static(u, "tcp"))
+            else if (strstartswith_static(u, "tcp"))
                 hops = &tcp_ops;
-            else if (strpartcmp_static(u, "udp"))
+            else if (strstartswith_static(u, "udp"))
                 hops = &udp_ops;
-            else if (strpartcmp_static(u, "dev"))
+            else if (strstartswith_static(u, "dev"))
                 hops = &dev_ops;
             break;
 
         case 4:
-            if (strpartcmp_static(u, "file"))
+            if (strstartswith_static(u, "file"))
                 hops = &file_ops;
-            else if (strpartcmp_static(u, "pipe"))
+            else if (strstartswith_static(u, "pipe"))
                 hops = &pipe_ops;
-            else if (strpartcmp_static(u, "gipc"))
+            else if (strstartswith_static(u, "gipc"))
                 hops = &gipc_ops;
             break;
 
         case 7:
-            if (strpartcmp_static(u, "tcp.srv"))
+            if (strstartswith_static(u, "tcp.srv"))
                 hops = &tcp_ops;
-            else if (strpartcmp_static(u, "udp.srv"))
+            else if (strstartswith_static(u, "udp.srv"))
                 hops = &udp_ops;
             break;
 
         case 8:
-            if (strpartcmp_static(u, "pipe.srv"))
+            if (strstartswith_static(u, "pipe.srv"))
                 hops = &pipe_ops;
             break;
 

--- a/Pal/src/host/FreeBSD/db_devices.c
+++ b/Pal/src/host/FreeBSD/db_devices.c
@@ -63,7 +63,7 @@ static int parse_device_uri(const char ** uri, char ** type, struct handle_ops *
 
     for (p = u ; (*p) && (*p) != ',' && (*p) != '/' ; p++);
 
-    if (strpartcmp_static(u, "tty"))
+    if (strstartswith_static(u, "tty"))
         dops = &term_ops;
 
     if (!dops)

--- a/Pal/src/host/FreeBSD/db_pipes.c
+++ b/Pal/src/host/FreeBSD/db_pipes.c
@@ -303,7 +303,7 @@ static int pipe_private (PAL_HANDLE * handle, int options)
 static int pipe_open (PAL_HANDLE *handle, const char * type, const char * uri,
                       int access, int share, int create, int options)
 {
-    if (strcmp_static(type, "pipe") && !*uri)
+    if (!strcmp_static(type, "pipe") && !*uri)
         return pipe_private(handle, options);
 
     char * endptr;
@@ -314,10 +314,10 @@ static int pipe_open (PAL_HANDLE *handle, const char * type, const char * uri,
 
     options = HOST_OPTIONS(options & PAL_OPTION_MASK);
 
-    if (strcmp_static(type, "pipe.srv"))
+    if (!strcmp_static(type, "pipe.srv"))
         return pipe_listen(handle, pipeid, options);
 
-    if (strcmp_static(type, "pipe"))
+    if (!strcmp_static(type, "pipe"))
         return pipe_connect(handle, pipeid, options);
 
     return -PAL_ERROR_INVAL;

--- a/Pal/src/host/FreeBSD/db_sockets.c
+++ b/Pal/src/host/FreeBSD/db_sockets.c
@@ -544,10 +544,10 @@ static int tcp_open (PAL_HANDLE *handle, const char * type, const char * uri,
     char uri_buf[PAL_SOCKADDR_SIZE];
     memcpy(uri_buf, uri, uri_len);
 
-    if (strcmp_static(type, "tcp.srv"))
+    if (!strcmp_static(type, "tcp.srv"))
         return tcp_listen(handle, uri_buf, options);
 
-    if (strcmp_static(type, "tcp"))
+    if (!strcmp_static(type, "tcp"))
         return tcp_connect(handle, uri_buf, options);
 
     return -PAL_ERROR_NOTSUPPORT;
@@ -766,10 +766,10 @@ static int udp_open (PAL_HANDLE *hdl, const char * type, const char * uri,
     memcpy(buf, uri, len + 1);
     options &= PAL_OPTION_MASK;
 
-    if (strcmp_static(type, "udp.srv"))
+    if (!strcmp_static(type, "udp.srv"))
         return udp_bind(hdl, buf, options);
 
-    if (strcmp_static(type, "udp"))
+    if (!strcmp_static(type, "udp"))
         return udp_connect(hdl, buf, options);
 
     return -PAL_ERROR_NOTSUPPORT;

--- a/Pal/src/host/FreeBSD/db_sockets.c
+++ b/Pal/src/host/FreeBSD/db_sockets.c
@@ -766,10 +766,10 @@ static int udp_open (PAL_HANDLE *hdl, const char * type, const char * uri,
     memcpy(buf, uri, len + 1);
     options &= PAL_OPTION_MASK;
 
-    if (!strcmp_static(type, "udp.srv"))
+    if (strcmp_static(type, "udp.srv"))
         return udp_bind(hdl, buf, options);
 
-    if (!strcmp_static(type, "udp"))
+    if (strcmp_static(type, "udp"))
         return udp_connect(hdl, buf, options);
 
     return -PAL_ERROR_NOTSUPPORT;
@@ -908,7 +908,7 @@ static int udp_sendbyaddr (PAL_HANDLE handle, int offset, int len,
     if (handle->sock.fd == PAL_IDX_POISON)
         return -PAL_ERROR_BADHANDLE;
 
-    if (strpartcmp_static(addr, "udp:"))
+    if (!strpartcmp_static(addr, "udp:"))
         return -PAL_ERROR_INVAL;
 
     addr += static_strlen("udp:");

--- a/Pal/src/host/FreeBSD/db_sockets.c
+++ b/Pal/src/host/FreeBSD/db_sockets.c
@@ -908,7 +908,7 @@ static int udp_sendbyaddr (PAL_HANDLE handle, int offset, int len,
     if (handle->sock.fd == PAL_IDX_POISON)
         return -PAL_ERROR_BADHANDLE;
 
-    if (!strpartcmp_static(addr, "udp:"))
+    if (!strstartswith_static(addr, "udp:"))
         return -PAL_ERROR_INVAL;
 
     addr += static_strlen("udp:");

--- a/Pal/src/host/Linux-SGX/db_devices.c
+++ b/Pal/src/host/Linux-SGX/db_devices.c
@@ -115,7 +115,7 @@ static int open_standard_term(PAL_HANDLE* handle, const char* param, int access)
 /* 'open' operation for terminal stream */
 static int term_open(PAL_HANDLE* handle, const char* type, const char* uri, int access, int share,
                      int create, int options) {
-    if (!strcmp_static(type, "tty"))
+    if (strcmp_static(type, "tty"))
         return -PAL_ERROR_INVAL;
 
     if (!WITHIN_MASK(share, PAL_SHARE_MASK) || !WITHIN_MASK(create, PAL_CREATE_MASK) ||
@@ -151,7 +151,7 @@ static int term_close(PAL_HANDLE handle) {
 static int term_attrquery(const char* type, const char* uri, PAL_STREAM_ATTR* attr) {
     __UNUSED(uri);
 
-    if (!strcmp_static(type, "tty"))
+    if (strcmp_static(type, "tty"))
         return -PAL_ERROR_INVAL;
 
     attr->handle_type  = pal_type_dev;
@@ -218,7 +218,7 @@ static int64_t char_write(PAL_HANDLE handle, uint64_t offset, uint64_t size, con
 /* 'open' operation for device streams */
 static int dev_open(PAL_HANDLE* handle, const char* type, const char* uri, int access, int share,
                     int create, int options) {
-    if (!strcmp_static(type, "dev"))
+    if (strcmp_static(type, "dev"))
         return -PAL_ERROR_INVAL;
 
     struct handle_ops* ops = NULL;
@@ -327,7 +327,7 @@ static int dev_flush(PAL_HANDLE handle) {
 
 /* 'attrquery' operation for device streams */
 static int dev_attrquery(const char* type, const char* uri, PAL_STREAM_ATTR* attr) {
-    if (!strcmp_static(type, "dev"))
+    if (strcmp_static(type, "dev"))
         return -PAL_ERROR_INVAL;
 
     struct handle_ops* ops = NULL;

--- a/Pal/src/host/Linux-SGX/db_devices.c
+++ b/Pal/src/host/Linux-SGX/db_devices.c
@@ -66,7 +66,7 @@ static int parse_device_uri(const char** uri, char** type, struct handle_ops** o
     for (p = u; (*p) && (*p) != ',' && (*p) != '/'; p++)
         ;
 
-    if (strpartcmp_static(u, "tty"))
+    if (strstartswith_static(u, "tty"))
         dops = &term_ops;
 
     if (!dops)

--- a/Pal/src/host/Linux-SGX/db_files.c
+++ b/Pal/src/host/Linux-SGX/db_files.c
@@ -45,7 +45,7 @@ typedef __kernel_pid_t pid_t;
 /* 'open' operation for file streams */
 static int file_open(PAL_HANDLE* handle, const char* type, const char* uri, int access, int share,
                      int create, int options) {
-    if (!strcmp_static(type, "file"))
+    if (strcmp_static(type, "file"))
         return -PAL_ERROR_INVAL;
     /* try to do the real open */
     int fd = ocall_open(uri, access | create | options, share);
@@ -314,7 +314,7 @@ static inline void file_attrcopy(PAL_STREAM_ATTR* attr, struct stat* stat) {
 
 /* 'attrquery' operation for file streams */
 static int file_attrquery(const char* type, const char* uri, PAL_STREAM_ATTR* attr) {
-    if (!strcmp_static(type, "file") && !strcmp_static(type, "dir"))
+    if (strcmp_static(type, "file") && strcmp_static(type, "dir"))
         return -PAL_ERROR_INVAL;
     /* try to do the real open */
     int fd = ocall_open(uri, 0, 0);
@@ -356,7 +356,7 @@ static int file_attrsetbyhdl(PAL_HANDLE handle, PAL_STREAM_ATTR* attr) {
 }
 
 static int file_rename(PAL_HANDLE handle, const char* type, const char* uri) {
-    if (!strcmp_static(type, "file"))
+    if (strcmp_static(type, "file"))
         return -PAL_ERROR_INVAL;
 
     char* tmp = strdup(uri);
@@ -418,7 +418,7 @@ struct handle_ops file_ops = {
    ended with slashes. dir_open will be called by file_open. */
 static int dir_open(PAL_HANDLE* handle, const char* type, const char* uri, int access, int share,
                     int create, int options) {
-    if (!strcmp_static(type, "dir"))
+    if (strcmp_static(type, "dir"))
         return -PAL_ERROR_INVAL;
     if (!WITHIN_MASK(access, PAL_ACCESS_MASK))
         return -PAL_ERROR_INVAL;
@@ -567,7 +567,7 @@ static int dir_delete(PAL_HANDLE handle, int access) {
 }
 
 static int dir_rename(PAL_HANDLE handle, const char* type, const char* uri) {
-    if (!strcmp_static(type, "dir"))
+    if (strcmp_static(type, "dir"))
         return -PAL_ERROR_INVAL;
 
     char* tmp = strdup(uri);

--- a/Pal/src/host/Linux-SGX/db_main.c
+++ b/Pal/src/host/Linux-SGX/db_main.c
@@ -96,7 +96,7 @@ int init_child_process(PAL_HANDLE* parent_handle);
  */
 static PAL_HANDLE setup_dummy_file_handle (const char * name)
 {
-    if (!strpartcmp_static(name, "file:"))
+    if (!strstartswith_static(name, "file:"))
         return NULL;
 
     name += static_strlen("file:");

--- a/Pal/src/host/Linux-SGX/db_pipes.c
+++ b/Pal/src/host/Linux-SGX/db_pipes.c
@@ -157,7 +157,7 @@ static int pipe_open(PAL_HANDLE* handle, const char* type, const char* uri, int 
         !WITHIN_MASK(create, PAL_CREATE_MASK) || !WITHIN_MASK(options, PAL_OPTION_MASK))
         return -PAL_ERROR_INVAL;
 
-    if (strcmp_static(type, "pipe") && !*uri)
+    if (!strcmp_static(type, "pipe") && !*uri)
         return pipe_private(handle, options);
 
     char* endptr;
@@ -166,10 +166,10 @@ static int pipe_open(PAL_HANDLE* handle, const char* type, const char* uri, int 
     if (*endptr)
         return -PAL_ERROR_INVAL;
 
-    if (strcmp_static(type, "pipe.srv"))
+    if (!strcmp_static(type, "pipe.srv"))
         return pipe_listen(handle, pipeid, options);
 
-    if (strcmp_static(type, "pipe"))
+    if (!strcmp_static(type, "pipe"))
         return pipe_connect(handle, pipeid, options);
 
     return -PAL_ERROR_INVAL;

--- a/Pal/src/host/Linux-SGX/db_process.c
+++ b/Pal/src/host/Linux-SGX/db_process.c
@@ -248,7 +248,7 @@ static int check_child_mrenclave(PAL_HANDLE child, sgx_arch_hash_t* mrenclave,
 int _DkProcessCreate (PAL_HANDLE * handle, const char * uri, const char ** args)
 {
     /* only access creating process with regular file */
-    if (!strpartcmp_static(uri, "file:"))
+    if (!strstartswith_static(uri, "file:"))
         return -PAL_ERROR_INVAL;
 
     unsigned int child_pid;

--- a/Pal/src/host/Linux-SGX/db_rtld.c
+++ b/Pal/src/host/Linux-SGX/db_rtld.c
@@ -121,7 +121,7 @@ void _DkDebugAddMap (struct link_map * map)
             continue;
         if (s->sh_type == SHT_NULL)
             continue;
-        if (strpartcmp_static(shstrtab + s->sh_name, ".debug_"))
+        if (strstartswith_static(shstrtab + s->sh_name, ".debug_"))
             continue;
 
         snprintf(ptr, BUFFER_LENGTH - (ptr - buffer),

--- a/Pal/src/host/Linux-SGX/db_rtld.c
+++ b/Pal/src/host/Linux-SGX/db_rtld.c
@@ -98,7 +98,7 @@ void _DkDebugAddMap (struct link_map * map)
 
     ElfW(Addr) text_addr = 0;
     for (ElfW(Shdr) * s = shdr ; s < shdrend ; s++)
-        if (strcmp_static(shstrtab + s->sh_name, ".text")) {
+        if (!strcmp_static(shstrtab + s->sh_name, ".text")) {
             text_addr = map->l_addr + s->sh_addr;
             break;
         }
@@ -117,7 +117,7 @@ void _DkDebugAddMap (struct link_map * map)
     for (ElfW(Shdr) * s = shdr ; s < shdrend ; s++) {
         if (!s->sh_name || !s->sh_addr)
             continue;
-        if (strcmp_static(shstrtab + s->sh_name, ".text"))
+        if (!strcmp_static(shstrtab + s->sh_name, ".text"))
             continue;
         if (s->sh_type == SHT_NULL)
             continue;

--- a/Pal/src/host/Linux-SGX/db_sockets.c
+++ b/Pal/src/host/Linux-SGX/db_sockets.c
@@ -708,7 +708,7 @@ static int64_t udp_sendbyaddr(PAL_HANDLE handle, uint64_t offset, uint64_t len, 
     if (handle->sock.fd == PAL_IDX_POISON)
         return -PAL_ERROR_BADHANDLE;
 
-    if (!strpartcmp_static(addr, "udp:"))
+    if (!strstartswith_static(addr, "udp:"))
         return -PAL_ERROR_INVAL;
 
     if (len >= (1ULL << (sizeof(unsigned int) * 8)))

--- a/Pal/src/host/Linux-SGX/db_sockets.c
+++ b/Pal/src/host/Linux-SGX/db_sockets.c
@@ -447,10 +447,10 @@ static int tcp_open(PAL_HANDLE* handle, const char* type, const char* uri, int a
     char uri_buf[PAL_SOCKADDR_SIZE];
     memcpy(uri_buf, uri, uri_len);
 
-    if (strcmp_static(type, "tcp.srv"))
+    if (!strcmp_static(type, "tcp.srv"))
         return tcp_listen(handle, uri_buf, options);
 
-    if (strcmp_static(type, "tcp"))
+    if (!strcmp_static(type, "tcp"))
         return tcp_connect(handle, uri_buf, options);
 
     return -PAL_ERROR_NOTSUPPORT;
@@ -608,10 +608,10 @@ static int udp_open(PAL_HANDLE* hdl, const char* type, const char* uri, int acce
 
     memcpy(buf, uri, len + 1);
 
-    if (strcmp_static(type, "udp.srv"))
+    if (!strcmp_static(type, "udp.srv"))
         return udp_bind(hdl, buf, options);
 
-    if (strcmp_static(type, "udp"))
+    if (!strcmp_static(type, "udp"))
         return udp_connect(hdl, buf, options);
 
     return -PAL_ERROR_NOTSUPPORT;

--- a/Pal/src/host/Linux-SGX/enclave_framework.c
+++ b/Pal/src/host/Linux-SGX/enclave_framework.c
@@ -280,7 +280,7 @@ int load_trusted_file (PAL_HANDLE file, sgx_stub_t ** stubptr,
     }
 
     /* Normalize the uri */
-    if (!strpartcmp_static(uri, "file:")) {
+    if (!strstartswith_static(uri, "file:")) {
         SGX_DBG(DBG_E, "Invalid URI [%s]: Trusted files must start with 'file:'\n", uri);;
         return -PAL_ERROR_INVAL;
     }
@@ -707,7 +707,7 @@ static int init_trusted_file (const char * key, const char * uri)
         return 0;
 
     /* Normalize the uri */
-    if (!strpartcmp_static(uri, "file:")) {
+    if (!strstartswith_static(uri, "file:")) {
         SGX_DBG(DBG_E, "Invalid URI [%s]: Trusted files must start with 'file:'\n", uri);
         return -PAL_ERROR_INVAL;
     }

--- a/Pal/src/host/Linux-SGX/enclave_platform.c
+++ b/Pal/src/host/Linux-SGX/enclave_platform.c
@@ -349,13 +349,13 @@ static int parse_x509_pem(char* cert, char** cert_end, uint8_t** body, size_t* b
         return 0;
     }
 
-    if (!strpartcmp_static(start, "-----BEGIN CERTIFICATE-----"))
+    if (!strstartswith_static(start, "-----BEGIN CERTIFICATE-----"))
         return -PAL_ERROR_INVAL;
 
     start += static_strlen("-----BEGIN CERTIFICATE-----");
     char* end = strchr(start, '-');
 
-    if (!strpartcmp_static(end, "-----END CERTIFICATE-----"))
+    if (!strstartswith_static(end, "-----END CERTIFICATE-----"))
         return -PAL_ERROR_INVAL;
 
     size_t cert_der_len;
@@ -595,8 +595,8 @@ int sgx_verify_platform(sgx_spid_t* spid, const char* subkey, sgx_quote_nonce_t*
     SGX_DBG(DBG_S, "  timestamp: %s\n", ias_timestamp);
 
     // Only accept status to be "OK" or "GROUP_OUT_OF_DATE" (if accept_out_of_date is true)
-    if (!strcmp_static(ias_status, "OK") &&
-        (!accept_group_out_of_date || !strcmp_static(ias_status, "GROUP_OUT_OF_DATE"))) {
+    if (strcmp_static(ias_status, "OK") &&
+        (!accept_group_out_of_date || strcmp_static(ias_status, "GROUP_OUT_OF_DATE"))) {
         SGX_DBG(DBG_E, "IAS returned invalid status: %s\n", ias_status);
         goto failed;
     }

--- a/Pal/src/host/Linux-SGX/sgx_main.c
+++ b/Pal/src/host/Linux-SGX/sgx_main.c
@@ -450,7 +450,7 @@ int initialize_enclave (struct pal_enclave * enclave)
 
         void * data = NULL;
 
-        if (strcmp_static(areas[i].desc, "tls")) {
+        if (!strcmp_static(areas[i].desc, "tls")) {
             data = (void *) INLINE_SYSCALL(mmap, 6, NULL, areas[i].size,
                                            PROT_READ|PROT_WRITE,
                                            MAP_ANONYMOUS|MAP_PRIVATE, -1, 0);
@@ -484,7 +484,7 @@ int initialize_enclave (struct pal_enclave * enclave)
                 }
                 gs->thread = NULL;
             }
-        } else if (strcmp_static(areas[i].desc, "tcs")) {
+        } else if (!strcmp_static(areas[i].desc, "tcs")) {
             data = (void *) INLINE_SYSCALL(mmap, 6, NULL, areas[i].size,
                                            PROT_READ|PROT_WRITE,
                                            MAP_ANONYMOUS|MAP_PRIVATE, -1, 0);
@@ -793,7 +793,7 @@ static int load_enclave (struct pal_enclave * enclave,
 #ifdef DEBUG
     size_t env_i = 0;
     while (env_i < env_size) {
-        if (strcmp_static(&env[env_i], "IN_GDB=1")) {
+        if (!strcmp_static(&env[env_i], "IN_GDB=1")) {
             SGX_DBG(DBG_I, "[ Running under GDB ]\n");
             pal_sec->in_gdb = true;
         } else if (strpartcmp_static(&env[env_i], "LD_PRELOAD=")) {
@@ -983,7 +983,7 @@ int main (int argc, char ** argv, char ** envp)
         if (!argc)
             goto usage;
 
-        if (strcmp_static(argv[0], "file:")) {
+        if (!strcmp_static(argv[0], "file:")) {
             exec_uri = alloc_concat(argv[0], -1, NULL, -1);
         } else {
             exec_uri = alloc_concat("file:", -1, argv[0], -1);

--- a/Pal/src/host/Linux-SGX/sgx_main.c
+++ b/Pal/src/host/Linux-SGX/sgx_main.c
@@ -79,7 +79,7 @@ static unsigned long parse_int (const char * str)
 
 static char * resolve_uri (const char * uri, const char ** errstring)
 {
-    if (!strpartcmp_static(uri, "file:")) {
+    if (!strstartswith_static(uri, "file:")) {
         *errstring = "Invalid URI";
         return NULL;
     }
@@ -796,7 +796,7 @@ static int load_enclave (struct pal_enclave * enclave,
         if (!strcmp_static(&env[env_i], "IN_GDB=1")) {
             SGX_DBG(DBG_I, "[ Running under GDB ]\n");
             pal_sec->in_gdb = true;
-        } else if (strpartcmp_static(&env[env_i], "LD_PRELOAD=")) {
+        } else if (strstartswith_static(&env[env_i], "LD_PRELOAD=")) {
             uint64_t env_i_size = strnlen(&env[env_i], env_size - env_i) + 1;
             memmove(&env[env_i], &env[env_i + env_i_size], env_size - env_i - env_i_size);
             env_size -= env_i_size;

--- a/Pal/src/host/Linux-SGX/sgx_main.c
+++ b/Pal/src/host/Linux-SGX/sgx_main.c
@@ -796,7 +796,7 @@ static int load_enclave (struct pal_enclave * enclave,
         if (strcmp_static(&env[env_i], "IN_GDB=1")) {
             SGX_DBG(DBG_I, "[ Running under GDB ]\n");
             pal_sec->in_gdb = true;
-        } else if (strcmp_static(&env[env_i], "LD_PRELOAD=")) {
+        } else if (strpartcmp_static(&env[env_i], "LD_PRELOAD=")) {
             uint64_t env_i_size = strnlen(&env[env_i], env_size - env_i) + 1;
             memmove(&env[env_i], &env[env_i + env_i_size], env_size - env_i - env_i_size);
             env_size -= env_i_size;

--- a/Pal/src/host/Linux-SGX/sgx_platform.c
+++ b/Pal/src/host/Linux-SGX/sgx_platform.c
@@ -278,7 +278,7 @@ int contact_intel_attest_service(const char* subkey, const sgx_quote_nonce_t* no
         if (end > start + 1 && *(end - 1) == '\r')
             end--;
 
-        if (strpartcmp_static(start, "X-IASReport-Signature: ")) {
+        if (strstartswith_static(start, "X-IASReport-Signature: ")) {
             start += static_strlen("X-IASReport-Signature: ");
 
             // Decode IAS report signature
@@ -301,7 +301,7 @@ int contact_intel_attest_service(const char* subkey, const sgx_quote_nonce_t* no
                 SGX_DBG(DBG_E, "Malformed IAS report signature\n");
                 goto failed;
             }
-        } else if (strpartcmp_static(start, "X-IASReport-Signing-Certificate: ")) {
+        } else if (strstartswith_static(start, "X-IASReport-Signing-Certificate: ")) {
             start += static_strlen("X-IASReport-Signing-Certificate: ");
 
             // Decode IAS signature chain

--- a/Pal/src/host/Linux-SGX/sgx_process.c
+++ b/Pal/src/host/Linux-SGX/sgx_process.c
@@ -84,7 +84,7 @@ int sgx_create_process(const char* uri, int nargs, const char** args, int * retf
     int ret, rete, child;
     int fds[6] = { -1, -1, -1, -1, -1, -1 };
 
-    if (!uri || !strpartcmp_static(uri, "file:"))
+    if (!uri || !strstartswith_static(uri, "file:"))
         return -EINVAL;
 
     if (IS_ERR((ret = INLINE_SYSCALL(pipe, 1, &fds[0]))) ||

--- a/Pal/src/host/Linux/db_devices.c
+++ b/Pal/src/host/Linux/db_devices.c
@@ -113,7 +113,7 @@ static int open_standard_term(PAL_HANDLE* handle, const char* param, int access)
 /* 'open' operation for terminal stream */
 static int term_open(PAL_HANDLE* handle, const char* type, const char* uri, int access, int share,
                      int create, int options) {
-    if (!strcmp_static(type, "tty"))
+    if (strcmp_static(type, "tty"))
         return -PAL_ERROR_INVAL;
 
     if (!WITHIN_MASK(share, PAL_SHARE_MASK) || !WITHIN_MASK(create, PAL_CREATE_MASK) ||
@@ -150,7 +150,7 @@ static int term_close(PAL_HANDLE handle) {
 static int term_attrquery(const char* type, const char* uri, PAL_STREAM_ATTR* attr) {
     __UNUSED(uri);
 
-    if (!strcmp_static(type, "tty"))
+    if (strcmp_static(type, "tty"))
         return -PAL_ERROR_INVAL;
 
     attr->handle_type  = pal_type_dev;
@@ -219,7 +219,7 @@ static int64_t char_write(PAL_HANDLE handle, uint64_t offset, uint64_t size, con
 /* 'open' operation for device streams */
 static int dev_open(PAL_HANDLE* handle, const char* type, const char* uri, int access, int share,
                     int create, int options) {
-    if (!strcmp_static(type, "dev"))
+    if (strcmp_static(type, "dev"))
         return -PAL_ERROR_INVAL;
 
     struct handle_ops* ops = NULL;
@@ -356,7 +356,7 @@ static int dev_flush(PAL_HANDLE handle) {
 
 /* 'attrquery' operation for device streams */
 static int dev_attrquery(const char* type, const char* uri, PAL_STREAM_ATTR* attr) {
-    if (!strcmp_static(type, "dev"))
+    if (strcmp_static(type, "dev"))
         return -PAL_ERROR_INVAL;
 
     struct handle_ops* ops = NULL;

--- a/Pal/src/host/Linux/db_devices.c
+++ b/Pal/src/host/Linux/db_devices.c
@@ -64,7 +64,7 @@ static int parse_device_uri(const char** uri, char** type, struct handle_ops** o
     for (p = u; (*p) && (*p) != ',' && (*p) != '/'; p++)
         ;
 
-    if (strpartcmp_static(u, "tty"))
+    if (strstartswith_static(u, "tty"))
         dops = &term_ops;
 
     if (!dops)

--- a/Pal/src/host/Linux/db_files.c
+++ b/Pal/src/host/Linux/db_files.c
@@ -41,7 +41,7 @@ typedef __kernel_pid_t pid_t;
 static int file_open (PAL_HANDLE * handle, const char * type, const char * uri,
                       int access, int share, int create, int options)
 {
-    if (!strcmp_static(type, "file"))
+    if (strcmp_static(type, "file"))
         return -PAL_ERROR_INVAL;
 
     /* try to do the real open */
@@ -235,7 +235,7 @@ file_attrcopy (PAL_STREAM_ATTR * attr, struct stat * stat)
 static int file_attrquery (const char * type, const char * uri,
                            PAL_STREAM_ATTR * attr)
 {
-    if (!strcmp_static(type, "file") && !strcmp_static(type, "dir"))
+    if (strcmp_static(type, "file") && strcmp_static(type, "dir"))
         return -PAL_ERROR_INVAL;
 
     struct stat stat_buf;
@@ -281,7 +281,7 @@ static int file_attrsetbyhdl (PAL_HANDLE handle,
 static int file_rename (PAL_HANDLE handle, const char * type,
                         const char * uri)
 {
-    if (!strcmp_static(type, "file"))
+    if (strcmp_static(type, "file"))
         return -PAL_ERROR_INVAL;
 
     char* tmp = strdup(uri);
@@ -347,7 +347,7 @@ struct handle_ops file_ops = {
 static int dir_open (PAL_HANDLE * handle, const char * type, const char * uri,
                      int access, int share, int create, int options)
 {
-    if (!strcmp_static(type, "dir"))
+    if (strcmp_static(type, "dir"))
         return -PAL_ERROR_INVAL;
     if (!WITHIN_MASK(access, PAL_ACCESS_MASK))
         return -PAL_ERROR_INVAL;
@@ -528,7 +528,7 @@ static int dir_delete (PAL_HANDLE handle, int access)
 static int dir_rename (PAL_HANDLE handle, const char * type,
                        const char * uri)
 {
-    if (!strcmp_static(type, "dir"))
+    if (strcmp_static(type, "dir"))
         return -PAL_ERROR_INVAL;
 
     char* tmp = strdup(uri);

--- a/Pal/src/host/Linux/db_ipc.c
+++ b/Pal/src/host/Linux/db_ipc.c
@@ -34,7 +34,7 @@
 int gipc_open (PAL_HANDLE * handle, const char * type, const char * uri,
                int access, int share, int create, int options)
 {
-    if (!strcmp_static(type, "gipc"))
+    if (strcmp_static(type, "gipc"))
         return -PAL_ERROR_INVAL;
 
     if (!WITHIN_MASK(access, PAL_ACCESS_MASK) ||

--- a/Pal/src/host/Linux/db_pipes.c
+++ b/Pal/src/host/Linux/db_pipes.c
@@ -287,7 +287,7 @@ static int pipe_open(PAL_HANDLE* handle, const char* type, const char* uri, int 
         !WITHIN_MASK(create, PAL_CREATE_MASK) || !WITHIN_MASK(options, PAL_OPTION_MASK))
         return -PAL_ERROR_INVAL;
 
-    if (strcmp_static(type, "pipe") && !*uri)
+    if (!strcmp_static(type, "pipe") && !*uri)
         return pipe_private(handle, options);
 
     char* endptr;
@@ -296,10 +296,10 @@ static int pipe_open(PAL_HANDLE* handle, const char* type, const char* uri, int 
     if (*endptr)
         return -PAL_ERROR_INVAL;
 
-    if (strcmp_static(type, "pipe.srv"))
+    if (!strcmp_static(type, "pipe.srv"))
         return pipe_listen(handle, pipeid, options);
 
-    if (strcmp_static(type, "pipe"))
+    if (!strcmp_static(type, "pipe"))
         return pipe_connect(handle, pipeid, options);
 
     return -PAL_ERROR_INVAL;

--- a/Pal/src/host/Linux/db_sockets.c
+++ b/Pal/src/host/Linux/db_sockets.c
@@ -879,7 +879,7 @@ static int64_t udp_sendbyaddr(PAL_HANDLE handle, uint64_t offset, size_t len, co
     if (handle->sock.fd == PAL_IDX_POISON)
         return -PAL_ERROR_BADHANDLE;
 
-    if (!strpartcmp_static(addr, "udp:"))
+    if (!strstartswith_static(addr, "udp:"))
         return -PAL_ERROR_INVAL;
 
     addr += static_strlen("udp:");

--- a/Pal/src/host/Linux/db_sockets.c
+++ b/Pal/src/host/Linux/db_sockets.c
@@ -537,10 +537,10 @@ static int tcp_open(PAL_HANDLE* handle, const char* type, const char* uri, int a
     char uri_buf[PAL_SOCKADDR_SIZE];
     memcpy(uri_buf, uri, uri_len);
 
-    if (strcmp_static(type, "tcp.srv"))
+    if (!strcmp_static(type, "tcp.srv"))
         return tcp_listen(handle, uri_buf, options);
 
-    if (strcmp_static(type, "tcp"))
+    if (!strcmp_static(type, "tcp"))
         return tcp_connect(handle, uri_buf, options);
 
     return -PAL_ERROR_NOTSUPPORT;
@@ -752,10 +752,10 @@ static int udp_open(PAL_HANDLE* hdl, const char* type, const char* uri, int acce
 
     memcpy(buf, uri, len + 1);
 
-    if (strcmp_static(type, "udp.srv"))
+    if (!strcmp_static(type, "udp.srv"))
         return udp_bind(hdl, buf, options);
 
-    if (strcmp_static(type, "udp"))
+    if (!strcmp_static(type, "udp"))
         return udp_connect(hdl, buf, options);
 
     return -PAL_ERROR_NOTSUPPORT;

--- a/Pal/src/host/Skeleton/db_devices.c
+++ b/Pal/src/host/Skeleton/db_devices.c
@@ -56,7 +56,7 @@ static int parse_device_uri(const char ** uri, char ** type, struct handle_ops *
 
     for (p = u ; (*p) && (*p) != ',' && (*p) != '/' ; p++);
 
-    if (strpartcmp_static(u, "tty"))
+    if (strstartswith_static(u, "tty"))
         dops = &term_ops;
 
     if (!dops)

--- a/Pal/src/host/Skeleton/db_pipes.c
+++ b/Pal/src/host/Skeleton/db_pipes.c
@@ -57,7 +57,7 @@ static int pipe_open (PAL_HANDLE *handle, const char * type,
                       const char * uri, int access, int share,
                       int create, int options)
 {
-    if (strcmp_static(type, "pipe") && !*uri)
+    if (!strcmp_static(type, "pipe") && !*uri)
         return pipe_private(handle);
 
     char * endptr;
@@ -74,10 +74,10 @@ static int pipe_open (PAL_HANDLE *handle, const char * type,
     if (*endptr)
         return -PAL_ERROR_INVAL;
 
-    if (strcmp_static(type, "pipe.srv"))
+    if (!strcmp_static(type, "pipe.srv"))
         return pipe_listen(handle, pipeid, create);
 
-    if (strcmp_static(type, "pipe"))
+    if (!strcmp_static(type, "pipe"))
         return pipe_connect(handle, pipeid, connid, create);
 
     return -PAL_ERROR_INVAL;

--- a/Pal/src/host/Skeleton/db_sockets.c
+++ b/Pal/src/host/Skeleton/db_sockets.c
@@ -62,10 +62,10 @@ static int tcp_open (PAL_HANDLE *handle, const char * type, const char * uri,
     char uri_buf[PAL_SOCKADDR_SIZE];
     memcpy(uri_buf, uri, uri_len);
 
-    if (strcmp_static(type, "tcp.srv"))
+    if (!strcmp_static(type, "tcp.srv"))
         return tcp_listen(handle, uri_buf, create);
 
-    if (strcmp_static(type, "tcp"))
+    if (!strcmp_static(type, "tcp"))
         return tcp_connect(handle, uri_buf, create);
 
     return -PAL_ERROR_NOTSUPPORT;
@@ -106,10 +106,10 @@ static int udp_open (PAL_HANDLE *hdl, const char * type, const char * uri,
 
     memcpy(buf, uri, len + 1);
 
-    if (strcmp_static(type, "udp.srv"))
+    if (!strcmp_static(type, "udp.srv"))
         return udp_bind(hdl, buf, create);
 
-    if (strcmp_static(type, "udp"))
+    if (!strcmp_static(type, "udp"))
         return udp_connect(hdl, buf);
 
     return -PAL_ERROR_NOTSUPPORT;

--- a/Pal/src/host/Skeleton/db_sockets.c
+++ b/Pal/src/host/Skeleton/db_sockets.c
@@ -62,10 +62,10 @@ static int tcp_open (PAL_HANDLE *handle, const char * type, const char * uri,
     char uri_buf[PAL_SOCKADDR_SIZE];
     memcpy(uri_buf, uri, uri_len);
 
-    if (!strcmp_static(type, "tcp.srv"))
+    if (strcmp_static(type, "tcp.srv"))
         return tcp_listen(handle, uri_buf, create);
 
-    if (!strcmp_static(type, "tcp"))
+    if (strcmp_static(type, "tcp"))
         return tcp_connect(handle, uri_buf, create);
 
     return -PAL_ERROR_NOTSUPPORT;


### PR DESCRIPTION
## Affected components

- [ ] README and global configuration
- [X] Linux PAL
- [X] SGX PAL
- [X] FreeBSD PAL
- [X] Common PAL code
- [X] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->

This PR:
* Fixes multiple bugs in string comparisons,
* Fixes `strcmp_static` semantics to match the standard `strcmp`,
* Renames `strpartcmp_static` to `strstartswith_static`.

Fixes #462.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1055)
<!-- Reviewable:end -->
