### PR TITLE
[Pal/Linux-SGX] save/restore callee save registers by sgx_ecall and s…

### DIFF
--- a/Pal/src/host/Linux-SGX/sgx_entry.S
+++ b/Pal/src/host/Linux-SGX/sgx_entry.S
@@ -9,12 +9,18 @@
 	.type sgx_ecall, @function
 
 sgx_ecall:
-	pushq %rbx
-
 	# put entry address in RDX
-	leaq sgx_entry(%rip), %rdx
+	leaq .Lsgx_entry(%rip), %rdx
 
 	# other arguments: RDI - code, RSI - ms
+
+.Ldo_ecall_callee_save:
+	pushq %rbx
+	pushq %rbp
+	pushq %r12
+	pushq %r13
+	pushq %r14
+	pushq %r15
 
 .Ldo_ecall:
 	# RBX has to be the TCS of the thread
@@ -27,6 +33,12 @@ sgx_ecall:
 	ENCLU
 
 	# currently only ECALL_THREAD_RESET returns
+.Lafter_resume:
+	popq %r15
+	popq %r14
+	popq %r13
+	popq %r12
+	popq %rbp
 	popq %rbx
 	retq
 
@@ -41,12 +53,9 @@ async_exit_pointer:
 
 sgx_raise:
 	leaq .Lafter_resume(%rip), %rdx
-	jmp .Ldo_ecall
+	jmp .Ldo_ecall_callee_save
 
-.Lafter_resume:
-	retq
-
-sgx_entry:
+.Lsgx_entry:
 	# arguments: RDI - code, RSI - ms
 
 	.cfi_startproc


### PR DESCRIPTION
…gx_raise

They should preserve callee save registers.

Fixes #1313. 

<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [x] SGX PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->


## How to test this PR? <!-- (if applicable) -->
compile with DEBUG=0 (not DEBUG undefined) and all the tests

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1315)
<!-- Reviewable:end -->
