### PR TITLE
[Pal/Linux-SGX] Don't measure ssa and stack areas

### DIFF
--- a/Pal/src/host/Linux-SGX/sgx_main.c
+++ b/Pal/src/host/Linux-SGX/sgx_main.c
@@ -335,7 +335,7 @@ int initialize_enclave (struct pal_enclave * enclave)
     area_num++;
 
     areas[area_num] = (struct mem_area) {
-        .desc = "ssa", .skip_eextend = false, .is_binary = false,
+        .desc = "ssa", .skip_eextend = true, .is_binary = false,
         .fd = -1, .addr = 0, .size = enclave->thread_num * enclave->ssaframesize * SSAFRAMENUM,
         .prot = PROT_READ | PROT_WRITE, .type = SGX_PAGE_REG
     };
@@ -358,7 +358,7 @@ int initialize_enclave (struct pal_enclave * enclave)
     struct mem_area* stack_areas = &areas[area_num]; /* memorize for later use */
     for (uint32_t t = 0; t < enclave->thread_num; t++) {
         areas[area_num] = (struct mem_area) {
-            .desc = "stack", .skip_eextend = false, .is_binary = false,
+            .desc = "stack", .skip_eextend = true, .is_binary = false,
             .fd = -1, .addr = 0, .size = ENCLAVE_STACK_SIZE,
             .prot = PROT_READ | PROT_WRITE, .type = SGX_PAGE_REG
         };

--- a/Pal/src/host/Linux-SGX/signer/pal-sgx-sign
+++ b/Pal/src/host/Linux-SGX/signer/pal-sgx-sign
@@ -363,7 +363,7 @@ def get_memory_areas(attr, args):
     areas.append(
         MemoryArea('ssa',
                    size=attr['thread_num'] * SSAFRAMESIZE * SSAFRAMENUM,
-                   flags=PAGEINFO_R | PAGEINFO_W | PAGEINFO_REG))
+                   flags=PAGEINFO_R | PAGEINFO_W | PAGEINFO_REG, measure=False))
     areas.append(MemoryArea('tcs', size=attr['thread_num'] * TCS_SIZE,
                             flags=PAGEINFO_TCS))
     areas.append(MemoryArea('tls', size=attr['thread_num'] * PAGESIZE,
@@ -371,7 +371,8 @@ def get_memory_areas(attr, args):
 
     for _ in range(attr['thread_num']):
         areas.append(MemoryArea('stack', size=ENCLAVE_STACK_SIZE,
-                                flags=PAGEINFO_R | PAGEINFO_W | PAGEINFO_REG))
+                                flags=PAGEINFO_R | PAGEINFO_W | PAGEINFO_REG,
+                                measure=False))
 
     areas.append(MemoryArea('pal', file=args['libpal'], flags=PAGEINFO_REG))
 
@@ -441,12 +442,17 @@ def gen_area_content(attr, areas):
     # on enclave startup.
     for area in areas:
         if (area.addr + area.size <= enclave_heap_min or
-                area.addr >= enclave_heap_max or area is exec_area):
+                area.addr >= enclave_heap_max):
+            if ((area not in stacks) and area is not ssa_area and
+                    not area.measure):
+                raise ValueError("Memory area \"{0}\", which is not the heap, "
+                                 "is not measured".format(area.desc))
+        elif area is exec_area:
             if not area.measure:
-                raise ValueError("Memory area, which is not the heap, "
-                                 "is not measured")
+                raise ValueError("Exec area in heap region is not measured")
         elif area.desc != 'free':
-            raise ValueError("Unexpected memory area is in heap range")
+            raise ValueError("Unexpected memory area \"{0}\" is in heap "
+                             "range".format(area.desc))
 
     for t in range(0, attr['thread_num']):
         ssa_offset = ssa_area.addr + SSAFRAMESIZE * SSAFRAMENUM * t


### PR DESCRIPTION
These two regions don't have valid initialized contents, so it is not
worthy measuring them.

Signed-off-by: Jia Zhang <zhang.jia@linux.alibaba.com>

<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->


## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1103)
<!-- Reviewable:end -->
