### PR TITLE
[Makefile] Fix lack of config.h dependency in lib/Makefile

### DIFF
--- a/Pal/lib/Makefile
+++ b/Pal/lib/Makefile
@@ -65,9 +65,11 @@ crypto/mbedtls/CMakeLists.txt: crypto/$(MBEDTLS_SRC)
 	mv crypto/mbedtls-mbedtls-$(MBEDTLS_VERSION) crypto/mbedtls
 	mkdir crypto/mbedtls/install
 	cd crypto/mbedtls && ./scripts/config.pl set MBEDTLS_CMAC_C && make DESTDIR=install install .
+
+crypto/mbedtls/include/mbedtls/config.h: crypto/config.h crypto/mbedtls/CMakeLists.txt
 	cp crypto/config.h crypto/mbedtls/include/mbedtls
 
-crypto/mbedtls/library/aes.c: crypto/mbedtls/CMakeLists.txt
+crypto/mbedtls/library/aes.c: crypto/mbedtls/CMakeLists.txt crypto/mbedtls/include/mbedtls/config.h
 $(addprefix crypto/mbedtls/library/,$(filter-out aes.c,$(patsubst %.o,%.c,$(crypto_mbedtls_library_objs)))): crypto/mbedtls/library/aes.c
 
 string_objs = $(addsuffix .o,atoi memcmp memcpy memset strchr strendswith strlen wordcopy strcmp)


### PR DESCRIPTION
<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->
`Pal/lib/config.h` was not listed as dependency anywhere in the Makefile, so any change to it broke building process (of course it works when you ~download code for the first time~ run `make -C Pal/lib distclean`, like Jenkins does).

## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1281)
<!-- Reviewable:end -->
