### PR TITLE
[Pal/Linux-SGX] Add sgx.ra_accept_configuration_needed manifest option

### DIFF
--- a/Pal/regression/test_pal.py
+++ b/Pal/regression/test_pal.py
@@ -585,7 +585,7 @@ class TC_50_Attestation(RegressionTestCase):
             # Check the attestation status
             if line.startswith("Attestation status:"):
                 status = line[19:].strip()
-                self.assertIn(status, ["OK", "GROUP_OUT_OF_DATE"])
+                self.assertIn(status, ["OK", "GROUP_OUT_OF_DATE", "CONFIGURATION_NEEDED"])
 
             # Check the timestamp
             if line.startswith("Attestation timestamp:"):

--- a/Pal/src/host/Linux-SGX/sgx_attest.h
+++ b/Pal/src/host/Linux-SGX/sgx_attest.h
@@ -67,8 +67,9 @@ typedef struct {
 
 int sgx_verify_platform(sgx_spid_t* spid, const char* subkey, sgx_quote_nonce_t* nonce,
                         sgx_report_data_t* report_data, bool linkable,
-                        bool accept_group_out_of_date, sgx_attestation_t* ret_attestation,
-                        char** ret_ias_status, char** ret_ias_timestamp);
+                        bool accept_group_out_of_date, bool accept_configuration_needed,
+                        sgx_attestation_t* ret_attestation, char** ret_ias_status,
+                        char** ret_ias_timestamp);
 
 #define HTTPS_REQUEST_MAX_LENGTH   (256)
 

--- a/README.rst
+++ b/README.rst
@@ -217,6 +217,12 @@ you can specify the following option in the manifest::
 
     sgx.ra_accept_group_out_of_date = 1
 
+Similarly, if you receive a ``CONFIGURATION_NEEDED`` status from IAS, this status indicates that
+additional configuration of your SGX platform may be needed. If you wish to bypass this error,
+you can specify the following option in the manifest::
+
+    sgx.ra_accept_configuration_needed = 1
+
 *Security advisories:*
 
 - ``GROUP_OUT_OF_DATE`` may indicate that the firmware (microcode) of you CPU is not updated


### PR DESCRIPTION
<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [x] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->

This PR adds `sgx.ra_accept_configuration_needed` manifest option to handle the case when SGX remote attestation from IAS returns status `CONFIGURATION_NEEDED` (which means that this SGX platform is not known to be compromised but has e.g. hyper-threading enabled).

See #1231 and https://software.intel.com/en-us/forums/intel-software-guard-extensions-intel-sgx/topic/798777.

Fixes #1231.

## How to test this PR? <!-- (if applicable) -->

All tests must pass.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1232)
<!-- Reviewable:end -->
