### PR TITLE
[CI] run-pylint: exclude .py from external source

### DIFF
--- a/.ci/run-pylint
+++ b/.ci/run-pylint
@@ -5,12 +5,16 @@ set -e
 cd "$(git rev-parse --show-toplevel)"
 
 # pylint3 was replaced with pylint from Ubuntu 19.10
-PYLINT=$(command -v pylint3)
+PYLINT=$(command -v pylint3) || true
 if [ -z "$PYLINT" ]; then
     PYLINT=$(command -v pylint)
 fi
 
 find . -name \*.py \
+    -and -not -path ./Pal/lib/crypto/mbedtls/\* \
+    -and -not -path ./LibOS/glibc-build/\* \
+    -and -not -path ./LibOS/glibc-\?.\?\?/\* \
+    -and -not -path ./LibOS/shim/test/apps/ltp/opt/\* \
     -and -not -path ./LibOS/shim/test/apps/ltp/src/\* \
 | sed 's/./\\&/g' \
 | xargs "${PYLINT}" "$@" \


### PR DESCRIPTION
- exclude .py from glibc, ltp.
- ignore error of return code of command

<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [x] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->


## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1301)
<!-- Reviewable:end -->
