### PR TITLE
Correctly release resources during str_close().

### DIFF
--- a/LibOS/shim/src/fs/str/fs.c
+++ b/LibOS/shim/src/fs/str/fs.c
@@ -76,6 +76,13 @@ int str_close(struct shim_handle* hdl) {
     }
 
     str_dput(hdl->dentry);
+
+    if (hdl->info.str.data) {
+        free(hdl->info.str.data->str);
+        free(hdl->info.str.data);
+        hdl->info.str.data = NULL;
+    }
+
     return 0;
 }
 

--- a/LibOS/shim/test/regression/str_close_leak.c
+++ b/LibOS/shim/test/regression/str_close_leak.c
@@ -1,0 +1,17 @@
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+int main(int argc, char** argv) {
+    for (int i = 0; i < 1000000; i++) {
+        int fd = open("/proc/meminfo", O_RDONLY);
+        if (fd == -1)
+            abort();
+        close(fd);
+    }
+
+    printf("Success\n");
+
+    return 0;
+}

--- a/LibOS/shim/test/regression/test_libos.py
+++ b/LibOS/shim/test/regression/test_libos.py
@@ -395,6 +395,10 @@ class TC_40_FileSystem(RegressionTestCase):
         stdout, stderr = self.run_binary(['fdleak'], timeout=10)
         self.assertIn("Test succeeded.", stdout)
 
+    def test_040_str_close_leak(self):
+        stdout, _ = self.run_binary(['str_close_leak'], timeout=60)
+        self.assertIn("Success", stdout)
+
 class TC_80_Socket(RegressionTestCase):
     def test_000_getsockopt(self):
         stdout, stderr = self.run_binary(['getsockopt'])


### PR DESCRIPTION
<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->

Fixes a resources leak where repeatedly opening and closing files in, for example, proc, led to memory exhaustion.

## How to test this PR? <!-- (if applicable) -->

This PR comes with a regression test. Regression should still pass.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1219)
<!-- Reviewable:end -->
