### PR TITLE
make .dir-locals.el aware of COMMIT_EDITMSG for 80 column

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -6,5 +6,6 @@
  (makefile-mode . ((indent-tabs-mode . t)))
  (asm-mode . ((indent-tabs-mode . t)))
  (shell-script-mode . ((indent-tabs-mode . t)))
+ ("\.git/COMMIT_EDITMSG" . ((nil . ((fill-column . 80)))))
  ((nil . ((truncate-lines . t)))
           (text-mode . ((eval . ((turn-on-auto-fill)))))))


### PR DESCRIPTION
<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [x] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->
update .dir-locals.el aware of COMIMT_EDITMSG for 80 columns

What column is desired for our graphene project?
Typically 72 columns for message body(50 for subject line) is recommended. We can chose our own.

## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1274)
<!-- Reviewable:end -->
