### PR TITLE
[LibOS] Add missing put_thread calls

### DIFF
--- a/LibOS/shim/include/shim_thread.h
+++ b/LibOS/shim/include/shim_thread.h
@@ -216,10 +216,11 @@ static inline void thread_setwait (struct shim_thread ** queue,
 {
     if (!thread)
         thread = get_cur_thread();
-    get_thread(thread);
     DkEventClear(thread->scheduler_event);
-    if (queue)
+    if (queue) {
+        get_thread(thread);
         *queue = thread;
+    }
 }
 
 static inline int thread_sleep (uint64_t timeout_us)
@@ -246,8 +247,16 @@ static inline void thread_wakeup (struct shim_thread * thread)
 
 extern struct shim_lock thread_list_lock;
 
-struct shim_thread * __lookup_thread (IDTYPE tid);
-struct shim_thread * lookup_thread (IDTYPE tid);
+/*!
+ * \brief Look up the thread for a given id.
+ *
+ * \param tid Thread id to look for.
+ *
+ * Searches global threads list for a thread with id equal to \p tid.
+ * If no thread was found returns NULL.
+ * Increases refcount of the returned thread.
+ */
+struct shim_thread* lookup_thread(IDTYPE tid);
 struct shim_simple_thread * __lookup_simple_thread (IDTYPE tid);
 struct shim_simple_thread * lookup_simple_thread (IDTYPE tid);
 

--- a/LibOS/shim/src/bookkeep/shim_thread.c
+++ b/LibOS/shim/src/bookkeep/shim_thread.c
@@ -76,9 +76,8 @@ void dump_threads (void)
     unlock(&thread_list_lock);
 }
 
