### PR TITLE
[CI] fix linting test names

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -274,11 +274,11 @@ class-attribute-naming-style=any
 #class-attribute-rgx=
 
 # Naming style matching correct class names.
-class-naming-style=PascalCase
+#class-naming-style=PascalCase
 
 # Regular expression matching correct class names. Overrides class-naming-
 # style.
-#class-rgx=
+class-rgx=[A-Z_][A-Za-z0-9]*|TC_\d\d_.*
 
 # Naming style matching correct constant names.
 const-naming-style=UPPER_CASE
@@ -318,11 +318,11 @@ inlinevar-naming-style=any
 #inlinevar-rgx=
 
 # Naming style matching correct method names.
-method-naming-style=snake_case
+#method-naming-style=snake_case
 
 # Regular expression matching correct method names. Overrides method-naming-
 # style.
-#method-rgx=
+method-rgx=[a-z_][a-z0-9_]*|test_\d\d\d_.*
 
 # Naming style matching correct module names.
 module-naming-style=snake_case


### PR DESCRIPTION
<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [x] README and global configuration

## Description of the changes <!-- (reasons and measures) -->

Test classes and functions are named TC_01_Example and test_012_example,
respectively. Those are not conforming to the usual style enforced by
pylint but that's okay.

## How to test this PR? <!-- (if applicable) -->
There should not be any pylint problems against `test_{pal,libos}` test modules.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1222)
<!-- Reviewable:end -->
