### PR TITLE
add generated-cacert.h and glibc-build to .gitignore

### DIFF
--- a/LibOS/.gitignore
+++ b/LibOS/.gitignore
@@ -1,3 +1,4 @@
 /glibc-*.tar.gz
 /glibc-*.*/
+/glibc-build/
 /build.log

--- a/Pal/src/host/Linux-SGX/quote/.gitignore
+++ b/Pal/src/host/Linux-SGX/quote/.gitignore
@@ -1,0 +1,1 @@
+/generated-cacert.h


### PR DESCRIPTION
<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [x] SGX PAL
- [ ] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->


## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1280)
<!-- Reviewable:end -->