-struct shim_thread * __lookup_thread (IDTYPE tid)
-{
-    struct shim_thread * tmp;
+static struct shim_thread* __lookup_thread(IDTYPE tid) {
+    struct shim_thread* tmp;
 
     LISTP_FOR_EACH_ENTRY(tmp, &thread_list, list) {
         if (tmp->tid == tid) {
@@ -90,10 +89,9 @@ struct shim_thread * __lookup_thread (IDTYPE tid)
     return NULL;
 }
 
-struct shim_thread * lookup_thread (IDTYPE tid)
-{
+struct shim_thread* lookup_thread(IDTYPE tid) {
     lock(&thread_list_lock);
-    struct shim_thread * thread = __lookup_thread(tid);
+    struct shim_thread* thread = __lookup_thread(tid);
     unlock(&thread_list_lock);
     return thread;
 }
@@ -319,7 +317,7 @@ void put_thread (struct shim_thread * thread)
     int ref_count = REF_DEC(thread->ref_count);
 
 #ifdef DEBUG_REF
-    debug("put thread %p(%d) (ref_count = %d)\n", thread, thread->tid,
+    debug("put_thread %p(%d) (ref_count = %d)\n", thread, thread->tid,
           ref_count);
 #endif
 

--- a/LibOS/shim/src/sys/shim_alarm.c
+++ b/LibOS/shim/src/sys/shim_alarm.c
@@ -39,6 +39,7 @@ static void signal_alarm(IDTYPE target, void* arg) {
     lock(&thread->lock);
     append_signal(thread, SIGALRM, NULL, true);
     unlock(&thread->lock);
+    put_thread(thread);
 }
 
 int shim_do_alarm(unsigned int seconds) {

--- a/LibOS/shim/src/sys/shim_clone.c
+++ b/LibOS/shim/src/sys/shim_clone.c
@@ -125,9 +125,10 @@ int clone_implementation_wrapper(struct clone_args * arg)
     object_wait_with_retry(arg->create_event);
     DkObjectClose(arg->create_event);
 
-    struct shim_thread * my_thread = arg->thread;
+    /* We acquired ownership of arg->thread from the caller, hence there is
+     * no need to call get_thread. */
+    struct shim_thread* my_thread = arg->thread;
     assert(my_thread);
-    get_thread(my_thread);
 
     if (!my_thread->tcb) {
         stack_allocated = 1;
@@ -171,6 +172,8 @@ int clone_implementation_wrapper(struct clone_args * arg)
     tcb->context.regs = &regs;
     fixup_child_context(tcb->context.regs);
     tcb->context.regs->rsp = (unsigned long)stack;
+
+    put_thread(my_thread);
 
     restore_context(&tcb->context);
     return 0;
@@ -387,6 +390,9 @@ int shim_do_clone (int flags, void * user_stack_addr, int * parent_tidptr,
         goto clone_thread_failed;
     }
 
+    /* Increasing refcount due to copy below. Passing ownership of the new copy
+     * of this pointer to the new thread (receiver of new_args). */
+    get_thread(thread);
     new_args.thread    = thread;
     new_args.parent    = self;
     new_args.stack     = user_stack_addr;
@@ -401,6 +407,7 @@ int shim_do_clone (int flags, void * user_stack_addr, int * parent_tidptr,
                                           &new_args);
     if (!pal_handle) {
         ret = -PAL_ERRNO;
+        put_thread(new_args.thread);
         goto clone_thread_failed;
     }
 

--- a/LibOS/shim/src/sys/shim_futex.c
+++ b/LibOS/shim/src/sys/shim_futex.c
@@ -51,6 +51,28 @@ DEFINE_LISTP(shim_futex_handle);
 static LISTP_TYPE(shim_futex_handle) futex_list = LISTP_INIT;
 static struct shim_lock futex_list_lock;
 
+static void add_futex_waiter(struct futex_waiter* waiter,
+                             struct shim_futex_handle* futex,
+                             uint32_t bitset) {
+    thread_setwait(&waiter->thread, NULL);
+    INIT_LIST_HEAD(waiter, list);
+    waiter->bitset = bitset;
+    LISTP_ADD_TAIL(waiter, &futex->waiters, list);
+}
+
+static void del_futex_waiter(struct futex_waiter* waiter, struct shim_futex_handle* futex) {
+    LISTP_DEL_INIT(waiter, &futex->waiters, list);
+    assert(waiter->thread);
+    put_thread(waiter->thread);
+}
+
+static void del_futex_waiter_wakeup(struct futex_waiter* waiter, struct shim_futex_handle* futex) {
+    LISTP_DEL_INIT(waiter, &futex->waiters, list);
+    assert(waiter->thread);
+    thread_wakeup(waiter->thread);
+    put_thread(waiter->thread);
+}
+
 int shim_do_futex(int* uaddr, int op, int val, void* utime, int* uaddr2, int val3) {
     struct shim_futex_handle* tmp = NULL;
     struct shim_futex_handle* futex = NULL;
@@ -172,24 +194,23 @@ int shim_do_futex(int* uaddr, int op, int val, void* utime, int* uaddr2, int val
                     break;
                 }
 
-                struct futex_waiter waiter;
-                thread_setwait(&waiter.thread, NULL);
-                INIT_LIST_HEAD(&waiter, list);
-                waiter.bitset = bitset;
-                LISTP_ADD_TAIL(&waiter, &futex->waiters, list);
+                struct futex_waiter waiter = { 0 };
+                add_futex_waiter(&waiter, futex, bitset);
 
                 unlock(&hdl->lock);
                 ret = thread_sleep(timeout_us);
                 /* DEP 1/28/17: Should return ETIMEDOUT, not EAGAIN, on timeout. */
                 if (ret == -EAGAIN)
                     ret = -ETIMEDOUT;
-                if (ret == -ETIMEDOUT)
-                    LISTP_DEL(&waiter, &futex->waiters, list);
+                if (ret == -ETIMEDOUT) {
+                    del_futex_waiter(&waiter, futex);
+                }
                 lock(&hdl->lock);
                 /* Chia-Che 10/17/17: FUTEX_WAKE should remove the waiter
                  * from the list; if not, we should remove it now. */
-                if (!LIST_EMPTY(&waiter, list))
-                    LISTP_DEL(&waiter, &futex->waiters, list);
+                if (!LIST_EMPTY(&waiter, list)) {
+                    del_futex_waiter(&waiter, futex);
+                }
                 break;
             }
 
@@ -209,8 +230,7 @@ int shim_do_futex(int* uaddr, int op, int val, void* utime, int* uaddr2, int val
                 debug("FUTEX_WAKE wake thread %d: %p (val = %d)\n", waiter->thread->tid, uaddr,
                       *uaddr);
 
-                LISTP_DEL_INIT(waiter, &futex->waiters, list);
-                thread_wakeup(waiter->thread);
+                del_futex_waiter_wakeup(waiter, futex);
                 nwaken++;
                 if (nwaken >= val)
                     break;
@@ -273,8 +293,7 @@ int shim_do_futex(int* uaddr, int op, int val, void* utime, int* uaddr2, int val
             LISTP_FOR_EACH_ENTRY_SAFE(waiter, wtmp, &futex->waiters, list) {
                 debug("FUTEX_WAKE_OP wake thread %d: %p (val = %d)\n", waiter->thread->tid, uaddr,
                       *uaddr);
-                LISTP_DEL_INIT(waiter, &futex->waiters, list);
-                thread_wakeup(waiter->thread);
+                del_futex_waiter_wakeup(waiter, futex);
                 nwaken++;
             }
 
@@ -287,8 +306,7 @@ int shim_do_futex(int* uaddr, int op, int val, void* utime, int* uaddr2, int val
                 LISTP_FOR_EACH_ENTRY_SAFE(waiter, wtmp, &futex2->waiters, list) {
                     debug("FUTEX_WAKE_OP(2) wake thread %d: %p (val = %d)\n", waiter->thread->tid,
                           uaddr2, *uaddr2);
-                    LISTP_DEL_INIT(waiter, &futex2->waiters, list);
-                    thread_wakeup(waiter->thread);
+                    del_futex_waiter_wakeup(waiter, futex2);
                     nwaken++;
                 }
             }
@@ -308,8 +326,7 @@ int shim_do_futex(int* uaddr, int op, int val, void* utime, int* uaddr2, int val
             struct futex_waiter* wtmp;
             int nwaken = 0;
             LISTP_FOR_EACH_ENTRY_SAFE(waiter, wtmp, &futex->waiters, list) {
-                LISTP_DEL_INIT(waiter, &futex->waiters, list);
-                thread_wakeup(waiter->thread);
+                del_futex_waiter_wakeup(waiter, futex);
                 nwaken++;
                 if (nwaken >= val)
                     break;
@@ -361,10 +378,12 @@ int shim_do_get_robust_list(pid_t pid, struct robust_list_head** head, size_t* l
             return -ESRCH;
     } else {
         thread = get_cur_thread();
+        get_thread(thread);
     }
 
     *head = (struct robust_list_head*)thread->robust_list;
     *len  = sizeof(struct robust_list_head);
+    put_thread(thread);
     return 0;
 }
 
@@ -403,8 +422,7 @@ void release_robust_list(struct robust_list_head* head) {
         debug("release robust list: %p\n", futex_addr);
         *(int*)futex_addr = 0;
         LISTP_FOR_EACH_ENTRY_SAFE(waiter, wtmp, &futex->waiters, list) {
-            LISTP_DEL_INIT(waiter, &futex->waiters, list);
-            thread_wakeup(waiter->thread);
+            del_futex_waiter_wakeup(waiter, futex);
         }
 
         unlock(&hdl->lock);
@@ -443,8 +461,7 @@ void release_clear_child_id(int* clear_child_tid) {
     debug("release futex at %p\n", clear_child_tid);
     *clear_child_tid = 0;
     LISTP_FOR_EACH_ENTRY_SAFE(waiter, wtmp, &futex->waiters, list) {
-        LISTP_DEL_INIT(waiter, &futex->waiters, list);
-        thread_wakeup(waiter->thread);
+        del_futex_waiter_wakeup(waiter, futex);
     }
 
     unlock(&hdl->lock);

--- a/LibOS/shim/src/sys/shim_futex.c
+++ b/LibOS/shim/src/sys/shim_futex.c
@@ -202,9 +202,6 @@ int shim_do_futex(int* uaddr, int op, int val, void* utime, int* uaddr2, int val
                 /* DEP 1/28/17: Should return ETIMEDOUT, not EAGAIN, on timeout. */
                 if (ret == -EAGAIN)
                     ret = -ETIMEDOUT;
-                if (ret == -ETIMEDOUT) {
-                    del_futex_waiter(&waiter, futex);
-                }
                 lock(&hdl->lock);
                 /* Chia-Che 10/17/17: FUTEX_WAKE should remove the waiter
                  * from the list; if not, we should remove it now. */

--- a/LibOS/shim/src/sys/shim_ioctl.c
+++ b/LibOS/shim/src/sys/shim_ioctl.c
@@ -300,6 +300,7 @@ void signal_io(IDTYPE target, void* arg) {
     lock(&thread->lock);
     append_signal(thread, SIGIO, NULL, true);
     unlock(&thread->lock);
+    put_thread(thread);
 }
 
 int shim_do_ioctl(int fd, int cmd, unsigned long arg) {

--- a/LibOS/shim/src/sys/shim_wait.c
+++ b/LibOS/shim/src/sys/shim_wait.c
@@ -71,12 +71,12 @@ pid_t shim_do_wait4(pid_t pid, int* status, int option, struct __kernel_rusage* 
             lock(&parent->lock);
             /* DEP 5/15/17: These threads are exited */
             assert(!thread->is_alive);
-            LISTP_DEL_INIT(thread, &thread->parent->exited_children, siblings);
+            LISTP_DEL_INIT(thread, &parent->exited_children, siblings);
             unlock(&parent->lock);
 
             put_thread(parent);
-            put_thread(thread);
             thread->parent = NULL;
+            put_thread(thread);
         }
 
         unlock(&thread->lock);


### PR DESCRIPTION

<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->
There were some places that put_thread calls were missing. This caused
reference counter never reaching 0, hence struct never being freed
and effectively leaking memory.
This fixes only one of issues causing #969

## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1067)
<!-- Reviewable:end -->
