### PR TITLE
Increase large-mmap timeout

### DIFF
--- a/LibOS/shim/test/regression/test_libos.py
+++ b/LibOS/shim/test/regression/test_libos.py
@@ -283,7 +283,7 @@ class TC_30_Syscall(RegressionTestCase):
         self.assertIn('mmap test 8 passed', stdout)
 
     def test_52_large_mmap(self):
-        stdout, stderr = self.run_binary(['large-mmap'], timeout=240)
+        stdout, stderr = self.run_binary(['large-mmap'], timeout=480)
 
         # Ftruncate
         self.assertIn('large-mmap: ftruncate OK', stdout)


### PR DESCRIPTION
<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->

In trying to bring up a NUC as a Jenkins worker, we found we needed a larger timeout on the large-mmap unit test.  Go ahead and bump this up.

## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1076)
<!-- Reviewable:end -->
