### PR TITLE
[Pal/Linux-SGX] Do not show SGX context debug info in non-debug build

### DIFF
--- a/Pal/src/host/Linux-SGX/db_exception.c
+++ b/Pal/src/host/Linux-SGX/db_exception.c
@@ -57,9 +57,6 @@ _DkGenericSignalHandle(int event_num, PAL_NUM arg, PAL_CONTEXT* context) {
  */
 noreturn static void restore_sgx_context(sgx_cpu_context_t* uc,
                                          PAL_XREGS_STATE* xregs_state) {
-    SGX_DBG(DBG_E, "uc %p rsp 0x%08lx &rsp %p rip 0x%08lx +0x%08lx &rip %p\n",
-            uc, uc->rsp, &uc->rsp, uc->rip, uc->rip - (uintptr_t)TEXT_START, &uc->rip);
-
     if (xregs_state == NULL)
         xregs_state = (PAL_XREGS_STATE*)xsave_reset_state;
     _restore_sgx_context(uc, xregs_state);

--- a/Pal/src/host/Linux-SGX/enclave_xstate.c
+++ b/Pal/src/host/Linux-SGX/enclave_xstate.c
@@ -82,7 +82,7 @@ void init_xsave_size(uint64_t xfrm) {
     xsave_features = PAL_XFEATURE_MASK_FPSSE;
     xsave_size = 512 + 64;
     if (!xfrm || (xfrm & SGX_XFRM_RESERVED)) {
-        SGX_DBG(DBG_I, "xsave is disabled, xfrm 0x%lx\n", xfrm);
+        SGX_DBG(DBG_M, "xsave is disabled, xfrm 0x%lx\n", xfrm);
         return;
     }
 
@@ -93,5 +93,5 @@ void init_xsave_size(uint64_t xfrm) {
             xsave_size = xsave_size_table[i].size;
         }
     }
-    SGX_DBG(DBG_I, "xsave is enabled with xsave_size: %u\n", xsave_size);
+    SGX_DBG(DBG_M, "xsave is enabled with xsave_size: %u\n", xsave_size);
 }


### PR DESCRIPTION
<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [x] SGX PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->

PR https://github.com/oscarlab/graphene/pull/1238 was merged. But it accidentally prints debug information even in non-debug mode. This is annoying and confuses people. This PR simply changes debug level to not show this info in non-debug mode.

## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1285)
<!-- Reviewable:end -->
