### PR TITLE
[Pal/Linux-SGX] Correctly propagate arguments to _DkHandleExternalEvent()

### DIFF
--- a/Pal/src/host/Linux-SGX/enclave_entry.S
+++ b/Pal/src/host/Linux-SGX/enclave_entry.S
@@ -306,7 +306,7 @@ enclave_entry:
 	# If there is registered signal handler for the current exception,
 	# _DkHandleExternalEvent() will be called (and thus we need to save
 	# %rdi = <external event>) before returning from ocall.
-	movq $-EINTR, %rdi # return value for .Lreturn_from_ocall
+	movq $-EINTR, SGX_GPR_RDI(%rbx) # return value for .Lreturn_from_ocall
 	# fallthrough to Case C.
 
 	# This code cannot land in Case B because:


### PR DESCRIPTION
## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [x] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->

Previously, Case A in the in-enclave exception handler in enclave_entry.S incorrectly set RDI register to -EINTR (to indicate interrupted syscall) of the current CPU context, instead of setting RDI register of the interrupted CPU context (which is accessed via SGX_GPR_RDI). This led to very rare data races that hanged the interrupted thread/corrupted its memory, because -EINTR incorrectly propated to SGX_GPR_RSI that holds external event (signal number) and this led to buffer overflows.

This was once a part of PR #1162 but I decided to split that one in several new PRs.

## How to test this PR? <!-- (if applicable) -->

All tests must pass.

Since this fixes a data race, the bug manifested itself in multi-threaded tests with Pthreads and signals. In particular, LibOS tests `abort_multithread` and `spinlock` are good candidates for stress testing. I ran tests in an endless loop something like this: `bash -c "exit 134"; while [ $? -eq 134 ]; do SGX=1 ~/graphene/Runtime/pal_loader abort_multithread; done`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1169)
<!-- Reviewable:end -->
