### PR TITLE
[LibOS] gs tcb cleanup

### DIFF
--- a/LibOS/shim/include/shim_internal.h
+++ b/LibOS/shim/include/shim_internal.h
@@ -39,7 +39,7 @@
 #include <shim_types.h>
 #include <shim_defs.h>
 #include <atomic.h>
-#include <shim_tls.h>
+#include <shim_tcb.h>
 
 /* important macros and static inline functions */
 static inline unsigned int get_cur_tid(void)

--- a/LibOS/shim/include/shim_tcb.h
+++ b/LibOS/shim/include/shim_tcb.h
@@ -1,5 +1,5 @@
-#ifndef _SHIM_TLS_H_
-#define _SHIM_TLS_H_
+#ifndef _SHIM_TCB_H_
+#define _SHIM_TCB_H_
 
 #include <atomic.h>
 

--- a/LibOS/shim/include/shim_tcb.h
+++ b/LibOS/shim/include/shim_tcb.h
@@ -28,6 +28,7 @@ struct shim_regs {
 
 struct shim_context {
     struct shim_regs *      regs;
+    unsigned long           fs_base;
     struct shim_context *   next;
     uint64_t                enter_time;
     struct atomic_int       preempt;

--- a/LibOS/shim/include/shim_tcb.h
+++ b/LibOS/shim/include/shim_tcb.h
@@ -3,7 +3,7 @@
 
 #include <atomic.h>
 
-#define SHIM_TLS_CANARY 0xdeadbeef
+#define SHIM_TCB_CANARY 0xdeadbeef
 
 struct shim_regs {
     unsigned long           orig_rax;
@@ -69,7 +69,7 @@ static inline bool shim_tcb_check_canary(void)
 {
     /* TODO: optimize to use single movq %gs:<offset> */
     shim_tcb_t * shim_tcb = shim_get_tcb();
-    return shim_tcb->canary == SHIM_TLS_CANARY;
+    return shim_tcb->canary == SHIM_TCB_CANARY;
 }
 
 #endif /* _SHIM_H_ */

--- a/LibOS/shim/include/shim_thread.h
+++ b/LibOS/shim/include/shim_thread.h
@@ -82,7 +82,6 @@ struct shim_thread {
     struct shim_handle * exec;
 
     void * stack, * stack_top, * stack_red;
-    unsigned long fs_base;
     shim_tcb_t * shim_tcb;
     void * frameptr;
 
@@ -185,7 +184,6 @@ void set_cur_thread (struct shim_thread * thread)
     IDTYPE tid = 0;
 
     if (thread) {
-        unsigned long fs_base = tcb->tp ? tcb->tp->fs_base : 0;
         if (tcb->tp && tcb->tp != thread)
             put_thread(tcb->tp);
 
@@ -193,7 +191,6 @@ void set_cur_thread (struct shim_thread * thread)
             get_thread(thread);
 
         tcb->tp = thread;
-        thread->fs_base = fs_base;
         thread->shim_tcb = tcb;
         tid = thread->tid;
 
@@ -328,6 +325,7 @@ struct clone_args {
     PAL_HANDLE initialize_event;
     struct shim_thread * parent, * thread;
     void * stack;
+    unsigned long fs_base;
 };
 
 void * allocate_stack (size_t size, size_t protect_size, bool user);

--- a/LibOS/shim/include/shim_thread.h
+++ b/LibOS/shim/include/shim_thread.h
@@ -3,7 +3,7 @@
 
 #include <shim_defs.h>
 #include <shim_internal.h>
-#include <shim_tls.h>
+#include <shim_tcb.h>
 #include <shim_utils.h>
 #include <shim_signal.h>
 #include <shim_handle.h>

--- a/LibOS/shim/include/shim_tls.h
+++ b/LibOS/shim/include/shim_tls.h
@@ -64,7 +64,7 @@ static inline shim_tcb_t * shim_get_tcb(void)
     return (shim_tcb_t*)tcb->libos_tcb;
 }
 
-static inline bool shim_tls_check_canary(void)
+static inline bool shim_tcb_check_canary(void)
 {
     /* TODO: optimize to use single movq %gs:<offset> */
     shim_tcb_t * shim_tcb = shim_get_tcb();

--- a/LibOS/shim/include/shim_tls.h
+++ b/LibOS/shim/include/shim_tls.h
@@ -1,20 +1,7 @@
 #ifndef _SHIM_TLS_H_
 #define _SHIM_TLS_H_
 
-#ifdef IN_SHIM
-
 #include <atomic.h>
-
-#else  /* !IN_SHIM */
-/* workaround to make glibc build
- * the following structure must match to the one defined in pal/lib/atomic.h
- */
-#ifdef __x86_64__
-struct atomic_int {
-    volatile int64_t counter;
-};
-#endif
-#endif /* IN_SHIM */
 
 #define SHIM_TLS_CANARY 0xdeadbeef
 
@@ -68,14 +55,11 @@ struct shim_tcb {
     } test_range;
 };
 
-#ifdef IN_SHIM
-
-#include <stddef.h>
-
 void init_tcb (shim_tcb_t * tcb);
 
 static inline shim_tcb_t * shim_get_tcb(void)
 {
+    /* TODO: optimize to use single movq %gs:<offset> */
     PAL_TCB * tcb = pal_get_tcb();
     return (shim_tcb_t*)tcb->libos_tcb;
 }
@@ -86,7 +70,5 @@ static inline bool shim_tls_check_canary(void)
     shim_tcb_t * shim_tcb = shim_get_tcb();
     return shim_tcb->canary == SHIM_TLS_CANARY;
 }
-
-#endif /* IN_SHIM */
 
 #endif /* _SHIM_H_ */

--- a/LibOS/shim/src/generated-offsets.c
+++ b/LibOS/shim/src/generated-offsets.c
@@ -3,7 +3,7 @@
 #include <stddef.h>
 
 #include <shim_internal.h>
-#include <shim_tls.h>
+#include <shim_tcb.h>
 
 void dummy(void)
 {

--- a/LibOS/shim/src/ipc/shim_ipc_helper.c
+++ b/LibOS/shim/src/ipc/shim_ipc_helper.c
@@ -791,8 +791,7 @@ static void shim_ipc_helper_prepare(void* arg) {
     if (!arg)
         return;
 
-    unsigned long fs_base = 0;
-    init_fs_base(fs_base, self);
+    init_fs_base(0, self);
     debug_setbuf(shim_get_tcb(), true);
 
     lock(&ipc_helper_lock);

--- a/LibOS/shim/src/shim_async.c
+++ b/LibOS/shim/src/shim_async.c
@@ -144,8 +144,7 @@ static void shim_async_helper(void * arg) {
     if (!arg)
         return;
 
-    unsigned long fs_base = 0;
-    init_fs_base(fs_base, self);
+    init_fs_base(0, self);
     debug_setbuf(shim_get_tcb(), true);
 
     lock(&async_helper_lock);

--- a/LibOS/shim/src/shim_checkpoint.c
+++ b/LibOS/shim/src/shim_checkpoint.c
@@ -1304,7 +1304,9 @@ void restore_context (struct shim_context * context)
     shim_tcb_t * tcb = shim_get_tcb();
     __enable_preempt(tcb);
 
+    unsigned long fs_base = context->fs_base;
     memset(context, 0, sizeof(struct shim_context));
+    context->fs_base = fs_base;
 
     __asm__ volatile("movq %0, %%rsp\r\n"
                      "addq $2 * 8, %%rsp\r\n"    /* skip orig_rax and rsp */

--- a/LibOS/shim/src/shim_debug.c
+++ b/LibOS/shim/src/shim_debug.c
@@ -27,7 +27,7 @@
 #include <shim_handle.h>
 #include <shim_internal.h>
 #include <shim_ipc.h>
-#include <shim_tls.h>
+#include <shim_tcb.h>
 #include <shim_vma.h>
 
 #ifndef DEBUG

--- a/LibOS/shim/src/shim_init.c
+++ b/LibOS/shim/src/shim_init.c
@@ -201,7 +201,7 @@ bool lock_enabled;
 
 void init_tcb (shim_tcb_t * tcb)
 {
-    tcb->canary = SHIM_TLS_CANARY;
+    tcb->canary = SHIM_TCB_CANARY;
     tcb->self = tcb;
 }
 

--- a/LibOS/shim/src/shim_init.c
+++ b/LibOS/shim/src/shim_init.c
@@ -222,7 +222,7 @@ void init_fs_base (unsigned long fs_base, struct shim_thread * thread)
     }
 
     DkSegmentRegister(PAL_SEGMENT_FS, (PAL_PTR)fs_base);
-    assert(shim_tls_check_canary());
+    assert(shim_tcb_check_canary());
 }
 
 void update_fs_base (unsigned long fs_base)
@@ -236,7 +236,7 @@ void update_fs_base (unsigned long fs_base)
     }
 
     DkSegmentRegister(PAL_SEGMENT_FS, (PAL_PTR)fs_base);
-    assert(shim_tls_check_canary());
+    assert(shim_tcb_check_canary());
 }
 
 DEFINE_PROFILE_OCCURENCE(alloc_stack, memory);

--- a/LibOS/shim/src/shim_init.c
+++ b/LibOS/shim/src/shim_init.c
@@ -23,7 +23,7 @@
 #include <shim_defs.h>
 #include <shim_internal.h>
 #include <shim_table.h>
-#include <shim_tls.h>
+#include <shim_tcb.h>
 #include <shim_thread.h>
 #include <shim_handle.h>
 #include <shim_vma.h>

--- a/LibOS/shim/src/shim_parser.c
+++ b/LibOS/shim/src/shim_parser.c
@@ -40,7 +40,7 @@
 #include <shim_internal.h>
 #include <shim_table.h>
 #include <shim_thread.h>
-#include <shim_tls.h>
+#include <shim_tcb.h>
 #include <shim_utils.h>
 
 static void parse_open_flags(va_list);

--- a/LibOS/shim/src/shim_syscalls.c
+++ b/LibOS/shim/src/shim_syscalls.c
@@ -30,7 +30,7 @@
 #include <shim_profile.h>
 #include <shim_table.h>
 #include <shim_thread.h>
-#include <shim_tls.h>
+#include <shim_tcb.h>
 #include <shim_unistd.h>
 #include <shim_utils.h>
 

--- a/LibOS/shim/src/sys/shim_clone.c
+++ b/LibOS/shim/src/sys/shim_clone.c
@@ -125,7 +125,7 @@ static int clone_implementation_wrapper(struct clone_args * arg)
     struct shim_thread* my_thread = arg->thread;
     assert(my_thread);
 
-    init_fs_base(my_thread->fs_base, my_thread); /* set up TCB */
+    init_fs_base(arg->fs_base, my_thread);
     shim_tcb_t * tcb = my_thread->shim_tcb;
 
     /* only now we can call LibOS/PAL functions because they require a set-up TCB;
@@ -136,7 +136,7 @@ static int clone_implementation_wrapper(struct clone_args * arg)
     __disable_preempt(tcb); // Temporarily disable preemption, because the preemption
                             // will be re-enabled when the thread starts.
     debug_setbuf(tcb, true);
-    debug("set fs_base to 0x%lx\n", my_thread->fs_base);
+    debug("set fs_base to 0x%lx\n", tcb->context.fs_base);
 
     struct shim_regs regs = *arg->parent->shim_tcb->context.regs;
     if (my_thread->set_child_tid) {
@@ -290,14 +290,13 @@ int shim_do_clone (int flags, void * user_stack_addr, int * parent_tidptr,
         /* Implemented in shim_futex.c: release_clear_child_id */
         thread->clear_child_tid = parent_tidptr;
 
+    unsigned long fs_base = 0;
     if (flags & CLONE_SETTLS) {
         if (!tls) {
             ret = -EINVAL;
             goto failed;
         }
-        thread->fs_base = (unsigned long)tls;
-    } else {
-        thread->fs_base = 0;
+        fs_base = (unsigned long)tls;
     }
 
     if (!(flags & CLONE_THREAD))
@@ -319,18 +318,16 @@ int shim_do_clone (int flags, void * user_stack_addr, int * parent_tidptr,
     }
 
     if (!(flags & CLONE_VM)) {
-        unsigned long fs_base;
-        shim_tcb_t * old_shim_tcb = NULL;
         void * parent_stack = NULL;
 
-        if (thread->fs_base) {
-            fs_base = thread->fs_base;
-        } else {
-            thread->fs_base = fs_base = self->fs_base;
-            old_shim_tcb = __alloca(sizeof(shim_tcb_t));
-            memcpy(old_shim_tcb, self->shim_tcb, sizeof(shim_tcb_t));
-            thread->shim_tcb = self->shim_tcb;
+        if (!fs_base) {
+            fs_base = self->shim_tcb->context.fs_base;
         }
+        /* associate cpu context to new forking thread for migration */
+        shim_tcb_t shim_tcb;
+        memcpy(&shim_tcb, self->shim_tcb, sizeof(shim_tcb_t));
+        shim_tcb.context.fs_base = fs_base;
+        thread->shim_tcb = &shim_tcb;
 
         if (user_stack_addr) {
             struct shim_vma_val vma;
@@ -347,10 +344,8 @@ int shim_do_clone (int flags, void * user_stack_addr, int * parent_tidptr,
         set_as_child(self, thread);
 
         ret = do_migrate_process(&migrate_fork, NULL, NULL, thread);
-        if (old_shim_tcb) {
-            thread->shim_tcb = NULL;
-            memcpy(self->shim_tcb, old_shim_tcb, sizeof(*self->shim_tcb));
-        }
+        thread->shim_tcb = NULL; /* cpu context of forked thread isn't
+                                  * needed any more */
         if (parent_stack)
             self->shim_tcb->context.regs->rsp = (unsigned long)parent_stack;
         if (ret < 0)
@@ -394,6 +389,7 @@ int shim_do_clone (int flags, void * user_stack_addr, int * parent_tidptr,
     new_args.thread    = thread;
     new_args.parent    = self;
     new_args.stack     = user_stack_addr;
+    new_args.fs_base   = fs_base;
 
     // Invoke DkThreadCreate to spawn off a child process using the actual
     // "clone" system call. DkThreadCreate allocates a stack for the child

--- a/LibOS/shim/src/sys/shim_exec.c
+++ b/LibOS/shim/src/sys/shim_exec.c
@@ -489,14 +489,12 @@ err:
 
     void * stack     = cur_thread->stack;
     void * stack_top = cur_thread->stack_top;
-    unsigned long fs_base = cur_thread->fs_base;
     shim_tcb_t * shim_tcb = cur_thread->shim_tcb;
     void * frameptr  = cur_thread->frameptr;
 
     cur_thread->stack     = NULL;
     cur_thread->stack_top = NULL;
     cur_thread->frameptr  = NULL;
-    cur_thread->fs_base   = 0;
     cur_thread->shim_tcb  = NULL;
     cur_thread->in_vm     = false;
     unlock(&cur_thread->lock);
@@ -507,7 +505,6 @@ err:
     cur_thread->stack       = stack;
     cur_thread->stack_top   = stack_top;
     cur_thread->frameptr    = frameptr;
-    cur_thread->fs_base     = fs_base;
     cur_thread->shim_tcb    = shim_tcb;
 
     if (ret < 0) {

--- a/LibOS/shim/src/sys/shim_fork.c
+++ b/LibOS/shim/src/sys/shim_fork.c
@@ -84,7 +84,6 @@ int shim_do_fork (void)
     if (!new_thread)
         return -ENOMEM;
 
-    new_thread->fs_base  = cur_thread->fs_base;
     new_thread->shim_tcb = cur_thread->shim_tcb;
     new_thread->tgid     = new_thread->tid;
     new_thread->in_vm    = false;

--- a/LibOS/shim/src/sys/shim_vfork.c
+++ b/LibOS/shim/src/sys/shim_vfork.c
@@ -76,7 +76,6 @@ int shim_do_vfork(void) {
     new_thread->is_alive  = true;
     new_thread->stack     = cur_thread->stack;
     new_thread->stack_top = cur_thread->stack_top;
-    new_thread->fs_base   = cur_thread->fs_base;
     cur_thread->stack     = dummy_stack;
     cur_thread->stack_top = dummy_stack + stack_size;
     cur_thread->frameptr  = NULL;

--- a/Pal/src/host/Linux-SGX/db_threading.c
+++ b/Pal/src/host/Linux-SGX/db_threading.c
@@ -88,6 +88,8 @@ void pal_start_thread (void)
     new_thread->param = NULL;
     SET_ENCLAVE_TLS(thread, new_thread);
     SET_ENCLAVE_TLS(ready_for_exceptions, 1UL);
+    PAL_TCB* pal_tcb = pal_get_tcb();
+    memset(&pal_tcb->libos_tcb, 0, sizeof(pal_tcb->libos_tcb));
     callback((void *) param);
     _DkThreadExit();
 }


### PR DESCRIPTION
<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->
As follow up of #556 , more code clean up.
- remove dead code in shim_thread.h
- rename shim_tls.h -> shim_tcb.h
- rename shim_tls_check_canary to shim_tcb_check_canaryo
- move fs_base from shim_thread to shim_tcb

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->


## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1143)
<!-- Reviewable:end -->
