### PR TITLE
[Pal/Linux-SGX] Avoid confusing message about the path of executable file

### DIFF
--- a/Pal/src/host/Linux-SGX/sgx_main.c
+++ b/Pal/src/host/Linux-SGX/sgx_main.c
@@ -1084,7 +1084,10 @@ int main (int argc, char ** argv, char ** envp)
     }
 
     SGX_DBG(DBG_I, "Manifest file: %s\n", manifest_uri);
-    SGX_DBG(DBG_I, "Executable file: %s\n", exec_uri);
+    if (exec_uri_inferred)
+        SGX_DBG(DBG_I, "Inferred executable file: %s\n", exec_uri);
+    else
+        SGX_DBG(DBG_I, "Executable file: %s\n", exec_uri);
 
     /*
      * While C does not guarantee that the argv[i] and envp[i] strings are


### PR DESCRIPTION
If the path of executable file is inferred, add the key word "inferred"
to emphasize this fact.

Signed-off-by: Jia Zhang <zhang.jia@linux.alibaba.com>

<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [x] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->


## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1127)
<!-- Reviewable:end -->
