### PR TITLE
[LibOS] eliminated unnecessary nested function

### DIFF
--- a/LibOS/shim/include/shim_checkpoint.h
+++ b/LibOS/shim/include/shim_checkpoint.h
@@ -326,9 +326,9 @@ struct shim_cp_map_entry* get_cp_map_entry(void* map, void* addr, bool create);
         e->off                      = (off);                                      \
     } while (0)
 
-#define BEGIN_MIGRATION_DEF(name, ...)                               \
-    int migrate_##name(struct shim_cp_store* store, ##__VA_ARGS__) { \
-        int ret    = 0;                                              \
+#define BEGIN_MIGRATION_DEF(name, ...)                                  \
+    int migrate_cp_##name(struct shim_cp_store* store, ##__VA_ARGS__) { \
+        int ret    = 0;                                                 \
         ptr_t base = store->base;
 
 #define END_MIGRATION_DEF(name)     \
@@ -367,7 +367,7 @@ struct shim_cp_map_entry* get_cp_map_entry(void* map, void* addr, bool create);
             }                                                              \
             SAVE_PROFILE_INTERVAL(checkpoint_create_map);                  \
                                                                            \
-            ret = migrate_##name(store, ##__VA_ARGS__);                    \
+            ret = migrate_cp_##name(store, ##__VA_ARGS__);                 \
             if (ret < 0)                                                   \
                 goto out;                                                  \
                                                                            \

--- a/LibOS/shim/src/sys/shim_fork.c
+++ b/LibOS/shim/src/sys/shim_fork.c
@@ -35,24 +35,24 @@
 #include <shim_table.h>
 #include <shim_thread.h>
 
+static BEGIN_MIGRATION_DEF(fork, struct shim_thread* thread, struct shim_process* process) {
+    DEFINE_MIGRATE(process, process, sizeof(struct shim_process));
+    DEFINE_MIGRATE(all_mounts, NULL, 0);
+    DEFINE_MIGRATE(all_vmas, NULL, 0);
+    DEFINE_MIGRATE(running_thread, thread, sizeof(struct shim_thread));
+    DEFINE_MIGRATE(handle_map, thread->handle_map, sizeof(struct shim_handle_map));
+    DEFINE_MIGRATE(migratable, NULL, 0);
+    DEFINE_MIGRATE(brk, NULL, 0);
+    DEFINE_MIGRATE(loaded_libraries, NULL, 0);
+#ifdef DEBUG
+    DEFINE_MIGRATE(gdb_map, NULL, 0);
+#endif
+}
+END_MIGRATION_DEF(fork)
+
 int migrate_fork(struct shim_cp_store* store, struct shim_thread* thread,
                  struct shim_process* process, va_list ap) {
     __UNUSED(ap);
-    BEGIN_MIGRATION_DEF(fork, struct shim_thread* thread, struct shim_process* process) {
-        DEFINE_MIGRATE(process, process, sizeof(struct shim_process));
-        DEFINE_MIGRATE(all_mounts, NULL, 0);
-        DEFINE_MIGRATE(all_vmas, NULL, 0);
-        DEFINE_MIGRATE(running_thread, thread, sizeof(struct shim_thread));
-        DEFINE_MIGRATE(handle_map, thread->handle_map, sizeof(struct shim_handle_map));
-        DEFINE_MIGRATE(migratable, NULL, 0);
-        DEFINE_MIGRATE(brk, NULL, 0);
-        DEFINE_MIGRATE(loaded_libraries, NULL, 0);
-#ifdef DEBUG
-        DEFINE_MIGRATE(gdb_map, NULL, 0);
-#endif
-    }
-    END_MIGRATION_DEF(fork)
-
     int ret = START_MIGRATE(store, fork, thread, process);
 
     thread->in_vm = false;

--- a/LibOS/shim/src/sys/shim_migrate.c
+++ b/LibOS/shim/src/sys/shim_migrate.c
@@ -220,25 +220,25 @@ static void* file_alloc(struct shim_cp_store* store, void* addr, size_t size) {
     return addr;
 }
 
+static BEGIN_MIGRATION_DEF(checkpoint) {
+    DEFINE_MIGRATE(process, &cur_process, sizeof(struct shim_process));
+    DEFINE_MIGRATE(all_mounts, NULL, 0);
+    DEFINE_MIGRATE(all_vmas, NULL, 0);
+    DEFINE_MIGRATE(all_running_threads, NULL, 0);
+    DEFINE_MIGRATE(brk, NULL, 0);
+    DEFINE_MIGRATE(loaded_libraries, NULL, 0);
+#ifdef DEBUG
+    DEFINE_MIGRATE(gdb_map, NULL, 0);
+#endif
+    DEFINE_MIGRATE(migratable, NULL, 0);
+}
+END_MIGRATION_DEF(checkpoint)
+
 static int finish_checkpoint(struct cp_session* cpsession) {
     struct shim_cp_store* cpstore = &cpsession->cpstore;
     int ret;
 
     cpstore->alloc = file_alloc;
-
-    BEGIN_MIGRATION_DEF(checkpoint) {
-        DEFINE_MIGRATE(process, &cur_process, sizeof(struct shim_process));
-        DEFINE_MIGRATE(all_mounts, NULL, 0);
-        DEFINE_MIGRATE(all_vmas, NULL, 0);
-        DEFINE_MIGRATE(all_running_threads, NULL, 0);
-        DEFINE_MIGRATE(brk, NULL, 0);
-        DEFINE_MIGRATE(loaded_libraries, NULL, 0);
-#ifdef DEBUG
-        DEFINE_MIGRATE(gdb_map, NULL, 0);
-#endif
-        DEFINE_MIGRATE(migratable, NULL, 0);
-    }
-    END_MIGRATION_DEF(checkpoint)
 
     if ((ret = START_MIGRATE(cpstore, checkpoint)) < 0)
         return ret;


### PR DESCRIPTION
BEGIN_MIGRATION_DEF() is used to define nested function unnecessarily.
make them normal(non-nested) function.

<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->


## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1310)
<!-- Reviewable:end -->
