### PR TITLE
[PAL/Linux-SGX] Add exitless system calls (new version)

### DIFF
--- a/Documentation/manifest-syntax.rst
+++ b/Documentation/manifest-syntax.rst
@@ -179,6 +179,35 @@ of thread slots). The application cannot have more threads than this limit *at
 a time* (however, it is possible to create new threads after old threads are
 destroyed).
 
+Number of RPC Threads (Exitless Feature)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+::
+
+    sgx.rpc_thread_num=[NUM]
+    (Default: 0)
+
+This syntax specifies the number of RPC threads that are created outside of
+the enclave. RPC threads are helper threads that run in untrusted mode
+alongside enclave threads. RPC threads issue system calls on behalf of enclave
+threads. This allows "exitless" design when application threads never leave
+the enclave (except for a few syscalls where there is no benefit, e.g.,
+``nanosleep()``).
+
+If user specifies ``0`` or omits this directive, then no RPC threads are
+created and all system calls perform an enclave exit ("normal" execution).
+
+Note that the number of created RPC threads must match the maximum number of
+simultaneous enclave threads. If there are more RPC threads, then CPU time is
+wasted. If there are less RPC threads, some enclave threads may starve,
+especially if there are many blocking system calls by other enclave threads.
+
+The Exitless feature *may be detrimental for performance*. It trades slow
+OCALLs/ECALLs for fast shared-memory communication at the cost of occupying
+more CPU cores and burning more CPU cycles. For example, a single-threaded
+Redis instance on Linux becomes 5-threaded on Graphene with Exitless. Thus,
+Exitless may negatively impact throughput but may improve latency.
+
 Debug/Production Enclave
 ^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/LibOS/shim/test/regression/Makefile
+++ b/LibOS/shim/test/regression/Makefile
@@ -75,6 +75,7 @@ manifests = \
 	large-mmap.manifest \
 	mmap-file.manifest \
 	multi_pthread.manifest \
+	multi_pthread_exitless.manifest \
 	openmp.manifest \
 	proc-path.manifest \
 	shared_object.manifest
@@ -83,7 +84,8 @@ exec_target = \
 	$(c_executables) \
 	$(cxx_executables) \
 	file_check_policy_strict.manifest \
-	file_check_policy_allow_all_but_log.manifest
+	file_check_policy_allow_all_but_log.manifest \
+	multi_pthread_exitless.manifest
 
 target = \
 	$(exec_target) \

--- a/LibOS/shim/test/regression/multi_pthread_exitless.manifest.template
+++ b/LibOS/shim/test/regression/multi_pthread_exitless.manifest.template
@@ -1,0 +1,19 @@
+loader.exec = file:multi_pthread
+loader.execname = multi_pthread
+
+loader.preload = file:../../src/libsysdb.so
+loader.env.LD_LIBRARY_PATH = /lib
+loader.debug_type = none
+loader.syscall_symbol = syscalldb
+
+fs.mount.lib.type = chroot
+fs.mount.lib.path = /lib
+fs.mount.lib.uri = file:../../../../Runtime
+
+sgx.trusted_files.ld = file:../../../../Runtime/ld-linux-x86-64.so.2
+sgx.trusted_files.libc = file:../../../../Runtime/libc.so.6
+sgx.trusted_files.libpthread = file:../../../../Runtime/libpthread.so.0
+
+# app runs with 4 parallel threads + Graphene has couple internal threads
+sgx.thread_num = 8
+sgx.rpc_thread_num = 8

--- a/LibOS/shim/test/regression/test_libos.py
+++ b/LibOS/shim/test/regression/test_libos.py
@@ -86,14 +86,14 @@ class TC_01_Bootstrap(RegressionTestCase):
         self.assertIn('hello from execv process', stdout)
 
     def test_202_fork_and_exec(self):
