### PR TITLE
[LibOS] tests: Fix missing/wrong return values from main()

### DIFF
--- a/LibOS/shim/test/inline/fork.c
+++ b/LibOS/shim/test/inline/fork.c
@@ -16,5 +16,5 @@ int main(int argc, char** argv) {
     }
 
     shim_exit_group(0);
-    return 0;  // should not reach here.
+    return 1;  // should not reach here.
 }

--- a/LibOS/shim/test/inline/helloworld.c
+++ b/LibOS/shim/test/inline/helloworld.c
@@ -3,5 +3,5 @@
 int main(int argc, char** argv) {
     shim_write(1, "Hello world\n", 12);
     shim_exit_group(0);
-    return 0;  // should not reach here.
+    return 1;  // should not reach here.
 }

--- a/LibOS/shim/test/inline/vfork.c
+++ b/LibOS/shim/test/inline/vfork.c
@@ -16,5 +16,5 @@ int main(int argc, char** argv) {
     }
 
     shim_exit_group(0);
-    return 0;  // should not reach here.
+    return 1;  // should not reach here.
 }

--- a/LibOS/shim/test/native/fs.c
+++ b/LibOS/shim/test/native/fs.c
@@ -19,4 +19,5 @@ int main() {
     }
 
     close(fd);
+    return 0;
 }

--- a/LibOS/shim/test/native/kill.c
+++ b/LibOS/shim/test/native/kill.c
@@ -33,7 +33,6 @@ int main(int argc, char** argv) {
             kill(parent_pid, SIGKILL);
 
         printf("[pid=%d|ppid=%d] Hello, Dad!\n", getpid(), getppid());
-        return 0;
     } else {
         struct timespec rem;
         rem.tv_sec  = kill_parent ? 60 : 1;
@@ -47,6 +46,6 @@ int main(int argc, char** argv) {
             kill(pid, SIGKILL);
 
         printf("[pid=%d|ppid=%d] Hello, Kid!\n", getpid(), getppid());
-        return 0;
     }
+    return 0;
 }

--- a/LibOS/shim/test/native/script.c
+++ b/LibOS/shim/test/native/script.c
@@ -12,5 +12,5 @@ int main(int argc, const char** argv, const char** envp) {
     setenv("IN_EXECVE", "1", 1);
 
     execv(new_argv[0], new_argv);
-    return 0;
+    return 1;
 }

--- a/LibOS/shim/test/regression/exec.c
+++ b/LibOS/shim/test/regression/exec.c
@@ -12,5 +12,5 @@ int main(int argc, const char** argv, const char** envp) {
     setenv("IN_EXECVE", "1", 1);
 
     execv(new_argv[0], new_argv);
-    return 0;
+    return 1;
 }

--- a/LibOS/shim/test/regression/proc-path.c
+++ b/LibOS/shim/test/regression/proc-path.c
@@ -21,4 +21,5 @@ int main(int argc, char** argv) {
     } else {
         printf("proc path test failure\n");
     }
+    return 0;
 }

--- a/Pal/src/host/Linux-SGX/test-sgx.c
+++ b/Pal/src/host/Linux-SGX/test-sgx.c
@@ -76,4 +76,5 @@ int main(int argc, char** argv) {
         native_cpuid(&eax, &ebx, &ecx, &edx);
         printf("eax: %x ebx: %x ecx: %x edx: %x\n", eax, ebx, ecx, edx);
     }
+    return 0;
 }


### PR DESCRIPTION
Fixes some bloopers in our tests regarding return values (e.g. missing `return 0` at the end of `main()`).

Should fix failures such as [this one](https://leeroy.cs.unc.edu/job/graphene-sgx/3034/testReport/junit/test_libos/TC_40_FileSystem/test_010_path/) (`subprocess.CalledProcessError: Command '['proc-path']' returned non-zero exit status 139`, but no other errors on the output).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1237)
<!-- Reviewable:end -->
