### PR TITLE
remove shim tcb embedded in glibc tcb

### DIFF
--- a/LibOS/glibc-patches/glibc-2.19.patch
+++ b/LibOS/glibc-patches/glibc-2.19.patch
@@ -653,26 +653,14 @@ diff --git a/nptl/sysdeps/x86_64/tls.h b/nptl/sysdeps/x86_64/tls.h
 index cbb5e9e..9b87e25 100644
 --- a/nptl/sysdeps/x86_64/tls.h
 +++ b/nptl/sysdeps/x86_64/tls.h
-@@ -28,6 +28,8 @@
+@@ -28,6 +28,7 @@
  # include <sysdep.h>
  # include <libc-internal.h>
  # include <kernel-features.h>
-+# include <shim_tls.h>
 +# include <syscalldb.h>
  
  /* Replacement type for __m128 since this file is included by ld.so,
     which is compiled with -mno-sse.  It must not change the alignment
-@@ -67,6 +69,10 @@ typedef struct
- # else
-   int __glibc_reserved1;
- # endif
-+
-+  shim_tcb_t shim_tcb;	/* For graphene, we allocate a shim_tcb
-+			   in the real tcb. */
-+
-   int rtld_must_xmm_save;
-   /* Reservation of some values for the TM ABI.  */
-   void *__private_tm[4];
 @@ -154,7 +159,7 @@ typedef struct
       _head->self = _thrdescr;						      \
  									      \

--- a/LibOS/glibc-patches/glibc-2.23.patch
+++ b/LibOS/glibc-patches/glibc-2.23.patch
@@ -602,26 +602,14 @@ diff -ruNp a/sysdeps/x86_64/dl-machine.h b/sysdeps/x86_64/dl-machine.h
 diff -ruNp a/sysdeps/x86_64/nptl/tls.h b/sysdeps/x86_64/nptl/tls.h
 --- a/sysdeps/x86_64/nptl/tls.h
 +++ b/sysdeps/x86_64/nptl/tls.h
-@@ -28,6 +28,8 @@
+@@ -28,6 +28,7 @@
  # include <sysdep.h>
  # include <libc-internal.h>
  # include <kernel-features.h>
-+# include <shim_tls.h>
 +# include <syscalldb.h>
  
  /* Replacement type for __m128 since this file is included by ld.so,
     which is compiled with -mno-sse.  It must not change the alignment
-@@ -67,6 +69,10 @@ typedef struct
- # else
-   int __glibc_reserved1;
- # endif
-+
-+  shim_tcb_t shim_tcb;	/* For graphene, we allocate a shim_tcb
-+			   in the real tcb. */
-+
-   int __glibc_unused1;
-   /* Reservation of some values for the TM ABI.  */
-   void *__private_tm[4];
 @@ -138,7 +144,6 @@ typedef struct
  # define GET_DTV(descr) \
    (((tcbhead_t *) (descr))->dtv)

--- a/LibOS/glibc-patches/glibc-2.27.patch
+++ b/LibOS/glibc-patches/glibc-2.27.patch
@@ -458,26 +458,14 @@ diff -ruNp a/sysdeps/x86_64/dl-machine.h b/sysdeps/x86_64/dl-machine.h
 diff -ruNp a/sysdeps/x86_64/nptl/tls.h b/sysdeps/x86_64/nptl/tls.h
 --- a/sysdeps/x86_64/nptl/tls.h
 +++ b/sysdeps/x86_64/nptl/tls.h
-@@ -29,6 +29,8 @@
+@@ -29,6 +29,7 @@
  # include <libc-pointer-arith.h> /* For cast_to_integer.  */
  # include <kernel-features.h>
  # include <dl-dtv.h>
-+# include <shim_tls.h>
 +# include <syscalldb.h>
  
  /* Replacement type for __m128 since this file is included by ld.so,
     which is compiled with -mno-sse.  It must not change the alignment
-@@ -56,6 +58,10 @@ typedef struct
- # else
-   int __glibc_reserved1;
- # endif
-+
-+  shim_tcb_t shim_tcb;	/* For graphene, we allocate a shim_tcb
-+			   in the real tcb. */
-+
-   int __glibc_unused1;
-   /* Reservation of some values for the TM ABI.  */
-   void *__private_tm[4];
 @@ -144,7 +149,7 @@ typedef struct
       _head->self = _thrdescr;						      \
  									      \


### PR DESCRIPTION
<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

[LibOS/glibc] remove struct shim_tcb embedded in glibc tcb
    
By https://github.com/oscarlab/graphene/pull/556, struct shim_tcb
embedded in glibc tcb isn't needed any more. Remove it from glibc patches.

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->


## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1135)
<!-- Reviewable:end -->
