### PR TITLE
[Pal/Linux-SGX] Do not fail on empty sgx.trusted_files

### DIFF
--- a/Pal/src/host/Linux-SGX/db_files.c
+++ b/Pal/src/host/Linux-SGX/db_files.c
@@ -84,7 +84,7 @@ static int file_open(PAL_HANDLE* handle, const char* type, const char* uri, int 
     hdl->file.total  = total;
     hdl->file.offset = 0;
 
-    if (hdl->file.stubs) {
+    if (hdl->file.stubs && hdl->file.total) {
         /* case of trusted file: mmap the whole file in untrusted memory for future reads/writes */
         ret = ocall_mmap_untrusted(hdl->file.fd, 0, hdl->file.total, PROT_READ, &hdl->file.umem);
         if (IS_ERR(ret)) {
@@ -172,7 +172,7 @@ static int64_t file_write(PAL_HANDLE handle, uint64_t offset, uint64_t count, co
 static int file_close(PAL_HANDLE handle) {
     int fd = handle->file.fd;
 
-    if (handle->file.stubs) {
+    if (handle->file.stubs && handle->file.total) {
         /* case of trusted file: the whole file was mmapped in untrusted memory */
         ocall_munmap_untrusted(handle->file.umem, handle->file.total);
     }


### PR DESCRIPTION
## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [x] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->

Previously, if a file marked as sgx.trusted_files was empty, Graphene-SGX still tried to mmap it. However, mmap with zero length fails, so Graphene-SGX refused such empty files. In some cases (e.g. Python's `__init__.py` files) trusted files indeed must be empty. This commit allows to open empty trusted files.


## How to test this PR? <!-- (if applicable) -->

Python's PR (https://github.com/oscarlab/graphene-tests/pull/29) must run correctly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1145)
<!-- Reviewable:end -->
