### PR TITLE
Clean up page size and alignment in PAL

### DIFF
--- a/Documentation/oldwiki/PAL-Host-ABI.md
+++ b/Documentation/oldwiki/PAL-Host-ABI.md
@@ -130,8 +130,12 @@ The fields of the Graphene control block are defined as follows:
         PAL_PTR_RANGE manifest_preload;
 
         /***** Host information *****/
-        /* host page size / allocation alignment */
-        PAL_NUM pagesize, alloc_align;
+        /* Host allocation alignment.
+         * This currently is (and most likely will always be) indistinguishable from the page size,
+         * looking from the LibOS perspective. The two values can be different on the PAL level though,
+         * see e.g. SYSTEM_INFO::dwAllocationGranularity on Windows.
+         */
+        PAL_NUM alloc_align;
         /* CPU information */
         PAL_CPU_INFO cpu_info;
         /* Memory information */

--- a/LibOS/shim/include/shim_internal.h
+++ b/LibOS/shim/include/shim_internal.h
@@ -743,13 +743,13 @@ static inline uint64_t hash64 (uint64_t key)
 #endif
 
 extern size_t g_pal_alloc_align;
-#define PAGE_SIZE g_pal_alloc_align
-#define IS_PAGE_ALIGNED(x) IS_ALIGNED_POW2(x, g_pal_alloc_align)
-#define IS_PAGE_ALIGNED_PTR(x) IS_ALIGNED_PTR_POW2(x, g_pal_alloc_align)
-#define PAGE_ALIGN_DOWN(x) ALIGN_DOWN_POW2(x, g_pal_alloc_align)
-#define PAGE_ALIGN_UP(x) ALIGN_UP_POW2(x, g_pal_alloc_align)
-#define PAGE_ALIGN_DOWN_PTR(x) ALIGN_DOWN_PTR_POW2(x, g_pal_alloc_align)
-#define PAGE_ALIGN_UP_PTR(x) ALIGN_UP_PTR_POW2(x, g_pal_alloc_align)
+#define ALLOC_ALIGNMENT         g_pal_alloc_align
+#define IS_ALLOC_ALIGNED(x)     IS_ALIGNED_POW2(x, g_pal_alloc_align)
+#define IS_ALLOC_ALIGNED_PTR(x) IS_ALIGNED_PTR_POW2(x, g_pal_alloc_align)
+#define ALLOC_ALIGN_DOWN(x)     ALIGN_DOWN_POW2(x, g_pal_alloc_align)
+#define ALLOC_ALIGN_UP(x)       ALIGN_UP_POW2(x, g_pal_alloc_align)
+#define ALLOC_ALIGN_DOWN_PTR(x) ALIGN_DOWN_PTR_POW2(x, g_pal_alloc_align)
+#define ALLOC_ALIGN_UP_PTR(x)   ALIGN_UP_PTR_POW2(x, g_pal_alloc_align)
 
 void * __system_malloc (size_t size);
 void __system_free (void * addr, size_t size);

--- a/LibOS/shim/src/bookkeep/shim_signal.c
+++ b/LibOS/shim/src/bookkeep/shim_signal.c
@@ -384,7 +384,7 @@ bool test_user_memory (void * addr, size_t size, bool write)
         } else {
             *(volatile char *) tmp;
         }
-        tmp = PAGE_ALIGN_UP_PTR(tmp + 1);
+        tmp = ALLOC_ALIGN_UP_PTR(tmp + 1);
     }
 
 ret_fault:
@@ -411,7 +411,7 @@ bool test_user_string (const char * addr)
         return true;
 
     size_t size, maxlen;
-    const char* next = PAGE_ALIGN_UP_PTR(addr + 1);
+    const char* next = ALLOC_ALIGN_UP_PTR(addr + 1);
 
     /* SGX path: check if [addr, addr+size) is addressable (in some VMA). */
     if (is_sgx_pal()) {
@@ -425,7 +425,7 @@ bool test_user_string (const char * addr)
 
             size = strnlen(addr, maxlen);
             addr = next;
-            next = PAGE_ALIGN_UP_PTR(addr + 1);
+            next = ALLOC_ALIGN_UP_PTR(addr + 1);
         } while (size == maxlen);
 
         return false;
@@ -457,7 +457,7 @@ bool test_user_string (const char * addr)
 
         size = strnlen(addr, maxlen);
         addr = next;
-        next = PAGE_ALIGN_UP_PTR(addr + 1);
+        next = ALLOC_ALIGN_UP_PTR(addr + 1);
     } while (size == maxlen);
 
 ret_fault:

