### PR TITLE
[LibOS, Pal/{Linux,Linux-SGX}] Add EAFNOSUPPORT error code

### DIFF
--- a/LibOS/shim/src/shim_init.c
+++ b/LibOS/shim/src/shim_init.c
@@ -104,6 +104,7 @@ static int pal_errno_to_unix_errno [PAL_ERROR_NATIVE_COUNT + 1] = {
         /* PAL_ERROR_ZEROSIZE       */  0,
         /* PAL_ERROR_CONNFAILED     */  ECONNRESET,
         /* PAL_ERROR_ADDRNOTEXIST   */  EADDRNOTAVAIL,
+        /* PAL_ERROR_AFNOSUPPORT    */  EAFNOSUPPORT,
     };
 
 long convert_pal_errno (long err)

--- a/Pal/src/host/Linux-SGX/pal_linux_error.h
+++ b/Pal/src/host/Linux-SGX/pal_linux_error.h
@@ -34,8 +34,8 @@ static inline __attribute__((unused)) int unix_to_pal_error(int unix_errno) {
         case ECONNRESET:
         case EPIPE:
             return -PAL_ERROR_CONNFAILED;
-        case EPERM:
-            return -PAL_ERROR_DENIED;
+        case EAFNOSUPPORT:
+            return -PAL_ERROR_AFNOSUPPORT;
         default:
             return -PAL_ERROR_DENIED;
     }

--- a/Pal/src/host/Linux/pal_linux_error.h
+++ b/Pal/src/host/Linux/pal_linux_error.h
@@ -34,6 +34,8 @@ static inline __attribute__((unused)) int unix_to_pal_error(int unix_errno) {
         case ECONNRESET:
         case EPIPE:
             return -PAL_ERROR_CONNFAILED;
+        case EAFNOSUPPORT:
+            return -PAL_ERROR_AFNOSUPPORT;
         default:
             return -PAL_ERROR_DENIED;
     }

--- a/Pal/src/pal_error.c
+++ b/Pal/src/pal_error.c
@@ -48,6 +48,7 @@ static const struct pal_error_description pal_error_list[] = {
     { PAL_ERROR_ZEROSIZE, "Zero size" },
     { PAL_ERROR_CONNFAILED, "Connection failed" },
     { PAL_ERROR_ADDRNOTEXIST, "Resource address does not exist" },
+    { PAL_ERROR_AFNOSUPPORT, "Address family not supported by protocol" },
 
     { PAL_ERROR_CRYPTO_FEATURE_UNAVAILABLE, "[Crypto] Feature not available" },
     { PAL_ERROR_CRYPTO_INVALID_CONTEXT, "[Crypto] Invalid context" },

--- a/Pal/src/pal_error.h
+++ b/Pal/src/pal_error.h
@@ -52,8 +52,9 @@ typedef enum _pal_error_t {
     PAL_ERROR_ZEROSIZE,
     PAL_ERROR_CONNFAILED,
     PAL_ERROR_ADDRNOTEXIST,
+    PAL_ERROR_AFNOSUPPORT,
 
-#define PAL_ERROR_NATIVE_COUNT PAL_ERROR_ADDRNOTEXIST
+#define PAL_ERROR_NATIVE_COUNT PAL_ERROR_AFNOSUPPORT
 #define PAL_ERROR_CRYPTO_START PAL_ERROR_CRYPTO_FEATURE_UNAVAILABLE
 
     /* Crypto error constants and their descriptions are adapted from mbedtls. */


### PR DESCRIPTION
## Affected components

- [ ] README and global configuration
- [x] Linux PAL
- [x] SGX PAL
- [ ] FreeBSD PAL
- [x] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->

Some hosts do not support IPv6 (e.g., Docker can be configured without it). In this case, socket() host syscall will return EAFNOSUPPORT. Some applications rely on this error code (e.g., Redis), so Graphene must propagate this error code all the way to the application. This commit makes LibOS and Linux/Linux-SGX PALs aware of this error code.

**Note:** This PR closes #1032 from @pangzi85480. I have no permission to access his repo, so I duplicated the rebased and ready-to-merge commit into this branch.

## How to test this PR? <!-- (if applicable) -->

Run regression tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1077)
<!-- Reviewable:end -->
