### PR TITLE
[LibOS] Reorder argv in user stack

### DIFF
--- a/LibOS/shim/test/regression/bootstrap.c
+++ b/LibOS/shim/test/regression/bootstrap.c
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include <string.h>
 
 int main(int argc, const char** argv, const char** envp) {
     printf("User Program Started\n");
@@ -7,6 +8,19 @@ int main(int argc, const char** argv, const char** envp) {
 
     for (int i = 0; i < argc; i++) {
         printf("argv[%d] = %s\n", i, argv[i]);
+    }
+
+    /* Make sure argv strings follow the compact encoding where (1) all strings
+       are located adjacently and (2) in increasing order. */
+    size_t sum_len = 0;
+    for (int i = 0; i < argc; i++) {
+        sum_len += strlen(argv[i]) + 1;
+    }
+
+    size_t chunk_len = argv[argc - 1] + strlen(argv[argc - 1]) - argv[0];
+    if (sum_len != chunk_len + 1) {
+        printf("argv strings are not adjacent or not in increasing order\n");
+        return 1;
     }
 
     return 0;


### PR DESCRIPTION
Reorder argv strings in initial user stack in a way that the former string is located at lower address.

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes

Reorders the location of `argv` and `envp` strings in user stack when they are copied during `populate_user_stack()`. After this patch, following equations should hold:

```
argv[0] < argv[1] < .. < argv[argc - 1];  (increasing order)
argv[i + 1] - argv[i] == strlen(argv[i]) + 1;  (compact)
``` 

I found the need for change when I tried to run node.js in Graphene. As soon as the process starts, `libuv` complained at below check (https://github.com/libuv/libuv/blob/v1.32.0/src/unix/proctitle.c#L62):

```c
process_title.str = argv[0];
process_title.len = argv[argc - 1] + strlen(argv[argc - 1]) - argv[0];
assert(process_title.len + 1 == size); /* argv memory should be adjacent. */
```

According to the [SYS V ABI](https://www.uclibc.org/docs/psABI-x86_64.pdf) (p29), the order of the argv strings does not matter. However it would be useful to allow some programs that follow this argv ordering convention.

Regarding coding style, I have tried `clang-format` but it just changed everything. So here I followed existing code.

## How to test this PR?

I have modified the `bootstrap.c` LibOS regression test case to check the libuv condition. `make regression` in `LibOS/shim/test/regression` should succeed as before.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1082)
<!-- Reviewable:end -->
