### PR TITLE
[LibOS] Add user pointer test in debug pipe parser

### DIFF
--- a/LibOS/shim/src/bookkeep/shim_signal.c
+++ b/LibOS/shim/src/bookkeep/shim_signal.c
@@ -250,7 +250,7 @@ static void memfault_upcall (PAL_PTR event, PAL_NUM arg, PAL_CONTEXT * context)
     shim_tcb_t * tcb = shim_get_tcb();
     assert(tcb);
 
-    if (tcb->test_range.cont_addr && arg
+    if (tcb->test_range.cont_addr
         && (void *) arg >= tcb->test_range.start
         && (void *) arg <= tcb->test_range.end) {
         assert(context);

--- a/LibOS/shim/src/shim_parser.c
+++ b/LibOS/shim/src/shim_parser.c
@@ -793,6 +793,10 @@ static void parse_exec_envp(va_list ap) {
 static void parse_pipe_fds(va_list ap) {
     int* fds = va_arg(ap, int*);
 
+    if (test_user_memory(fds, 2 * sizeof(*fds), false)) {
+        PRINTF("[invalid-addr %p]", fds);
+        return;
+    }
     PRINTF("[%d, %d]", fds[0], fds[1]);
 }
 


### PR DESCRIPTION
<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->
`test_user_memory` did not work correctly with NULL pointer + fixes #1189

## How to test this PR? <!-- (if applicable) -->
LTP and LibOS regression with debug = inline

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1192)
<!-- Reviewable:end -->
