### PR TITLE
[Pal/Linux] Make _DkSystemTimeQuery return REALTIME, not MONOTONIC

### DIFF
--- a/Pal/src/host/Linux/db_misc.c
+++ b/Pal/src/host/Linux/db_misc.c
@@ -40,7 +40,7 @@ unsigned long _DkSystemTimeQueryEarly (void)
     struct timespec time;
     int ret;
 
-    ret = INLINE_SYSCALL(clock_gettime, 2, CLOCK_MONOTONIC, &time);
+    ret = INLINE_SYSCALL(clock_gettime, 2, CLOCK_REALTIME, &time);
 
     /* Come on, gettimeofday mostly never fails */
     if (IS_ERR(ret))
@@ -71,10 +71,10 @@ unsigned long _DkSystemTimeQuery (void)
 
 #if USE_VDSO_GETTIME == 1
     if (linux_state.vdso_clock_gettime) {
-        ret = linux_state.vdso_clock_gettime(CLOCK_MONOTONIC, &time);
+        ret = linux_state.vdso_clock_gettime(CLOCK_REALTIME, &time);
     } else {
 #endif
-        ret = INLINE_SYSCALL(clock_gettime, 2, CLOCK_MONOTONIC, &time);
+        ret = INLINE_SYSCALL(clock_gettime, 2, CLOCK_REALTIME, &time);
 #if USE_VDSO_GETTIME == 1
     }
 #endif


### PR DESCRIPTION
_DkSystemTimeQuery should return realtime. Not MONOTONIC.
CLOCK_MONOTONIC returns from unspecified starting point.

<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [x] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->


## How to test this PR? <!-- (if applicable) -->
apps/bash/date.manifest

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1059)
<!-- Reviewable:end -->
