### PR TITLE
Replace pipes with socketpairs

### DIFF
--- a/Pal/src/host/FreeBSD/db_process.c
+++ b/Pal/src/host/FreeBSD/db_process.c
@@ -52,21 +52,15 @@ static inline int create_process_handle (PAL_HANDLE * parent,
                                          PAL_HANDLE * child)
 {
     PAL_HANDLE phdl = NULL, chdl = NULL;
-    int fds[6] = { -1, -1, -1, -1, -1, -1 };
+    int fds[4] = { -1, -1, -1, -1 };
     int socktype = SOCK_STREAM | SOCK_CLOEXEC;
     int ret;
 
     if (IS_ERR((ret = INLINE_SYSCALL(socketpair, 4, AF_UNIX, socktype, 0, &fds[0]))) ||
-        IS_ERR((ret = INLINE_SYSCALL(socketpair, 4, AF_UNIX, socktype, 0, &fds[2]))) ||
-        IS_ERR((ret = INLINE_SYSCALL(socketpair, 4, AF_UNIX, socktype, 0, &fds[4])))) {
+        IS_ERR((ret = INLINE_SYSCALL(socketpair, 4, AF_UNIX, socktype, 0, &fds[2])))) {
         ret = -PAL_ERROR_DENIED;
         goto out;
     }
-
-    int proc_fds[2][3] = {
-        { fds[0], fds[3], fds[4] },
-        { fds[2], fds[1], fds[5] },
-    };
 
     phdl = malloc(HANDLE_SIZE(process));
     if (!phdl) {
@@ -75,10 +69,9 @@ static inline int create_process_handle (PAL_HANDLE * parent,
     }
 
     SET_HANDLE_TYPE(phdl, process);
-    phdl->hdr.flags |= RFD(0)|WFD(1)|RFD(2)|WFD(2)|WRITABLE(1)|WRITABLE(2);
-    phdl->process.stream_in   = proc_fds[0][0];
-    phdl->process.stream_out  = proc_fds[0][1];
-    phdl->process.cargo       = proc_fds[0][2];
+    phdl->hdr.flags |= RFD(0)|WFD(0)|RFD(1)|WFD(1)|WRITABLE(0)|WRITABLE(1);
+    phdl->process.stream      = fds[0];
+    phdl->process.cargo       = fds[2];
     phdl->process.pid         = bsd_state.pid;
     phdl->process.nonblocking = PAL_FALSE;
 
@@ -89,10 +82,9 @@ static inline int create_process_handle (PAL_HANDLE * parent,
     }
 
     SET_HANDLE_TYPE(chdl, process);
-    chdl->hdr.flags |= RFD(0)|WFD(1)|RFD(2)|WFD(2)|WRITABLE(1)|WRITABLE(2);
-    chdl->process.stream_in   = proc_fds[1][0];
-    chdl->process.stream_out  = proc_fds[1][1];
-    chdl->process.cargo       = proc_fds[1][2];
+    chdl->hdr.flags |= RFD(0)|WFD(0)|RFD(1)|WFD(1)|WRITABLE(0)|WRITABLE(1);
+    chdl->process.stream      = fds[1];
+    chdl->process.cargo       = fds[3];
     chdl->process.pid         = 0; /* unknown yet */
     chdl->process.nonblocking = PAL_FALSE;
 
@@ -105,7 +97,7 @@ out:
             _DkObjectClose(phdl);
         if (chdl)
             _DkObjectClose(chdl);
-        for (int i = 0 ; i < 6 ; i++)
+        for (int i = 0; i < 4; i++)
             if (fds[i] != -1)
                 INLINE_SYSCALL(close, 1, fds[i]);
     }
@@ -133,8 +125,7 @@ static int child_process (void * param)
     struct proc_param * proc_param = param;
     int ret;
 
-    ret = INLINE_SYSCALL(dup2, 2, proc_param->parent->process.stream_in,
-                         PROC_INIT_FD);
+    ret = INLINE_SYSCALL(dup2, 2, proc_param->parent->process.stream, PROC_INIT_FD);
     if (IS_ERR(ret))
         goto failed;
 
@@ -272,7 +263,7 @@ int _DkProcessCreate (PAL_HANDLE * handle, const char * uri, const char ** args)
     /* step 4: send parameters over the process handle */
 
     ret = INLINE_SYSCALL(write, 3,
-                         child_handle->process.stream_out,
+                         child_handle->process.stream,
                          proc_args,
                          sizeof(struct proc_args) + datasz);
 
@@ -388,8 +379,7 @@ noreturn void _DkProcessExit (int exitcode)
 static int proc_read (PAL_HANDLE handle, int offset, int count,
                           void * buffer)
 {
-    int bytes = INLINE_SYSCALL(read, 3, handle->process.stream_in, buffer,
-                               count);
+    int bytes = INLINE_SYSCALL(read, 3, handle->process.stream, buffer, count);
 
     if (IS_ERR(bytes))
         switch(ERRNO(bytes)) {
@@ -407,13 +397,12 @@ static int proc_read (PAL_HANDLE handle, int offset, int count,
 static int proc_write (PAL_HANDLE handle, int offset, int count,
                        const void * buffer)
 {
-    int bytes = INLINE_SYSCALL(write, 3, handle->process.stream_out, buffer,
-                               count);
+    int bytes = INLINE_SYSCALL(write, 3, handle->process.stream, buffer, count);
 
     if (IS_ERR(bytes))
         switch(ERRNO(bytes)) {
             case EWOULDBLOCK:
-                handle->hdr.flags &= ~WRITABLE(1);
+                handle->hdr.flags &= ~WRITABLE(0);
                 return-PAL_ERROR_TRYAGAIN;
             case EINTR:
                 return -PAL_ERROR_INTERRUPTED;
@@ -422,23 +411,18 @@ static int proc_write (PAL_HANDLE handle, int offset, int count,
         }
 
     if (bytes == count)
-        handle->hdr.flags |= WRITABLE(1);
+        handle->hdr.flags |= WRITABLE(0);
     else
-        handle->hdr.flags &= ~WRITABLE(1);
+        handle->hdr.flags &= ~WRITABLE(0);
 
     return bytes;
 }
 
 static int proc_close (PAL_HANDLE handle)
 {
-    if (handle->process.stream_in != PAL_IDX_POISON) {
-        INLINE_SYSCALL(close, 1, handle->process.stream_in);
-        handle->process.stream_in = PAL_IDX_POISON;
-    }
-
-    if (handle->process.stream_out != PAL_IDX_POISON) {
-        INLINE_SYSCALL(close, 1, handle->process.stream_out);
-        handle->process.stream_out = PAL_IDX_POISON;
+    if (handle->process.stream != PAL_IDX_POISON) {
+        INLINE_SYSCALL(close, 1, handle->process.stream);
+        handle->process.stream = PAL_IDX_POISON;
     }
 
     if (handle->process.cargo != PAL_IDX_POISON) {
@@ -466,17 +450,8 @@ static int proc_delete (PAL_HANDLE handle, int access)
             return -PAL_ERROR_INVAL;
     }
 
-    if (access != PAL_DELETE_WR &&
-        handle->process.stream_in != PAL_IDX_POISON) {
-        INLINE_SYSCALL(close, 1, handle->process.stream_in);
-        handle->process.stream_in = PAL_IDX_POISON;
-    }
-
-    if (access != PAL_DELETE_RD &&
-        handle->process.stream_out != PAL_IDX_POISON) {
-        INLINE_SYSCALL(close, 1, handle->process.stream_out);
-        handle->process.stream_out = PAL_IDX_POISON;
-    }
+    if (handle->process.stream != PAL_IDX_POISON)
+        INLINE_SYSCALL(shutdown, 2, handle->process.stream, shutdown);
 
     if (handle->process.cargo != PAL_IDX_POISON)
         INLINE_SYSCALL(shutdown, 2, handle->process.cargo, shutdown);
@@ -488,18 +463,18 @@ static int proc_attrquerybyhdl (PAL_HANDLE handle, PAL_STREAM_ATTR * attr)
 {
     int ret, val;
 
-    if (handle->process.stream_in == PAL_IDX_POISON)
+    if (handle->process.stream == PAL_IDX_POISON)
         return -PAL_ERROR_BADHANDLE;
 
-    ret = INLINE_SYSCALL(ioctl, 3, handle->process.stream_in, FIONREAD, &val);
+    ret = INLINE_SYSCALL(ioctl, 3, handle->process.stream, FIONREAD, &val);
     if (IS_ERR(ret))
         return unix_to_pal_error(ERRNO(ret));
 
     attr->handle_type  = pal_type_process;
     attr->nonblocking  = handle->process.nonblocking;
-    attr->disconnected = handle->hdr.flags & (ERROR(0)|ERROR(1));
+    attr->disconnected = handle->hdr.flags & ERROR(0);
     attr->readable     = !!val;
-    attr->writable     = handle->hdr.flags & WRITABLE(1);
+    attr->writable     = handle->hdr.flags & WRITABLE(0);
     attr->runnable     = PAL_FALSE;
     attr->pending_size = val;
 
@@ -508,12 +483,12 @@ static int proc_attrquerybyhdl (PAL_HANDLE handle, PAL_STREAM_ATTR * attr)
 
 static int proc_attrsetbyhdl (PAL_HANDLE handle, PAL_STREAM_ATTR * attr)
 {
-    if (handle->process.stream_in == PAL_IDX_POISON)
+    if (handle->process.stream == PAL_IDX_POISON)
         return -PAL_ERROR_BADHANDLE;
 
     int ret;
     if (attr->nonblocking != handle->process.nonblocking) {
-        ret = INLINE_SYSCALL(fcntl, 3, handle->process.stream_in, F_SETFL,
+        ret = INLINE_SYSCALL(fcntl, 3, handle->process.stream, F_SETFL,
                              handle->process.nonblocking ? O_NONBLOCK : 0);
 
         if (IS_ERR(ret))

--- a/Pal/src/host/FreeBSD/db_streams.c
+++ b/Pal/src/host/FreeBSD/db_streams.c
@@ -284,7 +284,7 @@ int _DkSendHandle (PAL_HANDLE hdl, PAL_HANDLE cargo)
     int fds[MAX_FDS];
     int nfds = 0;
     for (int i = 0 ; i < MAX_FDS ; i++)
-        if (cargo->hdr.flags & (RFD(i)|WFD(1))) {
+        if (cargo->hdr.flags & (RFD(i)|WFD(i))) {
             hdl_hdr.fds |= 1U << i;
             fds[nfds++] = cargo->hdr.fds[i];
         }

--- a/Pal/src/host/FreeBSD/pal_freebsd_defs.h
+++ b/Pal/src/host/FreeBSD/pal_freebsd_defs.h
@@ -4,9 +4,6 @@
 #define USER_ADDRESS_LOWEST  0x10000
 #define USER_ADDRESS_HIGHEST 0x80000000
 
-/* internal wrap native pipe inside pipe streams */
-#define USE_PIPE_SYSCALL 0
-
 #define USE_CLOCK_GETTIME 0
 
 #define USE_ARCH_RDRAND 0

--- a/Pal/src/host/FreeBSD/pal_host.h
+++ b/Pal/src/host/FreeBSD/pal_host.h
@@ -126,7 +126,7 @@ typedef union pal_handle
 
     struct {
         PAL_HDR hdr;
-        PAL_IDX stream_in, stream_out;
+        PAL_IDX stream;
         PAL_IDX cargo;
         PAL_IDX pid;
         PAL_BOL nonblocking;

--- a/Pal/src/host/Linux-SGX/db_main.c
+++ b/Pal/src/host/Linux-SGX/db_main.c
@@ -262,7 +262,9 @@ void pal_linux_main(char * uptr_args, uint64_t args_size,
     COPY_ARRAY(pal_sec.manifest_name, sec_info.manifest_name);
     pal_sec.manifest_name[sizeof(pal_sec.manifest_name) - 1] = '\0';
 
-    COPY_ARRAY(pal_sec.proc_fds, sec_info.proc_fds);
+    pal_sec.stream_fd = sec_info.stream_fd;
+    pal_sec.cargo_fd  = sec_info.cargo_fd;
+
     COPY_ARRAY(pal_sec.pipe_prefix, sec_info.pipe_prefix);
     pal_sec.aesm_targetinfo = sec_info.aesm_targetinfo;
     pal_sec.mcast_port = sec_info.mcast_port;

--- a/Pal/src/host/Linux-SGX/db_streams.c
+++ b/Pal/src/host/Linux-SGX/db_streams.c
@@ -267,7 +267,7 @@ int _DkSendHandle(PAL_HANDLE hdl, PAL_HANDLE cargo) {
     unsigned int fds[MAX_FDS];
     unsigned int nfds = 0;
     for (int i = 0; i < MAX_FDS; i++)
-        if (HANDLE_HDR(cargo)->flags & (RFD(i) | WFD(1))) {
+        if (HANDLE_HDR(cargo)->flags & (RFD(i) | WFD(i))) {
             hdl_hdr.fds |= 1U << i;
             fds[nfds++] = cargo->generic.fds[i];
         }

--- a/Pal/src/host/Linux-SGX/enclave_framework.c
+++ b/Pal/src/host/Linux-SGX/enclave_framework.c
@@ -105,8 +105,6 @@ static void print_report(sgx_report_t* r) {
 
 static sgx_key_128bit_t enclave_key;
 
-#define KEYBUF_SIZE ((sizeof(sgx_key_128bit_t) * 2) + 1)
-
 /*
  * sgx_get_report() obtains a CPU-signed report for local attestation
  * @target_info:  the enclave target info
@@ -963,67 +961,6 @@ int init_file_check_policy (void)
     return 0;
 }
 
-#if 0
-void test_dh (void)
-{
-    int ret;
-    DhKey key1, key2;
-    uint32_t privsz1, privsz2, pubsz1, pubsz2, agreesz1, agreesz2;
-    unsigned char priv1[128], pub1[128], priv2[128], pub2[128], agree1[128],
-        agree2[128], scratch[257];
-
-    InitDhKey(&key1);
-    InitDhKey(&key2);
-
-    ret = DhSetKey(&key1, dh_param.p, sizeof(dh_param.p), dh_param.g,
-                   sizeof(dh_param.g));
-    if (ret < 0) {
-        SGX_DBG(DBG_S, "DhSetKey for key 1 failed: %d\n", ret);
-        return;
-    }
-    ret = DhSetKey(&key2, dh_param.p, sizeof(dh_param.p), dh_param.g,
-                   sizeof(dh_param.g));
-    if (ret < 0) {
-        SGX_DBG(DBG_S, "DhSetKey for key 2 failed: %d\n", ret);
-        return;
-    }
-
-    ret = DhGenerateKeyPair(&key1, priv1, &privsz1, pub1, &pubsz1);
-    if (ret < 0) {
-        SGX_DBG(DBG_S, "DhGenerateKeyPair for key 1 failed: %d\n", ret);
-        return;
-    }
-    ret = DhGenerateKeyPair(&key2, priv2, &privsz2, pub2, &pubsz2);
-    if (ret < 0) {
-        SGX_DBG(DBG_S, "DhGenerateKeyPair for key 2 failed: %d\n", ret);
-        return;
-    }
-
-    ret = DhAgree(&key1, agree1, &agreesz1, priv1, privsz1, pub2, pubsz2);
-    if (ret < 0) {
-        SGX_DBG(DBG_S, "DhAgree for key 1 failed: %d\n", ret);
-        return;
-    }
-
-    ret = DhAgree(&key2, agree2, &agreesz2, priv2, privsz2, pub1, pubsz1);
-    if (ret < 0) {
-        SGX_DBG(DBG_S, "DhAgree for key 1 failed: %d\n", ret);
-        return;
-    }
-
-    FreeDhKey(&key1);
-    FreeDhKey(&key2);
-
-    SGX_DBG(DBG_S, "key exchange(side A): %s\n",
-            __bytes2hexstr(agree1, agreesz1, scratch, agreesz1 * 2 + 1));
-    SGX_DBG(DBG_S, "key exchange(side B): %s\n",
-            __bytes2hexstr(agree2, agreesz2, scratch, agreesz2 * 2 + 1));
-}
-#endif
-
-#define RSA_KEY_SIZE        2048
-#define RSA_E               3
-
 int init_enclave (void)
 {
     // Get report to initialize info (MR_ENCLAVE, etc.) about this enclave from
@@ -1045,26 +982,6 @@ int init_enclave (void)
     memcpy(&pal_sec.mr_enclave, &report.body.mr_enclave, sizeof(pal_sec.mr_enclave));
     memcpy(&pal_sec.mr_signer, &report.body.mr_signer, sizeof(pal_sec.mr_signer));
     pal_sec.enclave_attributes = report.body.attributes;
-
-#if 0
-    /*
-     * This enclave-specific key is a building block for authenticating
-     * new pipe connections with other enclaves that are already
-     * authenticated. Since pipe protection is a future feature, this key
-     * is currently unused and hence deprecated.
-     */
-    int ret;
-    LIB_RSA_KEY *rsa = malloc(sizeof(LIB_RSA_KEY));
-    lib_RSAInitKey(rsa);
-
-    ret = lib_RSAGenerateKey(rsa, RSA_KEY_SIZE, RSA_E);
-    if (ret < 0) {
-        SGX_DBG(DBG_E, "lib_RSAGenerateKey failed: %d\n", ret);
-        return ret;
-    }
-
-    pal_enclave_config.enclave_key = rsa;
-#endif
 
     /*
      * The enclave id is uniquely created for each enclave as a token

--- a/Pal/src/host/Linux-SGX/enclave_ocalls.c
+++ b/Pal/src/host/Linux-SGX/enclave_ocalls.c
@@ -472,8 +472,8 @@ int ocall_clone_thread (void)
     return sgx_ocall(OCALL_CLONE_THREAD, dummy);
 }
 
-int ocall_create_process(const char* uri, int nargs, const char** args, int procfds[3],
-                         unsigned int* pid) {
+int ocall_create_process(const char* uri, int nargs, const char** args, int* stream_fd,
+                         int* cargo_fd, unsigned int* pid) {
     int retval = 0;
     int ulen = uri ? strlen(uri) + 1 : 0;
     ms_ocall_create_process_t * ms;
@@ -506,9 +506,10 @@ int ocall_create_process(const char* uri, int nargs, const char** args, int proc
     if (!retval) {
         if (pid)
             *pid = ms->ms_pid;
-        procfds[0] = ms->ms_proc_fds[0];
-        procfds[1] = ms->ms_proc_fds[1];
-        procfds[2] = ms->ms_proc_fds[2];
+        if (stream_fd)
+            *stream_fd = ms->ms_stream_fd;
+        if (cargo_fd)
+            *cargo_fd = ms->ms_cargo_fd;
     }
 
     sgx_reset_ustack();

--- a/Pal/src/host/Linux-SGX/enclave_ocalls.h
+++ b/Pal/src/host/Linux-SGX/enclave_ocalls.h
@@ -74,8 +74,8 @@ int ocall_resume_thread (void * tcs);
 
 int ocall_clone_thread (void);
 
-int ocall_create_process(const char* uri, int nargs, const char** args, int procfds[3],
-                         unsigned int* pid);
+int ocall_create_process(const char* uri, int nargs, const char** args, int* stream_fd,
+                         int* cargo_fd, unsigned int* pid);
 
 int ocall_futex(int* uaddr, int op, int val, int64_t timeout_us);
 

--- a/Pal/src/host/Linux-SGX/ocall_types.h
+++ b/Pal/src/host/Linux-SGX/ocall_types.h
@@ -154,7 +154,8 @@ typedef struct {
 typedef struct {
     unsigned int ms_pid;
     const char * ms_uri;
-    int ms_proc_fds[3];
+    int ms_stream_fd;
+    int ms_cargo_fd;
     int ms_nargs;
     const char * ms_args[];
 } ms_ocall_create_process_t;

--- a/Pal/src/host/Linux-SGX/pal_host.h
+++ b/Pal/src/host/Linux-SGX/pal_host.h
@@ -150,7 +150,7 @@ typedef struct pal_handle
         } sock;
 
         struct {
-            PAL_IDX stream_in, stream_out;
+            PAL_IDX stream;
             PAL_IDX cargo;
             PAL_IDX pid;
             PAL_BOL nonblocking;

--- a/Pal/src/host/Linux-SGX/pal_linux.h
+++ b/Pal/src/host/Linux-SGX/pal_linux.h
@@ -192,7 +192,7 @@ extern struct pal_enclave_config {
 
 #else
 
-int sgx_create_process(const char* uri, int nargs, const char** args, int* retfds);
+int sgx_create_process(const char* uri, int nargs, const char** args, int* stream_fd, int* cargo_fd);
 
 #ifdef DEBUG
 # ifndef SIGCHLD

--- a/Pal/src/host/Linux-SGX/pal_security.h
+++ b/Pal/src/host/Linux-SGX/pal_security.h
@@ -43,8 +43,9 @@ struct pal_sec {
 
     PAL_SEC_STR     manifest_name;
 
-    /* need three proc fds if it has a parent */
-    PAL_IDX         proc_fds[3];
+    /* child's stream and cargo FDs created and sent over by parent */
+    PAL_IDX         stream_fd;
+    PAL_IDX         cargo_fd;
 
     /* additional information */
     PAL_SEC_STR     pipe_prefix;

--- a/Pal/src/host/Linux-SGX/sgx_enclave.c
+++ b/Pal/src/host/Linux-SGX/sgx_enclave.c
@@ -232,7 +232,8 @@ static int sgx_ocall_create_process(void * pms)
 {
     ms_ocall_create_process_t * ms = (ms_ocall_create_process_t *) pms;
     ODEBUG(OCALL_CREATE_PROCESS, ms);
-    int ret = sgx_create_process(ms->ms_uri, ms->ms_nargs, ms->ms_args, ms->ms_proc_fds);
+    int ret = sgx_create_process(ms->ms_uri, ms->ms_nargs, ms->ms_args,
+                                 &ms->ms_stream_fd, &ms->ms_cargo_fd);
     if (ret < 0)
         return ret;
     ms->ms_pid = ret;

--- a/Pal/src/host/Linux-SGX/sgx_process.c
+++ b/Pal/src/host/Linux-SGX/sgx_process.c
@@ -57,7 +57,7 @@ struct proc_args {
  * NOTE: more tricks may be needed to prevent unexpected optimization for
  * future compiler.
  */
-int __attribute_noinline
+static int __attribute_noinline
 vfork_exec(int pipe_input, int proc_fds[3], const char** argv)
 {
     int ret = ARCH_VFORK();
@@ -87,10 +87,10 @@ int sgx_create_process(const char* uri, int nargs, const char** args, int * retf
     if (!uri || !strstartswith_static(uri, "file:"))
         return -EINVAL;
 
-    if (IS_ERR((ret = INLINE_SYSCALL(pipe, 1, &fds[0]))) ||
-        IS_ERR((ret = INLINE_SYSCALL(pipe, 1, &fds[2]))) ||
-        IS_ERR((ret = INLINE_SYSCALL(socketpair, 4, AF_UNIX, SOCK_STREAM,
-                                     0, &fds[4]))))
+    int socktype = SOCK_STREAM;
+    if (IS_ERR((ret = INLINE_SYSCALL(socketpair, 4, AF_UNIX, socktype, 0, &fds[0]))) ||
+        IS_ERR((ret = INLINE_SYSCALL(socketpair, 4, AF_UNIX, socktype, 0, &fds[2]))) ||
+        IS_ERR((ret = INLINE_SYSCALL(socketpair, 4, AF_UNIX, socktype, 0, &fds[4]))))
         goto out;
 
     int proc_fds[2][3] = {

--- a/Pal/src/host/Linux/db_process.c
+++ b/Pal/src/host/Linux/db_process.c
@@ -52,13 +52,12 @@ static inline int create_process_handle (PAL_HANDLE * parent,
 {
     PAL_HANDLE phdl = NULL, chdl = NULL;
     int fds[6] = { -1, -1, -1, -1, -1, -1 };
+    int socktype = SOCK_STREAM | SOCK_CLOEXEC;
     int ret;
 
-    if (IS_ERR((ret = INLINE_SYSCALL(pipe2, 2, &fds[0], O_CLOEXEC))) ||
-        IS_ERR((ret = INLINE_SYSCALL(pipe2, 2, &fds[2], O_CLOEXEC))) ||
-        IS_ERR((ret = INLINE_SYSCALL(socketpair, 4, AF_UNIX,
-                                     SOCK_STREAM|SOCK_CLOEXEC,
-                                     0, &fds[4])))) {
+    if (IS_ERR((ret = INLINE_SYSCALL(socketpair, 4, AF_UNIX, socktype, 0, &fds[0]))) ||
+        IS_ERR((ret = INLINE_SYSCALL(socketpair, 4, AF_UNIX, socktype, 0, &fds[2]))) ||
+        IS_ERR((ret = INLINE_SYSCALL(socketpair, 4, AF_UNIX, socktype, 0, &fds[4])))) {
         ret = -PAL_ERROR_DENIED;
         goto out;
     }
@@ -144,7 +143,7 @@ struct proc_args {
  * NOTE: more tricks may be needed to prevent unexpected optimization for
  * future compiler.
  */
-int __attribute_noinline
+static int __attribute_noinline
 child_process (struct proc_param * proc_param)
 {
     int ret = ARCH_VFORK();

--- a/Pal/src/host/Linux/db_streams.c
+++ b/Pal/src/host/Linux/db_streams.c
@@ -279,7 +279,7 @@ int _DkSendHandle(PAL_HANDLE hdl, PAL_HANDLE cargo) {
     int fds[MAX_FDS];
     int nfds = 0;
     for (int i = 0; i < MAX_FDS; i++)
-        if (HANDLE_HDR(cargo)->flags & (RFD(i) | WFD(1))) {
+        if (HANDLE_HDR(cargo)->flags & (RFD(i) | WFD(i))) {
             hdl_hdr.fds |= 1U << i;
             fds[nfds++] = cargo->generic.fds[i];
         }

--- a/Pal/src/host/Linux/pal_host.h
+++ b/Pal/src/host/Linux/pal_host.h
@@ -135,7 +135,7 @@ typedef struct pal_handle
         } sock;
 
         struct {
-            PAL_IDX stream_in, stream_out;
+            PAL_IDX stream;
             PAL_IDX cargo;
             PAL_IDX pid;
             PAL_BOL nonblocking;

--- a/Pal/src/host/Linux/pal_linux_defs.h
+++ b/Pal/src/host/Linux/pal_linux_defs.h
@@ -6,9 +6,6 @@
 #define THREAD_STACK_SIZE (PRESET_PAGESIZE * 2)
 #define ALT_STACK_SIZE    PRESET_PAGESIZE
 
-/* internal wrap native pipe inside pipe streams */
-#define USE_PIPE_SYSCALL 0
-
 #define USE_VSYSCALL_GETTIME 0
 #define USE_VDSO_GETTIME     1
 #define USE_CLOCK_GETTIME    1


### PR DESCRIPTION
## Affected components

- [ ] README and global configuration
- [x] Linux PAL
- [x] SGX PAL
- [x] FreeBSD PAL
- [x] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->

The main objective of this PR is to replace host-level pipes with UNIX domain socketpairs.

This is in preparation for follow-up encrypted IPC PRs.

Graphene already emulates pipes via UNIX domain socketpairs. The only place where Graphene still uses host pipes is in `DkCreateProcess()`, for communication and checkpoint send/receive between parent and child. UNIX domain socketpairs are more convenient than pipes and allow bidirectional communication, which is useful for IPC encryption via SSL/TLS. This commit replaces all lingering uses of pipes with socketpairs.

This PR also removes some dead code:

1. Graphene now has a reworked parent-child verification and SGX local attestation protocol. Remove the dead commented-out code that is not needed anymore, along with unused macros.
2. Remove unused USE_PIPE_SYSCALL and PIPE_USE_SENDMSG_RECVMSG. These macros and the associated code are useless and not tested.

## How to test this PR? <!-- (if applicable) -->

All tests must succeed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1224)
<!-- Reviewable:end -->
