### PR TITLE
[LibOS] Remove the data race on thread::is_alive

### DIFF
--- a/LibOS/shim/include/shim_internal.h
+++ b/LibOS/shim/include/shim_internal.h
@@ -41,6 +41,8 @@
 #include <atomic.h>
 #include <shim_tcb.h>
 
+noreturn void shim_clean_and_exit(int exit_code);
+
 /* important macros and static inline functions */
 static inline unsigned int get_cur_tid(void)
 {
@@ -144,8 +146,6 @@ static inline PAL_HANDLE __open_shim_stdio (void)
     return shim_stdio;
 }
 
-noreturn void shim_terminate (int err);
-
 #define USE_PAUSE       0
 
 static inline void do_pause (void);
@@ -160,7 +160,7 @@ static inline void do_pause (void);
     do {                                                                    \
         __SYS_PRINTF("BUG() " __FILE__ ":%d\n", __LINE__);                  \
         PAUSE();                                                            \
-        shim_terminate(-ENOTRECOVERABLE);                                   \
+        shim_clean_and_exit(-ENOTRECOVERABLE);                              \
     } while (0)
 
 #define DEBUG_HERE() \
@@ -769,9 +769,6 @@ static inline bool memory_migrated(void * mem)
 extern void * __load_address, * __load_address_end;
 extern void * __code_address, * __code_address_end;
 
-/* cleanup and terminate process, preserve exit code if err == 0 */
-noreturn void shim_clean_and_exit(int err);
-
 unsigned long parse_int (const char * str);
 
 extern void * initial_stack;
@@ -797,13 +794,7 @@ void set_rlimit_cur(int resource, uint64_t rlim);
 
 int object_wait_with_retry(PAL_HANDLE handle);
 
-/* this struct is passed as the second argument to release_clear_child_id() */
-struct clear_child_tid_struct {
-    int* clear_child_tid;         /* passed to LibOS's clone() from user app */
-    int  clear_child_tid_val_pal; /* ptr to it is passed to PAL's DkThreadExit() */
-};
-
-void release_clear_child_id(IDTYPE caller, void* clear_child_tids);
+void release_clear_child_tid(int* clear_child_tid);
 
 #ifdef __x86_64__
 #define __SWITCH_STACK(stack_top, func, arg)                    \

--- a/LibOS/shim/include/shim_thread.h
+++ b/LibOS/shim/include/shim_thread.h
@@ -50,7 +50,9 @@ struct shim_thread {
     struct shim_handle_map * handle_map;
 
     /* child tid */
-    int * set_child_tid, * clear_child_tid;
+    int* set_child_tid;
+    int* clear_child_tid;      /* LibOS zeroes it to notify parent that thread exited */
+    int  clear_child_tid_pal;  /* PAL zeroes it to notify LibOS that thread exited */
 
     /* signal handling */
     __sigset_t signal_mask;
@@ -272,7 +274,8 @@ void del_thread (struct shim_thread * thread);
 void add_simple_thread (struct shim_simple_thread * thread);
 void del_simple_thread (struct shim_simple_thread * thread);
 
-int check_last_thread (struct shim_thread * self);
+void cleanup_thread(IDTYPE caller, void* thread);
+int check_last_thread(struct shim_thread* self);
 
 #ifndef ALIAS_VFORK_AS_FORK
 void switch_dummy_thread (struct shim_thread * thread);
@@ -313,10 +316,7 @@ void set_handle_map (struct shim_thread * thread,
     thread->handle_map = map;
 }
 
-/* shim exit callback */
-int thread_exit(struct shim_thread* self, bool send_ipc, int** clear_child_tid_pal_ptr);
-/* If the process was killed by a signal, pass it in the second
- *  argument, else pass zero */
+int thread_exit(struct shim_thread* self, bool send_ipc);
 noreturn void thread_or_process_exit(int error_code, int term_signal);
 
 /* thread cloning helpers */

--- a/LibOS/shim/src/ipc/shim_ipc_child.c
+++ b/LibOS/shim/src/ipc/shim_ipc_child.c
@@ -80,7 +80,7 @@ static int child_thread_exit(struct shim_thread* thread, void* arg, bool* unlock
             /* remote thread is "virtually" exited: SIGCHLD is generated for
              * the parent thread and exit events are arranged for subsequent
              * wait4(). */
-            thread_exit(thread, /*send_ipc=*/false, /*clear_child_tid_pal_ptr*/NULL);
+            thread_exit(thread, /*send_ipc=*/false);
             goto out;
         }
     }
@@ -207,7 +207,7 @@ int ipc_cld_exit_callback(struct shim_ipc_msg* msg, struct shim_ipc_port* port) 
 
         /* Remote thread is "virtually" exited: SIGCHLD is generated for the
          * parent thread and exit events are arranged for subsequent wait4(). */
