### PR TITLE
[LibOS] Fix SIGABRT, SIGTERM, SIGINT to kill the whole process

### DIFF
--- a/LibOS/shim/test/regression/Makefile
+++ b/LibOS/shim/test/regression/Makefile
@@ -21,6 +21,7 @@ CFLAGS-syscall += -I$(PALDIR)/../include -I$(PALDIR)/host/$(PAL_HOST)
 CFLAGS-openmp = -fopenmp
 CFLAGS-multi_pthread = -pthread
 CFLAGS-exit_group = -pthread
+CFLAGS-abort_multithread = -pthread
 
 %: %.c
 	$(call cmd,csingle)

--- a/LibOS/shim/test/regression/abort_multithread.c
+++ b/LibOS/shim/test/regression/abort_multithread.c
@@ -1,0 +1,20 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <pthread.h>
+
+/* Test if abort() in a child thread kills the whole process. This should report
+ * 134 (128 + 6 where 6 is SIGABRT) as its return code. */
+
+void* thread_abort(void* arg) {
+    abort();
+    return NULL;  /* not reached */
+}
+
+int main(int argc, char* arvg[]) {
+    pthread_t thread;
+    pthread_create(&thread, NULL, thread_abort, NULL);
+    pthread_join(thread, NULL);
+
+    printf("Main thread returns successfully (must not happen)\n");
+    return 0;
+}

--- a/LibOS/shim/test/regression/test_libos.py
+++ b/LibOS/shim/test/regression/test_libos.py
@@ -126,9 +126,13 @@ class TC_00_Bootstrap(RegressionTestCase):
         except subprocess.CalledProcessError as e:
             self.assertTrue(1 <= e.returncode and e.returncode <= 4)
 
-    def test_401_signalexit(self):
+    def test_402_signalexit(self):
         with self.expect_returncode(134):
             self.run_binary(['abort'])
+
+    def test_403_signalexit_multithread(self):
+        with self.expect_returncode(134):
+            self.run_binary(['abort_multithread'])
 
     def test_500_init_fail(self):
         try:


### PR DESCRIPTION
## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->

Previously, there was a bug that SIGTERM and SIGINT sent from the host OS killed only one thread but not the whole process (including child processes). Additionally, SIGABRT of the application also killed only one thread instead of the whole process. This commit fixes this.

## How to test this PR? <!-- (if applicable) -->

Maybe I need to introduce a LibOS test to spawn several threads, and one of them calls `abort()`. Without this PR, it will hang. With this PR, it will kill all threads and finish.

This bug was found and fixed while debugging TensorFlow. So at least one program is affected by this fix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1079)
<!-- Reviewable:end -->
