### PR TITLE
[Pal/Linux-SGX] Remove calculation of frame from _DkExceptionHandler()

### DIFF
--- a/Documentation/oldwiki/Signal-Handling-in-Graphene.md
+++ b/Documentation/oldwiki/Signal-Handling-in-Graphene.md
@@ -154,8 +154,6 @@ On the example of SIGINT, until we arrive into `_DkGenericSignalHandle()`.
 | | | +                                                                                           |a
 | | | | PAL_CONTEXT ctx = copy(uc)  <ctx contains interrupted-context frame>                      |v
 | | | |                                                                                           |e
-| | | | _DkExceptionRealHandler(PAL_EVENT_SUSPEND, ctx)                                           |
-| | | |                                                                                           |
 + + + + _DkGenericSignalHandle(PAL_EVENT_SUSPEND, ctx)                                            v
           < ... >
 ```


### PR DESCRIPTION
<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [x] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->

Graphene-SGX has two logical paths: (1) starting from `_DkHandleExternalEvent()` if thread received a signal while not in enclave mode, and (2) starting from `_DkExceptionHandler()` if thread was in enclave mode (both in `db_exception.c`).

`_DkExceptionHandler()` contained two racy bugs pertaining to the frame variable. Bugs are described in detail in issue #230. The frame tries to find the outer-most enclosing `Dk*` PAL function, but since `_DkExceptionHandler()` happens during enclave-mode execution, there may be no such frame at all. That is why `_DkExceptionHandler()` always calculates and passes further the enclave context. Thus, the frame is not needed at all and can be removed, thus eliminating the corresponding bugs. As a result, an intermediate function `_DkExceptionRealHandler()` was also removed.

This was once a part of PR #1162 but I decided to split that one in several new PRs.

Fixes #230.

## How to test this PR? <!-- (if applicable) -->

All tests must pass.

Since this fixes a data race, the bug manifested itself in multi-threaded tests with Pthreads and signals. In particular, LibOS tests `abort_multithread` and `spinlock` are good candidates for stress testing. I ran tests in an endless loop something like this: `bash -c "exit 134"; while [ $? -eq 134 ]; do SGX=1 ~/graphene/Runtime/pal_loader abort_multithread; done`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1170)
<!-- Reviewable:end -->
