### PR TITLE
[LibOS] use right type, struct wake_queue_node*, instead of void*

### DIFF
--- a/LibOS/shim/include/shim_thread.h
+++ b/LibOS/shim/include/shim_thread.h
@@ -251,7 +251,7 @@ static inline void thread_wakeup (struct shim_thread * thread)
  *
  * Returns 0 if the thread was added to the queue, 1 otherwise. */
 static inline int add_thread_to_queue(struct wake_queue_head* queue, struct shim_thread* thread) {
-    void* nptr = NULL;
+    struct wake_queue_node* nptr = NULL;
     struct wake_queue_node* qnode = &thread->wake_queue;
 
     /* Atomic cmpxchg is enough, no need to take thread->lock */


### PR DESCRIPTION
add_thread_to_queue() should use struct wake_queue_node* instead of void*.

add_thread_to_queue

<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->


## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1308)
<!-- Reviewable:end -->
