### PR TITLE
[Pal/Linux-SGX] Rewrite link-intel-driver.py in Python3

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -54,7 +54,7 @@ Run the following command on Ubuntu to install dependencies for Graphene::
 
 For building Graphene for SGX, run the following command in addition::
 
-    sudo apt-get install -y python-protobuf libprotobuf-c-dev protobuf-c-compiler
+    sudo apt-get install -y python3-protobuf libprotobuf-c-dev protobuf-c-compiler
 
 To run tests locally, you also need the python3-pytest package::
 


### PR DESCRIPTION
## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [x] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->

This PR simply moves the needle to point to https://github.com/oscarlab/graphene-sgx-driver/pull/8. This is to remove a dependency on Python2 (by re-writing the script in Python3).

Fixes #1097.

## How to test this PR? <!-- (if applicable) -->

All test should run correctly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1101)
<!-- Reviewable:end -->
