### PR TITLE
[Makefile] list object files in plain manner

### DIFF
--- a/LibOS/shim/src/Makefile
+++ b/LibOS/shim/src/Makefile
@@ -24,21 +24,87 @@ files_to_install = $(addprefix $(RUNTIME_DIR)/,$(files_to_build))
 defs	= -DIN_SHIM
 CFLAGS += $(defs)
 ASFLAGS += $(defs)
-fs	= chroot str pipe socket proc dev eventfd
-ipcns	= pid sysv
-objs	= $(addprefix bookkeep/shim_,handle vma thread signal) \
-	  $(addprefix utils/,md5 printf strobjs) \
-	  $(addprefix fs/shim_,dcache namei fs_hash fs) \
-	  $(foreach f,$(fs),fs/$(f)/fs) \
-	  $(addprefix fs/proc/,info ipc-thread thread) \
-	  $(addprefix ipc/shim_,ipc ipc_helper ipc_child) \
-	  $(addprefix ipc/shim_ipc_,$(ipcns)) \
-	  elf/shim_rtld \
-	  $(addprefix shim_,init table syscalls checkpoint malloc \
-	  async parser debug object) syscallas start \
-	  $(addprefix sys/shim_,access alarm benchmark brk clone dup epoll eventfd exec exit fcntl fork fs futex getcwd getpid getrlimit ioctl migrate mmap msgget open pipe poll sched semget sigaction sleep socket stat time uname vfork wait wrappers) \
-	  vdso/vdso-data
-all_objs = $(objs) vdso/vdso-note vdso/vdso
+
+objs = \
+	shim_async.o \
+	shim_checkpoint.o \
+	shim_debug.o \
+	shim_init.o \
+	shim_malloc.o \
+	shim_object.o \
+	shim_parser.o \
+	shim_syscalls.o \
+	shim_table.o \
+	start.o \
+	syscallas.o \
+	bookkeep/shim_handle.o \
+	bookkeep/shim_signal.o \
+	bookkeep/shim_thread.o \
+	bookkeep/shim_vma.o \
+	elf/shim_rtld.o \
+	fs/shim_dcache.o \
+	fs/shim_fs.o \
+	fs/shim_fs_hash.o \
+	fs/shim_namei.o \
+	fs/chroot/fs.o \
+	fs/dev/fs.o \
+	fs/eventfd/fs.o \
+	fs/pipe/fs.o \
+	fs/proc/fs.o \
+	fs/proc/info.o \
+	fs/proc/ipc-thread.o \
+	fs/proc/thread.o \
+	fs/socket/fs.o \
+	fs/str/fs.o \
+	ipc/shim_ipc.o \
+	ipc/shim_ipc_child.o \
+	ipc/shim_ipc_helper.o \
+	ipc/shim_ipc_pid.o \
+	ipc/shim_ipc_sysv.o \
+	sys/shim_access.o \
+	sys/shim_alarm.o \
+	sys/shim_benchmark.o \
+	sys/shim_brk.o \
+	sys/shim_clone.o \
+	sys/shim_dup.o \
+	sys/shim_epoll.o \
+	sys/shim_eventfd.o \
+	sys/shim_exec.o \
+	sys/shim_exit.o \
+	sys/shim_fcntl.o \
+	sys/shim_fork.o \
+	sys/shim_fs.o \
+	sys/shim_futex.o \
+	sys/shim_getcwd.o \
+	sys/shim_getpid.o \
+	sys/shim_getrlimit.o \
+	sys/shim_ioctl.o \
+	sys/shim_migrate.o \
+	sys/shim_mmap.o \
+	sys/shim_msgget.o \
+	sys/shim_open.o \
+	sys/shim_pipe.o \
+	sys/shim_poll.o \
+	sys/shim_sched.o \
+	sys/shim_semget.o \
+	sys/shim_sigaction.o \
+	sys/shim_sleep.o \
+	sys/shim_socket.o \
+	sys/shim_stat.o \
+	sys/shim_time.o \
+	sys/shim_uname.o \
+	sys/shim_vfork.o \
+	sys/shim_wait.o \
+	sys/shim_wrappers.o \
+	utils/md5.o \
+	utils/printf.o \
+	utils/strobjs.o \
+	vdso/vdso-data.o
+
+all_objs = \
+	$(objs) \
+	vdso/vdso-note.o \
+	vdso/vdso.o
 
 graphene_lib = .lib/graphene-lib.a
 pal_lib = $(RUNTIME_DIR)/libpal-$(PAL_HOST).so
