### PR TITLE
[Pal/Linux-SGX] Remove "unmap TCS..." output message

### DIFF
--- a/Pal/src/host/Linux-SGX/sgx_thread.c
+++ b/Pal/src/host/Linux-SGX/sgx_thread.c
@@ -59,7 +59,6 @@ bool unmap_tcs(void) {
     struct thread_map * map = &enclave_thread_map[index];
 
     assert(index < enclave_thread_num);
-    SGX_DBG(DBG_I, "unmap TCS at %p\n", map->tcs);
 
     pthread_mutex_lock(&tcs_lock);
     current_tcs = NULL;


### PR DESCRIPTION
## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [x] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->

Remove "unmap TCS..." output message. This message is always printed (even in non-debug mode) whenever an application thread exits (and thus a TCS is remapped for reuse). It confuses too many people these days. Simply remove it as we don't experience any issues with SGX threads/TCSes these days.


## How to test this PR? <!-- (if applicable) -->

Everything should work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1073)
<!-- Reviewable:end -->
