### PR TITLE
[Pal/Linux-SGX] Do not overwrite sgx.static_address in manifest

### DIFF
--- a/Pal/src/host/Linux-SGX/signer/pal-sgx-sign
+++ b/Pal/src/host/Linux-SGX/signer/pal-sgx-sign
@@ -842,12 +842,14 @@ def main_sign(args):
     # Try populate memory areas
     memory_areas = get_memory_areas(attr, args)
 
-    if any([a.addr is not None for a in memory_areas]):
-        manifest['sgx.static_address'] = '1'
-    else:
-        global enclave_heap_min
-        enclave_heap_min = 0
-        manifest['sgx.static_address'] = '0'
+    if manifest.get('sgx.static_address', None) is None:
+        # If static_address is not specified explicitly, deduce from executable
+        if any([a.addr is not None for a in memory_areas]):
+            manifest['sgx.static_address'] = '1'
+        else:
+            global enclave_heap_min
+            enclave_heap_min = 0
+            manifest['sgx.static_address'] = '0'
 
     # Add manifest at the top
     shutil.copy2(args['manifest'], args['output'])


### PR DESCRIPTION
## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [x] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->

Previously, the "sgx.static_address" field was overwritten by the pal-sgx-sign tool in the manifest, even if the manifest author explicitly specified it as 0 or 1. Sometimes, it is important to keep sgx.static_address as the manifest author intended. This PR adds a check to overwrite sgx.static_address only if not specified in manifest.

## How to test this PR? <!-- (if applicable) -->

This bug triggers in the following case:
- One program will call another program (e.g., `python` will execve `bash`)
- As part of execve, Graphene-SGX will create a checkpoint and allocate it in the child at exactly the same address as in the parent
- Now if the parent program (`python`) is a non-PIE executable, it will have its `sgx.static_address = 1`. This will force Graphene to create the manifest which starts the enclave at e.g. addresses `0 - 4GB`.
- But if the child program (`bash`) is a PIE executable, it will have `sgx.static_address = 0`. This will force Graphene to create the manifest which starts the enclave at non-zero addresses e.g. `4GB-8GB`.
- Now the parent creates the checkpoint somewhere in `0-4GB` range, but Graphene wants to have the same checkpoint range in the child. But since the child doesn't have `0-4GB` addresses, the child fails with allocation error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1080)
<!-- Reviewable:end -->
