### PR TITLE
[Pal/Linux-SGX] eliminate an unused function, unset_sighandler()

### DIFF
--- a/Pal/src/host/Linux-SGX/sgx_exception.c
+++ b/Pal/src/host/Linux-SGX/sgx_exception.c
@@ -161,22 +161,6 @@ int block_async_signals (bool block)
     return block_signals(block, async_signals, nasync_signals);
 }
 
-int unset_sighandler (int * sigs, int nsig)
-{
-    for (int i = 0 ; i < nsig ; i++) {
-#if defined(__i386__)
-        int ret = INLINE_SYSCALL(sigaction, 4, sigs[i], SIG_DFL, NULL)
-#else
-        int ret = INLINE_SYSCALL(rt_sigaction, 4, sigs[i],
-                                 (struct sigaction *) SIG_DFL, NULL,
-                                 sizeof(__sigset_t));
-#endif
-        if (IS_ERR(ret))
-            return -ERRNO(ret);
-    }
-    return 0;
-}
-
 static int get_event_num (int signum)
 {
     switch(signum) {


### PR DESCRIPTION
unset_sighandler() is broken. SIG_DFL can't be struct sigaction.
delete the function instead of fixing it because it's unused.

<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [x] SGX PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->


## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1316)
<!-- Reviewable:end -->
