### PR TITLE
[LibOS] Add dummy implementation of Linux-specific mbind()

### DIFF
--- a/LibOS/shim/include/shim_table.h
+++ b/LibOS/shim/include/shim_table.h
@@ -465,6 +465,8 @@ int shim_do_clock_gettime(clockid_t which_clock, struct timespec* tp);
 int shim_do_clock_getres(clockid_t which_clock, struct timespec* tp);
 noreturn int shim_do_exit_group(int error_code);
 int shim_do_tgkill(int tgid, int pid, int sig);
+int shim_do_mbind(void* start, unsigned long len, int mode, unsigned long* nmask,
+                  unsigned long maxnode, int flags);
 int shim_do_openat(int dfd, const char* filename, int flags, int mode);
 int shim_do_mkdirat(int dfd, const char* pathname, int mode);
 int shim_do_newfstatat(int dirfd, const char* pathname, struct stat* statbuf, int flags);

--- a/LibOS/shim/src/shim_syscalls.c
+++ b/LibOS/shim/src/shim_syscalls.c
@@ -815,8 +815,8 @@ SHIM_SYSCALL_PASSTHROUGH(utimes, 2, int, char*, filename, struct timeval*, utime
    TODO: vserver syscall is not implemented (kernel always returns -ENOSYS),
    how should we handle this?*/
 
-SHIM_SYSCALL_PASSTHROUGH(mbind, 6, int, void*, start, unsigned long, len, int, mode, unsigned long*,
-                         nmask, unsigned long, maxnode, int, flags)
+DEFINE_SHIM_SYSCALL(mbind, 6, shim_do_mbind, int, void*, start, unsigned long, len, int, mode,
+                    unsigned long*, nmask, unsigned long, maxnode, int, flags)
 
 SHIM_SYSCALL_PASSTHROUGH(set_mempolicy, 3, int, int, mode, unsigned long*, nmask, unsigned long,
                          maxnode)

--- a/LibOS/shim/src/sys/shim_mmap.c
+++ b/LibOS/shim/src/sys/shim_mmap.c
@@ -247,3 +247,16 @@ int shim_do_mincore(void* addr, size_t len, unsigned char* vec) {
 
     return 0;
 }
+
+
+int shim_do_mbind(void* start, unsigned long len, int mode, unsigned long* nmask,
+                  unsigned long maxnode, int flags) {
+    /* dummy implementation, always return success */
+    __UNUSED(start);
+    __UNUSED(len);
+    __UNUSED(mode);
+    __UNUSED(nmask);
+    __UNUSED(maxnode);
+    __UNUSED(flags);
+    return 0;
+}


### PR DESCRIPTION
## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->

This call is used by libnuma. Always returning success seems to be enough.

This is probably not needed at all, but I'll leave this here for future. This was detected when working on Python3 with NumPy (it loads libnuma which does `mbind()`).

## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1123)
<!-- Reviewable:end -->
