### PR TITLE
[LibOS] Disallow eventfd emulation by default

### DIFF
--- a/Documentation/oldwiki/Graphene-Manifest-Syntax.md
+++ b/Documentation/oldwiki/Graphene-Manifest-Syntax.md
@@ -79,6 +79,14 @@ This specifies the program break (brk) size in each Graphene process. The defaul
 program break size is determined by the library OS. Units like `K` (KB), `M` (MB), and `G` (GB) can
 be appended to the values for convenience. For example, `sys.brk.size=1M` indicates a 1MB brk size.
 
+### Allowing eventfd
+
+    sys.allow_insecure_eventfd=[1|0]
+    (Default: 0)
+
+This specifies whether to allow system calls `eventfd()` and `eventfd2()`. Since eventfd emulation
+currently relies on the host, these system calls are disallowed by default due to security concerns.
+
 
 ## FS-related (Required by LibOS)
 

--- a/LibOS/shim/src/sys/shim_eventfd.c
+++ b/LibOS/shim/src/sys/shim_eventfd.c
@@ -17,7 +17,10 @@
 /*
  * shim_eventfd.c
  *
- * Implementation of system calls "eventfd" and "eventfd2".
+ * Implementation of system calls "eventfd" and "eventfd2". Since eventfd emulation currently
+ * relies on the host, these system calls are disallowed by default due to security concerns.
+ * To use them, they must be explicitly allowed through the "sys.allow_insecure_eventfd" manifest
+ * key.
  */
 
 #include <asm/fcntl.h>
@@ -31,6 +34,19 @@
 #include <shim_fs.h>
 
 static int create_eventfd(PAL_HANDLE* efd, unsigned count, int flags) {
+    if (!root_config) {
+        /* eventfd must be explicitly allowed in manifest; error out if no manifest found */
+        return -ENOSYS;
+    }
+
+    char eventfd_cfg[2];
+    ssize_t len = get_config(root_config, "sys.allow_insecure_eventfd", eventfd_cfg,
+                             sizeof(eventfd_cfg));
+    if (len != 1 || eventfd_cfg[0] != '1') {
+        /* eventfd is not explicitly allowed in manifest */
+        return -ENOSYS;
+    }
+
     PAL_HANDLE hdl = NULL;
     int pal_flags = 0;
 

--- a/LibOS/shim/test/regression/eventfd.manifest.template
+++ b/LibOS/shim/test/regression/eventfd.manifest.template
@@ -1,0 +1,16 @@
+loader.preload = file:../../src/libsysdb.so
+loader.env.LD_LIBRARY_PATH = /lib
+loader.debug_type = none
+loader.syscall_symbol = syscalldb
+
+sys.allow_insecure_eventfd = 1
+
+fs.mount.graphene_lib.type = chroot
+fs.mount.graphene_lib.path = /lib
+fs.mount.graphene_lib.uri = file:../../../../Runtime
+
+sgx.trusted_files.ld = file:../../../../Runtime/ld-linux-x86-64.so.2
+sgx.trusted_files.libc = file:../../../../Runtime/libc.so.6
+sgx.trusted_files.libdl = file:../../../../Runtime/libdl.so.2
+sgx.trusted_files.libm = file:../../../../Runtime/libm.so.6
+sgx.trusted_files.libpthread = file:../../../../Runtime/libpthread.so.0


### PR DESCRIPTION
## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->

Eventfd emulation currently relies on the host, thus eventfd syscalls are disallowed by default due to security concerns. To use them, they must be explicitly allowed through `sys.allow_insecure_eventfd` in manifest.

## How to test this PR? <!-- (if applicable) -->

LibOS regression test `eventfd` now has its own manifest file with `sys.allow_insecure_eventfd = 1`. One can remove this line and see how this test fails with `eventfd failed: Function not implemented`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1233)
<!-- Reviewable:end -->
