### PR TITLE
[Pal/Linux-SGX] cache mmap of untrusted area for read/write/recv/send

### DIFF
--- a/Pal/src/host/Linux-SGX/enclave_ecalls.c
+++ b/Pal/src/host/Linux-SGX/enclave_ecalls.c
@@ -54,6 +54,7 @@ void handle_ecall (long ecall_index, void * ecall_args, void * exit_target,
     SET_ENCLAVE_TLS(ustack_top,      untrusted_stack);
     SET_ENCLAVE_TLS(ustack,          untrusted_stack);
     SET_ENCLAVE_TLS(clear_child_tid, NULL);
+    SET_ENCLAVE_TLS(untrusted_area_cache.in_use, 0UL);
 
     if (atomic_cmpxchg(&enclave_start_called, 0, 1) == 0) {
         // ENCLAVE_START not yet called, so only valid ecall is ENCLAVE_START.


### PR DESCRIPTION
So that the number of ocall can be reduced.

<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [x] SGX PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->


## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1320)
<!-- Reviewable:end -->