-        stdout, _ = self.run_binary(['fork_and_exec'])
+        stdout, _ = self.run_binary(['fork_and_exec'], timeout=60)
 
         # fork and exec 2 page child binary
         self.assertIn('child exited with status: 0', stdout)
         self.assertIn('test completed successfully', stdout)
 
     def test_203_vfork_and_exec(self):
-        stdout, _ = self.run_binary(['vfork_and_exec'])
+        stdout, _ = self.run_binary(['vfork_and_exec'], timeout=60)
 
         # vfork and exec 2 page child binary
         self.assertIn('child exited with status: 0', stdout)

--- a/LibOS/shim/test/regression/test_libos.py
+++ b/LibOS/shim/test/regression/test_libos.py
@@ -155,6 +155,14 @@ class TC_01_Bootstrap(RegressionTestCase):
         # Multiple thread creation
         self.assertIn('128 Threads Created', stdout)
 
+    @unittest.skipUnless(HAS_SGX, 'This test is only meaningful on SGX PAL')
+    def test_601_multi_pthread_exitless(self):
+        manifest = self.get_manifest('multi_pthread_exitless')
+        stdout, _ = self.run_binary([manifest], timeout=60)
+
+        # Multiple thread creation
+        self.assertIn('128 Threads Created', stdout)
+
 @unittest.skipUnless(HAS_SGX,
     'This test is only meaningful on SGX PAL because only SGX catches raw '
     'syscalls and redirects to Graphene\'s LibOS. If we will add seccomp to '

--- a/Pal/regression/Makefile
+++ b/Pal/regression/Makefile
@@ -51,6 +51,7 @@ manifests = \
 	Process3.manifest \
 	SendHandle.manifest \
 	Thread2.manifest \
+	Thread2_exitless.manifest \
 	nonelf_binary.manifest
 
 target = $(executables) $(manifests)

--- a/Pal/regression/Thread2_exitless.manifest.template
+++ b/Pal/regression/Thread2_exitless.manifest.template
@@ -1,0 +1,5 @@
+loader.exec = file:Thread2
+loader.execname = Thread2
+
+sgx.thread_num = 2
+sgx.rpc_thread_num = 2

--- a/Pal/regression/test_pal.py
+++ b/Pal/regression/test_pal.py
@@ -512,7 +512,7 @@ class TC_20_SingleProcess(RegressionTestCase):
 
 class TC_21_ProcessCreation(RegressionTestCase):
     def test_100_process(self):
-        _, stderr = self.run_binary(['Process'], timeout=8)
+        _, stderr = self.run_binary(['Process'], timeout=60)
         counter = collections.Counter(stderr.split('\n'))
         # Process Creation
         self.assertEqual(counter['Child Process Created'], 3)

--- a/Pal/regression/test_pal.py
+++ b/Pal/regression/test_pal.py
@@ -490,6 +490,21 @@ class TC_20_SingleProcess(RegressionTestCase):
         # Thread Cleanup: Can still start threads.
         self.assertIn('Thread 4 ok.', stderr)
 
+    @unittest.skipUnless(HAS_SGX, 'This test is only meaningful on SGX PAL')
+    def test_511_thread2_exitless(self):
+        manifest = self.get_manifest('Thread2_exitless')
+        _, stderr = self.run_binary([manifest], timeout=60)
+
+        # Thread Cleanup: Exit by return.
+        self.assertIn('Thread 2 ok.', stderr)
+
+        # Thread Cleanup: Exit by DkThreadExit.
+        self.assertIn('Thread 3 ok.', stderr)
+        self.assertNotIn('Exiting thread 3 failed.', stderr)
+
+        # Thread Cleanup: Can still start threads.
+        self.assertIn('Thread 4 ok.', stderr)
+
     def test_900_misc(self):
         _, stderr = self.run_binary(['Misc'])
         # Query System Time

--- a/Pal/src/host/Linux-SGX/ecall_types.h
+++ b/Pal/src/host/Linux-SGX/ecall_types.h
@@ -8,11 +8,13 @@ enum {
 };
 
 struct pal_sec;
+struct rpc_queue;
 
 typedef struct {
-    char * ms_args;
-    size_t ms_args_size;
-    char * ms_env;
-    size_t ms_env_size;
-    struct pal_sec * ms_sec_info;
+    char*             ms_args;
+    size_t            ms_args_size;
+    char*             ms_env;
+    size_t            ms_env_size;
+    struct pal_sec*   ms_sec_info;
+    struct rpc_queue* rpc_queue; /* pointer to RPC queue in untrusted mem */
 } ms_ecall_enclave_start_t;

--- a/Pal/src/host/Linux-SGX/enclave_framework.c
+++ b/Pal/src/host/Linux-SGX/enclave_framework.c
@@ -48,14 +48,19 @@ void* sgx_prepare_ustack(void) {
     return old_ustack;
 }
 
-void* sgx_alloc_on_ustack(uint64_t size) {
+void* sgx_alloc_on_ustack_aligned(uint64_t size, size_t alignment) {
+    assert(IS_POWER_OF_2(alignment));
     void* ustack = GET_ENCLAVE_TLS(ustack) - size;
-    ustack = ALIGN_DOWN_PTR(ustack, 16);
+    ustack = ALIGN_DOWN_PTR_POW2(ustack, alignment);
     if (!sgx_is_completely_outside_enclave(ustack, size)) {
         return NULL;
     }
     SET_ENCLAVE_TLS(ustack, ustack);
     return ustack;
+}
+
+void* sgx_alloc_on_ustack(uint64_t size) {
+    return sgx_alloc_on_ustack_aligned(size, 1);
 }
 
 void* sgx_copy_to_ustack(const void* ptr, uint64_t size) {

--- a/Pal/src/host/Linux-SGX/pal_linux_defs.h
+++ b/Pal/src/host/Linux-SGX/pal_linux_defs.h
@@ -3,6 +3,7 @@
 
 #define THREAD_STACK_SIZE (PRESET_PAGESIZE * 512)  /* 2MB untrusted stack */
 #define ALT_STACK_SIZE    PRESET_PAGESIZE
+#define RPC_STACK_SIZE    (PRESET_PAGESIZE * 2)
 
 #define ENCLAVE_HIGH_ADDRESS    0x800000000
 #define SSAFRAMENUM         2

--- a/Pal/src/host/Linux-SGX/rpc_queue.h
+++ b/Pal/src/host/Linux-SGX/rpc_queue.h
@@ -1,0 +1,151 @@
+/*
+ * RPC threads are helper threads that run in untrusted mode alongside enclave threads. RPC threads
+ * issue system calls on behalf of enclave threads. This allows "exitless" design when app threads
+ * never leave the enclave (except for a few syscalls where there is no benefit, e.g., nanosleep).
+ *
+ * "Exitless" design alleviates expensive OCALLs/ECALLs. This was first proposed by SCONE (by
+ * Arnautov et al at OSDI 2016) and by Eleos (by Orenbach et al at EuroSys 2017).
+ *
+ * Brief description: user must specify "sgx.rpc_thread_num = 2" in manifest to create two RPC
+ * threads. If user specifies "0" or omits this directive, then no RPC threads are created and all
+ * syscalls perform an enclave exit (as in previous versions of Graphene).
+ *
+ * All enclave and RPC threads work on a single shared RPC queue (global variable `g_rpc_queue`).
+ * To issue a syscall, enclave thread enqueues syscall request in the queue and spins waiting for
+ * result. RPC threads spin waiting for syscall requests; when request comes, first lucky RPC
+ * thread grabs request, issues syscall to OS, and notifies enclave thread by releasing the request
+ * lock. RPC queue is implemented as a FIFO ring buffer with one global lock.
+ *
+ * The RPC queue with its ring buffer resides in *untrusted memory*. The enclave code accessing the
+ * RPC queue must be carefully written to withstand attacks tampering with the queue.
+ *
+ * RPC queue can have up to RPC_QUEUE_SIZE requests simultaneously. All requests are allocated on
+ * the untrusted stack of the enclave thread; enclave thread owns its requests and pops them off
+ * stack when done with the system call. After enqueuing the request, enclave thread first spins
+ * for some time in hope the system call returns immediately (fast path), then sleeps waiting on
+ * futex (slow path, useful for blocking syscalls).
+ *
+ * NOTE: number of created RPC threads must match max number of simultaneous enclave threads. If
+ * there are more RPC threads, CPU time is wasted. If there are less, some enclave threads may
+ * starve, especially if there are many blocking syscalls by other enclave threads.
+ *
+ * NOTE: The Exitless feature trades slow OCALLs/ECALLs for fast RPC-queue communication at the
+ * cost of occupying more CPU cores and burning more CPU cycles. For example, a single-threaded
+ * Redis instance on Linux becomes 5-threaded on Graphene-SGX. Therefore, Exitless may negatively
+ * impact throughput but may improve latency. Only a subset of applications may benefit from
+ * Exitless, in particular, single-threaded latency-sensitive apps that cannot be parallelized.
+ *
+ * Prototype code was written by Meni Orenbach and adapted to Graphene by Dmitrii Kuvaiskii.
+ */
+#ifndef QUEUE_H_
+#define QUEUE_H_
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "spinlock.h"
+
+/* Number of iterations to spin before sleeping. We choose 1M as follows: we want to sleep on
+ * blocking syscalls but we want to allow ample time for fast syscalls to complete. We choose
+ * 1 millisecond -- more than enough time to complete any non-blocking syscall. Assuming a 1GHz
+ * CPU and no pipelining (and ignoring the pause instruction), 1 millisecond is 1M cycles. This
+ * works well in practice. */
+#define RPC_SPINLOCK_TIMEOUT 1000000
+
+#define RPC_QUEUE_SIZE  1024        /* max # of requests in RPC queue */
+#define MAX_RPC_THREADS 256         /* max number of RPC threads */
+
+typedef struct {
+    spinlock_t lock;  /* can be UNLOCKED / LOCKED_NO_WAITERS / LOCKED_WITH_WAITERS */
+    long result;
+    uint64_t ocall_index;
+    void* buffer;
+} rpc_request_t;
+
+typedef struct rpc_queue {
+    spinlock_t lock;                  /* global lock for enclave and RPC threads */
+    uint64_t front, rear;             /* indexes into front and rear ends of q */
+    rpc_request_t* q[RPC_QUEUE_SIZE]; /* queue of syscall requests */
+    int rpc_threads[MAX_RPC_THREADS]; /* RPC threads (thread IDs) */
+    size_t rpc_threads_cnt;           /* number of RPC threads */
+} rpc_queue_t;
+
+extern rpc_queue_t* g_rpc_queue;  /* global RPC queue */
+
+static inline void rpc_queue_init(rpc_queue_t* q) {
+    spinlock_init(&q->lock);
+    q->front = 0;
+    q->rear  = 0;
+    for (size_t i = 0; i < RPC_QUEUE_SIZE; i++)
+        q->q[i] = NULL;
+}
+
+/*!
+ * \brief Enqueue OCALL request `req` in the shared RPC queue `q`.
+ *
+ * This function is called from the enclave code and thus must be written carefully to withstand
+ * attacks tampering with untrusted `req` and untrusted `q`. In particular, `req` and `q` must not
+ * have arbitrary pointers (or alternatively the code below must sanitize possible pointer values)
+ * to prevent arbitrary writes to/reads from the enclave memory. Similarly, `q->q[idx]` code must
+ * ensure that `idx` points inside the `q->q` array to prevent buffer overflows.
+ */
+static inline bool rpc_enqueue(rpc_queue_t* q, rpc_request_t* req) {
+    bool ret = false;
+    spinlock_lock(&q->lock);
+
+    if (q->rear - q->front >= RPC_QUEUE_SIZE) {
+        /* queue is full, cannot enqueue */
+        goto out;
+    }
+
+    if (q->q[q->rear % RPC_QUEUE_SIZE]) {
+        /* current slot is occupied, cannot enqueue but the caller can try again */
+        q->rear++;
+        goto out;
+    }
+
+    q->q[q->rear % RPC_QUEUE_SIZE] = req;
+    q->rear++;
+    ret = true;
+out:
+    spinlock_unlock(&q->lock);
+    return ret;
+}
+
+/*!
+ * \brief Dequeue OCALL request `req` from the shared RPC queue `q`.
+ *
+ * This function is called only from the untrusted code and thus has no security implications.
+ */
+static inline rpc_request_t* rpc_dequeue(rpc_queue_t* q) {
+    if (__atomic_load_n(&q->front, __ATOMIC_RELAXED) == __atomic_load_n(&q->rear, __ATOMIC_RELAXED)) {
+        /* quick check that queue is empty; this doesn't acquire a spinlock and thus lowers latency
+         * on rpc_enqueue() performed by enclave threads (they don't have to wait for spinlock
+         * release); note that untrusted RPC threads will simply retry again if this check fails */
+        return NULL;
+    }
+
+    rpc_request_t* ret = NULL;
+    spinlock_lock(&q->lock);
+
+    if (q->front == q->rear) {
+        /* queue is empty, nothing to dequeue */
+        goto out;
+    }
+
+    if (!q->q[q->front % RPC_QUEUE_SIZE]) {
+        /* current slot is empty, cannot dequeue but the caller can try next one */
+        q->front++;
+        goto out;
+    }
+
+    ret = q->q[q->front % RPC_QUEUE_SIZE];
+    q->q[q->front % RPC_QUEUE_SIZE] = NULL;
+    q->front++;
+out:
+    spinlock_unlock(&q->lock);
+    return ret;
+}
+
+#endif /* QUEUE_H_ */

--- a/Pal/src/host/Linux-SGX/sgx_api.h
+++ b/Pal/src/host/Linux-SGX/sgx_api.h
@@ -26,6 +26,7 @@ bool sgx_is_completely_within_enclave(const void* addr, uint64_t size);
 bool sgx_is_completely_outside_enclave(const void* addr, uint64_t size);
 
 void* sgx_prepare_ustack(void);
+void* sgx_alloc_on_ustack_aligned(uint64_t size, size_t alignment);
 void* sgx_alloc_on_ustack(uint64_t size);
 void* sgx_copy_to_ustack(const void* ptr, uint64_t size);
 void sgx_reset_ustack(const void* old_ustack);

--- a/Pal/src/host/Linux-SGX/sgx_enclave.c
+++ b/Pal/src/host/Linux-SGX/sgx_enclave.c
@@ -2,6 +2,7 @@
 #include "ocall_types.h"
 #include "pal_linux_error.h"
 #include "pal_security.h"
+#include "rpc_queue.h"
 #include "sgx_enclave.h"
 #include "sgx_internal.h"
 
@@ -10,9 +11,12 @@
 #include <asm/mman.h>
 #include <asm/socket.h>
 #include <linux/fs.h>
+#include <linux/futex.h>
 #include <linux/in.h>
 #include <linux/in6.h>
+#include <linux/signal.h>
 #include <math.h>
+#include <sigset.h>
 #include <sys/wait.h>
 
 #define ODEBUG(code, ms) do {} while (0)
@@ -59,6 +63,12 @@ static long sgx_ocall_exit(void* pms)
     ecall_thread_reset();
 
     unmap_tcs();
+
+    if (!current_enclave_thread_cnt()) {
+        /* no enclave threads left, kill the whole process */
+        INLINE_SYSCALL(exit_group, 1, (int)ms->ms_exitcode);
+    }
+
     thread_exit((int)ms->ms_exitcode);
     return 0;
 }
@@ -683,14 +693,117 @@ sgx_ocall_fn_t ocall_table[OCALL_NR] = {
 
 #define EDEBUG(code, ms) do {} while (0)
 
+rpc_queue_t* g_rpc_queue = NULL; /* pointer to untrusted queue */
+
+static int rpc_thread_loop(void* arg) {
+    __UNUSED(arg);
+    long mytid = INLINE_SYSCALL(gettid, 0);
+
+    /* block all signals except SIGUSR2 for RPC thread */
+    __sigset_t mask;
+    __sigfillset(&mask);
+    __sigdelset(&mask, SIGUSR2);
+    INLINE_SYSCALL(rt_sigprocmask, 4, SIG_SETMASK, &mask, NULL, sizeof(mask));
+
+    spinlock_lock(&g_rpc_queue->lock);
+    g_rpc_queue->rpc_threads[g_rpc_queue->rpc_threads_cnt] = mytid;
+    g_rpc_queue->rpc_threads_cnt++;
+    spinlock_unlock(&g_rpc_queue->lock);
+
+    while (1) {
+        rpc_request_t* req = rpc_dequeue(g_rpc_queue);
+        if (!req) {
+            __asm__ volatile("pause");
+            continue;
+        }
+
+        /* call actual function and notify awaiting enclave thread when done */
+        sgx_ocall_fn_t f = ocall_table[req->ocall_index];
+        req->result = f(req->buffer);
+
+        /* this code is based on Mutex 2 from Futexes are Tricky */
+        int old_lock_state = __atomic_fetch_sub(&req->lock.lock, 1, __ATOMIC_ACQ_REL);
+        if (old_lock_state == SPINLOCK_LOCKED_WITH_WAITERS) {
+            /* must unlock and wake waiters */
+            spinlock_unlock(&req->lock);
+            int ret = INLINE_SYSCALL(futex, 6, &req->lock.lock, FUTEX_WAKE_PRIVATE,
+                                     1, NULL, NULL, 0);
+            if (ret == -1)
+                SGX_DBG(DBG_E, "RPC thread failed to wake up enclave thread\n");
+        }
+    }
+
+    /* NOTREACHED */
+    return 0;
+}
+
+static int start_rpc(size_t num_of_threads) {
+    g_rpc_queue = (rpc_queue_t*)INLINE_SYSCALL(mmap, 6, NULL,
+                                               ALIGN_UP(sizeof(rpc_queue_t), PRESET_PAGESIZE),
+                                               PROT_READ | PROT_WRITE,
+                                               MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
+    if (IS_ERR_P(g_rpc_queue))
+        return -ENOMEM;
+
+    /* initialize g_rpc_queue just for sanity, it will be overwritten by in-enclave code */
+    rpc_queue_init(g_rpc_queue);
+
+    for (size_t i = 0; i < num_of_threads; i++) {
+        void* stack = (void*)INLINE_SYSCALL(mmap, 6, NULL, RPC_STACK_SIZE,
+                                            PROT_READ | PROT_WRITE,
+                                            MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+        if (IS_ERR_P(stack))
+            return -ENOMEM;
+
+        void* child_stack_top = stack + RPC_STACK_SIZE;
+        child_stack_top = ALIGN_DOWN_PTR(child_stack_top, 16);
+
+        int dummy_parent_tid_field = 0;
+        int ret = clone(rpc_thread_loop, child_stack_top,
+                        CLONE_VM | CLONE_FS | CLONE_FILES | CLONE_SYSVSEM |
+                        CLONE_THREAD | CLONE_SIGHAND | CLONE_PTRACE | CLONE_PARENT_SETTID,
+                        NULL, &dummy_parent_tid_field, NULL);
+
+        if (IS_ERR(ret)) {
+            INLINE_SYSCALL(munmap, 2, stack, RPC_STACK_SIZE);
+            return -ENOMEM;
+        }
+    }
+
+    /* wait until all RPC threads are initialized in rpc_thread_loop */
+    while (1) {
+        spinlock_lock(&g_rpc_queue->lock);
+        size_t n = g_rpc_queue->rpc_threads_cnt;
+        spinlock_unlock(&g_rpc_queue->lock);
+        if (n == pal_enclave.rpc_thread_num)
+            break;
+        INLINE_SYSCALL(sched_yield, 0);
+    }
+
+    return 0;
+}
+
+
 int ecall_enclave_start (char * args, size_t args_size, char * env, size_t env_size)
 {
+    g_rpc_queue = NULL;
+
+    if (pal_enclave.rpc_thread_num > 0) {
+        int ret = start_rpc(pal_enclave.rpc_thread_num);
+        if (ret < 0) {
+            /* failed to create RPC threads */
+            return ret;
+        }
+        /* after this point, g_rpc_queue != NULL */
+    }
+
     ms_ecall_enclave_start_t ms;
     ms.ms_args = args;
     ms.ms_args_size = args_size;
     ms.ms_env = env;
     ms.ms_env_size = env_size;
     ms.ms_sec_info = &pal_enclave.pal_sec;
+    ms.rpc_queue = g_rpc_queue;
     EDEBUG(ECALL_ENCLAVE_START, &ms);
     return sgx_ecall(ECALL_ENCLAVE_START, &ms);
 }

--- a/Pal/src/host/Linux-SGX/sgx_exception.c
+++ b/Pal/src/host/Linux-SGX/sgx_exception.c
@@ -21,20 +21,19 @@
  * host, and the methods to pass the exceptions to the upcalls.
  */
 
-#include "pal_linux.h"
 #include "api.h"
 #include "ecall_types.h"
 #include "ocall_types.h"
-#include "sgx_internal.h"
 #include "pal_linux.h"
-
-#include <atomic.h>
-#include <sigset.h>
-#include <linux/signal.h>
-#include <ucontext.h>
-#include <asm/errno.h>
-
+#include "rpc_queue.h"
 #include "sgx_enclave.h"
+#include "sgx_internal.h"
+
+#include <asm/errno.h>
+#include <atomic.h>
+#include <linux/signal.h>
+#include <sigset.h>
+#include <ucontext.h>
 
 #if !defined(__i386__)
 /* In x86_64 kernels, sigaction is required to have a user-defined
@@ -181,6 +180,11 @@ static void _DkTerminateSighandler (int signum, siginfo_t * info,
 {
     __UNUSED(info);
 
+    /* send dummy signal to RPC threads so they interrupt blocked syscalls */
+    if (g_rpc_queue)
+        for (size_t i = 0; i < g_rpc_queue->rpc_threads_cnt; i++)
+            INLINE_SYSCALL(tkill, 2, g_rpc_queue->rpc_threads[i], SIGUSR2);
+
     unsigned long rip = uc->uc_mcontext.gregs[REG_RIP];
 
     if (rip != (unsigned long) async_exit_pointer) {
@@ -196,6 +200,11 @@ static void _DkResumeSighandler (int signum, siginfo_t * info,
                                  struct ucontext * uc)
 {
     __UNUSED(info);
+
+    /* send dummy signal to RPC threads so they interrupt blocked syscalls */
+    if (g_rpc_queue)
+        for (size_t i = 0; i < g_rpc_queue->rpc_threads_cnt; i++)
+            INLINE_SYSCALL(tkill, 2, g_rpc_queue->rpc_threads[i], SIGUSR2);
 
     unsigned long rip = uc->uc_mcontext.gregs[REG_RIP];
 
@@ -224,6 +233,13 @@ static void _DkResumeSighandler (int signum, siginfo_t * info,
     sgx_raise(event);
 }
 
+static void _DkEmptySighandler(int signum, siginfo_t* info, struct ucontext* uc) {
+    __UNUSED(signum);
+    __UNUSED(info);
+    __UNUSED(uc);
+    /* we need this handler to interrupt blocking syscalls in RPC threads */
+}
+
 int sgx_signal_setup (void)
 {
     int ret, sig[4];
@@ -239,6 +255,14 @@ int sgx_signal_setup (void)
     sig[2] = SIGFPE;
     sig[3] = SIGBUS;
     if ((ret = set_sighandler(sig, 4, &_DkResumeSighandler)) < 0)
+        goto err;
+
+    /* SIGUSR2 is reserved for Graphene usage: interrupting blocking syscalls in RPC threads.
+     * We block SIGUSR2 in enclave threads; it is unblocked by each RPC thread explicitly. */
+    sig[0] = SIGUSR2;
+    if ((ret = set_sighandler(sig, 1, &_DkEmptySighandler)) < 0)
+        goto err;
+    if (block_signals(true, sig, 1) < 0)
         goto err;
 
     return 0;

--- a/Pal/src/host/Linux-SGX/sgx_internal.h
+++ b/Pal/src/host/Linux-SGX/sgx_internal.h
@@ -67,6 +67,7 @@ extern struct pal_enclave {
     unsigned long baseaddr;
     unsigned long size;
     unsigned long thread_num;
+    unsigned long rpc_thread_num;
     unsigned long ssaframesize;
 
     /* files */
@@ -141,6 +142,7 @@ void create_tcs_mapper (void * tcs_base, unsigned int thread_num);
 int pal_thread_init(void* tcbptr);
 void map_tcs(unsigned int tid);
 void unmap_tcs(void);
+int current_enclave_thread_cnt(void);
 void thread_exit(int status);
 
 uint64_t sgx_edbgrd (void * addr);

--- a/Pal/src/host/Linux-SGX/sgx_thread.c
+++ b/Pal/src/host/Linux-SGX/sgx_thread.c
@@ -73,6 +73,16 @@ void unmap_tcs(void) {
     spinlock_unlock(&tcs_lock);
 }
 
+int current_enclave_thread_cnt(void) {
+    int ret = 0;
+    spinlock_lock(&tcs_lock);
+    for (int i = 0; i < enclave_thread_num; i++)
+        if (enclave_thread_map[i].tid)
+            ret++;
+    spinlock_unlock(&tcs_lock);
+    return ret;
+}
+
 /*
  * pal_thread_init(): An initialization wrapper of a newly-created thread (including
  * the first thread). This function accepts a TCB pointer to be set to the GS register


### PR DESCRIPTION
## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [x] SGX PAL
- [ ] FreeBSD PAL
- [x] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->

This PR succeeds PR #405. It is largely based on the old PR, but is rebased to the current master, and thus some fixes are not needed anymore. No logic was changed.

This PR adds the ability to invoke system calls in an "exitless" fashion (aka asynchronously), similar to solutions from [Eleos by Orenbach](https://dl.acm.org/citation.cfm?id=3064219) and [SCONE by Arnautov et al](https://dl.acm.org/citation.cfm?id=3026930).

New directive `sgx.rpc_thread_num = X` in the manifest instructs Graphene-SGX to create X outside-enclave RPC threads that spin-wait for syscalls (and any OCALLs in general) on a shared queue. In-enclave threads do not exit the enclave now but instead enqueue the syscall in the queue and wait for it to be processed by an RPC thread. Not to waste CPU resources, enclave threads first spin (in the hope syscall will return immediately) and then sleep on a futex.

This PR reserves the SIGUSR2 signal for internal usage. In particular, when a signal arrives to the enclave application (e.g. SIGINT or SIGCONT), RPC threads are notified using SIGUSR2. This notification is required in case RPC threads are blocked on system calls; POSIX mandates that signals interrupt such blocked system calls ([`signal` manpage](http://man7.org/linux/man-pages/man7/signal.7.html)).

Omitting `sgx.rpc_thread_num` defaults to the old way of executing syscalls: exiting the enclave, executing the syscall, and re-entering it again.

This PR is stable. It works with multi-process applications and correctly handles signals.

Closes #405.

## How to test this PR? <!-- (if applicable) -->

Two new regression tests are added (one in LibOS, one in PAL).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1142)
<!-- Reviewable:end -->
