### PR TITLE
[Makefile] Remove mbedtls's config.h on first build in lib/Makefile

### DIFF
--- a/Pal/lib/Makefile
+++ b/Pal/lib/Makefile
@@ -65,6 +65,7 @@ crypto/mbedtls/CMakeLists.txt: crypto/$(MBEDTLS_SRC)
 	mv crypto/mbedtls-mbedtls-$(MBEDTLS_VERSION) crypto/mbedtls
 	mkdir crypto/mbedtls/install
 	cd crypto/mbedtls && ./scripts/config.pl set MBEDTLS_CMAC_C && make DESTDIR=install install .
+	$(RM) crypto/mbedtls/include/mbedtls/config.h
 
 crypto/mbedtls/include/mbedtls/config.h: crypto/config.h crypto/mbedtls/CMakeLists.txt
 	cp crypto/config.h crypto/mbedtls/include/mbedtls


### PR DESCRIPTION
<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [x] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->

Previous commit fixed the dependency on crypto/config.h (it must be copied into mbedtls include directory). However, config.h with default and incorrect settings already exists in mbedtls include
dir after its download, and Graphene needs to replace it with our version of configuration. This commit simply removes default config.h on first build of mbedTLS to force the dependency introduced in the previous commit.

## How to test this PR? <!-- (if applicable) -->

All tests must pass.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1282)
<!-- Reviewable:end -->
