### PR TITLE
[Pal/Linux] make _DkTerminateSighandler robust

### DIFF
--- a/Pal/src/host/Linux/pal_host.h
+++ b/Pal/src/host/Linux/pal_host.h
@@ -179,7 +179,10 @@ typedef struct pal_handle
 
 #define HANDLE_TYPE(handle)  ((handle)->hdr.type)
 
+extern void __enter_pal_call(void);
 extern void __check_pending_event (void);
+
+#define ENTER_PAL_CALL(name) __enter_pal_call()
 
 #define LEAVE_PAL_CALL() do { __check_pending_event(); } while (0)
 

--- a/Pal/src/host/Linux/pal_linux.h
+++ b/Pal/src/host/Linux/pal_linux.h
@@ -191,7 +191,9 @@ typedef struct pal_tcb_linux {
     PAL_TCB common;
     struct {
         /* private to Linux PAL */
-        int         pending_event;
+        struct atomic_int in_pal;
+        int         pending_event;  /* needs to be accessed by atomic
+                                     * operation */
         LISTP_TYPE(event_queue) pending_queue;
         PAL_HANDLE  handle;
         void *      alt_stack;


### PR DESCRIPTION
- atomic access to PAL_TCB_LINUX::pending_event
- replace IN_PAL() condition in _DkTerminateSighandler to avoid race
NOTE: there may still remain races.

Signed-off-by: Isaku Yamahata <isaku.yamahata@gmail.com>

<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [x] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->


## How to test this PR? <!-- (if applicable) -->
ltp kill12

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1203)
<!-- Reviewable:end -->
