### PR TITLE
[LibOS] properly initialize/free shim_thread::shim_signal_logs

### DIFF
--- a/LibOS/shim/include/shim_signal.h
+++ b/LibOS/shim/include/shim_signal.h
@@ -98,12 +98,10 @@ struct shim_signal {
     PAL_CONTEXT * pal_context;
 };
 
-#define MAX_SIGNAL_LOG      32
-
-struct shim_signal_log {
-    struct atomic_int head, tail;
-    struct shim_signal * logs[MAX_SIGNAL_LOG];
-};
+struct shim_signal_log;
+struct shim_signal_log* signal_logs_alloc(void);
+void signal_logs_free(struct shim_signal_log* signal_log);
+bool signal_logs_pending(const struct shim_signal_log* signal_log, int sig);
 
 extern const char * const siglist[NUM_KNOWN_SIGS + 1];
 

--- a/LibOS/shim/include/shim_thread.h
+++ b/LibOS/shim/include/shim_thread.h
@@ -192,9 +192,10 @@ void set_cur_thread (struct shim_thread * thread)
         thread->shim_tcb = tcb;
         tid = thread->tid;
 
-        if (!is_internal(thread) && !thread->signal_logs)
-            thread->signal_logs = malloc(sizeof(struct shim_signal_log) *
-                                         NUM_SIGS);
+        if (!is_internal(thread) && !thread->signal_logs) {
+            thread->signal_logs = signal_logs_alloc();
+            assert(thread->signal_logs); /* FIXME on ENOMEM */
+        }
     } else if (tcb->tp) {
         put_thread(tcb->tp);
         tcb->tp = NULL;

--- a/LibOS/shim/src/sys/shim_sigaction.c
+++ b/LibOS/shim/src/sys/shim_sigaction.c
@@ -202,8 +202,7 @@ int shim_do_sigsuspend(const __sigset_t* mask) {
 
     /* return immediately on some pending unblocked signal */
     for (int sig = 1; sig <= NUM_SIGS; sig++) {
-        if (atomic_read(&cur->signal_logs[sig - 1].head) !=
-            atomic_read(&cur->signal_logs[sig - 1].tail)) {
+        if (signal_logs_pending(cur->signal_logs, sig)) {
             /* at least one signal of type sig... */
             if (!__sigismember(mask, sig)) {
                 /* ...and this type is not blocked in supplied mask */
@@ -245,8 +244,7 @@ int shim_do_sigpending(__sigset_t* set, size_t sigsetsize) {
         return 0;
 
     for (int sig = 1; sig <= NUM_SIGS; sig++) {
-        if (atomic_read(&cur->signal_logs[sig - 1].head) !=
-            atomic_read(&cur->signal_logs[sig - 1].tail))
+        if (signal_logs_pending(cur->signal_logs, sig))
             __sigaddset(set, sig);
     }
 

--- a/LibOS/shim/src/sys/shim_sleep.c
+++ b/LibOS/shim/src/sys/shim_sleep.c
@@ -44,8 +44,7 @@ static bool signal_pending(void) {
     }
 
     for (int sig = 1; sig <= NUM_SIGS; sig++) {
-        if (atomic_read(&cur->signal_logs[sig - 1].head) !=
-            atomic_read(&cur->signal_logs[sig - 1].tail)) {
+        if (signal_logs_pending(cur->signal_logs, sig)) {
             /* at least one signal of type sig... */
             if (!__sigismember(&cur->signal_mask, sig)) {
                 /* ...and this type is not blocked  */


### PR DESCRIPTION
shim_signal_logs::{head, tail} aren't initialized correctly.
and shim_signal_logs::logs aren't freed on thread exit. (memory leak)

<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->


## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1294)
<!-- Reviewable:end -->
