### PR TITLE
[LibOS] Return ENOENT on open_namei(path = "")

### DIFF
--- a/LibOS/shim/src/fs/shim_namei.c
+++ b/LibOS/shim/src/fs/shim_namei.c
@@ -513,6 +513,11 @@ int open_namei (struct shim_handle * hdl, struct shim_dentry * start,
     int err = 0, newly_created = 0;
     struct shim_dentry *mydent = NULL;
 
+    if (*path == '\0') {
+        /* corner case: trying to open with empty filename */
+        return -ENOENT;
+    }
+
     lock(&dcache_lock);
 
     // lookup the path from start, passing flags

--- a/LibOS/shim/test/regression/fopen_cornercases.c
+++ b/LibOS/shim/test/regression/fopen_cornercases.c
@@ -20,9 +20,15 @@ int main(int argc, char** argv) {
 
     printf("filepath = %s (len = %lu)\n", filepath, strlen(filepath));
 
+    /* sanity check: try fopening empty filename (must fail) */
+    FILE* fp = fopen("", "r");
+    if (fp != NULL || errno != ENOENT) {
+        perror("(sanity check) fopen with empty filename did not fail with ENOENT");
+        return 1;
+    }
+
     /* sanity check: try fopening dir in write mode (must fail) */
-    errno    = 0;
-    FILE* fp = fopen(PATH, "w");
+    fp    = fopen(PATH, "w");
     if (fp != NULL || errno != EISDIR) {
         perror("(sanity check) fopen of dir with write access did not fail");
         return 1;


### PR DESCRIPTION

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->

Applications like OpenVINO sometimes do open("") and expect ENOENT. This corner case is correctly handled by Linux, so Graphene must have the exact same semantics. Previously, open("") under Graphene resulted in success, and subsequent read() failed.


## How to test this PR? <!-- (if applicable) -->

The LibOS test `fopen_cornercases` was updated to include this test. So simply running LibOS regression tests checks this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1065)
<!-- Reviewable:end -->
