### PR TITLE
[LibOS] Makefile remove OMIT_FRAME_POINTER

### DIFF
--- a/LibOS/shim/src/Makefile
+++ b/LibOS/shim/src/Makefile
@@ -2,8 +2,6 @@ RUNTIME_DIR = $(CURDIR)/../../../Runtime
 
 include ../../../Scripts/Makefile.configs
 
-OMIT_FRAME_POINTER = no
-
 CFLAGS += -fPIC -Winline -Wwrite-strings \
 	  -fmerge-all-constants -Wstrict-prototypes -Wtrampolines \
 	  -Werror=implicit-function-declaration \
@@ -14,11 +12,6 @@ CFLAGS += -fPIC -Winline -Wwrite-strings \
 
 CFLAGS += -Wextra
 
-ifeq ($(OMIT_FRAME_POINTER),yes)
-CFLAGS += -DOMIT_FRAME_POINTER=1
-else
-CFLAGS += -fno-omit-frame-pointer -DOMIT_FRAME_POINTER=0
-endif
 ASFLAGS += -Wa,--noexecstack -x assembler-with-cpp -I../include
 
 LDFLAGS += -shared -nostdlib -z combreloc -z relro -z now -z defs \


### PR DESCRIPTION
There is no code depending OMIT_FRAME_POINTER.
Remove it. If it's wanted, simply specify CFLAGS.

<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->


## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1312)
<!-- Reviewable:end -->
