### PR TITLE
[LIBOS]In set_signal_mask(), remove the mask of SIGKILL and SIGSTOP.

### DIFF
--- a/LibOS/shim/src/bookkeep/shim_signal.c
+++ b/LibOS/shim/src/bookkeep/shim_signal.c
@@ -607,8 +607,13 @@ __sigset_t * set_sig_mask (struct shim_thread * thread,
 
     assert(thread);
 
-    if (set)
+    if (set) {
         memcpy(&thread->signal_mask, set, sizeof(__sigset_t));
+
+        /* SIGKILL and SIGSTOP cannot be ignored */
+        __sigdelset(&thread->signal_mask, SIGKILL);
+        __sigdelset(&thread->signal_mask, SIGSTOP);
+    }
 
     return &thread->signal_mask;
 }

--- a/LibOS/shim/test/regression/Makefile
+++ b/LibOS/shim/test/regression/Makefile
@@ -25,6 +25,7 @@ CFLAGS-abort_multithread = -pthread
 CFLAGS-eventfd = -pthread
 CFLAGS-futex = -pthread
 CFLAGS-spinlock += -I$(PALDIR)/../lib -pthread
+CFLAGS-sigprocmask += -pthread
 
 %: %.c
 	$(call cmd,csingle)

--- a/LibOS/shim/test/regression/sigprocmask.c
+++ b/LibOS/shim/test/regression/sigprocmask.c
@@ -1,0 +1,51 @@
+#include <pthread.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+void* thread_func(void* arg)
+{
+    exit(113);
+    return NULL;
+}
+
+int main(int argc, char* argv[])
+{
+    sigset_t newmask;
+    sigset_t oldmask;
+    sigemptyset(&newmask);
+    sigemptyset(&oldmask);
+    sigaddset(&newmask, SIGKILL);
+    sigaddset(&newmask, SIGSTOP);
+
+    int ret = sigprocmask(SIG_SETMASK, &newmask, NULL);
+
+    if (ret < 0) {
+        perror("sigprocmask failed");
+        return -1;
+    }
+
+    ret = sigprocmask(SIG_SETMASK, NULL, &oldmask);
+    if (ret < 0) {
+        perror("sigprocmask failed");
+        return -1;
+    }
+
+    if (sigismember(&oldmask, SIGKILL) || sigismember(&oldmask, SIGSTOP)) {
+        printf("SIGKILL or SIGSTOP should be ignored, but not.\n");
+        return -1;
+    }
+
+    pthread_t thread;
+    ret = pthread_create(&thread, NULL, thread_func, NULL);
+    if (ret < 0) {
+        perror("pthread_create failed");
+        return -1;
+    }
+
+    while(1)
+        sleep(1);
+
+    return -1;
+}

--- a/LibOS/shim/test/regression/test_libos.py
+++ b/LibOS/shim/test/regression/test_libos.py
@@ -140,6 +140,10 @@ class TC_01_Bootstrap(RegressionTestCase):
         with self.expect_returncode(134):
             self.run_binary(['abort_multithread'])
 
+    def test_404_sigprocmask(self):
+        with self.expect_returncode(113):
+            self.run_binary(['sigprocmask'])
+
     def test_500_init_fail(self):
         try:
             self.run_binary(['init_fail'])


### PR DESCRIPTION
In set_signal_mask(), remove the mask of SIGKILL and SIGSTOP.

Signed-off-by: jack.wxz <jack.wxz@alibaba-inc.com>

<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->
In signal processing, SIGKILL and SIGSTOP cannot be ignored.
This causes the multi-thread program to call exit() but hang: because the SIGKILL is ignored.

## How to test this PR? <!-- (if applicable) -->
testcase added to LibOS/shim/test/regression/test_libos.py
```
def test_404_sigprocmask(self)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1159)
<!-- Reviewable:end -->
