### PR TITLE
[LibOS] Add bunch of asserts on locks state and fix all found bugs

### DIFF
--- a/LibOS/shim/include/shim_fs.h
+++ b/LibOS/shim/include/shim_fs.h
@@ -324,7 +324,7 @@ extern struct shim_lock dcache_lock;
 /* Checks permission (specified by mask) of a dentry. If force is not set, permission is considered
  * granted on invalid dentries.
  * Assumes that caller has acquired dcache_lock. */
-int permission(struct shim_dentry* dent, mode_t mask);
+int __permission(struct shim_dentry* dent, mode_t mask);
 
 /* This function looks up a single dentry based on its parent dentry pointer and the name. `namelen`
  * is the length of char* name. The dentry is returned in pointer *new.

--- a/LibOS/shim/include/shim_internal.h
+++ b/LibOS/shim/include/shim_internal.h
@@ -608,14 +608,17 @@ extern struct shim_lock __master_lock;
 # define MASTER_UNLOCK() do { unlock(&__master_lock); } while (0)
 #endif
 
-static inline void create_lock_runtime(struct shim_lock* l)
-{
+static inline bool create_lock_runtime(struct shim_lock* l) {
+    bool ret = true;
+
     if (!lock_created(l)) {
         MASTER_LOCK();
         if (!lock_created(l))
-            create_lock(l);
+            ret = create_lock(l);
         MASTER_UNLOCK();
     }
+
+    return ret;
 }
 
 static inline void create_event (AEVENTTYPE * e)

--- a/LibOS/shim/src/bookkeep/shim_handle.c
+++ b/LibOS/shim/src/bookkeep/shim_handle.c
@@ -34,6 +34,7 @@ static struct shim_lock handle_mgr_lock;
 
 #define SYSTEM_LOCK()   lock(&handle_mgr_lock)
 #define SYSTEM_UNLOCK() unlock(&handle_mgr_lock)
+#define SYSTEM_LOCKED() locked(&handle_mgr_lock)
 
 #define OBJ_TYPE struct shim_handle
 #include <memmgr.h>
@@ -199,6 +200,8 @@ done:
 }
 
 struct shim_handle* __get_fd_handle(FDTYPE fd, int* flags, struct shim_handle_map* map) {
+    assert(locked(&map->lock));
+
     struct shim_fd_handle* fd_handle = NULL;
 
     if (map->fd_top != FD_NULL && fd <= map->fd_top) {
@@ -228,6 +231,8 @@ struct shim_handle* get_fd_handle(FDTYPE fd, int* flags, struct shim_handle_map*
 
 struct shim_handle* __detach_fd_handle(struct shim_fd_handle* fd, int* flags,
                                        struct shim_handle_map* map) {
+    assert(locked(&map->lock));
+
     struct shim_handle* handle = NULL;
 
     if (HANDLE_ALLOCATED(fd)) {
@@ -556,6 +561,8 @@ static struct shim_handle_map* get_new_handle_map(FDTYPE size) {
 }
 
 static struct shim_handle_map* __enlarge_handle_map(struct shim_handle_map* map, FDTYPE size) {
+    assert(locked(&map->lock));
+
     if (size <= map->fd_size)
         return map;
 

--- a/LibOS/shim/src/bookkeep/shim_signal.c
+++ b/LibOS/shim/src/bookkeep/shim_signal.c
@@ -619,6 +619,8 @@ __sigset_t * set_sig_mask (struct shim_thread * thread,
 }
 
 static __rt_sighandler_t __get_sighandler(struct shim_thread* thread, int sig) {
+    assert(locked(&thread->lock));
+
     struct shim_signal_handle* sighdl = &thread->signal_handles[sig - 1];
     __rt_sighandler_t handler = NULL;
 
@@ -745,6 +747,8 @@ void handle_signal (void)
 
 // Need to hold thread->lock when calling this function
 void append_signal(struct shim_thread* thread, int sig, siginfo_t* info, bool need_interrupt) {
+    assert(locked(&thread->lock));
+
     __rt_sighandler_t handler = __get_sighandler(thread, sig);
 
     if (!handler) {

--- a/LibOS/shim/src/bookkeep/shim_thread.c
+++ b/LibOS/shim/src/bookkeep/shim_thread.c
@@ -78,6 +78,8 @@ void dump_threads (void)
 }
 
 static struct shim_thread* __lookup_thread(IDTYPE tid) {
+    assert(locked(&thread_list_lock));
+
     struct shim_thread* tmp;
 
     LISTP_FOR_EACH_ENTRY(tmp, &thread_list, list) {
@@ -253,6 +255,8 @@ struct shim_thread * get_new_internal_thread (void)
 
 struct shim_simple_thread * __lookup_simple_thread (IDTYPE tid)
 {
+    assert(locked(&thread_list_lock));
+
     struct shim_simple_thread * tmp;
 
     LISTP_FOR_EACH_ENTRY(tmp, &simple_thread_list, list) {
@@ -343,6 +347,8 @@ void get_simple_thread (struct shim_simple_thread * thread)
 
 void put_simple_thread (struct shim_simple_thread * thread)
 {
+    assert(locked(&thread_list_lock));
+
     int ref_count = REF_DEC(thread->ref_count);
 
     if (!ref_count) {
@@ -454,6 +460,8 @@ void del_simple_thread (struct shim_simple_thread * thread)
 }
 
 static int _check_last_thread(struct shim_thread* self) {
+    assert(locked(&thread_list_lock));
+
     IDTYPE self_tid = self ? self->tid : 0;
 
     struct shim_thread* thread;

--- a/LibOS/shim/src/bookkeep/shim_vma.c
+++ b/LibOS/shim/src/bookkeep/shim_vma.c
@@ -165,6 +165,8 @@ static inline bool test_vma_overlap (struct shim_vma * vma,
 
 static inline void __assert_vma_list (void)
 {
+    assert(locked(&vma_list_lock));
+
     struct shim_vma * tmp;
     struct shim_vma * prev __attribute__((unused)) = NULL;
 
@@ -196,6 +198,8 @@ static inline void assert_vma_list (void)
 static inline struct shim_vma *
 __lookup_vma (void * addr, struct shim_vma ** pprev)
 {
+    assert(locked(&vma_list_lock));
+
     struct shim_vma * vma, * prev = NULL;
     struct shim_vma * found = NULL;
 
@@ -224,6 +228,7 @@ __lookup_vma (void * addr, struct shim_vma ** pprev)
 static inline void
 __insert_vma (struct shim_vma * vma, struct shim_vma * prev)
 {
+    assert(locked(&vma_list_lock));
     assert(!prev || prev->end <= vma->start);
     assert(vma != prev);
 
@@ -249,6 +254,7 @@ __insert_vma (struct shim_vma * vma, struct shim_vma * prev)
 static inline void
 __remove_vma (struct shim_vma * vma, struct shim_vma * prev)
 {
+    assert(locked(&vma_list_lock));
     __UNUSED(prev);
     assert(vma != prev);
     LISTP_DEL(vma, &vma_list, list);
@@ -276,6 +282,8 @@ static int
 __bkeep_preloaded (void * start, void * end, int prot, int flags,
                    const char * comment)
 {
+    assert(locked(&vma_list_lock));
+
     if (!start || !end || start == end)
         return 0;
 
@@ -375,6 +383,8 @@ int init_vma (void)
 
 static inline struct shim_vma * __get_new_vma (void)
 {
+    assert(locked(&vma_list_lock));
+
     struct shim_vma * tmp = NULL;
 
     if (vma_mgr)
@@ -401,6 +411,8 @@ static inline struct shim_vma * __get_new_vma (void)
 
 static inline void __restore_reserved_vmas (void)
 {
+    assert(locked(&vma_list_lock));
+
     bool nothing_reserved;
     do {
         nothing_reserved = true;
@@ -420,6 +432,8 @@ static inline void __restore_reserved_vmas (void)
 
 static inline void __drop_vma (struct shim_vma * vma)
 {
+    assert(locked(&vma_list_lock));
+
     if (vma->file)
         put_handle(vma->file);
 
@@ -476,6 +490,8 @@ static int __bkeep_mmap (struct shim_vma * prev,
                          struct shim_handle * file, off_t offset,
                          const char * comment)
 {
+    assert(locked(&vma_list_lock));
+
     int ret = 0;
     struct shim_vma * new = __get_new_vma();
 
@@ -534,6 +550,8 @@ int bkeep_mmap (void * addr, size_t length, int prot, int flags,
 static inline void __shrink_vma (struct shim_vma * vma, void * start, void * end,
                                  struct shim_vma ** tailptr)
 {
+    assert(locked(&vma_list_lock));
+
     if (test_vma_startin(vma, start, end)) {
         /*
          * Dealing with the head: if the starting address of "vma" is in
@@ -609,6 +627,8 @@ static inline void __shrink_vma (struct shim_vma * vma, void * start, void * end
 static int __bkeep_munmap (struct shim_vma ** pprev,
                            void * start, void * end, int flags)
 {
+    assert(locked(&vma_list_lock));
+
     struct shim_vma * prev = *pprev;
     struct shim_vma * cur, * next;
 
@@ -705,6 +725,8 @@ int bkeep_munmap (void * addr, size_t length, int flags)
 static int __bkeep_mprotect (struct shim_vma * prev,
                              void * start, void * end, int prot, int flags)
 {
+    assert(locked(&vma_list_lock));
+
     struct shim_vma * cur, * next;
 
     if (!prev) {
@@ -814,6 +836,7 @@ static void * __bkeep_unmapped (void * top_addr, void * bottom_addr,
                                 struct shim_handle * file,
                                 off_t offset, const char * comment)
 {
+    assert(locked(&vma_list_lock));
     assert(top_addr > bottom_addr);
 
     if (!length || length > (uintptr_t) top_addr - (uintptr_t) bottom_addr)

--- a/LibOS/shim/src/fs/chroot/fs.c
+++ b/LibOS/shim/src/fs/chroot/fs.c
@@ -180,6 +180,8 @@ static ssize_t make_uri (struct shim_dentry * dent)
    be held */
 static int create_data (struct shim_dentry * dent, const char * uri, size_t len)
 {
+    assert(locked(&dent->lock));
+
     if (dent->data)
         return 0;
 

--- a/LibOS/shim/src/fs/chroot/fs.c
+++ b/LibOS/shim/src/fs/chroot/fs.c
@@ -141,13 +141,15 @@ static inline ssize_t concat_uri (char * buffer, size_t size, int type,
 
 /* simply just create data, sometimes it is individually called when the
    handle is not linked to a dentry */
-static struct shim_file_data * __create_data (void)
-{
-    struct shim_file_data * data = calloc(1, sizeof(struct shim_file_data));
+static struct shim_file_data* __create_data(void) {
+    struct shim_file_data* data = calloc(1, sizeof(struct shim_file_data));
     if (!data)
         return NULL;
 
-    create_lock(&data->lock);
+    if (!create_lock(&data->lock)) {
+        free(data);
+        return NULL;
+    }
     return data;
 }
 

--- a/LibOS/shim/src/fs/proc/ipc-thread.c
+++ b/LibOS/shim/src/fs/proc/ipc-thread.c
@@ -192,7 +192,9 @@ static int proc_match_ipc_thread(const char* name) {
     if (parse_ipc_thread_name(name, &pid, NULL, NULL, NULL) < 0)
         return 0;
 
-    create_lock_runtime(&status_lock);
+    if (!create_lock_runtime(&status_lock)) {
+        return -ENOMEM;
+    }
     lock(&status_lock);
 
     if (pid_status_cache)
@@ -214,7 +216,9 @@ static int proc_ipc_thread_dir_mode(const char* name, mode_t* mode) {
     if (ret < 0)
         return ret;
 
-    create_lock_runtime(&status_lock);
+    if (!create_lock_runtime(&status_lock)) {
+        return -ENOMEM;
+    }
     lock(&status_lock);
 
     if (pid_status_cache)
@@ -237,7 +241,9 @@ static int proc_ipc_thread_dir_stat(const char* name, struct stat* buf) {
     if (ret < 0)
         return ret;
 
-    create_lock_runtime(&status_lock);
+    if (!create_lock_runtime(&status_lock)) {
+        return -ENOMEM;
+    }
     lock(&status_lock);
 
     if (pid_status_cache)
@@ -265,7 +271,9 @@ static int proc_list_ipc_thread(const char* name, struct shim_dirent** buf, int 
     struct pid_status_cache* status = NULL;
     int ret                         = 0;
 
-    create_lock_runtime(&status_lock);
+    if (!create_lock_runtime(&status_lock)) {
+        return -ENOMEM;
+    }
 
     lock(&status_lock);
     if (pid_status_cache && !pid_status_cache->dirty) {

--- a/LibOS/shim/src/fs/shim_dcache.c
+++ b/LibOS/shim/src/fs/shim_dcache.c
@@ -28,12 +28,18 @@
 #include <shim_internal.h>
 #include <shim_types.h>
 
-struct shim_lock dcache_lock;
+static struct shim_lock dcache_mgr_lock;
+
+#define SYSTEM_LOCK()   lock(&dcache_mgr_lock)
+#define SYSTEM_UNLOCK() unlock(&dcache_mgr_lock)
+#define SYSTEM_LOCKED() locked(&dcache_mgr_lock)
 
 #define DCACHE_MGR_ALLOC 64
 
 #define OBJ_TYPE struct shim_dentry
 #include <memmgr.h>
+
+struct shim_lock dcache_lock;
 
 static MEM_MGR dentry_mgr = NULL;
 
@@ -59,13 +65,20 @@ static struct shim_dentry* alloc_dentry(void) {
     INIT_LISTP(&dent->children);
     INIT_LIST_HEAD(dent, siblings);
 
+    if (!create_lock(&dent->lock)) {
+        free_mem_obj_to_mgr(dentry_mgr, dent);
+        return NULL;
+    }
+
     return dent;
 }
 
 int init_dcache(void) {
-    dentry_mgr = create_mem_mgr(init_align_up(DCACHE_MGR_ALLOC));
+    if (!create_lock(&dcache_mgr_lock) || !create_lock(&dcache_lock)) {
+        return -ENOMEM;
+    }
 
-    create_lock(&dcache_lock);
+    dentry_mgr = create_mem_mgr(init_align_up(DCACHE_MGR_ALLOC));
 
     dentry_root = alloc_dentry();
 
@@ -100,6 +113,7 @@ void get_dentry(struct shim_dentry* dent) {
 }
 
 static void free_dentry(struct shim_dentry* dent) {
+    destroy_lock(&dent->lock);
     free_mem_obj_to_mgr(dentry_mgr, dent);
 }
 
@@ -378,7 +392,9 @@ BEGIN_RS_FUNC(dentry) {
     CP_REBASE(dent->parent);
     CP_REBASE(dent->mounted);
 
-    create_lock(&dent->lock);
+    if (!create_lock(&dent->lock)) {
+        return -ENOMEM;
+    }
 
     /* DEP 6/16/17: I believe the point of this line is to
      * fix up the children linked list.  Presumably the ref count and

--- a/LibOS/shim/src/fs/shim_dcache.c
+++ b/LibOS/shim/src/fs/shim_dcache.c
@@ -146,6 +146,8 @@ void put_dentry(struct shim_dentry* dent) {
  */
 struct shim_dentry* get_new_dentry(struct shim_mount* mount, struct shim_dentry* parent,
                                    const char* name, int namelen, HASHTYPE* hashptr) {
+    assert(locked(&dcache_lock));
+
     struct shim_dentry* dent = alloc_dentry();
     HASHTYPE hash;
 
@@ -211,6 +213,8 @@ struct shim_dentry* get_new_dentry(struct shim_mount* mount, struct shim_dentry*
  */
 struct shim_dentry* __lookup_dcache(struct shim_dentry* start, const char* name, int namelen,
                                     HASHTYPE* hashptr) {
+    assert(locked(&dcache_lock));
+
     /* In this implementation, we just look at the children
      * under the parent and see if there are matches.  It so,
      * return it; if not, don't.
@@ -284,6 +288,8 @@ out:
  * structure on the heap to track progress.
  */
 int __del_dentry_tree(struct shim_dentry* root) {
+    assert(locked(&dcache_lock));
+
     struct shim_dentry *cursor, *n;
 
     LISTP_FOR_EACH_ENTRY_SAFE(cursor, n, &root->children, siblings) {

--- a/LibOS/shim/src/fs/shim_fs.c
+++ b/LibOS/shim/src/fs/shim_fs.c
@@ -71,6 +71,7 @@ static struct shim_lock mount_mgr_lock;
 
 #define SYSTEM_LOCK()   lock(&mount_mgr_lock)
 #define SYSTEM_UNLOCK() unlock(&mount_mgr_lock)
+#define SYSTEM_LOCKED() locked(&mount_mgr_lock)
 
 #define MOUNT_MGR_ALLOC 64
 
@@ -278,6 +279,8 @@ int search_builtin_fs(const char* type, struct shim_mount** fs) {
 }
 
 int __mount_fs(struct shim_mount* mount, struct shim_dentry* dent) {
+    assert(locked(&dcache_lock));
+
     int ret = 0;
 
     dent->state |= DENTRY_MOUNTPOINT;

--- a/LibOS/shim/src/fs/shim_fs.c
+++ b/LibOS/shim/src/fs/shim_fs.c
@@ -89,8 +89,10 @@ int init_fs(void) {
     if (!mount_mgr)
         return -ENOMEM;
 
-    create_lock(&mount_mgr_lock);
-    create_lock(&mount_list_lock);
+    if (!create_lock(&mount_mgr_lock) || !create_lock(&mount_list_lock)) {
+        destroy_mem_mgr(mount_mgr);
+        return -ENOMEM;
+    }
     return 0;
 }
 
@@ -401,6 +403,8 @@ int mount_fs(const char* type, const char* uri, const char* mount_point, struct 
     size_t last_len;
     find_last_component(mount_point, &last, &last_len);
 
+    lock(&dcache_lock);
+
     if (!parent) {
         // See if we are not at the root mount
         if (last_len > 0) {
@@ -412,7 +416,7 @@ int mount_fs(const char* type, const char* uri, const char* mount_point, struct 
             if ((ret = __path_lookupat(dentry_root, parent_path, 0, &parent, 0, dentry_root->fs,
                                        make_ancestor)) < 0) {
                 debug("Path lookup failed %d\n", ret);
-                goto out;
+                goto out_with_unlock;
             }
         }
     }
@@ -423,11 +427,9 @@ int mount_fs(const char* type, const char* uri, const char* mount_point, struct 
         if (parent->rel_path.len + 1 + last_len >= STR_SIZE) {  /* +1 for '/' */
             debug("Relative path exceeds the limit %d\n", STR_SIZE);
             ret = -ENAMETOOLONG;
-            goto out;
+            goto out_with_unlock;
         }
     }
-
-    lock(&dcache_lock);
 
     struct shim_mount* mount = alloc_mount();
     void* mount_data         = NULL;

--- a/LibOS/shim/src/fs/shim_namei.c
+++ b/LibOS/shim/src/fs/shim_namei.c
@@ -73,6 +73,7 @@ static inline int __lookup_flags (int flags)
  */
 /* Assume caller has acquired dcache_lock */
 int permission (struct shim_dentry * dent, mode_t mask) {
+    assert(locked(&dcache_lock));
 
     mode_t mode = 0;
 
@@ -156,6 +157,8 @@ int permission (struct shim_dentry * dent, mode_t mask) {
  */
 int lookup_dentry (struct shim_dentry * parent, const char * name, int namelen, struct shim_dentry ** new, struct shim_mount * fs)
 {
+    assert(locked(&dcache_lock));
+
     struct shim_dentry * dent = NULL;
     int do_fs_lookup = 0;
     int err = 0;
@@ -265,6 +268,7 @@ int __path_lookupat (struct shim_dentry * start, const char * path, int flags,
                      struct shim_dentry ** dent, int link_depth,
                      struct shim_mount * fs, bool make_ancestor)
 {
+    assert(locked(&dcache_lock));
     // Basic idea: recursively iterate over path, peeling off one atom at a
     // time.
     /* Chia-Che 12/5/2014:

--- a/LibOS/shim/src/fs/shim_namei.c
+++ b/LibOS/shim/src/fs/shim_namei.c
@@ -72,7 +72,7 @@ static inline int __lookup_flags (int flags)
  * Returns 0 on success, negative on failure.
  */
 /* Assume caller has acquired dcache_lock */
-int permission (struct shim_dentry * dent, mode_t mask) {
+int __permission(struct shim_dentry* dent, mode_t mask) {
     assert(locked(&dcache_lock));
 
     mode_t mode = 0;
@@ -548,7 +548,7 @@ int open_namei (struct shim_handle * hdl, struct shim_dentry * start,
         }
 
         // Check the parent permission first
-        err = permission(dir, MAY_WRITE | MAY_EXEC);
+        err = __permission(dir, MAY_WRITE | MAY_EXEC);
         if (err)  goto out;
 
         // Try EINVAL when creat isn't an option
@@ -593,7 +593,7 @@ int open_namei (struct shim_handle * hdl, struct shim_dentry * start,
     // creat/O_CREAT have idiosyncratic semantics about opening a
     // newly-created, read-only file for writing, but only the first time.
     if (!newly_created) {
-        if ((err = permission(mydent, acc_mode)) < 0)
+        if ((err = __permission(mydent, acc_mode)) < 0)
             goto out;
     }
 

--- a/LibOS/shim/src/ipc/shim_ipc_helper.c
+++ b/LibOS/shim/src/ipc/shim_ipc_helper.c
@@ -34,6 +34,12 @@
 
 #define IPC_HELPER_STACK_SIZE (g_pal_alloc_align * 4)
 
+static struct shim_lock ipc_port_mgr_lock;
+
+#define SYSTEM_LOCK()   lock(&ipc_port_mgr_lock)
+#define SYSTEM_UNLOCK() unlock(&ipc_port_mgr_lock)
+#define SYSTEM_LOCKED() locked(&ipc_port_mgr_lock)
+
 #define PORT_MGR_ALLOC 32
 #define OBJ_TYPE       struct shim_ipc_port
 #include "memmgr.h"
@@ -168,6 +174,10 @@ static int init_ns_ipc_port(int ns_idx) {
 }
 
 int init_ipc_ports(void) {
+    if (!create_lock(&ipc_port_mgr_lock)) {
+        return -ENOMEM;
+    }
+
     if (!(port_mgr = create_mem_mgr(init_align_up(PORT_MGR_ALLOC))))
         return -ENOMEM;
 
@@ -187,7 +197,9 @@ int init_ipc_ports(void) {
 int init_ipc_helper(void) {
     /* early enough in init, can write global vars without the lock */
     ipc_helper_state = HELPER_NOTALIVE;
-    create_lock(&ipc_helper_lock);
+    if (!create_lock(&ipc_helper_lock)) {
+        return -ENOMEM;
+    }
     create_event(&install_new_event);
 
     /* some IPC ports were already added before this point, so spawn IPC helper thread (and enable
@@ -211,7 +223,10 @@ static struct shim_ipc_port* __create_ipc_port(PAL_HANDLE hdl) {
     INIT_LIST_HEAD(port, list);
     INIT_LISTP(&port->msgs);
     REF_SET(port->ref_count, 0);
-    create_lock(&port->msgs_lock);
+    if (!create_lock(&port->msgs_lock)) {
+        free_mem_obj_to_mgr(port_mgr, port);
+        return NULL;
+    }
     return port;
 }
 
@@ -388,7 +403,7 @@ void del_ipc_port_fini(struct shim_ipc_port* port, unsigned int exitcode) {
             port->fini[i] = NULL;
         }
 
-    __put_ipc_port(port);
+    put_ipc_port(port);
 }
 
 void del_all_ipc_ports(void) {

--- a/LibOS/shim/src/ipc/shim_ipc_nsimpl.h
+++ b/LibOS/shim/src/ipc/shim_ipc_nsimpl.h
@@ -700,8 +700,11 @@ out:
     unlock(&range_map_lock);
 }
 
-static inline void init_namespace(void) {
-    create_lock(&range_map_lock);
+static inline int init_namespace(void) {
+    if (!create_lock(&range_map_lock)) {
+        return -ENOMEM;
+    }
+    return 0;
 }
 
 #define _NS_ID(ns)     __NS_ID(ns)

--- a/LibOS/shim/src/ipc/shim_ipc_nsimpl.h
+++ b/LibOS/shim/src/ipc/shim_ipc_nsimpl.h
@@ -76,7 +76,7 @@ struct range_bitmap {
     unsigned char map[];
 };
 
-/* Helper functions __*_range_*() must be called with range_map_lock held */
+/* Helper functions __*_range*() must be called with range_map_lock held */
 static struct range_bitmap* range_map;
 static struct shim_lock range_map_lock;
 
@@ -170,6 +170,8 @@ void CONCAT3(debug_print, NS, ranges)(void) {
 #define INIT_RANGE_MAP_SIZE 32
 
 static int __extend_range_bitmap(IDTYPE expected) {
+    assert(locked(&range_map_lock));
+
     IDTYPE size = INIT_RANGE_MAP_SIZE;
 
     if (range_map)
@@ -197,6 +199,8 @@ static int __extend_range_bitmap(IDTYPE expected) {
 }
 
 static int __set_range_bitmap(IDTYPE off, bool unset) {
+    assert(locked(&range_map_lock));
+
     IDTYPE i         = off / BITS;
     IDTYPE j         = off - i * BITS;
     unsigned char* m = range_map->map + i;
@@ -214,6 +218,8 @@ static int __set_range_bitmap(IDTYPE off, bool unset) {
 }
 
 static bool __check_range_bitmap(IDTYPE off) {
+    assert(locked(&range_map_lock));
+
     IDTYPE i         = off / BITS;
     IDTYPE j         = off - i * BITS;
     unsigned char* m = range_map->map + i;
@@ -222,6 +228,8 @@ static bool __check_range_bitmap(IDTYPE off) {
 }
 
 static struct range* __get_range(IDTYPE off) {
+    assert(locked(&range_map_lock));
+
     LISTP_TYPE(range)* head = range_table + RANGE_HASH(off);
 
     if (!range_map || off >= range_map->map_size)
@@ -242,6 +250,8 @@ static struct range* __get_range(IDTYPE off) {
 
 static int __add_range(struct range* r, IDTYPE off, IDTYPE owner, const char* uri,
                        LEASETYPE lease) {
+    assert(locked(&range_map_lock));
+
     LISTP_TYPE(range)* head = range_table + RANGE_HASH(off);
     int ret                 = 0;
 

--- a/LibOS/shim/src/ipc/shim_ipc_sysv.c
+++ b/LibOS/shim/src/ipc/shim_ipc_sysv.c
@@ -892,6 +892,8 @@ out:
 int __balance_sysv_score(struct sysv_balance_policy* policy, struct shim_handle* hdl,
                          struct sysv_score* scores, int nscores, struct sysv_client* src,
                          long score) {
+    assert(locked(&hdl->lock));
+
     struct sysv_score* s    = scores;
     struct sysv_score* last = scores + nscores;
 

--- a/LibOS/shim/src/ipc/shim_ipc_sysv.c
+++ b/LibOS/shim/src/ipc/shim_ipc_sysv.c
@@ -48,8 +48,7 @@
 #include "shim_ipc_nsimpl.h"
 
 int init_ns_sysv(void) {
-    init_namespace();
-    return 0;
+    return init_namespace();
 }
 
 DEFINE_PROFILE_INTERVAL(ipc_sysv_delres_send, ipc);

--- a/LibOS/shim/src/shim_async.c
+++ b/LibOS/shim/src/shim_async.c
@@ -364,6 +364,8 @@ out_err:
 
 /* this should be called with the async_helper_lock held */
 static int create_async_helper(void) {
+    assert(locked(&async_helper_lock));
+
     if (async_helper_state == HELPER_ALIVE)
         return 0;
 

--- a/LibOS/shim/src/shim_async.c
+++ b/LibOS/shim/src/shim_async.c
@@ -41,7 +41,7 @@ struct async_event {
 DEFINE_LISTP(async_event);
 static LISTP_TYPE(async_event) async_list;
 
-/* can be read without async_helper_lock but always written with lock held */
+/* Should be accessed with async_helper_lock held. */
 static enum { HELPER_NOTALIVE, HELPER_ALIVE } async_helper_state;
 
 static struct shim_thread* async_helper_thread;
@@ -137,7 +137,9 @@ int64_t install_async_event(PAL_HANDLE object, uint64_t time,
 int init_async(void) {
     /* early enough in init, can write global vars without the lock */
     async_helper_state = HELPER_NOTALIVE;
-    create_lock(&async_helper_lock);
+    if (!create_lock(&async_helper_lock)) {
+        return -ENOMEM;
+    }
     create_event(&install_new_event);
 
     /* enable locking mechanisms since we are going in multi-threaded mode */

--- a/LibOS/shim/src/shim_init.c
+++ b/LibOS/shim/src/shim_init.c
@@ -663,7 +663,10 @@ noreturn void* shim_init (int argc, void * args)
         shim_clean_and_exit(-EINVAL);
     }
 
-    create_lock(&__master_lock);
+    if (!create_lock(&__master_lock)) {
+        SYS_PRINTF("shim_init(): error: failed to allocate __master_lock\n");
+        shim_clean_and_exit(-ENOMEM);
+    }
 
     int * argcp = &argc;
     const char ** argv, ** envp, ** argp = NULL;

--- a/LibOS/shim/src/shim_malloc.c
+++ b/LibOS/shim/src/shim_malloc.c
@@ -99,8 +99,13 @@ void __system_free(void* addr, size_t size) {
 }
 
 int init_slab(void) {
-    create_lock(&slab_mgr_lock);
+    if (!create_lock(&slab_mgr_lock)) {
+        return -ENOMEM;
+    }
     slab_mgr = create_slab_mgr();
+    if (!slab_mgr) {
+        return -ENOMEM;
+    }
     return 0;
 }
 

--- a/LibOS/shim/src/shim_malloc.c
+++ b/LibOS/shim/src/shim_malloc.c
@@ -37,6 +37,7 @@ static struct shim_lock slab_mgr_lock;
 
 #define SYSTEM_LOCK()   lock(&slab_mgr_lock)
 #define SYSTEM_UNLOCK() unlock(&slab_mgr_lock)
+#define SYSTEM_LOCKED() locked(&slab_mgr_lock)
 
 #ifdef SLAB_DEBUG_TRACE
 #define SLAB_DEBUG

--- a/LibOS/shim/src/sys/shim_epoll.c
+++ b/LibOS/shim/src/sys/shim_epoll.c
@@ -100,6 +100,8 @@ int shim_do_epoll_create(int size) {
 
 /* lock of shim_handle enclosing this epoll should be held while calling this function */
 static void update_epoll(struct shim_epoll_handle* epoll) {
+    assert(locked(&container_of(epoll, struct shim_handle, info.epoll)->lock));
+
     struct shim_epoll_item* tmp;
     epoll->pal_cnt = 0;
 

--- a/LibOS/shim/src/sys/shim_sigaction.c
+++ b/LibOS/shim/src/sys/shim_sigaction.c
@@ -263,6 +263,8 @@ struct walk_arg {
 
 // Need to hold thread->lock
 static inline void __append_signal(struct shim_thread* thread, int sig, IDTYPE sender) {
+    assert(locked(&thread->lock));
+
     debug("Thread %d killed by signal %d\n", thread->tid, sig);
     siginfo_t info;
     memset(&info, 0, sizeof(siginfo_t));

--- a/LibOS/shim/src/sys/shim_socket.c
+++ b/LibOS/shim/src/sys/shim_socket.c
@@ -419,6 +419,8 @@ static int create_socket_uri(struct shim_handle* hdl) {
 
 /* hdl->lock must be held */
 static bool __socket_is_ipv6_v6only(struct shim_handle* hdl) {
+    assert(locked(&hdl->lock));
+
     struct shim_sock_option* o = hdl->info.sock.pending_options;
     while (o) {
         if (o->level == IPPROTO_IPV6 && o->optname == IPV6_V6ONLY) {

--- a/LibOS/shim/src/utils/strobjs.c
+++ b/LibOS/shim/src/utils/strobjs.c
@@ -27,6 +27,7 @@ static struct shim_lock str_mgr_lock;
 
 #define SYSTEM_LOCK()   lock(&str_mgr_lock)
 #define SYSTEM_UNLOCK() unlock(&str_mgr_lock)
+#define SYSTEM_LOCKED() locked(&str_mgr_lock)
 
 #define STR_MGR_ALLOC 32
 

--- a/LibOS/shim/src/utils/strobjs.c
+++ b/LibOS/shim/src/utils/strobjs.c
@@ -37,8 +37,14 @@ static struct shim_lock str_mgr_lock;
 static MEM_MGR str_mgr = NULL;
 
 int init_str_mgr(void) {
-    create_lock(&str_mgr_lock);
+    if (!create_lock(&str_mgr_lock)) {
+        return -ENOMEM;
+    }
     str_mgr = create_mem_mgr(init_align_up(STR_MGR_ALLOC));
+    if (!str_mgr) {
+        destroy_lock(&str_mgr_lock);
+        return -ENOMEM;
+    }
     return 0;
 }
 

--- a/Pal/lib/memmgr.h
+++ b/Pal/lib/memmgr.h
@@ -45,6 +45,9 @@
 #ifndef SYSTEM_UNLOCK
 #define SYSTEM_UNLOCK() ({})
 #endif
+#ifndef SYSTEM_LOCKED
+#define SYSTEM_LOCKED() true
+#endif
 
 DEFINE_LIST(mem_obj);
 typedef struct mem_obj {
@@ -111,6 +114,8 @@ static inline int init_align_up(int size) {
 #endif
 
 static inline void __set_free_mem_area(MEM_AREA area, MEM_MGR mgr) {
+    assert(SYSTEM_LOCKED());
+
     mgr->size += area->size;
     mgr->obj         = area->objs;
     mgr->obj_top     = area->objs + area->size;

--- a/Pal/lib/slabmgr.h
+++ b/Pal/lib/slabmgr.h
@@ -277,6 +277,7 @@ static inline void destroy_slab_mgr(SLAB_MGR mgr) {
 
 // SYSTEM_LOCK needs to be held by the caller on entry.
 static inline int enlarge_slab_mgr(SLAB_MGR mgr, int level) {
+    assert(SYSTEM_LOCKED());
     assert(level < SLAB_LEVEL);
     /* DEP 11/24/17: This strategy basically doubles a level's size
      * every time it grows.  The assumption if we get this far is that

--- a/Pal/src/host/Linux-SGX/enclave_untrusted.c
+++ b/Pal/src/host/Linux-SGX/enclave_untrusted.c
@@ -27,6 +27,7 @@ static size_t g_page_size   = PRESET_PAGESIZE;
 
 #define SYSTEM_LOCK()   spinlock_lock(&malloc_lock)
 #define SYSTEM_UNLOCK() spinlock_unlock(&malloc_lock)
+#define SYSTEM_LOCKED() spinlock_is_locked(&malloc_lock)
 
 #define ALLOC_ALIGNMENT g_page_size
 

--- a/Pal/src/host/Linux-SGX/pal_host.h
+++ b/Pal/src/host/Linux-SGX/pal_host.h
@@ -35,6 +35,7 @@ typedef spinlock_t PAL_LOCK;
 #define LOCK_INIT INIT_SPINLOCK_UNLOCKED
 #define _DkInternalLock spinlock_lock
 #define _DkInternalUnlock spinlock_unlock
+#define _DkInternalIsLocked spinlock_is_locked
 
 void * malloc_untrusted (int size);
 void free_untrusted (void * mem);

--- a/Pal/src/host/Linux/db_mutex.c
+++ b/Pal/src/host/Linux/db_mutex.c
@@ -187,6 +187,20 @@ void _DkMutexRelease(PAL_HANDLE handle) {
     return;
 }
 
+bool _DkMutexIsLocked(struct mutex_handle* m) {
+    if (!m->locked) {
+        return false;
+    }
+
+#ifdef DEBUG_MUTEX
+    if (m->owner != INLINE_SYSCALL(gettid, 0)) {
+        return false;
+    }
+#endif
+
+    return true;
+}
+
 void _DkInternalLock(PAL_LOCK* lock) {
     // Retry the lock if being interrupted by signals
     while (_DkMutexLock(lock) < 0)
@@ -195,6 +209,10 @@ void _DkInternalLock(PAL_LOCK* lock) {
 
 void _DkInternalUnlock(PAL_LOCK* lock) {
     _DkMutexUnlock(lock);
+}
+
+bool _DkInternalIsLocked(PAL_LOCK* lock) {
+    return _DkMutexIsLocked(lock);
 }
 
 static int mutex_wait(PAL_HANDLE handle, int64_t timeout_us) {

--- a/Pal/src/host/Skeleton/db_misc.c
+++ b/Pal/src/host/Skeleton/db_misc.c
@@ -37,7 +37,6 @@ void _DkInternalUnlock(PAL_LOCK* lock) {
 
 bool _DkInternalIsLocked(PAL_LOCK* lock) {
     __abort();
-    return false;
 }
 
 unsigned long _DkSystemTimeQuery(void) {

--- a/Pal/src/host/Skeleton/db_misc.c
+++ b/Pal/src/host/Skeleton/db_misc.c
@@ -35,6 +35,11 @@ void _DkInternalUnlock(PAL_LOCK* lock) {
     __abort();
 }
 
+bool _DkInternalIsLocked(PAL_LOCK* lock) {
+    __abort();
+    return false;
+}
+
 unsigned long _DkSystemTimeQuery(void) {
     return 0;
 }

--- a/Pal/src/pal_internal.h
+++ b/Pal/src/pal_internal.h
@@ -336,6 +336,7 @@ void _DkExceptionReturn (void * event);
 /* other DK calls */
 void _DkInternalLock(PAL_LOCK* mut);
 void _DkInternalUnlock(PAL_LOCK* mut);
+bool _DkInternalIsLocked(PAL_LOCK* mut);
 unsigned long _DkSystemTimeQuery (void);
 
 /*

--- a/Pal/src/slab.c
+++ b/Pal/src/slab.c
@@ -34,6 +34,7 @@ static PAL_LOCK slab_mgr_lock = LOCK_INIT;
 
 #define SYSTEM_LOCK()   _DkInternalLock(&slab_mgr_lock)
 #define SYSTEM_UNLOCK() _DkInternalUnlock(&slab_mgr_lock)
+#define SYSTEM_LOCKED() _DkInternalIsLocked(&slab_mgr_lock)
 
 #if STATIC_SLAB == 1
 #define POOL_SIZE 64 * 1024 * 1024 /* 64MB by default */


### PR DESCRIPTION
<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->
First commit makes all locks assertable, adds bunch of assets on their state.
Second commit fixes all bugs found by the previous commit and some found in the process.
`shim_dentry` locks are not included in this, as they require substantial changes. ~I'll soon add another commit or even separate PR.~ (Not likely: in the end I don't think it's doable without rewriting at least part of fs subsystem.)
Generally these are best effort fixes, there are probably many more places where such asserts could be placed and reveal more issues - these are just those I could identify.

Fixes #1216

## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1279)
<!-- Reviewable:end -->
