### PR TITLE
[Pal/Linux-SGX] add 'key' to dependency calculation

### DIFF
--- a/Pal/src/host/Linux-SGX/Makefile.manifest
+++ b/Pal/src/host/Linux-SGX/Makefile.manifest
@@ -18,13 +18,13 @@ $(SGX_SIGNER_KEY):
 %.token: %.sig
 	$(call cmd,sgx_get_token)
 
-%.sig %.manifest.sgx: %.manifest % $(LIBPAL) $(SGX_SIGNER_KEY) %.manifest.sgx.d
+%.sig %.manifest.sgx: %.manifest % %.manifest.sgx.d
 	$(call cmd,sgx_sign_exec)
 
-%.sig %.manifest.sgx: manifest % $(LIBPAL) $(SGX_SIGNER_KEY) %.manifest.sgx.d
+%.sig %.manifest.sgx: manifest % %.manifest.sgx.d
 	$(call cmd,sgx_sign_exec)
 
-%.sig %.manifest.sgx: %.manifest $(LIBPAL) $(SGX_SIGNER_KEY) %.manifest.sgx.d
+%.sig %.manifest.sgx: %.manifest %.manifest.sgx.d
 	$(call cmd,sgx_sign)
 
 .PRECIOUS: %.manifest.sgx.d

--- a/Pal/src/host/Linux-SGX/signer/pal_sgx_sign.py
+++ b/Pal/src/host/Linux-SGX/signer/pal_sgx_sign.py
@@ -918,6 +918,7 @@ def make_depend(args):
                                          do_checksum=False).values():
         dependencies.add(filename[1])
     dependencies.add(args['libpal'])
+    dependencies.add(args['key'])
 
     with open(output, 'w') as file:
         manifest_sgx = output


### PR DESCRIPTION
- pal-sgx-sign: add 'key' to dependecy
- cleanup Makefile.manifest

<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [x] SGX PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->


## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1321)
<!-- Reviewable:end -->
