### PR TITLE
[Makefiles] Link Graphene libraries in a fixed order

### DIFF
--- a/LibOS/shim/src/Makefile
+++ b/LibOS/shim/src/Makefile
@@ -42,15 +42,16 @@ ASFLAGS += $(defs)
 fs	= chroot str pipe socket proc dev eventfd
 ipcns	= pid sysv
 objs	= $(addprefix bookkeep/shim_,handle vma thread signal) \
-	  $(patsubst %.c,%,$(wildcard utils/*.c)) \
+	  $(addprefix utils/,md5 printf strobjs) \
 	  $(addprefix fs/shim_,dcache namei fs_hash fs) \
-	  $(patsubst %.c,%,$(foreach f,$(fs),$(wildcard fs/$(f)/*.c))) \
+	  $(foreach f,$(fs),fs/$(f)/fs) \
+	  $(addprefix fs/proc/,info ipc-thread thread) \
 	  $(addprefix ipc/shim_,ipc ipc_helper ipc_child) \
 	  $(addprefix ipc/shim_ipc_,$(ipcns)) \
 	  elf/shim_rtld \
 	  $(addprefix shim_,init table syscalls checkpoint malloc \
 	  async parser debug object) syscallas start \
-	  $(patsubst %.c,%,$(wildcard sys/*.c)) \
+	  $(addprefix sys/shim_,access alarm benchmark brk clone dup epoll eventfd exec exit fcntl fork fs futex getcwd getpid getrlimit ioctl migrate mmap msgget open pipe poll sched semget sigaction sleep socket stat time uname vfork wait wrappers) \
 	  vdso/vdso-data
 all_objs = $(objs) vdso/vdso-note vdso/vdso
 

--- a/Pal/lib/Makefile
+++ b/Pal/lib/Makefile
@@ -20,7 +20,7 @@ else
 CFLAGS += -I$(target)
 endif
 
-subdirs = string stdlib network graphene util crypto
+subdirs = string stdlib network graphene crypto
 
 # Choose Crypto provider among (mbedtls|wolfssl)
 CRYPTO_PROVIDER ?= mbedtls
@@ -35,12 +35,19 @@ CRYPTO_PROVIDER ?= mbedtls
 # symbols.
 ifeq ($(CRYPTO_PROVIDER),mbedtls)
 subdirs += crypto/mbedtls
+crypto_mbedtls_objs = $(addsuffix .o,aes aesni asn1parse base64 bignum cipher cipher_wrap cmac dhm md md_wrap oid rsa sha256)
 endif
 ifeq ($(CRYPTO_PROVIDER),wolfssl)
 subdirs += crypto/wolfssl
+crypto_wolfssl_objs = $(addsuffix .o,$(patsubst %.c,%.o,$(sort $(wildcard crypto/wolfssl/*.c))))
 endif
 
-objs	= $(foreach dir,$(subdirs),$(patsubst %.c,%.o,$(wildcard $(dir)/*.c)))
+string_objs = $(addsuffix .o,atoi memcmp memcpy memset strchr strendswith strlen wordcopy)
+stdlib_objs = $(addsuffix .o,printfmt)
+network_objs = $(addsuffix .o,hton inet_pton)
+graphene_objs = $(addsuffix .o,config path)
+crypto_objs = $(addsuffix .o,udivmodti4)
+objs += $(foreach dir,$(subdirs),$(addprefix $(dir)/,$($(subst /,_,$(dir))_objs)))
 
 ifeq ($(CRYPTO_PROVIDER),mbedtls)
 CFLAGS += -DCRYPTO_USE_MBEDTLS


### PR DESCRIPTION
## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [x] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->

This PR is a rebase of #1163. That PR used a master branch in the forked repo, and I screwed up in the process of rebase & push. Anyway, #1163 is closed now, and this PR is its rebase.

Previously, Graphene libraries were built using `wildcard` make function. The output of this function (list of files) is non-deterministic (list items can be in any order). This results in different SGX measurements on rebuilds.

In some build environments (e.g., a dedicated Graphene container), it is important to keep these measurements deterministic. This commit achieves this by removing wildcards and explicitly specifying required files.


## How to test this PR? <!-- (if applicable) -->

All tests must pass.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1180)
<!-- Reviewable:end -->
