### PR TITLE
[Pal/Linux-SGX] db_pipes.c: fix segfault due to redundant deletion of pipe

### DIFF
--- a/Pal/src/host/Linux-SGX/db_pipes.c
+++ b/Pal/src/host/Linux-SGX/db_pipes.c
@@ -284,13 +284,6 @@ static int pipe_delete(PAL_HANDLE handle, int access) {
         }
     }
 
-    if (IS_HANDLE_TYPE(handle, pipesrv)) {
-        char buffer[108];
-        pipe_path(handle->pipe.pipeid, buffer, 108);
-        ocall_delete(buffer);
-        return 0;
-    }
-
     if (handle->pipe.fd == PAL_IDX_POISON)
         return 0;
 


### PR DESCRIPTION
## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [x] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->

During Graphene initialization, a "server" pipe is created by the IPC thread. Previously, upon app exit, Graphene's Linux-SGX PAL removed this named pipe. However, this is not needed and led to occasional segfaults. (Note that Linux PAL never had this code). This commit simply removes the offending code.

This bug was first found here: https://github.com/oscarlab/graphene/issues/1117#issuecomment-549642291. The fix (same as in this PR) was subsequently incorporated in this PR: https://github.com/oscarlab/graphene/pull/1128 (see commit fc2039674d2b71af3e924cbbdc6d94634a933142).

Currently, our master branch fails on LibOS tests `test_403_signalexit_multithread` and `test_404_sigprocmask` due to this bug. This only happens on Graphene-SGX built in *debug* mode (thus it was not catched by our Jenkins). PR https://github.com/oscarlab/graphene/pull/1168, though completely unrelated, changed something deep inside Graphene binaries, and revealed this bug.

## How to test this PR? <!-- (if applicable) -->

LibOS regression tests on Graphene-SGX built with `DEBUG=1` must pass now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1184)
<!-- Reviewable:end -->
