### PR TITLE
[LibOS,Pal] Rewrite poll and ObjectWait logic from scratch

### DIFF
--- a/Documentation/oldwiki/PAL-Host-ABI.md
+++ b/Documentation/oldwiki/PAL-Host-ABI.md
@@ -523,11 +523,25 @@ This API clears a notification event or a synchronization event.
 #### DkObjectsWaitAny
 
     #define NO_TIMEOUT ((PAL_NUM)-1)
-    PAL_HANDLE DkObjectsWaitAny(PAL_NUM count, PAL_HANDLE* handleArray, PAL_NUM timeout_us);
+    PAL_HANDLE DkObjectsWaitAny(PAL_NUM count, PAL_HANDLE* handle_array, PAL_NUM timeout_us);
 
-This API polls an array of handles and returns one handle with recent activity. `timeout` is the
-maximum time that the API should wait (in microseconds), or `NO_TIMEOUT` to indicate it is to be
-blocked until at least one handle is ready.
+This API polls an array of handles and returns one handle with recent activity. `timeout_us` is
+the maximum time that the API should wait (in microseconds), or `NO_TIMEOUT` to indicate it is to
+be blocked until at least one handle is ready.
+
+#### DkObjectsWaitEvents
+
+    #define NO_TIMEOUT ((PAL_NUM)-1)
+    PAL_BOL DkObjectsWaitEvents(PAL_NUM count, PAL_HANDLE* handle_array, PAL_FLG* events,
+                                PAL_FLG* ret_events, PAL_NUM timeout_us);
+
+This API polls an array of handles with user-defined events `events` and returns polled-handles'
+events in `ret_events`. `timeout_us` is the maximum time that the API should wait (in
+microseconds), or `NO_TIMEOUT` to indicate it is to be blocked until at least one handle is ready.
+It returns true if there was an event on at least one handle and false otherwise.
+
+This API is a more efficient version of `DkObjectsWaitAny()` and closely resembles Linux poll
+semantics. Therefore, `DkObjectsWaitAny()` should be considered deprecated.
 
 #### DkObjectClose
 

--- a/LibOS/shim/include/shim_handle.h
+++ b/LibOS/shim/include/shim_handle.h
@@ -304,16 +304,13 @@ DEFINE_LIST(shim_epoll_item);
 DEFINE_LISTP(shim_epoll_item);
 struct shim_epoll_handle {
     int maxfds;
-    int nread;
-    int nwaiters;
+    int waiter_cnt;
 
-    int npals;
+    int pal_cnt;
     PAL_HANDLE* pal_handles;
 
     AEVENTTYPE event;
-    LISTP_TYPE(shim_epoll_item) fds; /* this list contains all the
-                                    * shim_epoll_item objects in correspondence
-                                    * with the registered handles. */
+    LISTP_TYPE(shim_epoll_item) fds;
 };
 
 struct shim_mount;

--- a/LibOS/shim/include/shim_handle.h
+++ b/LibOS/shim/include/shim_handle.h
@@ -300,27 +300,27 @@ struct shim_str_handle {
     char* ptr;
 };
 
-DEFINE_LIST(shim_epoll_fd);
-DEFINE_LISTP(shim_epoll_fd);
+DEFINE_LIST(shim_epoll_item);
+DEFINE_LISTP(shim_epoll_item);
 struct shim_epoll_handle {
     int maxfds;
-    int nfds;
-    LISTP_TYPE(shim_epoll_fd) fds; /* this list contains all the
-                                    * shim_epoll_fd objects in correspondence
-                                    * with the registered handles. */
-    FDTYPE* pal_fds;
-    PAL_HANDLE* pal_handles;
-    int npals;
     int nread;
     int nwaiters;
+
+    int npals;
+    PAL_HANDLE* pal_handles;
+
     AEVENTTYPE event;
+    LISTP_TYPE(shim_epoll_item) fds; /* this list contains all the
+                                    * shim_epoll_item objects in correspondence
+                                    * with the registered handles. */
 };
 
 struct shim_mount;
 struct shim_qstr;
 struct shim_dentry;
 
