### PR TITLE
[LibOS] Fix type of checkpoint's total memory size variable

### DIFF
--- a/LibOS/shim/include/shim_checkpoint.h
+++ b/LibOS/shim/include/shim_checkpoint.h
@@ -112,7 +112,7 @@ struct shim_cp_store {
     /* entries of out-of-band data */
     struct shim_mem_entry* last_mem_entry;
     int mem_nentries;
-    int mem_size;
+    size_t mem_size;
 
     /* entries of pal handles to send */
     struct shim_palhdl_entry* last_palhdl_entry;


### PR DESCRIPTION
## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->

Checkpoint's total memory size is stored in `shim_cp_store::mem_size` field. Previously, this field was of type `int`. When a process allocates more than 2GB of memory and then tries to spawn a child,
the checkpoint send/receive fails due to int overflow of `mem_size`. This PR simply changes mem_size type to `size_t`. This is enough to make the bug go away on e.g. a huge Python app with TensorFlow.

## How to test this PR? <!-- (if applicable) -->

This bug was triggered on a huge Python app with TensorFlow. Generally, this bug is triggered on huge apps. I don't think it deserve a separate test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1264)
<!-- Reviewable:end -->
