### PR TITLE
[LibOS] Allow MSG_PEEK on recv() + small bug fixes

### DIFF
--- a/LibOS/shim/include/shim_handle.h
+++ b/LibOS/shim/include/shim_handle.h
@@ -154,6 +154,8 @@ struct shim_pipe_handle {
 #define AF_INET  PF_INET
 #define AF_INET6 PF_INET6
 
+#define SOCK_URI_SIZE 108
+
 enum shim_sock_state {
     SOCK_CREATED,
     SOCK_BOUND,
@@ -202,7 +204,15 @@ struct shim_sock_handle {
         int optname;
         int optlen;
         char optval[];
-    } * pending_options;
+    }* pending_options;
+
+    struct shim_peek_buffer {
+        size_t size;             /* total size (capacity) of buffer `buf` */
+        size_t start;            /* beginning of buffered but yet unread data in `buf` */
+        size_t end;              /* end of buffered but yet unread data in `buf` */
+        char uri[SOCK_URI_SIZE]; /* cached URI for recvfrom(udp_socket) case */
+        char buf[];              /* peek buffer of size `size` */
+    }* peek_buffer;
 };
 
 struct shim_dirent {

--- a/LibOS/shim/include/shim_types.h
+++ b/LibOS/shim/include/shim_types.h
@@ -332,6 +332,14 @@ struct __kernel_ustat
   };
 
 /* bits/socket.h */