-        ret = thread_exit(thread, /*send_ipc=*/false, /*clear_child_tid_pal_ptr*/NULL);
+        ret = thread_exit(thread, /*send_ipc=*/false);
         put_thread(thread);
     } else {
         /* Uncommon case: remote child thread was already exited and deleted

--- a/LibOS/shim/src/shim_async.c
+++ b/LibOS/shim/src/shim_async.c
@@ -85,7 +85,7 @@ int64_t install_async_event(PAL_HANDLE object, uint64_t time,
 
     lock(&async_helper_lock);
 
-    if (callback != &release_clear_child_id && !object) {
+    if (callback != &cleanup_thread && !object) {
         /* This is alarm() or setitimer() emulation, treat both according to
          * alarm() syscall semantics: cancel any pending alarm/timer. */
         struct async_event * tmp, * n;
@@ -210,8 +210,8 @@ static void shim_async_helper(void * arg) {
              *   1. Exited child:  trigger callback and remove from the list;
              *   2. IO events:     trigger callback and keep in the list;
              *   3. alarms/timers: trigger callback and remove from the list. */
-            if (tmp->callback == &release_clear_child_id) {
-                debug("Child exited, notifying parent if any\n");
+            if (tmp->callback == &cleanup_thread) {
+                debug("Thread exited, cleaning up\n");
                 LISTP_DEL(tmp, &async_list, list);
                 LISTP_ADD_TAIL(tmp, &triggered, list);
                 continue;

--- a/LibOS/shim/src/sys/shim_clone.c
+++ b/LibOS/shim/src/sys/shim_clone.c
@@ -287,7 +287,6 @@ int shim_do_clone (int flags, void * user_stack_addr, int * parent_tidptr,
     }
 
     if (flags & CLONE_CHILD_CLEARTID)
-        /* Implemented in shim_futex.c: release_clear_child_id */
         thread->clear_child_tid = child_tidptr;
 
     unsigned long fs_base = 0;

--- a/LibOS/shim/src/sys/shim_exec.c
+++ b/LibOS/shim/src/sys/shim_exec.c
@@ -202,7 +202,7 @@ retry_dump_vmas:
 
 error:
     debug("execve: failed %d\n", ret);
-    shim_terminate(ret);
+    shim_clean_and_exit(ret);
 }
 
 static int shim_do_execve_rtld (struct shim_handle * hdl, const char ** argv,

--- a/LibOS/shim/src/sys/shim_exit.c
+++ b/LibOS/shim/src/sys/shim_exit.c
@@ -40,7 +40,7 @@
 
 void release_robust_list (struct robust_list_head * head);
 
-int thread_exit(struct shim_thread* self, bool send_ipc, int** clear_child_tid_pal_ptr) {
+int thread_exit(struct shim_thread* self, bool send_ipc) {
     bool sent_exit_msg = false;
 
     /* Chia-Che: Broadcast exit message as early as possible,
@@ -64,7 +64,11 @@ int thread_exit(struct shim_thread* self, bool send_ipc, int** clear_child_tid_p
     #endif
 
     int exit_code = self->exit_code;
-    self->is_alive = false;
+
+    if (!self->in_vm) {
+        /* thread is in another process, we cannot rely on Async Helper thread to clean it */
+        self->is_alive = false;
+    }
 
     if (is_internal(self))
         goto out;
@@ -119,24 +123,6 @@ int thread_exit(struct shim_thread* self, bool send_ipc, int** clear_child_tid_p
     if (robust_list)
         release_robust_list(robust_list);
 
-    if (parent && self->in_vm && self->clear_child_tid) {
-        /* ask Async Helper thread to wake up parent when this child thread finally exits;
-         * we must alloc clear_child_tids on heap instead of this thread's stack; it is
-         * freed in release_clear_child_id() */
-        struct clear_child_tid_struct* clear_child_tids = malloc(sizeof(*clear_child_tids));
-        if (clear_child_tids) {
-            clear_child_tids->clear_child_tid         = self->clear_child_tid;
-            clear_child_tids->clear_child_tid_val_pal = 1; /* any non-zero value suffices */
-            install_async_event(NULL, 0, &release_clear_child_id, clear_child_tids);
-
-            if (clear_child_tid_pal_ptr) {
-                /* caller wants to performs DkThreadExit() and needs to know which address
-                 * PAL must set to inform the Async Helper thread */
-                *clear_child_tid_pal_ptr = &clear_child_tids->clear_child_tid_val_pal;
-            }
-        }
-    }
-
     DkEventSet(self->exit_event);
     return 0;
 }
@@ -146,15 +132,17 @@ noreturn void thread_or_process_exit(int error_code, int term_signal) {
     struct shim_thread * cur_thread = get_cur_thread();
 
     cur_thread->exit_code = -error_code;
-    cur_process.exit_code = term_signal ? term_signal : error_code;
     cur_thread->term_signal = term_signal;
 
-    int* clear_child_tid_pal = NULL;
     if (cur_thread->in_vm)
-        thread_exit(cur_thread, true, &clear_child_tid_pal);
+        thread_exit(cur_thread, true);
 
     if (check_last_thread(cur_thread)) {
-        DkThreadExit(clear_child_tid_pal);
+        /* ask Async Helper thread to cleanup this thread */
+        cur_thread->clear_child_tid_pal = 1; /* any non-zero value suffices */
+        install_async_event(NULL, 0, &cleanup_thread, cur_thread);
+
+        DkThreadExit(&cur_thread->clear_child_tid_pal);
     }
 
     struct shim_thread * async_thread = terminate_async_helper();
@@ -173,7 +161,7 @@ noreturn void thread_or_process_exit(int error_code, int term_signal) {
          */
         put_thread(ipc_thread); /* free resources of the thread */
 
-    shim_clean_and_exit(0);
+    shim_clean_and_exit(term_signal ? term_signal : error_code);
 }
 
 noreturn int shim_do_exit_group (int error_code)
@@ -197,19 +185,13 @@ noreturn int shim_do_exit_group (int error_code)
 #ifndef ALIAS_VFORK_AS_FORK
     if (cur_thread->dummy) {
         cur_thread->term_signal = 0;
-        thread_exit(cur_thread, true, NULL);
+        thread_exit(cur_thread, true);
         switch_dummy_thread(cur_thread);
     }
 #endif
 
     debug("now kill other threads in the process\n");
     do_kill_proc(cur_thread->tgid, cur_thread->tgid, SIGKILL, false);
-    /* This loop ensures that the current thread, which issues exit_group(), wins in setting the
-     * process's exit code. thread_or_process_exit() first sets the exit_code before updating the
-     * thread's state to "dead". Once check_last_thread() indicates that the current thread is the
-     * last thread, all the children will already have set thread->exit_code. Hence, this thread's
-     * execution of thread_or_process_exit() gets to determine the final exit_code, which is the
-     * desired outcome. */
     while (check_last_thread(cur_thread)) {
         DkThreadYieldExecution();
     }
@@ -237,7 +219,7 @@ noreturn int shim_do_exit (int error_code)
 #ifndef ALIAS_VFORK_AS_FORK
     if (cur_thread->dummy) {
         cur_thread->term_signal = 0;
-        thread_exit(cur_thread, true, NULL);
+        thread_exit(cur_thread, true);
         switch_dummy_thread(cur_thread);
     }
 #endif

--- a/LibOS/shim/src/sys/shim_futex.c
+++ b/LibOS/shim/src/sys/shim_futex.c
@@ -427,28 +427,10 @@ void release_robust_list(struct robust_list_head* head) {
     }
 }
 
-/* Function is called by Async Helper thread to wait on clear_child_tid_val_pal to be set to 0
- * (PAL does it when child thread finally exits). Next, *clear_child_tid is set to 0 and parent
- * threads are woken up. Since it is a callback to Async Helper thread, it must follow the
- * `void (*callback) (IDTYPE caller, void * arg)` signature even though we don't use caller. */
-void release_clear_child_id(IDTYPE caller, void* clear_child_tids) {
-    __UNUSED(caller);
+void release_clear_child_tid(int* clear_child_tid) {
+    /* child thread exited, now parent can wake up */
+    __atomic_store_n(clear_child_tid, 0, __ATOMIC_RELAXED);
 
-    struct clear_child_tid_struct* child = (struct clear_child_tid_struct*)clear_child_tids;
-    if (!child || !child->clear_child_tid)
-        goto out;
-
-    /* wait on clear_child_tid_val_pal; this signals that PAL layer exited child thread */
-    while (__atomic_load_n(&child->clear_child_tid_val_pal, __ATOMIC_RELAXED) != 0) {
-        __asm__ volatile ("pause");
-    }
-
-    /* child thread exited, now parent can wake up; note that PAL layer can't set clear_child_tid
-     * itself, because parent thread could spuriously wake up, notice 0 on clear_child_tid, and
-     * continue its execution without waiting for this function to succeed first */
-    __atomic_store_n(child->clear_child_tid, 0, __ATOMIC_RELAXED);
-
-    /* at this point, child thread finally exited, can wake up parents if any */
     create_lock_runtime(&futex_list_lock);
 
     struct shim_futex_handle* tmp;
@@ -456,19 +438,17 @@ void release_clear_child_id(IDTYPE caller, void* clear_child_tids) {
 
     lock(&futex_list_lock);
     LISTP_FOR_EACH_ENTRY(tmp, &futex_list, list) {
-        if (tmp->uaddr == (void*)child->clear_child_tid) {
+        if (tmp->uaddr == (void*)clear_child_tid) {
             futex = tmp;
             break;
         }
     }
     unlock(&futex_list_lock);
 
-    if (!futex) {
-        /* no parent threads waiting on this child to exit */
-        goto out;
-    }
+    if (!futex)
+        return;
 
-    debug("release futex at %p\n", child->clear_child_tid);
+    debug("release futex at %p\n", clear_child_tid);
     struct futex_waiter* waiter;
     struct futex_waiter* wtmp;
     struct shim_handle* hdl = container_of(futex, struct shim_handle, info.futex);
@@ -481,7 +461,4 @@ void release_clear_child_id(IDTYPE caller, void* clear_child_tids) {
     }
     unlock(&hdl->lock);
     put_handle(hdl);
-
-out:
-    free(child);
 }

--- a/LibOS/shim/test/regression/test_libos.py
+++ b/LibOS/shim/test/regression/test_libos.py
@@ -128,8 +128,6 @@ class TC_01_Bootstrap(RegressionTestCase):
         with self.expect_returncode(113):
             self.run_binary(['exit'])
 
-    @unittest.skipIf(HAS_SGX,
-        'Exposes a rare memory corruption on SGX PAL. Disable for now.')
     def test_401_exit_group(self):
         try:
             self.run_binary(['exit_group'])

--- a/Pal/src/host/Linux-SGX/sgx_thread.c
+++ b/Pal/src/host/Linux-SGX/sgx_thread.c
@@ -157,7 +157,10 @@ noreturn void thread_exit(int status) {
 
     /* free the thread stack (via munmap) and exit; note that exit() needs a "status" arg
      * but it could be allocated on a stack, so we must put it in register and do asm */
-    __asm__ volatile("syscall \n\t"            /* all args are already prepared, call munmap */
+    __asm__ volatile("cmpq $0, %%rdi \n\t"     /* check if tcb->stack != NULL */
+                     "je 1f \n\t"
+                     "syscall \n\t"            /* all args are already prepared, call munmap */
+                     "1: \n\t"
                      "movq %%rdx, %%rax \n\t"  /* prepare for exit: rax = __NR_exit */
                      "movq %%rbx, %%rdi \n\t"  /* prepare for exit: rdi = status    */
                      "syscall \n\t"            /* all args are prepared, call exit  */


### PR DESCRIPTION
## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [x] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->

Previously, there was a data race on `thread::is_alive` between one thread checking whether it is the last thread alive via `check_last_thread()` and another thread exiting via `thread_exit()`. The former checks if `is_alive` is true, the latter sets it to false. However, the exiting thread will truly exit only after it called `DkThreadExit()`, thus the race on `is_alive` led to scenarios where two threads believe to be the last threads alive and compete on terminating Async Helper/IPC threads and exiting the whole process.

This PR introduces `cleanup_thread()` called by Async Helper to set `is_alive` to false and delete the thread, freeing its resources. The data race is thus removed, and shim_thread object leak is prevented.

Additionally, I found a bug in thread-exiting in Linux-SGX PAL:

In Linux-SGX PAL, the main thread's stack is provided by host Linux, unlike child threads which stacks are mmapped by the PAL. Therefore, the main thread's stack must not be munmapped, unlike child threads' stacks. Previously, PAL tried to munmap stack of even the main thread, leading to spurious segfaults in e.g. `abort_multithread` test.

Finally, I re-enabled the LibOS regression test `exit_group` which was disabled before (due to the bugs during thread exiting on SGX which were fixed in this and previous PRs).

This PR removes a `shim_thread` data leak, as part of this issue: https://github.com/oscarlab/graphene/issues/969 (but I observe some residual leakage still, so this PR doesn't fix all problems in that issue!).

Ironically, this PR reverts some changes done in https://github.com/oscarlab/graphene/pull/1171. But this is good, I significantly simplified the logic of "ask Async Helper thread to cleanup after exiting thread".

## How to test this PR? <!-- (if applicable) -->

All tests must pass. A couple good ways to check stability:

- `bash -c "exit 134"; while [ $? -eq 134 ]; do SGX=1 ~/graphene/Runtime/pal_loader abort_multithread; done`
- `bash -c "exit 0"; while [ $? -le 4 ]; do SGX=1 ~/graphene/Runtime/pal_loader exit_group; done`
- `bash -c "exit 0"; while [ $? -eq 0 ]; do SGX=1 ~/graphene/Runtime/pal_loader multi_pthread 2>/dev/null; done`

My tests show both non-SGX and SGX versions never fail on our regression tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1199)
<!-- Reviewable:end -->
