### PR TITLE
[LibOS, Pal, Pal/Linux-SGX] Clean up CONFIG_MAX

### DIFF
--- a/LibOS/shim/src/bookkeep/shim_thread.c
+++ b/LibOS/shim/src/bookkeep/shim_thread.c
@@ -225,7 +225,7 @@ struct shim_thread * get_new_thread (IDTYPE new_tid)
         path_lookupat(NULL, "/", 0, &thread->root, NULL);
         char dir_cfg[CONFIG_MAX];
         if (root_config &&
-            get_config(root_config, "fs.start_dir", dir_cfg, CONFIG_MAX) > 0) {
+            get_config(root_config, "fs.start_dir", dir_cfg, sizeof(dir_cfg)) > 0) {
             path_lookupat(NULL, dir_cfg, 0, &thread->cwd, NULL);
         } else if (thread->root) {
             get_dentry(thread->root);

--- a/LibOS/shim/src/fs/shim_fs.c
+++ b/LibOS/shim/src/fs/shim_fs.c
@@ -96,8 +96,8 @@ static int __mount_root (struct shim_dentry ** root)
     int ret = 0;
 
     if (root_config &&
-            get_config(root_config, "fs.root.type", type, CONFIG_MAX) > 0 &&
-            get_config(root_config, "fs.root.uri", uri, CONFIG_MAX) > 0) {
+            get_config(root_config, "fs.root.type", type, sizeof(type)) > 0 &&
+            get_config(root_config, "fs.root.uri", uri, sizeof(uri)) > 0) {
         debug("mounting root filesystem: %s from %s\n", type, uri);
         if ((ret = mount_fs(type, uri, "/", NULL, root, 0)) < 0) {
             debug("mounting root filesystem failed (%d)\n", ret);
@@ -157,15 +157,15 @@ static int __mount_one_other (const char * key, int keylen)
     char * kp = k + 9 + keylen;
 
     memcpy(kp, ".path", 6);
-    if (get_config(root_config, k, p, CONFIG_MAX) <= 0)
+    if (get_config(root_config, k, p, sizeof(p)) <= 0)
         return -EINVAL;
 
     memcpy(kp, ".type", 6);
-    if (get_config(root_config, k, t, CONFIG_MAX) <= 0)
+    if (get_config(root_config, k, t, sizeof(t)) <= 0)
         return -EINVAL;
 
     memcpy(kp, ".uri", 5);
-    if (get_config(root_config, k, u, CONFIG_MAX) > 0)
+    if (get_config(root_config, k, u, sizeof(u)) > 0)
         uri = u;
 
     debug("mounting as %s filesystem: from %s to %s\n", t, uri, p);

--- a/LibOS/shim/src/shim_init.c
+++ b/LibOS/shim/src/shim_init.c
@@ -167,7 +167,7 @@ long int glibc_option (const char * opt)
     char cfg[CONFIG_MAX];
 
     if (!strcmp_static(opt, "heap_size")) {
-        ssize_t ret = get_config(root_config, "glibc.heap_size", cfg, CONFIG_MAX);
+        ssize_t ret = get_config(root_config, "glibc.heap_size", cfg, sizeof(cfg));
         if (ret <= 0) {
             debug("no glibc option: %s (err=%ld)\n", opt, ret);
             return -ENOENT;
@@ -386,7 +386,7 @@ int init_stack (const char ** argv, const char ** envp,
 
     if (root_config) {
         char stack_cfg[CONFIG_MAX];
-        if (get_config(root_config, "sys.stack.size", stack_cfg, CONFIG_MAX) > 0) {
+        if (get_config(root_config, "sys.stack.size", stack_cfg, sizeof(stack_cfg)) > 0) {
             stack_size = PAGE_ALIGN_UP(parse_int(stack_cfg));
             set_rlimit_cur(RLIMIT_STACK, stack_size);
         }

--- a/LibOS/shim/src/sys/shim_brk.c
+++ b/LibOS/shim/src/sys/shim_brk.c
@@ -64,7 +64,7 @@ int init_brk_region(void* brk_region, size_t data_segment_size) {
 
     if (root_config) {
         char brk_cfg[CONFIG_MAX];
-        if (get_config(root_config, "sys.brk.size", brk_cfg, CONFIG_MAX) > 0)
+        if (get_config(root_config, "sys.brk.size", brk_cfg, sizeof(brk_cfg)) > 0)
             brk_max_size = parse_int(brk_cfg);
     }
 

--- a/LibOS/shim/src/sys/shim_socket.c
+++ b/LibOS/shim/src/sys/shim_socket.c
@@ -78,7 +78,7 @@ static int init_port_rebase(void) {
     char cfg[CONFIG_MAX];
     int rebase = 0;
 
-    if (!root_config || get_config(root_config, "net.port.rebase_on_lo", cfg, CONFIG_MAX) <= 0) {
+    if (!root_config || get_config(root_config, "net.port.rebase_on_lo", cfg, sizeof(cfg)) <= 0) {
         rebase_on_lo = 0;
         return 0;
     }

--- a/Pal/src/db_main.c
+++ b/Pal/src/db_main.c
@@ -51,7 +51,7 @@ static void load_libraries (void)
        any other libraries to preload. The can be multiple URIs,
        seperated by commas */
     len = get_config(pal_state.root_config, "loader.preload", cfgbuf,
-                     CONFIG_MAX);
+                     sizeof(cfgbuf));
     if (len <= 0)
         return;
 
@@ -153,7 +153,7 @@ static void read_environments (const char *** envpp)
         ssize_t bytes;
         ptr = &envp[(idx == -1) ? nenvs++ : idx];
         memcpy(key + prefix_len, str, len + 1);
-        if ((bytes = get_config(store, key, cfgbuf, CONFIG_MAX)) > 0) {
+        if ((bytes = get_config(store, key, cfgbuf, sizeof(char) * CONFIG_MAX)) > 0) {
             char * e = malloc(len + bytes + 2);
             memcpy(e, str, len);
             e[len] = '=';
@@ -180,7 +180,7 @@ static void set_debug_type (void)
         return;
 
     ret = get_config(pal_state.root_config, "loader.debug_type",
-                     cfgbuf, CONFIG_MAX);
+                     cfgbuf, sizeof(cfgbuf));
     if (ret <= 0)
         return;
 
@@ -190,7 +190,7 @@ static void set_debug_type (void)
         ret = _DkStreamOpen(&handle, "dev:tty", PAL_ACCESS_RDWR, 0, 0, 0);
     } else if (!strcmp_static(cfgbuf, "file")) {
         ret = get_config(pal_state.root_config, "loader.debug_file",
-                         cfgbuf, CONFIG_MAX);
+                         cfgbuf, sizeof(cfgbuf));
         if (ret <= 0)
             INIT_FAIL(PAL_ERROR_INVAL, "debug file not specified");
 
@@ -398,7 +398,7 @@ noreturn void pal_main (
         /* Run as a manifest file,
          * replace argv[0] with the contents of the manifest's loader.execname */
         char cfgbuf[CONFIG_MAX];
-        ret = get_config(pal_state.root_config, "loader.execname", cfgbuf, CONFIG_MAX);
+        ret = get_config(pal_state.root_config, "loader.execname", cfgbuf, sizeof(cfgbuf));
         if (ret > 0)
             *arguments = malloc_copy(cfgbuf, ret + 1);
     }

--- a/Pal/src/host/Linux-SGX/enclave_framework.c
+++ b/Pal/src/host/Linux-SGX/enclave_framework.c
@@ -729,7 +729,7 @@ static int init_trusted_file (const char * key, const char * uri)
     tmp = strcpy_static(cskey, "sgx.trusted_checksum.", URI_MAX);
     memcpy(tmp, key, strlen(key) + 1);
 
-    ssize_t ret = get_config(pal_state.root_config, cskey, checksum, CONFIG_MAX);
+    ssize_t ret = get_config(pal_state.root_config, cskey, checksum, sizeof(checksum));
     if (ret < 0)
         return 0;
 
@@ -816,7 +816,7 @@ int init_trusted_files (void) {
     if (nuris <= 0)
         goto no_trusted;
 
-    tmp = strcpy_static(key, "sgx.trusted_files.", CONFIG_MAX);
+    tmp = strcpy_static(key, "sgx.trusted_files.", sizeof(key));
 
     k = cfgbuf;
 
@@ -824,7 +824,7 @@ int init_trusted_files (void) {
         len = strlen(k);
         memcpy(tmp, k, len + 1);
         k += len + 1;
-        len = get_config(store, key, uri, CONFIG_MAX);
+        len = get_config(store, key, uri, sizeof(uri));
         if (len > 0) {
             ret = init_trusted_file(key + static_strlen("sgx.trusted_files."), uri);
             if (ret < 0)
@@ -849,8 +849,7 @@ no_trusted:
     if (nuris <= 0)
         goto no_allowed;
 
-
-    tmp = strcpy_static(key, "sgx.allowed_files.", CONFIG_MAX);
+    tmp = strcpy_static(key, "sgx.allowed_files.", sizeof(key));
 
     k = cfgbuf;
 
@@ -858,7 +857,7 @@ no_trusted:
         len = strlen(k);
         memcpy(tmp, k, len + 1);
         k += len + 1;
-        len = get_config(store, key, uri, CONFIG_MAX);
+        len = get_config(store, key, uri, sizeof(uri));
         if (len <= 0) {
             continue;
         }
@@ -893,7 +892,7 @@ no_trusted:
 no_allowed:
     ret = 0;
 
-    if (get_config(store, "sgx.allow_file_creation", cfgbuf, CONFIG_MAX) <= 0) {
+    if (get_config(store, "sgx.allow_file_creation", cfgbuf, cfgsize) <= 0) {
         allow_file_creation = false;
     } else
         allow_file_creation = true;
@@ -910,8 +909,8 @@ int init_trusted_children (void)
     char key[CONFIG_MAX], mrkey[CONFIG_MAX];
     char uri[CONFIG_MAX], mr_enclave[CONFIG_MAX];
 
-    char * tmp1 = strcpy_static(key, "sgx.trusted_children.", CONFIG_MAX);
-    char * tmp2 = strcpy_static(mrkey, "sgx.trusted_mrenclave.", CONFIG_MAX);
+    char * tmp1 = strcpy_static(key, "sgx.trusted_children.", sizeof(key));
+    char * tmp2 = strcpy_static(mrkey, "sgx.trusted_mrenclave.", sizeof(mrkey));
 
     ssize_t cfgsize = get_config_entries_size(store, "sgx.trusted_mrenclave");
     if (cfgsize <= 0)
@@ -931,11 +930,11 @@ int init_trusted_children (void)
             memcpy(tmp2, k, len + 1);
             k += len + 1;
 
-            ssize_t ret = get_config(store, key, uri, CONFIG_MAX);
+            ssize_t ret = get_config(store, key, uri, sizeof(uri));
             if (ret < 0)
                 continue;
 
-            ret = get_config(store, mrkey, mr_enclave, CONFIG_MAX);
+            ret = get_config(store, mrkey, mr_enclave, sizeof(mr_enclave));
             if (ret > 0)
                 register_trusted_child(uri, mr_enclave);
         }
@@ -948,7 +947,7 @@ int init_file_check_policy (void)
 {
     char cfgbuf[CONFIG_MAX];
     ssize_t ret = get_config(pal_state.root_config, "sgx.file_check_policy",
-                             cfgbuf, CONFIG_MAX);
+                             cfgbuf, sizeof(cfgbuf));
 
     if (ret > 0) {
         if (!strcmp_static(cfgbuf, "strict"))

--- a/Pal/src/host/Linux-SGX/enclave_platform.c
+++ b/Pal/src/host/Linux-SGX/enclave_platform.c
@@ -141,7 +141,7 @@ int init_trusted_platform(void) {
     }
 
     char subkey[CONFIG_MAX];
-    len = get_config(pal_state.root_config, "sgx.ra_client_key", subkey, CONFIG_MAX);
+    len = get_config(pal_state.root_config, "sgx.ra_client_key", subkey, sizeof(subkey));
     if (len <= 0) {
         SGX_DBG(DBG_E, "No sgx.ra_client_key in the manifest\n");
         return -PAL_ERROR_INVAL;

--- a/Pal/src/host/Linux-SGX/sgx_main.c
+++ b/Pal/src/host/Linux-SGX/sgx_main.c
@@ -248,7 +248,7 @@ int initialize_enclave (struct pal_enclave * enclave)
     char cfgbuf[CONFIG_MAX];
 
     /* Reading sgx.enclave_size from manifest */
-    if (get_config(enclave->config, "sgx.enclave_size", cfgbuf, CONFIG_MAX) <= 0) {
+    if (get_config(enclave->config, "sgx.enclave_size", cfgbuf, sizeof(cfgbuf)) <= 0) {
         SGX_DBG(DBG_E, "Enclave size is not specified\n");
         ret = -EINVAL;
         goto out;
@@ -262,7 +262,7 @@ int initialize_enclave (struct pal_enclave * enclave)
     }
 
     /* Reading sgx.thread_num from manifest */
-    if (get_config(enclave->config, "sgx.thread_num", cfgbuf, CONFIG_MAX) > 0) {
+    if (get_config(enclave->config, "sgx.thread_num", cfgbuf, sizeof(cfgbuf)) > 0) {
         enclave->thread_num = parse_int(cfgbuf);
 
         if (enclave->thread_num > MAX_DBG_THREADS) {
@@ -275,7 +275,7 @@ int initialize_enclave (struct pal_enclave * enclave)
     }
 
     /* Reading sgx.static_address from manifest */
-    if (get_config(enclave->config, "sgx.static_address", cfgbuf, CONFIG_MAX) > 0 && cfgbuf[0] == '1')
+    if (get_config(enclave->config, "sgx.static_address", cfgbuf, sizeof(cfgbuf)) > 0 && cfgbuf[0] == '1')
         enclave->baseaddr = heap_min;
     else
         enclave->baseaddr = heap_min = 0;
@@ -820,7 +820,7 @@ static int load_enclave (struct pal_enclave * enclave,
     // A manifest can specify an executable with a different base name
     // than the manifest itself.  Always give the exec field of the manifest
     // precedence if specified.
-    if (get_config(enclave->config, "loader.exec", cfgbuf, CONFIG_MAX) > 0) {
+    if (get_config(enclave->config, "loader.exec", cfgbuf, sizeof(cfgbuf)) > 0) {
         exec_uri = resolve_uri(cfgbuf, &errstring);
         exec_uri_inferred = false;
         if (!exec_uri) {
@@ -849,7 +849,7 @@ static int load_enclave (struct pal_enclave * enclave,
         }
     }
 
-    if (get_config(enclave->config, "sgx.sigfile", cfgbuf, CONFIG_MAX) < 0) {
+    if (get_config(enclave->config, "sgx.sigfile", cfgbuf, sizeof(cfgbuf)) < 0) {
         SGX_DBG(DBG_E, "Sigstruct file not found ('sgx.sigfile' must be specified in manifest)\n");
         return -EINVAL;
     }


### PR DESCRIPTION
Using sizeof() instead of hard coding CONFIG_MAX would be more canonical.

Signed-off-by: Jia Zhang <zhang.jia@linux.alibaba.com>

<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->
As mentioned in https://reviewable.io/reviews/oscarlab/graphene/1102#-Lrtu2lD67GbcuSg7qxM, clean up all hard coding CONFIG_MAX.

## How to test this PR? <!-- (if applicable) -->
Run pal and libos regression.

