### PR TITLE
[LibOS] shim_ipc_helper.c: Actually wait for 0.5 seconds on IPC exit

### DIFF
--- a/LibOS/shim/src/ipc/shim_ipc_helper.c
+++ b/LibOS/shim/src/ipc/shim_ipc_helper.c
@@ -869,7 +869,7 @@ struct shim_thread* terminate_ipc_helper(void) {
      * prevent such cases, we simply wait for a bit before exiting.
      * */
     debug("Waiting for 0.5s for all in-flight IPC messages to reach their destinations\n");
-    DkThreadDelayExecution(500);
+    DkThreadDelayExecution(500000);  /* in microseconds */
 
     lock(&ipc_helper_lock);
     if (ipc_helper_state != HELPER_ALIVE) {


### PR DESCRIPTION
## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->

Before exiting, the IPC helper is supposed to wait for 0.5s for all in-flight IPC messages to reach their destinations (e.g., child processes). Otherwise, the destination processes may become abandoned zombies. Previously, this was achieved by `DkThreadDelayExecution(500)`. However, this function uses
microseconds not milliseconds, thus, Graphene actually waited only for 0.005 seconds (which is not enough under heavy system-wide load). This commit fixes this time-unit bug.

## How to test this PR? <!-- (if applicable) -->

This bug was found while debugging non-deterministic failures of several LTP tests (`recvmsg01`, `recvfrom01`, `waitpid03`, etc) on Jenkins-18.04/Jenkins-Debug-18.04 pipelines. Hopefully this pipelines won't fail so often now.

I will try ~10-20 retests on Jenkins and see how it goes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1136)
<!-- Reviewable:end -->