@@ -53,12 +119,12 @@ $(files_to_install): $(RUNTIME_DIR)/%: %
 	$(call cmd,ln_sf)
 
 LDFLAGS-libsysdb.so += --version-script shim.map -T shim.lds
-libsysdb.so: $(addsuffix .o,$(objs)) $(filter %.map %.lds,$(LDFLAGS-$@)) \
+libsysdb.so: $(objs) $(filter %.map %.lds,$(LDFLAGS-$@)) \
 	     $(graphene_lib) $(pal_lib)
 	$(call cmd,ld_so_o)
 
 LDFLAGS-libsysdb_debug.so += --version-script shim-debug.map -T shim.lds
-libsysdb_debug.so: $(addsuffix .o,$(filter-out syscallas,$(objs))) \
+libsysdb_debug.so: $(filter-out syscallas.o,$(objs)) \
 		   $(filter %.map %.lds,$(LDFLAGS-$@)) \
 		   $(graphene_lib) $(pal_lib)
 	$(call cmd,ld_so_o)
@@ -70,7 +136,7 @@ graphene_lib_recurse:
 $(graphene_lib): graphene_lib_recurse
 	@true
 
-libsysdb.a: $(addsuffix .o,$(objs))
+libsysdb.a: $(objs)
 	$(call cmd,ar_a_o)
 
 %.o: %.c
@@ -121,12 +187,12 @@ CLEAN_FILES += vdso/vdso.so.dbg vdso/vdso.so vdso/.vdso-linked-for-reloc-check.s
 
 .PHONY: clean
 clean:
-	$(RM) -r $(addsuffix .o,$(all_objs)) $(addsuffix .d,$(all_objs)) \
-	         $(addsuffix .i.d,$(all_objs)) $(addsuffix .s.d,$(all_objs)) \
+	$(RM) -r $(all_objs) $(patsubst %.o,%.d,$(all_objs)) \
+	         $(patsubst %.o,%.i.d,$(all_objs)) $(patsubst %.o,%.s.d,$(all_objs)) \
 	         $(shim_target) $(files_to_build) .lib $(CLEAN_FILES)
 
 ifeq ($(filter %clean,$(MAKECMDGOALS)),)
--include $(addsuffix .d,$(all_objs)) $(addsuffix .i.d,$(all_objs)) $(addsuffix .s.d,$(all_objs))
+-include $(patsubst %.o,%.d,$(all_objs)) $(patsubst %.o,%.i.d,$(all_objs)) $(patsubst %.o,%.s.d,$(all_objs))
 endif
 
 .PHONY: distclean

--- a/Pal/lib/Makefile
+++ b/Pal/lib/Makefile
@@ -4,8 +4,6 @@ include ../src/host/$(PAL_HOST)/Makefile.am
 
 CFLAGS += -I../include/lib -I../include -I../include/pal -Icrypto/mbedtls/include -I../include/host/$(PAL_HOST)
 
-subdirs = string stdlib network graphene crypto
-
 CRYPTO_PROVIDER ?= mbedtls
 
 # Select which crypto adpater you want to use here. This has to match
@@ -17,11 +15,32 @@ CRYPTO_PROVIDER ?= mbedtls
 # this pulls Diffie-Hellman code into LibOS shim, resulting in unsatisfied
 # symbols.
 ifeq ($(CRYPTO_PROVIDER),mbedtls)
