### PR TITLE
[Pal/{Linux,Linux-SGX}] Remove IPV6_V6ONLY flag on socket creation

### DIFF
--- a/LibOS/shim/test/regression/tcp_ipv6_v6only.c
+++ b/LibOS/shim/test/regression/tcp_ipv6_v6only.c
@@ -1,0 +1,88 @@
+#include <arpa/inet.h>
+#include <errno.h>
+#include <netinet/in.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+/* use the same loopback address and port for both IPV6 and IPV4 */
+#define SRV_IPV6 "::1/128"
+#define SRV_IPV4 "127.0.0.1"
+#define PORT 11112
+
+int main(int argc, char** argv) {
+    int socket_ipv4;
+    int socket_ipv6;
+    int ret;
+
+    if ((socket_ipv6 = socket(AF_INET6, SOCK_STREAM, 0)) < 0) {
+        perror("socket(ipv6)");
+        return 1;
+    }
+
+    if ((socket_ipv4 = socket(AF_INET, SOCK_STREAM, 0)) < 0) {
+        perror("socket(ipv4)");
+        return 1;
+    }
+
+    int enable = 1;
+    if (setsockopt(socket_ipv6, SOL_SOCKET, SO_REUSEADDR, &enable, sizeof(enable)) < 0) {
+        perror("setsockopt(ipv6, SO_REUSEADDR = 1)");
+        return 1;
+    }
+    if (setsockopt(socket_ipv4, SOL_SOCKET, SO_REUSEADDR, &enable, sizeof(enable)) < 0) {
+        perror("setsockopt(ipv4, SO_REUSEADDR = 1)");
+        return 1;
+    }
+
+    /* this forces IPV6 to listen for both IPV4 and IPV6 connections; this in turn makes binding
+     * another (IPV4) socket on the same port meaningless and results in -EADDRINUSE */
+    int disable = 0;
+    if (setsockopt(socket_ipv6, IPPROTO_IPV6, IPV6_V6ONLY, &disable, sizeof(disable)) < 0) {
+        perror("setsockopt(IPV6_V6ONLY = 0)");
+        return 1;
+    }
+
+    struct sockaddr_in6 address_ipv6;
+    memset(&address_ipv6, 0, sizeof(address_ipv6));
+    address_ipv6.sin6_family = AF_INET6;
+    address_ipv6.sin6_port   = htons(PORT);
+
+    if (inet_pton(AF_INET6, SRV_IPV6, &address_ipv6.sin6_addr) < 0) {
+        perror("inet_pton(ipv6)");
+        return 1;
+    }
+
+    if (bind(socket_ipv6, (struct sockaddr*)&address_ipv6, sizeof(address_ipv6)) < 0) {
+        perror("bind(ipv6)");
+        return 1;
+    }
+
+    /* we must start listening on IPV6 socket to make it active and kick in Linux rules for bind() */
+    if (listen(socket_ipv6, 3) < 0) {
+        perror("listen(ipv6)");
+        return 1;
+    }
+
+    struct sockaddr_in address_ipv4;
+    memset(&address_ipv4, 0, sizeof(address_ipv4));
+    address_ipv4.sin_family      = AF_INET;
+    address_ipv4.sin_port        = htons(PORT);       /* note the same port! */
+
+    if (inet_pton(AF_INET, SRV_IPV4, &address_ipv4.sin_addr) < 0) {
+        perror("inet_pton(ipv4)");
+        return 1;
+    }
+
+    ret = bind(socket_ipv4, (struct sockaddr*)&address_ipv4, sizeof(address_ipv4));
+    if (ret != -1 || errno != EADDRINUSE) {
+        fprintf(stderr, "bind(ipv4) was successful even though there is no IPV6_V6ONLY on same port\n");
+        return 1;
+    }
+
+    puts("test completed successfully");
+    return 0;
+}

--- a/LibOS/shim/test/regression/test_libos.py
+++ b/LibOS/shim/test/regression/test_libos.py
@@ -475,3 +475,7 @@ class TC_80_Socket(RegressionTestCase):
         self.assertIn('[client] checking how many bytes are left unread: 0', stdout)
         self.assertIn('[client] done', stdout)
         self.assertIn('[server] done', stdout)
