### PR TITLE
[Jenkins] Add Nginx test to all Jenkins pipelines

### DIFF
--- a/Jenkinsfiles/Linux
+++ b/Jenkinsfiles/Linux
@@ -77,6 +77,13 @@ pipeline {
                             LOOP=1 CONCURRENCY_LIST="1 32" ./benchmark-http.sh 127.0.0.1:8003
                             '''
                         sh '''
+                            cd LibOS/shim/test/apps/nginx
+                            make
+                            make start-graphene-server &
+                            sleep 1
+                            LOOP=1 CONCURRENCY_LIST="1 32" ./benchmark-http.sh 127.0.0.1:8002
+                            '''
+                        sh '''
                             cd LibOS/shim/test/apps/apache
                             make
                             make start-graphene-server &
@@ -104,6 +111,7 @@ pipeline {
                            make -C LibOS/shim/test/apps/gcc clean
                            make -C LibOS/shim/test/apps/lmbench clean
                            make -C LibOS/shim/test/apps/lighttpd distclean
+                           make -C LibOS/shim/test/apps/nginx distclean
                            make -C LibOS/shim/test/apps/apache distclean
                            make -C Pal/src PAL_HOST=Skeleton clean
 

--- a/Jenkinsfiles/Linux-18.04
+++ b/Jenkinsfiles/Linux-18.04
@@ -71,6 +71,13 @@ pipeline {
                             LOOP=1 CONCURRENCY_LIST="1 32" ./benchmark-http.sh 127.0.0.1:8003
                             '''
                         sh '''
+                            cd LibOS/shim/test/apps/nginx
+                            make
+                            make start-graphene-server &
+                            sleep 1
+                            LOOP=1 CONCURRENCY_LIST="1 32" ./benchmark-http.sh 127.0.0.1:8002
+                            '''
+                        sh '''
                             cd LibOS/shim/test/apps/apache
                             make
                             make start-graphene-server &

--- a/Jenkinsfiles/Linux-Debug
+++ b/Jenkinsfiles/Linux-Debug
@@ -73,6 +73,13 @@ pipeline {
                             LOOP=1 CONCURRENCY_LIST="1 32" ./benchmark-http.sh 127.0.0.1:8003
                             '''
                         sh '''
+                            cd LibOS/shim/test/apps/nginx
+                            make
+                            make start-graphene-server &
+                            sleep 1
+                            LOOP=1 CONCURRENCY_LIST="1 32" ./benchmark-http.sh 127.0.0.1:8002
+                            '''
+                        sh '''
                             cd LibOS/shim/test/apps/apache
                             make
                             make start-graphene-server &
@@ -98,6 +105,7 @@ pipeline {
                            make -C LibOS/shim/test/apps/gcc clean
                            make -C LibOS/shim/test/apps/lmbench clean
                            make -C LibOS/shim/test/apps/lighttpd distclean
+                           make -C LibOS/shim/test/apps/nginx distclean
                            make -C LibOS/shim/test/apps/apache distclean
                            make -C Pal/src PAL_HOST=Skeleton clean
 

--- a/Jenkinsfiles/Linux-Debug-18.04
+++ b/Jenkinsfiles/Linux-Debug-18.04
@@ -68,6 +68,13 @@ pipeline {
                             LOOP=1 CONCURRENCY_LIST="1 32" ./benchmark-http.sh 127.0.0.1:8003
                             '''
                         sh '''
+                            cd LibOS/shim/test/apps/nginx
+                            make
+                            make start-graphene-server &
+                            sleep 1
+                            LOOP=1 CONCURRENCY_LIST="1 32" ./benchmark-http.sh 127.0.0.1:8002
+                            '''
+                        sh '''
                             cd LibOS/shim/test/apps/apache
                             make
                             make start-graphene-server &

--- a/Jenkinsfiles/Linux-SGX
+++ b/Jenkinsfiles/Linux-SGX
@@ -115,6 +115,13 @@ pipeline {
                             LOOP=1 CONCURRENCY_LIST="1 32" ./benchmark-http.sh 127.0.0.1:8003
                             '''
                         sh '''
+                            cd LibOS/shim/test/apps/nginx
+                            make SGX=1
+                            make SGX=1 start-graphene-server &
+                            sleep 30
+                            LOOP=1 CONCURRENCY_LIST="1 32" ./benchmark-http.sh 127.0.0.1:8002
+                            '''
+                        sh '''
                             cd LibOS/shim/test/apps/apache
                             make SGX=1
                             make SGX=1 start-graphene-server &
@@ -141,6 +148,7 @@ pipeline {
                            make -C LibOS/shim/test/apps/gcc SGX=1 clean
                            make -C LibOS/shim/test/apps/lmbench SGX=1 clean
                            make -C LibOS/shim/test/apps/lighttpd SGX=1 distclean
+                           make -C LibOS/shim/test/apps/nginx SGX=1 distclean
                            make -C LibOS/shim/test/apps/apache SGX=1 distclean
 
                            ./Scripts/clean-check

--- a/Jenkinsfiles/Linux-SGX-18.04
+++ b/Jenkinsfiles/Linux-SGX-18.04
@@ -111,6 +111,13 @@ pipeline {
                             sleep 10
                             LOOP=1 CONCURRENCY_LIST="1 32" ./benchmark-http.sh 127.0.0.1:8003
                             '''
+                        sh '''
+                            cd LibOS/shim/test/apps/nginx
+                            make SGX=1
+                            make SGX=1 start-graphene-server &
+                            sleep 30
+                            LOOP=1 CONCURRENCY_LIST="1 32" ./benchmark-http.sh 127.0.0.1:8002
+                            '''
                             /*
                         sh '''
                             cd LibOS/shim/test/apps/apache

--- a/Jenkinsfiles/ubuntu-16.04.dockerfile
+++ b/Jenkinsfiles/ubuntu-16.04.dockerfile
@@ -37,6 +37,8 @@ RUN apt-get update \
        python3-scipy \
        texinfo \
        wget \
+       zlib1g \
+       zlib1g-dev \
     && /usr/bin/pip3 install protobuf \
 
 # Add the user UID:1001, GID:1001, home at /leeroy

--- a/Jenkinsfiles/ubuntu-18.04.dockerfile
+++ b/Jenkinsfiles/ubuntu-18.04.dockerfile
@@ -37,7 +37,9 @@ RUN apt-get update && env DEBIAN_FRONTEND=noninteractive apt-get install -y \
     python3-pytest \
     python3-scipy \
     texinfo \
-    wget
+    wget \
+    zlib1g \
+    zlib1g-dev
 
 RUN pip3 install 'Sphinx>=1.8' sphinx_rtd_theme recommonmark
 


### PR DESCRIPTION
<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->

We are missing Nginx from Jenkins tests for no good reason. This PR adds it to all Jenkins pipelines.

The corresponding PR in graphene-tests is https://github.com/oscarlab/graphene-tests/pull/55.

## How to test this PR? <!-- (if applicable) -->

Jenkins must run Nginx now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1176)
<!-- Reviewable:end -->
