### PR TITLE
[PAL] pal_loader: Detect PAL_HOST if make is unavailable

### DIFF
--- a/Runtime/pal_loader
+++ b/Runtime/pal_loader
@@ -18,7 +18,28 @@ do
 done
 
 RUNTIME_DIR=$(/usr/bin/dirname $(readlink -f ${BASH_SOURCE[0]}))
-PAL_HOST=$(/usr/bin/make --no-print-directory --quiet -f $RUNTIME_DIR/../Pal/src/Makefile.Host print_host 2>&1)
+if [ -z $PAL_HOST ]; then
+    if [ ! -f /usr/bin/make ]; then
+        libpal="$RUNTIME_DIR/libpal-*.so"
+        libpal="$(echo -n $libpal)"
+        libpal="${libpal//$RUNTIME_DIR\//}"
+        if [ "$libpal" = 'libpal-*.so' ]; then
+            echo "Unable to detect PAL_HOST. Please install the make program."
+            exit 1
+        fi
+
+        array=($libpal)
+        if [ ${#array[@]} -ne 1 ]; then
+            echo "Multiple libpal detected ($libpal). Please explicitly set the environment variable PAL_HOST."
+            exit 1
+        fi
+
+        PAL_HOST="${libpal%.so}"
+        PAL_HOST="${PAL_HOST#libpal-}"
+    else
+        PAL_HOST=$(/usr/bin/make --no-print-directory --quiet -f $RUNTIME_DIR/../Pal/src/Makefile.Host print_host 2>&1)
+    fi
+fi
 
 MANIFEST=
 PREFIX=


### PR DESCRIPTION
In certain case, e.g, a container runtime for production delivery,
the make and gcc programs may be not available. In this case, detect
PAL_HOST according to the base name of libpal.

Signed-off-by: Jia Zhang <zhang.jia@linux.alibaba.com>

<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [x] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->


## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1083)
<!-- Reviewable:end -->
