### PR TITLE
[CI] Runtime/pal_loader has been cleaned up, remove from ignore list

### DIFF
--- a/.ci/prfilter
+++ b/.ci/prfilter
@@ -45,7 +45,6 @@ THE_BIG_LIST_OF_NAUGHTY_FILES = list(map(pathlib.Path, [
     'LibOS/shim/test/native',
     'Pal/src/host/Linux-SGX/debugger/gdb',
     'Pal/src/host/Linux-SGX/sgx-driver/load.sh',
-    'Runtime/pal_loader',
     'Scripts/list-all-graphene.sh',
     'Scripts/memusg',
     '.ci/run-pylint',


### PR DESCRIPTION
<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [x] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->

This is a tiny followup to PR #976: It drops pal_loader from the ignore list in 'prfilter'.

## How to test this PR? <!-- (if applicable) -->

Run CI.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1299)
<!-- Reviewable:end -->
