### PR TITLE
[Pal/Linux-SGX] Skip attestion test if no RA key is configured

### DIFF
--- a/Pal/regression/test_pal.py
+++ b/Pal/regression/test_pal.py
@@ -9,6 +9,7 @@ import random
 import shutil
 import string
 import subprocess
+import sys
 import unittest
 from datetime import datetime, timedelta
 
@@ -17,6 +18,10 @@ from regression import (
     RegressionTestCase,
     expectedFailureIf,
 )
+
+if HAS_SGX:
+    sys.path.insert(0, os.path.dirname(__file__) + '/../src/host/Linux-SGX/signer')
+    from pal_sgx_sign import read_manifest
 
 CPUINFO_FLAGS_WHITELIST = [
     'fpu', 'vme', 'de', 'pse', 'tsc', 'msr', 'pae', 'mce', 'cx8', 'apic', 'sep',
@@ -566,6 +571,10 @@ class TC_40_AVXDisable(RegressionTestCase):
 @unittest.skipUnless(HAS_SGX, 'need SGX')
 class TC_50_Attestation(RegressionTestCase):
     def test_000_remote_attestation(self):
+        manifest, _ = read_manifest(self.get_manifest("Attestation"))
+        if not manifest.get('sgx.ra_client_spid'):
+            raise unittest.SkipTest('needs RA SPID and key')
+
         _, stderr = self.run_binary(["Attestation"])
 
         for line in stderr.split("\n"):


### PR DESCRIPTION
<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [x] SGX PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->

Before this commit the attestation regression test was run even if there
was no SPID/key configured.

## How to test this PR? <!-- (if applicable) -->

Run Pal regression tests on SGX without setting a RA SPID/key

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1289)
<!-- Reviewable:end -->
