### PR TITLE
[LibOS] copy signal handler on get_new_thread()

### DIFF
--- a/LibOS/shim/src/bookkeep/shim_thread.c
+++ b/LibOS/shim/src/bookkeep/shim_thread.c
@@ -206,7 +206,7 @@ struct shim_thread * get_new_thread (IDTYPE new_tid)
 
             thread->signal_handles[i].action =
                     malloc_copy(cur_thread->signal_handles[i].action,
-                                sizeof(struct shim_signal_handle));
+                                sizeof(*thread->signal_handles[i].action));
         }
 
         memcpy(&thread->signal_mask, &cur_thread->signal_mask,


### PR DESCRIPTION
shim_thread::signal_handles[].action is __kernel_sigaction, not struct shim_signal_handle.
the copy size was wrongly 8 byte.
Because the first member of __kernel_sigaction is signal handler (un?)fortunately,
signal handler is copied. That's the reason why this issue hasn't been revieled.

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->


## How to test this PR? <!-- (if applicable) -->
ltp kill12

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1202)
<!-- Reviewable:end -->
