### PR TITLE
[Pal/lib] Remove lingering mentions of WolfSSL

### DIFF
--- a/Pal/lib/Makefile
+++ b/Pal/lib/Makefile
@@ -22,7 +22,6 @@ endif
 
 subdirs = string stdlib network graphene crypto
 
-# Choose Crypto provider among (mbedtls|wolfssl)
 CRYPTO_PROVIDER ?= mbedtls
 
 # Select which crypto adpater you want to use here. This has to match
@@ -37,10 +36,6 @@ ifeq ($(CRYPTO_PROVIDER),mbedtls)
 subdirs += crypto/mbedtls
 crypto_mbedtls_objs = $(addsuffix .o,aes aesni asn1parse base64 bignum cipher cipher_wrap cmac dhm md md_wrap oid rsa sha256)
 endif
-ifeq ($(CRYPTO_PROVIDER),wolfssl)
-subdirs += crypto/wolfssl
-crypto_wolfssl_objs = $(addsuffix .o,$(patsubst %.c,%.o,$(sort $(wildcard crypto/wolfssl/*.c))))
-endif
 
 string_objs = $(addsuffix .o,atoi memcmp memcpy memset strchr strendswith strlen wordcopy)
 stdlib_objs = $(addsuffix .o,printfmt)
@@ -54,11 +49,6 @@ CFLAGS += -DCRYPTO_USE_MBEDTLS
 objs += crypto/adapters/mbedtls_adapter.o
 objs += crypto/adapters/mbedtls_dh.o
 objs += crypto/adapters/mbedtls_encoding.o
-endif
-ifeq ($(CRYPTO_PROVIDER),wolfssl)
-CFLAGS += -DCRYPTO_USE_WOLFSSL
-objs += crypto/adapters/wolfssl_adapter.o
-objs += crypto/adapters/wolfssl_dh.o
 endif
 
 .PHONY: all

--- a/Pal/lib/pal_crypto.h
+++ b/Pal/lib/pal_crypto.h
@@ -30,28 +30,6 @@
 
 #define SHA256_DIGEST_LEN 32
 
-#ifdef CRYPTO_USE_WOLFSSL
-#define CRYPTO_PROVIDER_SPECIFIED
-
-#include "crypto/wolfssl/cmac.h"
-#include "crypto/wolfssl/aes.h"
-#include "crypto/wolfssl/sha256.h"
-#include "crypto/wolfssl/dh.h"
-#include "crypto/wolfssl/rsa.h"
-
-typedef SHA256 LIB_SHA256_CONTEXT;
-
-#define DH_SIZE 128
-
-typedef struct {
-    uint8_t priv[DH_SIZE];
-    uint32_t priv_size;
-    DhKey key;
-} LIB_DH_CONTEXT __attribute__((aligned(DH_SIZE)));
-
-typedef struct RSAKey LIB_RSA_KEY;
-#endif /* CRYPTO_USE_WOLFSSL */
-
 #ifdef CRYPTO_USE_MBEDTLS
 #define CRYPTO_PROVIDER_SPECIFIED
 


### PR DESCRIPTION
## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [x] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->

Graphene moved to mbedTLS due to licensing issues, and all WolfSSL files were deleted from the repo long time ago.

## How to test this PR? <!-- (if applicable) -->

All tests must pass.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1191)
<!-- Reviewable:end -->
