### PR TITLE
[CI] run-pylint: use pylint if pylint3 is missing

### DIFF
--- a/.ci/run-pylint
+++ b/.ci/run-pylint
@@ -4,10 +4,16 @@ set -e
 
 cd "$(git rev-parse --show-toplevel)"
 
+# pylint3 was replaced with pylint from Ubuntu 19.10
+PYLINT=$(command -v pylint3)
+if [ -z "$PYLINT" ]; then
+    PYLINT=$(command -v pylint)
+fi
+
 find . -name \*.py \
     -and -not -path ./LibOS/shim/test/apps/ltp/src/\* \
 | sed 's/./\\&/g' \
-| xargs pylint3 "$@" \
+| xargs "${PYLINT}" "$@" \
     Pal/src/host/Linux-SGX/signer/pal-sgx-get-token \
     Pal/src/host/Linux-SGX/signer/pal-sgx-sign \
     .ci/prfilter


### PR DESCRIPTION
From Ubuntu 19.10 pylint3 was replaced with pylint.
use pylint if pylint3 is missing.

<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [x] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->


## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1269)
<!-- Reviewable:end -->
