### PR TITLE
Add string length check in strcmp_static macro.

### DIFF
--- a/Pal/lib/api.h
+++ b/Pal/lib/api.h
@@ -146,8 +146,10 @@ void *calloc(size_t nmemb, size_t size);
 #define force_literal_cstr(str)   ("" str "")
 
 /* check if the var is exactly the same as the static string */
-#define strcmp_static(var, str) \
-    (memcmp(var, force_literal_cstr(str), static_strlen(force_literal_cstr(str)) + 1))
+#define strcmp_static(var, str)                                               \
+    (memcmp(var,                                                              \
+            force_literal_cstr(str),                                          \
+            MIN(strlen(var) + 1, static_strlen(force_literal_cstr(str))) + 1))
 
 /* check if the var starts with the static string */
 #define strstartswith_static(var, str) \


### PR DESCRIPTION
<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [X] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->
Per description of macro->"check if the var is exactly the same as the static string".
Fix the check in macro->strcmp_static, to check if both str and var are of same length.
Without this strlen check, memcmp, can scan outside the length of var argument.

## How to test this PR? <!-- (if applicable) -->
Regression should be enough.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1108)
<!-- Reviewable:end -->
