### PR TITLE
[LibOS] Update TYPE_DEV handles with correct function pointers in dev_ops

### DIFF
--- a/Jenkinsfiles/Linux
+++ b/Jenkinsfiles/Linux
@@ -56,10 +56,12 @@ pipeline {
                                 make check
                             '''
                         }
-                        sh '''
-                            cd LibOS/shim/test/apps/bash
-                            make regression
+                        timeout(time: 5, unit: 'MINUTES') {
+                            sh '''
+                                cd LibOS/shim/test/apps/bash
+                                make regression
                             '''
+                        }
                         timeout(time: 5, unit: 'MINUTES') {
                             sh '''
                                 cd LibOS/shim/test/apps/curl
@@ -87,28 +89,34 @@ pipeline {
                                 ./src/src/redis-benchmark
                             '''
                         }
-                        sh '''
-                            cd LibOS/shim/test/apps/lighttpd
-                            make
-                            make start-graphene-server &
-                            sleep 1
-                            LOOP=1 CONCURRENCY_LIST="1 32" ./benchmark-http.sh 127.0.0.1:8003
+                        timeout(time: 10, unit: 'MINUTES') {
+                            sh '''
+                                cd LibOS/shim/test/apps/lighttpd
+                                make
+                                make start-graphene-server &
+                                sleep 1
+                                LOOP=1 CONCURRENCY_LIST="1 32" ./benchmark-http.sh 127.0.0.1:8003
                             '''
-                        sh '''
-                            cd LibOS/shim/test/apps/nginx
-                            make
-                            make start-graphene-server &
-                            sleep 1
-                            LOOP=1 CONCURRENCY_LIST="1 32" ./benchmark-http.sh 127.0.0.1:8002
+                        }
+                        timeout(time: 10, unit: 'MINUTES') {
+                            sh '''
+                                cd LibOS/shim/test/apps/nginx
+                                make
+                                make start-graphene-server &
+                                sleep 1
+                                LOOP=1 CONCURRENCY_LIST="1 32" ./benchmark-http.sh 127.0.0.1:8002
                             '''
-                        sh '''
-                            cd LibOS/shim/test/apps/apache
-                            make
-                            make start-graphene-server &
-                            sleep 1
-                            LOOP=1 CONCURRENCY_LIST="1 32" ./benchmark-http.sh 127.0.0.1:8001
-                            LOOP=1 CONCURRENCY_LIST="1 32" ./benchmark-http.sh https://127.0.0.1:8443
+                        }
+                        timeout(time: 20, unit: 'MINUTES') {
+                            sh '''
+                                cd LibOS/shim/test/apps/apache
+                                make
+                                make start-graphene-server &
+                                sleep 1
+                                LOOP=1 CONCURRENCY_LIST="1 32" ./benchmark-http.sh 127.0.0.1:8001
+                                LOOP=1 CONCURRENCY_LIST="1 32" ./benchmark-http.sh https://127.0.0.1:8443
                             '''
+                        }
                         sh '''
                            cd "$(./Scripts/clean-check-test-copy)"
 

--- a/Jenkinsfiles/Linux
+++ b/Jenkinsfiles/Linux
@@ -107,6 +107,7 @@ pipeline {
                             make start-graphene-server &
                             sleep 1
                             LOOP=1 CONCURRENCY_LIST="1 32" ./benchmark-http.sh 127.0.0.1:8001
+                            LOOP=1 CONCURRENCY_LIST="1 32" ./benchmark-http.sh https://127.0.0.1:8443
                             '''
                         sh '''
                            cd "$(./Scripts/clean-check-test-copy)"

--- a/Jenkinsfiles/Linux-18.04
+++ b/Jenkinsfiles/Linux-18.04
@@ -54,10 +54,12 @@ pipeline {
                                 PYTHONVERSION=python3.6 make check
                             '''
                         }
-                        sh '''
-                            cd LibOS/shim/test/apps/bash
-                            make regression
+                        timeout(time: 5, unit: 'MINUTES') {
+                            sh '''
+                                cd LibOS/shim/test/apps/bash
+                                make regression
                             '''
+                        }
                         timeout(time: 5, unit: 'MINUTES') {
                             sh '''
                                 cd LibOS/shim/test/apps/curl
@@ -85,28 +87,34 @@ pipeline {
                                 ./src/src/redis-benchmark
                             '''
                         }
-                        sh '''
-                            cd LibOS/shim/test/apps/lighttpd
-                            make
-                            make start-graphene-server &
-                            sleep 1
-                            LOOP=1 CONCURRENCY_LIST="1 32" ./benchmark-http.sh 127.0.0.1:8003
+                        timeout(time: 10, unit: 'MINUTES') {
+                            sh '''
+                                cd LibOS/shim/test/apps/lighttpd
+                                make
+                                make start-graphene-server &
+                                sleep 1
+                                LOOP=1 CONCURRENCY_LIST="1 32" ./benchmark-http.sh 127.0.0.1:8003
                             '''
-                        sh '''
-                            cd LibOS/shim/test/apps/nginx
-                            make
-                            make start-graphene-server &
-                            sleep 1
-                            LOOP=1 CONCURRENCY_LIST="1 32" ./benchmark-http.sh 127.0.0.1:8002
+                        }
+                        timeout(time: 10, unit: 'MINUTES') {
+                            sh '''
+                                cd LibOS/shim/test/apps/nginx
+                                make
+                                make start-graphene-server &
+                                sleep 1
+                                LOOP=1 CONCURRENCY_LIST="1 32" ./benchmark-http.sh 127.0.0.1:8002
                             '''
-                        sh '''
-                            cd LibOS/shim/test/apps/apache
-                            make
-                            make start-graphene-server &
-                            sleep 1
-                            LOOP=1 CONCURRENCY_LIST="1 32" ./benchmark-http.sh 127.0.0.1:8001
-                            LOOP=1 CONCURRENCY_LIST="1 32" ./benchmark-http.sh https://127.0.0.1:8443
+                        }
+                        timeout(time: 20, unit: 'MINUTES') {
+                            sh '''
+                                cd LibOS/shim/test/apps/apache
+                                make
+                                make start-graphene-server &
+                                sleep 1
+                                LOOP=1 CONCURRENCY_LIST="1 32" ./benchmark-http.sh 127.0.0.1:8001
+                                LOOP=1 CONCURRENCY_LIST="1 32" ./benchmark-http.sh https://127.0.0.1:8443
                             '''
+                        }
                         sh '''
                            cd "$(./Scripts/clean-check-test-copy)"
 

--- a/Jenkinsfiles/Linux-18.04
+++ b/Jenkinsfiles/Linux-18.04
@@ -105,6 +105,7 @@ pipeline {
                             make start-graphene-server &
                             sleep 1
                             LOOP=1 CONCURRENCY_LIST="1 32" ./benchmark-http.sh 127.0.0.1:8001
+                            LOOP=1 CONCURRENCY_LIST="1 32" ./benchmark-http.sh https://127.0.0.1:8443
                             '''
                         sh '''
                            cd "$(./Scripts/clean-check-test-copy)"

--- a/Jenkinsfiles/Linux-Debug
+++ b/Jenkinsfiles/Linux-Debug
@@ -106,6 +106,7 @@ pipeline {
                             make start-graphene-server &
                             sleep 1
                             LOOP=1 CONCURRENCY_LIST="1 32" ./benchmark-http.sh 127.0.0.1:8001
+                            LOOP=1 CONCURRENCY_LIST="1 32" ./benchmark-http.sh https://127.0.0.1:8443
                             '''
                         sh '''
                            cd "$(./Scripts/clean-check-test-copy)"

--- a/Jenkinsfiles/Linux-Debug
+++ b/Jenkinsfiles/Linux-Debug
@@ -55,10 +55,12 @@ pipeline {
                                 make check
                             '''
                         }
-                        sh '''
-                            cd LibOS/shim/test/apps/bash
-                            make regression
+                        timeout(time: 5, unit: 'MINUTES') {
+                            sh '''
+                                cd LibOS/shim/test/apps/bash
+                                make regression
                             '''
+                        }
                         timeout(time: 5, unit: 'MINUTES') {
                             sh '''
                                 cd LibOS/shim/test/apps/curl
@@ -86,28 +88,34 @@ pipeline {
                                 ./src/src/redis-benchmark
                             '''
                         }
-                        sh '''
-                            cd LibOS/shim/test/apps/lighttpd
-                            make
-                            make start-graphene-server &
-                            sleep 1
-                            LOOP=1 CONCURRENCY_LIST="1 32" ./benchmark-http.sh 127.0.0.1:8003
+                        timeout(time: 10, unit: 'MINUTES') {
+                            sh '''
+                                cd LibOS/shim/test/apps/lighttpd
+                                make
+                                make start-graphene-server &
+                                sleep 1
+                                LOOP=1 CONCURRENCY_LIST="1 32" ./benchmark-http.sh 127.0.0.1:8003
                             '''
-                        sh '''
-                            cd LibOS/shim/test/apps/nginx
-                            make
-                            make start-graphene-server &
-                            sleep 1
-                            LOOP=1 CONCURRENCY_LIST="1 32" ./benchmark-http.sh 127.0.0.1:8002
+                        }
+                        timeout(time: 10, unit: 'MINUTES') {
+                            sh '''
+                                cd LibOS/shim/test/apps/nginx
+                                make
+                                make start-graphene-server &
+                                sleep 1
+                                LOOP=1 CONCURRENCY_LIST="1 32" ./benchmark-http.sh 127.0.0.1:8002
                             '''
-                        sh '''
-                            cd LibOS/shim/test/apps/apache
-                            make
-                            make start-graphene-server &
-                            sleep 1
-                            LOOP=1 CONCURRENCY_LIST="1 32" ./benchmark-http.sh 127.0.0.1:8001
-                            LOOP=1 CONCURRENCY_LIST="1 32" ./benchmark-http.sh https://127.0.0.1:8443
+                        }
+                        timeout(time: 20, unit: 'MINUTES') {
+                            sh '''
+                                cd LibOS/shim/test/apps/apache
+                                make
+                                make start-graphene-server &
+                                sleep 1
+                                LOOP=1 CONCURRENCY_LIST="1 32" ./benchmark-http.sh 127.0.0.1:8001
+                                LOOP=1 CONCURRENCY_LIST="1 32" ./benchmark-http.sh https://127.0.0.1:8443
                             '''
+                        }
                         sh '''
                            cd "$(./Scripts/clean-check-test-copy)"
 

--- a/Jenkinsfiles/Linux-Debug-18.04
+++ b/Jenkinsfiles/Linux-Debug-18.04
@@ -54,10 +54,12 @@ pipeline {
                                 PYTHONVERSION=python3.6 make check
                             '''
                         }
-                        sh '''
-                            cd LibOS/shim/test/apps/bash
-                            make regression
+                        timeout(time: 5, unit: 'MINUTES') {
+                            sh '''
+                                cd LibOS/shim/test/apps/bash
+                                make regression
                             '''
+                        }
                         timeout(time: 5, unit: 'MINUTES') {
                             sh '''
                                 cd LibOS/shim/test/apps/curl
@@ -85,28 +87,34 @@ pipeline {
                                 ./src/src/redis-benchmark
                             '''
                         }
-                        sh '''
-                            cd LibOS/shim/test/apps/lighttpd
-                            make
-                            make start-graphene-server &
-                            sleep 1
-                            LOOP=1 CONCURRENCY_LIST="1 32" ./benchmark-http.sh 127.0.0.1:8003
+                        timeout(time: 10, unit: 'MINUTES') {
+                            sh '''
+                                cd LibOS/shim/test/apps/lighttpd
+                                make
+                                make start-graphene-server &
+                                sleep 1
+                                LOOP=1 CONCURRENCY_LIST="1 32" ./benchmark-http.sh 127.0.0.1:8003
                             '''
-                        sh '''
-                            cd LibOS/shim/test/apps/nginx
-                            make
-                            make start-graphene-server &
-                            sleep 1
-                            LOOP=1 CONCURRENCY_LIST="1 32" ./benchmark-http.sh 127.0.0.1:8002
+                        }
+                        timeout(time: 10, unit: 'MINUTES') {
+                            sh '''
+                                cd LibOS/shim/test/apps/nginx
+                                make
+                                make start-graphene-server &
+                                sleep 1
+                                LOOP=1 CONCURRENCY_LIST="1 32" ./benchmark-http.sh 127.0.0.1:8002
                             '''
-                        sh '''
-                            cd LibOS/shim/test/apps/apache
-                            make
-                            make start-graphene-server &
-                            sleep 1
-                            LOOP=1 CONCURRENCY_LIST="1 32" ./benchmark-http.sh 127.0.0.1:8001
-                            LOOP=1 CONCURRENCY_LIST="1 32" ./benchmark-http.sh https://127.0.0.1:8443
+                        }
+                        timeout(time: 20, unit: 'MINUTES') {
+                            sh '''
+                                cd LibOS/shim/test/apps/apache
+                                make
+                                make start-graphene-server &
+                                sleep 1
+                                LOOP=1 CONCURRENCY_LIST="1 32" ./benchmark-http.sh 127.0.0.1:8001
+                                LOOP=1 CONCURRENCY_LIST="1 32" ./benchmark-http.sh https://127.0.0.1:8443
                             '''
+                        }
                         sh '''
                            cd "$(./Scripts/clean-check-test-copy)"
 

--- a/Jenkinsfiles/Linux-Debug-18.04
+++ b/Jenkinsfiles/Linux-Debug-18.04
@@ -105,6 +105,7 @@ pipeline {
                             make start-graphene-server &
                             sleep 1
                             LOOP=1 CONCURRENCY_LIST="1 32" ./benchmark-http.sh 127.0.0.1:8001
+                            LOOP=1 CONCURRENCY_LIST="1 32" ./benchmark-http.sh https://127.0.0.1:8443
                             '''
                         sh '''
                            cd "$(./Scripts/clean-check-test-copy)"

--- a/Jenkinsfiles/Linux-SGX-18.04-apps
+++ b/Jenkinsfiles/Linux-SGX-18.04-apps
@@ -94,28 +94,34 @@ pipeline {
                                 ./src/src/redis-benchmark
                             '''
                         }
-                        sh '''
-                            cd LibOS/shim/test/apps/lighttpd
-                            make SGX=1
-                            make SGX=1 start-graphene-server &
-                            sleep 10
-                            LOOP=1 CONCURRENCY_LIST="1 32" ./benchmark-http.sh 127.0.0.1:8003
+                        timeout(time: 15, unit: 'MINUTES') {
+                            sh '''
+                                cd LibOS/shim/test/apps/lighttpd
+                                make SGX=1
+                                make SGX=1 start-graphene-server &
+                                sleep 10
+                                LOOP=1 CONCURRENCY_LIST="1 32" ./benchmark-http.sh 127.0.0.1:8003
                             '''
-                        sh '''
-                            cd LibOS/shim/test/apps/nginx
-                            make SGX=1
-                            make SGX=1 start-graphene-server &
-                            sleep 30
-                            LOOP=1 CONCURRENCY_LIST="1 32" ./benchmark-http.sh 127.0.0.1:8002
+                        }
+                        timeout(time: 15, unit: 'MINUTES') {
+                            sh '''
+                                cd LibOS/shim/test/apps/nginx
+                                make SGX=1
+                                make SGX=1 start-graphene-server &
+                                sleep 30
+                                LOOP=1 CONCURRENCY_LIST="1 32" ./benchmark-http.sh 127.0.0.1:8002
                             '''
-                        sh '''
-                            cd LibOS/shim/test/apps/apache
-                            make SGX=1
-                            make SGX=1 start-graphene-server &
-                            sleep 30
-                            LOOP=1 CONCURRENCY_LIST="1 32" ./benchmark-http.sh 127.0.0.1:8001
-                            LOOP=1 CONCURRENCY_LIST="1 32" ./benchmark-http.sh https://127.0.0.1:8443
+                        }
+                        timeout(time: 25, unit: 'MINUTES') {
+                            sh '''
+                                cd LibOS/shim/test/apps/apache
+                                make SGX=1
+                                make SGX=1 start-graphene-server &
+                                sleep 30
+                                LOOP=1 CONCURRENCY_LIST="1 32" ./benchmark-http.sh 127.0.0.1:8001
+                                LOOP=1 CONCURRENCY_LIST="1 32" ./benchmark-http.sh https://127.0.0.1:8443
                             '''
+                        }
                         sh '''
                            cd "$(./Scripts/clean-check-test-copy)"
 

--- a/Jenkinsfiles/Linux-SGX-18.04-apps
+++ b/Jenkinsfiles/Linux-SGX-18.04-apps
@@ -114,6 +114,7 @@ pipeline {
                             make SGX=1 start-graphene-server &
                             sleep 30
                             LOOP=1 CONCURRENCY_LIST="1 32" ./benchmark-http.sh 127.0.0.1:8001
+                            LOOP=1 CONCURRENCY_LIST="1 32" ./benchmark-http.sh https://127.0.0.1:8443
                             '''
                         sh '''
                            cd "$(./Scripts/clean-check-test-copy)"

--- a/Jenkinsfiles/Linux-SGX-apps
+++ b/Jenkinsfiles/Linux-SGX-apps
@@ -91,28 +91,34 @@ pipeline {
                                 ./src/src/redis-benchmark
                             '''
                         }
-                        sh '''
-                            cd LibOS/shim/test/apps/lighttpd
-                            make SGX=1
-                            make SGX=1 start-graphene-server &
-                            sleep 10
-                            LOOP=1 CONCURRENCY_LIST="1 32" ./benchmark-http.sh 127.0.0.1:8003
+                        timeout(time: 15, unit: 'MINUTES') {
+                            sh '''
+                                cd LibOS/shim/test/apps/lighttpd
+                                make SGX=1
+                                make SGX=1 start-graphene-server &
+                                sleep 10
+                                LOOP=1 CONCURRENCY_LIST="1 32" ./benchmark-http.sh 127.0.0.1:8003
                             '''
-                        sh '''
-                            cd LibOS/shim/test/apps/nginx
-                            make SGX=1
-                            make SGX=1 start-graphene-server &
-                            sleep 30
-                            LOOP=1 CONCURRENCY_LIST="1 32" ./benchmark-http.sh 127.0.0.1:8002
+                        }
+                        timeout(time: 15, unit: 'MINUTES') {
+                            sh '''
+                                cd LibOS/shim/test/apps/nginx
+                                make SGX=1
+                                make SGX=1 start-graphene-server &
+                                sleep 30
+                                LOOP=1 CONCURRENCY_LIST="1 32" ./benchmark-http.sh 127.0.0.1:8002
                             '''
-                        sh '''
-                            cd LibOS/shim/test/apps/apache
-                            make SGX=1
-                            make SGX=1 start-graphene-server &
-                            sleep 30
-                            LOOP=1 CONCURRENCY_LIST="1 32" ./benchmark-http.sh 127.0.0.1:8001
-                            LOOP=1 CONCURRENCY_LIST="1 32" ./benchmark-http.sh https://127.0.0.1:8443
+                        }
+                        timeout(time: 25, unit: 'MINUTES') {
+                            sh '''
+                                cd LibOS/shim/test/apps/apache
+                                make SGX=1
+                                make SGX=1 start-graphene-server &
+                                sleep 30
+                                LOOP=1 CONCURRENCY_LIST="1 32" ./benchmark-http.sh 127.0.0.1:8001
+                                LOOP=1 CONCURRENCY_LIST="1 32" ./benchmark-http.sh https://127.0.0.1:8443
                             '''
+                        }
                         sh '''
                            cd "$(./Scripts/clean-check-test-copy)"
 

--- a/Jenkinsfiles/Linux-SGX-apps
+++ b/Jenkinsfiles/Linux-SGX-apps
@@ -111,6 +111,7 @@ pipeline {
                             make SGX=1 start-graphene-server &
                             sleep 30
                             LOOP=1 CONCURRENCY_LIST="1 32" ./benchmark-http.sh 127.0.0.1:8001
+                            LOOP=1 CONCURRENCY_LIST="1 32" ./benchmark-http.sh https://127.0.0.1:8443
                             '''
                         sh '''
                            cd "$(./Scripts/clean-check-test-copy)"

--- a/Jenkinsfiles/ubuntu-16.04.dockerfile
+++ b/Jenkinsfiles/ubuntu-16.04.dockerfile
@@ -22,6 +22,7 @@ RUN apt-get update \
        libpcre2-dev \
        libpcre3-dev \
        libprotobuf-c-dev \
+       libssl-dev \
        libxml2-dev \
        linux-headers-4.4.0-161-generic \
        net-tools \

--- a/Jenkinsfiles/ubuntu-18.04.dockerfile
+++ b/Jenkinsfiles/ubuntu-18.04.dockerfile
@@ -22,6 +22,7 @@ RUN apt-get update && env DEBIAN_FRONTEND=noninteractive apt-get install -y \
     libpcre2-dev \
     libpcre3-dev \
     libprotobuf-c-dev \
+    libssl-dev \
     libxml2-dev \
     linux-headers-4.15.0-20-generic \
     net-tools \

--- a/LibOS/shim/include/shim_handle.h
+++ b/LibOS/shim/include/shim_handle.h
@@ -125,6 +125,8 @@ struct shim_dev_ops {
     int (*hstat)(struct shim_handle* hdl, struct stat* buf);
 };
 
+int dev_update_dev_ops(struct shim_handle* hdl);
+
 struct shim_dev_handle {
     struct shim_dev_ops dev_ops;
 };

--- a/LibOS/shim/src/bookkeep/shim_handle.c
+++ b/LibOS/shim/src/bookkeep/shim_handle.c
@@ -803,6 +803,14 @@ BEGIN_RS_FUNC(handle) {
         }
     }
 
+    if (hdl->type == TYPE_DEV) {
+        /* for device handles, info.dev.dev_ops contains function pointers into LibOS; they may
+           have become invalid due to relocation of LibOS text section in the child, update them */
+        if (dev_update_dev_ops(hdl) < 0) {
+            return -EINVAL;
+        }
+    }
+
     if (hdl->fs && hdl->fs->fs_ops && hdl->fs->fs_ops->checkin)
         hdl->fs->fs_ops->checkin(hdl);
 

--- a/LibOS/shim/src/fs/dev/fs.c
+++ b/LibOS/shim/src/fs/dev/fs.c
@@ -438,6 +438,26 @@ static int dev_follow_link(struct shim_dentry* dent, struct shim_qstr* link) {
     return -ENOENT;
 }
 
+int dev_update_dev_ops(struct shim_handle* hdl) {
+    int ret;
+    char buf[STR_SIZE];
+    size_t bufsize = sizeof(buf);
+    struct shim_dev_ops ops_buf = EMPTY_DEV_OPS;
+
+    assert(hdl && hdl->type == TYPE_DEV);
+
+    ret = get_base_name(qstrgetstr(&hdl->path), buf, &bufsize);
+    if (ret < 0)
+        return -ENOENT;
+
+    ret = search_dev_driver(buf, &ops_buf);
+    if (ret < 0)
+        return ret;
+
+    memcpy(&hdl->info.dev.dev_ops, &ops_buf, sizeof(ops_buf));
+    return 0;
+}
+
 struct shim_fs_ops dev_fs_ops = {
     .mount    = &dev_mount,
     .unmount  = &dev_unmount,


### PR DESCRIPTION
<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->

For device handles, `info.dev.dev_ops` contains function pointers into LibOS. They may become invalid due to relocation of LibOS text section in the child process on fork. This commit forces an update of these function pointers.

In particular, this bug was found on Ubuntu 18.04 while working on Apache with SSL/TLS. For some reason, LibOS text segment (`libsysdb.so`) is relocated in another place in memory in the child process, so Apache tried to access `/dev/urandom` that ended up in a function pointer that pointed to the old (parent's) value in memory, and we had a segfault. See https://github.com/oscarlab/graphene-tests/pull/68.

Closes #1277.

## How to test this PR? <!-- (if applicable) -->

Apache with SSL/TLS must pass now (included as a separate commit in this PR).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1293)
<!-- Reviewable:end -->
