### PR TITLE
[Pal/{Linux,Linux-SGX}] Remove CLONE_PTRACE flag on thread creation

### DIFF
--- a/Pal/src/host/Linux-SGX/sgx_thread.c
+++ b/Pal/src/host/Linux-SGX/sgx_thread.c
@@ -215,11 +215,9 @@ int clone_thread(void) {
 
     int dummy_parent_tid_field = 0;
     ret = clone(pal_thread_init, child_stack_top,
-                CLONE_VM|CLONE_FS|CLONE_FILES|CLONE_SYSVSEM|
-                CLONE_THREAD|CLONE_SIGHAND|CLONE_PTRACE|
-                CLONE_PARENT_SETTID,
-                (void*) tcb,
-                &dummy_parent_tid_field, NULL);
+                CLONE_VM | CLONE_FS | CLONE_FILES | CLONE_SYSVSEM | CLONE_THREAD |
+                CLONE_SIGHAND | CLONE_PARENT_SETTID,
+                (void*)tcb, &dummy_parent_tid_field, NULL);
 
     if (IS_ERR(ret)) {
         INLINE_SYSCALL(munmap, 2, stack, THREAD_STACK_SIZE + ALT_STACK_SIZE);

--- a/Pal/src/host/Linux/db_threading.c
+++ b/Pal/src/host/Linux/db_threading.c
@@ -181,10 +181,9 @@ int _DkThreadCreate (PAL_HANDLE * handle, int (*callback) (void *),
     child_stack = ALIGN_DOWN_PTR(child_stack, 16);
 
     ret = clone(pal_thread_init, child_stack,
-                    CLONE_VM|CLONE_FS|CLONE_FILES|CLONE_SYSVSEM|
-                    CLONE_THREAD|CLONE_SIGHAND|CLONE_PTRACE|
-                    CLONE_PARENT_SETTID,
-                    (void *) tcb, &hdl->thread.tid, NULL);
+                CLONE_VM | CLONE_FS | CLONE_FILES | CLONE_SYSVSEM | CLONE_THREAD |
+                CLONE_SIGHAND | CLONE_PARENT_SETTID,
+                (void*)tcb, &hdl->thread.tid, NULL);
 
     if (IS_ERR(ret)) {
         ret = -PAL_ERROR_DENIED;


### PR DESCRIPTION
## Affected components

- [ ] README and global configuration
- [x] Linux PAL
- [x] SGX PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->

Previously, Graphene's PALs specified `CLONE_PTRACE` flag on any thread creation. This led to debuggers (GDB, strace, other ptrace-based debuggers) always tracing child threads, even if they did not subscribe to such events (debuggers usually use `PTRACE_O_TRACECLONE` and similar flags to start tracing child threads/processes). This PR removes `CLONE_PTRACE` flag such that debuggers have a chance to ignore child threads; this improves stability and performance of ptracing.

This bug was found when working on a custom ptrace-based debugger on a machine with a huge number of cores (~100 logical cores). Even though I was only interested in one (main) thread, the debugger suddenly ptraced all 100 spawned threads, and this led to awful performance. This PR allows to pass the decision on what to ptrace exactly to the debugger. This improves performance of ptracing dramatically.

## How to test this PR? <!-- (if applicable) -->

All tests must pass. You can assure yourself that things still work correctly by running GDB and strace and observing that threads are still debuggable. E.g., `multi_pthread` LibOS test is a good candidate (`strace -ff ./pal_loader ./multi_pthread`).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1271)
<!-- Reviewable:end -->
