### PR TITLE
Error return was not being set, when set_new_fd_handle fails, in shim_pipe.c

### DIFF
--- a/LibOS/shim/src/sys/shim_pipe.c
+++ b/LibOS/shim/src/sys/shim_pipe.c
@@ -114,6 +114,7 @@ int shim_do_pipe2(int* filedes, int flags) {
             if (tmp)
                 put_handle(tmp);
         }
+        ret = (vfd1 < 0) ? vfd1 : vfd2;
         goto out;
     }
 
@@ -193,6 +194,7 @@ int shim_do_socketpair(int domain, int type, int protocol, int* sv) {
             if (tmp)
                 put_handle(tmp);
         }
+        ret = (vfd1 < 0) ? vfd1 : vfd2;
         goto out;
     }
 


### PR DESCRIPTION
<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [X] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->
Error return was not being set, when set_new_fd_handle fails, in shim_pipe.c
Bug was found during code review by Dmitrii.


## How to test this PR? <!-- (if applicable) -->
Regression testing, should be enough.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1099)
<!-- Reviewable:end -->