-subdirs += crypto/mbedtls/library
-crypto_mbedtls_library_objs = $(addsuffix .o, aes aesni asn1parse base64 bignum cipher \
-                                              cipher_wrap cmac ctr_drbg dhm entropy gcm md \
-                                              md_wrap oid rsa rsa_internal sha256 ssl_tls \
-                                              ssl_ciphersuites ssl_cli ssl_srv platform_util)
+crypto_mbedtls_library_objs = \
+	crypto/mbedtls/library/aes.o \
+	crypto/mbedtls/library/aesni.o \
+	crypto/mbedtls/library/asn1parse.o \
+	crypto/mbedtls/library/base64.o \
+	crypto/mbedtls/library/bignum.o \
+	crypto/mbedtls/library/cipher.o \
+	crypto/mbedtls/library/cipher_wrap.o \
+	crypto/mbedtls/library/cmac.o \
+	crypto/mbedtls/library/ctr_drbg.o \
+	crypto/mbedtls/library/dhm.o \
+	crypto/mbedtls/library/entropy.o \
+	crypto/mbedtls/library/gcm.o \
+	crypto/mbedtls/library/md.o \
+	crypto/mbedtls/library/md_wrap.o \
+	crypto/mbedtls/library/oid.o \
+	crypto/mbedtls/library/platform_util.o \
+	crypto/mbedtls/library/rsa.o \
+	crypto/mbedtls/library/rsa_internal.o \
+	crypto/mbedtls/library/sha256.o \
+	crypto/mbedtls/library/ssl_ciphersuites.o \
+	crypto/mbedtls/library/ssl_cli.o \
+	crypto/mbedtls/library/ssl_srv.o \
+	crypto/mbedtls/library/ssl_tls.o
+
+objs += $(crypto_mbedtls_library_objs)
 endif
 
 MBEDTLS_VERSION ?= 2.16.3
@@ -52,14 +71,24 @@ crypto/mbedtls/include/mbedtls/config.h: crypto/config.h crypto/mbedtls/CMakeLis
 	cp crypto/config.h crypto/mbedtls/include/mbedtls
 
 crypto/mbedtls/library/aes.c: crypto/mbedtls/CMakeLists.txt crypto/mbedtls/include/mbedtls/config.h
-$(addprefix crypto/mbedtls/library/,$(filter-out aes.c,$(patsubst %.o,%.c,$(crypto_mbedtls_library_objs)))): crypto/mbedtls/library/aes.c
+$(filter-out crypto/mbedtls/library/aes.c,$(patsubst %.o,%.c,$(crypto_mbedtls_library_objs))): crypto/mbedtls/library/aes.c
 
-string_objs = $(addsuffix .o,atoi memcmp memcpy memset strchr strendswith strlen wordcopy strcmp)
-stdlib_objs = $(addsuffix .o,printfmt)
-network_objs = $(addsuffix .o,hton inet_pton)
-graphene_objs = $(addsuffix .o,config path)
-crypto_objs = $(addsuffix .o,udivmodti4)
-objs += $(foreach dir,$(subdirs),$(addprefix $(dir)/,$($(subst /,_,$(dir))_objs)))
+objs += \
+	crypto/udivmodti4.o \
+	graphene/config.o \
+	graphene/path.o \
+	network/hton.o \
+	network/inet_pton.o \
+	stdlib/printfmt.o \
+	string/atoi.o \
+	string/memcmp.o \
+	string/memcpy.o \
+	string/memset.o \
+	string/strchr.o \
+	string/strcmp.o \
+	string/strendswith.o \
+	string/strlen.o \
+	string/wordcopy.o
 
 $(addprefix $(target),crypto/adapters/mbedtls_adapter.o crypto/adapters/mbedtls_dh.o crypto/adapters/mbedtls_encoding.o): crypto/mbedtls/library/aes.c
 

--- a/Pal/src/Makefile
+++ b/Pal/src/Makefile
@@ -36,8 +36,21 @@ files_to_build = $(pal_lib) $(pal_lib_post) $(pal_static) \
 defs	= -DIN_PAL -DHOST_TYPE="$(PAL_HOST)" -D$(PAL_HOST_MACRO) -DPAL_DIR=$(PAL_DIR) \
 	  -DRUNTIME_DIR=$(RUNTIME_DIR)
 CFLAGS += $(defs)
-objs	= $(addprefix db_,streams memory threading mutex events process \
-	    object main misc exception rtld) slab printf pal_error
+objs = \
+	db_events.o \
+	db_exception.o \
+	db_main.o \
+	db_memory.o \
+	db_misc.o \
+	db_mutex.o \
+	db_object.o \
+	db_process.o \
+	db_rtld.o \
+	db_streams.o \
+	db_threading.o \
+	pal_error.o \
+	printf.o \
+	slab.o
 
 graphene_lib = $(LIB_DIR)/graphene-lib.a
 host_lib = $(HOST_DIR)/libpal-$(PAL_HOST).a
@@ -91,7 +104,7 @@ $(runtime_loader): $(pal_loader)
 endif
 
 ifneq ($(pal_lib),)