+
+    def test_310_socket_tcp_ipv6_v6only(self):
+        stdout, _ = self.run_binary(['tcp_ipv6_v6only'], timeout=50)
+        self.assertIn('test completed successfully', stdout)

--- a/Pal/src/host/Linux-SGX/db_pipes.c
+++ b/Pal/src/host/Linux-SGX/db_pipes.c
@@ -65,8 +65,8 @@ static int pipe_listen(PAL_HANDLE* handle, PAL_NUM pipeid, int options) {
 
     unsigned int addrlen = sizeof(struct sockaddr_un);
     struct sockopt sock_options;
-    ret = ocall_listen(AF_UNIX, pipe_type(options), 0, (struct sockaddr*)&addr, &addrlen,
-                       &sock_options);
+    ret = ocall_listen(AF_UNIX, pipe_type(options), 0, /*ipv6_v6only=*/0,
+                       (struct sockaddr*)&addr, &addrlen, &sock_options);
     if (IS_ERR(ret))
         return unix_to_pal_error(ERRNO(ret));
 
@@ -111,7 +111,7 @@ static int pipe_connect(PAL_HANDLE* handle, PAL_NUM pipeid, int options) {
         return ret;
 
     struct sockopt sock_options;
-    ret = ocall_connect(AF_UNIX, pipe_type(options), 0, (void*)&addr,
+    ret = ocall_connect(AF_UNIX, pipe_type(options), 0, /*ipv6_v6only=*/0, (void*)&addr,
                         sizeof(struct sockaddr_un), NULL, NULL, &sock_options);
     if (IS_ERR(ret))
         return unix_to_pal_error(ERRNO(ret));

--- a/Pal/src/host/Linux-SGX/enclave_ocalls.c
+++ b/Pal/src/host/Linux-SGX/enclave_ocalls.c
@@ -570,14 +570,12 @@ int ocall_socketpair (int domain, int type, int protocol,
     return retval;
 }
 
-int ocall_listen (int domain, int type, int protocol,
-                  struct sockaddr * addr, unsigned int * addrlen,
-                  struct sockopt * sockopt)
-{
+int ocall_listen(int domain, int type, int protocol, int ipv6_v6only,
+                 struct sockaddr* addr, unsigned int* addrlen, struct sockopt* sockopt) {
     int retval = 0;
     unsigned int copied;
     unsigned int len = addrlen ? *addrlen : 0;
-    ms_ocall_listen_t * ms;
+    ms_ocall_listen_t* ms;
 
     ms = sgx_alloc_on_ustack(sizeof(*ms));
     if (!ms) {
@@ -588,6 +586,7 @@ int ocall_listen (int domain, int type, int protocol,
     ms->ms_domain = domain;
     ms->ms_type = type;
     ms->ms_protocol = protocol;
+    ms->ms_ipv6_v6only = ipv6_v6only;
     ms->ms_addrlen = len;
     ms->ms_addr = (addr && len) ? sgx_copy_to_ustack(addr, len) : NULL;
 
@@ -661,16 +660,14 @@ int ocall_accept (int sockfd, struct sockaddr * addr,
     return retval;
 }
 
-int ocall_connect (int domain, int type, int protocol,
-                   const struct sockaddr * addr,
-                   unsigned int addrlen,
-                   struct sockaddr * bind_addr,
-                   unsigned int * bind_addrlen, struct sockopt * sockopt)
-{
+int ocall_connect(int domain, int type, int protocol, int ipv6_v6only,
+                  const struct sockaddr* addr, unsigned int addrlen,
+                  struct sockaddr* bind_addr, unsigned int* bind_addrlen,
+                  struct sockopt* sockopt) {
     int retval = 0;
     unsigned int copied;
     unsigned int bind_len = bind_addrlen ? *bind_addrlen : 0;
-    ms_ocall_connect_t * ms;
+    ms_ocall_connect_t* ms;
 
     ms = sgx_alloc_on_ustack(sizeof(*ms));
     if (!ms) {
@@ -681,6 +678,7 @@ int ocall_connect (int domain, int type, int protocol,
     ms->ms_domain = domain;
     ms->ms_type = type;
     ms->ms_protocol = protocol;
+    ms->ms_ipv6_v6only = ipv6_v6only;
     ms->ms_addrlen = addrlen;
     ms->ms_bind_addrlen = bind_len;
     ms->ms_addr = addr ? sgx_copy_to_ustack(addr, addrlen) : NULL;

--- a/Pal/src/host/Linux-SGX/enclave_ocalls.h
+++ b/Pal/src/host/Linux-SGX/enclave_ocalls.h
@@ -45,17 +45,16 @@ int ocall_mkdir (const char *pathname, unsigned short mode);
 
 int ocall_getdents (int fd, struct linux_dirent64 *dirp, unsigned int size);
 
-int ocall_listen (int domain, int type, int protocol,
-                  struct sockaddr * addr, unsigned int * addrlen,
-                  struct sockopt * opt);
+int ocall_listen(int domain, int type, int protocol, int ipv6_v6only,
+                 struct sockaddr* addr, unsigned int* addrlen, struct sockopt* sockopt);
 
 int ocall_accept (int sockfd, struct sockaddr * addr,
                   unsigned int * addrlen, struct sockopt * opt);
 
-int ocall_connect (int domain, int type, int protocol,
-                   const struct sockaddr * addr, unsigned int addrlen,
-                   struct sockaddr * connaddr,
-                   unsigned int * connaddrlen, struct sockopt * opt);
+int ocall_connect(int domain, int type, int protocol, int ipv6_v6only,
+                  const struct sockaddr* addr, unsigned int addrlen,
+                  struct sockaddr* bind_addr, unsigned int* bind_addrlen,
+                  struct sockopt* sockopt);
 
 int ocall_recv (int sockfd, void * buf, unsigned int count,
                 struct sockaddr * addr, unsigned int * addrlenptr,

--- a/Pal/src/host/Linux-SGX/ocall_types.h
+++ b/Pal/src/host/Linux-SGX/ocall_types.h
@@ -172,8 +172,11 @@ typedef struct {
 } ms_ocall_socketpair_t;
 
 typedef struct {
-    int ms_domain, ms_type, ms_protocol;
-    const struct sockaddr * ms_addr;
+    int ms_domain;
+    int ms_type;
+    int ms_protocol;
+    int ms_ipv6_v6only;
+    const struct sockaddr* ms_addr;
     unsigned int ms_addrlen;
     struct sockopt ms_sockopt;
 } ms_ocall_listen_t;
@@ -186,10 +189,13 @@ typedef struct {
 } ms_ocall_accept_t;
 
 typedef struct {
-    int ms_domain, ms_type, ms_protocol;
-    const struct sockaddr * ms_addr;
+    int ms_domain;
+    int ms_type;
+    int ms_protocol;
+    int ms_ipv6_v6only;
+    const struct sockaddr* ms_addr;
     unsigned int ms_addrlen;
-    struct sockaddr * ms_bind_addr;
+    struct sockaddr* ms_bind_addr;
     unsigned int ms_bind_addrlen;
     struct sockopt ms_sockopt;
 } ms_ocall_connect_t;

--- a/Pal/src/host/Linux-SGX/pal_linux_error.h
+++ b/Pal/src/host/Linux-SGX/pal_linux_error.h
@@ -22,6 +22,7 @@ static inline __attribute__((unused)) int unix_to_pal_error(int unix_errno) {
         case EFAULT:
             return -PAL_ERROR_BADADDR;
         case EEXIST:
+        case EADDRINUSE:
             return -PAL_ERROR_STREAMEXIST;
         case ENOTDIR:
             return -PAL_ERROR_STREAMISFILE;

--- a/Pal/src/host/Linux-SGX/sgx_enclave.c
+++ b/Pal/src/host/Linux-SGX/sgx_enclave.c
@@ -290,11 +290,7 @@ static int sgx_ocall_listen(void * pms)
         goto err;
 
     fd = ret;
-    if (ms->ms_addr->sa_family == AF_INET6) {
-        int ipv6only = 1;
-        INLINE_SYSCALL(setsockopt, 5, fd, SOL_IPV6, IPV6_V6ONLY, &ipv6only,
-                       sizeof(int));
-    }
+
     /* must set the socket to be reuseable */
     int reuseaddr = 1;
     INLINE_SYSCALL(setsockopt, 5, fd, SOL_SOCKET, SO_REUSEADDR, &reuseaddr,
@@ -369,11 +365,6 @@ static int sgx_ocall_connect(void * pms)
         goto err;
 
     fd = ret;
-    if (ms->ms_addr && ms->ms_addr->sa_family == AF_INET6) {
-        int ipv6only = 1;
-        INLINE_SYSCALL(setsockopt, 5, fd, SOL_IPV6, IPV6_V6ONLY, &ipv6only,
-                       sizeof(int));
-    }
 
     if (ms->ms_bind_addr && ms->ms_bind_addr->sa_family) {
         ret = INLINE_SYSCALL(bind, 3, fd, ms->ms_bind_addr,

--- a/Pal/src/host/Linux-SGX/sgx_enclave.c
+++ b/Pal/src/host/Linux-SGX/sgx_enclave.c
@@ -14,10 +14,6 @@
 #include <math.h>
 #include <asm/errno.h>
 
-#ifndef SOL_IPV6
-# define SOL_IPV6 41
-#endif
-
 #define ODEBUG(code, ms) do {} while (0)
 
 static int sgx_ocall_exit(void* pms)
@@ -293,8 +289,17 @@ static int sgx_ocall_listen(void * pms)
 
     /* must set the socket to be reuseable */
     int reuseaddr = 1;
-    INLINE_SYSCALL(setsockopt, 5, fd, SOL_SOCKET, SO_REUSEADDR, &reuseaddr,
-                   sizeof(int));
+    ret = INLINE_SYSCALL(setsockopt, 5, fd, SOL_SOCKET, SO_REUSEADDR, &reuseaddr, sizeof(reuseaddr));
+    if (IS_ERR(ret))
+        goto err_fd;
+
+    if (ms->ms_domain == AF_INET6) {
+        /* IPV6_V6ONLY socket option can only be set before first bind */
+        ret = INLINE_SYSCALL(setsockopt, 5, fd, IPPROTO_IPV6, IPV6_V6ONLY, &ms->ms_ipv6_v6only,
+                             sizeof(ms->ms_ipv6_v6only));
+        if (IS_ERR(ret))
+            goto err_fd;
+    }
 
     ret = INLINE_SYSCALL(bind, 3, fd, ms->ms_addr, ms->ms_addrlen);
     if (IS_ERR(ret))
@@ -367,6 +372,14 @@ static int sgx_ocall_connect(void * pms)
     fd = ret;
 
     if (ms->ms_bind_addr && ms->ms_bind_addr->sa_family) {
+        if (ms->ms_domain == AF_INET6) {
+            /* IPV6_V6ONLY socket option can only be set before first bind */
+            ret = INLINE_SYSCALL(setsockopt, 5, fd, IPPROTO_IPV6, IPV6_V6ONLY, &ms->ms_ipv6_v6only,
+                                 sizeof(ms->ms_ipv6_v6only));
+            if (IS_ERR(ret))
+                goto err_fd;
+        }
+
         ret = INLINE_SYSCALL(bind, 3, fd, ms->ms_bind_addr,
                              ms->ms_bind_addrlen);
         if (IS_ERR(ret))

--- a/Pal/src/host/Linux/db_sockets.c
+++ b/Pal/src/host/Linux/db_sockets.c
@@ -348,11 +348,6 @@ static int tcp_listen(PAL_HANDLE* handle, char* uri, int options) {
     if (IS_ERR(fd))
         return -PAL_ERROR_DENIED;
 
-    if (bind_addr->sa_family == AF_INET6) {
-        int ipv6only = 1;
-        INLINE_SYSCALL(setsockopt, 5, fd, SOL_IPV6, IPV6_V6ONLY, &ipv6only, sizeof(int));
-    }
-
     /* must set the socket to be reuseable */
     int reuseaddr = 1;
     INLINE_SYSCALL(setsockopt, 5, fd, SOL_SOCKET, SO_REUSEADDR, &reuseaddr, sizeof(int));
@@ -478,11 +473,6 @@ static int tcp_connect(PAL_HANDLE* handle, char* uri, int options) {
                     goto failed;
             }
         }
-    }
-
-    if (dest_addr->sa_family == AF_INET6) {
-        int ipv6only = 1;
-        INLINE_SYSCALL(setsockopt, 5, fd, SOL_IPV6, IPV6_V6ONLY, &ipv6only, sizeof(int));
     }
 
     ret = INLINE_SYSCALL(connect, 3, fd, dest_addr, dest_addrlen);
@@ -635,11 +625,6 @@ static int udp_bind(PAL_HANDLE* handle, char* uri, int options) {
     if (IS_ERR(fd))
         return -PAL_ERROR_DENIED;
 
-    if (bind_addr->sa_family == AF_INET6) {
-        int ipv6only = 1;
-        INLINE_SYSCALL(setsockopt, 5, fd, SOL_IPV6, IPV6_V6ONLY, &ipv6only, sizeof(int));
-    }
-
     ret = INLINE_SYSCALL(bind, 3, fd, bind_addr, bind_addrlen);
 
     if (IS_ERR(ret)) {
@@ -693,11 +678,6 @@ static int udp_connect(PAL_HANDLE* handle, char* uri, int options) {
 
     if (IS_ERR(fd))
         return -PAL_ERROR_DENIED;
-
-    if (dest_addr && dest_addr->sa_family == AF_INET6) {
-        int ipv6only = 1;
-        INLINE_SYSCALL(setsockopt, 5, fd, SOL_IPV6, IPV6_V6ONLY, &ipv6only, sizeof(int));
-    }
 
     if (bind_addr) {
         ret = INLINE_SYSCALL(bind, 3, fd, bind_addr, bind_addrlen);

--- a/Pal/src/host/Linux/pal_linux_error.h
+++ b/Pal/src/host/Linux/pal_linux_error.h
@@ -22,6 +22,7 @@ static inline __attribute__((unused)) int unix_to_pal_error(int unix_errno) {
         case EFAULT:
             return -PAL_ERROR_BADADDR;
         case EEXIST:
+        case EADDRINUSE:
             return -PAL_ERROR_STREAMEXIST;
         case ENOTDIR:
             return -PAL_ERROR_STREAMISFILE;

--- a/Pal/src/pal.h
+++ b/Pal/src/pal.h
@@ -426,11 +426,10 @@ DkProcessExit (PAL_NUM exitCode);
 #define PAL_SHARE_MASK      0777
 
 /* Stream Create Flags */
-#define PAL_CREATE_TRY        0100       /* 0100 Create file if file not
-                                           exist (O_CREAT) */
-#define PAL_CREATE_ALWAYS     0200       /* 0300 Create file and fail if file
-                                           already exist (O_CREAT|O_EXCL) */
-#define PAL_CREATE_MASK       0300
+#define PAL_CREATE_TRY        0100       /* Create file if file not exist (O_CREAT) */
+#define PAL_CREATE_ALWAYS     0200       /* Create file and fail if file already exist (O_CREAT|O_EXCL) */
+#define PAL_CREATE_DUALSTACK  0400       /* Create dual-stack socket (opposite of IPV6_V6ONLY) */
+#define PAL_CREATE_MASK       0700
 
 /* Stream Option Flags */
 #define PAL_OPTION_NONBLOCK     04000


### PR DESCRIPTION
## Affected components

- [ ] README and global configuration
- [x] Linux PAL
- [x] SGX PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->

Previously, PALs in Graphene set `IPV6_V6ONLY = 1` on socket creation in case of IPv6 protocol. This setting made Graphene silently ignore connection requests from IPv4 clients. In particular, this made
Apache web server with SSL/TLS unresponsive to clients. There is no reason to have this explicit setting, so this commit removes it.

## How to test this PR? <!-- (if applicable) -->

All tests must pass. Another of my PRs will introduce Apache with SSL/TLS that fails without this PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1276)
<!-- Reviewable:end -->