-/* The epolls list links to the back field of the shim_epoll_fd structure
+/* The epolls list links to the back field of the shim_epoll_item structure
  */
 struct shim_handle {
     enum shim_handle_type type;
@@ -333,8 +333,8 @@ struct shim_handle {
     struct shim_dentry* dentry;
 
     /* If this handle is registered for any epoll handle, this list contains
-     * a shim_epoll_fd object in correspondence with the epoll handle. */
-    LISTP_TYPE(shim_epoll_fd) epolls;
+     * a shim_epoll_item object in correspondence with the epoll handle. */
+    LISTP_TYPE(shim_epoll_item) epolls;
 
     struct shim_qstr uri; /* URI representing this handle, it is not
                            * necessary to be set. */

--- a/LibOS/shim/include/shim_internal.h
+++ b/LibOS/shim/include/shim_internal.h
@@ -796,6 +796,8 @@ int object_wait_with_retry(PAL_HANDLE handle);
 
 void release_clear_child_tid(int* clear_child_tid);
 
+void delete_from_epoll_handles(struct shim_handle* handle);
+
 #ifdef __x86_64__
 #define __SWITCH_STACK(stack_top, func, arg)                    \
     do {                                                        \

--- a/LibOS/shim/src/bookkeep/shim_handle.c
+++ b/LibOS/shim/src/bookkeep/shim_handle.c
@@ -741,7 +741,7 @@ BEGIN_CP_FUNC(handle) {
         }
 
         if (hdl->type == TYPE_EPOLL)
-            DO_CP(epoll_fd, &hdl->info.epoll.fds, &new_hdl->info.epoll.fds);
+            DO_CP(epoll_item, &hdl->info.epoll.fds, &new_hdl->info.epoll.fds);
 
         INIT_LISTP(&new_hdl->epolls);
 

--- a/LibOS/shim/src/bookkeep/shim_handle.c
+++ b/LibOS/shim/src/bookkeep/shim_handle.c
@@ -434,8 +434,6 @@ static void destroy_handle(struct shim_handle* hdl) {
         free_mem_obj_to_mgr(handle_mgr, hdl);
 }
 
-extern int delete_from_epoll_handles(struct shim_handle* handle);
-
 void put_handle(struct shim_handle* hdl) {
     int ref_count = REF_DEC(hdl->ref_count);
 

--- a/LibOS/shim/src/sys/shim_epoll.c
+++ b/LibOS/shim/src/sys/shim_epoll.c
@@ -50,9 +50,10 @@ struct shim_mount epoll_builtin_fs;
 
 struct shim_epoll_item {
     FDTYPE fd;
-    __u64 data;
+    uint64_t data;
     unsigned int events;
     unsigned int revents;
+    bool connected;
     struct shim_handle* handle;      /* reference to monitored object (socket, pipe, file, etc) */
     struct shim_handle* epoll;       /* reference to epoll object that monitors handle object */
     LIST_TYPE(shim_epoll_item) list; /* list of shim_epoll_items, used by epoll object (via `fds`) */
@@ -67,15 +68,20 @@ int shim_do_epoll_create1(int flags) {
     if (!hdl)
         return -ENOMEM;
 
+    PAL_HANDLE* pal_handles = malloc(sizeof(*pal_handles) * MAX_EPOLL_HANDLES);
+    if (!pal_handles) {
+        put_handle(hdl);
+        return -ENOMEM;
+    }
+
     struct shim_epoll_handle* epoll = &hdl->info.epoll;
 
     hdl->type = TYPE_EPOLL;
     set_handle_fs(hdl, &epoll_builtin_fs);
     epoll->maxfds      = MAX_EPOLL_HANDLES;
-    epoll->npals       = 0;
-    epoll->nread       = 0;
-    epoll->nwaiters    = 0;
-    epoll->pal_handles = malloc(sizeof(PAL_HANDLE) * MAX_EPOLL_HANDLES);
+    epoll->pal_cnt     = 0;
+    epoll->waiter_cnt  = 0;
+    epoll->pal_handles = pal_handles;
     create_event(&epoll->event);
     INIT_LISTP(&epoll->fds);
 
@@ -92,30 +98,26 @@ int shim_do_epoll_create(int size) {
     return shim_do_epoll_create1(0);
 }
 
+/* lock of shim_handle enclosing this epoll should be held while calling this function */
 static void update_epoll(struct shim_epoll_handle* epoll) {
     struct shim_epoll_item* tmp;
-    epoll->npals = 0;
-    epoll->nread = 0;
+    epoll->pal_cnt = 0;
 
     LISTP_FOR_EACH_ENTRY(tmp, &epoll->fds, list) {
-        if (!tmp->handle->pal_handle)
+        if (!tmp->connected || !tmp->handle || !tmp->handle->pal_handle)
             continue;
 
-        debug("found handle %p (pal handle %p) from epoll handle %p\n", tmp->handle,
-              tmp->handle->pal_handle, epoll);
-
-        epoll->pal_handles[epoll->npals++] = tmp->handle->pal_handle;
-        if (tmp->handle->acc_mode & MAY_READ)
-            epoll->nread++;
+        assert(epoll->pal_cnt < MAX_EPOLL_HANDLES);
+        epoll->pal_handles[epoll->pal_cnt++] = tmp->handle->pal_handle;
     }
 
     /* if other threads are currently waiting on epoll_wait(), send a signal to update their
-     * epoll items (note that we send nwaiters number of signals -- to each waiting thread) */
-    if (epoll->nwaiters)
-        set_event(&epoll->event, epoll->nwaiters);
+     * epoll items (note that we send waiter_cnt number of signals -- to each waiting thread) */
+    if (epoll->waiter_cnt)
+        set_event(&epoll->event, epoll->waiter_cnt);
 }
 
-int delete_from_epoll_handles(struct shim_handle* handle) {
+void delete_from_epoll_handles(struct shim_handle* handle) {
     /* handle may be registered in several epolls, delete it from all of them via handle->epolls */
     while (1) {
         /* first, get any epoll-item from this handle (via `back` list) and delete it from `back` */
@@ -147,8 +149,6 @@ int delete_from_epoll_handles(struct shim_handle* handle) {
         free(epoll_item);
         put_handle(hdl);
     }
-
-    return 0;
 }
 
 int shim_do_epoll_ctl(int epfd, int op, int fd, struct __kernel_epoll_event* event) {
@@ -157,6 +157,13 @@ int shim_do_epoll_ctl(int epfd, int op, int fd, struct __kernel_epoll_event* eve
 
     if (epfd == fd)
         return -EINVAL;
+
+    if (op == EPOLL_CTL_ADD || op == EPOLL_CTL_MOD)
+        if (!event || test_user_memory(event, sizeof(*event), false)) {
+            /* surprisingly, man(epoll_ctl) does not specify EFAULT if event is invalid so
+             * we re-use EINVAL; also note that EPOLL_CTL_DEL ignores event completely */
+            return -EINVAL;
+        }
 
     struct shim_handle* epoll_hdl = get_fd_handle(epfd, NULL, cur->handle_map);
     if (!epoll_hdl)
@@ -186,26 +193,33 @@ int shim_do_epoll_ctl(int epfd, int op, int fd, struct __kernel_epoll_event* eve
                 goto out;
             }
             /* note that pipe and socket may not have pal_handle yet (e.g. before bind()) */
-            if ((hdl->type != TYPE_PIPE && hdl->type != TYPE_SOCK) || !hdl->pal_handle) {
+            if ((hdl->type != TYPE_PIPE && hdl->type != TYPE_SOCK && hdl->type != TYPE_EVENTFD) || !hdl->pal_handle) {
                 ret = -EPERM;
                 put_handle(hdl);
                 goto out;
             }
-            if (epoll->npals == MAX_EPOLL_HANDLES) {
+            if (epoll->pal_cnt == MAX_EPOLL_HANDLES) {
                 ret = -ENOSPC;
                 put_handle(hdl);
                 goto out;
             }
 
-            debug("add handle %p to epoll handle %p\n", hdl, epoll);
+            epoll_item = malloc(sizeof(struct shim_epoll_item));
+            if (!epoll_item) {
+                ret = -ENOMEM;
+                put_handle(hdl);
+                goto out;
 
-            epoll_item             = malloc(sizeof(struct shim_epoll_item));
-            epoll_item->fd         = fd;
-            epoll_item->events     = event->events;
-            epoll_item->data       = event->data;
-            epoll_item->revents    = 0;
-            epoll_item->handle     = hdl;
-            epoll_item->epoll      = epoll_hdl;
+            }
+
+            debug("add fd %d (handle %p) to epoll handle %p\n", fd, hdl, epoll);
+            epoll_item->fd        = fd;
+            epoll_item->events    = event->events;
+            epoll_item->data      = event->data;
+            epoll_item->revents   = 0;
+            epoll_item->handle    = hdl;
+            epoll_item->epoll     = epoll_hdl;
+            epoll_item->connected = true;
             get_handle(epoll_hdl);
 
             /* register hdl (corresponding to FD) in epoll (corresponding to EPFD):
@@ -221,7 +235,9 @@ int shim_do_epoll_ctl(int epfd, int op, int fd, struct __kernel_epoll_event* eve
             LISTP_ADD_TAIL(epoll_item, &epoll->fds, list);
 
             put_handle(hdl);
-            goto update;
+
+            update_epoll(epoll);
+            break;
         }
 
         case EPOLL_CTL_MOD: {
@@ -229,18 +245,22 @@ int shim_do_epoll_ctl(int epfd, int op, int fd, struct __kernel_epoll_event* eve
                 if (epoll_item->fd == fd) {
                     epoll_item->events = event->events;
                     epoll_item->data   = event->data;
-                    goto update;
+
+                    debug("modified fd %d at epoll handle %p\n", fd, epoll);
+                    update_epoll(epoll);
+                    goto out;
                 }
             }
 
             ret = -ENOENT;
-            goto out;
+            break;
         }
 
         case EPOLL_CTL_DEL: {
             LISTP_FOR_EACH_ENTRY(epoll_item, &epoll->fds, list) {
                 if (epoll_item->fd == fd) {
                     struct shim_handle* hdl = epoll_item->handle;
+                    debug("delete fd %d (handle %p) from epoll handle %p\n", fd, hdl, epoll);
 
                     /* unregister hdl (corresponding to FD) in epoll (corresponding to EPFD):
                      * - unbind hdl from epoll-item via the `back` list
@@ -249,26 +269,26 @@ int shim_do_epoll_ctl(int epfd, int op, int fd, struct __kernel_epoll_event* eve
                     LISTP_DEL(epoll_item, &hdl->epolls, back);
                     unlock(&hdl->lock);
 
-                    /* note that we already grabbed epoll_hdl->lock so can safely update epoll */
+                    /* note that we already grabbed epoll_hdl->lock so we can safely update epoll */
                     LISTP_DEL(epoll_item, &epoll->fds, list);
 
                     put_handle(epoll_hdl);
                     free(epoll_item);
-                    goto update;
+
+                    update_epoll(epoll);
+                    goto out;
                 }
             }
 
             ret = -ENOENT;
-            goto out;
+            break;
         }
 
         default:
             ret = -EINVAL;
-            goto out;
+            break;
     }
 
-update:
-    update_epoll(epoll);
 out:
     unlock(&epoll_hdl->lock);
     put_handle(epoll_hdl);
@@ -296,68 +316,93 @@ int shim_do_epoll_wait(int epfd, struct __kernel_epoll_event* events, int maxeve
 
     lock(&epoll_hdl->lock);
 
-    int npals = epoll->npals;
-    while (npals) {
+    /* loop to retry on interrupted epoll waits (due to epoll being concurrently updated) */
+    while (1) {
         /* wait on epoll's PAL handles + one "event" handle that signals epoll updates */
-        PAL_HANDLE* pal_handles = malloc((npals + 1) * sizeof(PAL_HANDLE));
-        if (!pal_handles)
+        PAL_HANDLE* pal_handles = malloc((epoll->pal_cnt + 1) * sizeof(PAL_HANDLE));
+        if (!pal_handles) {
+            unlock(&epoll_hdl->lock);
+            put_handle(epoll_hdl);
             return -ENOMEM;
+        }
 
-        memcpy(pal_handles, epoll->pal_handles, npals * sizeof(PAL_HANDLE));
-        pal_handles[npals] = epoll->event.event;
+        /* allocate one memory region to hold two PAL_FLG arrays: events and revents */
+        PAL_FLG* pal_events = malloc((epoll->pal_cnt + 1) * sizeof(PAL_FLG) * 2);
+        if (!pal_events) {
+            free(pal_handles);
+            unlock(&epoll_hdl->lock);
+            put_handle(epoll_hdl);
+            return -ENOMEM;
+        }
+        PAL_FLG* ret_events = pal_events + (epoll->pal_cnt + 1);
 
-        epoll->nwaiters++;  /* mark epoll as being waited on (so epoll-update signal is sent) */
+        /* populate pal_events with read/write events from user-supplied epoll items */
+        int pal_cnt = 0;
+        struct shim_epoll_item* epoll_item;
+        LISTP_FOR_EACH_ENTRY(epoll_item, &epoll->fds, list) {
+            if (!epoll_item->handle || !epoll_item->handle->pal_handle)
+                continue;
+
+            pal_handles[pal_cnt] = epoll_item->handle->pal_handle;
+            pal_events[pal_cnt]  = (epoll_item->events & (EPOLLIN | EPOLLRDNORM)) ? PAL_WAIT_READ  : 0;
+            pal_events[pal_cnt] |= (epoll_item->events & (EPOLLOUT | EPOLLWRNORM)) ? PAL_WAIT_WRITE : 0;
+            ret_events[pal_cnt]  = 0;
+            pal_cnt++;
+        }
+
+        /* populate "event" handle so it waits on read (meaning epoll-update signal arrived);
+         * note that we don't increment pal_cnt because this is a special not-user-supplied item */
+        pal_handles[pal_cnt] = epoll->event.event;
+        pal_events[pal_cnt]  = PAL_WAIT_READ;
+        ret_events[pal_cnt]  = 0;
+
+        epoll->waiter_cnt++;  /* mark epoll as being waited on (so epoll-update signal is sent) */
         unlock(&epoll_hdl->lock);
 
-        PAL_NUM pal_timeout = timeout_ms == -1 ? NO_TIMEOUT : (PAL_NUM)timeout_ms * 1000;
-        if (!epoll->nread) {
-            /* special case: epoll doesn't contain a single handle with MAY_READ, thus there are
-             * only write events possible, and for this we don't wait but return immediately
-             * TODO: this is an ugly corner case which may backfire */
-            pal_timeout = 0;
-        }
-
-        /* TODO: This is highly inefficient, since DkObjectsWaitAny returns only one (random)
-         *       handle out of the whole array of handles-waiting-for-events. We must replace
-         *       this with DkObjectsWaitEvents(). */
-        PAL_HANDLE polled = DkObjectsWaitAny(npals + 1, pal_handles, pal_timeout);
+        /* TODO: Timeout must be updated in case of retries; otherwise, we may wait for too long */
+        PAL_BOL polled = DkObjectsWaitEvents(pal_cnt + 1, pal_handles, pal_events, ret_events, timeout_ms * 1000);
 
         lock(&epoll_hdl->lock);
-        epoll->nwaiters--;
-        free(pal_handles);
+        epoll->waiter_cnt--;
 
-        if (polled == epoll->event.event) {
-            wait_event(&epoll->event);
-            npals = epoll->npals; /* epoll was updated, probably npals is new */
-            continue;
-        }
+        /* update user-supplied epoll items' revents with ret_events of polled PAL handles */
+        if (!ret_events[pal_cnt] && polled) {
+            /* only if epoll was not updated concurrently and something was actually polled */
+            for (int i = 0; i < pal_cnt; i++) {
+                LISTP_FOR_EACH_ENTRY(epoll_item, &epoll->fds, list) {
+                    if (!epoll_item->handle || !epoll_item->handle->pal_handle)
+                        continue;
+                    if (epoll_item->handle->pal_handle != pal_handles[i])
+                        continue;
 
-        PAL_STREAM_ATTR attr;
-        if (!polled || !DkStreamAttributesQueryByHandle(polled, &attr))
-            break;
-
-        struct shim_epoll_item* epoll_item = NULL;
-        struct shim_epoll_item* tmp;
-        LISTP_FOR_EACH_ENTRY(tmp, &epoll->fds, list) {
-            if (polled == tmp->handle->pal_handle) {
-                epoll_item = tmp;
-                break;
+                    if (ret_events[i] & PAL_WAIT_ERROR) {
+                        epoll_item->revents  |= EPOLLERR | EPOLLHUP | EPOLLRDHUP;
+                        epoll_item->connected = false;
+                        /* handle disconnected, must remove it from epoll list */
+                        need_update = true;
+                    }
+                    if (ret_events[i] & PAL_WAIT_READ)
+                        epoll_item->revents |= EPOLLIN | EPOLLRDNORM;
+                    if (ret_events[i] & PAL_WAIT_WRITE)
+                        epoll_item->revents |= EPOLLOUT | EPOLLWRNORM;
+                    break;
+                }
             }
         }
 
-        /* found epoll item that was polled, update its revents according to attr */
-        assert(epoll_item);
-        if (attr.disconnected) {
-            epoll_item->revents |= EPOLLERR | EPOLLHUP | EPOLLRDHUP;
-            epoll_item->handle   = NULL;
-            need_update        = true; /* handle disconnected, need to remove from epoll list */
-        }
-        if (attr.readable)
-            epoll_item->revents |= EPOLLIN | EPOLLRDNORM;
-        if (attr.writable)
-            epoll_item->revents |= EPOLLOUT | EPOLLWRNORM;
+        PAL_FLG event_handle_update = ret_events[pal_cnt];
+        free(pal_handles);
+        free(pal_events);
 
-        npals = 0; /* to exit the while loop */
+        if (event_handle_update) {
+            /* retry if epoll was updated concurrently (similar to Linux semantics) */
+            unlock(&epoll_hdl->lock);
+            wait_event(&epoll->event);
+            lock(&epoll_hdl->lock);
+        } else {
+            /* no need to retry, exit the while loop */
+            break;
+        }
     }
 
     /* update user-supplied events array with all events detected till now on epoll */

--- a/LibOS/shim/src/sys/shim_poll.c
+++ b/LibOS/shim/src/sys/shim_poll.c
@@ -34,29 +34,26 @@
 typedef long int __fd_mask;
 
 #ifndef __NFDBITS
-#define __NFDBITS    (8 * (int)sizeof(__fd_mask))
+#define __NFDBITS (8 * (int)sizeof(__fd_mask))
 #endif
+
 #ifndef __FDS_BITS
 #define __FDS_BITS(set) ((set)->fds_bits)
 #endif
 
-# define __FD_ZERO(set)                                     \
-    do {                                                    \
-        unsigned int __i;                                   \
-        fd_set *__arr = (set);                              \
-        for (__i = 0; __i < sizeof (fd_set) / sizeof (__fd_mask); ++__i) \
-        __FDS_BITS (__arr)[__i] = 0;                        \
+#define __FD_ZERO(set)                                         \
+    do {                                                       \
+        unsigned int i;                                        \
+        fd_set* arr = (set);                                   \
+        for (i = 0; i < sizeof(fd_set)/sizeof(__fd_mask); i++) \
+            __FDS_BITS(arr)[i] = 0;                            \
     } while (0)
 
-#define __FD_ELT(d)     ((d) / __NFDBITS)
-#define __FD_MASK(d)    ((__fd_mask)1 << ((d) % __NFDBITS))
-
-#define __FD_SET(d, set)                                    \
-  ((void)(__FDS_BITS(set)[__FD_ELT(d)] |= __FD_MASK(d)))
-#define __FD_CLR(d, set)                                    \
-  ((void)(__FDS_BITS(set)[__FD_ELT(d)] &= ~__FD_MASK(d)))
-#define __FD_ISSET(d, set)                                  \
-  ((__FDS_BITS(set)[__FD_ELT(d)] & __FD_MASK(d)) != 0)
+#define __FD_ELT(d) ((d) / __NFDBITS)
+#define __FD_MASK(d) ((__fd_mask)1 << ((d) % __NFDBITS))
+#define __FD_SET(d, set) ((void)(__FDS_BITS(set)[__FD_ELT(d)] |= __FD_MASK(d)))
+#define __FD_CLR(d, set) ((void)(__FDS_BITS(set)[__FD_ELT(d)] &= ~__FD_MASK(d)))
+#define __FD_ISSET(d, set) ((__FDS_BITS(set)[__FD_ELT(d)] & __FD_MASK(d)) != 0)
 
 #define POLL_NOTIMEOUT  ((uint64_t)-1)
 
@@ -76,14 +73,27 @@ int shim_do_poll(struct pollfd* fds, nfds_t nfds, int timeout_ms) {
     if (!pals)
         return -ENOMEM;
 
-    /* for bookkeeping, need to have a mapping FD -> handle */
-    struct shim_handle** fds_to_hdls = malloc(nfds * sizeof(struct shim_handle*));
-    if (!fds_to_hdls) {
+    /* for bookkeeping, need to have a mapping FD -> {shim handle, index-in-pals} */
+    struct fds_mapping_t {
+        struct shim_handle* hdl;  /* NULL if no mapping (handle is not used in polling) */
+        nfds_t idx;               /* index from fds array to pals array */
+    };
+    struct fds_mapping_t* fds_mapping = malloc(nfds * sizeof(struct fds_mapping_t));
+    if (!fds_mapping) {
         free(pals);
         return -ENOMEM;
     }
 
-    nfds_t npals = 0;
+    /* allocate one memory region to hold two PAL_FLG arrays: events and revents */
+    PAL_FLG* pal_events = malloc(nfds * sizeof(PAL_FLG) * 2);
+    if (!pal_events) {
+        free(pals);
+        free(fds_mapping);
+        return -ENOMEM;
+    }
+    PAL_FLG* ret_events = pal_events + nfds;
+
+    nfds_t pal_cnt  = 0;
     nfds_t nrevents = 0;
 
     lock(&map->lock);
@@ -91,109 +101,72 @@ int shim_do_poll(struct pollfd* fds, nfds_t nfds, int timeout_ms) {
     /* collect PAL handles that correspond to user-supplied FDs (only those that can be polled) */
     for (nfds_t i = 0; i < nfds; i++) {
         fds[i].revents = 0;
-        fds_to_hdls[i] = NULL;
+        fds_mapping[i].hdl = NULL;
 
         if (fds[i].fd < 0) {
             /* FD is negative, must be ignored */
             continue;
         }
 
-        if (!(fds[i].events & (POLLIN|POLLRDNORM)) &&
-            !(fds[i].events & (POLLOUT|POLLWRNORM))) {
-            /* user didn't ask for read or write, ignore this FD */
-            continue;
-        }
-
         struct shim_handle* hdl = __get_fd_handle(fds[i].fd, NULL, map);
         if (!hdl || !hdl->fs || !hdl->fs->fs_ops) {
-            /* the corresponding handle doesn't exist or doesn't provide FS-like semantics */
+            /* the corresponding handle doesn't exist or doesn't provide FS-like semantics;
+             * do not include it in handles-to-poll array but notify user about invalid request */
+            fds[i].revents = POLLNVAL;
+            nrevents++;
             continue;
         }
 
-        int allowed_events = 2; /* read + write */
-        if ((fds[i].events & (POLLIN|POLLRDNORM)) && !(hdl->acc_mode & MAY_READ))
-            allowed_events -= 1; /* minus read */
-        if ((fds[i].events & (POLLOUT|POLLWRNORM)) && !(hdl->acc_mode & MAY_WRITE))
-            allowed_events -= 1; /* minus write */
-        if (!allowed_events) {
-            /* the corresponding handle cannot be read or written */
-            continue;
-        }
+        PAL_FLG allowed_events = 0;
+        if ((fds[i].events & (POLLIN|POLLRDNORM)) && (hdl->acc_mode & MAY_READ))
+            allowed_events |= PAL_WAIT_READ;
+        if ((fds[i].events & (POLLOUT|POLLWRNORM)) && (hdl->acc_mode & MAY_WRITE))
+            allowed_events |= PAL_WAIT_WRITE;
 
-        if (!(fds[i].events & (POLLIN|POLLRDNORM)) && (fds[i].events & (POLLOUT|POLLWRNORM))) {
-            /* special case: user is interested only in write event on this handle, and whether
-             * write event occurs is always known in PAL layer, so simply consult PAL and
-             * update revents and skip this handle for polling (note that otherwise PAL could get
-             * stuck in host poll() because PAL always polls on read events) */
-            PAL_STREAM_ATTR attr;
-            if (!DkStreamAttributesQueryByHandle(hdl->pal_handle, &attr)) {
-                /* something went wrong with this handle, silently skip this handle */
-                continue;
-            }
-
-            if (attr.writable)
-                fds[i].revents |= (fds[i].events & (POLLOUT|POLLWRNORM));
-            if (attr.disconnected)
-                fds[i].revents |= (POLLERR|POLLHUP);
-
-            if (fds[i].revents)
-                nrevents++;
+        if ((fds[i].events & (POLLIN|POLLRDNORM|POLLOUT|POLLWRNORM)) && !allowed_events) {
+            /* if user requested read/write events but they are not allowed on this handle,
+             * ignore this handle (but note that user may only be interested in errors, and
+             * this is a valid request) */
             continue;
         }
 
         get_handle(hdl);
-        fds_to_hdls[i] = hdl;
-        pals[npals]    = hdl->pal_handle;
-        npals++;
+        fds_mapping[i].hdl = hdl;
+        fds_mapping[i].idx = pal_cnt;
+        pals[pal_cnt]        = hdl->pal_handle;
+        pal_events[pal_cnt]  = allowed_events;
+        ret_events[pal_cnt]  = 0;
+        pal_cnt++;
     }
 
     unlock(&map->lock);
 
-    /* TODO: This loop is highly inefficient, since DkObjectsWaitAny returns only one (random)
-     *       handle out of the whole array of handles-waiting-for-events. We must replace this
-     *       loop with a single DkObjectsWaitEvents(). */
-    while (npals) {
-        PAL_HANDLE polled = DkObjectsWaitAny(npals, pals, timeout_us);
-        if (!polled)
-            break;
+    PAL_BOL polled = DkObjectsWaitEvents(pal_cnt, pals, pal_events, ret_events, timeout_us);
 
-        PAL_STREAM_ATTR attr;
-        if (!DkStreamAttributesQueryByHandle(polled, &attr))
-            continue;
-
+    /* update fds.revents, but only if something was actually polled */
+    if (polled) {
         for (nfds_t i = 0; i < nfds; i++) {
-            if (fds_to_hdls[i]->pal_handle == polled) {
-                /* found user-supplied FD, update it with returned events */
-                fds[i].revents = 0;
-                if (attr.readable)
-                    fds[i].revents |= (fds[i].events & (POLLIN|POLLRDNORM));
-                if (attr.writable)
-                    fds[i].revents |= (fds[i].events & (POLLOUT|POLLWRNORM));
-                if (attr.disconnected)
-                    fds[i].revents |= (POLLERR|POLLHUP);
+            if (!fds_mapping[i].hdl)
+                continue;
 
-                if (fds[i].revents)
-                    nrevents++;
-                break;
-            }
-        }
+            fds[i].revents = 0;
+            if (ret_events[fds_mapping[i].idx] & PAL_WAIT_ERROR)
+                fds[i].revents |= POLLERR | POLLHUP;
+            if (ret_events[fds_mapping[i].idx] & PAL_WAIT_READ)
+                fds[i].revents |= fds[i].events & (POLLIN|POLLRDNORM);
+            if (ret_events[fds_mapping[i].idx] & PAL_WAIT_WRITE)
+                fds[i].revents |= fds[i].events & (POLLOUT|POLLWRNORM);
 
-        /* done with this PAL handle, remove it from array on which to DkObjectsWaitAny */
-        nfds_t skip = 0;
-        for (nfds_t i = 0; i < npals; i++) {
-            if (pals[i] == polled)
-                skip = 1;
-            else
-                pals[i - skip] = pals[i];
+            if (fds[i].revents)
+                nrevents++;
+
+            put_handle(fds_mapping[i].hdl);
         }
-        npals -= skip;
     }
 
-    for (nfds_t i = 0; i < nfds; i++)
-        if (fds_to_hdls[i])
-            put_handle(fds_to_hdls[i]);
     free(pals);
-    free(fds_to_hdls);
+    free(pal_events);
+    free(fds_mapping);
 
     return nrevents;
 }

--- a/LibOS/shim/src/sys/shim_poll.c
+++ b/LibOS/shim/src/sys/shim_poll.c
@@ -17,463 +17,19 @@
 /*
  * shim_poll.c
  *
- * Implementation of system call "poll", "ppoll", "select" and "pselect6".
+ * Implementation of system calls "poll", "ppoll", "select" and "pselect6".
  */
 
-#include <shim_internal.h>
-#include <shim_table.h>
-#include <shim_utils.h>
-#include <shim_thread.h>
-#include <shim_handle.h>
-#include <shim_fs.h>
-#include <shim_profile.h>
-
+#include <errno.h>
+#include <linux/fcntl.h>
 #include <pal.h>
 #include <pal_error.h>
-#include <list.h>
-
-#include <errno.h>
-
-#include <linux/fcntl.h>
-
-noreturn void
-fortify_fail (const char *msg)
-{
-    /* The loop is added only to keep gcc happy.  */
-    while (1)
-        debug("*** %s ***\n", msg);
-}
-
-noreturn void
-chk_fail (void)
-{
-    fortify_fail ("buffer overflow detected");
-}
-
-static inline __attribute__((always_inline))
-void * __try_alloca (struct shim_thread * cur, int size)
-{
-    if (!size)
-        return NULL;
-
-    if (check_stack_size(cur, size))
-        return __alloca(size);
-    else
-        return malloc(size);
-}
-
-static inline __attribute__((always_inline))
-void __try_free (struct shim_thread * cur, void * mem)
-{
-    if (mem && !check_on_stack(cur, mem))
-        free(mem);
-}
-
-DEFINE_PROFILE_CATEGORY(__do_poll, select);
-DEFINE_PROFILE_INTERVAL(do_poll_get_handle, __do_poll);
-DEFINE_PROFILE_INTERVAL(do_poll_search_repeat, __do_poll);
-DEFINE_PROFILE_INTERVAL(do_poll_set_bookkeeping, __do_poll);
-DEFINE_PROFILE_INTERVAL(do_poll_check_accmode, __do_poll);
-DEFINE_PROFILE_INTERVAL(do_poll_vfs_polling, __do_poll);
-DEFINE_PROFILE_INTERVAL(do_poll_update_bookkeeping, __do_poll);
-DEFINE_PROFILE_INTERVAL(do_poll_first_loop, __do_poll);
-DEFINE_PROFILE_INTERVAL(do_poll_second_loop, __do_poll);
-DEFINE_PROFILE_INTERVAL(do_poll_wait_any, __do_poll);
-DEFINE_PROFILE_INTERVAL(do_poll_wait_any_peek, __do_poll);
-DEFINE_PROFILE_INTERVAL(do_poll_third_loop, __do_poll);
-DEFINE_PROFILE_INTERVAL(do_poll_fourth_loop, __do_poll);
-
-#define DO_R            0001
-#define DO_W            0002
-#define KNOWN_R         0004
-#define KNOWN_W         0010
-#define RET_R           0020
-#define RET_W           0040
-#define RET_E           0100
-#define POLL_R          0200
-#define POLL_W          0400
-
-struct poll_handle {
-    unsigned short       flags;
-    FDTYPE               fd;
-    struct shim_handle * handle;
-    struct poll_handle * next;
-    struct poll_handle * children;
-};
-
-#define POLL_NOTIMEOUT  ((uint64_t)-1)
-
-static int __do_poll(int npolls, struct poll_handle* polls, uint64_t timeout_us)
-{
-    struct shim_thread * cur = get_cur_thread();
-
-    struct shim_handle_map * map = cur->handle_map;
-    int npals = 0;
-    bool has_r = false, has_known = false;
-    struct poll_handle * polling = NULL;
-    struct poll_handle * p, ** n, * q;
-    PAL_HANDLE * pals = NULL;
-    int ret = 0;
-
-#ifdef PROFILE
-    unsigned long begin_time = GET_PROFILE_INTERVAL();
-    BEGIN_PROFILE_INTERVAL_SET(begin_time);
-#endif
-
-    lock(&map->lock);
-
-    for (p = polls ; p < polls + npolls ; p++) {
-        bool do_r = p->flags & DO_R;
-        bool do_w = p->flags & DO_W;
-
-        if (!do_r && !do_w) {
-no_op:
-            p->flags  = 0;
-            p->handle = NULL;
-            UPDATE_PROFILE_INTERVAL();
-            continue;
-        }
-
-        struct shim_handle * hdl = __get_fd_handle(p->fd, NULL, map);
-        if (!hdl->fs || !hdl->fs->fs_ops)
-            goto no_op;
-
-        SAVE_PROFILE_INTERVAL(do_poll_get_handle);
-
-        /* search for a repeated entry */
-        struct poll_handle * rep = polling;
-        for ( ; rep ; rep = rep->next)
-            if (rep->handle == hdl)
-                break;
-
-        SAVE_PROFILE_INTERVAL(do_poll_search_repeat);
-
-        p->flags    = (do_r ? DO_R : 0)|(do_w ? DO_W : 0);
-        p->handle   = NULL;
-        p->next     = NULL;
-        p->children = NULL;
-
-        if (rep) {
-            /* if there is repeated handles and we already know the
-               result, let's skip them */
-            if (rep->flags & (KNOWN_R|POLL_R)) {
-                p->flags = rep->flags & (KNOWN_R|RET_R|RET_E|POLL_R);
-                do_r = false;
-            }
-
-            if (rep->flags & (KNOWN_W|POLL_W)) {
-                p->flags = rep->flags & (KNOWN_W|RET_W|RET_E|POLL_W);
-                do_w = false;
-            }
-
-            p->next = rep->children;
-            rep->children = p;
-
-            if (!do_r && !do_w) {
-                SAVE_PROFILE_INTERVAL(do_poll_set_bookkeeping);
-                continue;
-            }
-        } else {
-            get_handle(hdl);
-            p->handle = hdl;
-            p->next = polling;
-            polling = p;
-        }
-
-        SAVE_PROFILE_INTERVAL(do_poll_set_bookkeeping);
-
-        /* do the easiest check, check handle's access mode */
-        if (do_r && !(hdl->acc_mode & MAY_READ)) {
-            p->flags |= KNOWN_R;
-            debug("fd %d known to be not readable\n", p->fd);
-            do_r = false;
-        }
-
-        if (do_w && !(hdl->acc_mode & MAY_WRITE)) {
-            p->flags |= KNOWN_W;
-            debug("fd %d known to be not writable\n", p->fd);
-            do_w = false;
-        }
-
-        SAVE_PROFILE_INTERVAL(do_poll_check_accmode);
-
-        if (!do_r && !do_w)
-            goto done_finding;
-
-        /* if fs provides a poll operator, let's try it. */
-        if (hdl->fs->fs_ops->poll) {
-            int need_poll = 0;
-
-            if (do_r && !(p->flags & POLL_R))
-                need_poll |= FS_POLL_RD;
-            if (do_w && !(p->flags & POLL_W))
-                need_poll |= FS_POLL_WR;
-
-            if (need_poll) {
-                int polled = hdl->fs->fs_ops->poll(hdl, need_poll);
-
-                if (polled < 0) {
-                    if (polled != -EAGAIN) {
-                        unlock(&map->lock);
-                        ret = polled;
-                        goto done_polling;
-                    }
-                } else {
-                    if (polled & FS_POLL_ER) {
-                        debug("fd %d known to have error\n", p->fd);
-                        p->flags |= KNOWN_R|KNOWN_W|RET_E;
-                        do_r = do_w = false;
-                    }
-
-                    if ((polled & FS_POLL_RD)) {
-                        debug("fd %d known to be readable\n", p->fd);
-                        p->flags |= KNOWN_R|RET_R;
-                        do_r = false;
-                    }
-
-                    if (polled & FS_POLL_WR) {
-                        debug("fd %d known to be writable\n", p->fd);
-                        p->flags |= KNOWN_W|RET_W;
-                        do_w = false;
-                    }
-                }
-            }
-
-            SAVE_PROFILE_INTERVAL(do_poll_vfs_polling);
-
-            if (!do_r && !do_w)
-                goto done_finding;
-        }
-
-        struct poll_handle * to_poll = rep ? : p;
-
-        if (!(to_poll->flags & (POLL_R|POLL_W))) {
-            if (!hdl->pal_handle) {
-                p->flags |= KNOWN_R|KNOWN_W|RET_E;
-                do_r = do_w = false;
-                goto done_finding;
-            }
-
-            debug("polling fd %d\n", to_poll->fd);
-            npals++;
-        }
-
-        to_poll->flags |= (do_r ? POLL_R : 0)|(do_w ? POLL_W : 0);
-
-done_finding:
-        /* feedback the new knowledge of repeated handles */
-        if (rep)
-            rep->flags |= p->flags &
-                          (KNOWN_R|KNOWN_W|RET_R|RET_W|RET_E|POLL_R|POLL_W);
-
-        if (do_r)
-            has_r = true;
-
-        if (p->flags & (RET_R|RET_W|RET_E))
-            has_known = true;
-
-        SAVE_PROFILE_INTERVAL(do_poll_update_bookkeeping);
-    }
-
-    unlock(&map->lock);
-
-    SAVE_PROFILE_INTERVAL_SINCE(do_poll_first_loop, begin_time);
-
-    if (!npals) {
-        ret = 0;
-        goto done_polling;
-    }
-
-    pals = __try_alloca(cur, sizeof(PAL_HANDLE) * npals);
-    npals = 0;
-
-    n = &polling;
-    for (p = polling ; p ; p = p->next) {
-        assert(p->handle);
-
-        if (!(p->flags & (POLL_R|POLL_W))) {
-            *n = p->next;
-            put_handle(p->handle);
-            p->handle = NULL;
-            continue;
-        }
-
-        pals[npals++] = p->handle->pal_handle;
-        n = &p->next;
-    }
-
-    SAVE_PROFILE_INTERVAL(do_poll_second_loop);
-
-    while (npals) {
-        int pal_timeout_us = (has_r && !has_known) ? timeout_us : 0;
-        PAL_HANDLE polled = DkObjectsWaitAny(npals, pals, pal_timeout_us);
-
-        if (pal_timeout_us)
-            SAVE_PROFILE_INTERVAL(do_poll_wait_any);
-        else
-            SAVE_PROFILE_INTERVAL(do_poll_wait_any_peek);
-
-        if (!polled)
-            break;
-
-        PAL_STREAM_ATTR attr;
-        if (!DkStreamAttributesQueryByHandle(polled, &attr))
-            break;
-
-        n = &polling;
-        for (p = polling ; p ; p = p->next) {
-            if (p->handle->pal_handle == polled)
-                break;
-            n = &p->next;
-        }
-
-        if (!p)
-            break;
-
-        debug("handle %s is polled\n", qstrgetstr(&p->handle->uri));
-
-        p->flags |= KNOWN_R|KNOWN_W;
-
-        if (attr.disconnected) {
-            debug("handle is polled to be disconnected\n");
-            p->flags |= RET_E;
-        }
-        if (attr.readable) {
-            debug("handle is polled to be readable\n");
-            p->flags |= RET_R;
-        }
-        if (attr.writable) {
-            debug("handle is polled to be writable\n");
-            p->flags |= RET_W;
-        }
-
-        for (q = p->children ; q ; q = q->next)
-            q->flags |= p->flags & (KNOWN_R|KNOWN_W|RET_W|RET_R|RET_E);
-
-        if ((p->flags & (POLL_R|KNOWN_R)) != (POLL_R|KNOWN_R) &&
-            (p->flags & (POLL_W|KNOWN_W)) != (POLL_W|KNOWN_W))
-            continue;
-
-        has_known = true;
-        *n = p->next;
-        put_handle(p->handle);
-        p->handle = NULL;
-
-        int nskip = 0;
-        for (int i = 0 ; i < npals ; i++)
-            if (pals[i] == polled) {
-                nskip = 1;
-            } else if (nskip) {
-                pals[i - nskip] = pals[i];
-            }
-        npals -= nskip;
-
-        SAVE_PROFILE_INTERVAL(do_poll_third_loop);
-    }
-
-    ret = 0;
-done_polling:
-    for (p = polling ; p ; p = p->next)
-        put_handle(p->handle);
-
-    SAVE_PROFILE_INTERVAL(do_poll_fourth_loop);
-
-    if (pals)
-        __try_free(cur, pals);
-
-    return ret;
-}
-
-int shim_do_poll (struct pollfd * fds, nfds_t nfds, int timeout_ms)
-{
-    struct shim_thread * cur = get_cur_thread();
-
-    struct poll_handle * polls =
-            __try_alloca(cur, sizeof(struct poll_handle) * nfds);
-
-    for (size_t i = 0 ; i < nfds ; i++) {
-        polls[i].fd = fds[i].fd;
-        polls[i].flags = 0;
-        if (fds[i].events & (POLLIN|POLLRDNORM))
-            polls[i].flags |= DO_R;
-        if (fds[i].events & (POLLOUT|POLLWRNORM))
-            polls[i].flags |= DO_W;
-    }
-
-    int ret = __do_poll(nfds, polls,
-                        timeout_ms < 0 ? POLL_NOTIMEOUT : timeout_ms * 1000ULL);
-
-    if (ret < 0)
-        goto out;
-
-    ret = 0;
-
-    for (size_t i = 0 ; i < nfds ; i++) {
-        fds[i].revents = 0;
-
-        if (polls[i].flags & RET_R)
-            fds[i].revents |= (fds[i].events & (POLLIN|POLLRDNORM));
-        if (polls[i].flags & RET_W)
-            fds[i].revents |= (fds[i].events & (POLLOUT|POLLWRNORM));
-        if (polls[i].flags & RET_E)
-            fds[i].revents |= (POLLERR|POLLHUP);
-
-        if (fds[i].revents)
-            ret++;
-    }
-
-out:
-    __try_free(cur, polls);
-
-    return ret;
-}
-
-int shim_do_ppoll (struct pollfd * fds, int nfds, struct timespec * tsp,
-                   const __sigset_t * sigmask, size_t sigsetsize)
-{
-    __UNUSED(sigmask);
-    __UNUSED(sigsetsize);
-    struct shim_thread * cur = get_cur_thread();
-
-    struct poll_handle * polls =
-            __try_alloca(cur, sizeof(struct poll_handle) * nfds);
-
-    for (int i = 0 ; i < nfds ; i++) {
-        polls[i].fd = fds[i].fd;
-        polls[i].flags = 0;
-        if (fds[i].events & (POLLIN|POLLRDNORM))
-            polls[i].flags |= DO_R;
-        if (fds[i].events & (POLLOUT|POLLWRNORM))
-            polls[i].flags |= DO_W;
-    }
-
-    uint64_t timeout_us = tsp ? tsp->tv_sec * 1000000ULL + tsp->tv_nsec / 1000 : POLL_NOTIMEOUT;
-    int ret = __do_poll(nfds, polls, timeout_us);
-
-    if (ret < 0)
-        goto out;
-
-    ret = 0;
-
-    for (int i = 0 ; i < nfds ; i++) {
-        fds[i].revents = 0;
-
-        if (polls[i].flags & RET_R)
-            fds[i].revents |= (fds[i].events & (POLLIN|POLLRDNORM));
-        if (polls[i].flags & RET_W)
-            fds[i].revents |= (fds[i].events & (POLLOUT|POLLWRNORM));
-        if (polls[i].flags & RET_E)
-            fds[i].revents |= (fds[i].events & (POLLERR|POLLHUP));
-
-        if (fds[i].revents)
-            ret++;
-    }
-
-out:
-    __try_free(cur, polls);
-
-    return ret;
-}
+#include <shim_fs.h>
+#include <shim_handle.h>
+#include <shim_internal.h>
+#include <shim_table.h>
+#include <shim_thread.h>
+#include <shim_utils.h>
 
 typedef long int __fd_mask;
 
@@ -484,8 +40,6 @@ typedef long int __fd_mask;
 #define __FDS_BITS(set) ((set)->fds_bits)
 #endif
 
-/* We don't use `memset' because this would require a prototype and
-   the array isn't too big.  */
 # define __FD_ZERO(set)                                     \
     do {                                                    \
         unsigned int __i;                                   \
@@ -504,60 +58,226 @@ typedef long int __fd_mask;
 #define __FD_ISSET(d, set)                                  \
   ((__FDS_BITS(set)[__FD_ELT(d)] & __FD_MASK(d)) != 0)
 
-DEFINE_PROFILE_CATEGORY(select, );
-DEFINE_PROFILE_INTERVAL(select_tryalloca_1, select);
-DEFINE_PROFILE_INTERVAL(select_setup_array, select);
-DEFINE_PROFILE_INTERVAL(select_do_poll, select);
-DEFINE_PROFILE_INTERVAL(select_fd_zero, select);
-DEFINE_PROFILE_INTERVAL(select_fd_sets, select);
-DEFINE_PROFILE_INTERVAL(select_try_free, select);
+#define POLL_NOTIMEOUT  ((uint64_t)-1)
 
-int shim_do_select (int nfds, fd_set * readfds, fd_set * writefds,
-                    fd_set * errorfds, struct __kernel_timeval * tsv)
-{
-    BEGIN_PROFILE_INTERVAL();
+int shim_do_poll(struct pollfd* fds, nfds_t nfds, int timeout_ms) {
+    if (!fds || test_user_memory(fds, sizeof(*fds) * nfds, true))
+        return -EFAULT;
+
+    if ((uint64_t)nfds > get_rlimit_cur(RLIMIT_NOFILE))
+        return -EINVAL;
+
+    struct shim_handle_map* map = get_cur_thread()->handle_map;
+
+    uint64_t timeout_us = timeout_ms < 0 ? POLL_NOTIMEOUT : timeout_ms * 1000ULL;
+
+    /* nfds is the upper limit for actual number of handles */
+    PAL_HANDLE* pals = malloc(nfds * sizeof(PAL_HANDLE));
+    if (!pals)
+        return -ENOMEM;
+
+    /* for bookkeeping, need to have a mapping FD -> handle */
+    struct shim_handle** fds_to_hdls = malloc(nfds * sizeof(struct shim_handle*));
+    if (!fds_to_hdls) {
+        free(pals);
+        return -ENOMEM;
+    }
+
+    nfds_t npals = 0;
+    nfds_t nrevents = 0;
+
+    lock(&map->lock);
+
+    /* collect PAL handles that correspond to user-supplied FDs (only those that can be polled) */
+    for (nfds_t i = 0; i < nfds; i++) {
+        fds[i].revents = 0;
+        fds_to_hdls[i] = NULL;
+
+        if (fds[i].fd < 0) {
+            /* FD is negative, must be ignored */
+            continue;
+        }
+
+        if (!(fds[i].events & (POLLIN|POLLRDNORM)) &&
+            !(fds[i].events & (POLLOUT|POLLWRNORM))) {
+            /* user didn't ask for read or write, ignore this FD */
+            continue;
+        }
+
+        struct shim_handle* hdl = __get_fd_handle(fds[i].fd, NULL, map);
+        if (!hdl || !hdl->fs || !hdl->fs->fs_ops) {
+            /* the corresponding handle doesn't exist or doesn't provide FS-like semantics */
+            continue;
+        }
+
+        int allowed_events = 2; /* read + write */
+        if ((fds[i].events & (POLLIN|POLLRDNORM)) && !(hdl->acc_mode & MAY_READ))
+            allowed_events -= 1; /* minus read */
+        if ((fds[i].events & (POLLOUT|POLLWRNORM)) && !(hdl->acc_mode & MAY_WRITE))
+            allowed_events -= 1; /* minus write */
+        if (!allowed_events) {
+            /* the corresponding handle cannot be read or written */
+            continue;
+        }
+
+        if (!(fds[i].events & (POLLIN|POLLRDNORM)) && (fds[i].events & (POLLOUT|POLLWRNORM))) {
+            /* special case: user is interested only in write event on this handle, and whether
+             * write event occurs is always known in PAL layer, so simply consult PAL and
+             * update revents and skip this handle for polling (note that otherwise PAL could get
+             * stuck in host poll() because PAL always polls on read events) */
+            PAL_STREAM_ATTR attr;
+            if (!DkStreamAttributesQueryByHandle(hdl->pal_handle, &attr)) {
+                /* something went wrong with this handle, silently skip this handle */
+                continue;
+            }
+
+            if (attr.writable)
+                fds[i].revents |= (fds[i].events & (POLLOUT|POLLWRNORM));
+            if (attr.disconnected)
+                fds[i].revents |= (POLLERR|POLLHUP);
+
+            if (fds[i].revents)
+                nrevents++;
+            continue;
+        }
+
+        get_handle(hdl);
+        fds_to_hdls[i] = hdl;
+        pals[npals]    = hdl->pal_handle;
+        npals++;
+    }
+
+    unlock(&map->lock);
+
+    /* TODO: This loop is highly inefficient, since DkObjectsWaitAny returns only one (random)
+     *       handle out of the whole array of handles-waiting-for-events. We must replace this
+     *       loop with a single DkObjectsWaitEvents(). */
+    while (npals) {
+        PAL_HANDLE polled = DkObjectsWaitAny(npals, pals, timeout_us);
+        if (!polled)
+            break;
+
+        PAL_STREAM_ATTR attr;
+        if (!DkStreamAttributesQueryByHandle(polled, &attr))
+            continue;
+
+        for (nfds_t i = 0; i < nfds; i++) {
+            if (fds_to_hdls[i]->pal_handle == polled) {
+                /* found user-supplied FD, update it with returned events */
+                fds[i].revents = 0;
+                if (attr.readable)
+                    fds[i].revents |= (fds[i].events & (POLLIN|POLLRDNORM));
+                if (attr.writable)
+                    fds[i].revents |= (fds[i].events & (POLLOUT|POLLWRNORM));
+                if (attr.disconnected)
+                    fds[i].revents |= (POLLERR|POLLHUP);
+
+                if (fds[i].revents)
+                    nrevents++;
+                break;
+            }
+        }
+
+        /* done with this PAL handle, remove it from array on which to DkObjectsWaitAny */
+        nfds_t skip = 0;
+        for (nfds_t i = 0; i < npals; i++) {
+            if (pals[i] == polled)
+                skip = 1;
+            else
+                pals[i - skip] = pals[i];
+        }
+        npals -= skip;
+    }
+
+    for (nfds_t i = 0; i < nfds; i++)
+        if (fds_to_hdls[i])
+            put_handle(fds_to_hdls[i]);
+    free(pals);
+    free(fds_to_hdls);
+
+    return nrevents;
+}
+
+int shim_do_ppoll(struct pollfd* fds, int nfds, struct timespec* tsp,
+                  const __sigset_t* sigmask, size_t sigsetsize) {
+    __UNUSED(sigmask);
+    __UNUSED(sigsetsize);
+
+    uint64_t timeout_ms = tsp ? tsp->tv_sec * 1000ULL + tsp->tv_nsec / 1000000 : POLL_NOTIMEOUT;
+    return shim_do_poll(fds, nfds, timeout_ms);
+}
+
+int shim_do_select(int nfds, fd_set* readfds, fd_set* writefds,
+                   fd_set* errorfds, struct __kernel_timeval* tsv) {
+    if (tsv && (tsv->tv_sec < 0 || tsv->tv_usec < 0))
+            return -EINVAL;
+
+    if (nfds < 0 || (uint64_t)nfds > get_rlimit_cur(RLIMIT_NOFILE))
+        return -EINVAL;
 
     if (!nfds) {
         if (!tsv)
             return -EINVAL;
 
+        /* special case of select(0, ..., tsv) used for sleep */
         struct __kernel_timespec tsp;
         tsp.tv_sec = tsv->tv_sec;
         tsp.tv_nsec = tsv->tv_usec * 1000;
-        return shim_do_nanosleep (&tsp, NULL);
+        return shim_do_nanosleep(&tsp, NULL);
     }
 
-    struct shim_thread * cur = get_cur_thread();
+    if (nfds < __NFDBITS) {
+        /* interesting corner case: Linux always checks at least 64 first FDs */
+        nfds = __NFDBITS;
+    }
 
-    struct poll_handle * polls =
-            __try_alloca(cur, sizeof(struct poll_handle) * nfds);
-    int npolls = 0;
+    /* nfds is the upper limit for actual number of fds for poll */
+    struct pollfd* fds_poll = malloc(nfds * sizeof(struct pollfd));
+    if (!fds_poll)
+        return -ENOMEM;
 
-    SAVE_PROFILE_INTERVAL(select_tryalloca_1);
+    /* populate array of pollfd's based on user-supplied readfds & writefds */
+    nfds_t nfds_poll = 0;
+    for (int fd = 0; fd < nfds; fd++) {
+        short events = 0;
+        if (readfds && __FD_ISSET(fd, readfds))
+            events |= POLLIN;
+        if (writefds && __FD_ISSET(fd, writefds))
+            events |= POLLOUT;
 
-    for (int fd = 0 ; fd < nfds ; fd++) {
-        bool do_r = (readfds  && __FD_ISSET(fd, readfds));
-        bool do_w = (writefds && __FD_ISSET(fd, writefds));
-        if (!do_r && !do_w)
+        if (!events)
             continue;
-        debug("poll fd %d %s%s\n", fd, do_r ? "R" : "", do_w ? "W" : "");
-        polls[npolls].fd = fd;
-        polls[npolls].flags = (do_r ? DO_R : 0)|(do_w ? DO_W : 0);
-        npolls++;
+
+        fds_poll[nfds_poll].fd      = fd;
+        fds_poll[nfds_poll].events  = events;
+        fds_poll[nfds_poll].revents = 0;
+        nfds_poll++;
     }
 
-    SAVE_PROFILE_INTERVAL(select_setup_array);
+    /* select()/pselect() return -EBADF if invalid FD was given by user in readfds/writefds;
+     * note that poll()/ppoll() don't have this error code, so we return this code only here */
+    struct shim_handle_map* map = get_cur_thread()->handle_map;
+    lock(&map->lock);
+    for (nfds_t i = 0; i < nfds_poll; i++) {
+        struct shim_handle* hdl = __get_fd_handle(fds_poll[i].fd, NULL, map);
+        if (!hdl || !hdl->fs || !hdl->fs->fs_ops) {
+            /* the corresponding handle doesn't exist or doesn't provide FS-like semantics */
+            free(fds_poll);
+            unlock(&map->lock);
+            return -EBADF;
+        }
+    }
+    unlock(&map->lock);
 
-    uint64_t timeout_us = tsv ? tsv->tv_sec * 1000000ULL + tsv->tv_usec : POLL_NOTIMEOUT;
-    int ret = __do_poll(npolls, polls, timeout_us);
+    uint64_t timeout_ms = tsv ? tsv->tv_sec * 1000ULL + tsv->tv_usec / 1000 : POLL_NOTIMEOUT;
+    int ret = shim_do_poll(fds_poll, nfds_poll, timeout_ms);
 
-    SAVE_PROFILE_INTERVAL(select_do_poll);
+    if (ret < 0) {
+        free(fds_poll);
+        return ret;
+    }
 
-    if (ret < 0)
-        goto out;
-
-    ret = 0;
-
+    /* modify readfds, writefds, and errorfds in-place with returned events */
     if (readfds)
         __FD_ZERO(readfds);
     if (writefds)
@@ -565,85 +285,37 @@ int shim_do_select (int nfds, fd_set * readfds, fd_set * writefds,
     if (errorfds)
         __FD_ZERO(errorfds);
 
-    SAVE_PROFILE_INTERVAL(select_fd_zero);
-
-    for (int i = 0 ; i < npolls ; i++) {
-        if (readfds && ((polls[i].flags & (DO_R|RET_R)) == (DO_R|RET_R))) {
-            __FD_SET(polls[i].fd, readfds);
+    ret = 0;
+    for (nfds_t i = 0; i < nfds_poll; i++) {
+        if (readfds && (fds_poll[i].revents & POLLIN)) {
+            __FD_SET(fds_poll[i].fd, readfds);
             ret++;
         }
-        if (writefds && ((polls[i].flags & (DO_W|RET_W)) == (DO_W|RET_W))) {
-            __FD_SET(polls[i].fd, writefds);
+        if (writefds && (fds_poll[i].revents & POLLOUT)) {
+            __FD_SET(fds_poll[i].fd, writefds);
             ret++;
         }
-        if (errorfds && ((polls[i].flags & (DO_R|DO_W|RET_E)) > RET_E)) {
-            __FD_SET(polls[i].fd, errorfds);
+        if (errorfds && (fds_poll[i].revents & POLLERR)) {
+            __FD_SET(fds_poll[i].fd, errorfds);
             ret++;
         }
     }
-    SAVE_PROFILE_INTERVAL(select_fd_sets);
 
-out:
-    __try_free(cur, polls);
-    SAVE_PROFILE_INTERVAL(select_try_free);
+    free(fds_poll);
     return ret;
 }
 
-int shim_do_pselect6 (int nfds, fd_set * readfds, fd_set * writefds,
-                      fd_set * errorfds, const struct __kernel_timespec * tsp,
-                      const __sigset_t * sigmask)
-{
+int shim_do_pselect6(int nfds, fd_set* readfds, fd_set* writefds,
+                     fd_set* errorfds, const struct __kernel_timespec* tsp,
+                     const __sigset_t* sigmask) {
     __UNUSED(sigmask);
-    if (!nfds)
-        return tsp ? shim_do_nanosleep (tsp, NULL) : -EINVAL;
 
-    struct shim_thread * cur = get_cur_thread();
-
-    struct poll_handle * polls =
-            __try_alloca(cur, sizeof(struct poll_handle) * nfds);
-    int npolls = 0;
-
-    for (int fd = 0 ; fd < nfds ; fd++) {
-        bool do_r = (readfds  && __FD_ISSET(fd, readfds));
-        bool do_w = (writefds && __FD_ISSET(fd, writefds));
-        if (!do_r && !do_w)
-            continue;
-        polls[npolls].fd = fd;
-        polls[npolls].flags = (do_r ? DO_R : 0)|(do_w ? DO_W : 0);
-        npolls++;
+    if (tsp) {
+        struct __kernel_timeval tsv;
+        tsv.tv_sec = tsp->tv_sec;
+        tsv.tv_usec = tsp->tv_nsec / 1000;
+        return shim_do_select(nfds, readfds, writefds, errorfds, &tsv);
     }
 
-    uint64_t timeout_us = tsp ? tsp->tv_sec * 1000000ULL + tsp->tv_nsec / 1000 : POLL_NOTIMEOUT;
-    int ret = __do_poll(npolls, polls, timeout_us);
-
-    if (ret < 0)
-        goto out;
-
-    ret = 0;
-
-    if (readfds)
-        __FD_ZERO(readfds);
-    if (writefds)
-        __FD_ZERO(writefds);
-    if (errorfds)
-        __FD_ZERO(errorfds);
-
-    for (int i = 0 ; i < npolls ; i++) {
-        if (readfds && ((polls[i].flags & (DO_R|RET_R)) == (DO_R|RET_R))) {
-            __FD_SET(polls[i].fd, readfds);
-            ret++;
-        }
-        if (writefds && ((polls[i].flags & (DO_W|RET_W)) == (DO_W|RET_W))) {
-            __FD_SET(polls[i].fd, writefds);
-            ret++;
-        }
-        if (errorfds && ((polls[i].flags & (DO_R|DO_W|RET_E)) > RET_E)) {
-            __FD_SET(polls[i].fd, errorfds);
-            ret++;
-        }
-    }
-
-out:
-    __try_free(cur, polls);
-    return ret;
+    return shim_do_select(nfds, readfds, writefds, errorfds, NULL);
 }

--- a/LibOS/shim/test/regression/poll.c
+++ b/LibOS/shim/test/regression/poll.c
@@ -1,0 +1,38 @@
+#include <poll.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+int main(void) {
+    int  ret;
+    int  fd[2];
+    char string[] = "Hello, world!\n";
+
+    ret = pipe(fd);
+    if (ret < 0) {
+        perror("pipe creation failed");
+        return 1;
+    }
+
+    struct pollfd outfds[] = { {.fd = fd[1], .events = POLLOUT}, };
+    ret = poll(outfds, 1, -1);
+    if (ret <= 0) {
+        perror("poll with POLLOUT failed");
+        return 1;
+    }
+    printf("poll(POLLOUT) returned %d file descriptors\n", ret);
+
+    struct pollfd infds[] = { {.fd = fd[0], .events = POLLIN}, };
+    write(fd[1], string, (strlen(string)+1));
+    ret = poll(infds, 1, -1);
+    if (ret <= 0) {
+        perror("poll with POLLIN failed");
+        return 1;
+    }
+    printf("poll(POLLIN) returned %d file descriptors\n", ret);
+
+    return 0;
+}
+
+

--- a/LibOS/shim/test/regression/ppoll.c
+++ b/LibOS/shim/test/regression/ppoll.c
@@ -1,0 +1,41 @@
+#define _GNU_SOURCE
+#include <poll.h>
+#include <signal.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+int main(void) {
+    int  ret;
+    int  fd[2];
+    char string[] = "Hello, world!\n";
+    struct timespec tv = { .tv_sec = 10, .tv_nsec = 0};
+
+    ret = pipe(fd);
+    if (ret < 0) {
+        perror("pipe creation failed");
+        return 1;
+    }
+
+    struct pollfd outfds[] = { {.fd = fd[1], .events = POLLOUT}, };
+    ret = ppoll(outfds, 1, &tv, NULL);
+    if (ret <= 0) {
+        perror("ppoll with POLLOUT failed");
+        return 1;
+    }
+    printf("ppoll(POLLOUT) returned %d file descriptors\n", ret);
+
+    struct pollfd infds[] = { {.fd = fd[0], .events = POLLIN}, };
+    write(fd[1], string, (strlen(string)+1));
+    ret = ppoll(infds, 1, &tv, NULL);
+    if (ret <= 0) {
+        perror("ppoll with POLLIN failed");
+        return 1;
+    }
+    printf("ppoll(POLLIN) returned %d file descriptors\n", ret);
+
+    return 0;
+}
+
+

--- a/LibOS/shim/test/regression/pselect.c
+++ b/LibOS/shim/test/regression/pselect.c
@@ -1,0 +1,44 @@
+#include <stdio.h>
+#include <string.h>
+#include <sys/select.h>
+#include <sys/time.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+int main(void) {
+    fd_set rfds;
+    fd_set wfds;
+
+    int  ret;
+    int  fd[2];
+    char string[] = "Hello, world!\n";
+    struct timespec tv = {.tv_sec = 10, .tv_nsec = 0};
+
+    ret = pipe(fd);
+    if (ret < 0) {
+        perror("pipe creation failed");
+        return 1;
+    }
+
+    FD_ZERO(&rfds);
+    FD_ZERO(&wfds);
+    FD_SET(fd[0], &rfds);
+    FD_SET(fd[1], &wfds);
+
+    ret = pselect(fd[1] + 1, NULL, &wfds, NULL, &tv, NULL);
+    if (ret <= 0) {
+        perror("pselect() on write event failed");
+        return 1;
+    }
+    printf("pselect() on write event returned %d file descriptors\n", ret);
+
+    write(fd[1], string, (strlen(string)+1));
+    ret = pselect(fd[1] + 1, &rfds, NULL, NULL, &tv, NULL);
+    if (ret <= 0) {
+        perror("pselect() on read event failed");
+        return 1;
+    }
+    printf("pselect() on read event returned %d file descriptors\n", ret);
+
+    return 0;
+}

--- a/LibOS/shim/test/regression/select.c
+++ b/LibOS/shim/test/regression/select.c
@@ -1,0 +1,44 @@
+#include <stdio.h>
+#include <string.h>
+#include <sys/select.h>
+#include <sys/time.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+int main(void) {
+    fd_set rfds;
+    fd_set wfds;
+
+    int  ret;
+    int  fd[2];
+    char string[] = "Hello, world!\n";
+    struct timeval tv = {.tv_sec = 10, .tv_usec = 0};
+
+    ret = pipe(fd);
+    if (ret < 0) {
+        perror("pipe creation failed");
+        return 1;
+    }
+
+    FD_ZERO(&rfds);
+    FD_ZERO(&wfds);
+    FD_SET(fd[0], &rfds);
+    FD_SET(fd[1], &wfds);
+
+    ret = select(fd[1] + 1, NULL, &wfds, NULL, &tv);
+    if (ret <= 0) {
+        perror("select() on write event failed");
+        return 1;
+    }
+    printf("select() on write event returned %d file descriptors\n", ret);
+
+    write(fd[1], string, (strlen(string)+1));
+    ret = select(fd[1] + 1, &rfds, NULL, NULL, &tv);
+    if (ret <= 0) {
+        perror("select() on read event failed");
+        return 1;
+    }
+    printf("select() on read event returned %d file descriptors\n", ret);
+
+    return 0;
+}

--- a/LibOS/shim/test/regression/test_libos.py
+++ b/LibOS/shim/test/regression/test_libos.py
@@ -411,6 +411,26 @@ class TC_80_Socket(RegressionTestCase):
         # epoll_wait timeout
         self.assertIn('epoll_wait test passed', stdout)
 
+    def test_020_poll(self):
+        stdout, _ = self.run_binary(['poll'])
+        self.assertIn('poll(POLLOUT) returned 1 file descriptors', stdout)
+        self.assertIn('poll(POLLIN) returned 1 file descriptors', stdout)
+
+    def test_030_ppoll(self):
+        stdout, _ = self.run_binary(['ppoll'])
+        self.assertIn('ppoll(POLLOUT) returned 1 file descriptors', stdout)
+        self.assertIn('ppoll(POLLIN) returned 1 file descriptors', stdout)
+
+    def test_040_select(self):
+        stdout, _ = self.run_binary(['select'])
+        self.assertIn('select() on write event returned 1 file descriptors', stdout)
+        self.assertIn('select() on read event returned 1 file descriptors', stdout)
+
+    def test_050_pselect(self):
+        stdout, _ = self.run_binary(['pselect'])
+        self.assertIn('pselect() on write event returned 1 file descriptors', stdout)
+        self.assertIn('pselect() on read event returned 1 file descriptors', stdout)
+
     def test_100_socket_unix(self):
         stdout, stderr = self.run_binary(['unix'])
         self.assertIn('Data: This is packet 0', stdout)

--- a/Pal/src/host/Linux/db_object.c
+++ b/Pal/src/host/Linux/db_object.c
@@ -17,193 +17,90 @@
 /*
  * db_object.c
  *
- * This file contains APIs for closing or polling PAL handles.
+ * This file contains APIs for waiting on PAL handles (polling): DkObjectsWaitAny.
  */
 
-#include "pal_defs.h"
-#include "pal_linux_defs.h"
+#include "api.h"
 #include "pal.h"
+#include "pal_debug.h"
+#include "pal_defs.h"
+#include "pal_error.h"
 #include "pal_internal.h"
 #include "pal_linux.h"
-#include "pal_error.h"
-#include "pal_debug.h"
-#include "api.h"
+#include "pal_linux_defs.h"
 
-#include <linux/time.h>
-#include <linux/poll.h>
-#include <linux/wait.h>
-#include <atomic.h>
 #include <asm/errno.h>
+#include <linux/poll.h>
+#include <linux/time.h>
+#include <linux/wait.h>
 
-#define DEFAULT_QUANTUM 500
-
-/* internally to wait for one object. Also used as a shortcut to wait
- *  on events and semaphores.
- *
- *  Returns 0 on success, negative value on failure (e.g., -PAL_ERROR_TRYAGAIN)
- */
-static int _DkObjectWaitOne(PAL_HANDLE handle, int64_t timeout_us) {
-    /* only for all these handle which has a file descriptor, or
-       a eventfd. events and semaphores will skip this part */
-    if (HANDLE_HDR(handle)->flags & HAS_FDS) {
-        struct timespec timeout_ts;
-
-        if (timeout_us >= 0) {
-            int64_t sec = timeout_us / 1000000;
-            int64_t microsec = timeout_us - (sec * 1000000);
-            timeout_ts.tv_sec = sec;
-            timeout_ts.tv_nsec = microsec * 1000;
-        }
-
-        struct pollfd fds[MAX_FDS];
-        int off[MAX_FDS];
-        int nfds = 0;
-        for (int i = 0 ; i < MAX_FDS ; i++) {
-            int events = 0;
-
-            if ((HANDLE_HDR(handle)->flags & RFD(i)) &&
-                !(HANDLE_HDR(handle)->flags & ERROR(i)))
-                events |= POLLIN;
-
-            if ((HANDLE_HDR(handle)->flags & WFD(i)) &&
-                !(HANDLE_HDR(handle)->flags & WRITABLE(i)) &&
-                !(HANDLE_HDR(handle)->flags & ERROR(i)))
-                events |= POLLOUT;
-
-            if (events) {
-                fds[nfds].fd = handle->generic.fds[i];
-                fds[nfds].events = events|POLLHUP|POLLERR;
-                fds[nfds].revents = 0;
-                off[nfds] = i;
-                nfds++;
-            }
-        }
-
-        if (!nfds)
-            return -PAL_ERROR_TRYAGAIN;
-
-        int ret = INLINE_SYSCALL(ppoll, 5, &fds, nfds,
-                                 timeout_us >= 0 ? &timeout_ts : NULL,
-                                 NULL, 0);
-
-        if (IS_ERR(ret))
-            switch (ERRNO(ret)) {
-                case EINTR:
-                case ERESTART:
-                    return -PAL_ERROR_INTERRUPTED;
-                default:
-                    return unix_to_pal_error(ERRNO(ret));
-            }
-
-        if (!ret)
-            return -PAL_ERROR_TRYAGAIN;
-
-        for (int i = 0 ; i < nfds ; i++) {
-            if (!fds[i].revents)
-                continue;
-            if (fds[i].revents & POLLOUT)
-                HANDLE_HDR(handle)->flags |= WRITABLE(off[i]);
-            if (fds[i].revents & (POLLHUP|POLLERR))
-                HANDLE_HDR(handle)->flags |= ERROR(off[i]);
-        }
-
-        return 0;
-    }
-
-    const struct handle_ops * ops = HANDLE_OPS(handle);
-
-    if (!ops)
-        return -PAL_ERROR_BADHANDLE;
-
-    if (!ops->wait)
-        return -PAL_ERROR_NOTSUPPORT;
-
-    return ops->wait(handle, timeout_us);
-}
-
-/* _DkObjectsWaitAny for internal use. The function wait for any of the handle
-   in the handle array. timeout can be set for the wait. */
+/* Wait for an event on any handle in the handle array and return this handle in polled.
+ * If no ready-event handle was found, polled is set to NULL. */
 int _DkObjectsWaitAny(int count, PAL_HANDLE* handleArray, int64_t timeout_us,
                       PAL_HANDLE* polled) {
     if (count <= 0)
         return 0;
 
-    if (count == 1) {
-        // It is possible to have NULL pointers in the handle array.
-        // In this case, assume nothing is polled.
-        if (!handleArray[0])
-            return -PAL_ERROR_TRYAGAIN;
+    if (count == 1 && handleArray[0]) {
+        /* Special case of DkObjectsWaitAny(1, mutex/event, ...): perform a mutex-specific or
+         * event-specific wait() callback instead of host-OS poll. */
+        if (IS_HANDLE_TYPE(handleArray[0], mutex) || IS_HANDLE_TYPE(handleArray[0], event)) {
+            const struct handle_ops* ops = HANDLE_OPS(handleArray[0]);
+            assert(ops && ops->wait);
 
-        int rv = _DkObjectWaitOne(handleArray[0], timeout_us);
-        if (rv == 0)
-            *polled = handleArray[0];
-        return rv;
-    }
-
-    int i, j, ret, maxfds = 0, nfds = 0;
-
-    /* we are not gonna to allow any polling on muliple synchronous
-       objects, doing this is simply violating the division of
-       labor between PAL and library OS */
-    for (i = 0 ; i < count ; i++) {
-        PAL_HANDLE hdl = handleArray[i];
-
-        if (!hdl)
-            continue;
-
-        if (!(HANDLE_HDR(hdl)->flags & HAS_FDS))
-            return -PAL_ERROR_NOTSUPPORT;
-
-        /* eliminate repeated entries */
-        for (j = 0 ; j < i ; j++)
-            if (hdl == handleArray[j])
-                break;
-        if (j == i) {
-            for (j = 0 ; j < MAX_FDS ; j++)
-                if (HANDLE_HDR(hdl)->flags & (RFD(j)|WFD(j)))
-                    maxfds++;
+            int rv = ops->wait(handleArray[0], timeout_us);
+            if (rv == 0)
+                *polled = handleArray[0];
+            return rv;
         }
     }
 
-    struct pollfd * fds = __alloca(sizeof(struct pollfd) * maxfds);
-    PAL_HANDLE * hdls = __alloca(sizeof(PAL_HANDLE) * maxfds);
+    /* Normal case of not mutex/event: poll on all handles in the array (their handle types can be
+     * process, socket, pipe, device, file, eventfd). */
+    struct pollfd fds[count]; /* TODO: if count is too big, stack overflow may occur */
+    PAL_HANDLE hdls[count];   /* TODO: if count is too big, stack overflow may occur */
+    int nfds = 0;
 
-    for (i = 0 ; i < count ; i++) {
+    /* collect all FDs of all PAL handles that may report read/write events */
+    for (int i = 0; i < count; i++) {
         PAL_HANDLE hdl = handleArray[i];
-
         if (!hdl)
             continue;
 
-        for (j = 0 ; j < i ; j++)
+        /* ignore duplicate handles */
+        for (int j = 0; j < i; j++)
             if (hdl == handleArray[j])
-                break;
-        if (j < i)
-            continue;
+                continue;
 
-        for (j = 0 ; j < MAX_FDS ; j++) {
+        /* collect all internal-handle FDs (only those which are readable/writable) */
+        for (int j = 0; j < MAX_FDS; j++) {
+            PAL_FLG flags = HANDLE_HDR(hdl)->flags;
+
+            if (hdl->generic.fds[j] == PAL_IDX_POISON)
+                continue;
+            if (flags & ERROR(j))
+                continue;
+
+            /* always ask host to wait for read event (if FD allows read events); however, no need
+             * to ask host to wait for write event if FD is already known to be writable */
             int events = 0;
+            events |= (flags & RFD(j)) ? POLLIN : 0;
+            events |= ((flags & WFD(j)) && !(flags & WRITABLE(j))) ? POLLOUT : 0;
 
-            if ((HANDLE_HDR(hdl)->flags & RFD(j)) &&
-                !(HANDLE_HDR(hdl)->flags & ERROR(j)))
-                events |= POLLIN;
-
-            if ((HANDLE_HDR(hdl)->flags & WFD(j)) &&
-                !(HANDLE_HDR(hdl)->flags & WRITABLE(j)) &&
-                !(HANDLE_HDR(hdl)->flags & ERROR(j)))
-                events |= POLLOUT;
-
-            if (events && hdl->generic.fds[j] != PAL_IDX_POISON) {
-                fds[nfds].fd = hdl->generic.fds[j];
-                fds[nfds].events = events|POLLHUP|POLLERR;
+            if (events) {
+                fds[nfds].fd      = hdl->generic.fds[j];
+                fds[nfds].events  = events | POLLHUP | POLLERR;
                 fds[nfds].revents = 0;
-                hdls[nfds] = hdl;
+                hdls[nfds]        = hdl;
                 nfds++;
             }
         }
     }
 
-    if (!nfds)
+    if (!nfds) {
+        /* did not find any wait-able FDs (probably because their events were already cached) */
         return -PAL_ERROR_TRYAGAIN;
+    }
 
     struct timespec timeout_ts;
 
@@ -214,9 +111,7 @@ int _DkObjectsWaitAny(int count, PAL_HANDLE* handleArray, int64_t timeout_us,
         timeout_ts.tv_nsec = microsec * 1000;
     }
 
-    ret = INLINE_SYSCALL(ppoll, 5, fds, nfds,
-                         timeout_us >= 0 ? &timeout_ts : NULL,
-                         NULL, 0);
+    int ret = INLINE_SYSCALL(ppoll, 5, fds, nfds, timeout_us >= 0 ? &timeout_ts : NULL, NULL, 0);
 
     if (IS_ERR(ret))
         switch (ERRNO(ret)) {
@@ -227,36 +122,41 @@ int _DkObjectsWaitAny(int count, PAL_HANDLE* handleArray, int64_t timeout_us,
                 return unix_to_pal_error(ERRNO(ret));
         }
 
-    if (!ret)
+    if (!ret) {
+        /* timed out */
         return -PAL_ERROR_TRYAGAIN;
+    }
 
     PAL_HANDLE polled_hdl = NULL;
 
-    for (i = 0 ; i < nfds ; i++) {
+    for (int i = 0; i < nfds; i++) {
         if (!fds[i].revents)
             continue;
 
-        PAL_HANDLE hdl = hdls[i];
+        /* One PAL handle can have MAX_FDS internal FDs, so we must select one handle (randomly)
+         * from the ones on which the host reported events and then collect all revents on this
+         * handle's internal FDs.
+         * TODO: This is very inefficient. Each DkObjectsWaitAny() returns only one of possibly
+         *       many event-ready PAL handles. We must introduce new DkObjectsWaitEvents(). */
+        if (!polled_hdl)
+            polled_hdl = hdls[i];
 
-        if (polled_hdl) {
-            if (hdl != polled_hdl)
-                continue;
-        } else {
-            polled_hdl = hdl;
-        }
-
-        for (j = 0 ; j < MAX_FDS ; j++)
-            if ((HANDLE_HDR(hdl)->flags & (RFD(j)|WFD(j))) &&
-                hdl->generic.fds[j] == (PAL_IDX)fds[i].fd)
-                break;
-
-        if (j == MAX_FDS)
+        if (polled_hdl != hdls[i])
             continue;
 
-        if (fds[i].revents & POLLOUT)
-            HANDLE_HDR(hdl)->flags |= WRITABLE(j);
-        if (fds[i].revents & (POLLHUP|POLLERR))
-            HANDLE_HDR(hdl)->flags |= ERROR(j);
+        for (int j = 0; j < MAX_FDS; j++) {
+            if (!(HANDLE_HDR(polled_hdl)->flags & (RFD(j) | WFD(j))))
+                continue;
+            if (polled_hdl->generic.fds[j] != (PAL_IDX)fds[i].fd)
+                continue;
+
+            /* found internal FD of PAL handle that corresponds to the FD of event-ready fds[i] */
+            if (fds[i].revents & POLLOUT)
+                HANDLE_HDR(polled_hdl)->flags |= WRITABLE(j);
+            if (fds[i].revents & (POLLHUP|POLLERR))
+                HANDLE_HDR(polled_hdl)->flags |= ERROR(j);
+            /* TODO: Why is there no READABLE flag? Are FDs always assumed to be readable? */
+        }
     }
 
     *polled = polled_hdl;

--- a/Pal/src/host/Linux/db_object.c
+++ b/Pal/src/host/Linux/db_object.c
@@ -17,7 +17,7 @@
 /*
  * db_object.c
  *
- * This file contains APIs for waiting on PAL handles (polling): DkObjectsWaitAny.
+ * This file contains APIs for waiting on PAL handles (polling).
  */
 
 #include "api.h"
@@ -34,48 +34,51 @@
 #include <linux/time.h>
 #include <linux/wait.h>
 
-/* Wait for an event on any handle in the handle array and return this handle in polled.
- * If no ready-event handle was found, polled is set to NULL. */
-int _DkObjectsWaitAny(int count, PAL_HANDLE* handleArray, int64_t timeout_us,
+/* Wait for an event on any handle in the handle array and return this handle in `polled`.
+ * If no ready-event handle was found, `polled` is set to NULL. */
+int _DkObjectsWaitAny(size_t count, PAL_HANDLE* handle_array, int64_t timeout_us,
                       PAL_HANDLE* polled) {
-    if (count <= 0)
+    int ret;
+
+    if (count == 0)
         return 0;
 
-    if (count == 1 && handleArray[0]) {
+    if (count == 1 && handle_array[0] &&
+        (IS_HANDLE_TYPE(handle_array[0], mutex) || IS_HANDLE_TYPE(handle_array[0], event))) {
         /* Special case of DkObjectsWaitAny(1, mutex/event, ...): perform a mutex-specific or
          * event-specific wait() callback instead of host-OS poll. */
-        if (IS_HANDLE_TYPE(handleArray[0], mutex) || IS_HANDLE_TYPE(handleArray[0], event)) {
-            const struct handle_ops* ops = HANDLE_OPS(handleArray[0]);
-            assert(ops && ops->wait);
+        const struct handle_ops* ops = HANDLE_OPS(handle_array[0]);
+        assert(ops && ops->wait);
 
-            int rv = ops->wait(handleArray[0], timeout_us);
-            if (rv == 0)
-                *polled = handleArray[0];
-            return rv;
-        }
+        int rv = ops->wait(handle_array[0], timeout_us);
+        if (!rv)
+            *polled = handle_array[0];
+        return rv;
     }
 
     /* Normal case of not mutex/event: poll on all handles in the array (their handle types can be
-     * process, socket, pipe, device, file, eventfd). */
-    struct pollfd fds[count]; /* TODO: if count is too big, stack overflow may occur */
-    PAL_HANDLE hdls[count];   /* TODO: if count is too big, stack overflow may occur */
-    int nfds = 0;
+     * process, socket, pipe, device, file, eventfd). Note that this function is used only for
+     * Graphene-internal purposes, so we can allocate arrays on stack (since they are small). */
+    struct pollfd fds[count * MAX_FDS];
+    PAL_HANDLE hdls[count * MAX_FDS];
 
     /* collect all FDs of all PAL handles that may report read/write events */
-    for (int i = 0; i < count; i++) {
-        PAL_HANDLE hdl = handleArray[i];
+    size_t nfds = 0;
+    for (size_t i = 0; i < count; i++) {
+        PAL_HANDLE hdl = handle_array[i];
         if (!hdl)
             continue;
 
         /* ignore duplicate handles */
-        for (int j = 0; j < i; j++)
-            if (hdl == handleArray[j])
+        for (size_t j = 0; j < i; j++)
+            if (hdl == handle_array[j])
                 continue;
 
         /* collect all internal-handle FDs (only those which are readable/writable) */
-        for (int j = 0; j < MAX_FDS; j++) {
+        for (size_t j = 0; j < MAX_FDS; j++) {
             PAL_FLG flags = HANDLE_HDR(hdl)->flags;
 
+            /* hdl might be a mutex/event/non-pollable object, simply ignore it */
             if (hdl->generic.fds[j] == PAL_IDX_POISON)
                 continue;
             if (flags & ERROR(j))
@@ -89,7 +92,7 @@ int _DkObjectsWaitAny(int count, PAL_HANDLE* handleArray, int64_t timeout_us,
 
             if (events) {
                 fds[nfds].fd      = hdl->generic.fds[j];
-                fds[nfds].events  = events | POLLHUP | POLLERR;
+                fds[nfds].events  = events;
                 fds[nfds].revents = 0;
                 hdls[nfds]        = hdl;
                 nfds++;
@@ -98,53 +101,58 @@ int _DkObjectsWaitAny(int count, PAL_HANDLE* handleArray, int64_t timeout_us,
     }
 
     if (!nfds) {
-        /* did not find any wait-able FDs (probably because their events were already cached) */
-        return -PAL_ERROR_TRYAGAIN;
+        /* did not find any waitable FDs (probably because their events were already cached) */
+        ret = -PAL_ERROR_TRYAGAIN;
+        goto out;
     }
 
     struct timespec timeout_ts;
 
     if (timeout_us >= 0) {
         int64_t sec = timeout_us / 1000000;
-        int64_t microsec = timeout_us - (sec * 1000000);
+        int64_t microsec = timeout_us - sec * 1000000;
         timeout_ts.tv_sec = sec;
         timeout_ts.tv_nsec = microsec * 1000;
     }
 
-    int ret = INLINE_SYSCALL(ppoll, 5, fds, nfds, timeout_us >= 0 ? &timeout_ts : NULL, NULL, 0);
+    ret = INLINE_SYSCALL(ppoll, 5, fds, nfds, timeout_us >= 0 ? &timeout_ts : NULL, NULL, 0);
 
-    if (IS_ERR(ret))
+    if (IS_ERR(ret)) {
         switch (ERRNO(ret)) {
             case EINTR:
             case ERESTART:
-                return -PAL_ERROR_INTERRUPTED;
+                ret = -PAL_ERROR_INTERRUPTED;
+                break;
             default:
-                return unix_to_pal_error(ERRNO(ret));
+                ret = unix_to_pal_error(ERRNO(ret));
+                break;
         }
+        goto out;
+    }
 
     if (!ret) {
         /* timed out */
-        return -PAL_ERROR_TRYAGAIN;
+        ret = -PAL_ERROR_TRYAGAIN;
+        goto out;
     }
 
     PAL_HANDLE polled_hdl = NULL;
 
-    for (int i = 0; i < nfds; i++) {
+    for (size_t i = 0; i < nfds; i++) {
         if (!fds[i].revents)
             continue;
 
-        /* One PAL handle can have MAX_FDS internal FDs, so we must select one handle (randomly)
+        /* One PAL handle can have MAX_FDS internal FDs, so we must select one handle (first found)
          * from the ones on which the host reported events and then collect all revents on this
-         * handle's internal FDs.
-         * TODO: This is very inefficient. Each DkObjectsWaitAny() returns only one of possibly
-         *       many event-ready PAL handles. We must introduce new DkObjectsWaitEvents(). */
+         * handle's internal FDs. Note that this is very inefficient. Each DkObjectsWaitAny()
+         * returns only one of possibly many event-ready PAL handles. */
         if (!polled_hdl)
             polled_hdl = hdls[i];
 
         if (polled_hdl != hdls[i])
             continue;
 
-        for (int j = 0; j < MAX_FDS; j++) {
+        for (size_t j = 0; j < MAX_FDS; j++) {
             if (!(HANDLE_HDR(polled_hdl)->flags & (RFD(j) | WFD(j))))
                 continue;
             if (polled_hdl->generic.fds[j] != (PAL_IDX)fds[i].fd)
@@ -155,10 +163,122 @@ int _DkObjectsWaitAny(int count, PAL_HANDLE* handleArray, int64_t timeout_us,
                 HANDLE_HDR(polled_hdl)->flags |= WRITABLE(j);
             if (fds[i].revents & (POLLHUP|POLLERR))
                 HANDLE_HDR(polled_hdl)->flags |= ERROR(j);
-            /* TODO: Why is there no READABLE flag? Are FDs always assumed to be readable? */
         }
     }
 
     *polled = polled_hdl;
-    return polled_hdl ? 0 : -PAL_ERROR_TRYAGAIN;
+    ret = polled_hdl ? 0 : -PAL_ERROR_TRYAGAIN;
+out:
+    return ret;
+}
+
+
+/* Improved version of _DkObjectsWaitAny(): wait for specific events on all handles in the handle
+ * array and return multiple events (including errors) reported by the host. Returns 0 on success,
+ * PAL error on failure. */
+int _DkObjectsWaitEvents(size_t count, PAL_HANDLE* handle_array, PAL_FLG* events, PAL_FLG* ret_events,
+                         int64_t timeout_us) {
+    int ret;
+
+    if (count == 0)
+        return 0;
+
+    struct pollfd* fds = malloc(count * MAX_FDS * sizeof(*fds));
+    if (!fds) {
+        return -PAL_ERROR_NOMEM;
+    }
+
+    size_t* offsets = malloc(count * MAX_FDS * sizeof(*offsets));
+    if (!offsets) {
+        free(fds);
+        return -PAL_ERROR_NOMEM;
+    }
+
+    /* collect all FDs of all PAL handles that may report read/write events */
+    size_t nfds = 0;
+    for (size_t i = 0; i < count; i++) {
+        ret_events[i] = 0;
+
+        PAL_HANDLE hdl = handle_array[i];
+        if (!hdl)
+            continue;
+
+        /* collect all internal-handle FDs (only those which are readable/writable) */
+        for (size_t j = 0; j < MAX_FDS; j++) {
+            PAL_FLG flags = HANDLE_HDR(hdl)->flags;
+
+            /* hdl might be a mutex/event/non-pollable object, simply ignore it */
+            if (hdl->generic.fds[j] == PAL_IDX_POISON)
+                continue;
+            if (flags & ERROR(j))
+                continue;
+
+            int fdevents = 0;
+            fdevents |= ((flags & RFD(j)) && (events[i] & PAL_WAIT_READ)) ? POLLIN : 0;
+            fdevents |= ((flags & WFD(j)) && (events[i] & PAL_WAIT_WRITE)) ? POLLOUT : 0;
+
+            if (fdevents) {
+                fds[nfds].fd      = hdl->generic.fds[j];
+                fds[nfds].events  = fdevents;
+                fds[nfds].revents = 0;
+                offsets[nfds]     = i;
+                nfds++;
+            }
+        }
+    }
+
+    if (!nfds) {
+        /* did not find any waitable FDs (LibOS supplied closed/errored FDs or empty events) */
+        ret = -PAL_ERROR_TRYAGAIN;
+        goto out;
+    }
+
+    struct timespec timeout_ts;
+
+    if (timeout_us >= 0) {
+        int64_t sec = timeout_us / 1000000;
+        int64_t microsec = timeout_us - sec * 1000000;
+        timeout_ts.tv_sec = sec;
+        timeout_ts.tv_nsec = microsec * 1000;
+    }
+
+    ret = INLINE_SYSCALL(ppoll, 5, fds, nfds, timeout_us >= 0 ? &timeout_ts : NULL, NULL, 0);
+
+    if (IS_ERR(ret)) {
+        switch (ERRNO(ret)) {
+            case EINTR:
+            case ERESTART:
+                ret = -PAL_ERROR_INTERRUPTED;
+                break;
+            default:
+                ret = unix_to_pal_error(ERRNO(ret));
+                break;
+        }
+        goto out;
+    }
+
+    if (!ret) {
+        /* timed out */
+        ret = -PAL_ERROR_TRYAGAIN;
+        goto out;
+    }
+
+    for (size_t i = 0; i < nfds; i++) {
+        if (!fds[i].revents)
+            continue;
+
+        size_t j = offsets[i];
+        if (fds[i].revents & POLLIN)
+            ret_events[j] |= PAL_WAIT_READ;
+        if (fds[i].revents & POLLOUT)
+            ret_events[j] |= PAL_WAIT_WRITE;
+        if (fds[i].revents & (POLLHUP|POLLERR|POLLNVAL))
+            ret_events[j] |= PAL_WAIT_ERROR;
+    }
+
+    ret = 0;
+out:
+    free(fds);
+    free(offsets);
+    return ret;
 }

--- a/Pal/src/host/Linux/db_pipes.c
+++ b/Pal/src/host/Linux/db_pipes.c
@@ -357,10 +357,6 @@ static int pipe_attrquerybyhdl(PAL_HANDLE handle, PAL_STREAM_ATTR* attr) {
         attr->writable     = HANDLE_HDR(handle)->flags &
                                  (IS_HANDLE_TYPE(handle, pipeprv) ? WRITABLE(1) : WRITABLE(0));
     } else {
-        struct pollfd pfd  = {.fd = handle->generic.fds[0], .events = POLLIN, .revents = 0};
-        struct timespec tp = {0, 0};
-        ret                = INLINE_SYSCALL(ppoll, 5, &pfd, 1, &tp, NULL, 0);
-        attr->readable     = (ret == 1 && pfd.revents == POLLIN);
         attr->pending_size = 0;
         attr->writable     = PAL_FALSE;
     }

--- a/Pal/src/host/Skeleton/db_object.c
+++ b/Pal/src/host/Skeleton/db_object.c
@@ -29,6 +29,13 @@
 
 /* _DkObjectsWaitAny for internal use. The function wait for any of the handle
    in the handle array. timeout can be set for the wait. */
-int _DkObjectsWaitAny(int count, PAL_HANDLE* handleArray, int64_t timeout_us, PAL_HANDLE* polled) {
+int _DkObjectsWaitAny(size_t count, PAL_HANDLE* handle_array, int64_t timeout_us, PAL_HANDLE* polled) {
+    return -PAL_ERROR_NOTIMPLEMENTED;
+}
+
+/* Improved version of _DkObjectsWaitAny(): wait for specific events on all handles in the handle
+ * array and return multiple events (including errors) reported by the host. */
+int _DkObjectsWaitEvents(size_t count, PAL_HANDLE* handle_array, PAL_FLG* events, PAL_FLG* ret_events,
+                         int64_t timeout_us) {
     return -PAL_ERROR_NOTIMPLEMENTED;
 }

--- a/Pal/src/pal-symbols
+++ b/Pal/src/pal-symbols
@@ -13,6 +13,7 @@ DkMutexRelease
 DkEventSet
 DkEventClear
 DkObjectsWaitAny
+DkObjectsWaitEvents
 DkStreamOpen
 DkStreamRead
 DkStreamWrite

--- a/Pal/src/pal.h
+++ b/Pal/src/pal.h
@@ -491,7 +491,15 @@ DkEventClear (PAL_HANDLE eventHandle);
 
 /* Returns: NULL if the call times out, the ready handle on success */
 PAL_HANDLE
-DkObjectsWaitAny (PAL_NUM count, PAL_HANDLE * handleArray, PAL_NUM timeout_us);
+DkObjectsWaitAny (PAL_NUM count, PAL_HANDLE* handle_array, PAL_NUM timeout_us);
+
+#define PAL_WAIT_SIGNAL     1   /* ignored in events */
+#define PAL_WAIT_READ       2
+#define PAL_WAIT_WRITE      4
+#define PAL_WAIT_ERROR      8   /* ignored in events */
+
+PAL_BOL DkObjectsWaitEvents(PAL_NUM count, PAL_HANDLE* handle_array, PAL_FLG* events,
+                            PAL_FLG* ret_events, PAL_NUM timeout_us);
 
 /* Deprecate DkObjectReference */
 

--- a/Pal/src/pal_internal.h
+++ b/Pal/src/pal_internal.h
@@ -325,7 +325,9 @@ int _DkVirtualMemoryProtect (void * addr, uint64_t size, int prot);
 /* DkObject calls */
 int _DkObjectReference (PAL_HANDLE objectHandle);
 int _DkObjectClose (PAL_HANDLE objectHandle);
-int _DkObjectsWaitAny(int count, PAL_HANDLE* handleArray, int64_t timeout_us, PAL_HANDLE* polled);
+int _DkObjectsWaitAny(size_t count, PAL_HANDLE* handle_array, int64_t timeout_us, PAL_HANDLE* polled);
+int _DkObjectsWaitEvents(size_t count, PAL_HANDLE* handle_array, PAL_FLG* events, PAL_FLG* ret_events,
+                         int64_t timeout_us);
 
 /* DkException calls & structures */
 PAL_EVENT_HANDLER _DkGetExceptionHandler (PAL_NUM event_num);


### PR DESCRIPTION
## Affected components

- [ ] README and global configuration
- [x] Linux PAL
- [x] SGX PAL
- [ ] FreeBSD PAL
- [x] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->

- [Pal/{Linux,Linux-SGX}] Cleanup of db_object.c:
    - Remove _DkObjectWaitOne() and incorporate its special-case of
      waiting on single mutex/event in _DkObjectsWaitAny().
    - Refactor _DkObjectsWaitAny() for readability.
    - Remove unused DEFAULT_QUANTUM and TRACE_HEAP_LEAK.

- [LibOS] Comprehensive cleanup of poll()/ppoll()/select()/pselect()

- [LibOS] Comprehensive cleanup of epoll_create()/epoll_ctl()/epoll_wait()

- [Pal/Linux-SGX] db_pipes.c: fix segfault due to redundant deletion of pipe

- [LibOS, Pal/{Linux,Linux-SGX}] Better emulation of polling; improves the emulation of polling mechanisms (select, pselect, poll, ppoll, epoll_wait) and cleans up the corresponding code:
    - New DkObjectsWaitEvents() PAL interface, replaces the inefficient DkObjectsWaitAny() interface. This interface closely resembles Linux/POSIX poll() in semantics.
    - Improved shim_do_epoll_wait() implementation, now using the new DkObjectsWaitEvents() interface.
    - Improved shim_do_poll() implementation, now using the new DkObjectsWaitEvents() interface.

This PR is based on #960 but additionally cleans up all the old (and badly written) code.

See issue #1117 for more details and performance numbers.

Closes #960. Closes #1117. Closes #229. Closes #228.  Closes #434.

## How to test this PR? <!-- (if applicable) -->

All tests must pass. Plus I tested with Redis (in two versions: select and epoll).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1128)
<!-- Reviewable:end -->
