### PR TITLE
[Makefile] handle DEBUG more cleanly

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -68,7 +68,8 @@ source tree::
 
 Each part of Graphene can be built separately in the subdirectories.
 
-To build Graphene with debug symbols, run ``make DEBUG=1``
+To build Graphene with debug symbols without optimization, run ``make DEBUG=1``
+To build Graphene with debug symbols with optimization, run ``make DEBUG=2``
 instead of ``make``. To specify custom mirrors for downloading the GLIBC
 source, use ``make GLIBC_MIRRORS=...``.
 
@@ -130,9 +131,13 @@ command::
 
    make SGX=1
 
-To build with debug symbols, instead run the command::
+To build with debug symbols without optimization, instead run the command::
 
    make SGX=1 DEBUG=1
+
+To build with debug symbols with optimization, instead run the command::
+
+   make SGX=1 DEBUG=2
 
 Running ``make SGX=1`` in the test or regression directory will automatically generate the required
 manifest signatures (.sig files).

--- a/README.rst
+++ b/README.rst
@@ -69,7 +69,7 @@ source tree::
 Each part of Graphene can be built separately in the subdirectories.
 
 To build Graphene with debug symbols without optimization, run ``make DEBUG=1``
-To build Graphene with debug symbols with optimization, run ``make DEBUG=2``
+To build Graphene with debug symbols with optimization, run ``make DEBUG=1 OPTDEBUG=1``
 instead of ``make``. To specify custom mirrors for downloading the GLIBC
 source, use ``make GLIBC_MIRRORS=...``.
 
@@ -137,7 +137,7 @@ To build with debug symbols without optimization, instead run the command::
 
 To build with debug symbols with optimization, instead run the command::
 
-   make SGX=1 DEBUG=2
+   make SGX=1 DEBUG=1 OPTDEBUG=1
 
 Running ``make SGX=1`` in the test or regression directory will automatically generate the required
 manifest signatures (.sig files).

--- a/Scripts/Makefile.configs
+++ b/Scripts/Makefile.configs
@@ -23,22 +23,37 @@ OBJCOPY ?= objcopy
 SYS ?= $(shell $(CC) -dumpmachine)
 export SYS
 
-DEBUG ?=
-export DEBUG
-
 CFLAGS += -Wall -std=c11
 CXXFLAGS += -Wall -std=c++14
 
-ifeq ($(DEBUG),1)
+DEBUG ?=
+export DEBUG
+
+# make DEBUG=0 synonym for undefined DEBUG
+ifeq ($(DEBUG),0)
+override DEBUG =
+endif
+
+ifeq ($(DEBUG),)
+# -O2: yes -DDEBUG: no
+CFLAGS += -O2
+CXXFLAGS += -O2
+else ifeq ($(DEBUG),1)
+# -O2: yes -DDEBUG: yes
+CFLAGS += -O2 -gdwarf-2 -g3
+CXXFLAGS += -O2 -gdwarf-2 -g3
+CFLAGS += -DDEBUG
+ASFLAGS += -DDEBUG
+else ifeq ($(DEBUG),2)
+# -O2: no -DDEBUG: yes
 CFLAGS += -gdwarf-2 -g3
 CXXFLAGS += -gdwarf-2 -g3
 CFLAGS += -DDEBUG
 ASFLAGS += -DDEBUG
-endif
-
-ifeq ($(DEBUG),)
-CFLAGS += -O2
-CXXFLAGS += -O2
+# other makefiles assumes only DEBUG=1 for debug
+override DEBUG = 1
+else
+$(error unknown DEBUG value "$(DEBUG)")
 endif
 
 ifeq ($(WERROR),1)

--- a/Scripts/Makefile.configs
+++ b/Scripts/Makefile.configs
@@ -39,18 +39,18 @@ ifeq ($(DEBUG),)
 CFLAGS += -O2
 CXXFLAGS += -O2
 else ifeq ($(DEBUG),1)
-# -O2: yes -DDEBUG: yes
-CFLAGS += -O2 -gdwarf-2 -g3
-CXXFLAGS += -O2 -gdwarf-2 -g3
-CFLAGS += -DDEBUG
-ASFLAGS += -DDEBUG
-else ifeq ($(DEBUG),2)
 # -O2: no -DDEBUG: yes
 CFLAGS += -gdwarf-2 -g3
 CXXFLAGS += -gdwarf-2 -g3
 CFLAGS += -DDEBUG
 ASFLAGS += -DDEBUG
-# other makefiles assumes only DEBUG=1 for debug
+else ifeq ($(DEBUG),2)
+# -O2: yes -DDEBUG: yes
+CFLAGS += -O2 -gdwarf-2 -g3
+CXXFLAGS += -O2 -gdwarf-2 -g3
+CFLAGS += -DDEBUG
+ASFLAGS += -DDEBUG
+# other makefiles assume only DEBUG=1 for debug
 override DEBUG = 1
 else
 $(error unknown DEBUG value "$(DEBUG)")

--- a/Scripts/Makefile.configs
+++ b/Scripts/Makefile.configs
@@ -29,29 +29,31 @@ CXXFLAGS += -Wall -std=c++14
 DEBUG ?=
 export DEBUG
 
+OPTDEBUG ?=
+export OPTDEBUG
+
 # make DEBUG=0 synonym for undefined DEBUG
 ifeq ($(DEBUG),0)
 override DEBUG =
 endif
 
+# make OPTDEBUG=0 synonym for undefined OPTDEBUG
+ifeq ($(OPTDEBUG),0)
+override OPTDEBUG =
+endif
+
 ifeq ($(DEBUG),)
-# -O2: yes -DDEBUG: no
 CFLAGS += -O2
 CXXFLAGS += -O2
 else ifeq ($(DEBUG),1)
-# -O2: no -DDEBUG: yes
+ifeq ($(OPTDEBUG),1)
+CFLAGS += -O2
+CXXFLAGS += -O2
+endif
 CFLAGS += -gdwarf-2 -g3
 CXXFLAGS += -gdwarf-2 -g3
 CFLAGS += -DDEBUG
 ASFLAGS += -DDEBUG
-else ifeq ($(DEBUG),2)
-# -O2: yes -DDEBUG: yes
-CFLAGS += -O2 -gdwarf-2 -g3
-CXXFLAGS += -O2 -gdwarf-2 -g3
-CFLAGS += -DDEBUG
-ASFLAGS += -DDEBUG
-# other makefiles assume only DEBUG=1 for debug
-override DEBUG = 1
 else
 $(error unknown DEBUG value "$(DEBUG)")
 endif


### PR DESCRIPTION
Handle DEBUG more cleanly.
- DEBUG undefined: -O2 (same as before)
- DEBUG=0: same as undefined DEBUG (newly supported)
- DEBUG=1: enable debug symbol + -DDEBUG with -O2 enabled
- DEBUG=2: debug symbol + -DDEBUG + turn off -O2 (newly supported)
- other:   explicit error

<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [x] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->


## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1317)
<!-- Reviewable:end -->
