### PR TITLE
Avoid segmentation fault errors when loading non-elf files.

### DIFF
--- a/Pal/regression/nonelf_binary
+++ b/Pal/regression/nonelf_binary
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+echo "pal_load needs to recognize that this file is not an elf file"

--- a/Pal/regression/nonelf_binary.manifest.template
+++ b/Pal/regression/nonelf_binary.manifest.template
@@ -1,0 +1,2 @@
+loader.exec = file:./nonelf_binary
+loader.debug_type = inline

--- a/Pal/regression/test_pal.py
+++ b/Pal/regression/test_pal.py
@@ -117,6 +117,13 @@ class TC_01_Bootstrap(RegressionTestCase):
         self.assertIn('Loaded Executable: file:Bootstrap', stderr)
         self.assertIn('argv[0] = Bootstrap', stderr)
 
+    @unittest.skipUnless(HAS_SGX, 'need SGX')
+    def test_107_manifest_with_nonelf_binary(self):
+        manifest = self.get_manifest('nonelf_binary')
+        #Expect return code is -ENOEXEC(248 as unsigned char)
+        with self.expect_returncode(248):
+            self.run_binary([manifest])
+
     def test_110_preload_libraries(self):
         stdout, stderr = self.run_binary(['Bootstrap3'])
         self.assertIn('Binary 1 Preloaded', stderr)

--- a/Pal/src/host/Linux-SGX/sgx_main.c
+++ b/Pal/src/host/Linux-SGX/sgx_main.c
@@ -111,9 +111,15 @@ int scan_enclave_binary (int fd, unsigned long * base, unsigned long * size,
     if (IS_ERR(ret))
         return -ERRNO(ret);
 
+    if ((size_t)ret < sizeof(ElfW(Ehdr)))
+        return -ENOEXEC;
+
     const ElfW(Ehdr) * header = (void *) filebuf;
     const ElfW(Phdr) * phdr = (void *) filebuf + header->e_phoff;
     const ElfW(Phdr) * ph;
+
+    if (memcmp(header->e_ident, ELFMAG, SELFMAG) != 0)
+        return -ENOEXEC;
 
     struct loadcmd {
         ElfW(Addr) mapstart, mapend;


### PR DESCRIPTION
Signed-off-by: jack.wxz <jack.wxz@alibaba-inc.com>

<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [x] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->
1. check that the binary file is not smaller than the elf-head size,
2. check if the binary is in elf format.

## How to test this PR? <!-- (if applicable) -->
1. set exec to a posix shell:
loader.exec = file:/tmp/non-elf

2. /tmp/non-elf:
```
#!/bin/sh

exec /bin/ls -DOHMYGODTHISISERROR



dasfsafsa

asdf
asf
```

3. run testcase will cause a segmentation fault,

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1146)
<!-- Reviewable:end -->
