### PR TITLE
[LibOS] fix syntax error shim.lds vdso/vdso.lds

### DIFF
--- a/LibOS/shim/src/Makefile
+++ b/LibOS/shim/src/Makefile
@@ -15,7 +15,6 @@ CFLAGS += -Wextra
 ASFLAGS += -Wa,--noexecstack -x assembler-with-cpp -I../include
 
 LDFLAGS += -shared -nostdlib -z combreloc -z relro -z now -z defs \
-	  -dynamic-link=libpal.so \
 	  -rpath-link=$(abspath $(RUNTIME_DIR))
 
 files_to_build = libsysdb.a libsysdb.so libsysdb_debug.so
@@ -120,13 +119,13 @@ $(files_to_install): $(RUNTIME_DIR)/%: %
 
 LDFLAGS-libsysdb.so += --version-script shim.map -T shim.lds
 libsysdb.so: $(objs) $(filter %.map %.lds,$(LDFLAGS-$@)) \
-	     $(graphene_lib) $(pal_lib)
+	     $(graphene_lib) $(pal_lib) shim.map shim.lds
 	$(call cmd,ld_so_o)
 
 LDFLAGS-libsysdb_debug.so += --version-script shim-debug.map -T shim.lds
 libsysdb_debug.so: $(filter-out syscallas.o,$(objs)) \
 		   $(filter %.map %.lds,$(LDFLAGS-$@)) \
-		   $(graphene_lib) $(pal_lib)
+		   $(graphene_lib) $(pal_lib) shim-debug.map shim.lds
 	$(call cmd,ld_so_o)
 
 .PHONY: graphene_lib_recurse

--- a/LibOS/shim/src/shim.lds
+++ b/LibOS/shim/src/shim.lds
@@ -47,11 +47,11 @@ SECTIONS
     *(.text .stub .text.*);
     . = ALIGN(8);
     __cp_name = .;
-    SORT(*)(SORT(.cp_name.*));
+    *(SORT(.cp_name.*));
     __cp_func = .;
-    SORT(*)(SORT(.cp_func.*));
+    *(SORT(.cp_func.*));
     __rs_func = .;
-    SORT(*)(SORT(.rs_func.*));
+    *(SORT(.rs_func.*));
     __code_address_end = .;
   }
   .fini          : { *(.fini) }

--- a/LibOS/shim/src/vdso/vdso.lds
+++ b/LibOS/shim/src/vdso/vdso.lds
@@ -26,7 +26,7 @@ PHDRS
         text            PT_LOAD         FLAGS(5) FILEHDR PHDRS;
         dynamic         PT_DYNAMIC      FLAGS(4);
         note            PT_NOTE         FLAGS(4);
-        eh_frame_header PT_GNU_EH_FRAME;
+        eh_frame_hdr    PT_GNU_EH_FRAME;
 }
 
 SECTIONS
@@ -53,7 +53,7 @@ SECTIONS
         .note : { *(.note.*) } :text :note
         .eh_frame_hdr : { *(.eh_frame_hdr) } :text :eh_frame_hdr
         .eh_frame : { KEEP (*(.eh_frame)) } :text
-        .text   : { *(.text*) } : text = 0x909090
+        .text   : { *(.text*) } : text = 0x90909090,
 
         /DISCARD/ : {
                 *(.discard)


### PR DESCRIPTION
fix syntax error in shim.lds and vdso/vdso.ld and remove useless option,
-dyanmic-link, for ld option which gnu ld ignores.

<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->


## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1306)
<!-- Reviewable:end -->
