### PR TITLE
[Pal/test] Fix strcmp incompatibility in one of the tests

### DIFF
--- a/Pal/regression/normalize_path.c
+++ b/Pal/regression/normalize_path.c
@@ -6,7 +6,7 @@
 static int strcmp(const char* a, const char* b) {
     for (; *a && *b && *a == *b; a++, b++)
         ;
-    return *a - *b;
+    return (unsigned char)*a - (unsigned char)*b;
 }
 
 static const char* get_norm_path_cases[][2] = {


### PR DESCRIPTION
<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->
A `strcmp` implementation in one of the tests was incompatible with the C standard and could return incorrect results.

## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1217)
<!-- Reviewable:end -->
