### PR TITLE
[Pal/Linux-SGX] optimize opening trusted file

### DIFF
--- a/Pal/src/host/Linux-SGX/db_files.c
+++ b/Pal/src/host/Linux-SGX/db_files.c
@@ -70,7 +70,8 @@ static int file_open(PAL_HANDLE* handle, const char* type, const char* uri, int 
 
     sgx_stub_t* stubs;
     uint64_t total;
-    ret = load_trusted_file(hdl, &stubs, &total, create);
+    void* umem;
+    ret = load_trusted_file(hdl, &stubs, &total, create, &umem);
     if (ret < 0) {
         SGX_DBG(DBG_E,
                 "Accessing file:%s is denied. (%s) "
@@ -79,19 +80,13 @@ static int file_open(PAL_HANDLE* handle, const char* type, const char* uri, int 
         free(hdl);
         return ret;
     }
+    if (stubs && total) {
+        assert(umem);
+    }
 
     hdl->file.stubs  = (PAL_PTR)stubs;
     hdl->file.total  = total;
-
-    if (hdl->file.stubs && hdl->file.total) {
-        /* case of trusted file: mmap the whole file in untrusted memory for future reads/writes */
-        ret = ocall_mmap_untrusted(hdl->file.fd, 0, hdl->file.total, PROT_READ, &hdl->file.umem);
-        if (IS_ERR(ret)) {
-            /* note that we don't free stubs because they are re-used in same trusted file */
-            free(hdl);
-            return unix_to_pal_error(ERRNO(ret));
-        }
-    }
+    hdl->file.umem = umem;
 
     *handle = hdl;
     return 0;

--- a/Pal/src/host/Linux-SGX/pal_linux.h
+++ b/Pal/src/host/Linux-SGX/pal_linux.h
@@ -138,8 +138,8 @@ int init_trusted_files (void);
  * return:  0 succeed
  */
 
-int load_trusted_file
-    (PAL_HANDLE file, sgx_stub_t ** stubptr, uint64_t * sizeptr, int create);
+int load_trusted_file(PAL_HANDLE file, sgx_stub_t** stubptr, uint64_t* sizeptr, int create,
+                      void** umem);
 
 enum {
     FILE_CHECK_POLICY_STRICT = 0,


### PR DESCRIPTION
eliminated unnecessary mmap/mumap file in untrusted area.

<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [x] SGX PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->


## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1323)
<!-- Reviewable:end -->
