### PR TITLE
[Pal] Remove unused TRACE_HEAP macro and code

### DIFF
--- a/Pal/src/db_events.c
+++ b/Pal/src/db_events.c
@@ -37,7 +37,6 @@ PAL_HANDLE DkNotificationEventCreate(PAL_BOL initialState) {
         handle = NULL;
     }
 
-    TRACE_HEAP(handle);
     LEAVE_PAL_CALL_RETURN(handle);
 }
 
@@ -52,7 +51,6 @@ PAL_HANDLE DkSynchronizationEventCreate(PAL_BOL initialState) {
         handle = NULL;
     }
 
-    TRACE_HEAP(handle);
     LEAVE_PAL_CALL_RETURN(handle);
 }
 

--- a/Pal/src/db_ipc.c
+++ b/Pal/src/db_ipc.c
@@ -39,7 +39,6 @@ DkCreatePhysicalMemoryChannel (PAL_NUM * key)
         handle = NULL;
     }
 
-    TRACE_HEAP(handle);
     LEAVE_PAL_CALL_RETURN(handle);
 }
 

--- a/Pal/src/db_mutex.c
+++ b/Pal/src/db_mutex.c
@@ -38,7 +38,6 @@ DkMutexCreate(PAL_NUM initialCount) {
         handle = NULL;
     }
 
-    TRACE_HEAP(handle);
     LEAVE_PAL_CALL_RETURN(handle);
 }
 

--- a/Pal/src/db_object.c
+++ b/Pal/src/db_object.c
@@ -64,8 +64,6 @@ void DkObjectClose (PAL_HANDLE objectHandle)
         LEAVE_PAL_CALL();
     }
 
-    UNTRACE_HEAP(objectHandle);
-
     int ret = _DkObjectClose(objectHandle);
     if (ret < 0)
         _DkRaiseFailure(-ret);

--- a/Pal/src/db_process.c
+++ b/Pal/src/db_process.c
@@ -53,7 +53,6 @@ DkProcessCreate(PAL_STR uri, PAL_STR* args) {
         handle = NULL;
     }
 
-    TRACE_HEAP(handle);
     LEAVE_PAL_CALL_RETURN(handle);
 }
 

--- a/Pal/src/db_streams.c
+++ b/Pal/src/db_streams.c
@@ -178,7 +178,6 @@ DkStreamOpen(PAL_STR uri, PAL_FLG access, PAL_FLG share, PAL_FLG create, PAL_FLG
     assert(handle);
     assert(!UNKNOWN_HANDLE(handle));
 
-    TRACE_HEAP(handle);
     LEAVE_PAL_CALL_RETURN(handle);
 }
 
@@ -208,7 +207,6 @@ DkStreamWaitForClient(PAL_HANDLE handle) {
         client = NULL;
     }
 
-    TRACE_HEAP(client);
     LEAVE_PAL_CALL_RETURN(client);
 }
 

--- a/Pal/src/db_threading.c
+++ b/Pal/src/db_threading.c
@@ -41,7 +41,6 @@ DkThreadCreate(PAL_PTR addr, PAL_PTR param) {
         handle = NULL;
     }
 
-    TRACE_HEAP(handle);
     LEAVE_PAL_CALL_RETURN(handle);
 }
 

--- a/Pal/src/pal.h
+++ b/Pal/src/pal.h
@@ -54,14 +54,6 @@ typedef struct {
 #  define HANDLE_HDR(handle) (&((handle)->hdr))
 # endif
 
-# ifndef TRACE_HEAP
-#  define TRACE_HEAP(handle) do {} while (0)
-# endif
-
-# ifndef UNTRACE_HEAP
-#  define UNTRACE_HEAP(handle) do {} while (0)
-# endif
-
 static inline void init_handle_hdr(PAL_HDR *hdr, int pal_type) {
     hdr->type = pal_type;
     hdr->flags = 0;


### PR DESCRIPTION
## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [x] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->

Trivial cleanup: remove unused `TRACE_HEAP` macro and code.

## How to test this PR? <!-- (if applicable) -->

All tests must pass.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1151)
<!-- Reviewable:end -->
