### PR TITLE
[Pal/{Linux, Linux-SGX}] remove duplicated label, thread_start in clo…

### DIFF
--- a/Pal/src/host/Linux-SGX/clone-x86_64.S
+++ b/Pal/src/host/Linux-SGX/clone-x86_64.S
@@ -91,7 +91,6 @@ ENTRY (clone)
 	ret
 
 ENTRY (thread_start)
-thread_start:
 	cfi_startproc
 	/* Clearing frame pointer is insufficient, use CFI.  */
 	cfi_undefined (rip)

--- a/Pal/src/host/Linux/clone-x86_64.S
+++ b/Pal/src/host/Linux/clone-x86_64.S
@@ -91,7 +91,6 @@ ENTRY (clone)
 	ret
 
 ENTRY (thread_start)
-thread_start:
 	cfi_startproc
 	/* Clearing frame pointer is insufficient, use CFI.  */
 	cfi_undefined (rip)


### PR DESCRIPTION
…ne-x86_64.S

ENTRY() macro defines label, so laben doesn't need to be defined again.

<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [x] Linux PAL
- [x] SGX PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->


## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1309)
<!-- Reviewable:end -->