+enum
+{
+    MSG_OOB  = 0x01, /* Process out-of-band data. */
+    MSG_PEEK = 0x02, /* Peek at incoming messages. */
+#define MSG_OOB MSG_OOB
+#define MSG_PEEK MSG_PEEK
+};
+
 struct msghdr {
     void *msg_name;         /* Address to send to/receive from.  */
     socklen_t msg_namelen;  /* Length of address data.  */

--- a/LibOS/shim/src/sys/shim_epoll.c
+++ b/LibOS/shim/src/sys/shim_epoll.c
@@ -193,7 +193,7 @@ int shim_do_epoll_ctl(int epfd, int op, int fd, struct __kernel_epoll_event* eve
                 goto out;
             }
             /* note that pipe and socket may not have pal_handle yet (e.g. before bind()) */
-            if ((hdl->type != TYPE_PIPE && hdl->type != TYPE_SOCK && hdl->type != TYPE_EVENTFD) || !hdl->pal_handle) {
+            if (hdl->type != TYPE_PIPE && hdl->type != TYPE_SOCK && hdl->type != TYPE_EVENTFD) {
                 ret = -EPERM;
                 put_handle(hdl);
                 goto out;

--- a/LibOS/shim/src/sys/shim_open.c
+++ b/LibOS/shim/src/sys/shim_open.c
@@ -65,6 +65,12 @@ size_t shim_do_read (int fd, void * buf, size_t count)
     if (!hdl)
         return -EBADF;
 
+    /* sockets may read from LibOS buffer due to MSG_PEEK, so need to call socket-specific recv */
+    if (hdl->type == TYPE_SOCK) {
+        put_handle(hdl);
+        return shim_do_recvfrom(fd, buf, count, 0, NULL, NULL);
+    }
+
     int ret = do_handle_read(hdl, buf, count);
     put_handle(hdl);
     return ret;

--- a/LibOS/shim/src/sys/shim_socket.c
+++ b/LibOS/shim/src/sys/shim_socket.c
@@ -56,8 +56,6 @@
 
 #define AF_UNSPEC 0
 
-#define SOCK_URI_SIZE 108
-
 static int rebase_on_lo __attribute_migratable = -1;
 
 static size_t minimal_addrlen(int domain) {
@@ -1127,9 +1125,8 @@ ssize_t shim_do_sendmmsg(int sockfd, struct mmsghdr* msg, size_t vlen, int flags
 
 static ssize_t do_recvmsg(int fd, struct iovec* bufs, int nbufs, int flags, struct sockaddr* addr,
                           socklen_t* addrlen) {
-    /* TODO handle flags properly. For now, explicitly return an error. */
-    if (flags) {
-        debug("recvmsg()/recvmmsg()/recvfrom(): flags parameter unsupported.\n");
+    if (flags & ~MSG_PEEK) {
+        debug("recvmsg()/recvmmsg()/recvfrom(): unknown flag (only MSG_PEEK is supported).\n");
         return -EOPNOTSUPP;
     }
 
@@ -1137,6 +1134,7 @@ static ssize_t do_recvmsg(int fd, struct iovec* bufs, int nbufs, int flags, stru
     if (!hdl)
         return -EBADF;
 
+    struct shim_peek_buffer* peek_buffer = NULL;
     int ret = -ENOTSOCK;
     if (hdl->type != TYPE_SOCK)
         goto out;
@@ -1159,13 +1157,16 @@ static ssize_t do_recvmsg(int fd, struct iovec* bufs, int nbufs, int flags, stru
     if (!bufs || test_user_memory(bufs, sizeof(*bufs) * nbufs, false))
         goto out;
 
+    size_t expected_size = 0;
     for (int i = 0; i < nbufs; i++) {
         if (!bufs[i].iov_base || test_user_memory(bufs[i].iov_base, bufs[i].iov_len, true))
             goto out;
+        expected_size += bufs[i].iov_len;
     }
 
     lock(&hdl->lock);
-
+    peek_buffer        = sock->peek_buffer;
+    sock->peek_buffer  = NULL;
     PAL_HANDLE pal_hdl = hdl->pal_handle;
     char* uri          = NULL;
 
@@ -1192,19 +1193,77 @@ static ssize_t do_recvmsg(int fd, struct iovec* bufs, int nbufs, int flags, stru
 
     unlock(&hdl->lock);
 
-    bool address_received = false;
-    int bytes             = 0;
-    ret                   = 0;
-
-    for (int i = 0; i < nbufs; i++) {
-        PAL_NUM pal_ret = DkStreamRead(pal_hdl, 0, bufs[i].iov_len, bufs[i].iov_base, uri, uri ? SOCK_URI_SIZE : 0);
-
-        if (pal_ret == PAL_STREAM_ERROR) {
-            ret = (PAL_NATIVE_ERRNO == PAL_ERROR_STREAMNOTEXIST) ? -ECONNABORTED : -PAL_ERRNO;
-            break;
+    if (flags & MSG_PEEK) {
+        if (!peek_buffer) {
+            /* create new peek buffer with expected read size */
+            peek_buffer = malloc(sizeof(*peek_buffer) + expected_size);
+            if (!peek_buffer) {
+                ret = -ENOMEM;
+                lock(&hdl->lock);
+                goto out_locked;
+            }
+            peek_buffer->size  = expected_size;
+            peek_buffer->start = 0;
+            peek_buffer->end   = 0;
+        } else {
+            /* realloc peek buffer to accommodate expected read size */
+            if (expected_size > peek_buffer->size - peek_buffer->start) {
+                size_t expand = expected_size - (peek_buffer->size - peek_buffer->start);
+                struct shim_peek_buffer* old_peek_buffer = peek_buffer;
+                peek_buffer = malloc(sizeof(*peek_buffer) + old_peek_buffer->size + expand);
+                if (!peek_buffer) {
+                    ret = -ENOMEM;
+                    lock(&hdl->lock);
+                    goto out_locked;
+                }
+                memcpy(peek_buffer, old_peek_buffer, sizeof(*peek_buffer) + old_peek_buffer->size);
+                peek_buffer->size += expand;
+                free(old_peek_buffer);
+            }
         }
 
-        bytes += pal_ret;
+        if (expected_size > peek_buffer->end - peek_buffer->start) {
+            /* fill peek buffer if this MSG_PEEK read request cannot be satisfied with data already
+             * present in peek buffer; note that buffer can hold expected read size at this point */
+            size_t left_to_read = expected_size - (peek_buffer->end - peek_buffer->start);
+            PAL_NUM pal_ret = DkStreamRead(pal_hdl, /*offset=*/0, left_to_read,
+                                           &peek_buffer->buf[peek_buffer->end],
+                                           uri, uri ? SOCK_URI_SIZE : 0);
+            if (pal_ret == PAL_STREAM_ERROR) {
+                ret = (PAL_NATIVE_ERRNO == PAL_ERROR_STREAMNOTEXIST) ? -ECONNABORTED : -PAL_ERRNO;
+                lock(&hdl->lock);
+                goto out_locked;
+            }
+
+            peek_buffer->end += pal_ret;
+            if (uri)
+                memcpy(peek_buffer->uri, uri, SOCK_URI_SIZE);
+        }
+    }
+
+    ret = 0;
+
+    bool address_received = false;
+    size_t total_bytes    = 0;
+
+    for (int i = 0; i < nbufs; i++) {
+        size_t iov_bytes = 0;
+        if (peek_buffer) {
+            /* some data left to read from peek buffer */
+            assert(total_bytes < peek_buffer->end - peek_buffer->start);
+            iov_bytes = MIN(bufs[i].iov_len, peek_buffer->end - peek_buffer->start - total_bytes);
+            memcpy(bufs[i].iov_base, &peek_buffer->buf[peek_buffer->start + total_bytes], iov_bytes);
+            uri = peek_buffer->uri;
+        } else {
+            PAL_NUM pal_ret = DkStreamRead(pal_hdl, 0, bufs[i].iov_len, bufs[i].iov_base, uri, uri ? SOCK_URI_SIZE : 0);
+            if (pal_ret == PAL_STREAM_ERROR) {
+                ret = (PAL_NATIVE_ERRNO == PAL_ERROR_STREAMNOTEXIST) ? -ECONNABORTED : -PAL_ERRNO;
+                break;
+            }
+            iov_bytes = pal_ret;
+        }
+
+        total_bytes += iov_bytes;
 
         if (addr && !address_received) {
             if (sock->domain == AF_UNIX) {
@@ -1238,23 +1297,52 @@ static ssize_t do_recvmsg(int fd, struct iovec* bufs, int nbufs, int flags, stru
 
         /* gap in iovecs is not allowed, return a partial read to user; it is the responsibility of
          * user application to deal with partial reads */
-        if (pal_ret < bufs[i].iov_len)
+        if (iov_bytes < bufs[i].iov_len)
+            break;
+
+        /* we read from peek_buffer and exhausted it, return a partial read to user; it is the
+         * responsibility of user application to deal with partial reads */
+        if (peek_buffer && total_bytes == peek_buffer->end - peek_buffer->start)
             break;
     }
 
-    if (bytes)
-        ret = bytes;
+    if (total_bytes)
+        ret = total_bytes;
     if (ret < 0) {
         lock(&hdl->lock);
         goto out_locked;
     }
+
+    if (!(flags & MSG_PEEK) && peek_buffer) {
+        /* we read from peek buffer without MSG_PEEK, need to "remove" this read data */
+        peek_buffer->start += total_bytes;
+        if (peek_buffer->start == peek_buffer->end) {
+            /* we may have exhausted peek buffer, free it to not leak memory */
+            free(peek_buffer);
+            peek_buffer = NULL;
+        }
+    }
+
+    if (peek_buffer) {
+        /* there is non-exhausted peek buffer for this socket, update socket's data */
+        lock(&hdl->lock);
+
+        /* we assume it is impossible for other thread to update this socket's peek buffer (i.e.,
+         * only single thread works on a particular socket); if some real-world program actually has
+         * two threads working on one socket, then we need to fix "grab the lock twice" logic */
+        assert(!sock->peek_buffer);
+
+        sock->peek_buffer = peek_buffer;
+        unlock(&hdl->lock);
+    }
+
     goto out;
 
 out_locked:
     if (ret < 0)
         sock->error = -ret;
-
     unlock(&hdl->lock);
+    free(peek_buffer);
 out:
     put_handle(hdl);
     return ret;

--- a/LibOS/shim/test/regression/poll_many_types.c
+++ b/LibOS/shim/test/regression/poll_many_types.c
@@ -1,0 +1,55 @@
+#include <fcntl.h>
+#include <poll.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+int main(int argc, char** argv) {
+    int ret;
+    char string[] = "Hello, world!\n";
+
+    /* type 1: pipe */
+    int pipefd[2];
+    ret = pipe(pipefd);
+    if (ret < 0) {
+        perror("pipe creation failed");
+        return 1;
+    }
+    /* write something into write end of pipe so read end becomes pollable */
+    ret = write(pipefd[1], string, (strlen(string) + 1));
+    if (ret < 0) {
+        perror("pipe write failed");
+        return 1;
+    }
+
+    /* type 2: regular file */
+    int filefd = open(argv[0], O_RDONLY);
+    if (filefd < 0) {
+        perror("file open failed");
+        return 1;
+    }
+
+    /* type 3: dev file */
+    int devfd = open("/dev/urandom", O_RDONLY);
+    if (devfd < 0) {
+        perror("dev/urandom open failed");
+        return 1;
+    }
+
+    struct pollfd infds[] = {
+        {.fd = pipefd[0], .events = POLLIN},
+        {.fd = filefd,    .events = POLLIN},
+        {.fd = devfd,     .events = POLLIN},
+    };
+
+    ret = poll(infds, 3, -1);
+    if (ret <= 0) {
+        perror("poll with POLLIN failed");
+        return 1;
+    }
+    printf("poll(POLLIN) returned %d file descriptors\n", ret);
+
+    return 0;
+}

--- a/LibOS/shim/test/regression/tcp_msg_peek.c
+++ b/LibOS/shim/test/regression/tcp_msg_peek.c
@@ -1,0 +1,219 @@
+#include <arpa/inet.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <netinet/in.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#define SRV_IP "127.0.0.1"
+#define PORT 11111
+#define BUFLEN 512
+
+enum { SINGLE, PARALLEL } mode = PARALLEL;
+int pipefds[2];
+
+void server(void) {
+    int listening_socket, client_socket;
+    struct sockaddr_in address;
+    socklen_t addrlen;
+
+    if ((listening_socket = socket(AF_INET, SOCK_STREAM, 0)) < 0) {
+        perror("socket");
+        exit(1);
+    }
+
+    int enable = 1;
+    if (setsockopt(listening_socket, SOL_SOCKET, SO_REUSEADDR, &enable, sizeof(enable)) < 0) {
+        perror("setsockopt");
+        exit(1);
+    }
+
+    memset(&address, 0, sizeof(address));
+    address.sin_family      = AF_INET;
+    address.sin_port        = htons(PORT);
+    address.sin_addr.s_addr = htonl(INADDR_ANY);
+
+    if (bind(listening_socket, (struct sockaddr*)&address, sizeof(address)) < 0) {
+        perror("bind");
+        exit(1);
+    }
+
+    if (listen(listening_socket, 3) < 0) {
+        perror("listen");
+        exit(1);
+    }
+
+    if (mode == PARALLEL) {
+        if (close(pipefds[0]) < 0) {
+            perror("close of pipe");
+            exit(1);
+        }
+
+        char byte = 0;
+
+        ssize_t written = 0;
+        while (written == 0) {
+            if ((written = write(pipefds[1], &byte, sizeof(byte))) < 0) {
+                if (errno == EINTR || errno == EAGAIN)
+                    continue;
+                perror("write on pipe");
+                exit(1);
+            }
+        }
+    }
+
+    addrlen       = sizeof(address);
+    client_socket = accept(listening_socket, (struct sockaddr*)&address, &addrlen);
+
+    if (client_socket < 0) {
+        perror("accept");
+        exit(1);
+    }
+
+    if (close(listening_socket) < 0) {
+        perror("close of listening socket");
+        exit(1);
+    }
+
+    puts("[server] client is connected...");
+
+    char buffer[] = "Hello from server!\n";
+
+    ssize_t written = 0;
+    while (written < sizeof(buffer)) {
+        ssize_t n;
+        if ((n = sendto(client_socket, buffer + written, sizeof(buffer) - written, 0, 0, 0)) < 0) {
+            if (errno == EINTR || errno == EAGAIN)
+                continue;
+            perror("sendto to client");
+            exit(1);
+        }
+        written += n;
+    }
+
+    if (close(client_socket) < 0) {
+        perror("close of client socket");
+        exit(1);
+    }
+
+    puts("[server] done");
+}
+
+static ssize_t client_recv(int server_socket, char* buf, size_t len, int flags) {
+    ssize_t read = 0;
+    while (1) {
+        ssize_t n;
+        if ((n = recv(server_socket, buf + read, len - read, flags)) < 0) {
+            if (errno == EINTR || errno == EAGAIN)
+                continue;
+            perror("client recv");
+            exit(1);
+        }
+
+        read += n;
+
+        if (!n || flags & MSG_PEEK) {
+            /* recv with MSG_PEEK flag should be done only once */
+            break;
+        }
+    }
+
+    return read;
+}
+
+void client(void) {
+    int server_socket;
+    struct sockaddr_in address;
+    char buffer[BUFLEN];
+    ssize_t count;
+
+    if (mode == PARALLEL) {
+        if (close(pipefds[1]) < 0) {
+            perror("close of pipe");
+            exit(1);
+        }
+
+        char byte = 0;
+
+        ssize_t received = 0;
+        while (received == 0) {
+            if ((received = read(pipefds[0], &byte, sizeof(byte))) < 0) {
+                if (errno == EINTR || errno == EAGAIN)
+                    continue;
+                perror("read on pipe");
+                exit(1);
+            }
+        }
+    }
+
+    if ((server_socket = socket(AF_INET, SOCK_STREAM, 0)) < 0) {
+        perror("socket");
+        exit(1);
+    }
+
+    memset(&address, 0, sizeof(address));
+    address.sin_family = AF_INET;
+    address.sin_port   = htons((PORT));
+    if (inet_aton(SRV_IP, &address.sin_addr) == 0) {
+        perror("inet_aton");
+        exit(1);
+    }
+
+    if (connect(server_socket, (struct sockaddr*)&address, sizeof(address)) < 0) {
+        perror("connect");
+        exit(1);
+    }
+
+    printf("[client] receiving with MSG_PEEK: ");
+    count = client_recv(server_socket, buffer, sizeof(buffer), MSG_PEEK);
+    fwrite(buffer, count, 1, stdout);
+
+    printf("[client] receiving without MSG_PEEK: ");
+    count = client_recv(server_socket, buffer, sizeof(buffer), 0);
+    fwrite(buffer, count, 1, stdout);
+
+    printf("[client] checking how many bytes are left unread: ");
+    count = client_recv(server_socket, buffer, sizeof(buffer), 0);
+    printf("%zu\n", count);
+
+    if (close(server_socket) < 0) {
+        perror("close of server socket");
+        exit(1);
+    }
+
+    puts("[client] done");
+}
+
+int main(int argc, char** argv) {
+    if (argc > 1) {
+        if (strcmp(argv[1], "client") == 0) {
+            mode = SINGLE;
+            client();
+            return 0;
+        }
+
+        if (strcmp(argv[1], "server") == 0) {
+            mode = SINGLE;
+            server();
+            return 0;
+        }
+    } else {
+        pipe(pipefds);
+
+        int pid = fork();
+
+        if (pid == 0) {
+            client();
+        } else {
+            server();
+        }
+    }
+
+    return 0;
+}

--- a/LibOS/shim/test/regression/test_libos.py
+++ b/LibOS/shim/test/regression/test_libos.py
@@ -473,3 +473,11 @@ class TC_80_Socket(RegressionTestCase):
         self.assertIn('Data: This is packet 7', stdout)
         self.assertIn('Data: This is packet 8', stdout)
         self.assertIn('Data: This is packet 9', stdout)
+
+    def test_300_socket_tcp_msg_peek(self):
+        stdout, _ = self.run_binary(['tcp_msg_peek'], timeout=50)
+        self.assertIn('[client] receiving with MSG_PEEK: Hello from server!', stdout)
+        self.assertIn('[client] receiving without MSG_PEEK: Hello from server!', stdout)
+        self.assertIn('[client] checking how many bytes are left unread: 0', stdout)
+        self.assertIn('[client] done', stdout)
+        self.assertIn('[server] done', stdout)

--- a/LibOS/shim/test/regression/test_libos.py
+++ b/LibOS/shim/test/regression/test_libos.py
@@ -429,6 +429,10 @@ class TC_80_Socket(RegressionTestCase):
         self.assertIn('poll(POLLOUT) returned 1 file descriptors', stdout)
         self.assertIn('poll(POLLIN) returned 1 file descriptors', stdout)
 
+    def test_021_poll_many_types(self):
+        stdout, _ = self.run_binary(['poll_many_types'])
+        self.assertIn('poll(POLLIN) returned 3 file descriptors', stdout)
+
     def test_030_ppoll(self):
         stdout, _ = self.run_binary(['ppoll'])
         self.assertIn('ppoll(POLLOUT) returned 1 file descriptors', stdout)


### PR DESCRIPTION
<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->

The main purpose of this PR is to add `MSG_PEEK` emulation in LibOS during `recv()`. I also had to fix a couple small bugs in poll and epoll to be able to test it with Nginx in SSL/TLS mode.

The commit summary:

- [LibOS] Allow `MSG_PEEK` on `recv()`. Previously, Graphene failed if `recv()` contained `MSG_PEEK` flag. This resulted in many TLS-based applications failing, including Nginx, Apache, and Lighttpd in SSL/TLS mode. This commit adds emulation of `MSG_PEEK` at LibOS level. A simple TCP test case is provided.

- [LibOS] Allow poll/ppoll/select/pselect on regular and dev files. Previously, Graphene incorrectly handled poll/ppoll/select/pselect of regular and dev files like `/dev/urandom`: it tried to perform an actual host-OS poll on these files. However, poll of such files must be emulated completely inside LibOS. This commit adds this special case to poll/ppoll/select/pselect. A test case is supplied.

- [LibOS] Allow LibOS handles without backing PAL handles in epoll. Previously, Graphene failed with `-EPERM` on `epoll_ctl(EPOLL_CTL_ADD)` of a LibOS shim handle without a backing PAL handle. However, it is possible for a LibOS socket handle to not have a PAL handle: if user app first creates the handle via `socket()`, then adds it to epoll via `epoll_ctl()`, and only then performs `bind()` at which point PAL handle is finally created. This commit removes this restriction.

Supersedes #1110. Closes #1110. Closes #1092. Closes #66. 

## How to test this PR? <!-- (if applicable) -->

Two new tests are added to LibOS regression suite:
- `poll_many_types`: tests poll bug fix
- `tcp_msg_peek`: tests ``recv(MSG_PEEK)`

Additionally, Nginx with SSL/TLS as described in https://github.com/oscarlab/graphene/issues/1092 now works. We may consider adding Nginx, Apache, Lighttpd with SSL/TLS modes to our Jenkins pipelines...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1253)
<!-- Reviewable:end -->