-$(pal_lib): $(addprefix $(OBJ_DIR)/,$(addsuffix .o,$(objs))) \
+$(pal_lib): $(addprefix $(OBJ_DIR)/,$(objs)) \
 	    $(host_lib) $(graphene_lib) $(pal_lib_deps)
 	$(call cmd,ld_so_o)
 
@@ -109,7 +122,7 @@ $(pal_lib_post): $(pal_lib)
 	@$(MAKE) -C $(HOST_DIR) $@
 endif
 
-$(pal_static): $(addprefix $(OBJ_DIR)/,$(addsuffix .o,$(objs))) \
+$(pal_static): $(addprefix $(OBJ_DIR)/,$(objs)) \
 	       $(host_lib) $(graphene_lib)
 	$(call cmd,ar_a_o)
 
@@ -127,7 +140,7 @@ $(OBJ_DIR)/%.s: %.c
 
 ifeq ($(filter %clean,$(MAKECMDGOALS)),)
 include $(wildcard *.d)
--include $(patsubst %,$(OBJ_DIR)/%.d,$(objs))
+-include $(patsubst %.o,$(OBJ_DIR)/%.d,$(objs))
 endif
 
 clean_targets = clean distclean

--- a/Pal/src/host/Linux-SGX/Makefile
+++ b/Pal/src/host/Linux-SGX/Makefile
@@ -15,30 +15,65 @@ host_files = libpal-Linux-SGX.a pal-sgx debugger/sgx_gdb.so pal.map generated_of
 defs	= -DIN_PAL -DPAL_DIR=$(PAL_DIR) -DRUNTIME_DIR=$(RUNTIME_DIR)
 CFLAGS += $(defs)
 ASFLAGS += $(defs)
-enclave-objs = $(addprefix db_,files devices pipes eventfd sockets streams memory \
-		 threading mutex events process object main rtld \
-		 exception misc) \
-	       $(addprefix enclave_,ocalls ecalls framework platform pages untrusted xstate)
-enclave-asm-objs = enclave_entry
-urts-objs = $(addprefix sgx_,enclave framework platform main rtld thread process exception graphene) \
-	    quote/aesm.pb-c clone-x86_64
-urts-asm-objs = sgx_entry
+
+enclave-objs = \
+	db_devices.o \
+	db_eventfd.o \
+	db_events.o \
+	db_exception.o \
+	db_files.o \
+	db_main.o \
+	db_memory.o \
+	db_misc.o \
+	db_mutex.o \
+	db_object.o \
+	db_pipes.o \
+	db_process.o \
+	db_rtld.o \
+	db_sockets.o \
+	db_streams.o \
+	db_threading.o \
+	enclave_ecalls.o \
+	enclave_framework.o \
+	enclave_ocalls.o \
+	enclave_pages.o \
+	enclave_platform.o \
+	enclave_untrusted.o \
+	enclave_xstate.o
+
+enclave-asm-objs = enclave_entry.o
+
+urts-objs = \
+	clone-x86_64.o \
+	sgx_enclave.o \
+	sgx_exception.o \
+	sgx_framework.o \
+	sgx_graphene.o \
+	sgx_main.o \
+	sgx_platform.o \
+	sgx_process.o \
+	sgx_rtld.o \
+	sgx_thread.o \
+	quote/aesm.pb-c.o
+
+urts-asm-objs = sgx_entry.o
+
 graphene_lib = .lib/graphene-lib.a
 
 .PHONY: all
 all: sgx-driver/isgx_version.h $(host_files)
 
-libpal-Linux-SGX.a: $(addsuffix .o,$(enclave-objs) $(enclave-asm-objs))
+libpal-Linux-SGX.a: $(enclave-objs) $(enclave-asm-objs)
 	$(call cmd,ar_a_o)
 
-$(addsuffix .o,$(enclave-objs)): CFLAGS += -DIN_ENCLAVE
-$(addsuffix .i,$(enclave-objs)): CFLAGS += -DIN_ENCLAVE
-$(addsuffix .s,$(enclave-objs)): CFLAGS += -DIN_ENCLAVE
-$(addsuffix .o,$(enclave-asm-objs)): ASFLAGS += -DIN_ENCLAVE
-$(addsuffix .s,$(enclave-asm-objs)): ASFLAGS += -DIN_ENCLAVE
+$(enclave-objs): CFLAGS += -DIN_ENCLAVE
+$(patsubst %.o,%.i,$(enclave-objs)): CFLAGS += -DIN_ENCLAVE
+$(patsubst %.o,%.s,$(enclave-objs)): CFLAGS += -DIN_ENCLAVE
+$(enclave-asm-objs): ASFLAGS += -DIN_ENCLAVE
+$(patsubst %.o,%.s,$(enclave-asm-objs)): ASFLAGS += -DIN_ENCLAVE
 
