### PR TITLE
Misc optimizations: use O2 for non-debug builds, allow up to 1024 enclave threads

### DIFF
--- a/LibOS/shim/src/Makefile
+++ b/LibOS/shim/src/Makefile
@@ -63,6 +63,8 @@ ifeq ($(DEBUG),1)
 CC += -gdwarf-2 -g3
 CFLAGS += -DDEBUG
 ASFLAGS += -DDEBUG
+else
+CFLAGS += -O2
 endif
 export DEBUG
 

--- a/Pal/src/host/Linux-SGX/debugger/sgx_gdb.h
+++ b/Pal/src/host/Linux-SGX/debugger/sgx_gdb.h
@@ -1,4 +1,4 @@
-#define MAX_DBG_THREADS 64
+#define MAX_DBG_THREADS 1024
 
 /* This address is shared between our GDB and Graphene-SGX and must
  * reside in non-enclave memory. Graphene-SGX puts an enclave_dbginfo

--- a/Pal/src/host/Linux-SGX/sgx_main.c
+++ b/Pal/src/host/Linux-SGX/sgx_main.c
@@ -234,8 +234,10 @@ int initialize_enclave (struct pal_enclave * enclave)
     sgx_arch_enclave_css_t enclave_sigstruct;
     sgx_arch_secs_t        enclave_secs;
     unsigned long          enclave_entry_addr;
-    void*                  tcs_addrs[MAX_DBG_THREADS];
     unsigned long          heap_min = DEFAULT_HEAP_MIN;
+
+    /* this array may overflow the stack, so we allocate it in BSS */
+    static void* tcs_addrs[MAX_DBG_THREADS];
 
     enclave_image = INLINE_SYSCALL(open, 3, ENCLAVE_FILENAME, O_RDONLY, 0);
     if (IS_ERR(enclave_image)) {


### PR DESCRIPTION
## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [x] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->

Two fixes found during performance-testing OpenVINO on huge servers:

1. [LibOS] Use -O2 optimization level when building in non-debug mode.
2. [Pal/Linux-SGX] Increase MAX_DBG_THREADS constant from 64 to 1024.

Explanation for the second fix:  an internal Graphene structure for GDB metadata limits the number of enclave threads to MAX_DBG_THREADS. Previously, it was set to 64, which was enough for typical platforms. However, powerful servers have hundreds of logical cores. Graphene-SGX failed with error on such servers. This commit increases the limit to 1024 (should be more than enough for all modern platforms).

## How to test this PR? <!-- (if applicable) -->

All tests should continue running.

Fixes #1040. 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1084)
<!-- Reviewable:end -->
