### PR TITLE
Clean up interaction between initialize_enclave() and create_enclave()

### DIFF
--- a/Pal/src/host/Linux-SGX/sgx_internal.h
+++ b/Pal/src/host/Linux-SGX/sgx_internal.h
@@ -86,8 +86,6 @@ int read_enclave_token (int token_file, sgx_arch_token_t * token);
 int read_enclave_sigstruct (int sigfile, sgx_arch_enclave_css_t * sig);
 
 int create_enclave(sgx_arch_secs_t * secs,
-                   unsigned long base,
-                   unsigned long size,
                    sgx_arch_token_t * token);
 
 enum sgx_page_type { SGX_PAGE_SECS, SGX_PAGE_TCS, SGX_PAGE_REG };


### PR DESCRIPTION
<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [x] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->

Clear up the responsibilities between create_enclave() and its caller.

create_enclave() now assumes its caller picks a suitable base address and size according to SGX's requirements. Use create_enclave()'s secs parameter for in and outputs to reduce total number of arguments (not sure if this violates some Graphene coding standard). Also, I believe the code tacitly assumes that create_enclave()'s mmap creates the mapping at whatever address we provide. Hence, I changed the secs->base = addr into an assert().

## How to test this PR? <!-- (if applicable) -->

Regression tests still pass.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1126)
<!-- Reviewable:end -->
