### PR TITLE
[LibOS] change ioctl(, int cmd) to ioctl(, unsigned long cmd)

### DIFF
--- a/LibOS/shim/include/shim_table.h
+++ b/LibOS/shim/include/shim_table.h
@@ -340,7 +340,7 @@ int shim_do_sigaction(int signum, const struct __kernel_sigaction* act,
                       struct __kernel_sigaction* oldact, size_t sigsetsize);
 int shim_do_sigprocmask(int how, const __sigset_t* set, __sigset_t* oldset);
 int shim_do_sigreturn(int __unused);
-int shim_do_ioctl(int fd, int cmd, unsigned long arg);
+int shim_do_ioctl(int fd, unsigned long cmd, unsigned long arg);
 ssize_t shim_do_pread64(int fd, char* buf, size_t count, loff_t pos);
 ssize_t shim_do_pwrite64(int fd, char* buf, size_t count, loff_t pos);
 ssize_t shim_do_readv(int fd, const struct iovec* vec, int vlen);
@@ -522,7 +522,7 @@ int shim_rt_sigaction(int signum, const struct __kernel_sigaction* act,
                       struct __kernel_sigaction* oldact, size_t sigsetsize);
 int shim_rt_sigprocmask(int how, const __sigset_t* set, __sigset_t* oldset);
 int shim_rt_sigreturn(int __unused);
-int shim_ioctl(int fd, int cmd, unsigned long arg);
+int shim_ioctl(int fd, unsigned long cmd, unsigned long arg);
 size_t shim_pread64(int fd, char* buf, size_t count, loff_t pos);
 size_t shim_pwrite64(int fd, char* buf, size_t count, loff_t pos);
 ssize_t shim_readv(int fd, const struct iovec* vec, int vlen);

--- a/LibOS/shim/src/shim_syscalls.c
+++ b/LibOS/shim/src/shim_syscalls.c
@@ -176,7 +176,7 @@ DEFINE_SHIM_SYSCALL(rt_sigprocmask, 3, shim_do_sigprocmask, int, int, how, const
 DEFINE_SHIM_SYSCALL(rt_sigreturn, 1, shim_do_sigreturn, int, int, __unused)
 
 /* ioctl: sys/shim_ioctl.c */
-DEFINE_SHIM_SYSCALL(ioctl, 3, shim_do_ioctl, int, int, fd, int, cmd, unsigned long, arg)
+DEFINE_SHIM_SYSCALL(ioctl, 3, shim_do_ioctl, int, int, fd, unsigned long, cmd, unsigned long, arg)
 
 /* pread64 : sys/shim_open.c */
 DEFINE_SHIM_SYSCALL(pread64, 4, shim_do_pread64, size_t, int, fd, char*, buf, size_t, count, loff_t,

--- a/LibOS/shim/src/sys/shim_ioctl.c
+++ b/LibOS/shim/src/sys/shim_ioctl.c
@@ -303,7 +303,7 @@ void signal_io(IDTYPE target, void* arg) {
     put_thread(thread);
 }
 
-int shim_do_ioctl(int fd, int cmd, unsigned long arg) {
+int shim_do_ioctl(int fd, unsigned long cmd, unsigned long arg) {
     struct shim_handle* hdl = get_fd_handle(fd, NULL, NULL);
     if (!hdl)
         return -EBADF;


### PR DESCRIPTION
The second argument to ioctl is unsigned long, not int.

<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->


## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1307)
<!-- Reviewable:end -->