-$(addsuffix .o,$(urts-objs)): quote/aesm.pb-c.h
-$(addsuffix .o,$(enclave-objs)): quote/generated-cacert.h
+$(urts-objs): quote/aesm.pb-c.h
+$(enclave-objs): quote/generated-cacert.h
 
 %.o: %.c
 	$(call cmd,cc_o_c)
@@ -57,7 +92,7 @@ $(addsuffix .o,$(enclave-objs)): quote/generated-cacert.h
 
 CFLAGS-pal-sgx = -Wl,-z,relro,-z,now -pie
 LDLIBS-pal-sgx += -lprotobuf-c
-pal-sgx: $(addsuffix .o,$(urts-objs) $(urts-asm-objs)) $(graphene_lib)
+pal-sgx: $(urts-objs) $(urts-asm-objs) $(graphene_lib)
 	$(call cmd,cmulti)
 
 quote/aesm.pb-c.o: quote/aesm.pb-c.c quote/aesm.pb-c.h

--- a/Pal/src/host/Linux/Makefile
+++ b/Pal/src/host/Linux/Makefile
@@ -11,15 +11,31 @@ host_files = libpal-Linux.a pal.map
 defs	= -DIN_PAL -DPAL_DIR=$(PAL_DIR) -DRUNTIME_DIR=$(RUNTIME_DIR)
 CFLAGS += $(defs)
 ASFLAGS += $(defs)
-objs	= $(addprefix db_,files devices pipes eventfd sockets streams memory threading \
-	    mutex events process object main rtld misc \
-	    exception) clone-x86_64
+objs = \
+	clone-x86_64.o \
+	db_devices.o \
+	db_eventfd.o \
+	db_events.o \
+	db_exception.o \
+	db_files.o \
+	db_main.o \
+	db_memory.o \
+	db_misc.o \
+	db_mutex.o \
+	db_object.o \
+	db_pipes.o \
+	db_process.o \
+	db_rtld.o \
+	db_sockets.o \
+	db_streams.o \
+	db_threading.o
+
 graphene_lib = .lib/graphene-lib.a
 
 .PHONY: all
 all: $(host_files)
 
-libpal-Linux.a: $(addsuffix .o,$(objs)) $(graphene_lib)
+libpal-Linux.a: $(objs) $(graphene_lib)
 	$(call cmd,ar_a_o)
 
 %.o: %.c
@@ -40,16 +56,16 @@ libpal-Linux.a: $(addsuffix .o,$(objs)) $(graphene_lib)
 include ../../../../Scripts/Makefile.rules
 
 ifeq ($(filter %clean,$(MAKECMDGOALS)),)
--include $(addsuffix .d,$(objs)) $(addsuffix .i.d,$(objs)) $(addsuffix .s.d,$(objs))
+-include $(patsubst %.o,%.d,$(objs)) $(patsubst %.o,%.i.d,$(objs)) $(patsubst %.o,%.s.d,$(objs))
 endif
 
 CLEAN_FILES += $(notdir $(pal_static) $(pal_lib) $(pal_sec) $(pal_loader))
 
 .PHONY: clean
 clean:
-	$(RM) $(addsuffix .o,$(objs)) $(host_files) $(CLEAN_FILES) \
-	      $(addsuffix .d,$(objs)) $(addsuffix .i.d,$(objs)) \
-	      $(addsuffix .s.d,$(objs))
+	$(RM) $(objs) $(host_files) $(CLEAN_FILES) \
+	      $(patsubst %.o,%.d,$(objs)) $(patsubst %.o,%.i.d,$(objs)) \
+	      $(patsubst %.o,%.s.d,$(objs))
 
 .PHONY: distclean
 distclean: clean


### PR DESCRIPTION
The current Makefiles are unnecessary too smart to avoid (too small, I think)
duplication. It resulted that it's hard to understand what files are listed.
Instead, use plain explicit listing.

Also append .o to objs variables. Usually obj means .o file, not the base name
of file. It was confusing.

<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [x] Linux PAL
- [x] SGX PAL
- [x] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->


## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1314)
<!-- Reviewable:end -->
