### PR TITLE
[Pal/Linux-SGX] fix file_map() to not call ocall_mmap_untrusted() unn…

### DIFF
--- a/Pal/src/host/Linux-SGX/db_files.c
+++ b/Pal/src/host/Linux-SGX/db_files.c
@@ -180,7 +180,6 @@ static int file_map(PAL_HANDLE handle, void** addr, int prot, uint64_t offset, u
     sgx_stub_t* stubs = (sgx_stub_t*)handle->file.stubs;
     uint64_t total    = handle->file.total;
     void* mem         = *addr;
-    void* umem;
     int ret;
 
     /*
@@ -208,37 +207,35 @@ static int file_map(PAL_HANDLE handle, void** addr, int prot, uint64_t offset, u
     if (!mem)
         return -PAL_ERROR_NOMEM;
 
-    uint64_t end = (offset + size > total) ? total : offset + size;
-    uint64_t map_start, map_end;
-
     if (stubs) {
-        map_start = ALIGN_DOWN(offset, TRUSTED_STUB_SIZE);
-        map_end   = ALIGN_UP(end, TRUSTED_STUB_SIZE);
-    } else {
-        map_start = ALLOC_ALIGN_DOWN(offset);
-        map_end   = ALLOC_ALIGN_UP(end);
-    }
+        uint64_t end = (offset + size > total) ? total : offset + size;
+        uint64_t map_start = ALIGN_DOWN(offset, TRUSTED_STUB_SIZE);
+        uint64_t map_end = ALIGN_UP(end, TRUSTED_STUB_SIZE);
 
-    ret = ocall_mmap_untrusted(handle->file.fd, map_start, map_end - map_start, PROT_READ, &umem);
-    if (IS_ERR(ret)) {
-        SGX_DBG(DBG_E, "file_map - ocall returned %d\n", ret);
-        return unix_to_pal_error(ERRNO(ret));
-    }
-
-    if (stubs) {
-        ret = copy_and_verify_trusted_file(handle->file.realpath, umem, map_start, map_end, mem,
-                                           offset, end - offset, stubs, total);
+        ret = copy_and_verify_trusted_file(handle->file.realpath, handle->file.umem + map_start, map_start, map_end,
+                                           mem, offset, end - offset, stubs, total);
 
         if (ret < 0) {
             SGX_DBG(DBG_E, "file_map - verify trusted returned %d\n", ret);
-            ocall_munmap_untrusted(umem, map_end - map_start);
             return ret;
         }
     } else {
-        memcpy(mem, umem + (offset - map_start), end - offset);
+        uint64_t end = offset + size;
+        uint64_t map_start = ALLOC_ALIGN_DOWN(offset);
+        uint64_t map_end   = ALLOC_ALIGN_UP(end);
+        uint64_t map_size = map_end - map_start;
+
+        ssize_t ret = __ocall_pread(handle->file.fd, mem, map_size, map_start, /*interruptible=*/false);
+        if (IS_ERR(ret)) {
+            assert(ERRNO(ret) != EINTR);
+            SGX_DBG(DBG_E, "file_map - ocall_pread returned %ld\n", ret);
+            return unix_to_pal_error(ERRNO(ret));
+        }
+        if (map_size - ret > 0) {
+            memset(mem + ret, 0, map_size - ret);
+        }
     }
 
-    ocall_munmap_untrusted(umem, map_end - map_start);
     *addr = mem;
     return 0;
 }

--- a/Pal/src/host/Linux-SGX/db_main.c
+++ b/Pal/src/host/Linux-SGX/db_main.c
@@ -303,6 +303,10 @@ void pal_linux_main(char * uptr_args, uint64_t args_size,
         return;
     }
 
+    /* Set the alignment early */
+    pal_state.alloc_align = g_page_size;
+    pal_state.start_time = start_time;
+
     /* set up page allocator and slab manager */
     init_slab_mgr(g_page_size);
     init_untrusted_slab_mgr();
@@ -313,9 +317,6 @@ void pal_linux_main(char * uptr_args, uint64_t args_size,
 
     /* now we can add a link map for PAL itself */
     setup_pal_map(&pal_map);
-
-    /* Set the alignment early */
-    pal_state.alloc_align = g_page_size;
 
     /* initialize enclave properties */
     rv = init_enclave();
@@ -335,8 +336,6 @@ void pal_linux_main(char * uptr_args, uint64_t args_size,
     if (!environments) {
         return;
     }
-
-    pal_state.start_time = start_time;
 
     linux_state.uid = pal_sec.uid;
     linux_state.gid = pal_sec.gid;

--- a/Pal/src/host/Linux-SGX/enclave_ocalls.c
+++ b/Pal/src/host/Linux-SGX/enclave_ocalls.c
@@ -362,7 +362,7 @@ out:
     return retval;
 }
 
-ssize_t ocall_pread(int fd, void* buf, size_t count, off_t offset) {
+ssize_t __ocall_pread(int fd, void* buf, size_t count, off_t offset, bool interruptible) {
     long retval = 0;
     void* obuf = NULL;
     ms_ocall_pread_t* ms;
@@ -400,6 +400,8 @@ ssize_t ocall_pread(int fd, void* buf, size_t count, off_t offset) {
         ssize_t ret = sgx_ocall(OCALL_PREAD, ms);
 
         if (IS_ERR(ret)) {
+            if (!interruptible && ret == -EINTR)
+                continue;
             if (!done)
                 done = ret;
             break;

--- a/Pal/src/host/Linux-SGX/enclave_ocalls.h
+++ b/Pal/src/host/Linux-SGX/enclave_ocalls.h
@@ -2,6 +2,9 @@
  * This is for enclave to make ocalls to untrusted runtime.
  */
 
+#ifndef ENCLAVE_OCALLS_H
+#define ENCLAVE_OCALLS_H
+
 #include "pal_linux.h"
 
 #include <asm/stat.h>
@@ -28,7 +31,10 @@ int ocall_read (int fd, void * buf, unsigned int count);
 
 int ocall_write (int fd, const void * buf, unsigned int count);
 
-ssize_t ocall_pread(int fd, void* buf, size_t count, off_t offset);
+ssize_t __ocall_pread(int fd, void* buf, size_t count, off_t offset, bool interruptible);
+static inline ssize_t ocall_pread(int fd, void* buf, size_t count, off_t offset) {
+    return __ocall_pread(fd, buf, count, offset, true);
+}
 
 ssize_t ocall_pwrite(int fd, const void* buf, size_t count, off_t offset);
 
@@ -100,3 +106,4 @@ int ocall_get_attestation(const sgx_spid_t* spid, const char* subkey, bool linka
                           sgx_attestation_t* attestation);
 int ocall_eventfd (unsigned int initval, int flags);
 
+#endif /* ENCLAVE_OCALLS_H */


### PR DESCRIPTION
…ecessary

Some how file_map() is unnecessarily convoluted. sort it out.

<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [x] SGX PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->


## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1324)
<!-- Reviewable:end -->