--- a/LibOS/shim/src/bookkeep/shim_vma.c
+++ b/LibOS/shim/src/bookkeep/shim_vma.c
@@ -72,7 +72,7 @@ static void * __bkeep_unmapped (void * top_addr, void * bottom_addr,
 static inline void * __malloc (size_t size)
 {
     void * addr;
-    size = PAGE_ALIGN_UP(size);
+    size = ALLOC_ALIGN_UP(size);
 
     /*
      * Chia-Che 3/3/18: We must enforce the policy that all VMAs have to
@@ -318,7 +318,7 @@ int init_vma (void)
 
     /* Keep track of LibOS code itself so nothing overwrites it */
     ret = __bkeep_preloaded(&__load_address,
-                            PAGE_ALIGN_UP_PTR(&__load_address_end),
+                            ALLOC_ALIGN_UP_PTR(&__load_address_end),
                             PROT_READ, MAP_PRIVATE|MAP_ANONYMOUS|VMA_INTERNAL,
                             "LibOS");
     if (ret < 0)
@@ -365,7 +365,7 @@ int init_vma (void)
     ret = DkRandomBitsRead(&rand, sizeof(rand));
     if (ret < 0)
         return -convert_pal_errno(-ret);
-    current_heap_top -= PAGE_ALIGN_DOWN(rand % addr_rand_size);
+    current_heap_top -= ALLOC_ALIGN_DOWN(rand % addr_rand_size);
 #endif
 
     debug("heap top adjusted to %p\n", current_heap_top);
@@ -1091,7 +1091,7 @@ BEGIN_CP_FUNC(vma)
                     (off_t)(vma->offset + vma->length) > file_len) {
                     send_size = file_len > vma->offset ?
                                 file_len - vma->offset : 0;
-                    send_size = PAGE_ALIGN_UP(send_size);
+                    send_size = ALLOC_ALIGN_UP(send_size);
                 }
             }
             if (send_size > 0) {

--- a/LibOS/shim/src/fs/chroot/fs.c
+++ b/LibOS/shim/src/fs/chroot/fs.c
@@ -45,8 +45,8 @@
 
 #define TTY_FILE_MODE   0666
 
-#define FILE_BUFMAP_SIZE (PAL_CB(pagesize) * 4)
-#define FILE_BUF_SIZE (PAL_CB(pagesize))
+#define FILE_BUFMAP_SIZE (PAL_CB(alloc_align) * 4)
+#define FILE_BUF_SIZE (PAL_CB(alloc_align))
 
 struct mount_data {
     size_t              data_size;

--- a/LibOS/shim/src/shim_init.c
+++ b/LibOS/shim/src/shim_init.c
@@ -246,8 +246,8 @@ DEFINE_PROFILE_OCCURENCE(alloc_stack_count, memory);
 
 void * allocate_stack (size_t size, size_t protect_size, bool user)
 {
-    size = PAGE_ALIGN_UP(size);
-    protect_size = PAGE_ALIGN_UP(protect_size);
+    size = ALLOC_ALIGN_UP(size);
+    protect_size = ALLOC_ALIGN_UP(protect_size);
 
     /* preserve a non-readable, non-writable page below the user
        stack to stop user program to clobber other vmas */
@@ -377,7 +377,7 @@ int init_stack (const char ** argv, const char ** envp,
     if (root_config) {
         char stack_cfg[CONFIG_MAX];
         if (get_config(root_config, "sys.stack.size", stack_cfg, sizeof(stack_cfg)) > 0) {
-            stack_size = PAGE_ALIGN_UP(parse_int(stack_cfg));
+            stack_size = ALLOC_ALIGN_UP(parse_int(stack_cfg));
             set_rlimit_cur(RLIMIT_STACK, stack_size);
         }
     }
@@ -483,13 +483,13 @@ int init_manifest (PAL_HANDLE manifest_handle)
             return -PAL_ERRNO;
 
         size = attr.pending_size;
-        map_size = PAGE_ALIGN_UP(size);
+        map_size = ALLOC_ALIGN_UP(size);
         addr = bkeep_unmapped_any(map_size, PROT_READ, MAP_FLAGS,
                                   0, "manifest");
         if (!addr)
             return -ENOMEM;
 
-        void* ret_addr = DkStreamMap(manifest_handle, addr, PAL_PROT_READ, 0, PAGE_ALIGN_UP(size));
+        void* ret_addr = DkStreamMap(manifest_handle, addr, PAL_PROT_READ, 0, ALLOC_ALIGN_UP(size));
 
         if (!ret_addr) {
             bkeep_munmap(addr, map_size, MAP_FLAGS);
@@ -1067,7 +1067,7 @@ void check_stack_hook (void)
     __asm__ volatile ("movq %%rsp, %0" : "=r"(rsp) :: "memory");
 
     if (rsp <= cur_thread->stack_top && rsp > cur_thread->stack) {
-        if ((uintptr_t) rsp - (uintptr_t) cur_thread->stack < PAL_CB(pagesize))
+        if ((uintptr_t)rsp - (uintptr_t)cur_thread->stack < PAL_CB(alloc_align))
             SYS_PRINTF("*** stack is almost drained (RSP = %p, stack = %p-%p) ***\n",
                        rsp, cur_thread->stack, cur_thread->stack_top);
     } else {

--- a/LibOS/shim/src/shim_malloc.c
+++ b/LibOS/shim/src/shim_malloc.c
@@ -53,7 +53,7 @@ DEFINE_PROFILE_CATEGORY(memory, );
 
 /* Returns NULL on failure */
 void* __system_malloc(size_t size) {
-    size_t alloc_size = PAGE_ALIGN_UP(size);
+    size_t alloc_size = ALLOC_ALIGN_UP(size);
     void* addr;
     void* ret_addr;
     int flags = MAP_PRIVATE | MAP_ANONYMOUS | VMA_INTERNAL;
@@ -91,9 +91,9 @@ void* __system_malloc(size_t size) {
 }
 
 void __system_free(void* addr, size_t size) {
-    DkVirtualMemoryFree(addr, PAGE_ALIGN_UP(size));
+    DkVirtualMemoryFree(addr, ALLOC_ALIGN_UP(size));
 
-    if (bkeep_munmap(addr, PAGE_ALIGN_UP(size), VMA_INTERNAL) < 0)
+    if (bkeep_munmap(addr, ALLOC_ALIGN_UP(size), VMA_INTERNAL) < 0)
         BUG();
 }
 

--- a/LibOS/shim/src/sys/shim_brk.c
+++ b/LibOS/shim/src/sys/shim_brk.c
@@ -59,7 +59,7 @@ int init_brk_region(void* brk_region, size_t data_segment_size) {
     if (region.brk_start)
         return 0;
 
-    data_segment_size = PAGE_ALIGN_UP(data_segment_size);
+    data_segment_size = ALLOC_ALIGN_UP(data_segment_size);
     uint64_t brk_max_size = DEFAULT_BRK_MAX_SIZE;
 
     if (root_config) {
@@ -103,7 +103,7 @@ int init_brk_region(void* brk_region, size_t data_segment_size) {
                     return -convert_pal_errno(-ret);
                 rand %= MIN((size_t)0x2000000,
                             (size_t)(PAL_CB(user_address.end) - brk_region - brk_max_size));
-                rand = PAGE_ALIGN_DOWN(rand);
+                rand = ALLOC_ALIGN_DOWN(rand);
 
                 if (brk_region + rand + brk_max_size >= PAL_CB(user_address.end))
                     continue;

--- a/LibOS/shim/src/sys/shim_clone.c
+++ b/LibOS/shim/src/sys/shim_clone.c
@@ -147,7 +147,7 @@ static int clone_implementation_wrapper(struct clone_args * arg)
     void * stack = arg->stack;
 
     struct shim_vma_val vma;
-    lookup_vma(PAGE_ALIGN_DOWN_PTR(stack), &vma);
+    lookup_vma(ALLOC_ALIGN_DOWN_PTR(stack), &vma);
     my_thread->stack_top = vma.addr + vma.length;
     my_thread->stack_red = my_thread->stack = vma.addr;
 
@@ -331,7 +331,7 @@ int shim_do_clone (int flags, void * user_stack_addr, int * parent_tidptr,
 
         if (user_stack_addr) {
             struct shim_vma_val vma;
-            lookup_vma(PAGE_ALIGN_DOWN_PTR(user_stack_addr), &vma);
+            lookup_vma(ALLOC_ALIGN_DOWN_PTR(user_stack_addr), &vma);
             thread->stack_top = vma.addr + vma.length;
             thread->stack_red = thread->stack = vma.addr;
             parent_stack = (void *)self->shim_tcb->context.regs->rsp;

--- a/LibOS/shim/src/sys/shim_fs.c
+++ b/LibOS/shim/src/sys/shim_fs.c
@@ -450,9 +450,9 @@ static ssize_t handle_copy (struct shim_handle * hdli, off_t * offseti,
             expectsize = bufsize = count - bytes;
 
         if (do_mapi && !bufi) {
-            boffi = offi - PAGE_ALIGN_DOWN(offi);
+            boffi = offi - ALLOC_ALIGN_DOWN(offi);
 
-            if (fsi->fs_ops->mmap(hdli, &bufi, PAGE_ALIGN_UP(bufsize + boffi),
+            if (fsi->fs_ops->mmap(hdli, &bufi, ALLOC_ALIGN_UP(bufsize + boffi),
                                   PROT_READ, MAP_FILE, offi - boffi) < 0) {
                 do_mapi = false;
                 boffi = 0;
@@ -470,9 +470,9 @@ static ssize_t handle_copy (struct shim_handle * hdli, off_t * offseti,
         }
 
         if (do_mapo && !bufo) {
-            boffo = offo - PAGE_ALIGN_DOWN(offo);
+            boffo = offo - ALLOC_ALIGN_DOWN(offo);
 
-            if (fso->fs_ops->mmap(hdlo, &bufo, PAGE_ALIGN_UP(bufsize + boffo),
+            if (fso->fs_ops->mmap(hdlo, &bufo, ALLOC_ALIGN_UP(bufsize + boffo),
                                   PROT_WRITE, MAP_FILE, offo - boffo) < 0) {
                 do_mapo = false;
                 boffo = 0;
@@ -493,19 +493,19 @@ static ssize_t handle_copy (struct shim_handle * hdli, off_t * offseti,
             copysize = count - bytes > bufsize ? bufsize :
                        count - bytes;
             memcpy(bufo + boffo, bufi + boffi, copysize);
-            DkVirtualMemoryFree(bufi, PAGE_ALIGN_UP(bufsize + boffi));
+            DkVirtualMemoryFree(bufi, ALLOC_ALIGN_UP(bufsize + boffi));
             bufi = NULL;
-            DkVirtualMemoryFree(bufo, PAGE_ALIGN_UP(bufsize + boffo));
+            DkVirtualMemoryFree(bufo, ALLOC_ALIGN_UP(bufsize + boffo));
             bufo = NULL;
         } else if (do_mapo) {
             copysize = fsi->fs_ops->read(hdli, bufo + boffo, bufsize);
-            DkVirtualMemoryFree(bufo, PAGE_ALIGN_UP(bufsize + boffo));
+            DkVirtualMemoryFree(bufo, ALLOC_ALIGN_UP(bufsize + boffo));
             bufo = NULL;
             if (copysize < 0)
                 break;
         } else if (do_mapi) {
             copysize = fso->fs_ops->write(hdlo, bufi + boffi, bufsize);
-            DkVirtualMemoryFree(bufi, PAGE_ALIGN_UP(bufsize + boffi));
+            DkVirtualMemoryFree(bufi, ALLOC_ALIGN_UP(bufsize + boffi));
             bufi = NULL;
             if (copysize < 0)
                 break;

--- a/LibOS/shim/src/sys/shim_msgget.c
+++ b/LibOS/shim/src/sys/shim_msgget.c
@@ -757,7 +757,7 @@ static int __store_msg_persist(struct shim_msg_handle* msgq) {
 
     void* mem =
         (void*)DkStreamMap(file, NULL, PAL_PROT_READ | PAL_PROT_WRITE, 0,
-                           PAGE_ALIGN_UP(expected_size));
+                           ALLOC_ALIGN_UP(expected_size));
     if (!mem) {
         ret = -EFAULT;
         goto err_file;
@@ -784,7 +784,7 @@ static int __store_msg_persist(struct shim_msg_handle* msgq) {
         mtype->msgs = mtype->msg_tail = NULL;
     }
 
-    DkStreamUnmap(mem, PAGE_ALIGN_UP(expected_size));
+    DkStreamUnmap(mem, ALLOC_ALIGN_UP(expected_size));
 
     if (msgq->owned)
         for (mtype = msgq->types; mtype < &msgq->types[msgq->ntypes]; mtype++) {
@@ -849,7 +849,7 @@ static int __load_msg_persist(struct shim_msg_handle* msgq, bool readmsg) {
     int expected_size = sizeof(struct msg_handle_backup) + sizeof(struct msg_backup) * mback.nmsgs +
                         mback.currentsize;
 
-    void* mem = (void*)DkStreamMap(file, NULL, PAL_PROT_READ, 0, PAGE_ALIGN_UP(expected_size));
+    void* mem = (void*)DkStreamMap(file, NULL, PAL_PROT_READ, 0, ALLOC_ALIGN_UP(expected_size));
 
     if (!mem) {
         ret = -PAL_ERRNO;
@@ -872,7 +872,7 @@ static int __load_msg_persist(struct shim_msg_handle* msgq, bool readmsg) {
             goto out;
     };
 
-    DkStreamUnmap(mem, PAGE_ALIGN_UP(expected_size));
+    DkStreamUnmap(mem, ALLOC_ALIGN_UP(expected_size));
 
 done:
     DkStreamDelete(file, 0);

--- a/Pal/lib/memmgr.h
+++ b/Pal/lib/memmgr.h
@@ -76,35 +76,35 @@ typedef struct mem_mgr {
 #define __MIN_MEM_SIZE()     (sizeof(MEM_MGR_TYPE) + sizeof(MEM_AREA_TYPE))
 #define __MAX_MEM_SIZE(size) (__MIN_MEM_SIZE() + __SUM_OBJ_SIZE(size))
 
-#ifdef PAGE_SIZE
+#ifdef ALLOC_ALIGNMENT
 static inline int size_align_down(int size) {
-    assert(IS_POWER_OF_2(PAGE_SIZE));
+    assert(IS_POWER_OF_2(ALLOC_ALIGNMENT));
     int s = __MAX_MEM_SIZE(size) - sizeof(MEM_MGR_TYPE);
-    int p = s - ALIGN_DOWN_POW2(s, PAGE_SIZE);
+    int p = s - ALIGN_DOWN_POW2(s, ALLOC_ALIGNMENT);
     int o = __SUM_OBJ_SIZE(1);
     return size - p / o - (p % o ? 1 : 0);
 }
 
 static inline int size_align_up(int size) {
-    assert(IS_POWER_OF_2(PAGE_SIZE));
+    assert(IS_POWER_OF_2(ALLOC_ALIGNMENT));
     int s = __MAX_MEM_SIZE(size) - sizeof(MEM_MGR_TYPE);
-    int p = ALIGN_UP_POW2(s, PAGE_SIZE) - s;
+    int p = ALIGN_UP_POW2(s, ALLOC_ALIGNMENT) - s;
     int o = __SUM_OBJ_SIZE(1);
     return size + p / o;
 }
 
 static inline int init_align_down(int size) {
-    assert(IS_POWER_OF_2(PAGE_SIZE));
+    assert(IS_POWER_OF_2(ALLOC_ALIGNMENT));
     int s = __MAX_MEM_SIZE(size);
-    int p = s - ALIGN_DOWN_POW2(s, PAGE_SIZE);
+    int p = s - ALIGN_DOWN_POW2(s, ALLOC_ALIGNMENT);
     int o = __SUM_OBJ_SIZE(1);
     return size - p / o - (p % o ? 1 : 0);
 }
 
 static inline int init_align_up(int size) {
-    assert(IS_POWER_OF_2(PAGE_SIZE));
+    assert(IS_POWER_OF_2(ALLOC_ALIGNMENT));
     int s = __MAX_MEM_SIZE(size);
-    int p = ALIGN_UP_POW2(s, PAGE_SIZE) - s;
+    int p = ALIGN_UP_POW2(s, ALLOC_ALIGNMENT) - s;
     int o = __SUM_OBJ_SIZE(1);
     return size + p / o;
 }

--- a/Pal/lib/slabmgr.h
+++ b/Pal/lib/slabmgr.h
@@ -169,39 +169,39 @@ typedef struct __attribute__((packed)) large_mem_obj {
 #define __INIT_MIN_MEM_SIZE()     (sizeof(SLAB_MGR_TYPE) + sizeof(SLAB_AREA_TYPE) * SLAB_LEVEL)
 #define __INIT_MAX_MEM_SIZE(size) (__INIT_MIN_MEM_SIZE() + __INIT_SUM_OBJ_SIZE(size))
 
-#ifdef PAGE_SIZE
+#ifdef ALLOC_ALIGNMENT
 static inline int size_align_down(int slab_size, int size) {
-    assert(IS_POWER_OF_2(PAGE_SIZE));
+    assert(IS_POWER_OF_2(ALLOC_ALIGNMENT));
     int s = __MAX_MEM_SIZE(slab_size, size);
-    int p = s - ALIGN_DOWN_POW2(s, PAGE_SIZE);
+    int p = s - ALIGN_DOWN_POW2(s, ALLOC_ALIGNMENT);
     int o = __SUM_OBJ_SIZE(slab_size, 1);
     return size - p / o - (p % o ? 1 : 0);
 }
 
 static inline int size_align_up(int slab_size, int size) {
-    assert(IS_POWER_OF_2(PAGE_SIZE));
+    assert(IS_POWER_OF_2(ALLOC_ALIGNMENT));
     int s = __MAX_MEM_SIZE(slab_size, size);
-    int p = ALIGN_UP_POW2(s, PAGE_SIZE) - s;
+    int p = ALIGN_UP_POW2(s, ALLOC_ALIGNMENT) - s;
     int o = __SUM_OBJ_SIZE(slab_size, 1);
     return size + p / o;
 }
 
 static inline int init_align_down(int size) {
-    assert(IS_POWER_OF_2(PAGE_SIZE));
+    assert(IS_POWER_OF_2(ALLOC_ALIGNMENT));
     int s = __INIT_MAX_MEM_SIZE(size);
-    int p = s - ALIGN_DOWN_POW2(s, PAGE_SIZE);
+    int p = s - ALIGN_DOWN_POW2(s, ALLOC_ALIGNMENT);
     int o = __INIT_SUM_OBJ_SIZE(1);
     return size - p / o - (p % o ? 1 : 0);
 }
 
 static inline int init_size_align_up(int size) {
-    assert(IS_POWER_OF_2(PAGE_SIZE));
+    assert(IS_POWER_OF_2(ALLOC_ALIGNMENT));
     int s = __INIT_MAX_MEM_SIZE(size);
-    int p = ALIGN_UP_POW2(s, PAGE_SIZE) - s;
+    int p = ALIGN_UP_POW2(s, ALLOC_ALIGNMENT) - s;
     int o = __INIT_SUM_OBJ_SIZE(1);
     return size + p / o;
 }
-#endif /* PAGE_SIZE */
+#endif /* ALLOC_ALIGNMENT */
 
 #ifndef STARTUP_SIZE
 #define STARTUP_SIZE 16
@@ -216,7 +216,7 @@ static inline void __set_free_slab_area(SLAB_AREA area, SLAB_MGR mgr, int level)
 }
 
 static inline SLAB_MGR create_slab_mgr(void) {
-#ifdef PAGE_SIZE
+#ifdef ALLOC_ALIGNMENT
     size_t size = init_size_align_up(STARTUP_SIZE);
 #else
     size_t size = STARTUP_SIZE;

--- a/Pal/lib/slabmgr.h
+++ b/Pal/lib/slabmgr.h
@@ -65,12 +65,6 @@
 
 #define LARGE_OBJ_PADDING 8
 
-/* Returns the smallest exact multiple of _y that is at least as large as _x.
- * In other words, returns _x if _x is a multiple of _y, otherwise rounds
- * _x up to be a multiple of _y.
- */
-#define ROUND_UP(_x, _y) ((((_x) + (_y) - 1) / (_y)) * (_y))
-
 DEFINE_LIST(slab_obj);
 
 typedef struct __attribute__((packed)) slab_obj {
@@ -116,10 +110,9 @@ struct slab_debug {
 #define SLAB_CANARY_SIZE 0
 #endif
 
-#define SLAB_HDR_SIZE                                                                 \
-    ROUND_UP((sizeof(SLAB_OBJ_TYPE) - sizeof(LIST_TYPE(slab_obj)) + SLAB_DEBUG_SIZE + \
-              SLAB_CANARY_SIZE),                                                      \
-             MIN_MALLOC_ALIGNMENT)
+#define SLAB_HDR_SIZE                                                                \
+    ALIGN_UP(sizeof(SLAB_OBJ_TYPE) - sizeof(LIST_TYPE(slab_obj)) + SLAB_DEBUG_SIZE + \
+             SLAB_CANARY_SIZE, MIN_MALLOC_ALIGNMENT)
 
 #ifndef SLAB_LEVEL
 #define SLAB_LEVEL 8

--- a/Pal/regression/Bootstrap.c
+++ b/Pal/regression/Bootstrap.c
@@ -40,8 +40,6 @@ int main(int argc, char** argv, char** envp) {
     char* msg = "Written to Debug Stream\n";
     DkStreamWrite(pal_control.debug_stream, 0, strlen(msg), msg, NULL);
 
-    /* page size */
-    pal_printf("Page Size: %ld\n", pal_control.pagesize);
     /* Allocation Alignment */
     pal_printf("Allocation Alignment: %ld\n", pal_control.alloc_align);
 

--- a/Pal/regression/test_pal.py
+++ b/Pal/regression/test_pal.py
@@ -55,9 +55,6 @@ class TC_01_Bootstrap(RegressionTestCase):
         # Control Block: Debug Stream (Inline)
         self.assertIn('Written to Debug Stream', stdout)
 
-        # Control Block: Page Size
-        self.assertIn('Page Size: {}'.format(mmap.PAGESIZE), stderr)
-
         # Control Block: Allocation Alignment
         self.assertIn('Allocation Alignment: {}'.format(mmap.ALLOCATIONGRANULARITY), stderr)
 

--- a/Pal/src/db_main.c
+++ b/Pal/src/db_main.c
@@ -235,8 +235,7 @@ noreturn void pal_main (
     pal_state.instance_id = instance_id;
     pal_state.pagesize    = _DkGetPagesize();
     pal_state.alloc_align = _DkGetAllocationAlignment();
-    pal_state.alloc_shift = pal_state.alloc_align - 1;
-    pal_state.alloc_mask  = ~pal_state.alloc_shift;
+    assert(IS_POWER_OF_2(pal_state.alloc_align));
 
     init_slab_mgr(pal_state.alloc_align);
 
@@ -310,7 +309,7 @@ noreturn void pal_main (
 
         ret = _DkStreamMap(manifest_handle, &cfg_addr,
                            PAL_PROT_READ, 0,
-                           ALLOC_ALIGNUP(cfg_size));
+                           ALLOC_ALIGN_UP(cfg_size));
         if (ret < 0)
             INIT_FAIL(-ret, "cannot open manifest file");
 

--- a/Pal/src/db_main.c
+++ b/Pal/src/db_main.c
@@ -233,7 +233,6 @@ noreturn void pal_main (
 #endif
 
     pal_state.instance_id = instance_id;
-    pal_state.pagesize    = _DkGetPagesize();
     pal_state.alloc_align = _DkGetAllocationAlignment();
     assert(IS_POWER_OF_2(pal_state.alloc_align));
 
@@ -443,7 +442,6 @@ noreturn void pal_main (
                                     &__pal_control.user_address_hole.start,
                                     &__pal_control.user_address_hole.end);
 
-    __pal_control.pagesize           = pal_state.pagesize;
     __pal_control.alloc_align        = pal_state.alloc_align;
     __pal_control.broadcast_stream   = _DkBroadcastStreamOpen();
 

--- a/Pal/src/db_memory.c
+++ b/Pal/src/db_memory.c
@@ -32,12 +32,12 @@ DkVirtualMemoryAlloc(PAL_PTR addr, PAL_NUM size, PAL_FLG alloc_type, PAL_FLG pro
     ENTER_PAL_CALL(DkVirtualMemoryAlloc);
     void* map_addr = (void*)addr;
 
-    if ((addr && !ALLOC_ALIGNED(addr)) || !size || !ALLOC_ALIGNED(size)) {
+    if ((addr && !IS_ALLOC_ALIGNED_PTR(addr)) || !size || !IS_ALLOC_ALIGNED(size)) {
         _DkRaiseFailure(PAL_ERROR_INVAL);
         LEAVE_PAL_CALL_RETURN((PAL_PTR)NULL);
     }
 
-    if (map_addr && _DkCheckMemoryMappable((void*)map_addr, size)) {
+    if (map_addr && _DkCheckMemoryMappable(map_addr, size)) {
         _DkRaiseFailure(PAL_ERROR_DENIED);
         LEAVE_PAL_CALL_RETURN((PAL_PTR)NULL);
     }
@@ -60,7 +60,7 @@ void DkVirtualMemoryFree(PAL_PTR addr, PAL_NUM size) {
         LEAVE_PAL_CALL();
     }
 
-    if (!ALLOC_ALIGNED(addr) || !ALLOC_ALIGNED(size)) {
+    if (!IS_ALLOC_ALIGNED_PTR(addr) || !IS_ALLOC_ALIGNED(size)) {
         _DkRaiseFailure(PAL_ERROR_INVAL);
         LEAVE_PAL_CALL();
     }
@@ -88,7 +88,7 @@ DkVirtualMemoryProtect(PAL_PTR addr, PAL_NUM size, PAL_FLG prot) {
         LEAVE_PAL_CALL_RETURN(PAL_FALSE);
     }
 
-    if (!ALLOC_ALIGNED((void*)addr) || !ALLOC_ALIGNED(size)) {
+    if (!IS_ALLOC_ALIGNED_PTR(addr) || !IS_ALLOC_ALIGNED(size)) {
         _DkRaiseFailure(PAL_ERROR_INVAL);
         LEAVE_PAL_CALL_RETURN(PAL_FALSE);
     }

--- a/Pal/src/db_streams.c
+++ b/Pal/src/db_streams.c
@@ -532,12 +532,13 @@ DkStreamMap(PAL_HANDLE handle, PAL_PTR addr, PAL_FLG prot, PAL_NUM offset, PAL_N
     }
 
     /* Check that all addresses and sizes are aligned */
-    if ((addr && !ALLOC_ALIGNED(addr)) || !size || !ALLOC_ALIGNED(size) || !ALLOC_ALIGNED(offset)) {
+    if ((addr && !IS_ALLOC_ALIGNED_PTR(addr)) || !size || !IS_ALLOC_ALIGNED(size) || 
+            !IS_ALLOC_ALIGNED(offset)) {
         _DkRaiseFailure(PAL_ERROR_INVAL);
         LEAVE_PAL_CALL_RETURN((PAL_PTR)NULL);
     }
 
-    if (map_addr && _DkCheckMemoryMappable((void*)map_addr, size)) {
+    if (map_addr && _DkCheckMemoryMappable(map_addr, size)) {
         _DkRaiseFailure(PAL_ERROR_DENIED);
         LEAVE_PAL_CALL_RETURN((PAL_PTR)NULL);
     }
@@ -558,7 +559,7 @@ DkStreamMap(PAL_HANDLE handle, PAL_PTR addr, PAL_FLG prot, PAL_NUM offset, PAL_N
 void DkStreamUnmap(PAL_PTR addr, PAL_NUM size) {
     ENTER_PAL_CALL(DkStreamUnmap);
 
-    if (!addr || !ALLOC_ALIGNED((void*)addr) || !size || !ALLOC_ALIGNED(size)) {
+    if (!addr || !IS_ALLOC_ALIGNED_PTR(addr) || !size || !IS_ALLOC_ALIGNED(size)) {
         _DkRaiseFailure(PAL_ERROR_INVAL);
         LEAVE_PAL_CALL();
     }

--- a/Pal/src/host/FreeBSD/db_main.c
+++ b/Pal/src/host/FreeBSD/db_main.c
@@ -55,7 +55,7 @@ asm (".global pal_start \n"
 struct pal_bsd_state bsd_state;
 struct pal_sec pal_sec;
 
-static int pagesz = PRESET_PAGESIZE;
+static size_t g_page_size = PRESET_PAGESIZE;
 static uid_t uid;
 static gid_t gid;
 
@@ -101,7 +101,7 @@ static void pal_init_bootstrap (void * args, const char ** pal_name,
     for (av = (ElfW(auxv_t) *)auxv ; av->a_type != AT_NULL ; av++)
         switch (av->a_type) {
             case AT_PAGESZ:
-                pagesz = av->a_un.a_val;
+                g_page_size = av->a_un.a_val;
                 break;
             case AT_UID:
             case AT_EUID:
@@ -127,12 +127,12 @@ static void pal_init_bootstrap (void * args, const char ** pal_name,
 
 unsigned long _DkGetPagesize (void)
 {
-    return pagesz;
+    return g_page_size;
 }
 
 unsigned long _DkGetAllocationAlignment (void)
 {
-    return pagesz;
+    return g_page_size;
 }
 
 void _DkGetAvailableUserAddressRange (PAL_PTR * start, PAL_PTR * end,
@@ -215,7 +215,7 @@ void pal_bsd_main (void * args)
                          pal_map.l_info, pal_map.l_addr);
     ELF_DYNAMIC_RELOCATE(&pal_map);
 
-    init_slab_mgr(pagesz);
+    init_slab_mgr(g_page_size);
     setup_pal_map(&pal_map);
 
     bsd_state.start_time = 1000000ULL * time.tv_sec + time.tv_usec;

--- a/Pal/src/host/FreeBSD/db_main.c
+++ b/Pal/src/host/FreeBSD/db_main.c
@@ -142,15 +142,15 @@ void _DkGetAvailableUserAddressRange (PAL_PTR * start, PAL_PTR * end,
 
     if ((void *) TEXT_START - (void *) USER_ADDRESS_LOWEST >
         (void *) USER_ADDRESS_HIGHEST - (void *) DATA_END){
-        end_addr = (void *) ALLOC_ALIGNDOWN(TEXT_START);
+        end_addr = (void*)ALLOC_ALIGN_DOWN(TEXT_START);
         start_addr = pal_sec.user_addr_base ? :
             (void *) USER_ADDRESS_LOWEST;
     } else {
-        end_addr = (void *) USER_ADDRESS_HIGHEST;
-        start_addr = (void *) ALLOC_ALIGNUP(DATA_END);
+        end_addr = (void*)USER_ADDRESS_HIGHEST;
+        start_addr = (void*)ALLOC_ALIGN_UP(DATA_END);
     }
 
-    assert(ALLOC_ALIGNED(start_addr) && ALLOC_ALIGNED(end_addr));
+    assert(IS_ALLOC_ALIGNED(start_addr) && IS_ALLOC_ALIGNED(end_addr));
 
     while (1) {
         if (start_addr >= end_addr)

--- a/Pal/src/host/Linux-SGX/db_files.c
+++ b/Pal/src/host/Linux-SGX/db_files.c
@@ -130,7 +130,7 @@ static int64_t file_read(PAL_HANDLE handle, uint64_t offset, uint64_t count, voi
     uint64_t map_end   = ALIGN_UP(end, TRUSTED_STUB_SIZE);
 
     if (map_end > total)
-        map_end = ALLOC_ALIGNUP(total);
+        map_end = ALLOC_ALIGN_UP(total);
 
     ret = copy_and_verify_trusted_file(handle->file.realpath, handle->file.umem + map_start,
             map_start, map_end, buffer, offset, end - offset, stubs, total);
@@ -236,8 +236,8 @@ static int file_map(PAL_HANDLE handle, void** addr, int prot, uint64_t offset, u
         map_start = ALIGN_DOWN(offset, TRUSTED_STUB_SIZE);
         map_end   = ALIGN_UP(end, TRUSTED_STUB_SIZE);
     } else {
-        map_start = ALLOC_ALIGNDOWN(offset);
-        map_end   = ALLOC_ALIGNUP(end);
+        map_start = ALLOC_ALIGN_DOWN(offset);
+        map_end   = ALLOC_ALIGN_UP(end);
     }
 
     ret = ocall_mmap_untrusted(handle->file.fd, map_start, map_end - map_start, PROT_READ, &umem);

--- a/Pal/src/host/Linux-SGX/db_main.c
+++ b/Pal/src/host/Linux-SGX/db_main.c
@@ -315,8 +315,6 @@ void pal_linux_main(char * uptr_args, uint64_t args_size,
 
     /* Set the alignment early */
     pal_state.alloc_align = pagesz;
-    pal_state.alloc_shift = pagesz - 1;
-    pal_state.alloc_mask  = ~pagesz;
 
     /* initialize enclave properties */
     rv = init_enclave();

--- a/Pal/src/host/Linux-SGX/db_memory.c
+++ b/Pal/src/host/Linux-SGX/db_memory.c
@@ -131,10 +131,10 @@ unsigned long _DkMemoryQuota (void)
 }
 
 extern struct atomic_int alloced_pages;
-extern unsigned int pagesz;
+extern unsigned int g_page_size;
 
 unsigned long _DkMemoryAvailableQuota (void)
 {
     return (pal_sec.heap_max - pal_sec.heap_min) -
-        atomic_read(&alloced_pages) * pagesz;
+        atomic_read(&alloced_pages) * g_page_size;
 }

--- a/Pal/src/host/Linux-SGX/db_rtld.c
+++ b/Pal/src/host/Linux-SGX/db_rtld.c
@@ -62,8 +62,8 @@ void _DkDebugAddMap (struct link_map * map)
 
     if (!shdr) {
         shdr = __alloca(shdrsz);
-        unsigned long s = ALLOC_ALIGNDOWN(ehdr->e_shoff);
-        unsigned long e = ALLOC_ALIGNUP(ehdr->e_shoff + shdrsz);
+        unsigned long s = ALLOC_ALIGN_DOWN(ehdr->e_shoff);
+        unsigned long e = ALLOC_ALIGN_UP(ehdr->e_shoff + shdrsz);
         void * umem;
         ocall_mmap_untrusted(fd, s, e - s, PROT_READ, &umem);
         memcpy(shdr, umem + ehdr->e_shoff - s, shdrsz);
@@ -86,8 +86,8 @@ void _DkDebugAddMap (struct link_map * map)
 
     if (!shstrtab) {
         shstrtab = __alloca(shstrsz);
-        unsigned long s = ALLOC_ALIGNDOWN(shstroff);
-        unsigned long e = ALLOC_ALIGNUP(shstroff + shstrsz);
+        unsigned long s = ALLOC_ALIGN_DOWN(shstroff);
+        unsigned long e = ALLOC_ALIGN_UP(shstroff + shstrsz);
         void * umem;
         ocall_mmap_untrusted(fd, s, e - s, PROT_READ, &umem);
         memcpy((void *) shstrtab, umem + shstroff - s, shstrsz);

--- a/Pal/src/host/Linux-SGX/enclave_ocalls.c
+++ b/Pal/src/host/Linux-SGX/enclave_ocalls.c
@@ -172,7 +172,7 @@ int ocall_read (int fd, void * buf, unsigned int count)
     ms_ocall_read_t * ms;
 
     if (count > MAX_UNTRUSTED_STACK_BUF) {
-        retval = ocall_mmap_untrusted(-1, 0, ALLOC_ALIGNUP(count), PROT_READ | PROT_WRITE, &obuf);
+        retval = ocall_mmap_untrusted(-1, 0, ALLOC_ALIGN_UP(count), PROT_READ | PROT_WRITE, &obuf);
         if (IS_ERR(retval))
             return retval;
     }
@@ -207,7 +207,7 @@ int ocall_read (int fd, void * buf, unsigned int count)
 out:
     sgx_reset_ustack();
     if (obuf)
-        ocall_munmap_untrusted(obuf, ALLOC_ALIGNUP(count));
+        ocall_munmap_untrusted(obuf, ALLOC_ALIGN_UP(count));
     return retval;
 }
 
@@ -224,7 +224,7 @@ int ocall_write (int fd, const void * buf, unsigned int count)
         /* typical case of buf inside of enclave memory */
         if (count > MAX_UNTRUSTED_STACK_BUF) {
             /* buf is too big and may overflow untrusted stack, so use untrusted heap */
-            retval = ocall_mmap_untrusted(-1, 0, ALLOC_ALIGNUP(count), PROT_READ | PROT_WRITE, &obuf);
+            retval = ocall_mmap_untrusted(-1, 0, ALLOC_ALIGN_UP(count), PROT_READ | PROT_WRITE, &obuf);
             if (IS_ERR(retval))
                 return retval;
             memcpy(obuf, buf, count);
@@ -257,7 +257,7 @@ int ocall_write (int fd, const void * buf, unsigned int count)
 out:
     sgx_reset_ustack();
     if (obuf && obuf != buf)
-        ocall_munmap_untrusted(obuf, ALLOC_ALIGNUP(count));
+        ocall_munmap_untrusted(obuf, ALLOC_ALIGN_UP(count));
     return retval;
 }
 
@@ -722,7 +722,7 @@ int ocall_recv (int sockfd, void * buf, unsigned int count,
     ms_ocall_recv_t * ms;
 
     if ((count + addrlen + controllen) > MAX_UNTRUSTED_STACK_BUF) {
-        retval = ocall_mmap_untrusted(-1, 0, ALLOC_ALIGNUP(count), PROT_READ | PROT_WRITE, &obuf);
+        retval = ocall_mmap_untrusted(-1, 0, ALLOC_ALIGN_UP(count), PROT_READ | PROT_WRITE, &obuf);
         if (IS_ERR(retval))
             return retval;
     }
@@ -779,7 +779,7 @@ int ocall_recv (int sockfd, void * buf, unsigned int count,
 out:
     sgx_reset_ustack();
     if (obuf)
-        ocall_munmap_untrusted(obuf, ALLOC_ALIGNUP(count));
+        ocall_munmap_untrusted(obuf, ALLOC_ALIGN_UP(count));
     return retval;
 }
 
@@ -798,7 +798,7 @@ int ocall_send (int sockfd, const void * buf, unsigned int count,
         /* typical case of buf inside of enclave memory */
         if ((count + addrlen + controllen) > MAX_UNTRUSTED_STACK_BUF) {
             /* buf is too big and may overflow untrusted stack, so use untrusted heap */
-            retval = ocall_mmap_untrusted(-1, 0, ALLOC_ALIGNUP(count), PROT_READ | PROT_WRITE, &obuf);
+            retval = ocall_mmap_untrusted(-1, 0, ALLOC_ALIGN_UP(count), PROT_READ | PROT_WRITE, &obuf);
             if (IS_ERR(retval))
                 return retval;
             memcpy(obuf, buf, count);
@@ -835,7 +835,7 @@ int ocall_send (int sockfd, const void * buf, unsigned int count,
 out:
     sgx_reset_ustack();
     if (obuf && obuf != buf)
-        ocall_munmap_untrusted(obuf, ALLOC_ALIGNUP(count));
+        ocall_munmap_untrusted(obuf, ALLOC_ALIGN_UP(count));
     return retval;
 }
 
@@ -1090,7 +1090,7 @@ int ocall_get_attestation (const sgx_spid_t* spid, const char* subkey, bool link
             sgx_quote_t* quote = malloc(len);
             if (!sgx_copy_to_enclave(quote, len, attestation->quote, len))
                 retval = -EACCES;
-            ocall_munmap_untrusted(attestation->quote, ALLOC_ALIGNUP(len));
+            ocall_munmap_untrusted(attestation->quote, ALLOC_ALIGN_UP(len));
             attestation->quote = quote;
         }
 
@@ -1099,7 +1099,7 @@ int ocall_get_attestation (const sgx_spid_t* spid, const char* subkey, bool link
             char* ias_report = malloc(len + 1);
             if (!sgx_copy_to_enclave(ias_report, len, attestation->ias_report, len))
                 retval = -EACCES;
-            ocall_munmap_untrusted(attestation->ias_report, ALLOC_ALIGNUP(len));
+            ocall_munmap_untrusted(attestation->ias_report, ALLOC_ALIGN_UP(len));
             ias_report[len] = 0; // Ensure null-ending
             attestation->ias_report = ias_report;
         }
@@ -1109,7 +1109,7 @@ int ocall_get_attestation (const sgx_spid_t* spid, const char* subkey, bool link
             uint8_t* ias_sig = malloc(len);
             if (!sgx_copy_to_enclave(ias_sig, len, attestation->ias_sig, len))
                 retval = -EACCES;
-            ocall_munmap_untrusted(attestation->ias_sig, ALLOC_ALIGNUP(len));
+            ocall_munmap_untrusted(attestation->ias_sig, ALLOC_ALIGN_UP(len));
             attestation->ias_sig = ias_sig;
         }
 
@@ -1118,7 +1118,7 @@ int ocall_get_attestation (const sgx_spid_t* spid, const char* subkey, bool link
             char* ias_certs = malloc(len + 1);
             if (!sgx_copy_to_enclave(ias_certs, len, attestation->ias_certs, len))
                 retval = -EACCES;
-            ocall_munmap_untrusted(attestation->ias_certs, ALLOC_ALIGNUP(len));
+            ocall_munmap_untrusted(attestation->ias_certs, ALLOC_ALIGN_UP(len));
             ias_certs[len] = 0; // Ensure null-ending
             attestation->ias_certs = ias_certs;
         }

--- a/Pal/src/host/Linux-SGX/enclave_untrusted.c
+++ b/Pal/src/host/Linux-SGX/enclave_untrusted.c
@@ -22,7 +22,7 @@
 #include "enclave_ocalls.h"
 
 static PAL_LOCK malloc_lock = LOCK_INIT;
-static int pagesize         = PRESET_PAGESIZE;
+static size_t pagesize      = PRESET_PAGESIZE;
 
 #define SYSTEM_LOCK()   _DkSpinLock(&malloc_lock)
 #define SYSTEM_UNLOCK() _DkSpinUnlock(&malloc_lock)

--- a/Pal/src/host/Linux-SGX/enclave_untrusted.c
+++ b/Pal/src/host/Linux-SGX/enclave_untrusted.c
@@ -22,12 +22,12 @@
 #include "enclave_ocalls.h"
 
 static PAL_LOCK malloc_lock = LOCK_INIT;
-static size_t pagesize      = PRESET_PAGESIZE;
+static size_t g_page_size   = PRESET_PAGESIZE;
 
 #define SYSTEM_LOCK()   _DkSpinLock(&malloc_lock)
 #define SYSTEM_UNLOCK() _DkSpinUnlock(&malloc_lock)
 
-#define PAGE_SIZE pagesize
+#define ALLOC_ALIGNMENT g_page_size
 
 static inline void* __malloc(int size) {
     void* addr = NULL;

--- a/Pal/src/host/Linux-SGX/sgx_enclave.c
+++ b/Pal/src/host/Linux-SGX/sgx_enclave.c
@@ -66,9 +66,9 @@ static int sgx_ocall_munmap_untrusted(void * pms)
 {
     ms_ocall_munmap_untrusted_t * ms = (ms_ocall_munmap_untrusted_t *) pms;
     ODEBUG(OCALL_MUNMAP_UNTRUSTED, ms);
-    INLINE_SYSCALL(munmap, 2, ALLOC_ALIGNDOWN(ms->ms_mem),
-                   ALLOC_ALIGNUP(ms->ms_mem + ms->ms_size) -
-                   ALLOC_ALIGNDOWN(ms->ms_mem));
+    INLINE_SYSCALL(munmap, 2, ALLOC_ALIGN_DOWN_PTR(ms->ms_mem),
+                   ALLOC_ALIGN_UP_PTR(ms->ms_mem + ms->ms_size) -
+                   ALLOC_ALIGN_DOWN_PTR(ms->ms_mem));
     return 0;
 }
 

--- a/Pal/src/host/Linux-SGX/sgx_framework.c
+++ b/Pal/src/host/Linux-SGX/sgx_framework.c
@@ -117,7 +117,7 @@ static size_t get_ssaframesize (uint64_t xfrm)
                 xsave_size = cpuinfo[0] + cpuinfo[1];
         }
 
-    return ALLOC_ALIGNUP(xsave_size + sizeof(sgx_pal_gpr_t) + 1);
+    return ALLOC_ALIGN_UP(xsave_size + sizeof(sgx_pal_gpr_t) + 1);
 }
 
 bool is_wrfsbase_supported (void)

--- a/Pal/src/host/Linux-SGX/sgx_framework.c
+++ b/Pal/src/host/Linux-SGX/sgx_framework.c
@@ -145,14 +145,14 @@ int create_enclave(sgx_arch_secs_t * secs,
 
     if (!zero_page) {
         zero_page = (void *)
-            INLINE_SYSCALL(mmap, 6, NULL, pagesize,
+            INLINE_SYSCALL(mmap, 6, NULL, g_page_size,
                            PROT_READ, MAP_PRIVATE|MAP_ANONYMOUS,
                            -1, 0);
         if (IS_ERR_P(zero_page))
             return -ENOMEM;
     }
 
-    secs->ssa_frame_size = get_ssaframesize(token->body.attributes.xfrm) / pagesize;
+    secs->ssa_frame_size = get_ssaframesize(token->body.attributes.xfrm) / g_page_size;
     secs->misc_select = token->masked_misc_select_le;
     memcpy(&secs->attributes, &token->body.attributes, sizeof(sgx_attributes_t));
 
@@ -259,7 +259,7 @@ int add_pages_to_enclave(sgx_arch_secs_t * secs,
             p[2] = 'X';
     }
 
-    if (size == pagesize)
+    if (size == g_page_size)
         SGX_DBG(DBG_I, "adding page  to enclave: %p [%s:%s] (%s)%s\n",
                 addr, t, p, comment, m);
     else
@@ -284,9 +284,9 @@ int add_pages_to_enclave(sgx_arch_secs_t * secs,
             return -ERRNO(ret);
         }
 
-        param.addr += pagesize;
-        if (param.src != (uint64_t) zero_page) param.src += pagesize;
-        added_size += pagesize;
+        param.addr += g_page_size;
+        if (param.src != (uint64_t) zero_page) param.src += g_page_size;
+        added_size += g_page_size;
     }
 #else
     struct gsgx_enclave_add_pages param = {
@@ -319,7 +319,7 @@ int init_enclave(sgx_arch_secs_t * secs,
                  sgx_arch_token_t * token)
 {
     unsigned long enclave_valid_addr =
-                secs->base + secs->size - pagesize;
+                secs->base + secs->size - g_page_size;
 
     SGX_DBG(DBG_I, "enclave initializing:\n");
     SGX_DBG(DBG_I, "    enclave id:   0x%016lx\n", enclave_valid_addr);

--- a/Pal/src/host/Linux-SGX/sgx_internal.h
+++ b/Pal/src/host/Linux-SGX/sgx_internal.h
@@ -41,18 +41,21 @@ int snprintf(char * str, int size, const char * fmt, ...) __attribute__((format(
 
 /* constants and macros to help rounding addresses to page
    boundaries */
-extern unsigned long pagesize, pageshift, pagemask;
+extern size_t pagesize;
 
-#undef ALLOC_ALIGNDOWN
-#undef ALLOC_ALIGNUP
-#undef ALLOC_ALIGNED
+#undef IS_ALLOC_ALIGNED
+#undef IS_ALLOC_ALIGNED_PTR
+#undef ALLOC_ALIGN_UP
+#undef ALLOC_ALIGN_UP_PTR
+#undef ALLOC_ALIGN_DOWN
+#undef ALLOC_ALIGN_DOWN_PTR
 
-#define ALLOC_ALIGNDOWN(addr) \
-    (pagesize ? ((unsigned long)(addr)) & pagemask : (unsigned long)(addr))
-#define ALLOC_ALIGNUP(addr) \
-    (pagesize ? (((unsigned long)(addr)) + pageshift) & pagemask : (unsigned long)(addr))
-#define ALLOC_ALIGNED(addr) \
-    (pagesize && ((unsigned long)(addr)) == (((unsigned long)(addr)) & pagemask))
+#define IS_ALLOC_ALIGNED(addr)     IS_ALIGNED_POW2(addr, pagesize)
+#define IS_ALLOC_ALIGNED_PTR(addr) IS_ALIGNED_PTR_POW2(addr, pagesize)
+#define ALLOC_ALIGN_UP(addr)       ALIGN_UP_POW2(addr, pagesize)
+#define ALLOC_ALIGN_UP_PTR(addr)   ALIGN_UP_PTR_POW2(addr, pagesize)
+#define ALLOC_ALIGN_DOWN(addr)     ALIGN_DOWN_POW2(addr, pagesize)
+#define ALLOC_ALIGN_DOWN_PTR(addr) ALIGN_DOWN_PTR_POW2(addr, pagesize)
 
 uint32_t htonl (uint32_t longval);
 uint16_t htons (uint16_t shortval);

--- a/Pal/src/host/Linux-SGX/sgx_internal.h
+++ b/Pal/src/host/Linux-SGX/sgx_internal.h
@@ -41,7 +41,7 @@ int snprintf(char * str, int size, const char * fmt, ...) __attribute__((format(
 
 /* constants and macros to help rounding addresses to page
    boundaries */
-extern size_t pagesize;
+extern size_t g_page_size;
 
 #undef IS_ALLOC_ALIGNED
 #undef IS_ALLOC_ALIGNED_PTR
@@ -50,12 +50,12 @@ extern size_t pagesize;
 #undef ALLOC_ALIGN_DOWN
 #undef ALLOC_ALIGN_DOWN_PTR
 
-#define IS_ALLOC_ALIGNED(addr)     IS_ALIGNED_POW2(addr, pagesize)
-#define IS_ALLOC_ALIGNED_PTR(addr) IS_ALIGNED_PTR_POW2(addr, pagesize)
-#define ALLOC_ALIGN_UP(addr)       ALIGN_UP_POW2(addr, pagesize)
-#define ALLOC_ALIGN_UP_PTR(addr)   ALIGN_UP_PTR_POW2(addr, pagesize)
-#define ALLOC_ALIGN_DOWN(addr)     ALIGN_DOWN_POW2(addr, pagesize)
-#define ALLOC_ALIGN_DOWN_PTR(addr) ALIGN_DOWN_PTR_POW2(addr, pagesize)
+#define IS_ALLOC_ALIGNED(addr)     IS_ALIGNED_POW2(addr, g_page_size)
+#define IS_ALLOC_ALIGNED_PTR(addr) IS_ALIGNED_PTR_POW2(addr, g_page_size)
+#define ALLOC_ALIGN_UP(addr)       ALIGN_UP_POW2(addr, g_page_size)
+#define ALLOC_ALIGN_UP_PTR(addr)   ALIGN_UP_PTR_POW2(addr, g_page_size)
+#define ALLOC_ALIGN_DOWN(addr)     ALIGN_DOWN_POW2(addr, g_page_size)
+#define ALLOC_ALIGN_DOWN_PTR(addr) ALIGN_DOWN_PTR_POW2(addr, g_page_size)
 
 uint32_t htonl (uint32_t longval);
 uint16_t htons (uint16_t shortval);

--- a/Pal/src/host/Linux-SGX/sgx_platform.c
+++ b/Pal/src/host/Linux-SGX/sgx_platform.c
@@ -246,7 +246,7 @@ int contact_intel_attest_service(const char* subkey, const sgx_quote_nonce_t* no
     https_output_len = INLINE_SYSCALL(lseek, 3, output_fd, 0, SEEK_END);
     if (IS_ERR(https_output_len) || !https_output_len)
         goto failed;
-    https_output = (char*)INLINE_SYSCALL(mmap, 6, NULL, ALLOC_ALIGNUP(https_output_len),
+    https_output = (char*)INLINE_SYSCALL(mmap, 6, NULL, ALLOC_ALIGN_UP(https_output_len),
                                          PROT_READ, MAP_PRIVATE|MAP_FILE, output_fd, 0);
     if (IS_ERR_P(https_output))
         goto failed;
@@ -260,7 +260,7 @@ int contact_intel_attest_service(const char* subkey, const sgx_quote_nonce_t* no
     https_header_len = INLINE_SYSCALL(lseek, 3, header_fd, 0, SEEK_END);
     if (IS_ERR(https_header_len) || !https_header_len)
         goto failed;
-    https_header = (char*)INLINE_SYSCALL(mmap, 6, NULL, ALLOC_ALIGNUP(https_header_len),
+    https_header = (char*)INLINE_SYSCALL(mmap, 6, NULL, ALLOC_ALIGN_UP(https_header_len),
                                          PROT_READ, MAP_PRIVATE|MAP_FILE, header_fd, 0);
     if (IS_ERR_P(https_header))
         goto failed;
@@ -288,7 +288,7 @@ int contact_intel_attest_service(const char* subkey, const sgx_quote_nonce_t* no
                 goto failed;
             }
 
-            ias_sig = (uint8_t*)INLINE_SYSCALL(mmap, 6, NULL, ALLOC_ALIGNUP(ias_sig_len),
+            ias_sig = (uint8_t*)INLINE_SYSCALL(mmap, 6, NULL, ALLOC_ALIGN_UP(ias_sig_len),
                                                PROT_READ|PROT_WRITE,
                                                MAP_PRIVATE|MAP_ANONYMOUS, -1, 0);
             if (IS_ERR_P(ias_sig)) {
@@ -306,7 +306,7 @@ int contact_intel_attest_service(const char* subkey, const sgx_quote_nonce_t* no
 
             // Decode IAS signature chain
             ias_certs_len = end - start;
-            ias_certs = (char*)INLINE_SYSCALL(mmap, 6, NULL, ALLOC_ALIGNUP(ias_certs_len),
+            ias_certs = (char*)INLINE_SYSCALL(mmap, 6, NULL, ALLOC_ALIGN_UP(ias_certs_len),
                                               PROT_READ|PROT_WRITE,
                                               MAP_PRIVATE|MAP_ANONYMOUS, -1, 0);
             if (IS_ERR_P(ias_certs)) {
@@ -339,9 +339,9 @@ int contact_intel_attest_service(const char* subkey, const sgx_quote_nonce_t* no
 
             // Adjust certificate chain length
             ias_certs[total_bytes++] = '\0';
-            if (ALLOC_ALIGNUP(total_bytes) < ALLOC_ALIGNUP(ias_certs_len))
-                INLINE_SYSCALL(munmap, 2, ALLOC_ALIGNUP(total_bytes),
-                               ALLOC_ALIGNUP(ias_certs_len) - ALLOC_ALIGNUP(total_bytes));
+            if (ALLOC_ALIGN_UP(total_bytes) < ALLOC_ALIGN_UP(ias_certs_len))
+                INLINE_SYSCALL(munmap, 2, ALLOC_ALIGN_UP(total_bytes),
+                               ALLOC_ALIGN_UP(ias_certs_len) - ALLOC_ALIGN_UP(total_bytes));
             ias_certs_len = total_bytes;
         }
 
@@ -371,9 +371,9 @@ int contact_intel_attest_service(const char* subkey, const sgx_quote_nonce_t* no
     ret = 0;
 done:
     if (https_header)
-        INLINE_SYSCALL(munmap, 2, https_header, ALLOC_ALIGNUP(https_header_len));
+        INLINE_SYSCALL(munmap, 2, https_header, ALLOC_ALIGN_UP(https_header_len));
     if (https_output)
-        INLINE_SYSCALL(munmap, 2, https_output, ALLOC_ALIGNUP(https_output_len));
+        INLINE_SYSCALL(munmap, 2, https_output, ALLOC_ALIGN_UP(https_output_len));
     if (pipefds[0] != -1) INLINE_SYSCALL(close, 1, pipefds[0]);
     if (pipefds[1] != -1) INLINE_SYSCALL(close, 1, pipefds[1]);
     if (header_fd != -1) {
@@ -451,7 +451,7 @@ int retrieve_verified_quote(const sgx_spid_t* spid, const char* subkey, bool lin
         goto failed;
     }
 
-    sgx_quote_t* quote = (sgx_quote_t*) INLINE_SYSCALL(mmap, 6, NULL, ALLOC_ALIGNUP(r->quote.len),
+    sgx_quote_t* quote = (sgx_quote_t*) INLINE_SYSCALL(mmap, 6, NULL, ALLOC_ALIGN_UP(r->quote.len),
                                                        PROT_READ|PROT_WRITE,
                                                        MAP_ANONYMOUS|MAP_PRIVATE, -1, 0);
     if (IS_ERR_P(quote)) {
@@ -465,7 +465,7 @@ int retrieve_verified_quote(const sgx_spid_t* spid, const char* subkey, bool lin
 
     ret = contact_intel_attest_service(subkey, nonce, (sgx_quote_t *) quote, attestation);
     if (ret < 0) {
-        INLINE_SYSCALL(munmap, 2, quote, ALLOC_ALIGNUP(r->quote.len));
+        INLINE_SYSCALL(munmap, 2, quote, ALLOC_ALIGN_UP(r->quote.len));
         goto failed;
     }
 

--- a/Pal/src/host/Linux/db_ipc.c
+++ b/Pal/src/host/Linux/db_ipc.c
@@ -127,8 +127,8 @@ int _DkPhysicalMemoryCommit (PAL_HANDLE channel, int entries,
     gs.len  = __alloca(sizeof(unsigned long) * entries);
 
     for (int i = 0 ; i < entries ; i++) {
-        if (!addrs[i] || !sizes[i] || !ALLOC_ALIGNED(addrs[i]) ||
-            !ALLOC_ALIGNED(sizes[i]))
+        if (!addrs[i] || !sizes[i] || !IS_ALLOC_ALIGNED_PTR(addrs[i]) ||
+            !IS_ALLOC_ALIGNED(sizes[i]))
             return -PAL_ERROR_INVAL;
 
         gs.addr[i] = (unsigned long) addrs[i];
@@ -155,7 +155,7 @@ int _DkPhysicalMemoryMap (PAL_HANDLE channel, int entries,
     gr.prot = __alloca(sizeof(unsigned long) * entries);
 
     for (int i = 0 ; i < entries ; i++) {
-        if (!sizes[i] || !ALLOC_ALIGNED(addrs[i]) || !ALLOC_ALIGNED(sizes[i]))
+        if (!sizes[i] || !IS_ALLOC_ALIGNED_PTR(addrs[i]) || !IS_ALLOC_ALIGNED(sizes[i]))
             return -PAL_ERROR_INVAL;
 
         gr.addr[i] = (unsigned long) addrs[i];

--- a/Pal/src/host/Linux/db_main.c
+++ b/Pal/src/host/Linux/db_main.c
@@ -150,10 +150,10 @@ unsigned long _DkGetAllocationAlignment (void)
 void _DkGetAvailableUserAddressRange (PAL_PTR * start, PAL_PTR * end,
                                       PAL_PTR * hole_start, PAL_PTR * hole_end)
 {
-    void * end_addr = (void *) ALLOC_ALIGNDOWN(TEXT_START);
-    void * start_addr = (void *) USER_ADDRESS_LOWEST;
+    void* end_addr = (void*)ALLOC_ALIGN_DOWN_PTR(TEXT_START);
+    void* start_addr = (void*)USER_ADDRESS_LOWEST;
 
-    assert(ALLOC_ALIGNED(start_addr) && ALLOC_ALIGNED(end_addr));
+    assert(IS_ALLOC_ALIGNED_PTR(start_addr) && IS_ALLOC_ALIGNED_PTR(end_addr));
 
     while (1) {
         if (start_addr >= end_addr)

--- a/Pal/src/host/Linux/db_main.c
+++ b/Pal/src/host/Linux/db_main.c
@@ -62,7 +62,7 @@ __asm__ (".pushsection \".debug_gdb_scripts\", \"MS\",@progbits,1\r\n"
 struct pal_linux_state linux_state;
 struct pal_sec pal_sec;
 
-static int pagesz = PRESET_PAGESIZE;
+static size_t g_page_size = PRESET_PAGESIZE;
 static int uid, gid;
 #if USE_VDSO_GETTIME == 1
 static ElfW(Addr) sysinfo_ehdr;
@@ -112,7 +112,7 @@ static void pal_init_bootstrap (void * args, const char ** pal_name,
     for (av = (ElfW(auxv_t) *) (e + 1) ; av->a_type != AT_NULL ; av++)
         switch (av->a_type) {
             case AT_PAGESZ:
-                pagesz = av->a_un.a_val;
+                g_page_size = av->a_un.a_val;
                 break;
             case AT_UID:
             case AT_EUID:
@@ -139,12 +139,12 @@ static void pal_init_bootstrap (void * args, const char ** pal_name,
 
 unsigned long _DkGetPagesize (void)
 {
-    return pagesz;
+    return g_page_size;
 }
 
 unsigned long _DkGetAllocationAlignment (void)
 {
-    return pagesz;
+    return g_page_size;
 }
 
 void _DkGetAvailableUserAddressRange (PAL_PTR * start, PAL_PTR * end,
@@ -229,7 +229,7 @@ void pal_linux_main (void * args)
 
     linux_state.environ = envp;
 
-    init_slab_mgr(pagesz);
+    init_slab_mgr(g_page_size);
 
     first_thread = malloc(HANDLE_SIZE(thread));
     if (!first_thread)

--- a/Pal/src/pal.h
+++ b/Pal/src/pal.h
@@ -187,8 +187,12 @@ typedef struct {
     PAL_PTR_RANGE manifest_preload;
 
     /***** Host information *****/
-    /* host page size / allocation alignment */
-    PAL_NUM pagesize, alloc_align;
+    /* Host allocation alignment.
+     * This currently is (and most likely will always be) indistinguishable from the page size,
+     * looking from the LibOS perspective. The two values can be different on the PAL level though,
+     * see e.g. SYSTEM_INFO::dwAllocationGranularity on Windows.
+     */
+    PAL_NUM alloc_align;
     /* CPU information (only required ones) */
     PAL_CPU_INFO cpu_info;
     /* Memory information (only required ones) */

--- a/Pal/src/pal_internal.h
+++ b/Pal/src/pal_internal.h
@@ -210,8 +210,9 @@ extern struct pal_internal_state {
 
     struct config_store * root_config;
 
-    unsigned long   pagesize;
-    unsigned long   alloc_align, alloc_shift, alloc_mask;
+    /* May not be the same as page size, see e.g. SYSTEM_INFO::dwAllocationGranularity on Windows.
+     */
+    size_t          alloc_align;
 
     PAL_HANDLE      console;
 
@@ -237,13 +238,12 @@ extern struct pal_internal_state {
 
 extern PAL_CONTROL __pal_control;
 
-#define ALLOC_ALIGNDOWN(addr)                               \
-        (((unsigned long)(addr)) & pal_state.alloc_mask)
-#define ALLOC_ALIGNUP(addr)                                 \
-        ((((unsigned long)(addr)) + pal_state.alloc_shift) & pal_state.alloc_mask)
-#define ALLOC_ALIGNED(addr)                                 \
-        ((unsigned long)(addr) ==                           \
-            (((unsigned long)(addr)) & pal_state.alloc_mask))
+#define IS_ALLOC_ALIGNED(addr)     IS_ALIGNED_POW2(addr, pal_state.alloc_align)
+#define IS_ALLOC_ALIGNED_PTR(addr) IS_ALIGNED_PTR_POW2(addr, pal_state.alloc_align)
+#define ALLOC_ALIGN_UP(addr)       ALIGN_UP_POW2(addr, pal_state.alloc_align)
+#define ALLOC_ALIGN_UP_PTR(addr)   ALIGN_UP_PTR_POW2(addr, pal_state.alloc_align)
+#define ALLOC_ALIGN_DOWN(addr)     ALIGN_DOWN_POW2(addr, pal_state.alloc_align)
+#define ALLOC_ALIGN_DOWN_PTR(addr) ALIGN_DOWN_PTR_POW2(addr, pal_state.alloc_align)
 
 /* Main initialization function */
 noreturn void pal_main (

--- a/Pal/src/slab.c
+++ b/Pal/src/slab.c
@@ -41,7 +41,7 @@ static char mem_pool[POOL_SIZE];
 static void* bump         = mem_pool;
 static void* mem_pool_end = &mem_pool[POOL_SIZE];
 #else
-#define PAGE_SIZE slab_alignment
+#define ALLOC_ALIGNMENT slab_alignment
 #endif
 
 #define STARTUP_SIZE 2


### PR DESCRIPTION
## Affected components

- [X] README and global configuration
- [X] Linux PAL
- [X] SGX PAL
- [X] FreeBSD PAL
- [X] Common PAL code
- [X] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->

The first commit is a follow-up to #1063 (which did the same, but for LibOS), the second merges page size and allocation alignment values into one in LibOS (they should be always the same from its perspective).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1168)
<!-- Reviewable:end -->
