### PR TITLE
[Pal/Linux-SGX] Fixing XSAVE estended state on EENTER/EEXIT

### DIFF
--- a/Pal/src/host/Linux-SGX/enclave_entry.S
+++ b/Pal/src/host/Linux-SGX/enclave_entry.S
@@ -91,6 +91,15 @@ enclave_entry:
 	xorq %r14, %r14
 	xorq %r15, %r15
 
+	# Clear "extended" state (FPU aka x87, SSE, AVX, ...).
+	# TODO: We currently clear only state covered by FXRSTOR but not by XRSTOR
+	#       (e.g., no clearing of YMM/ZMM regs). This is because we didn't read
+	#       the value of XFRM yet, so we don't know whether XRSTOR is safe at
+	#       this point.
+	leaq .Lxrstor_init_arg(%rip), %rax
+	fxrstor (%rax)
+	xorq %rax, %rax
+
 	# register states need to be carefully checked, so we move the handling
 	# to handle_ecall() in enclave_ecalls.c
 	callq handle_ecall

--- a/Pal/src/host/Linux-SGX/enclave_entry.S
+++ b/Pal/src/host/Linux-SGX/enclave_entry.S
@@ -585,10 +585,10 @@ __morestack:
 .section .rodata
 	.balign 64
 .Lxrstor_init_arg:
-	.byte 0x7f, 0x03 	# FCW
-	.skip 6, 0
-	.byte 0x80, 0x1f, 0, 0 	# MXCSR
-	.skip 500, 0	 	# rest of fxstore area
+	.byte 0x7f, 0x03        # FCW
+	.skip 22, 0             # FSW, FTW, FOP, etc: all zero-initialized
+	.byte 0x80, 0x1f, 0, 0  # MXCSR
+	.skip 484, 0            # rest of fxstore area
 
 	.skip 15, 0	 	# XSTATE_BV and XCOMP_BV[55:0]
 	.byte 0x80	 	# XCOMP_BV[63:56] i.e. "compact" format


### PR DESCRIPTION
## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->

This PR contains two fixes in `enclave_entry.S`:

1. Fix offset of MXCSR "reset" XSAVE area. Before EEXIT, Graphene-SGX resets the extended state (XSAVE) area to the default state (of mostly zero bytes). This prevents the leakage of  x87/SSE/AVX/MPX register values inside the enclave. However, the previous default state had an incorrectly calculated offset of MXCSR. This commit fixes the offset of MXCSR. (This particular error manifested in spurious "Numeric underflow (#U)" SSE hardware exceptions on OpenVINO.)

2. Reset FXSAVE extended state on EENTER. Previously, the FXSAVE extended state (ST, XMM, MXCSR registers) was not cleared on EENTER (i.e., enclave-thread enter). This could lead to maliciously crafted ST/XMM registers propagating into the enclave and subverting execution. This commit resets FXSAVE on every EENTER to a default mostly zero-byte state.

Note that this commit does not reset XSAVE state (YMM, ZMM registers). This will be fixed in a future commit.

## How to test this PR? <!-- (if applicable) -->

This bug was found during testing OpenVINO. The minimal example to reproduce SIGFPE is:
```c
#include <xmmintrin.h>
#include <pthread.h>
#include <stdio.h>
#include <stdlib.h>
#include <unistd.h>

void* child_print(void* arg) {
//    _mm_setcsr(0x1f80);  /* uncomment to get rid of SIGFPE in Graphene-SGX */
    float res = strtof("1.000000013351432e-10", NULL);
    printf("child: %f\n", res);
    return NULL;
}

int main(int argc, char** argv) {
    float res = strtof("1.000000013351432e-10", NULL);
    printf("parent: %f\n", res);

    pthread_t thread;
    pthread_create(&thread, NULL, child_print, NULL);
    pthread_join(thread, NULL);
    return 0;
}

// Graphene-SGX will fail with something like:
// [     2] arithmetic fault at 0x048a1cd8
// [     2] SIGFPE handled
```

More info on this bug can be found here: https://github.com/oscarlab/graphene/issues/627#issuecomment-538588324

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1064)
<!-- Reviewable:end -->
