### PR TITLE
[Pal/Linux-SGX] Init communication with AESM only when app requests RA

### DIFF
--- a/Pal/src/host/Linux-SGX/sgx_main.c
+++ b/Pal/src/host/Linux-SGX/sgx_main.c
@@ -938,9 +938,12 @@ static int load_enclave (struct pal_enclave * enclave,
     if (ret < 0)
         return ret;
 
-    ret = init_aesm_targetinfo(&pal_sec->aesm_targetinfo);
-    if (ret < 0)
-        return ret;
+    if (get_config(enclave->config, "sgx.ra_client_key", cfgbuf, sizeof(cfgbuf)) > 0) {
+        /* initialize communication with AESM enclave only if app requests remote attestation */
+        ret = init_aesm_targetinfo(&pal_sec->aesm_targetinfo);
+        if (ret < 0)
+            return ret;
+    }
 
     void* alt_stack = (void*)INLINE_SYSCALL(mmap, 6, NULL, ALT_STACK_SIZE,
                                             PROT_READ | PROT_WRITE,


### PR DESCRIPTION
## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [x] SGX PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->

Previously, Graphene-SGX always tried to initialize communication with AESM enclaves (Launch Enclave, Quoting Enclave, etc.) on startup. This is only needed for SGX Remote Attestation (RA). This commit disables AESM init if the manifest doesn't explicitly specify need for SGX RA.

This allows non-provisioned SGX machines to run Graphene locally.


## How to test this PR? <!-- (if applicable) -->

All tests must pass.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1270)
<!-- Reviewable:end -->
