### PR TITLE
[LibOS/PAL] Remove hardcoded URI prefix strings

### DIFF
--- a/LibOS/shim/include/shim_internal.h
+++ b/LibOS/shim/include/shim_internal.h
@@ -136,7 +136,7 @@ static inline PAL_HANDLE __open_shim_stdio (void)
     if (shim_stdio)
         return shim_stdio;
 
-    shim_stdio = DkStreamOpen("dev:tty", PAL_ACCESS_RDWR, 0, 0, 0);
+    shim_stdio = DkStreamOpen(URI_PREFIX_DEV "tty", PAL_ACCESS_RDWR, 0, 0, 0);
 
     if (!shim_stdio) {
         shim_stdio = (PAL_HANDLE) -1;
@@ -620,7 +620,7 @@ static inline void create_lock_runtime(struct shim_lock* l)
 static inline void create_event (AEVENTTYPE * e)
 {
     if (!e->event)
-        e->event = DkStreamOpen("pipe:", PAL_ACCESS_RDWR, 0, 0,
+        e->event = DkStreamOpen(URI_PREFIX_PIPE, PAL_ACCESS_RDWR, 0, 0,
                                 PAL_OPTION_NONBLOCK);
 }
 

--- a/LibOS/shim/src/fs/chroot/fs.c
+++ b/LibOS/shim/src/fs/chroot/fs.c
@@ -63,11 +63,11 @@ static int chroot_mount (const char * uri, void ** mount_data)
 {
     enum shim_file_type type;
 
-    if (strstartswith_static(uri, "file:")) {
+    if (strstartswith_static(uri, URI_PREFIX_FILE)) {
         type = FILE_UNKNOWN;
         uri += 5;
-    } else if (strstartswith_static(uri, "dev:")) {
-        type = strstartswith_static(uri + static_strlen("dev:"), "tty") ? FILE_TTY : FILE_DEV;
+    } else if (strstartswith_static(uri, URI_PREFIX_DEV)) {
+        type = strstartswith_static(uri + static_strlen(URI_PREFIX_DEV), "tty") ? FILE_TTY : FILE_DEV;
         uri += 4;
     } else
         return -EINVAL;
@@ -105,16 +105,16 @@ static inline ssize_t concat_uri (char * buffer, size_t size, int type,
     switch (type) {
         case FILE_UNKNOWN:
         case FILE_REGULAR:
-            tmp = strcpy_static(buffer, "file:", size);
+            tmp = strcpy_static(buffer, URI_PREFIX_FILE, size);
             break;
 
         case FILE_DIR:
-            tmp = strcpy_static(buffer, "dir:", size);
+            tmp = strcpy_static(buffer, URI_PREFIX_DIR, size);
             break;
 
         case FILE_DEV:
         case FILE_TTY:
-            tmp = strcpy_static(buffer, "dev:", size);
+            tmp = strcpy_static(buffer, URI_PREFIX_DEV, size);
             break;
 
         default:
@@ -1029,7 +1029,7 @@ static int chroot_readdir(struct shim_dentry* dent, struct shim_dirent** dirent)
     chroot_update_ino(dent);
 
     const char* uri = qstrgetstr(&data->host_uri);
-    assert(strstartswith_static(uri, "dir:"));
+    assert(strstartswith_static(uri, URI_PREFIX_DIR));
 
     pal_hdl = DkStreamOpen(uri, PAL_ACCESS_RDONLY, 0, 0, 0);
     if (!pal_hdl)
@@ -1356,7 +1356,7 @@ struct shim_d_ops chroot_d_ops = {
     };
 
 struct mount_data chroot_data = { .root_uri_len = 5,
-                                  .root_uri = "file:", };
+                                  .root_uri = URI_PREFIX_FILE, };
 
 struct shim_mount chroot_builtin_fs = { .type   = "chroot",
                                         .fs_ops = &chroot_fs_ops,

--- a/LibOS/shim/src/fs/eventfd/fs.c
+++ b/LibOS/shim/src/fs/eventfd/fs.c
@@ -95,6 +95,6 @@ struct shim_fs_ops eventfd_fs_ops = {
 };
 
 struct shim_mount eventfd_builtin_fs = {
-    .type = "eventfd",
+    .type = URI_TYPE_EVENTFD,
     .fs_ops = &eventfd_fs_ops,
 };

--- a/LibOS/shim/src/fs/pipe/fs.c
+++ b/LibOS/shim/src/fs/pipe/fs.c
@@ -161,6 +161,6 @@ struct shim_fs_ops pipe_fs_ops = {
 };
 
 struct shim_mount pipe_builtin_fs = {
-    .type   = "pipe",
+    .type   = URI_TYPE_PIPE,
     .fs_ops = &pipe_fs_ops,
 };

--- a/LibOS/shim/src/fs/shim_fs.c
+++ b/LibOS/shim/src/fs/shim_fs.c
@@ -108,7 +108,7 @@ static int __mount_root (struct shim_dentry ** root)
     }
 
     debug("mounting default root filesystem\n");
-    if ((ret = mount_fs("chroot", "file:", "/", NULL, root, 0)) < 0) {
+    if ((ret = mount_fs("chroot", URI_PREFIX_FILE, "/", NULL, root, 0)) < 0) {
         debug("mounting root filesystem failed (%d)\n", ret);
     }
     return ret;
@@ -135,7 +135,7 @@ static int __mount_sys (struct shim_dentry *root)
 
     debug("mounting as chroot filesystem: from dev:tty to /dev\n");
 
-    if ((ret = mount_fs("chroot", "dev:tty", "/dev/tty", dev_dent, NULL, 0)) < 0) {
+    if ((ret = mount_fs("chroot", URI_PREFIX_DEV "tty", "/dev/tty", dev_dent, NULL, 0)) < 0) {
         debug("mounting terminal device failed (%d)\n", ret);
         return ret;
     }

--- a/LibOS/shim/src/shim_checkpoint.c
+++ b/LibOS/shim/src/shim_checkpoint.c
@@ -910,7 +910,7 @@ int do_migrate_process (int (*migrate) (struct shim_cp_store *,
          * current process, so notify the leader regarding subleasing of TID
          * (child must create self-pipe with convention of pipe:child-vmid) */
         char new_process_self_uri[256];
-        snprintf(new_process_self_uri, sizeof(new_process_self_uri), "pipe:%u", res.child_vmid);
+        snprintf(new_process_self_uri, sizeof(new_process_self_uri), URI_PREFIX_PIPE "%u", res.child_vmid);
         ipc_pid_sublease_send(res.child_vmid, thread->tid, new_process_self_uri, NULL);
 
         /* listen on the new IPC port to the new child process */

--- a/LibOS/shim/src/shim_init.c
+++ b/LibOS/shim/src/shim_init.c
@@ -852,8 +852,8 @@ static int name_pipe_rand (char * uri, size_t size, void * id)
     int ret = DkRandomBitsRead(&pipeid, sizeof(pipeid));
     if (ret < 0)
         return -convert_pal_errno(-ret);
-    debug("creating pipe: pipe.srv:%u\n", pipeid);
-    if ((len = snprintf(uri, size, "pipe.srv:%u", pipeid)) >= size)
+    debug("creating pipe: " URI_PREFIX_PIPE_SRV "%u\n", pipeid);
+    if ((len = snprintf(uri, size, URI_PREFIX_PIPE_SRV "%u", pipeid)) >= size)
         return -ERANGE;
     *((IDTYPE *)id) = pipeid;
     return len;
@@ -863,8 +863,8 @@ static int name_pipe_vmid (char * uri, size_t size, void * id)
 {
     IDTYPE pipeid = cur_process.vmid;
     size_t len;
-    debug("creating pipe: pipe.srv:%u\n", pipeid);
-    if ((len = snprintf(uri, size, "pipe.srv:%u", pipeid)) >= size)
+    debug("creating pipe: " URI_PREFIX_PIPE_SRV "%u\n", pipeid);
+    if ((len = snprintf(uri, size, URI_PREFIX_PIPE_SRV "%u", pipeid)) >= size)
         return -ERANGE;
     *((IDTYPE *)id) = pipeid;
     return len;
@@ -888,7 +888,7 @@ static int pipe_addr (char * uri, size_t size, const void * id,
 {
     IDTYPE pipeid = *((IDTYPE *) id);
     size_t len;
-    if ((len = snprintf(uri, size, "pipe:%u", pipeid)) == size)
+    if ((len = snprintf(uri, size, URI_PREFIX_PIPE "%u", pipeid)) == size)
         return -ERANGE;
     if (qstr)
         qstrsetstr(qstr, uri, len);
@@ -970,7 +970,7 @@ static int open_pal_handle (const char * uri, void * obj)
 {
     PAL_HANDLE hdl;
 
-    if (strstartswith_static(uri, "dev:"))
+    if (strstartswith_static(uri, URI_PREFIX_DEV))
         hdl = DkStreamOpen(uri, 0,
                            PAL_SHARE_OWNER_X|PAL_SHARE_OWNER_W|
                            PAL_SHARE_OWNER_R,

--- a/LibOS/shim/src/sys/shim_eventfd.c
+++ b/LibOS/shim/src/sys/shim_eventfd.c
@@ -40,7 +40,7 @@ static int create_eventfd(PAL_HANDLE* efd, unsigned count, int flags) {
 
     /* eventfd() requires count (aka initval) but PAL's DkStreamOpen() doesn't have such an argument.
      * Using create arg as a work-around (note: initval is uint32 but create is int32).*/
-    if (!(hdl = DkStreamOpen("eventfd:", 0, 0, count, pal_flags))) {
+    if (!(hdl = DkStreamOpen(URI_PREFIX_EVENTFD, 0, 0, count, pal_flags))) {
         debug("eventfd open failure\n");
         return -PAL_ERRNO;
     }

--- a/LibOS/shim/src/sys/shim_exec.c
+++ b/LibOS/shim/src/sys/shim_exec.c
@@ -45,16 +45,17 @@ static int normalize_and_cmp_uris(const char* uri1, const char* uri2) {
     size_t len;
     int ret;
 
-    if (!strstartswith_static(uri1, "file:") || !strstartswith_static(uri2, "file:"))
+    if (!strstartswith_static(uri1, URI_PREFIX_FILE)
+            || !strstartswith_static(uri2, URI_PREFIX_FILE))
         return -1;
 
-    uri1 += static_strlen("file:");
+    uri1 += URI_PREFIX_FILE_LEN;
     len = sizeof(norm1);
     ret = get_norm_path(uri1, norm1, &len);
     if (ret < 0)
         return ret;
 
-    uri2 += static_strlen("file:");
+    uri2 += URI_PREFIX_FILE_LEN;
     len = sizeof(norm2);
     ret = get_norm_path(uri2, norm2, &len);
     if (ret < 0)

--- a/LibOS/shim/src/sys/shim_msgget.c
+++ b/LibOS/shim/src/sys/shim_msgget.c
@@ -741,7 +741,7 @@ static int __store_msg_persist(struct shim_msg_handle* msgq) {
     debug("store msgq %d to persistent store\n", msgq->msqid);
 
     char fileuri[20];
-    snprintf(fileuri, 20, "file:msgq.%08x", msgq->msqid);
+    snprintf(fileuri, 20, URI_PREFIX_FILE "msgq.%08x", msgq->msqid);
 
     PAL_HANDLE file = DkStreamOpen(fileuri, PAL_ACCESS_RDWR, 0600, PAL_CREATE_TRY, 0);
     if (!file) {
@@ -821,7 +821,7 @@ static int __load_msg_persist(struct shim_msg_handle* msgq, bool readmsg) {
     int ret = 0;
 
     char fileuri[20];
-    snprintf(fileuri, 20, "file:msgq.%08x", msgq->msqid);
+    snprintf(fileuri, 20, URI_PREFIX_FILE "msgq.%08x", msgq->msqid);
 
     PAL_HANDLE file = DkStreamOpen(fileuri, PAL_ACCESS_RDONLY, 0, 0, 0);
 

--- a/LibOS/shim/src/sys/shim_socket.c
+++ b/LibOS/shim/src/sys/shim_socket.c
@@ -158,11 +158,11 @@ static int unix_create_uri(char* uri, int count, enum shim_sock_state state, uns
         case SOCK_BOUND:
         case SOCK_LISTENED:
         case SOCK_ACCEPTED:
-            bytes = snprintf(uri, count, "pipe.srv:%u", pipeid);
+            bytes = snprintf(uri, count, URI_PREFIX_PIPE_SRV "%u", pipeid);
             break;
 
         case SOCK_CONNECTED:
-            bytes = snprintf(uri, count, "pipe:%u", pipeid);
+            bytes = snprintf(uri, count, URI_PREFIX_PIPE "%u", pipeid);
             break;
 
         default:
@@ -195,30 +195,28 @@ static void inet_rebase_port(bool reverse, int domain, struct addr_inet* addr, b
         addr->ext_port = addr->port + rebase_on_lo;
 }
 
-static int inet_translate_addr(int domain, char* uri, int count, struct addr_inet* addr) {
+static ssize_t inet_translate_addr(int domain, char* uri, size_t count, struct addr_inet* addr) {
     if (domain == AF_INET) {
         unsigned char* ad = (unsigned char*)&addr->addr.v4.s_addr;
-        int bytes =
-            snprintf(uri, count, "%u.%u.%u.%u:%u", ad[0], ad[1], ad[2], ad[3], addr->ext_port);
-        return bytes == count ? -ENAMETOOLONG : bytes;
+        return snprintf(uri, count, "%u.%u.%u.%u:%u", ad[0], ad[1], ad[2], ad[3], addr->ext_port);
     }
 
     if (domain == AF_INET6) {
         unsigned short* ad = (void*)&addr->addr.v6.s6_addr;
-        int bytes =
-            snprintf(uri, count, "[%04x:%04x:%x:%04x:%04x:%04x:%04x:%04x]:%u", __ntohs(ad[0]),
+        return snprintf(uri, count, "[%04x:%04x:%x:%04x:%04x:%04x:%04x:%04x]:%u", __ntohs(ad[0]),
                      __ntohs(ad[1]), __ntohs(ad[2]), __ntohs(ad[3]), __ntohs(ad[4]), __ntohs(ad[5]),
                      __ntohs(ad[6]), __ntohs(ad[7]), addr->ext_port);
-        return bytes == count ? -ENAMETOOLONG : bytes;
     }
 
     return -EPROTONOSUPPORT;
 }
 
-static int inet_create_uri(int domain, char* uri, int count, int sock_type,
-                           enum shim_sock_state state, struct addr_inet* bind,
-                           struct addr_inet* conn) {
-    int bytes = 0, ret;
+static ssize_t inet_create_uri(int domain, char* uri, size_t count, int sock_type,
+                               enum shim_sock_state state, struct addr_inet* bind,
+                               struct addr_inet* conn) {
+    size_t bytes = 0;
+    ssize_t ret;
+    size_t prefix_len;
 
     if (sock_type == SOCK_STREAM) {
         switch (state) {
@@ -228,32 +226,35 @@ static int inet_create_uri(int domain, char* uri, int count, int sock_type,
 
             case SOCK_BOUND:
             case SOCK_LISTENED:
-                if (count < 9)
+                prefix_len = static_strlen(URI_PREFIX_TCP_SRV);
+                if (count < prefix_len + 1)
                     return -ENAMETOOLONG;
-                memcpy(uri, "tcp.srv:", 9);
-                ret = inet_translate_addr(domain, uri + 8, count - 8, bind);
-                return ret < 0 ? ret : ret + 8;
+                memcpy(uri, URI_PREFIX_TCP_SRV, prefix_len + 1);
+                ret = inet_translate_addr(domain, uri + prefix_len, count - prefix_len, bind);
+                return ret < 0 ? ret : (ssize_t)(ret + prefix_len);
 
             case SOCK_BOUNDCONNECTED:
-                if (count < 5)
+                prefix_len = static_strlen(URI_PREFIX_TCP);
+                if (count < prefix_len + 1)
                     return -ENAMETOOLONG;
-                memcpy(uri, "tcp:", 5);
-                bytes = 4;
-                ret   = inet_translate_addr(domain, uri + bytes, count - bytes, bind);
+                memcpy(uri, URI_PREFIX_TCP, prefix_len + 1);
+                bytes = prefix_len;
+                ret = inet_translate_addr(domain, uri + bytes, count - bytes, bind);
                 if (ret < 0)
                     return ret;
                 uri[bytes + ret] = ':';
                 bytes += ret + 1;
                 ret = inet_translate_addr(domain, uri + bytes, count - bytes, conn);
-                return ret < 0 ? ret : ret + bytes;
+                return ret < 0 ? ret : (ssize_t)(ret + bytes);
 
             case SOCK_CONNECTED:
             case SOCK_ACCEPTED:
-                if (count < 5)
+                prefix_len = static_strlen(URI_PREFIX_TCP);
+                if (count < prefix_len + 1)
                     return -ENAMETOOLONG;
-                memcpy(uri, "tcp:", 5);
-                ret = inet_translate_addr(domain, uri + 4, count - 4, conn);
-                return ret < 0 ? ret : ret + 4;
+                memcpy(uri, URI_PREFIX_TCP, prefix_len + 1);
+                ret = inet_translate_addr(domain, uri + prefix_len, count - prefix_len, conn);
+                return ret < 0 ? ret : (ssize_t)(ret + prefix_len);
         }
     }
 
@@ -268,31 +269,34 @@ static int inet_create_uri(int domain, char* uri, int count, int sock_type,
                 return -EOPNOTSUPP;
 
             case SOCK_BOUNDCONNECTED:
-                if (count < 9)
+                prefix_len = static_strlen(URI_PREFIX_UDP_SRV);
+                if (count < prefix_len + 1)
                     return -ENAMETOOLONG;
-                memcpy(uri, "tcp.srv:", 9);
-                bytes = 8;
-                ret   = inet_translate_addr(domain, uri + bytes, count - bytes, bind);
+                memcpy(uri, URI_PREFIX_UDP_SRV, prefix_len + 1);
+                bytes = prefix_len;
+                ret = inet_translate_addr(domain, uri + bytes, count - bytes, bind);
                 if (ret < 0)
                     return ret;
                 uri[bytes + ret] = ':';
                 bytes += ret + 1;
                 ret = inet_translate_addr(domain, uri + bytes, count - bytes, conn);
-                return ret < 0 ? ret : ret + bytes;
+                return ret < 0 ? ret : (ssize_t)(ret + bytes);
 
             case SOCK_BOUND:
-                if (count < 9)
+                prefix_len = static_strlen(URI_PREFIX_UDP_SRV);
+                if (count < prefix_len + 1)
                     return -ENAMETOOLONG;
-                memcpy(uri, "udp.srv:", 9);
-                ret = inet_translate_addr(domain, uri + 8, count - 8, bind);
-                return ret < 0 ? ret : ret + 9;
+                memcpy(uri, URI_PREFIX_UDP_SRV, prefix_len + 1);
+                ret = inet_translate_addr(domain, uri + prefix_len, count - prefix_len, bind);
+                return ret < 0 ? ret : (ssize_t)(ret + prefix_len);
 
             case SOCK_CONNECTED:
-                if (count < 5)
+                prefix_len = static_strlen(URI_PREFIX_UDP);
+                if (count < prefix_len + 1)
                     return -ENAMETOOLONG;
-                memcpy(uri, "udp:", 5);
-                ret = inet_translate_addr(domain, uri + 4, count - 4, conn);
-                return ret < 0 ? ret : ret + 4;
+                memcpy(uri, URI_PREFIX_UDP, prefix_len + 1);
+                ret = inet_translate_addr(domain, uri + prefix_len, count - prefix_len, conn);
+                return ret < 0 ? ret : (ssize_t)(ret + prefix_len);
         }
     }
 
@@ -544,17 +548,17 @@ static int inet_parse_addr(int domain, int type, const char* uri, struct addr_in
 
     if (!(next_str = strchr(uri, ':')))
         return -EINVAL;
+    next_str++;
 
     enum { UDP, UDPSRV, TCP, TCPSRV } prefix;
-    int n = (next_str++) - uri;
 
-    if (!memcmp(uri, "udp", n))
+    if (strstartswith_static(uri, URI_PREFIX_UDP))
         prefix = UDP;
-    else if (!memcmp(uri, "udp.srv", n))
+    else if (strstartswith_static(uri, URI_PREFIX_UDP_SRV))
         prefix = UDPSRV;
-    else if (!memcmp(uri, "tcp", n))
+    else if (strstartswith_static(uri, URI_PREFIX_TCP))
         prefix = TCP;
-    else if (!memcmp(uri, "tcp.srv", n))
+    else if (strstartswith_static(uri, URI_PREFIX_TCP_SRV))
         prefix = TCPSRV;
     else
         return -EINVAL;
@@ -973,7 +977,7 @@ static ssize_t do_sendmsg(int fd, struct iovec* bufs, int nbufs, int flags,
     if (!hdl)
         return -EBADF;
 
-    int ret = -ENOTSOCK;
+    ssize_t ret = -ENOTSOCK;
     if (hdl->type != TYPE_SOCK)
         goto out;
 
@@ -1021,7 +1025,7 @@ static ssize_t do_sendmsg(int fd, struct iovec* bufs, int nbufs, int flags,
         }
 
         if (sock->sock_state == SOCK_CREATED && !pal_hdl) {
-            pal_hdl = DkStreamOpen("udp:", 0, 0, 0, hdl->flags & O_NONBLOCK);
+            pal_hdl = DkStreamOpen(URI_PREFIX_UDP, 0, 0, 0, hdl->flags & O_NONBLOCK);
             if (!pal_hdl) {
                 ret = -PAL_ERRNO;
                 goto out_locked;
@@ -1044,8 +1048,12 @@ static ssize_t do_sendmsg(int fd, struct iovec* bufs, int nbufs, int flags,
         struct addr_inet addr_buf;
         inet_save_addr(sock->domain, &addr_buf, addr);
         inet_rebase_port(false, sock->domain, &addr_buf, false);
-        memcpy(uri, "udp:", 5);
-        if ((ret = inet_translate_addr(sock->domain, uri + 4, SOCK_URI_SIZE - 4, &addr_buf)) < 0) {
+        size_t prefix_len = static_strlen(URI_PREFIX_UDP);
+        memcpy(uri, URI_PREFIX_UDP, prefix_len + 1);
+        if ((ret = inet_translate_addr(sock->domain,
+                                       uri + prefix_len,
+                                       SOCK_URI_SIZE - prefix_len,
+                                       &addr_buf)) < 0) {
             lock(&hdl->lock);
             goto out_locked;
         }

--- a/Pal/lib/api.h
+++ b/Pal/lib/api.h
@@ -235,4 +235,30 @@ int set_config (struct config_store * cfg, const char * key, const char * val);
 
 #define CONFIG_MAX      4096
 
+#define URI_PREFIX_SEPARATOR    ":"
+
+#define URI_TYPE_DIR            "dir"
+#define URI_TYPE_TCP            "tcp"
+#define URI_TYPE_TCP_SRV        "tcp.srv"
+#define URI_TYPE_UDP            "udp"
+#define URI_TYPE_UDP_SRV        "udp.srv"
+#define URI_TYPE_PIPE           "pipe"
+#define URI_TYPE_PIPE_SRV       "pipe.srv"
+#define URI_TYPE_DEV            "dev"
+#define URI_TYPE_EVENTFD        "eventfd"
+#define URI_TYPE_FILE           "file"
+
+#define URI_PREFIX_DIR          URI_TYPE_DIR        URI_PREFIX_SEPARATOR
+#define URI_PREFIX_TCP          URI_TYPE_TCP        URI_PREFIX_SEPARATOR
+#define URI_PREFIX_TCP_SRV      URI_TYPE_TCP_SRV    URI_PREFIX_SEPARATOR
+#define URI_PREFIX_UDP          URI_TYPE_UDP        URI_PREFIX_SEPARATOR
+#define URI_PREFIX_UDP_SRV      URI_TYPE_UDP_SRV    URI_PREFIX_SEPARATOR
+#define URI_PREFIX_PIPE         URI_TYPE_PIPE       URI_PREFIX_SEPARATOR
+#define URI_PREFIX_PIPE_SRV     URI_TYPE_PIPE_SRV   URI_PREFIX_SEPARATOR
+#define URI_PREFIX_DEV          URI_TYPE_DEV        URI_PREFIX_SEPARATOR
+#define URI_PREFIX_EVENTFD      URI_TYPE_EVENTFD    URI_PREFIX_SEPARATOR
+#define URI_PREFIX_FILE         URI_TYPE_FILE       URI_PREFIX_SEPARATOR
+
+#define URI_PREFIX_FILE_LEN     (static_strlen(URI_PREFIX_FILE))
+
 #endif /* API_H */

--- a/Pal/src/db_main.c
+++ b/Pal/src/db_main.c
@@ -185,7 +185,7 @@ static void set_debug_type (void)
     PAL_HANDLE handle = NULL;
 
     if (!strcmp_static(cfgbuf, "inline")) {
-        ret = _DkStreamOpen(&handle, "dev:tty", PAL_ACCESS_RDWR, 0, 0, 0);
+        ret = _DkStreamOpen(&handle, URI_PREFIX_DEV "tty", PAL_ACCESS_RDWR, 0, 0, 0);
     } else if (!strcmp_static(cfgbuf, "file")) {
         ret = get_config(pal_state.root_config, "loader.debug_file",
                          cfgbuf, sizeof(cfgbuf));
@@ -277,7 +277,7 @@ noreturn void pal_main (
         ret = _DkStreamOpen(&manifest_handle, uri_buf, PAL_ACCESS_RDONLY, 0, 0, 0);
         if (ret) {
             /* try open "file:manifest" */
-            manifest_uri = "file:manifest";
+            manifest_uri = URI_PREFIX_FILE "manifest";
             ret = _DkStreamOpen(&manifest_handle, manifest_uri, PAL_ACCESS_RDONLY,
                                 0, 0, 0);
             if (ret) {

--- a/Pal/src/db_rtld.c
+++ b/Pal/src/db_rtld.c
@@ -1201,10 +1201,10 @@ void DkDebugAttachBinary (PAL_STR uri, PAL_PTR start_addr)
     __UNUSED(uri);
     __UNUSED(start_addr);
 #else
-    if (!strstartswith_static(uri, "file:"))
+    if (!strstartswith_static(uri, URI_PREFIX_FILE))
         return;
 
-    const char * realname = uri + static_strlen("file:");
+    const char * realname = uri + URI_PREFIX_FILE_LEN;
     struct link_map * l = new_elf_object(realname, OBJECT_EXTERNAL);
 
     /* This is the ELF header.  We read it in `open_verify'.  */

--- a/Pal/src/db_streams.c
+++ b/Pal/src/db_streams.c
@@ -78,38 +78,54 @@ static int parse_stream_uri(const char** uri, char** prefix, struct handle_ops**
     if ((*p) != ':')
         return -PAL_ERROR_INVAL;
 
+    ++p;
+
     struct handle_ops* hops = NULL;
 
     switch (p - u) {
-        case 3:
-            if (strstartswith_static(u, "dir"))
+        case 4: ;
+            static_assert(static_strlen(URI_PREFIX_DIR) == 4, "URI_PREFIX_DIR has unexpected length");
+            static_assert(static_strlen(URI_PREFIX_TCP) == 4, "URI_PREFIX_TCP has unexpected length");
+            static_assert(static_strlen(URI_PREFIX_UDP) == 4, "URI_PREFIX_UDP has unexpected length");
+            static_assert(static_strlen(URI_PREFIX_DEV) == 4, "URI_PREFIX_DEV has unexpected length");
+
+            if (strstartswith_static(u, URI_PREFIX_DIR))
                 hops = &dir_ops;
-            else if (strstartswith_static(u, "tcp"))
+            else if (strstartswith_static(u, URI_PREFIX_TCP))
                 hops = &tcp_ops;
-            else if (strstartswith_static(u, "udp"))
+            else if (strstartswith_static(u, URI_PREFIX_UDP))
                 hops = &udp_ops;
-            else if (strstartswith_static(u, "dev"))
+            else if (strstartswith_static(u, URI_PREFIX_DEV))
                 hops = &dev_ops;
             break;
 
-        case 4:
-            if (strstartswith_static(u, "file"))
+        case 5: ;
+            static_assert(static_strlen(URI_PREFIX_FILE) == 5, "URI_PREFIX_FILE has unexpected length");
+            static_assert(static_strlen(URI_PREFIX_PIPE) == 5, "URI_PREFIX_PIPE has unexpected length");
+
+            if (strstartswith_static(u, URI_PREFIX_FILE))
                 hops = &file_ops;
-            else if (strstartswith_static(u, "pipe"))
+            else if (strstartswith_static(u, URI_PREFIX_PIPE))
                 hops = &pipe_ops;
             break;
 
-        case 7:
-            if (strstartswith_static(u, "tcp.srv"))
+        case 8: ;
+            static_assert(static_strlen(URI_PREFIX_TCP_SRV) == 8, "URI_PREFIX_TCP_SRV has unexpected length");
+            static_assert(static_strlen(URI_PREFIX_UDP_SRV) == 8, "URI_PREFIX_UDP_SRV has unexpected length");
+            static_assert(static_strlen(URI_PREFIX_EVENTFD) == 8, "URI_PREFIX_EVENTFD has unexpected length");
+
+            if (strstartswith_static(u, URI_PREFIX_TCP_SRV))
                 hops = &tcp_ops;
-            else if (strstartswith_static(u, "udp.srv"))
+            else if (strstartswith_static(u, URI_PREFIX_UDP_SRV))
                 hops = &udp_ops;
-            else if (strstartswith_static(u, "eventfd"))
+            else if (strstartswith_static(u, URI_PREFIX_EVENTFD))
                 hops = &eventfd_ops;
             break;
 
-        case 8:
-            if (strstartswith_static(u, "pipe.srv"))
+        case 9: ;
+            static_assert(static_strlen(URI_PREFIX_PIPE_SRV) == 9, "URI_PREFIX_PIPE_SRV has unexpected length");
+
+            if (strstartswith_static(u, URI_PREFIX_PIPE_SRV))
                 hops = &pipe_ops;
             break;
 
@@ -120,13 +136,14 @@ static int parse_stream_uri(const char** uri, char** prefix, struct handle_ops**
     if (!hops)
         return -PAL_ERROR_NOTSUPPORT;
 
-    *uri = p + 1;
+    *uri = p;
 
     if (prefix) {
-        *prefix = malloc_copy(u, p - u + 1);
+        *prefix = malloc_copy(u, p - u);
         if (!*prefix)
             return -PAL_ERROR_NOMEM;
-        (*prefix)[p - u] = '\0';
+        /* We don't want ':' in prefix, replacing that with nullbyte which also ends the string. */
+        (*prefix)[p - 1 - u] = '\0';
     }
 
     if (ops)

--- a/Pal/src/host/FreeBSD/db_files.c
+++ b/Pal/src/host/FreeBSD/db_files.c
@@ -294,7 +294,7 @@ static int file_getname (PAL_HANDLE handle, char * buffer, int count)
         return 0;
 
     int len = strlen(handle->file.realpath);
-    char * tmp = strcpy_static(buffer, "file:", count);
+    char * tmp = strcpy_static(buffer, URI_PREFIX_FILE, count);
 
     if (!tmp || buffer + count < tmp + len + 1)
         return -PAL_ERROR_TOOLONG;
@@ -526,7 +526,7 @@ static int dir_getname (PAL_HANDLE handle, char * buffer, int count)
         return 0;
 
     int len = strlen(handle->dir.realpath);
-    char * tmp = strcpy_static(buffer, "file:", count);
+    char * tmp = strcpy_static(buffer, URI_PREFIX_FILE, count);
 
     if (!tmp || buffer + count < tmp + len + 1)
         return -PAL_ERROR_TOOLONG;

--- a/Pal/src/host/FreeBSD/db_pipes.c
+++ b/Pal/src/host/FreeBSD/db_pipes.c
@@ -205,7 +205,7 @@ static int pipe_private (PAL_HANDLE * handle, int options)
 static int pipe_open (PAL_HANDLE *handle, const char * type, const char * uri,
                       int access, int share, int create, int options)
 {
-    if (!strcmp_static(type, "pipe") && !*uri)
+    if (!strcmp_static(type, URI_TYPE_PIPE) && !*uri)
         return pipe_private(handle, options);
 
     char * endptr;
@@ -216,10 +216,10 @@ static int pipe_open (PAL_HANDLE *handle, const char * type, const char * uri,
 
     options = HOST_OPTIONS(options & PAL_OPTION_MASK);
 
-    if (!strcmp_static(type, "pipe.srv"))
+    if (!strcmp_static(type, URI_TYPE_PIPE_SRV))
         return pipe_listen(handle, pipeid, options);
 
-    if (!strcmp_static(type, "pipe"))
+    if (!strcmp_static(type, URI_TYPE_PIPE))
         return pipe_connect(handle, pipeid, options);
 
     return -PAL_ERROR_INVAL;
@@ -455,12 +455,12 @@ static int pipe_getname (PAL_HANDLE handle, char * buffer, int count)
     switch (PAL_GET_TYPE(handle)) {
         case pal_type_pipesrv:
         case pal_type_pipecli:
-            prefix_len = 8;
-            prefix = "pipe.srv";
+            prefix_len = static_strlen(URI_TYPE_PIPE_SRV);
+            prefix = URI_TYPE_PIPE_SRV;
             break;
         case pal_type_pipe:
-            prefix_len = 4;
-            prefix = "pipe";
+            prefix_len = static_strlen(URI_TYPE_PIPE);
+            prefix = URI_TYPE_PIPE;
             break;
         case pal_type_pipeprv:
         default:

--- a/Pal/src/host/FreeBSD/db_sockets.c
+++ b/Pal/src/host/FreeBSD/db_sockets.c
@@ -544,10 +544,10 @@ static int tcp_open (PAL_HANDLE *handle, const char * type, const char * uri,
     char uri_buf[PAL_SOCKADDR_SIZE];
     memcpy(uri_buf, uri, uri_len);
 
-    if (!strcmp_static(type, "tcp.srv"))
+    if (!strcmp_static(type, URI_TYPE_TCP_SRV))
         return tcp_listen(handle, uri_buf, options);
 
-    if (!strcmp_static(type, "tcp"))
+    if (!strcmp_static(type, URI_TYPE_TCP))
         return tcp_connect(handle, uri_buf, options);
 
     return -PAL_ERROR_NOTSUPPORT;
@@ -766,10 +766,10 @@ static int udp_open (PAL_HANDLE *hdl, const char * type, const char * uri,
     memcpy(buf, uri, len + 1);
     options &= PAL_OPTION_MASK;
 
-    if (!strcmp_static(type, "udp.srv"))
+    if (!strcmp_static(type, URI_TYPE_UDP_SRV))
         return udp_bind(hdl, buf, options);
 
-    if (!strcmp_static(type, "udp"))
+    if (!strcmp_static(type, URI_TYPE_UDP))
         return udp_connect(hdl, buf, options);
 
     return -PAL_ERROR_NOTSUPPORT;
@@ -848,7 +848,7 @@ static int udp_receivebyaddr (PAL_HANDLE handle, int offset, int len,
                 return unix_to_pal_error(ERRNO(bytes));
         }
 
-    char * tmp = strcpy_static(addr, "udp:", addrlen);
+    char * tmp = strcpy_static(addr, URI_PREFIX_UDP, addrlen);
     if (!tmp)
         return -PAL_ERROR_OVERFLOW;
 
@@ -908,11 +908,11 @@ static int udp_sendbyaddr (PAL_HANDLE handle, int offset, int len,
     if (handle->sock.fd == PAL_IDX_POISON)
         return -PAL_ERROR_BADHANDLE;
 
-    if (!strstartswith_static(addr, "udp:"))
+    if (!strstartswith_static(addr, URI_PREFIX_UDP))
         return -PAL_ERROR_INVAL;
 
-    addr += static_strlen("udp:");
-    addrlen -= static_strlen("udp:");
+    addr += static_strlen(URI_PREFIX_UDP);
+    addrlen -= static_strlen(URI_PREFIX_UDP);
     char * addrbuf = __alloca(addrlen + 1);
     memcpy(addrbuf, addr, addrlen + 1);
 
@@ -1169,24 +1169,24 @@ static int socket_getname (PAL_HANDLE handle, char * buffer, int count)
 
     switch (PAL_GET_TYPE(handle)) {
         case pal_type_tcpsrv:
-            prefix_len = 7;
-            prefix = "tcp.srv";
+            prefix_len = static_strlen(URI_TYPE_TCP_SRV);
+            prefix = URI_TYPE_TCP_SRV;
             bind_addr = handle->sock.bind;
             break;
         case pal_type_tcp:
-            prefix_len = 3;
-            prefix = "tcp";
+            prefix_len = static_strlen(URI_TYPE_TCP);
+            prefix = URI_TYPE_TCP;
             bind_addr = handle->sock.bind;
             dest_addr = handle->sock.conn;
             break;
         case pal_type_udpsrv:
-            prefix_len = 7;
-            prefix = "udp.srv";
+            prefix_len = static_strlen(URI_TYPE_UDP_SRV);
+            prefix = URI_TYPE_UDP_SRV;
             bind_addr = handle->sock.bind;
             break;
         case pal_type_udp:
-            prefix_len = 3;
-            prefix = "udp";
+            prefix_len = static_strlen(URI_TYPE_UDP);
+            prefix = URI_TYPE_UDP;
             bind_addr = handle->sock.bind;
             dest_addr = handle->sock.conn;
             break;

--- a/Pal/src/host/Linux-SGX/db_devices.c
+++ b/Pal/src/host/Linux-SGX/db_devices.c
@@ -218,7 +218,7 @@ static int64_t char_write(PAL_HANDLE handle, uint64_t offset, uint64_t size, con
 /* 'open' operation for device streams */
 static int dev_open(PAL_HANDLE* handle, const char* type, const char* uri, int access, int share,
                     int create, int options) {
-    if (strcmp_static(type, "dev"))
+    if (strcmp_static(type, URI_TYPE_DEV))
         return -PAL_ERROR_INVAL;
 
     struct handle_ops* ops = NULL;
@@ -327,7 +327,7 @@ static int dev_flush(PAL_HANDLE handle) {
 
 /* 'attrquery' operation for device streams */
 static int dev_attrquery(const char* type, const char* uri, PAL_STREAM_ATTR* attr) {
-    if (strcmp_static(type, "dev"))
+    if (strcmp_static(type, URI_TYPE_DEV))
         return -PAL_ERROR_INVAL;
 
     struct handle_ops* ops = NULL;

--- a/Pal/src/host/Linux-SGX/db_eventfd.c
+++ b/Pal/src/host/Linux-SGX/db_eventfd.c
@@ -60,7 +60,7 @@ static int eventfd_pal_open(PAL_HANDLE* handle, const char* type, const char* ur
     __UNUSED(access);
     __UNUSED(share);
 
-    if ((strcmp_static(type, "eventfd") != 0) || (*uri != '\0')) {
+    if ((strcmp_static(type, URI_TYPE_EVENTFD) != 0) || (*uri != '\0')) {
         return -PAL_ERROR_INVAL;
     }
 

--- a/Pal/src/host/Linux-SGX/db_files.c
+++ b/Pal/src/host/Linux-SGX/db_files.c
@@ -45,7 +45,7 @@ typedef __kernel_pid_t pid_t;
 /* 'open' operation for file streams */
 static int file_open(PAL_HANDLE* handle, const char* type, const char* uri, int access, int share,
                      int create, int options) {
-    if (strcmp_static(type, "file"))
+    if (strcmp_static(type, URI_TYPE_FILE))
         return -PAL_ERROR_INVAL;
     /* try to do the real open */
     int fd = ocall_open(uri, access | create | options, share);
@@ -309,7 +309,7 @@ static inline void file_attrcopy(PAL_STREAM_ATTR* attr, struct stat* stat) {
 
 /* 'attrquery' operation for file streams */
 static int file_attrquery(const char* type, const char* uri, PAL_STREAM_ATTR* attr) {
-    if (strcmp_static(type, "file") && strcmp_static(type, "dir"))
+    if (strcmp_static(type, URI_TYPE_FILE) && strcmp_static(type, URI_TYPE_DIR))
         return -PAL_ERROR_INVAL;
     /* try to do the real open */
     int fd = ocall_open(uri, 0, 0);
@@ -351,7 +351,7 @@ static int file_attrsetbyhdl(PAL_HANDLE handle, PAL_STREAM_ATTR* attr) {
 }
 
 static int file_rename(PAL_HANDLE handle, const char* type, const char* uri) {
-    if (strcmp_static(type, "file"))
+    if (strcmp_static(type, URI_TYPE_FILE))
         return -PAL_ERROR_INVAL;
 
     char* tmp = strdup(uri);
@@ -378,7 +378,7 @@ static int file_getname(PAL_HANDLE handle, char* buffer, size_t count) {
         return 0;
 
     int len   = strlen(handle->file.realpath);
-    char* tmp = strcpy_static(buffer, "file:", count);
+    char* tmp = strcpy_static(buffer, URI_PREFIX_FILE, count);
 
     if (!tmp || buffer + count < tmp + len + 1)
         return -PAL_ERROR_TOOLONG;
@@ -413,7 +413,7 @@ struct handle_ops file_ops = {
    ended with slashes. dir_open will be called by file_open. */
 static int dir_open(PAL_HANDLE* handle, const char* type, const char* uri, int access, int share,
                     int create, int options) {
-    if (strcmp_static(type, "dir"))
+    if (strcmp_static(type, URI_TYPE_DIR))
         return -PAL_ERROR_INVAL;
     if (!WITHIN_MASK(access, PAL_ACCESS_MASK))
         return -PAL_ERROR_INVAL;
@@ -562,7 +562,7 @@ static int dir_delete(PAL_HANDLE handle, int access) {
 }
 
 static int dir_rename(PAL_HANDLE handle, const char* type, const char* uri) {
-    if (strcmp_static(type, "dir"))
+    if (strcmp_static(type, URI_TYPE_DIR))
         return -PAL_ERROR_INVAL;
 
     char* tmp = strdup(uri);
@@ -589,7 +589,7 @@ static int dir_getname(PAL_HANDLE handle, char* buffer, size_t count) {
         return 0;
 
     size_t len = strlen(handle->dir.realpath);
-    char* tmp  = strcpy_static(buffer, "dir:", count);
+    char* tmp  = strcpy_static(buffer, URI_PREFIX_DIR, count);
 
     if (!tmp || buffer + count < tmp + len + 1)
         return -PAL_ERROR_TOOLONG;

--- a/Pal/src/host/Linux-SGX/db_main.c
+++ b/Pal/src/host/Linux-SGX/db_main.c
@@ -96,10 +96,10 @@ int init_child_process(PAL_HANDLE* parent_handle);
  */
 static PAL_HANDLE setup_dummy_file_handle (const char * name)
 {
-    if (!strstartswith_static(name, "file:"))
+    if (!strstartswith_static(name, URI_PREFIX_FILE))
         return NULL;
 
-    name += static_strlen("file:");
+    name += URI_PREFIX_FILE_LEN;
     size_t len = strlen(name) + 1;
     PAL_HANDLE handle = malloc(HANDLE_SIZE(file) + len);
     SET_HANDLE_TYPE(handle, file);

--- a/Pal/src/host/Linux-SGX/db_pipes.c
+++ b/Pal/src/host/Linux-SGX/db_pipes.c
@@ -157,7 +157,7 @@ static int pipe_open(PAL_HANDLE* handle, const char* type, const char* uri, int 
         !WITHIN_MASK(create, PAL_CREATE_MASK) || !WITHIN_MASK(options, PAL_OPTION_MASK))
         return -PAL_ERROR_INVAL;
 
-    if (!strcmp_static(type, "pipe") && !*uri)
+    if (!strcmp_static(type, URI_TYPE_PIPE) && !*uri)
         return pipe_private(handle, options);
 
     char* endptr;
@@ -166,10 +166,10 @@ static int pipe_open(PAL_HANDLE* handle, const char* type, const char* uri, int 
     if (*endptr)
         return -PAL_ERROR_INVAL;
 
-    if (!strcmp_static(type, "pipe.srv"))
+    if (!strcmp_static(type, URI_TYPE_PIPE_SRV))
         return pipe_listen(handle, pipeid, options);
 
-    if (!strcmp_static(type, "pipe"))
+    if (!strcmp_static(type, URI_TYPE_PIPE))
         return pipe_connect(handle, pipeid, options);
 
     return -PAL_ERROR_INVAL;
@@ -370,12 +370,12 @@ static int pipe_getname(PAL_HANDLE handle, char* buffer, size_t count) {
     switch (HANDLE_TYPE(handle)) {
         case pal_type_pipesrv:
         case pal_type_pipecli:
-            prefix_len = 8;
-            prefix     = "pipe.srv";
+            prefix_len = static_strlen(URI_TYPE_PIPE_SRV);
+            prefix     = URI_TYPE_PIPE_SRV;
             break;
         case pal_type_pipe:
-            prefix_len = 4;
-            prefix     = "pipe";
+            prefix_len = static_strlen(URI_TYPE_PIPE);
+            prefix     = URI_TYPE_PIPE;
             break;
         case pal_type_pipeprv:
         default:

--- a/Pal/src/host/Linux-SGX/db_process.c
+++ b/Pal/src/host/Linux-SGX/db_process.c
@@ -248,7 +248,7 @@ static int check_child_mr_enclave(PAL_HANDLE child, sgx_measurement_t* mr_enclav
 int _DkProcessCreate (PAL_HANDLE * handle, const char * uri, const char ** args)
 {
     /* only access creating process with regular file */
-    if (!strstartswith_static(uri, "file:"))
+    if (!strstartswith_static(uri, URI_PREFIX_FILE))
         return -PAL_ERROR_INVAL;
 
     unsigned int child_pid;

--- a/Pal/src/host/Linux-SGX/db_sockets.c
+++ b/Pal/src/host/Linux-SGX/db_sockets.c
@@ -447,10 +447,10 @@ static int tcp_open(PAL_HANDLE* handle, const char* type, const char* uri, int a
     char uri_buf[PAL_SOCKADDR_SIZE];
     memcpy(uri_buf, uri, uri_len);
 
-    if (!strcmp_static(type, "tcp.srv"))
+    if (!strcmp_static(type, URI_TYPE_TCP_SRV))
         return tcp_listen(handle, uri_buf, options);
 
-    if (!strcmp_static(type, "tcp"))
+    if (!strcmp_static(type, URI_TYPE_TCP))
         return tcp_connect(handle, uri_buf, options);
 
     return -PAL_ERROR_NOTSUPPORT;
@@ -608,10 +608,10 @@ static int udp_open(PAL_HANDLE* hdl, const char* type, const char* uri, int acce
 
     memcpy(buf, uri, len + 1);
 
-    if (!strcmp_static(type, "udp.srv"))
+    if (!strcmp_static(type, URI_TYPE_UDP_SRV))
         return udp_bind(hdl, buf, options);
 
-    if (!strcmp_static(type, "udp"))
+    if (!strcmp_static(type, URI_TYPE_UDP))
         return udp_connect(hdl, buf, options);
 
     return -PAL_ERROR_NOTSUPPORT;
@@ -656,7 +656,7 @@ static int64_t udp_receivebyaddr(PAL_HANDLE handle, uint64_t offset, uint64_t le
     if (IS_ERR(bytes))
         return unix_to_pal_error(ERRNO(bytes));
 
-    char* addr_uri = strcpy_static(addr, "udp:", addrlen);
+    char* addr_uri = strcpy_static(addr, URI_PREFIX_UDP, addrlen);
     if (!addr_uri)
         return -PAL_ERROR_OVERFLOW;
 
@@ -708,14 +708,14 @@ static int64_t udp_sendbyaddr(PAL_HANDLE handle, uint64_t offset, uint64_t len, 
     if (handle->sock.fd == PAL_IDX_POISON)
         return -PAL_ERROR_BADHANDLE;
 
-    if (!strstartswith_static(addr, "udp:"))
+    if (!strstartswith_static(addr, URI_PREFIX_UDP))
         return -PAL_ERROR_INVAL;
 
     if (len >= (1ULL << (sizeof(unsigned int) * 8)))
         return -PAL_ERROR_INVAL;
 
-    addr += static_strlen("udp:");
-    addrlen -= static_strlen("udp:");
+    addr += static_strlen(URI_PREFIX_UDP);
+    addrlen -= static_strlen(URI_PREFIX_UDP);
 
     char* addrbuf = __alloca(addrlen);
     memcpy(addrbuf, addr, addrlen);
@@ -927,68 +927,78 @@ static int socket_attrsetbyhdl(PAL_HANDLE handle, PAL_STREAM_ATTR* attr) {
 }
 
 static int socket_getname(PAL_HANDLE handle, char* buffer, size_t count) {
-    int old_count = count;
+    size_t orig_count = count;
     int ret;
 
-    const char* prefix         = NULL;
-    size_t prefix_len          = 0;
+    const char* prefix = NULL;
+    size_t prefix_len = 0;
     struct sockaddr* bind_addr = NULL;
     struct sockaddr* dest_addr = NULL;
 
-    switch (HANDLE_TYPE(handle)) {
+    switch (PAL_GET_TYPE(handle)) {
         case pal_type_tcpsrv:
-            prefix_len = static_strlen("tcp.srv");
-            prefix     = "tcp.srv";
-            bind_addr  = (struct sockaddr*)handle->sock.bind;
+            prefix_len = static_strlen(URI_PREFIX_TCP_SRV);
+            prefix = URI_PREFIX_TCP_SRV;
+            bind_addr = (struct sockaddr*)handle->sock.bind;
             break;
         case pal_type_tcp:
-            prefix_len = static_strlen("tcp");
-            prefix     = "tcp";
-            bind_addr  = (struct sockaddr*)handle->sock.bind;
-            dest_addr  = (struct sockaddr*)handle->sock.conn;
+            prefix_len = static_strlen(URI_PREFIX_TCP);
+            prefix = URI_PREFIX_TCP;
+            bind_addr = (struct sockaddr*)handle->sock.bind;
+            dest_addr = (struct sockaddr*)handle->sock.conn;
             break;
         case pal_type_udpsrv:
-            prefix_len = static_strlen("udp.srv");
-            prefix     = "udp.srv";
-            bind_addr  = (struct sockaddr*)handle->sock.bind;
+            prefix_len = static_strlen(URI_PREFIX_UDP_SRV);
+            prefix = URI_PREFIX_UDP_SRV;
+            bind_addr = (struct sockaddr*)handle->sock.bind;
             break;
         case pal_type_udp:
-            prefix_len = static_strlen("udp");
-            prefix     = "udp";
-            bind_addr  = (struct sockaddr*)handle->sock.bind;
-            dest_addr  = (struct sockaddr*)handle->sock.conn;
+            prefix_len = static_strlen(URI_PREFIX_UDP);
+            prefix = URI_PREFIX_UDP;
+            bind_addr = (struct sockaddr*)handle->sock.bind;
+            dest_addr = (struct sockaddr*)handle->sock.conn;
             break;
         default:
             return -PAL_ERROR_INVAL;
     }
 
-    if (prefix_len >= count)
+    if (count < prefix_len + 1) {
         return -PAL_ERROR_OVERFLOW;
+    }
 
     memcpy(buffer, prefix, prefix_len + 1);
     buffer += prefix_len;
     count -= prefix_len;
 
-    for (int i = 0; i < 2; i++) {
-        struct sockaddr* addr = i ? dest_addr : bind_addr;
-        if (addr) {
-            if (count <= 1)
-                return -PAL_ERROR_OVERFLOW;
-
-            buffer[0] = ':';
-            buffer[1] = 0;
-            buffer++;
-            count--;
-
-            if ((ret = inet_create_uri(buffer, count, addr, addr_size(addr))) < 0)
-                return ret;
-
-            buffer += ret;
-            count -= ret;
+    if (bind_addr) {
+        if ((ret = inet_create_uri(buffer, count, bind_addr, addr_size(bind_addr))) < 0) {
+            return ret;
         }
+
+        buffer += ret;
+        count -= ret;
     }
 
-    return old_count - count;
+    if (dest_addr) {
+        if (bind_addr) {
+            if (count < 2) {
+                return -PAL_ERROR_OVERFLOW;
+            }
+
+            *buffer++ = ':';
+            *buffer = '\0';
+            count--;
+        }
+
+        if ((ret = inet_create_uri(buffer, count, dest_addr, addr_size(dest_addr))) < 0) {
+            return ret;
+        }
+
+        buffer += ret;
+        count -= ret;
+    }
+
+    return orig_count - count;
 }
 
 struct handle_ops tcp_ops = {

--- a/Pal/src/host/Linux-SGX/enclave_framework.c
+++ b/Pal/src/host/Linux-SGX/enclave_framework.c
@@ -11,8 +11,6 @@
 
 #include "enclave_pages.h"
 
-static const size_t URI_FILE_PREFIX_LEN = static_strlen("file:");
-
 __sgx_mem_aligned struct pal_enclave_state pal_enclave_state;
 
 void * enclave_base, * enclave_top;
@@ -241,7 +239,7 @@ static bool path_is_equal_or_subpath(const struct trusted_file* tf,
         /* tf->uri is a subpath of `path` */
         return true;
     }
-    if (tf->uri_len == URI_FILE_PREFIX_LEN && !memcmp(tf->uri, "file:", URI_FILE_PREFIX_LEN)) {
+    if (tf->uri_len == URI_PREFIX_FILE_LEN && !memcmp(tf->uri, URI_PREFIX_FILE, URI_PREFIX_FILE_LEN)) {
         /* Empty path is a prefix of everything */
         return true;
     }
@@ -285,26 +283,22 @@ int load_trusted_file (PAL_HANDLE file, sgx_stub_t ** stubptr,
     }
 
     /* Normalize the uri */
-    if (!strstartswith_static(uri, "file:")) {
+    if (!strstartswith_static(uri, URI_PREFIX_FILE)) {
         SGX_DBG(DBG_E, "Invalid URI [%s]: Trusted files must start with 'file:'\n", uri);
         return -PAL_ERROR_INVAL;
     }
-    assert(sizeof(normpath) > URI_FILE_PREFIX_LEN);
-    normpath [0] = 'f';
-    normpath [1] = 'i';
-    normpath [2] = 'l';
-    normpath [3] = 'e';
-    normpath [4] = ':';
-    size_t len = sizeof(normpath) - URI_FILE_PREFIX_LEN;
-    ret = get_norm_path(uri + URI_FILE_PREFIX_LEN, normpath + URI_FILE_PREFIX_LEN, &len);
+    assert(sizeof(normpath) > URI_PREFIX_FILE_LEN);
+    memcpy(normpath, URI_PREFIX_FILE, URI_PREFIX_FILE_LEN);
+    size_t len = sizeof(normpath) - URI_PREFIX_FILE_LEN;
+    ret = get_norm_path(uri + URI_PREFIX_FILE_LEN, normpath + URI_PREFIX_FILE_LEN, &len);
     if (ret < 0) {
         SGX_DBG(DBG_E,
                 "Path (%s) normalization failed: %s\n",
-                uri + URI_FILE_PREFIX_LEN,
+                uri + URI_PREFIX_FILE_LEN,
                 pal_strerror(ret));
         return ret;
     }
-    len += URI_FILE_PREFIX_LEN;
+    len += URI_PREFIX_FILE_LEN;
 
     _DkSpinLock(&trusted_file_lock);
 
@@ -732,22 +726,18 @@ static int init_trusted_file (const char * key, const char * uri)
         return 0;
 
     /* Normalize the uri */
-    if (!strstartswith_static(uri, "file:")) {
+    if (!strstartswith_static(uri, URI_PREFIX_FILE)) {
         SGX_DBG(DBG_E, "Invalid URI [%s]: Trusted files must start with 'file:'\n", uri);
         return -PAL_ERROR_INVAL;
     }
-    assert(sizeof(normpath) > URI_FILE_PREFIX_LEN);
-    normpath [0] = 'f';
-    normpath [1] = 'i';
-    normpath [2] = 'l';
-    normpath [3] = 'e';
-    normpath [4] = ':';
-    size_t len = sizeof(normpath) - URI_FILE_PREFIX_LEN;
-    ret = get_norm_path(uri + URI_FILE_PREFIX_LEN, normpath + URI_FILE_PREFIX_LEN, &len);
+    assert(sizeof(normpath) > URI_PREFIX_FILE_LEN);
+    memcpy(normpath, URI_PREFIX_FILE, URI_PREFIX_FILE_LEN);
+    size_t len = sizeof(normpath) - URI_PREFIX_FILE_LEN;
+    ret = get_norm_path(uri + URI_PREFIX_FILE_LEN, normpath + URI_PREFIX_FILE_LEN, &len);
     if (ret < 0) {
         SGX_DBG(DBG_E,
                 "Path (%s) normalization failed: %s\n",
-                uri + URI_FILE_PREFIX_LEN,
+                uri + URI_PREFIX_FILE_LEN,
                 pal_strerror(ret));
         return ret;
     }
@@ -863,23 +853,23 @@ no_trusted:
         /* Normalize the uri */
         char norm_path[URI_MAX];
 
-        if (!strstartswith_static(uri, "file:")) {
+        if (!strstartswith_static(uri, URI_PREFIX_FILE)) {
             SGX_DBG(DBG_E, "Invalid URI [%s]: Allowed files must start with 'file:'\n", uri);
             ret = -PAL_ERROR_INVAL;
             goto out;
         }
-        assert(sizeof(norm_path) > URI_FILE_PREFIX_LEN);
-        memcpy(norm_path, "file:", URI_FILE_PREFIX_LEN);
+        assert(sizeof(norm_path) > URI_PREFIX_FILE_LEN);
+        memcpy(norm_path, URI_PREFIX_FILE, URI_PREFIX_FILE_LEN);
 
-        size_t norm_path_len = sizeof(norm_path) - URI_FILE_PREFIX_LEN;
+        size_t norm_path_len = sizeof(norm_path) - URI_PREFIX_FILE_LEN;
 
-        ret = get_norm_path(uri + URI_FILE_PREFIX_LEN,
-                            norm_path + URI_FILE_PREFIX_LEN,
+        ret = get_norm_path(uri + URI_PREFIX_FILE_LEN,
+                            norm_path + URI_PREFIX_FILE_LEN,
                             &norm_path_len);
         if (ret < 0) {
             SGX_DBG(DBG_E,
                     "Path (%s) normalization failed: %s\n",
-                    uri + URI_FILE_PREFIX_LEN,
+                    uri + URI_PREFIX_FILE_LEN,
                     pal_strerror(ret));
             goto out;
         }

--- a/Pal/src/host/Linux-SGX/sgx_main.c
+++ b/Pal/src/host/Linux-SGX/sgx_main.c
@@ -79,7 +79,7 @@ static unsigned long parse_int (const char * str)
 
 static char * resolve_uri (const char * uri, const char ** errstring)
 {
-    if (!strstartswith_static(uri, "file:")) {
+    if (!strstartswith_static(uri, URI_PREFIX_FILE)) {
         *errstring = "Invalid URI";
         return NULL;
     }
@@ -92,7 +92,7 @@ static char * resolve_uri (const char * uri, const char ** errstring)
         return NULL;
     }
 
-    return alloc_concat("file:", static_strlen("file:"), path_buf, len);
+    return alloc_concat(URI_PREFIX_FILE, URI_PREFIX_FILE_LEN, path_buf, len);
 }
 
 static
@@ -837,7 +837,7 @@ static int load_enclave (struct pal_enclave * enclave,
         }
     }
 
-    enclave->exec = INLINE_SYSCALL(open, 3, exec_uri + static_strlen("file:"),
+    enclave->exec = INLINE_SYSCALL(open, 3, exec_uri + URI_PREFIX_FILE_LEN,
                                    O_RDONLY|O_CLOEXEC, 0);
     if (IS_ERR(enclave->exec)) {
         if (exec_uri_inferred) {
@@ -874,7 +874,7 @@ static int load_enclave (struct pal_enclave * enclave,
         return -EINVAL;
     }
 
-    enclave->sigfile = INLINE_SYSCALL(open, 3, sig_uri + static_strlen("file:"),
+    enclave->sigfile = INLINE_SYSCALL(open, 3, sig_uri + URI_PREFIX_FILE_LEN,
                                       O_RDONLY|O_CLOEXEC, 0);
     if (IS_ERR(enclave->sigfile)) {
         SGX_DBG(DBG_E, "Cannot open sigstruct file %s\n", sig_uri);
@@ -889,7 +889,7 @@ static int load_enclave (struct pal_enclave * enclave,
         return -ENOMEM;
     }
 
-    enclave->token = INLINE_SYSCALL(open, 3, token_uri + static_strlen("file:"),
+    enclave->token = INLINE_SYSCALL(open, 3, token_uri + URI_PREFIX_FILE_LEN,
                                     O_RDONLY|O_CLOEXEC, 0);
     if (IS_ERR(enclave->token)) {
         SGX_DBG(DBG_E, "Cannot open token \'%s\'. Use \'"
@@ -1014,10 +1014,10 @@ int main (int argc, char ** argv, char ** envp)
         if (!argc)
             goto usage;
 
-        if (!strcmp_static(argv[0], "file:")) {
+        if (!strcmp_static(argv[0], URI_PREFIX_FILE)) {
             exec_uri = alloc_concat(argv[0], -1, NULL, -1);
         } else {
-            exec_uri = alloc_concat("file:", -1, argv[0], -1);
+            exec_uri = alloc_concat(URI_PREFIX_FILE, -1, argv[0], -1);
         }
     } else {
         exec_uri = alloc_concat(pal_enclave.pal_sec.exec_name, -1, NULL, -1);
@@ -1028,7 +1028,7 @@ int main (int argc, char ** argv, char ** envp)
         goto out;
     }
 
-    fd = INLINE_SYSCALL(open, 3, exec_uri + static_strlen("file:"), O_RDONLY|O_CLOEXEC, 0);
+    fd = INLINE_SYSCALL(open, 3, exec_uri + URI_PREFIX_FILE_LEN, O_RDONLY|O_CLOEXEC, 0);
     if (IS_ERR(fd)) {
         SGX_DBG(DBG_E, "Input file not found: %s\n", exec_uri);
         ret = fd;
@@ -1047,7 +1047,7 @@ int main (int argc, char ** argv, char ** envp)
 
     char manifest_base_name[URI_MAX];
     size_t manifest_base_name_len = sizeof(manifest_base_name);
-    ret = get_base_name(exec_uri + static_strlen("file:"), manifest_base_name,
+    ret = get_base_name(exec_uri + URI_PREFIX_FILE_LEN, manifest_base_name,
                         &manifest_base_name_len);
     if (ret < 0) {
         goto out;
@@ -1100,7 +1100,7 @@ int main (int argc, char ** argv, char ** envp)
         }
     }
 
-    manifest_uri = alloc_concat("file:", static_strlen("file:"), manifest_base_name, -1);
+    manifest_uri = alloc_concat(URI_PREFIX_FILE, URI_PREFIX_FILE_LEN, manifest_base_name, -1);
     if (!manifest_uri) {
         ret = -ENOMEM;
         goto out;

--- a/Pal/src/host/Linux-SGX/sgx_process.c
+++ b/Pal/src/host/Linux-SGX/sgx_process.c
@@ -84,7 +84,7 @@ int sgx_create_process(const char* uri, int nargs, const char** args, int* strea
     int ret, rete, child;
     int fds[4] = { -1, -1, -1, -1 };
 
-    if (!uri || !strstartswith_static(uri, "file:"))
+    if (!uri || !strstartswith_static(uri, URI_PREFIX_FILE))
         return -EINVAL;
 
     int socktype = SOCK_STREAM;

--- a/Pal/src/host/Linux/db_devices.c
+++ b/Pal/src/host/Linux/db_devices.c
@@ -219,7 +219,7 @@ static int64_t char_write(PAL_HANDLE handle, uint64_t offset, uint64_t size, con
 /* 'open' operation for device streams */
 static int dev_open(PAL_HANDLE* handle, const char* type, const char* uri, int access, int share,
                     int create, int options) {
-    if (strcmp_static(type, "dev"))
+    if (strcmp_static(type, URI_TYPE_DEV))
         return -PAL_ERROR_INVAL;
 
     struct handle_ops* ops = NULL;
@@ -356,7 +356,7 @@ static int dev_flush(PAL_HANDLE handle) {
 
 /* 'attrquery' operation for device streams */
 static int dev_attrquery(const char* type, const char* uri, PAL_STREAM_ATTR* attr) {
-    if (strcmp_static(type, "dev"))
+    if (strcmp_static(type, URI_TYPE_DEV))
         return -PAL_ERROR_INVAL;
 
     struct handle_ops* ops = NULL;

--- a/Pal/src/host/Linux/db_eventfd.c
+++ b/Pal/src/host/Linux/db_eventfd.c
@@ -62,7 +62,7 @@ static int eventfd_pal_open(PAL_HANDLE* handle, const char* type, const char* ur
     __UNUSED(access);
     __UNUSED(share);
 
-    if ((strcmp_static(type, "eventfd") != 0) || (*uri != '\0')) {
+    if ((strcmp_static(type, URI_TYPE_EVENTFD) != 0) || (*uri != '\0')) {
         return -PAL_ERROR_INVAL;
     }
 

--- a/Pal/src/host/Linux/db_files.c
+++ b/Pal/src/host/Linux/db_files.c
@@ -41,7 +41,7 @@ typedef __kernel_pid_t pid_t;
 static int file_open (PAL_HANDLE * handle, const char * type, const char * uri,
                       int access, int share, int create, int options)
 {
-    if (strcmp_static(type, "file"))
+    if (strcmp_static(type, URI_TYPE_FILE))
         return -PAL_ERROR_INVAL;
 
     /* try to do the real open */
@@ -235,7 +235,7 @@ file_attrcopy (PAL_STREAM_ATTR * attr, struct stat * stat)
 static int file_attrquery (const char * type, const char * uri,
                            PAL_STREAM_ATTR * attr)
 {
-    if (strcmp_static(type, "file") && strcmp_static(type, "dir"))
+    if (strcmp_static(type, URI_TYPE_FILE) && strcmp_static(type, URI_TYPE_DIR))
         return -PAL_ERROR_INVAL;
 
     struct stat stat_buf;
@@ -281,7 +281,7 @@ static int file_attrsetbyhdl (PAL_HANDLE handle,
 static int file_rename (PAL_HANDLE handle, const char * type,
                         const char * uri)
 {
-    if (strcmp_static(type, "file"))
+    if (strcmp_static(type, URI_TYPE_FILE))
         return -PAL_ERROR_INVAL;
 
     char* tmp = strdup(uri);
@@ -310,7 +310,7 @@ static int file_getname (PAL_HANDLE handle, char * buffer, size_t count)
         return 0;
 
     size_t len = strlen(handle->file.realpath);
-    char * tmp = strcpy_static(buffer, "file:", count);
+    char * tmp = strcpy_static(buffer, URI_PREFIX_FILE, count);
 
     if (!tmp || buffer + count < tmp + len + 1)
         return -PAL_ERROR_TOOLONG;
@@ -347,7 +347,7 @@ struct handle_ops file_ops = {
 static int dir_open (PAL_HANDLE * handle, const char * type, const char * uri,
                      int access, int share, int create, int options)
 {
-    if (strcmp_static(type, "dir"))
+    if (strcmp_static(type, URI_TYPE_DIR))
         return -PAL_ERROR_INVAL;
     if (!WITHIN_MASK(access, PAL_ACCESS_MASK))
         return -PAL_ERROR_INVAL;
@@ -528,7 +528,7 @@ static int dir_delete (PAL_HANDLE handle, int access)
 static int dir_rename (PAL_HANDLE handle, const char * type,
                        const char * uri)
 {
-    if (strcmp_static(type, "dir"))
+    if (strcmp_static(type, URI_TYPE_DIR))
         return -PAL_ERROR_INVAL;
 
     char* tmp = strdup(uri);
@@ -557,7 +557,7 @@ static int dir_getname (PAL_HANDLE handle, char * buffer, size_t count)
         return 0;
 
     size_t len = strlen(handle->dir.realpath);
-    char * tmp = strcpy_static(buffer, "dir:", count);
+    char * tmp = strcpy_static(buffer, URI_PREFIX_DIR, count);
 
     if (!tmp || buffer + count < tmp + len + 1)
         return -PAL_ERROR_TOOLONG;

--- a/Pal/src/host/Linux/db_pipes.c
+++ b/Pal/src/host/Linux/db_pipes.c
@@ -192,7 +192,7 @@ static int pipe_open(PAL_HANDLE* handle, const char* type, const char* uri, int 
         !WITHIN_MASK(create, PAL_CREATE_MASK) || !WITHIN_MASK(options, PAL_OPTION_MASK))
         return -PAL_ERROR_INVAL;
 
-    if (!strcmp_static(type, "pipe") && !*uri)
+    if (!strcmp_static(type, URI_TYPE_PIPE) && !*uri)
         return pipe_private(handle, options);
 
     char* endptr;
@@ -201,10 +201,10 @@ static int pipe_open(PAL_HANDLE* handle, const char* type, const char* uri, int 
     if (*endptr)
         return -PAL_ERROR_INVAL;
 
-    if (!strcmp_static(type, "pipe.srv"))
+    if (!strcmp_static(type, URI_TYPE_PIPE_SRV))
         return pipe_listen(handle, pipeid, options);
 
-    if (!strcmp_static(type, "pipe"))
+    if (!strcmp_static(type, URI_TYPE_PIPE))
         return pipe_connect(handle, pipeid, options);
 
     return -PAL_ERROR_INVAL;
@@ -408,12 +408,12 @@ static int pipe_getname(PAL_HANDLE handle, char* buffer, size_t count) {
     switch (PAL_GET_TYPE(handle)) {
         case pal_type_pipesrv:
         case pal_type_pipecli:
-            prefix_len = 8;
-            prefix     = "pipe.srv";
+            prefix_len = static_strlen(URI_TYPE_PIPE_SRV);
+            prefix     = URI_TYPE_PIPE_SRV;
             break;
         case pal_type_pipe:
-            prefix_len = 4;
-            prefix     = "pipe";
+            prefix_len = static_strlen(URI_TYPE_PIPE);
+            prefix     = URI_TYPE_PIPE;
             break;
         case pal_type_pipeprv:
         default:

--- a/Pal/src/host/Linux/db_process.c
+++ b/Pal/src/host/Linux/db_process.c
@@ -188,13 +188,13 @@ int _DkProcessCreate (PAL_HANDLE * handle, const char * uri, const char ** args)
          * tell its address to forked process.
          */
         size_t len;
-        const char * file_uri = "file:";
+        const char * file_uri = URI_PREFIX_FILE;
         if (exec_map && exec_map->l_name &&
-            (len = strlen(uri)) >= 5 && !memcmp(uri, file_uri, 5) &&
+            (len = strlen(uri)) >= URI_PREFIX_FILE_LEN && !memcmp(uri, file_uri, URI_PREFIX_FILE_LEN) &&
             /* skip "file:"*/
-            strlen(exec_map->l_name) == len - 5 &&
+            strlen(exec_map->l_name) == len - URI_PREFIX_FILE_LEN &&
             /* + 1 for lasting * NUL */
-            !memcmp(exec_map->l_name, uri + 5, len - 5 + 1))
+            !memcmp(exec_map->l_name, uri + URI_PREFIX_FILE_LEN, len - URI_PREFIX_FILE_LEN + 1))
             exec->file.map_start = (PAL_PTR)exec_map->l_map_start;
     }
 

--- a/Pal/src/host/Skeleton/db_pipes.c
+++ b/Pal/src/host/Skeleton/db_pipes.c
@@ -57,7 +57,7 @@ static int pipe_open (PAL_HANDLE *handle, const char * type,
                       const char * uri, int access, int share,
                       int create, int options)
 {
-    if (!strcmp_static(type, "pipe") && !*uri)
+    if (!strcmp_static(type, URI_TYPE_PIPE) && !*uri)
         return pipe_private(handle);
 
     char * endptr;
@@ -74,10 +74,10 @@ static int pipe_open (PAL_HANDLE *handle, const char * type,
     if (*endptr)
         return -PAL_ERROR_INVAL;
 
-    if (!strcmp_static(type, "pipe.srv"))
+    if (!strcmp_static(type, URI_TYPE_PIPE_SRV))
         return pipe_listen(handle, pipeid, create);
 
-    if (!strcmp_static(type, "pipe"))
+    if (!strcmp_static(type, URI_TYPE_PIPE))
         return pipe_connect(handle, pipeid, connid, create);
 
     return -PAL_ERROR_INVAL;

--- a/Pal/src/host/Skeleton/db_sockets.c
+++ b/Pal/src/host/Skeleton/db_sockets.c
@@ -62,10 +62,10 @@ static int tcp_open (PAL_HANDLE *handle, const char * type, const char * uri,
     char uri_buf[PAL_SOCKADDR_SIZE];
     memcpy(uri_buf, uri, uri_len);
 
-    if (!strcmp_static(type, "tcp.srv"))
+    if (!strcmp_static(type, URI_TYPE_TCP_SRV))
         return tcp_listen(handle, uri_buf, create);
 
-    if (!strcmp_static(type, "tcp"))
+    if (!strcmp_static(type, URI_TYPE_TCP))
         return tcp_connect(handle, uri_buf, create);
 
     return -PAL_ERROR_NOTSUPPORT;
@@ -106,10 +106,10 @@ static int udp_open (PAL_HANDLE *hdl, const char * type, const char * uri,
 
     memcpy(buf, uri, len + 1);
 
-    if (!strcmp_static(type, "udp.srv"))
+    if (!strcmp_static(type, URI_TYPE_UDP_SRV))
         return udp_bind(hdl, buf, create);
 
-    if (!strcmp_static(type, "udp"))
+    if (!strcmp_static(type, URI_TYPE_UDP))
         return udp_connect(hdl, buf);
 
     return -PAL_ERROR_NOTSUPPORT;


### PR DESCRIPTION
<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->
This PR gets rid of hardcoded URI prefixes, replacing them with appropriate constants. More described in the issue linked below.
Fixes #1095

## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1230)
<!-- Reviewable:end -->
