### PR TITLE
[Pal/Linux-SGX]: use distclean for sgx-driver

### DIFF
--- a/Jenkinsfiles/Linux-SGX
+++ b/Jenkinsfiles/Linux-SGX
@@ -111,7 +111,7 @@ pipeline {
                            cd "$(./Scripts/clean-check-test-copy)"
 
                            rm Pal/src/host/Linux-SGX/signer/enclave-key.pem
-                           make -C Pal/src/host/Linux-SGX/sgx-driver clean
+                           make -C Pal/src/host/Linux-SGX/sgx-driver distclean
                            make SGX=1 clean
                            rm LibOS/glibc-*.tar.gz
                            make -C LibOS/shim/test/regression SGX=1 clean


### PR DESCRIPTION
This patch corresponds to
https://github.com/oscarlab/graphene-sgx-driver/pull/10
Once graphene-sgx-driver/pull/10 is merged, workaround to avoid error by distclean
should be removed.

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [x] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->


## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1132)
<!-- Reviewable:end -->
