### PR TITLE
[Makefile] add distclean target

### DIFF
--- a/Jenkinsfiles/Linux
+++ b/Jenkinsfiles/Linux
@@ -111,10 +111,9 @@ pipeline {
                         sh '''
                            cd "$(./Scripts/clean-check-test-copy)"
 
-                           make clean
-                           make -C Pal/lib distclean
+                           make distclean
                            rm -r LibOS/glibc-2.23
-                           rm LibOS/glibc-*.tar.gz
+                           rm LibOS/glibc-2.23.tar.gz
                            make -C LibOS/shim/test/regression clean
 
                            make -C LibOS/shim/test/apps/ltp clean

--- a/Jenkinsfiles/Linux-Debug
+++ b/Jenkinsfiles/Linux-Debug
@@ -110,9 +110,7 @@ pipeline {
                         sh '''
                            cd "$(./Scripts/clean-check-test-copy)"
 
-                           make clean
-                           make -C Pal/lib distclean
-                           rm LibOS/glibc-*.tar.gz
+                           make distclean
                            make -C LibOS/shim/test/regression clean
 
                            make -C LibOS/shim/test/apps/ltp clean

--- a/Jenkinsfiles/Linux-SGX
+++ b/Jenkinsfiles/Linux-SGX
@@ -84,10 +84,7 @@ pipeline {
                            cd "$(./Scripts/clean-check-test-copy)"
 
                            rm Pal/src/host/Linux-SGX/signer/enclave-key.pem
-                           make -C Pal/src/host/Linux-SGX/sgx-driver distclean
-                           make SGX=1 clean
-                           make -C Pal/lib distclean
-                           rm LibOS/glibc-*.tar.gz
+                           make SGX=1 distclean
                            make -C LibOS/shim/test/regression SGX=1 clean
                            make -C LibOS/shim/test/apps/ltp clean
                            # LTP's make clean is broken, see https://github.com/linux-test-project/ltp/issues/559

--- a/Jenkinsfiles/Linux-SGX-apps
+++ b/Jenkinsfiles/Linux-SGX-apps
@@ -116,10 +116,7 @@ pipeline {
                            cd "$(./Scripts/clean-check-test-copy)"
 
                            rm Pal/src/host/Linux-SGX/signer/enclave-key.pem
-                           make -C Pal/src/host/Linux-SGX/sgx-driver distclean
-                           make SGX=1 clean
-                           make -C Pal/lib distclean
-                           rm LibOS/glibc-*.tar.gz
+                           make SGX=1 distclean
 
                            make -C LibOS/shim/test/apps/python-simple SGX=1 clean
                            make -C LibOS/shim/test/apps/python-scipy-insecure SGX=1 clean

--- a/LibOS/Makefile
+++ b/LibOS/Makefile
@@ -124,10 +124,18 @@ $(GLIBC_SRC)/nptl/Versions: $(GLIBC_SRC)/configure
 
 $(GLIBC_SRC)/dlfcn/Versions: $(GLIBC_SRC)/configure
 
-.PHONY: clean
-clean:
-	$(MAKE) -C $(SHIM_DIR) clean
+.PHONY: clean_
+clean_:
 	rm -rf $(BUILD_DIR) $(GLIBC_SRC) build.log
+
+.PHONY: clean
+clean: clean_
+	$(MAKE) -C $(SHIM_DIR) clean
+
+.PHONY: distclean
+distclean: clean_
+	$(MAKE) -C $(SHIM_DIR) distclean
+	rm -f $(GLIBC_SRC).tar.gz
 
 else
 .IGNORE: $(GLIBC_TARGET)
@@ -136,6 +144,9 @@ $(GLIBC_TARGET):
 .PHONY: clean
 clean:
 	rm -rf $(BUILD_DIR)
+
+.PHONY: distclean
+distclean: clean
 endif
 
 .PHONY: test

--- a/LibOS/shim/Makefile
+++ b/LibOS/shim/Makefile
@@ -15,10 +15,11 @@ test:
 sgx-tokens:
 	$(MAKE) -C test sgx-tokens
 
-.PHONY: clean
-clean:
-	$(MAKE) -C src clean
-	$(MAKE) -C test clean
+clean_targets = clean distclean
+.PHONY: $(clean_targets)
+$(clean_targets):
+	$(MAKE) -C src $@
+	$(MAKE) -C test $@
 
 .PHONY: format
 format:

--- a/LibOS/shim/src/Makefile
+++ b/LibOS/shim/src/Makefile
@@ -152,11 +152,15 @@ vdso/vdso.so: vdso/vdso.so.dbg
 vdso/vdso-data.o: vdso/vdso.so
 CLEAN_FILES += vdso/vdso.so.dbg vdso/vdso.so vdso/.vdso-linked-for-reloc-check.so vdso/.vdso-no-reloc-checked
 
+.PHONY: clean
 clean:
 	rm -rf $(addsuffix .o,$(all_objs)) $(addsuffix .d,$(all_objs)) \
 	       $(addsuffix .i.d,$(all_objs)) $(addsuffix .s.d,$(all_objs)) \
 	       $(shim_target) $(files_to_build) .lib $(CLEAN_FILES)
 
-ifeq ($(filter clean,$(MAKECMDGOALS)),)
+ifeq ($(filter %clean,$(MAKECMDGOALS)),)
 -include $(addsuffix .d,$(all_objs)) $(addsuffix .i.d,$(all_objs)) $(addsuffix .s.d,$(all_objs))
 endif
+
+.PHONY: distclean
+distclean: clean

--- a/LibOS/shim/test/Makefile
+++ b/LibOS/shim/test/Makefile
@@ -7,8 +7,8 @@ export SYS
 .PHONY: default
 default: all
 
-.PHONY: all clean sgx-tokens
-all clean sgx-tokens:
+.PHONY: all clean sgx-tokens distclean
+all clean sgx-tokens distclean:
 	for d in $(SUBDIRS); do \
 		$(MAKE) -C $$d $@ || exit 255; \
 	done

--- a/LibOS/shim/test/Makefile.Test
+++ b/LibOS/shim/test/Makefile.Test
@@ -81,7 +81,7 @@ manifest: manifest.template
 	@echo [ $@ ]
 	sed $(manifest_rules) $< > $@
 
-ifeq ($(filter clean,$(MAKECMDGOALS)),)
+ifeq ($(filter %clean,$(MAKECMDGOALS)),)
 ifeq ($(SGX),1)
 include $(addsuffix .manifest.sgx.d,$(patsubst %.manifest,%,$(exec_target)))
 endif
@@ -91,3 +91,6 @@ endif
 clean: $(clean-extra)
 	rm -rf pal_loader $(call expand_target,$(exec_target)) $(target) $(wildcard *.d) .output.* \
 	       *.sig *.token *.manifest.sgx
+
+.PHONY: distclean
+distclean: clean

--- a/LibOS/shim/test/native/Makefile
+++ b/LibOS/shim/test/native/Makefile
@@ -29,7 +29,7 @@ $(c_executables): %: %.c
 $(cxx_executables): %: %.cpp
 	$(call cmd,cxxsingle)
 
-ifeq ($(filter clean,$(MAKECMDGOALS)),)
+ifeq ($(filter %clean,$(MAKECMDGOALS)),)
 include $(wildcard *.d)
 endif
 else

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 SYS ?= $(shell gcc -dumpmachine)
 export SYS
 
-targets = all clean format test sgx-tokens
+targets = all clean format test sgx-tokens distclean
 
 ifneq ($(filter sgx-tokens,$(MAKECMDGOALS)),)
 ifneq ($(SGX),1)

--- a/Pal/Makefile
+++ b/Pal/Makefile
@@ -6,11 +6,13 @@ DIRS = src test regression
 all:
 	$(MAKE) -C src
 
-.PHONY: clean
-clean:
-	$(MAKE) -C src clean
-	$(MAKE) -C test clean
-	$(MAKE) -C regression clean
+clean_targets = clean distclean
+.PHONY: $(clean_targets)
+$(clean_targets):
+	$(MAKE) -C src $@
+	$(MAKE) -C test $@
+	$(MAKE) -C regression $@
+	$(MAKE) -C lib $@
 
 .PHONY: test
 test:
@@ -29,3 +31,6 @@ format:
 	                               -path ./lib/crypto/udivmodti4.c -prune -o \
 	                               -path ./src/host/Linux-SGX/sgx-driver -prune -o \
 	                               \( -name '*.h' -o -name '*.c' \) -print)
+
+.PHONY: distclean
+distclean: clean

--- a/Pal/lib/Makefile
+++ b/Pal/lib/Makefile
@@ -105,7 +105,7 @@ $(target)%.o: %.c
 	@mkdir -p $(dir $@)
 	$(call cmd,cc_o_c)
 
-ifeq ($(filter clean,$(MAKECMDGOALS)),)
+ifeq ($(filter %clean,$(MAKECMDGOALS)),)
 -include $(patsubst %.o,%.d,$(addprefix $(target),$(objs)))
 endif
 

--- a/Pal/regression/Makefile
+++ b/Pal/regression/Makefile
@@ -76,7 +76,7 @@ $(executables): LDLIBS = $(LDLIBS-executables)
 $(executables): %: %.c $(LDLIBS-executables)
 	$(call cmd,csingle)
 
-ifeq ($(filter clean,$(MAKECMDGOALS)),)
+ifeq ($(filter %clean,$(MAKECMDGOALS)),)
 include $(wildcard *.d)
 ifeq ($(SGX), 1)
 # Bootstrap5.manifest doesn't have main executable, but only preloaded
@@ -113,3 +113,6 @@ pal-regression.xml: test_pal.py $(call expand_target_to_token,$(target))
 .PHONY: clean
 clean:
 	rm -rf $(call expand_target,$(target)) $(preloads) *.tmp .lib *.cached *.sig *.d .output.* *.token .*.d .*.sig .*.token __pycache__ .cache pal-regression.xml
+
+.PHONY: distclean
+distclean: clean

--- a/Pal/src/Makefile
+++ b/Pal/src/Makefile
@@ -149,14 +149,18 @@ $(OBJ_DIR)/%.s: %.c $(headers)
 	@mkdir -p $(OBJ_DIR)
 	$(call cmd,cc_s_c)
 
-ifeq ($(filter clean,$(MAKECMDGOALS)),)
+ifeq ($(filter %clean,$(MAKECMDGOALS)),)
 include $(wildcard *.d)
 endif
 
-.PHONY: clean
-clean:
+clean_targets = clean distclean
+.PHONY: $(clean_targets) clean_
+
+$(clean_targets): clean_
+	@[ ! -d $(HOST_DIR) ] || $(MAKE) -C $(HOST_DIR) $@
+
+clean_:
 	rm -rf $(LIB_DIR) $(OBJ_DIR) $(files_to_build) *.d
-	@[ ! -d $(HOST_DIR) ] || $(MAKE) -C $(HOST_DIR) clean
 
 .PHONY: test
 test:

--- a/Pal/src/host/Linux-SGX/Makefile
+++ b/Pal/src/host/Linux-SGX/Makefile
@@ -88,7 +88,7 @@ enclave_entry.o sgx_entry.o: asm-offsets.h
 sgx-driver/isgx_version.h:
 	$(MAKE) -C sgx-driver $(notdir $@)
 
-ifeq ($(filter clean,$(MAKECMDGOALS)),)
+ifeq ($(filter %clean,$(MAKECMDGOALS)),)
 include $(wildcard *.d) $(wildcard debugger/*.d)
 endif
 
@@ -97,12 +97,20 @@ include ../../../../Makefile.rules
 CLEAN_FILES += $(notdir $(pal_static) $(pal_lib) $(pal_loader))
 CLEAN_FILES += debugger/sgx_gdb.o
 CLEAN_FILES += quote/aesm.pb-c.c quote/aesm.pb-c.h quote/aesm.pb-c.d quote/aesm.pb-c.o
-CLEAN_FILES += $(ias_cert_file) quote/generated-cacert.h
+CLEAN_FILES += quote/generated-cacert.h
 
-.PHONY: clean
-clean:
+.PHONY: clean_
+clean_:
 	rm -rf *.o *.e *.i *.s $(host_files) $(CLEAN_FILES) *.d debugger/*.d signer/*.pyc __pycache__ \
 	       signer/__pycache__
+
+.PHONY: clean
+clean: clean_
+	$(MAKE) -C sgx-driver $@
+
+.PHONY: distclean
+distclean: clean_
+	rm -f $(ias_cert_file)
 	$(MAKE) -C sgx-driver $@
 
 .PHONY: test

--- a/Pal/src/host/Linux/Makefile
+++ b/Pal/src/host/Linux/Makefile
@@ -48,7 +48,7 @@ libpal-Linux.a: $(addsuffix .o,$(objs)) $(graphene_lib)
 
 include ../../../../Makefile.rules
 
-ifeq ($(filter clean,$(MAKECMDGOALS)),)
+ifeq ($(filter %clean,$(MAKECMDGOALS)),)
 -include $(addsuffix .d,$(objs)) $(addsuffix .i.d,$(objs)) $(addsuffix .s.d,$(objs))
 endif
 
@@ -59,6 +59,9 @@ clean:
 	rm -f $(addsuffix .o,$(objs)) $(host_files) $(CLEAN_FILES) \
 	      $(addsuffix .d,$(objs)) $(addsuffix .i.d,$(objs)) \
 	      $(addsuffix .s.d,$(objs))
+
+.PHONY: distclean
+distclean: clean
 
 .PHONY: test
 test:

--- a/Pal/src/host/Skeleton/Makefile
+++ b/Pal/src/host/Skeleton/Makefile
@@ -39,3 +39,6 @@ include ../../../../Makefile.rules
 .PHONY: clean
 clean:
 	rm -f $(addsuffix .o,$(objs)) $(addsuffix .d,$(objs)) $(host_files) $(pal_lib)
+
+.PHONY: distclean
+distclean: clean

--- a/Pal/test/Makefile
+++ b/Pal/test/Makefile
@@ -56,7 +56,7 @@ $(executables): %: %.c $(LDLIBS)
 
 $(graphene_lib): .lib/host_endian.h
 	$(MAKE) -C ../lib target=$(abspath .lib)/
-ifeq ($(filter clean,$(MAKECMDGOALS)),)
+ifeq ($(filter %clean,$(MAKECMDGOALS)),)
 ifeq ($(SGX), 1)
 include $(addsuffix .manifest.sgx.d,$(executables))
 endif
@@ -66,7 +66,7 @@ else
 $(executables):
 endif
 
-ifeq ($(filter clean,$(MAKECMDGOALS)),)
+ifeq ($(filter %clean,$(MAKECMDGOALS)),)
 -include $(addsuffix .d, $(executables)) $(addsuffix .i.d, $(executables)) $(addsuffix .s.d, $(executables))
 endif
 
@@ -77,3 +77,6 @@ clean:
 	       $(addsuffix .s.d, $(executables)) \
 	       $(addsuffix .manifest.sgx.d,$(executables)) \
 		   .output.*
+
+.PHONY: distclean
+distclean: clean

--- a/Runtime/Makefile
+++ b/Runtime/Makefile
@@ -5,6 +5,9 @@ all:
 clean:
 	rm -f *.a *.o *.so *.so.* pal_gdb* pal-*
 
+.PHONY: distclean
+distclean: clean
+
 .PHONY: format
 format:
 

--- a/Scripts/Makefile
+++ b/Scripts/Makefile
@@ -1,9 +1,12 @@
 .PHONY: all
 all: ;
 
-.PHONY:
+.PHONY: clean
 clean:
 	rm -rf __pycache__
+
+.PHONY: distclean
+distclean: clean
 
 .PHONY: format
 format: ;


### PR DESCRIPTION
<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [x] README and global configuration
- [x] Linux PAL
- [x] SGX PAL
- [x] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->

Before there were no target that cleaned up downloaded sources. To match
the 'apps' Makefiles add a distclean target.

## How to test this PR? <!-- (if applicable) -->

Run `make distclean` and/or see Jenkins.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1288)
<!-- Reviewable:end -->
