### PR TITLE
[LibOS/regression] Add test for host root FS

### DIFF
--- a/LibOS/shim/include/shim_fs.h
+++ b/LibOS/shim/include/shim_fs.h
@@ -104,7 +104,7 @@ struct shim_fs_ops {
 };
 
 #define DENTRY_VALID        0x0001  /* this dentry is verified to be valid */
-#define DENTRY_NEGATIVE     0x0002  /* negative, recently deleted */
+#define DENTRY_NEGATIVE     0x0002  /* recently deleted or inaccessible */
 #define DENTRY_RECENTLY     0x0004  /* recently used */
 #define DENTRY_PERSIST      0x0008  /* added as a persistent dentry */
 #define DENTRY_HASHED       0x0010  /* added in the dcache */

--- a/LibOS/shim/test/regression/host_root_fs.c
+++ b/LibOS/shim/test/regression/host_root_fs.c
@@ -1,0 +1,31 @@
+#include <dirent.h>
+#include <stdio.h>
+
+static int showdir(char* path) {
+    struct dirent* de;
+
+    DIR* dir = opendir(path);
+    if (!dir) {
+        printf("Could not open directory `%s`\n", path);
+        return 1;
+    }
+
+    printf("Contents of directory `%s`:\n", path);
+    while ((de = readdir(dir)))
+        printf("  %s\n", de->d_name);
+    printf("\n");
+
+    closedir(dir);
+    return 0;
+}
+
+int main(int argc, char** argv) {
+    if (showdir("/"))
+        return 1;
+
+    if (showdir("/var/"))
+        return 1;
+
+    puts("Test was successful");
+    return 0;
+}

--- a/LibOS/shim/test/regression/host_root_fs.manifest.template
+++ b/LibOS/shim/test/regression/host_root_fs.manifest.template
@@ -1,0 +1,16 @@
+loader.preload = file:../../src/libsysdb.so
+loader.env.LD_LIBRARY_PATH = /lib
+loader.debug_type = none
+loader.syscall_symbol = syscalldb
+
+fs.root.type = chroot
+fs.root.path = /
+fs.root.uri = file:/
+
+fs.mount.graphene_lib.type = chroot
+fs.mount.graphene_lib.path = /lib
+fs.mount.graphene_lib.uri = file:../../../../Runtime
+
+sgx.trusted_files.ld = file:../../../../Runtime/ld-linux-x86-64.so.2
+sgx.trusted_files.libc = file:../../../../Runtime/libc.so.6
+sgx.trusted_files.libdl = file:../../../../Runtime/libdl.so.2

--- a/LibOS/shim/test/regression/test_libos.py
+++ b/LibOS/shim/test/regression/test_libos.py
@@ -251,6 +251,10 @@ class TC_30_Syscall(RegressionTestCase):
 
         self.assertIn('Success!', stdout)
 
+    def test_022_host_root_fs(self):
+        stdout, _ = self.run_binary(['host_root_fs'])
+        self.assertIn('Test was successful', stdout)
+
     def test_030_fopen(self):
         if os.path.exists("tmp/filecreatedbygraphene"):
             os.remove("tmp/filecreatedbygraphene")


### PR DESCRIPTION
## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->

This PR does two things:

1. [LibOS] Allow inaccessible files during `getdents()`. Previously, if user performed `getdents()` on a directory containing inaccessible files (because user doesn't have permission), whole getdents failed with `-EACCES`. This is incorrect behavior: files must still be listed. This commit fixes the root cause of this bug by marking inaccessible files as `DENTRY_NEGATIVE`.

2. [LibOS/regression] Add test for host root FS. Graphene support a special "root FS" parameter in the manifest: `fs.root`. This commit adds a test that uses this parameter.

This PR is in response to https://github.com/oscarlab/graphene/issues/1179. It looks like Graphene supports host-root out of the box (bar a tiny fix in this PR). To close #1179, we'll need more tests on real applications though.

I am also not sure about the correctness of the proposed fix (see first commit). This may be too naive.

## How to test this PR? <!-- (if applicable) -->

All tests must pass.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1209)
<!-- Reviewable:end -->
