### PR TITLE
[LibOS] Allow Graphene-SGX to occupy the same process on execve()

### DIFF
--- a/LibOS/shim/include/shim_defs.h
+++ b/LibOS/shim/include/shim_defs.h
@@ -47,8 +47,6 @@
 
 #define CP_INIT_VMA_SIZE            (64 * 1024 * 1024)  /* 64MB */
 
-#define EXECVE_RTLD                 1
-
 #define ENABLE_ASLR                 1
 
 /* debug message printout */

--- a/LibOS/shim/test/regression/exec_same.c
+++ b/LibOS/shim/test/regression/exec_same.c
@@ -1,0 +1,16 @@
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+int main(int argc, char** argv, char** envp) {
+    if (argc > 1) {
+        puts(argv[1]);
+        return 0;
+    }
+    char* const new_argv[] = {argv[0], "hello from execv process", NULL};
+    execv(new_argv[0], new_argv);
+
+    /* must never reach this */
+    return 1;
+}

--- a/LibOS/shim/test/regression/test_libos.py
+++ b/LibOS/shim/test/regression/test_libos.py
@@ -85,14 +85,18 @@ class TC_01_Bootstrap(RegressionTestCase):
             '000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000 ',
             stdout)
 
-    def test_201_fork_and_exec(self):
+    def test_201_exec_same(self):
+        stdout, stderr = self.run_binary(['exec_same'])
+        self.assertIn('hello from execv process', stdout)
+
+    def test_202_fork_and_exec(self):
         stdout, stderr = self.run_binary(['fork_and_exec'])
 
         # fork and exec 2 page child binary
         self.assertIn('child exited with status: 0', stdout)
         self.assertIn('test completed successfully', stdout)
 
-    def test_202_vfork_and_exec(self):
+    def test_203_vfork_and_exec(self):
         stdout, stderr = self.run_binary(['vfork_and_exec'])
 
         # vfork and exec 2 page child binary


### PR DESCRIPTION
<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->

The execve() syscall starts a new executable in the *same* process. Previously, Graphene followed this convention *only* for non-SGX PALs. If PAL was Linux-SGX, Graphene silently terminated the process and created a new one.

This deviation from standard execve() behavior resulted in the host shell becoming detached from the Graphene-SGX process. In turn, this led to our Bash example (on Ubuntu 18.04, bash version 4.4.19) "terminating" early from the point of view of Jenkins, and SGX-18.04 pipeline failed.

This commit allows Graphene-SGX to execve() in the same process, but only if it is the same executable (as in the Bash example). It is still impossible to execve() in the same process for a different executable since this requires a new SGX enclave measurement and thus demands a new process.

## How to test this PR? <!-- (if applicable) -->

Let's see if anything fails. My limited local tests worked nicely.

I will submit a PR on Bash (the one that works on Ubuntu 18.04) separately. See https://github.com/oscarlab/graphene-tests/pull/57 and https://github.com/oscarlab/graphene/pull/1182.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1181)
<!-- Reviewable:end -->
