### PR TITLE
[LibOS/Makefile] Remove unwanted LibOS tests compilation flags

### DIFF
--- a/LibOS/shim/include/shim_unistd.h
+++ b/LibOS/shim/include/shim_unistd.h
@@ -4,6 +4,11 @@
 #ifdef IN_SHIM
 #include "shim_types.h"
 #else
+/* XXX(borysp): This is hacky. Normally we would want to just include <sys/types.h> but it would
+ * break some tests in "inline" directory. The main reason is that other header files are not
+ * prepared for being included both in LibOS and in standalone binaries. Fortunately this header
+ * only missed one type definition, hence this typedef suffices. */
+typedef int pid_t;
 #include <unistd.h>
 #endif
 

--- a/LibOS/shim/test/benchmark/fork_latency.c
+++ b/LibOS/shim/test/benchmark/fork_latency.c
@@ -19,19 +19,20 @@ int main(int argc, char** argv) {
     if (argc >= 2) {
         times = atoi(argv[1]);
         if (times > TEST_TIMES)
-            return -1;
+            return 1;
     }
 
-    pipe(&pipes[0]);
-    pipe(&pipes[2]);
-    pipe(&pipes[4]);
+    if (pipe(&pipes[0]) < 0 || pipe(&pipes[2]) < 0 || pipe(&pipes[4]) < 0) {
+        perror("pipe error");
+        return 1;
+    }
 
     for (i = 0; i < times; i++) {
         pids[i] = fork();
 
         if (pids[i] < 0) {
             printf("fork failed\n");
-            return -1;
+            return 1;
         }
 
         if (pids[i] == 0) {
@@ -40,7 +41,10 @@ int main(int argc, char** argv) {
             close(pipes[5]);
 
             char byte;
-            read(pipes[0], &byte, 1);
+            if (read(pipes[0], &byte, 1) != 1) {
+                perror("read error");
+                return 1;
+            }
 
             struct timeval timevals[2];
             gettimeofday(&timevals[0], NULL);
@@ -59,10 +63,17 @@ int main(int argc, char** argv) {
 
             close(pipes[0]);
 
-            write(pipes[3], timevals, sizeof(struct timeval) * 2);
+            if (write(pipes[3], timevals, sizeof(struct timeval) * 2)
+                    != sizeof(struct timeval) * 2) {
+                perror("write error");
+                return 1;
+            }
             close(pipes[3]);
 
-            read(pipes[4], &byte, 1);
+            if (read(pipes[4], &byte, 1) != 1) {
+                perror("read error");
+                return 1;
+            }
             close(pipes[4]);
             exit(0);
         }
@@ -74,7 +85,10 @@ int main(int argc, char** argv) {
 
     sleep(1);
     char bytes[times];
-    write(pipes[1], bytes, times);
+    if (write(pipes[1], bytes, times) != times) {
+        perror("write error");
+        return 1;
+    }
     close(pipes[1]);
 
     unsigned long long start_time = 0;
@@ -82,7 +96,10 @@ int main(int argc, char** argv) {
     unsigned long long total_time = 0;
     struct timeval timevals[2];
     for (int i = 0; i < times; i++) {
-        read(pipes[2], timevals, sizeof(struct timeval) * 2);
+        if (read(pipes[2], timevals, sizeof(struct timeval) * 2) != sizeof(struct timeval) * 2) {
+            perror("read error");
+            return 1;
+        }
         unsigned long s = timevals[0].tv_sec * 1000000ULL + timevals[0].tv_usec;
         unsigned long e = timevals[1].tv_sec * 1000000ULL + timevals[1].tv_usec;
         if (!start_time || s < start_time)
@@ -93,7 +110,10 @@ int main(int argc, char** argv) {
     }
     close(pipes[2]);
 
-    write(pipes[5], bytes, times);
+    if (write(pipes[5], bytes, times) != times) {
+        perror("write error");
+        return 1;
+    }
     close(pipes[5]);
 
     for (i = 0; i < times; i++) {

--- a/LibOS/shim/test/benchmark/rpc_latency.c
+++ b/LibOS/shim/test/benchmark/rpc_latency.c
@@ -18,19 +18,20 @@ int main(int argc, char** argv) {
     if (argc >= 2) {
         times = atoi(argv[1]) / 2;
         if (times > TEST_TIMES)
-            return -1;
+            return 1;
     }
 
-    pipe(&pipes[0]);
-    pipe(&pipes[2]);
-    pipe(&pipes[4]);
+    if (pipe(&pipes[0]) < 0 || pipe(&pipes[2]) < 0 || pipe(&pipes[4]) < 0) {
+        perror("pipe error");
+        return 1;
+    }
 
     for (i = 0; i < times; i++) {
         pids[i][0] = fork();
 
         if (pids[i][0] < 0) {
             printf("fork failed\n");
-            return -1;
+            return 1;
         }
 
         if (pids[i][0] == 0) {
@@ -40,7 +41,10 @@ int main(int argc, char** argv) {
             close(pipes[4]);
             close(pipes[5]);
             char byte;
-            read(pipes[2], &byte, 1);
+            if (read(pipes[2], &byte, 1) != 1) {
+                perror("read error");
+                return 1;
+            }
             close(pipes[2]);
             exit(0);
         }
@@ -49,7 +53,7 @@ int main(int argc, char** argv) {
 
         if (pids[i][1] < 0) {
             printf("fork failed\n");
-            return -1;
+            return 1;
         }
 
         if (pids[i][1] == 0) {
@@ -57,7 +61,10 @@ int main(int argc, char** argv) {
             close(pipes[3]);
             close(pipes[4]);
             char byte;
-            read(pipes[0], &byte, 1);
+            if (read(pipes[0], &byte, 1) != 1) {
+                perror("read error");
+                return 1;
+            }
 
             struct timeval timevals[2];
             gettimeofday(&timevals[0], NULL);
@@ -68,10 +75,17 @@ int main(int argc, char** argv) {
 
             close(pipes[0]);
 
-            write(pipes[5], timevals, sizeof(struct timeval) * 2);
+            if (write(pipes[5], timevals, sizeof(struct timeval) * 2)
+                    != sizeof(struct timeval) * 2) {
+                perror("write error");
+                return 1;
+            }
             close(pipes[5]);
 
-            read(pipes[2], &byte, 1);
+            if (read(pipes[2], &byte, 1) != 1) {
+                perror("read error");
+                return 1;
+            }
             close(pipes[2]);
 
             exit(0);
@@ -84,14 +98,20 @@ int main(int argc, char** argv) {
 
     sleep(1);
     char bytes[times * 2];
-    write(pipes[1], bytes, times);
+    if (write(pipes[1], bytes, times) != times) {
+        perror("write error");
+        return 1;
+    }
     close(pipes[1]);
 
     unsigned long long start_time = 0;
     unsigned long long end_time   = 0;
     struct timeval timevals[2];
     for (int i = 0; i < times; i++) {
-        read(pipes[4], timevals, sizeof(struct timeval) * 2);
+        if (read(pipes[4], timevals, sizeof(struct timeval) * 2) != sizeof(struct timeval) * 2) {
+            perror("read error");
+            return 1;
+        }
         unsigned long s = timevals[0].tv_sec * 1000000ULL + timevals[0].tv_usec;
         unsigned long e = timevals[1].tv_sec * 1000000ULL + timevals[1].tv_usec;
         if (!start_time || s < start_time)
@@ -101,7 +121,10 @@ int main(int argc, char** argv) {
     }
     close(pipes[4]);
 
-    write(pipes[3], bytes, times * 2);
+    if (write(pipes[3], bytes, times * 2) != times * 2) {
+        perror("write error");
+        return 1;
+    }
     close(pipes[3]);
 
     for (i = 0; i < times; i++) {

--- a/LibOS/shim/test/benchmark/rpc_latency2.c
+++ b/LibOS/shim/test/benchmark/rpc_latency2.c
@@ -18,19 +18,20 @@ int main(int argc, char** argv) {
     if (argc >= 2) {
         times = atoi(argv[1]) / 2;
         if (times > TEST_TIMES)
-            return -1;
+            return 1;
     }
 
-    pipe(&pipes[0]);
-    pipe(&pipes[2]);
-    pipe(&pipes[4]);
+    if (pipe(&pipes[0]) < 0 || pipe(&pipes[2]) < 0 || pipe(&pipes[4]) < 0) {
+        perror("pipe error");
+        return 1;
+    }
 
     for (i = 0; i < times; i++) {
         pids[i][0] = fork();
 
         if (pids[i][0] < 0) {
             printf("fork failed\n");
-            return -1;
+            return 1;
         }
 
         if (pids[i][0] == 0) {
@@ -47,7 +48,10 @@ int main(int argc, char** argv) {
                 send_rpc(pid, &byte, 1);
             }
 
-            read(pipes[2], &byte, 1);
+            if (read(pipes[2], &byte, 1) != 1) {
+                perror("read error");
+                return 1;
+            }
             close(pipes[2]);
             exit(0);
         }
@@ -56,7 +60,7 @@ int main(int argc, char** argv) {
 
         if (pids[i][1] < 0) {
             printf("fork failed\n");
-            return -1;
+            return 1;
         }
 
         if (pids[i][1] == 0) {
@@ -65,7 +69,10 @@ int main(int argc, char** argv) {
             close(pipes[4]);
 
             char byte;
-            read(pipes[0], &byte, 1);
+            if (read(pipes[0], &byte, 1) != 1) {
+                perror("read error");
+                return 1;
+            }
 
             struct timeval timevals[2];
             gettimeofday(&timevals[0], NULL);
@@ -79,10 +86,17 @@ int main(int argc, char** argv) {
             gettimeofday(&timevals[1], NULL);
             close(pipes[0]);
 
-            write(pipes[5], timevals, sizeof(struct timeval) * 2);
+            if (write(pipes[5], timevals, sizeof(struct timeval) * 2)
+                    != sizeof(struct timeval) * 2) {
+                perror("write error");
+                return 1;
+            }
             close(pipes[5]);
 
-            read(pipes[2], &byte, 1);
+            if (read(pipes[2], &byte, 1) != 1) {
+                perror("read error");
+                return 1;
+            }
             close(pipes[2]);
 
             exit(0);
@@ -95,14 +109,21 @@ int main(int argc, char** argv) {
 
     sleep(1);
     char bytes[times * 2];
-    write(pipes[1], bytes, times);
+    if (write(pipes[1], bytes, times) != times) {
+        perror("write error");
+        return 1;
+    }
+
     close(pipes[1]);
 
     unsigned long long start_time = 0;
     unsigned long long end_time   = 0;
     struct timeval timevals[2];
     for (int i = 0; i < times; i++) {
-        read(pipes[4], timevals, sizeof(struct timeval) * 2);
+        if (read(pipes[4], timevals, sizeof(struct timeval) * 2) != sizeof(struct timeval) * 2) {
+            perror("read error");
+            return 1;
+        }
         unsigned long s = timevals[0].tv_sec * 1000000ULL + timevals[0].tv_usec;
         unsigned long e = timevals[1].tv_sec * 1000000ULL + timevals[1].tv_usec;
         if (!start_time || s < start_time)
@@ -112,7 +133,10 @@ int main(int argc, char** argv) {
     }
     close(pipes[4]);
 
-    write(pipes[3], bytes, times * 2);
+    if (write(pipes[3], bytes, times * 2) != times * 2) {
+        perror("write error");
+        return 1;
+    }
     close(pipes[3]);
 
     for (i = 0; i < times; i++) {

--- a/LibOS/shim/test/benchmark/start.c
+++ b/LibOS/shim/test/benchmark/start.c
@@ -9,7 +9,7 @@ int main(int argc, char** argv, char** envp) {
     gettimeofday(&tv, NULL);
 
     if (argc < 2)
-        return -1;
+        return 1;
 
     unsigned long long msec1 = atoll(argv[1]);
     unsigned long long msec2 = tv.tv_sec * 1000000ULL + tv.tv_usec;

--- a/LibOS/shim/test/benchmark/test_start.c
+++ b/LibOS/shim/test/benchmark/test_start.c
@@ -3,6 +3,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/time.h>
+#include <sys/types.h>
 #include <sys/wait.h>
 #include <unistd.h>
 
@@ -68,7 +69,7 @@ int main(int argc, char** argv, char** envp) {
             get_time(time_arg, overhead);
 
             execve(new_argv[0], new_argv, envp);
-            exit(-1);
+            exit(1);
         }
 
         close(pipes[1]);

--- a/LibOS/shim/test/native/dup.c
+++ b/LibOS/shim/test/native/dup.c
@@ -1,3 +1,4 @@
+#define _XOPEN_SOURCE 700
 #include <stdio.h>
 #include <unistd.h>
 

--- a/LibOS/shim/test/native/epoll.c
+++ b/LibOS/shim/test/native/epoll.c
@@ -47,7 +47,10 @@ int main(int argc, char** argv) {
         for (int i = 0; i < TEST_TIMES; i++) {
             close(fds[i][0]);
             char c = 0;
-            write(fds[i][1], &c, 1);
+            if (write(fds[i][1], &c, 1) != 1) {
+                perror("write error");
+                exit(1);
+            }
             close(fds[i][1]);
         }
 
@@ -70,7 +73,10 @@ int main(int argc, char** argv) {
 
         if (event.events & EPOLLIN) {
             char c;
-            read(event.data.fd, &c, 1);
+            if (read(event.data.fd, &c, 1) != 1) {
+                perror("read error");
+                exit(1);
+            }
         }
 
         printf("fd %d polled:", event.data.fd);

--- a/LibOS/shim/test/native/epoll_socket.c
+++ b/LibOS/shim/test/native/epoll_socket.c
@@ -4,6 +4,7 @@
 
 // Meant to be used for edge triggered epoll
 
+#define _GNU_SOURCE
 #include <errno.h>
 #include <fcntl.h>
 #include <netdb.h>

--- a/LibOS/shim/test/native/file.c
+++ b/LibOS/shim/test/native/file.c
@@ -10,7 +10,10 @@ int main(int argc, char** argv) {
         return 1;
     }
 
-    write(fd1, "Hello World\n", 12);
+    if (write(fd1, "Hello World\n", 12) != 12) {
+        perror("write error");
+        return 1;
+    }
     close(fd1);
 
     int fd2 = open("testfile", O_RDONLY, 0600);

--- a/LibOS/shim/test/native/fork.c
+++ b/LibOS/shim/test/native/fork.c
@@ -2,6 +2,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/types.h>
 #include <sys/wait.h>
 #include <unistd.h>
 

--- a/LibOS/shim/test/native/fork_exec.c
+++ b/LibOS/shim/test/native/fork_exec.c
@@ -1,3 +1,4 @@
+#define _XOPEN_SOURCE 700
 #include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/LibOS/shim/test/native/fs.c
+++ b/LibOS/shim/test/native/fs.c
@@ -1,3 +1,4 @@
+#define _XOPEN_SOURCE 700
 #include <errno.h>
 #include <fcntl.h>
 #include <stdio.h>
@@ -14,8 +15,14 @@ int main() {
 
     int ret;
     while ((ret = read(fd2, buf, 4096)) > 0) {
-        write(1, buf, ret);
-        write(fd, buf, ret);
+        if (write(1, buf, ret) != ret || write(fd, buf, ret) != ret) {
+            perror("write error");
+            return 1;
+        }
+    }
+    if (ret < 0) {
+        perror("read error");
+        return 1;
     }
 
     close(fd);

--- a/LibOS/shim/test/native/get_time.c
+++ b/LibOS/shim/test/native/get_time.c
@@ -3,6 +3,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/time.h>
+#include <sys/types.h>
 #include <sys/wait.h>
 #include <unistd.h>
 
@@ -63,11 +64,14 @@ int main(int argc, char** argv, char** envp) {
             get_time(time_arg, overhead);
 
             close(pipes[0]);
-            write(pipes[1], time_arg, 30);
+            if (write(pipes[1], time_arg, 30) != 30) {
+                perror("write error");
+                return 1;
+            }
             close(pipes[1]);
 
             execve(new_argv[0], new_argv, envp);
-            exit(-1);
+            exit(1);
         }
 
         close(pipes[1]);

--- a/LibOS/shim/test/native/kill.c
+++ b/LibOS/shim/test/native/kill.c
@@ -1,8 +1,10 @@
+#define _XOPEN_SOURCE 700
 #include <errno.h>
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/types.h>
 #include <time.h>
 #include <unistd.h>
 

--- a/LibOS/shim/test/native/malloc.c
+++ b/LibOS/shim/test/native/malloc.c
@@ -1,14 +1,14 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+static const size_t sizes[] = { 16, 32, 64, 128, 256, 512 };
 int main(int argc, char** argv) {
     for (int i = 0; i < 100000; i++) {
-        malloc(16);
-        malloc(32);
-        malloc(64);
-        malloc(128);
-        malloc(256);
-        malloc(512);
+        for (int j = 0; j < sizeof(sizes) / sizeof(sizes[0]); j++) {
+            if (!malloc(sizes[j])) {
+                return 1;
+            }
+        }
     }
     return 0;
 }

--- a/LibOS/shim/test/native/msg_create_libos.c
+++ b/LibOS/shim/test/native/msg_create_libos.c
@@ -1,5 +1,6 @@
 /* Test to create 100 message queues and query them from another process*/
 
+#define _XOPEN_SOURCE 700
 #include <shim_unistd.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/LibOS/shim/test/native/msg_send.c
+++ b/LibOS/shim/test/native/msg_send.c
@@ -1,3 +1,5 @@
+#define _GNU_SOURCE
+#include <stdalign.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -10,11 +12,6 @@
 
 #define PAYLOAD_SIZE 10
 
-struct msgbuf {
-    long mtype;
-    char mtext[PAYLOAD_SIZE];
-};
-
 #define TEST_TIMES 1000
 #define TEST_TYPES 2
 #define DO_BENCH   1
@@ -26,7 +23,8 @@ int pipefds[4], key;
 void server(void) {
     struct timeval tv1, tv2;
     int msqid;
-    struct msgbuf buf;
+    alignas(struct msgbuf) char _data[sizeof(struct msgbuf) + PAYLOAD_SIZE];
+    struct msgbuf* buf = (struct msgbuf*)_data;
 
     if ((msqid = msgget(key, mode == SERIAL ? 0600 | IPC_CREAT : 0)) < 0) {
         perror("msgget");
@@ -36,14 +34,14 @@ void server(void) {
     gettimeofday(&tv1, NULL);
 
     for (int i = 0; i < TEST_TIMES; i++) {
-        buf.mtype = (i % TEST_TYPES) + 1;
-        if (msgsnd(msqid, &buf, PAYLOAD_SIZE, 0) < 0) {
+        buf->mtype = (i % TEST_TYPES) + 1;
+        if (msgsnd(msqid, buf, PAYLOAD_SIZE, 0) < 0) {
             perror("msgsnd");
             exit(1);
         }
 
 #ifndef DO_BENCH
-        printf("Message: \"%s\" sent\n", buf.mtext);
+        printf("Message: \"%s\" sent\n", buf->mtext);
 #endif
     }
 
@@ -53,10 +51,16 @@ void server(void) {
         char byte = 0;
 
         close(pipefds[0]);
-        write(pipefds[1], &byte, 1);
+        if (write(pipefds[1], &byte, 1) != 1) {
+            perror("write error");
+            exit(1);
+        }
 
         close(pipefds[3]);
-        read(pipefds[2], &byte, 1);
+        if (read(pipefds[2], &byte, 1) != 1) {
+            perror("read error");
+            exit(1);
+        }
     }
 
     printf("time spent on %d msgsnd: %llu microsecond\n", TEST_TIMES,
@@ -70,13 +74,17 @@ void server(void) {
 void client(void) {
     struct timeval tv1, tv2;
     int msqid;
-    struct msgbuf buf;
+    alignas(struct msgbuf) char _data[sizeof(struct msgbuf) + PAYLOAD_SIZE];
+    struct msgbuf* buf = (struct msgbuf*)_data;
     int ret;
 
     if (mode == PARALLEL) {
         char byte = 0;
         close(pipefds[1]);
-        read(pipefds[0], &byte, 1);
+        if (read(pipefds[0], &byte, 1) != 1) {
+            perror("read error");
+            exit(1);
+        }
     }
 
     if ((msqid = msgget(key, 0)) < 0) {
@@ -88,14 +96,14 @@ void client(void) {
 
     for (int i = 0; i < TEST_TIMES; i++) {
         int type = (i % TEST_TYPES) + 1;
-        if ((ret = msgrcv(msqid, &buf, PAYLOAD_SIZE, type, 0)) < 0) {
+        if ((ret = msgrcv(msqid, buf, PAYLOAD_SIZE, type, 0)) < 0) {
             perror("msgrcv");
             exit(1);
         }
 
 #ifndef DO_BENCH
-        buf.mtext[ret] = 0;
-        printf("Client received: \"%s\"\n", buf.mtext);
+        buf->mtext[ret] = 0;
+        printf("Client received: \"%s\"\n", buf->mtext);
 #endif
     }
 
@@ -104,7 +112,10 @@ void client(void) {
     if (mode == PARALLEL) {
         char byte = 0;
         close(pipefds[2]);
-        write(pipefds[3], &byte, 1);
+        if (write(pipefds[3], &byte, 1) != 1) {
+            perror("write error");
+            exit(1);
+        }
     }
 
     printf("time spent on %d msgrcv: %llu microsecond\n", TEST_TIMES,
@@ -149,8 +160,10 @@ int main(int argc, char** argv) {
         return 0;
     }
 
-    pipe(&pipefds[0]);
-    pipe(&pipefds[2]);
+    if (pipe(&pipefds[0]) < 0 || pipe(&pipefds[2]) < 0) {
+        perror("pipe error");
+        return 1;
+    }
 
     /* server to be the parent and client to be the child */
     if (argc == 1) {

--- a/LibOS/shim/test/native/msg_send_libos.c
+++ b/LibOS/shim/test/native/msg_send_libos.c
@@ -1,3 +1,4 @@
+#define _XOPEN_SOURCE 700
 #include <shim_unistd.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/LibOS/shim/test/native/multiproc.c
+++ b/LibOS/shim/test/native/multiproc.c
@@ -1,4 +1,5 @@
 #include <stdlib.h>
+#include <sys/types.h>
 #include <sys/wait.h>
 #include <unistd.h>
 

--- a/LibOS/shim/test/native/pid_alloc.c
+++ b/LibOS/shim/test/native/pid_alloc.c
@@ -1,7 +1,7 @@
+#define _GNU_SOURCE
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
-#define __USE_GNU
 #include <sched.h>
 #include <sys/time.h>
 #include <sys/wait.h>

--- a/LibOS/shim/test/native/pipe.c
+++ b/LibOS/shim/test/native/pipe.c
@@ -6,7 +6,10 @@
 int main(int argc, char** argv) {
     int pipes[2];
 
-    pipe(pipes);
+    if (pipe(pipes) < 0) {
+        perror("pipe error");
+        return 1;
+    }
 
     int pid1 = fork();
 
@@ -17,7 +20,10 @@ int main(int argc, char** argv) {
 
     if (pid1 == 0) {
         close(pipes[0]);
-        write(pipes[1], "hello world", 12);
+        if (write(pipes[1], "hello world", 12) != 12) {
+            perror("write error");
+            return 1;
+        }
         return 0;
     }
 

--- a/LibOS/shim/test/native/pipe_latency.c
+++ b/LibOS/shim/test/native/pipe_latency.c
@@ -17,23 +17,26 @@ int main(int argc, char** argv) {
     if (argc >= 2) {
         times = atoi(argv[1]) / 2;
         if (times > TEST_TIMES)
-            return -1;
+            return 1;
     }
 
-    pipe(&pipes[0]);
-    pipe(&pipes[2]);
-    pipe(&pipes[4]);
+    if (pipe(&pipes[0]) < 0 || pipe(&pipes[2]) < 0 || pipe(&pipes[4]) < 0) {
+        perror("pipe error");
+        return 1;
+    }
 
     for (i = 0; i < times; i++) {
         int pair_pipes[4];
-        pipe(&pair_pipes[0]);
-        pipe(&pair_pipes[2]);
+        if (pipe(&pair_pipes[0]) < 0 || pipe(&pair_pipes[2]) < 0) {
+            perror("pipe error");
+            return 1;
+        }
 
         pids[i][0] = fork();
 
         if (pids[i][0] < 0) {
             printf("fork failed\n");
-            return -1;
+            return 1;
         }
 
         if (pids[i][0] == 0) {
@@ -48,11 +51,20 @@ int main(int argc, char** argv) {
 
             char byte;
             for (int i = 0; i < NTRIES; i++) {
-                read(pair_pipes[0], &byte, 1);
-                write(pair_pipes[3], &byte, 1);
+                if (read(pair_pipes[0], &byte, 1) != 1) {
+                    perror("read error");
+                    exit(1);
+                }
+                if (write(pair_pipes[3], &byte, 1) != 1) {
+                    perror("write error");
+                    exit(1);
+                }
             }
 
-            read(pipes[2], &byte, 1);
+            if (read(pipes[2], &byte, 1) != 1) {
+                perror("read error");
+                exit(1);
+            }
             close(pipes[2]);
 
             close(pair_pipes[0]);
@@ -65,7 +77,7 @@ int main(int argc, char** argv) {
 
         if (pids[i][1] < 0) {
             printf("fork failed\n");
-            return -1;
+            return 1;
         }
 
         if (pids[i][1] == 0) {
@@ -77,14 +89,23 @@ int main(int argc, char** argv) {
             close(pair_pipes[3]);
 
             char byte;
-            read(pipes[0], &byte, 1);
+            if (read(pipes[0], &byte, 1) != 1) {
+                perror("read error");
+                exit(1);
+            }
 
             struct timeval timevals[2];
             gettimeofday(&timevals[0], NULL);
 
             for (int i = 0; i < NTRIES; i++) {
-                write(pair_pipes[1], &byte, 1);
-                read(pair_pipes[2], &byte, 1);
+                if (write(pair_pipes[1], &byte, 1) != 1) {
+                    perror("write error");
+                    exit(1);
+                }
+                if (read(pair_pipes[2], &byte, 1) != 1) {
+                    perror("read error");
+                    exit(1);
+                }
             }
 
             gettimeofday(&timevals[1], NULL);
@@ -94,10 +115,17 @@ int main(int argc, char** argv) {
 
             close(pipes[0]);
 
-            write(pipes[5], timevals, sizeof(struct timeval) * 2);
+            if (write(pipes[5], timevals, sizeof(struct timeval) * 2)
+                    != sizeof(struct timeval) * 2) {
+                perror("write error");
+                exit(1);
+            }
             close(pipes[5]);
 
-            read(pipes[2], &byte, 1);
+            if (read(pipes[2], &byte, 1) != 1) {
+                perror("read error");
+                exit(1);
+            }
             close(pipes[2]);
 
             exit(0);
@@ -110,14 +138,21 @@ int main(int argc, char** argv) {
 
     sleep(1);
     char bytes[times * 2];
-    write(pipes[1], bytes, times);
+    if (write(pipes[1], bytes, times) != times) {
+        perror("write error");
+        return 1;
+    }
     close(pipes[1]);
 
     unsigned long long start_time = 0;
     unsigned long long end_time   = 0;
     struct timeval timevals[2];
     for (int i = 0; i < times; i++) {
-        read(pipes[4], timevals, sizeof(struct timeval) * 2);
+        if (read(pipes[4], timevals, sizeof(struct timeval) * 2) != sizeof(struct timeval) * 2) {
+            perror("read error");
+            exit(1);
+        }
+
         unsigned long s = timevals[0].tv_sec * 1000000ULL + timevals[0].tv_usec;
         unsigned long e = timevals[1].tv_sec * 1000000ULL + timevals[1].tv_usec;
         if (!start_time || s < start_time)
@@ -127,7 +162,10 @@ int main(int argc, char** argv) {
     }
     close(pipes[4]);
 
-    write(pipes[3], bytes, times * 2);
+    if (write(pipes[3], bytes, times * 2) != times * 2) {
+        perror ("write error");
+        return 1;
+    }
     close(pipes[3]);
 
     for (i = 0; i < times; i++) {

--- a/LibOS/shim/test/native/script.c
+++ b/LibOS/shim/test/native/script.c
@@ -1,3 +1,4 @@
+#define _XOPEN_SOURCE 700
 #include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/LibOS/shim/test/native/sem.c
+++ b/LibOS/shim/test/native/sem.c
@@ -1,3 +1,4 @@
+#define _GNU_SOURCE
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -49,7 +50,10 @@ void server(void) {
     if (mode == PARALLEL) {
         close(pipefds[0]);
         char byte = 0;
-        write(pipefds[1], &byte, 1);
+        if (write(pipefds[1], &byte, 1) != 1) {
+            perror("write error");
+            exit(1);
+        }
 
         buf.sem_num = 1;
         buf.sem_op  = -1;
@@ -75,7 +79,10 @@ void client(void) {
     if (mode == PARALLEL) {
         close(pipefds[1]);
         char byte = 0;
-        read(pipefds[0], &byte, 1);
+        if (read(pipefds[0], &byte, 1) != 1) {
+            perror("read error");
+            exit(1);
+        }
     }
 
     if ((semid = semget(key, 0, 0)) < 0) {
@@ -154,7 +161,10 @@ int main(int argc, char** argv) {
         return 0;
     }
 
-    pipe(pipefds);
+    if (pipe(pipefds) < 0) {
+        perror("pipe error");
+        return 1;
+    }
 
     /* server to be the parent and client to be the child */
     if (argc == 1) {

--- a/LibOS/shim/test/native/socketpair.c
+++ b/LibOS/shim/test/native/socketpair.c
@@ -18,7 +18,9 @@ int main(int argc, char** argv) {
 
     if (pid1 == 0) {
         close(sv[0]);
-        write(sv[1], "hello world", 12);
+        if (write(sv[1], "hello world", 12) != 12) {
+            return 1;
+        }
         return 0;
     }
 

--- a/LibOS/shim/test/native/sqrt.c
+++ b/LibOS/shim/test/native/sqrt.c
@@ -6,7 +6,10 @@ int main(int argc, char** argv) {
 
     printf("enter a float: ");
     fflush(stdin);
-    scanf("%f", &x);
+    if (scanf("%f", &x) != 1) {
+        perror("reading error");
+        return 1;
+    }
     printf("sqrt(x) = %f\n", sqrt(x));
 
     return 0;

--- a/LibOS/shim/test/native/system.c
+++ b/LibOS/shim/test/native/system.c
@@ -1,6 +1,8 @@
 #include <stdlib.h>
 
 int main(int argc, char** argv) {
-    system("./helloworld");
+    if (system("./helloworld")) {
+        return 1;
+    }
     return 0;
 }

--- a/LibOS/shim/test/native/tcp.c
+++ b/LibOS/shim/test/native/tcp.c
@@ -54,7 +54,10 @@ int server(void) {
     if (mode == PARALLEL) {
         close(pipefds[0]);
         char byte = 0;
-        write(pipefds[1], &byte, 1);
+        if (write(pipefds[1], &byte, 1) != 1) {
+            perror("write error");
+            exit(1);
+        }
     }
 
     addrlen    = sizeof(address);
@@ -110,7 +113,10 @@ int client(void) {
     if (mode == PARALLEL) {
         close(pipefds[1]);
         char byte = 0;
-        read(pipefds[0], &byte, 1);
+        if (read(pipefds[0], &byte, 1) != 1) {
+            perror("read error");
+            exit(1);
+        }
     }
 
     if ((create_socket = socket(AF_INET, SOCK_STREAM, 0)) >= 0)
@@ -137,7 +143,10 @@ int client(void) {
     printf("Content:\n");
 
     while ((count = recv(create_socket, buffer, bufsize, 0)) > 0) {
-        write(1, buffer, count);
+        if (write(1, buffer, count) != count) {
+            perror("write error");
+            exit(1);
+        }
     }
 
     printf("EOF\n");
@@ -176,7 +185,10 @@ int main(int argc, char** argv) {
         }
     } else {
     old:
-        pipe(pipefds);
+        if (pipe(pipefds) < 0) {
+            perror("pipe error");
+            return 1;
+        }
 
         int pid = fork();
 

--- a/LibOS/shim/test/native/test_start_pthread_m.c
+++ b/LibOS/shim/test/native/test_start_pthread_m.c
@@ -3,6 +3,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/time.h>
+#include <sys/types.h>
 #include <sys/wait.h>
 #include <unistd.h>
 

--- a/LibOS/shim/test/native/vfork.c
+++ b/LibOS/shim/test/native/vfork.c
@@ -1,3 +1,4 @@
+#define _GNU_SOURCE
 #include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/LibOS/shim/test/native/vfork_exec.c
+++ b/LibOS/shim/test/native/vfork_exec.c
@@ -1,3 +1,4 @@
+#define _GNU_SOURCE
 #include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/LibOS/shim/test/regression/epoll_wait_timeout.c
+++ b/LibOS/shim/test/regression/epoll_wait_timeout.c
@@ -1,3 +1,4 @@
+#define _XOPEN_SOURCE 700
 #include <errno.h>
 #include <fcntl.h>
 #include <netdb.h>

--- a/LibOS/shim/test/regression/eventfd.c
+++ b/LibOS/shim/test/regression/eventfd.c
@@ -50,7 +50,10 @@ void* write_eventfd_thread(void* arg) {
 
     for (int i = 0; i < MAX_EFDS; i++) {
         sleep(1);
-        write(efds[i], &count, sizeof(count));
+        if (write(efds[i], &count, sizeof(count)) != sizeof(count)) {
+            perror("write error");
+            return NULL;
+        }
         count += 1;
     }
 
@@ -107,7 +110,11 @@ int eventfd_using_poll() {
             if (pollfds[i].revents & POLLIN) {
                 pollfds[i].revents = 0;
                 errno              = 0;
-                read(pollfds[i].fd, &count, sizeof(count));
+                if (read(pollfds[i].fd, &count, sizeof(count)) != sizeof(count)) {
+                    perror("read error");
+                    ret = 1;
+                    goto out;
+                }
                 printf("fd set=%d\n", pollfds[i].fd);
                 printf("efd = %d, count: %lu, errno=%d\n", pollfds[i].fd, count, errno);
                 nread_events++;
@@ -173,6 +180,7 @@ int eventfd_using_various_flags() {
                 close(efd);
                 return 1;
             }
+            close(efd);
             continue;
         }
 
@@ -189,7 +197,14 @@ int eventfd_using_various_flags() {
         if (eventfd_flags[i] & EFD_NONBLOCK) {
             count = 0;
             errno = 0;
-            read(efd, &count, sizeof(count));
+            ssize_t ret = read(efd, &count, sizeof(count));
+            if (ret != -1 || errno != EAGAIN) {
+                printf("read that should return -1 with EAGAIN returned: %ld with errno=%d\n",
+                       ret,
+                       errno);
+                close(efd);
+                return 1;
+            }
             printf("%d: efd = %d, count: %lu, errno=%d\n", __LINE__, efd, count, errno);
         }
 
@@ -218,7 +233,10 @@ int eventfd_using_fork() {
     if (pid == 0) {
         // child process
         count = 5;
-        write(efd, &count, sizeof(count));
+        if (write(efd, &count, sizeof(count)) != sizeof(count)) {
+            perror("write error");
+            exit(1);
+        }
         exit(0);
     } else if (pid > 0) {
         // parent process
@@ -230,7 +248,11 @@ int eventfd_using_fork() {
         }
 
         count = 0;
-        read(efd, &count, sizeof(count));
+        if (read(efd, &count, sizeof(count)) != sizeof(count)) {
+            perror("read error");
+            close(efd);
+            exit(1);
+        }
         if (count != 5) {
             printf("parent-pid=%d, efd = %d, count: %lu, errno=%d\n", getpid(), efd, count, errno);
             CLOSE_EFD_AND_EXIT(efd);

--- a/LibOS/shim/test/regression/exec.c
+++ b/LibOS/shim/test/regression/exec.c
@@ -1,3 +1,4 @@
+#define _XOPEN_SOURCE 700
 #include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/LibOS/shim/test/regression/exec_victim.c
+++ b/LibOS/shim/test/regression/exec_victim.c
@@ -1,3 +1,4 @@
+#define _XOPEN_SOURCE 700
 #include <stdio.h>
 #include <stdlib.h>
 

--- a/LibOS/shim/test/regression/exit_group.c
+++ b/LibOS/shim/test/regression/exit_group.c
@@ -1,3 +1,4 @@
+#define _XOPEN_SOURCE 700
 #include <linux/unistd.h>
 #include <pthread.h>
 #include <stdatomic.h>

--- a/LibOS/shim/test/regression/fopen_cornercases.c
+++ b/LibOS/shim/test/regression/fopen_cornercases.c
@@ -1,3 +1,4 @@
+#define _XOPEN_SOURCE 700
 #include <errno.h>
 #include <fcntl.h>
 #include <stdio.h>

--- a/LibOS/shim/test/regression/fork_and_exec.c
+++ b/LibOS/shim/test/regression/fork_and_exec.c
@@ -1,3 +1,4 @@
+#define _XOPEN_SOURCE 700
 #include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/LibOS/shim/test/regression/fstat_cwd.c
+++ b/LibOS/shim/test/regression/fstat_cwd.c
@@ -1,3 +1,4 @@
+#define _XOPEN_SOURCE 700
 #include <errno.h>
 #include <fcntl.h>
 #include <stdio.h>

--- a/LibOS/shim/test/regression/futex_timeout.c
+++ b/LibOS/shim/test/regression/futex_timeout.c
@@ -1,3 +1,4 @@
+#define _GNU_SOURCE
 #include <errno.h>
 #include <linux/futex.h>
 #include <stdio.h>

--- a/LibOS/shim/test/regression/getcwd.c
+++ b/LibOS/shim/test/regression/getcwd.c
@@ -1,3 +1,4 @@
+#define _GNU_SOURCE
 #include <errno.h>
 #include <linux/limits.h>
 #include <stdio.h>

--- a/LibOS/shim/test/regression/getdents.c
+++ b/LibOS/shim/test/regression/getdents.c
@@ -1,3 +1,4 @@
+#define _GNU_SOURCE
 #include <dirent.h>
 #include <fcntl.h>
 #include <inttypes.h>

--- a/LibOS/shim/test/regression/getsockopt.c
+++ b/LibOS/shim/test/regression/getsockopt.c
@@ -1,5 +1,6 @@
 /* Unit test for issues #92 and #644 */
 
+#define _GNU_SOURCE
 #include <assert.h>
 #include <errno.h>
 #include <netinet/tcp.h>

--- a/LibOS/shim/test/regression/large-mmap.c
+++ b/LibOS/shim/test/regression/large-mmap.c
@@ -1,3 +1,4 @@
+#define _GNU_SOURCE
 #include <stdio.h>
 #include <sys/mman.h>
 #include <sys/types.h>

--- a/LibOS/shim/test/regression/mmap-file.c
+++ b/LibOS/shim/test/regression/mmap-file.c
@@ -1,3 +1,4 @@
+#define _GNU_SOURCE
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -40,7 +41,7 @@ int main(int argc, const char** argv) {
     a[1023] = 0xff;
     a[4095] = 0xff;
 
-    asm volatile ("nop" ::: "memory");
+    __asm__ volatile ("nop" ::: "memory");
 
     int pid = fork();
     if (pid == -1) {
@@ -55,14 +56,14 @@ int main(int argc, const char** argv) {
         }
     }
 
-    asm volatile ("nop" ::: "memory");
+    __asm__ volatile ("nop" ::: "memory");
 
     a[0] = 0xff;
     printf(pid == 0 ? "mmap test 1 passed\n" : "mmap test 6 passed\n");
     a[1024] = 0xff;
     printf(pid == 0 ? "mmap test 2 passed\n" : "mmap test 7 passed\n");
 
-    asm volatile ("nop" ::: "memory");
+    __asm__ volatile ("nop" ::: "memory");
 
     if (pid == 0) {
         if (a[1023] == 0xff)
@@ -71,7 +72,7 @@ int main(int argc, const char** argv) {
             printf("mmap test 4 passed\n");
     }
 
-    asm volatile ("nop" ::: "memory");
+    __asm__ volatile ("nop" ::: "memory");
 
     if (signal(SIGBUS, SIGBUS_handler) == SIG_ERR) {
         perror("signal");
@@ -80,7 +81,7 @@ int main(int argc, const char** argv) {
 
     message = pid == 0 ? "mmap test 5 passed\n" : "mmap test 8 passed\n";
     /* need a barrier to assign message before SIGBUS due to a[4096] */
-    asm volatile ("nop" ::: "memory");
+    __asm__ volatile ("nop" ::: "memory");
     a[4096] = 0xff;
 
     if (signal(SIGBUS, SIG_DFL) == SIG_ERR) {

--- a/LibOS/shim/test/regression/mprotect_file_fork.c
+++ b/LibOS/shim/test/regression/mprotect_file_fork.c
@@ -1,3 +1,4 @@
+#define _XOPEN_SOURCE 700
 #include <err.h>
 #include <errno.h>
 #include <fcntl.h>

--- a/LibOS/shim/test/regression/poll.c
+++ b/LibOS/shim/test/regression/poll.c
@@ -28,7 +28,11 @@ int main(void) {
     struct pollfd infds[] = {
         {.fd = fd[0], .events = POLLIN},
     };
-    write(fd[1], string, (strlen(string) + 1));
+    size_t len = strlen(string) + 1;
+    if (write(fd[1], string, len) != len) {
+        perror("write error");
+        return 1;
+    }
     ret = poll(infds, 1, -1);
     if (ret <= 0) {
         perror("poll with POLLIN failed");

--- a/LibOS/shim/test/regression/ppoll.c
+++ b/LibOS/shim/test/regression/ppoll.c
@@ -31,7 +31,13 @@ int main(void) {
     struct pollfd infds[] = {
         {.fd = fd[0], .events = POLLIN},
     };
-    write(fd[1], string, (strlen(string) + 1));
+
+    size_t len = strlen(string) + 1;
+    if (write(fd[1], string, len) != len) {
+        perror("write error");
+        return 1;
+    }
+
     ret = ppoll(infds, 1, &tv, NULL);
     if (ret <= 0) {
         perror("ppoll with POLLIN failed");

--- a/LibOS/shim/test/regression/pselect.c
+++ b/LibOS/shim/test/regression/pselect.c
@@ -1,3 +1,4 @@
+#define _XOPEN_SOURCE 700
 #include <stdio.h>
 #include <string.h>
 #include <sys/select.h>
@@ -32,7 +33,11 @@ int main(void) {
     }
     printf("pselect() on write event returned %d file descriptors\n", ret);
 
-    write(fd[1], string, (strlen(string) + 1));
+    size_t len = strlen(string) + 1;
+    if (write(fd[1], string, len) != len) {
+        perror("write error");
+        return 1;
+    }
     ret = pselect(fd[1] + 1, &rfds, NULL, NULL, &tv, NULL);
     if (ret <= 0) {
         perror("pselect() on read event failed");

--- a/LibOS/shim/test/regression/select.c
+++ b/LibOS/shim/test/regression/select.c
@@ -32,7 +32,12 @@ int main(void) {
     }
     printf("select() on write event returned %d file descriptors\n", ret);
 
-    write(fd[1], string, (strlen(string) + 1));
+    size_t len = strlen(string) + 1;
+    if (write(fd[1], string, len) != len) {
+        perror("write error");
+        return 1;
+    }
+
     ret = select(fd[1] + 1, &rfds, NULL, NULL, &tv);
     if (ret <= 0) {
         perror("select() on read event failed");

--- a/LibOS/shim/test/regression/sigaltstack.c
+++ b/LibOS/shim/test/regression/sigaltstack.c
@@ -1,3 +1,4 @@
+#define _XOPEN_SOURCE 700
 #include <err.h>
 #include <inttypes.h>
 #include <signal.h>

--- a/LibOS/shim/test/regression/sigprocmask.c
+++ b/LibOS/shim/test/regression/sigprocmask.c
@@ -1,3 +1,4 @@
+#define _XOPEN_SOURCE 700
 #include <pthread.h>
 #include <signal.h>
 #include <stdio.h>

--- a/LibOS/shim/test/regression/stat_invalid_args.c
+++ b/LibOS/shim/test/regression/stat_invalid_args.c
@@ -1,3 +1,4 @@
+#define _XOPEN_SOURCE 700
 #include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/LibOS/shim/test/regression/tcp_msg_peek.c
+++ b/LibOS/shim/test/regression/tcp_msg_peek.c
@@ -1,3 +1,4 @@
+#define _GNU_SOURCE
 #include <arpa/inet.h>
 #include <errno.h>
 #include <fcntl.h>
@@ -204,7 +205,10 @@ int main(int argc, char** argv) {
             return 0;
         }
     } else {
-        pipe(pipefds);
+        if (pipe(pipefds) < 0) {
+            perror("pipe error");
+            return 1;
+        }
 
         int pid = fork();
 

--- a/LibOS/shim/test/regression/vfork_and_exec.c
+++ b/LibOS/shim/test/regression/vfork_and_exec.c
@@ -1,3 +1,4 @@
+#define _GNU_SOURCE
 #include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/Scripts/Makefile.Test
+++ b/Scripts/Makefile.Test
@@ -15,11 +15,6 @@ RUNTIME = $(abspath $(SCRIPTS_DIR)/../Runtime)
 
 include $(SCRIPTS_DIR)/Makefile.rules
 
-CFLAGS += -std=gnu99
-
-# TODO: enable -Wunused-result
-CFLAGS += -Wno-unused-result
-
 CFLAGS-libos = -I$(SHIMDIR)/include -L$(SHIMDIR)/../glibc-build/libos
 
 CFLAGS-libos-debug = -I$(SHIMDIR)/include -I$(PALDIR)/../include/pal -I$(PALDIR)/../include/lib -fno-builtin -nostdlib


### PR DESCRIPTION
<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->
This PR removes superfluous `std=gnu99` and `Wno-unused-result` from tests makefile.

Fixes  #1272
Closes #1302 

## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1305)
<!-- Reviewable:end -->
