### PR TITLE
[Pal/Linux-SGX] load_trusted_file(): fix uninitialized pointer

### DIFF
--- a/Documentation/oldwiki/Graphene-SGX-Manifest-Syntax.md
+++ b/Documentation/oldwiki/Graphene-SGX-Manifest-Syntax.md
@@ -60,6 +60,15 @@ This syntax specifies the files that are allowed to be loaded into the enclave u
 These files are not cryptographically hashed and are thus not protected. It is insecure to allow
 files containing code or critical information; developers must not allow files blindly!
 
+### Allowing File Creation
+
+    sgx.allow_file_creation=[1|0]
+    (Default: 0)
+
+This syntax specifies whether file creation is allowed from within the enclave. Set it to 1 to
+allow enclaves to create files and to 0 otherwise. Files created during enclave execution do not
+need to be marked as `allowed_files` or `trusted_files`.
+
 ### Trusted Child Processes
 
     sgx.trusted_children.[identifier]=[URI of signature (.sig)]

--- a/LibOS/shim/test/regression/fopen_cornercases.c
+++ b/LibOS/shim/test/regression/fopen_cornercases.c
@@ -1,7 +1,11 @@
 #include <errno.h>
+#include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
 
 #define FILENAME_MAX_LENGTH 255
 #define PATH                "tmp/"
@@ -28,9 +32,21 @@ int main(int argc, char** argv) {
     }
 
     /* sanity check: try fopening dir in write mode (must fail) */
-    fp    = fopen(PATH, "w");
+    fp = fopen(PATH, "w");
     if (fp != NULL || errno != EISDIR) {
         perror("(sanity check) fopen of dir with write access did not fail");
+        return 1;
+    }
+
+    /* creating file within Graphene (requires sgx.allow_file_creation = 1) */
+    int fd = openat(AT_FDCWD, "tmp/filecreatedbygraphene", O_WRONLY | O_CREAT | O_TRUNC, 0666);
+    if (fd < 0) {
+        perror("failed to create file from within Graphene");
+        return 1;
+    }
+    reti = close(fd);
+    if (reti < 0) {
+        perror("fclose failed");
         return 1;
     }
 

--- a/LibOS/shim/test/regression/manifest.template
+++ b/LibOS/shim/test/regression/manifest.template
@@ -35,4 +35,6 @@ sgx.trusted_files.libstdcxx = file:/usr/lib/x86_64-linux-gnu/libstdc++.so.6
 sgx.trusted_files.victim = file:exec_victim
 sgx.trusted_children.victim = file:exec_victim.sig
 
+sgx.allow_file_creation = 1
+
 sgx.allowed_files.tmp_dir = file:tmp/

--- a/LibOS/shim/test/regression/test_libos.py
+++ b/LibOS/shim/test/regression/test_libos.py
@@ -204,6 +204,8 @@ class TC_30_Syscall(RegressionTestCase):
         self.assertIn('Success!', stdout)
 
     def test_030_fopen(self):
+        if os.path.exists("tmp/filecreatedbygraphene"):
+            os.remove("tmp/filecreatedbygraphene")
         stdout, stderr = self.run_binary(['fopen_cornercases'])
 
         # fopen corner cases

--- a/Pal/src/host/Linux-SGX/enclave_framework.c
+++ b/Pal/src/host/Linux-SGX/enclave_framework.c
@@ -274,6 +274,7 @@ int load_trusted_file (PAL_HANDLE file, sgx_stub_t ** stubptr,
        The created file is added to allowed_file list for later access */
     if (create && allow_file_creation) {
        register_trusted_file(uri, NULL);
+       *stubptr = NULL;
        *sizeptr = 0;
        return 0;
     }


### PR DESCRIPTION
## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [x] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->

Previously, `*stubptr` was not initialized to NULL in the corner case of a file created from inside of the SGX enclave. This led to a subsequent failure in logic which tried to mmap an empty file (because it observed that `*stubptr` contained some value).

## How to test this PR? <!-- (if applicable) -->

This obvious bug doesn't seem to deserve a separate test. But this is the minimal test to reproduce the bug. Add this to the manifest:
```
sgx.allowed_files.testfile123 = file:tmp/testfile123
sgx.allow_file_creation = 1
```
Write this example:
```
int main(int argc, const char** argv) {
    int fd = openat(AT_FDCWD,"tmp/testfile123",O_WRONLY|O_CREAT|O_TRUNC,0666);
    printf("fd = %d\n", fd);
    ...
```
Graphene-SGX prints an error like this:
```
fd = -1
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1066)
<!-- Reviewable:end -->
