### PR TITLE
[Linux-SGX] Add protected files implementation (SGX SDK file format)

### DIFF
--- a/Jenkinsfiles/Linux-SGX
+++ b/Jenkinsfiles/Linux-SGX
@@ -40,6 +40,10 @@ pipeline {
                         sh '''
                             make SGX=1 sgx-tokens
                         '''
+                        sh '''
+                            cd Pal/src/host/Linux-SGX/tools
+                            make install PREFIX=../../../../../../LibOS/shim/test/fs
+                        '''
                     }
                 }
                 stage('Test') {

--- a/Jenkinsfiles/Linux-SGX-18.04
+++ b/Jenkinsfiles/Linux-SGX-18.04
@@ -59,6 +59,10 @@ pipeline {
                         sh '''
                             make SGX=1 sgx-tokens
                         '''
+                        sh '''
+                            cd Pal/src/host/Linux-SGX/tools
+                            make install PREFIX=../../../../../../LibOS/shim/test/fs
+                        '''
                     }
                 }
                 stage('Test') {

--- a/LICENSE.addendum.txt
+++ b/LICENSE.addendum.txt
@@ -16,6 +16,7 @@ MIT JOS (mix of MIT and BSD licenses):
 * Pal/lib/stdlib/printfmt.c
 
 cJSON - MIT
+uthash - BSD revised
 
 A number of files taken from other C libraries:
 * musl - MIT

--- a/LibOS/shim/test/fs/.gitignore
+++ b/LibOS/shim/test/fs/.gitignore
@@ -18,3 +18,6 @@
 /stat
 /truncate
 /.cache
+
+/bin
+/lib

--- a/LibOS/shim/test/fs/Makefile
+++ b/LibOS/shim/test/fs/Makefile
@@ -55,14 +55,22 @@ endif
 export PAL_LOADER = $(RUNTIME)/pal-$(PAL_HOST)
 export PYTHONPATH = ../../../../Scripts
 
-.PHONY: test
-test: $(target)
+.PHONY: fs-test
+fs-test: $(target)
 	$(RM) fs-test.xml
 	$(MAKE) fs-test.xml
+
+.PHONY: test
+test: $(target)
+	$(RM) pf-test.xml
+	$(MAKE) pf-test.xml
 
 fs-test.xml: test_fs.py $(call expand_target_to_token,$(target))
 	python3 -m pytest --junit-xml $@ -v $<
 
+pf-test.xml: test_pf.py $(call expand_target_to_token,$(target))
+	python3 -m pytest --junit-xml $@ -v $<
+
 .PHONY: clean-tmp
 clean-tmp:
-	$(RM) -r *.tmp *.cached *.manifest.sgx *~ *.sig *.token *.o __pycache__ .pytest_cache .cache *.xml
+	$(RM) -r *.tmp *.cached *.manifest.sgx *~ *.sig *.token *.o __pycache__ .pytest_cache .cache *.xml bin lib

--- a/LibOS/shim/test/fs/README.md
+++ b/LibOS/shim/test/fs/README.md
@@ -14,4 +14,12 @@ These tests perform common FS operations in various ways to exercise the Graphen
 How to execute
 --------------
 
-Run `make test`.
+Run `make test` (tests both regular files and protected files).
+Run `make fs-test` to only test regular files.
+
+(SGX only) Protected file tests assume that the SGX tools were installed in this directory:
+
+```
+cd $graphene/Pal/src/host/Linux-SGX/tools
+make install PREFIX=$graphene/LibOS/shim/test/fs
+```

--- a/LibOS/shim/test/fs/manifest.template
+++ b/LibOS/shim/test/fs/manifest.template
@@ -32,3 +32,7 @@ sgx.trusted_files.libpthread = file:../../../../Runtime/libpthread.so.0
 sgx.trusted_files.libgcc_s = file:$(ARCH_LIBDIR)/libgcc_s.so.1
 
 sgx.allowed_files.tmp_dir = file:tmp/
+
+sgx.protected_files_key = ffeeddccbbaa99887766554433221100
+sgx.protected_files.input = file:tmp/pf_input
+sgx.protected_files.output = file:tmp/pf_output

--- a/LibOS/shim/test/fs/test_pf.py
+++ b/LibOS/shim/test/fs/test_pf.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+
+import filecmp
+import os
+import shutil
+import subprocess
+import unittest
+
+from test_fs import (
+    TC_00_FileSystem,
+)
+
+from regression import (
+    HAS_SGX,
+    expectedFailureIf,
+)
+
+@unittest.skipUnless(HAS_SGX, 'Protected files require SGX support')
+class TC_50_ProtectedFiles(TC_00_FileSystem):
+    @classmethod
+    def setUpClass(cls):
+        cls.PF_CRYPT = 'bin/pf_crypt'
+        cls.PF_TAMPER = 'bin/pf_tamper'
+        cls.WRAP_KEY = os.path.join(cls.TEST_DIR, 'wrap-key')
+        # CONST_WRAP_KEY must match the one in manifest
+        cls.CONST_WRAP_KEY = [0xff, 0xee, 0xdd, 0xcc, 0xbb, 0xaa, 0x99, 0x88,
+                              0x77, 0x66, 0x55, 0x44, 0x33, 0x22, 0x11, 0x00]
+        cls.ENCRYPTED_DIR = os.path.join(cls.TEST_DIR, 'pf_input')
+        cls.ENCRYPTED_FILES = [os.path.join(cls.ENCRYPTED_DIR, str(v)) for v in cls.FILE_SIZES]
+        cls.LIB_PATH = os.path.join(os.getcwd(), 'lib')
+
+        super().setUpClass()
+        if not os.path.exists(cls.ENCRYPTED_DIR):
+            os.mkdir(cls.ENCRYPTED_DIR)
+        cls.OUTPUT_DIR = os.path.join(cls.TEST_DIR, 'pf_output')
+        cls.OUTPUT_FILES = [os.path.join(cls.OUTPUT_DIR, str(x)) for x in cls.FILE_SIZES]
+        # create encrypted files
+        cls.__set_default_key(cls)
+        for i in cls.INDEXES:
+            cmd = [cls.PF_CRYPT, 'encrypt', '-w', cls.WRAP_KEY, '-i', cls.INPUT_FILES[i], '-o',
+                   cls.ENCRYPTED_FILES[i]]
+            cls.run_native_binary(cls, cmd, libpath=os.path.join(os.getcwd(), 'lib'))
+
+    def __pf_crypt(self, args):
+        args.insert(0, self.PF_CRYPT)
+        return self.run_native_binary(args, libpath=os.path.join(os.getcwd(), 'lib'))
+
+    def __set_default_key(self):
+        with open(self.WRAP_KEY, 'wb') as file:
+            file.write(bytes(self.CONST_WRAP_KEY))
+
+    # overrides TC_00_FileSystem to encrypt the file instead of just copying
+    def copy_input(self, input_path, output_path):
+        self.__encrypt_file(input_path, output_path)
+
+    def __encrypt_file(self, input_path, output_path):
+        args = ['encrypt', '-w', self.WRAP_KEY, '-i', input_path, '-o', output_path]
+        stdout, stderr = self.__pf_crypt(args)
+        return (stdout, stderr)
+
+    def __decrypt_file(self, input_path, output_path):
+        args = ['decrypt', '-w', self.WRAP_KEY, '-i', input_path, '-o', output_path]
+        stdout, stderr = self.__pf_crypt(args)
+        return (stdout, stderr)
+
+    def test_000_gen_key(self):
+        # test random key generation
+        key_path = os.path.join(self.TEST_DIR, 'tmpkey')
+        args = ['gen-key', '-w', key_path]
+        stdout, _ = self.__pf_crypt(args)
+        self.assertIn('Wrap key saved to: ' + key_path, stdout)
+        self.assertEqual(os.path.getsize(key_path), 16)
+        os.remove(key_path)
+
+    def test_010_encrypt_decrypt(self):
+        for i in self.INDEXES:
+            self.__encrypt_file(self.INPUT_FILES[i], self.OUTPUT_FILES[i])
+            self.assertFalse(filecmp.cmp(self.INPUT_FILES[i], self.OUTPUT_FILES[i], shallow=False))
+            dec_path = os.path.join(self.OUTPUT_DIR,
+                                    os.path.basename(self.OUTPUT_FILES[i]) + '.dec')
+            self.__decrypt_file(self.OUTPUT_FILES[i], dec_path)
+            self.assertTrue(filecmp.cmp(self.INPUT_FILES[i], dec_path, shallow=False))
+
+    # overrides TC_00_FileSystem to change input dir (from plaintext to encrypted)
+    def test_100_open_close(self):
+        # the test binary expects a path to read-only (existing) file or a path to file that
+        # will get created
+        input_path = self.ENCRYPTED_FILES[-1] # existing file
+        output_path = os.path.join(self.OUTPUT_DIR, 'test_100') # new file
+        stdout, stderr = self.run_binary(['open_close', 'R', input_path])
+        self.verify_open_close(stdout, stderr, input_path, 'input')
+        # the following test tries to open multiple handles to a single writable PF, should fail
+        try:
+            stdout, stderr = self.run_binary(['open_close', 'W', output_path])
+            self.assertIn('ERROR: Failed to open output file', stderr)
+        except subprocess.CalledProcessError as exc:
+            self.assertNotEqual(exc.returncode, 0)
+            self.assertTrue(os.path.isfile(output_path))
+        else:
+            print('[!] Fail: open_close returned 0')
+            self.fail()
+
+    # overrides TC_00_FileSystem to change input dir (from plaintext to encrypted)
+    def test_101_open_flags(self):
+        # the test binary expects a path to file that will get created
+        file_path = os.path.join(self.OUTPUT_DIR, 'test_101') # new file
+        stdout, stderr = self.run_binary(['open_flags', file_path])
+        self.verify_open_flags(stdout, stderr)
+
+    # overrides TC_00_FileSystem to change input dir (from plaintext to encrypted)
+    def test_115_seek_tell(self):
+        # the test binary expects a path to read-only (existing) file and two paths to files that
+        # will get created
+        plaintext_path = self.INPUT_FILES[-1]
+        input_path = self.ENCRYPTED_FILES[-1] # existing file
+        output_path_1 = os.path.join(self.OUTPUT_DIR, 'test_115a') # writable files
+        output_path_2 = os.path.join(self.OUTPUT_DIR, 'test_115b')
+        self.copy_input(plaintext_path, output_path_1) # encrypt
+        self.copy_input(plaintext_path, output_path_2)
+        stdout, stderr = self.run_binary(['seek_tell', input_path, output_path_1, output_path_2])
+        self.verify_seek_tell(stdout, stderr, input_path, output_path_1, output_path_2,
+                              self.FILE_SIZES[-1])
+
+    # overrides TC_00_FileSystem to change input dir (from plaintext to encrypted)
+    def test_130_file_stat(self):
+        # the test binary expects a path to read-only (existing) file and a path to file that
+        # will get created
+        for i in self.INDEXES:
+            input_path = self.ENCRYPTED_FILES[i]
+            output_path = self.OUTPUT_FILES[i]
+            size = str(self.FILE_SIZES[i])
+            self.copy_input(self.INPUT_FILES[i], output_path)
+            stdout, stderr = self.run_binary(['stat', input_path, output_path])
+            self.verify_stat(stdout, stderr, input_path, output_path, size)
+
+    # overrides TC_00_FileSystem to decrypt output
+    def verify_size(self, file, size):
+        dec_path = os.path.join(self.OUTPUT_DIR, os.path.basename(file) + '.dec')
+        self.__decrypt_file(file, dec_path)
+        self.assertEqual(os.stat(dec_path).st_size, size)
+
+    @expectedFailureIf(HAS_SGX)
+    # pylint: disable=fixme
+    def test_140_file_truncate(self):
+        self.fail() # TODO: port these to the new file format
+
+    def test_150_file_rename(self):
+        path1 = os.path.join(self.OUTPUT_DIR, 'test_150a')
+        path2 = os.path.join(self.OUTPUT_DIR, 'test_150b')
+        self.copy_input(self.ENCRYPTED_FILES[-1], path1)
+        shutil.copy(path1, path2)
+        # accessing renamed file should fail
+        args = ['decrypt', '-V', '-w', self.WRAP_KEY, '-i', path2, '-o', path1]
+        try:
+            self.__pf_crypt(args)
+        except subprocess.CalledProcessError as exc:
+            self.assertNotEqual(exc.returncode, 0)
+        else:
+            print('[!] Fail: successfully decrypted renamed file: ' + path2)
+            self.fail()
+
+    # overrides TC_00_FileSystem to decrypt output
+    def verify_copy_content(self, input_path, output_path):
+        dec_path = os.path.join(self.OUTPUT_DIR, os.path.basename(output_path) + '.dec')
+        self.__decrypt_file(output_path, dec_path)
+        self.assertTrue(filecmp.cmp(input_path, dec_path, shallow=False))
+
+    # overrides TC_00_FileSystem to change input dir (from plaintext to encrypted)
+    def do_copy_test(self, executable, timeout):
+        stdout, stderr = self.run_binary([executable, self.ENCRYPTED_DIR, self.OUTPUT_DIR],
+                                         timeout=timeout)
+        self.verify_copy(stdout, stderr, self.ENCRYPTED_DIR, executable)
+
+    # overrides TC_00_FileSystem to not skip this on SGX
+    def test_203_copy_dir_mmap_whole(self):
+        self.do_copy_test('copy_mmap_whole', 30)
+
+    # overrides TC_00_FileSystem to not skip this on SGX
+    def test_204_copy_dir_mmap_seq(self):
+        self.do_copy_test('copy_mmap_seq', 60)
+
+    # overrides TC_00_FileSystem to not skip this on SGX
+    def test_205_copy_dir_mmap_rev(self):
+        self.do_copy_test('copy_mmap_rev', 60)
+
+    # overrides TC_00_FileSystem to change dirs (from plaintext to encrypted)
+    def test_210_copy_dir_mounted(self):
+        executable = 'copy_whole'
+        stdout, stderr = self.run_binary([executable, '/mounted/pf_input', '/mounted/pf_output'],
+                                         timeout=30)
+        self.verify_copy(stdout, stderr, '/mounted/pf_input', executable)
+
+    def __corrupt_file(self, input_path, output_path):
+        cmd = [self.PF_TAMPER, '-w', self.WRAP_KEY, '-i', input_path, '-o', output_path]
+        return self.run_native_binary(cmd)
+
+    # invalid/corrupted files
+    @expectedFailureIf(HAS_SGX)
+    # pylint: disable=fixme
+    def test_500_invalid(self):
+        # TODO: port these to the new file format
+        invalid_dir = os.path.join(self.TEST_DIR, 'pf_invalid')
+        # files below should work normally (benign modifications)
+        should_pass = ['chunk_padding_1_fixed', 'chunk_padding_2_fixed', 'chunk_data_3',
+                       'chunk_data_3_fixed', 'chunk_data_4', 'chunk_data_4_fixed']
+        if not os.path.exists(invalid_dir):
+            os.mkdir(invalid_dir)
+        # prepare valid encrypted file (largest one for maximum possible corruptions)
+        original_input = self.OUTPUT_FILES[-1]
+        self.__encrypt_file(self.INPUT_FILES[-1], original_input)
+        # generate invalid files based on the above
+        self.__corrupt_file(original_input, invalid_dir)
+        # try to decrypt invalid files
+        for name in os.listdir(invalid_dir):
+            invalid = os.path.join(invalid_dir, name)
+            output_path = os.path.join(self.OUTPUT_DIR, name)
+            input_path = os.path.join(invalid_dir, os.path.basename(original_input))
+            # copy the file so it has the original file name (for allowed path check)
+            shutil.copy(invalid, input_path)
+            should_pass = any(s in name for s in should_pass)
+
+            try:
+                args = ['decrypt', '-V', '-w', self.WRAP_KEY, '-i', input_path, '-o', output_path]
+                self.__pf_crypt(args)
+            except subprocess.CalledProcessError as exc:
+                if should_pass:
+                    self.assertEqual(exc.returncode, 0)
+                else:
+                    self.assertNotEqual(exc.returncode, 0)
+            else:
+                if not should_pass:
+                    print('[!] Fail: successfully decrypted file: ' + name)
+                    self.fail()

--- a/Pal/include/lib/.gitignore
+++ b/Pal/include/lib/.gitignore
@@ -1,0 +1,1 @@
+/uthash.h

--- a/Pal/include/lib/api.h
+++ b/Pal/include/lib/api.h
@@ -115,7 +115,7 @@ int atoi (const char *nptr);
 long int atol (const char *nptr);
 
 char* strchr(const char* s, int c_in);
-const char* strstr(const char* haystack, const char* needle);
+char* strstr(const char* haystack, const char* needle);
 
 void * memcpy (void *dstpp, const void *srcpp, size_t len);
 void * memmove (void *dstpp, const void *srcpp, size_t len);

--- a/Pal/include/lib/pal_crypto.h
+++ b/Pal/include/lib/pal_crypto.h
@@ -48,8 +48,8 @@ typedef struct {
     mbedtls_ssl_config conf;
     mbedtls_ssl_context ssl;
     int ciphersuites[2];  /* [0] is actual ciphersuite, [1] must be 0 to indicate end of array */
-    ssize_t (*pal_recv_cb)(int fd, void* buf, size_t len);
-    ssize_t (*pal_send_cb)(int fd, const void* buf, size_t len);
+    ssize_t (*pal_recv_cb)(int fd, void* buf, size_t buf_size);
+    ssize_t (*pal_send_cb)(int fd, const void* buf, size_t buf_size);
     int stream_fd;
 } LIB_SSL_CONTEXT;
 
@@ -60,44 +60,52 @@ typedef struct {
 #endif
 
 /* SHA256 */
-int lib_SHA256Init(LIB_SHA256_CONTEXT *context);
-int lib_SHA256Update(LIB_SHA256_CONTEXT *context, const uint8_t *data,
-		     uint64_t len);
-int lib_SHA256Final(LIB_SHA256_CONTEXT *context, uint8_t *output);
+int lib_SHA256Init(LIB_SHA256_CONTEXT* context);
+int lib_SHA256Update(LIB_SHA256_CONTEXT* context, const uint8_t* data, size_t data_size);
+int lib_SHA256Final(LIB_SHA256_CONTEXT* context, uint8_t* output);
 
 /* Diffie-Hellman Key Exchange */
-int lib_DhInit(LIB_DH_CONTEXT *context);
-int lib_DhCreatePublic(LIB_DH_CONTEXT *context, uint8_t *public,
-                       uint64_t *public_size);
-int lib_DhCalcSecret(LIB_DH_CONTEXT *context, uint8_t *peer, uint64_t peer_size,
-                     uint8_t *secret, uint64_t *secret_size);
-void lib_DhFinal(LIB_DH_CONTEXT *context);
+int lib_DhInit(LIB_DH_CONTEXT* context);
+int lib_DhCreatePublic(LIB_DH_CONTEXT* context, uint8_t* public, size_t* public_size);
+int lib_DhCalcSecret(LIB_DH_CONTEXT* context, uint8_t* peer, size_t peer_size, uint8_t* secret,
+                     size_t* secret_size);
+void lib_DhFinal(LIB_DH_CONTEXT* context);
 
 /* AES-CMAC */
-int lib_AESCMAC(const uint8_t *key, uint64_t key_len, const uint8_t *input,
-                uint64_t input_len, uint8_t *mac, uint64_t mac_len);
+int lib_AESCMAC(const uint8_t* key, size_t key_size, const uint8_t *input, size_t input_size,
+                uint8_t* mac, size_t mac_size);
+/* GCM encrypt, iv is assumed to be 12 bytes (and is changed by this call).
+ * input_size doesn't have to be a multiple of 16.
+ * Additional authenticated data (aad) may be NULL if absent.
+ * Output size is the same as input_size. */
+int lib_AESGCMEncrypt(const uint8_t* key, size_t key_size, const uint8_t* iv, const uint8_t* input,
+                      size_t input_size, const uint8_t* aad, size_t aad_size, uint8_t* output,
+                      uint8_t* tag, size_t tag_size);
+/* GCM decrypt, iv is assumed to be 12 bytes (and is changed by this call).
+ * input_len doesn't have to be a multiple of 16.
+ * Additional authenticated data (aad) may be NULL if absent.
+ * Output len is the same as input_len. */
+int lib_AESGCMDecrypt(const uint8_t* key, size_t key_size, const uint8_t* iv, const uint8_t* input,
+                      size_t input_size, const uint8_t* aad, size_t aad_size, uint8_t* output,
+                      const uint8_t* tag, size_t tag_size);
 
 /* note: 'lib_AESCMAC' is the combination of 'lib_AESCMACInit',
  * 'lib_AESCMACUpdate', and 'lib_AESCMACFinish'. */
-int lib_AESCMACInit(LIB_AESCMAC_CONTEXT * context,
-                    const uint8_t *key, uint64_t key_len);
-int lib_AESCMACUpdate(LIB_AESCMAC_CONTEXT * context, const uint8_t * input,
-                      uint64_t input_len);
-int lib_AESCMACFinish(LIB_AESCMAC_CONTEXT * context, uint8_t * mac,
-                      uint64_t mac_len);
+int lib_AESCMACInit(LIB_AESCMAC_CONTEXT* context, const uint8_t* key, size_t key_size);
+int lib_AESCMACUpdate(LIB_AESCMAC_CONTEXT* context, const uint8_t* input, size_t input_size);
+int lib_AESCMACFinish(LIB_AESCMAC_CONTEXT* context, uint8_t* mac, size_t mac_size);
 
 /* RSA. Limited functionality. */
 // Initializes the key structure
-int lib_RSAInitKey(LIB_RSA_KEY *key);
+int lib_RSAInitKey(LIB_RSA_KEY* key);
 // Must call lib_RSAInitKey first
-int lib_RSAGenerateKey(LIB_RSA_KEY *key, uint64_t length_in_bits,
-                       uint64_t exponent);
+int lib_RSAGenerateKey(LIB_RSA_KEY* key, uint64_t length_in_bits, uint64_t exponent);
 
-int lib_RSAExportPublicKey(LIB_RSA_KEY *key, uint8_t *e, uint64_t *e_size,
-                           uint8_t *n, uint64_t *n_size);
+int lib_RSAExportPublicKey(LIB_RSA_KEY* key, uint8_t* e, size_t* e_size, uint8_t* n,
+                           size_t* n_size);
 
-int lib_RSAImportPublicKey(LIB_RSA_KEY *key, const uint8_t *e, uint64_t e_size,
-                           const uint8_t *n, uint64_t n_size);
+int lib_RSAImportPublicKey(LIB_RSA_KEY* key, const uint8_t* e, size_t e_size, const uint8_t* n,
+                           size_t n_size);
 
 // Sign and verify signatures.
 
@@ -105,26 +113,26 @@ int lib_RSAImportPublicKey(LIB_RSA_KEY *key, const uint8_t *e, uint64_t e_size,
 // padding, with SHA256 as the hash mechanism. These signatures are generated
 // by the Graphene filesystem build (so outside of a running Graphene
 // application), but are verified within the Graphene application.
-int lib_RSAVerifySHA256(LIB_RSA_KEY* key, const uint8_t* hash, uint64_t hash_len,
-                        const uint8_t* signature, uint64_t signature_len);
+int lib_RSAVerifySHA256(LIB_RSA_KEY* key, const uint8_t* hash, size_t hash_size,
+                        const uint8_t* signature, size_t signature_size);
 
 // Frees memory allocated in lib_RSAInitKey.
-int lib_RSAFreeKey(LIB_RSA_KEY *key);
+int lib_RSAFreeKey(LIB_RSA_KEY* key);
 
 // Encode and decode Base64 messages.
 // These two functions can be used to query encode and decode sizes if dst is given NULL
-int lib_Base64Encode(const uint8_t* src, size_t slen, char* dst, size_t* dlen);
-int lib_Base64Decode(const char *src, size_t slen, uint8_t* dst, size_t* dlen);
+int lib_Base64Encode(const uint8_t* src, size_t src_size, char* dst, size_t* dst_size);
+int lib_Base64Decode(const char* src, size_t src_size, uint8_t* dst, size_t* dst_size);
 
 /* SSL/TLS */
 int lib_SSLInit(LIB_SSL_CONTEXT* ssl_ctx, int stream_fd, bool is_server,
                 const uint8_t* psk, size_t psk_size,
-                ssize_t (*pal_recv_cb)(int fd, void* buf, size_t len),
-                ssize_t (*pal_send_cb)(int fd, const void* buf, size_t len),
+                ssize_t (*pal_recv_cb)(int fd, void* buf, size_t buf_size),
+                ssize_t (*pal_send_cb)(int fd, const void* buf, size_t buf_size),
                 const uint8_t* buf_load_ssl_ctx, size_t buf_size);
 int lib_SSLFree(LIB_SSL_CONTEXT* ssl_ctx);
 int lib_SSLHandshake(LIB_SSL_CONTEXT* ssl_ctx);
-int lib_SSLRead(LIB_SSL_CONTEXT* ssl_ctx, uint8_t* buf, size_t len);
-int lib_SSLWrite(LIB_SSL_CONTEXT* ssl_ctx, const uint8_t* buf, size_t len);
-int lib_SSLSave(LIB_SSL_CONTEXT* ssl_ctx, uint8_t* buf, size_t len, size_t* olen);
+int lib_SSLRead(LIB_SSL_CONTEXT* ssl_ctx, uint8_t* buf, size_t buf_size);
+int lib_SSLWrite(LIB_SSL_CONTEXT* ssl_ctx, const uint8_t* buf, size_t buf_size);
+int lib_SSLSave(LIB_SSL_CONTEXT* ssl_ctx, uint8_t* buf, size_t buf_size, size_t* out_size);
 #endif

--- a/Pal/lib/Makefile
+++ b/Pal/lib/Makefile
@@ -132,7 +132,7 @@ objs += crypto/adapters/mbedtls_encoding.o
 endif
 
 .PHONY: all
-all: $(target)graphene-lib.a
+all: ../include/lib/uthash.h $(target)graphene-lib.a
 
 $(target)graphene-lib.a: $(addprefix $(target),$(objs))
 	@mkdir -p $(dir $@)
@@ -146,6 +146,12 @@ ifeq ($(filter %clean,$(MAKECMDGOALS)),)
 -include $(patsubst %.o,%.d,$(addprefix $(target),$(objs)))
 endif
 
+UTHASH_URI ?= https://raw.githubusercontent.com/troydhanson/uthash/8b214aefcb81df86a7e5e0d4fa20e59a6c18bc02/src/uthash.h
+UTHASH_CHECKSUM ?= ba9af0e8c902108cc40be8e742ff4fcbb0e93062d91aefd6070b70d4e067c2ac
+
+../include/lib/uthash.h:
+	../../Scripts/download --output $@ --url $(UTHASH_URI) --sha256 $(UTHASH_CHECKSUM)
+
 .PHONY: clean
 clean:
 	$(RM) $(objs) graphene-lib.a
@@ -153,3 +159,4 @@ clean:
 .PHONY: distclean
 distclean: clean
 	$(RM) -r crypto/$(MBEDTLS_SRC) crypto/$(MBEDCRYPTO_SRC) crypto/mbedtls
+	$(RM) ../include/lib/uthash.h

--- a/Pal/lib/crypto/adapters/mbedtls_dh.c
+++ b/Pal/lib/crypto/adapters/mbedtls_dh.c
@@ -50,7 +50,7 @@ int lib_DhInit(LIB_DH_CONTEXT* context) {
     return 0;
 }
 
-int lib_DhCreatePublic(LIB_DH_CONTEXT* context, uint8_t* public, uint64_t* public_size) {
+int lib_DhCreatePublic(LIB_DH_CONTEXT* context, uint8_t* public, size_t* public_size) {
     int ret;
 
     if (*public_size != DH_SIZE)
@@ -66,8 +66,8 @@ int lib_DhCreatePublic(LIB_DH_CONTEXT* context, uint8_t* public, uint64_t* publi
     return 0;
 }
 
-int lib_DhCalcSecret(LIB_DH_CONTEXT* context, uint8_t* peer, uint64_t peer_size, uint8_t* secret,
-                     uint64_t* secret_size) {
+int lib_DhCalcSecret(LIB_DH_CONTEXT* context, uint8_t* peer, size_t peer_size, uint8_t* secret,
+                     size_t* secret_size) {
     int ret;
 
     if (*secret_size != DH_SIZE)

--- a/Pal/lib/crypto/adapters/mbedtls_encoding.c
+++ b/Pal/lib/crypto/adapters/mbedtls_encoding.c
@@ -9,16 +9,16 @@
 /*!
  * \brief Encode a byte array into a Base64 string
  *
- * \param[in]     src  input data
- * \param[in]     slen size of input data
- * \param[out]    dst  buffer for the output
- * \param[in,out] dlen in: size of \p dst, out: length after encoding
+ * \param[in]     src      input data
+ * \param[in]     src_size size of input data
+ * \param[out]    dst      buffer for the output
+ * \param[in,out] dst_size in: size of \p dst, out: size after encoding
  *
- * If \p dst is NULL, `*dlen` is still set to expected size after encoding.
+ * If \p dst is NULL, `*dst_size` is still set to expected size after encoding.
  */
-int lib_Base64Encode(const uint8_t* src, size_t slen, char* dst, size_t* dlen) {
-    int ret = mbedtls_base64_encode((unsigned char*)dst, *dlen, dlen,
-                                    (const unsigned char*)src, slen);
+int lib_Base64Encode(const uint8_t* src, size_t src_size, char* dst, size_t* dst_size) {
+    int ret = mbedtls_base64_encode((unsigned char*)dst, *dst_size, dst_size,
+                                    (const unsigned char*)src, src_size);
     if (ret == MBEDTLS_ERR_BASE64_BUFFER_TOO_SMALL) {
         return !dst ? 0 : -PAL_ERROR_OVERFLOW;
     } else if (ret != 0) {
@@ -31,16 +31,16 @@ int lib_Base64Encode(const uint8_t* src, size_t slen, char* dst, size_t* dlen) {
 /*!
  * \brief Decode a Base64 string into a byte array
  *
- * \param[in]     src  input data
- * \param[in]     slen size of input data
- * \param[out]    dst  buffer for the output
- * \param[in,out] dlen in: size of \p dst, out: length after decoding
+ * \param[in]     src      input data
+ * \param[in]     src_size size of input data
+ * \param[out]    dst      buffer for the output
+ * \param[in,out] dst_size in: size of \p dst, out: size after decoding
  *
- * If \p dst is NULL, `*dlen` is still set to expected size after decoding.
+ * If \p dst is NULL, `*dst_size` is still set to expected size after decoding.
  */
-int lib_Base64Decode(const char* src, size_t slen, uint8_t* dst, size_t* dlen) {
-    int ret = mbedtls_base64_decode((unsigned char*)dst, *dlen, dlen,
-                                    (const unsigned char*)src, slen);
+int lib_Base64Decode(const char* src, size_t src_size, uint8_t* dst, size_t* dst_size) {
+    int ret = mbedtls_base64_decode((unsigned char*)dst, *dst_size, dst_size,
+                                    (const unsigned char*)src, src_size);
     if (ret == MBEDTLS_ERR_BASE64_BUFFER_TOO_SMALL) {
         return !dst ? 0 : -PAL_ERROR_OVERFLOW;
     } else if (ret != 0) {

--- a/Pal/lib/string/strstr.c
+++ b/Pal/lib/string/strstr.c
@@ -2,13 +2,14 @@
 
 #include "api.h"
 
-const char* strstr(const char* haystack, const char* needle) {
+char* strstr(const char* haystack, const char* needle) {
     size_t h_len = strlen(haystack);
     size_t n_len = strlen(needle);
     unsigned int o = 0;
 
     if (n_len == 0)
-        return haystack;
+        /* this is pretty bad, but it's done to mimic strstr's signature from libc */
+        return (char*)haystack;
 
     if (h_len < n_len)
         return NULL;
@@ -18,7 +19,7 @@ const char* strstr(const char* haystack, const char* needle) {
         while (i < n_len && haystack[o + i] == needle[i])
             i++;
         if (i == n_len)
-            return &haystack[o];
+            return (char*)&haystack[o];
         o++;
     }
     return NULL;

--- a/Pal/src/host/Linux-SGX/Makefile
+++ b/Pal/src/host/Linux-SGX/Makefile
@@ -14,6 +14,7 @@ CFLAGS += \
 	-I../../../include/lib \
 	-I../../../lib/crypto/mbedtls/include \
 	-I../../../lib/crypto/mbedtls/crypto/include \
+	-Iprotected-files \
 	-Isgx-driver
 
 ASFLAGS += \
@@ -52,9 +53,12 @@ enclave-objs = \
 	enclave_framework.o \
 	enclave_ocalls.o \
 	enclave_pages.o \
+	enclave_pf.o \
 	enclave_platform.o \
 	enclave_untrusted.o \
 	enclave_xstate.o \
+	protected-files/lru_cache.o \
+	protected-files/protected_files.o \
 	$(commons_objs)
 
 enclave-asm-objs = enclave_entry.o
@@ -147,6 +151,7 @@ CLEAN_FILES += quote/aesm.pb-c.c quote/aesm.pb-c.h quote/aesm.pb-c.d quote/aesm.
 clean_:
 	$(RM) -r *.o *.e *.i *.s $(host_files) $(CLEAN_FILES) *.d debugger/*.d signer/*.pyc __pycache__ \
 	         signer/__pycache__
+	$(RM) -r protected-files/*.o protected-files/*.d
 
 .PHONY: clean
 clean: clean_

--- a/Pal/src/host/Linux-SGX/db_files.c
+++ b/Pal/src/host/Linux-SGX/db_files.c
@@ -8,10 +8,7 @@
  * "file:" or "dir:".
  */
 
-#include <linux/types.h>
-
 #include "api.h"
-#include "assert.h"
 #include "pal.h"
 #include "pal_debug.h"
 #include "pal_defs.h"
@@ -27,6 +24,7 @@ typedef __kernel_pid_t pid_t;
 #include <asm/stat.h>
 #include <linux/fs.h>
 #include <linux/stat.h>
+#include <linux/types.h>
 
 #include "enclave_pages.h"
 
@@ -35,22 +33,19 @@ static int file_open(PAL_HANDLE* handle, const char* type, const char* uri, int 
                      int create, int options) {
     if (strcmp_static(type, URI_TYPE_FILE))
         return -PAL_ERROR_INVAL;
-    /* try to do the real open */
-    int fd = ocall_open(uri, PAL_ACCESS_TO_LINUX_OPEN(access)  |
-                             PAL_CREATE_TO_LINUX_OPEN(create)  |
-                             PAL_OPTION_TO_LINUX_OPEN(options),
-                        share);
 
-    if (IS_ERR(fd))
-        return unix_to_pal_error(ERRNO(fd));
+    SGX_DBG(DBG_D, "file_open: uri %s, access 0x%x, share 0x%x, create 0x%x, options 0x%x\n",
+            uri, access, share, create, options);
 
-    /* if try_create_path succeeded, prepare for the file handle */
+    /* prepare the file handle */
     size_t len     = strlen(uri) + 1;
-    PAL_HANDLE hdl = malloc(HANDLE_SIZE(file) + len);
+    PAL_HANDLE hdl = calloc(1, HANDLE_SIZE(file) + len);
+    if (!hdl)
+        return -PAL_ERROR_NOMEM;
+
     SET_HANDLE_TYPE(hdl, file);
     HANDLE_HDR(hdl)->flags |= RFD(0) | WFD(0);
-    hdl->file.fd     = fd;
-    char* path       = (void*)hdl + HANDLE_SIZE(file);
+    char* path = (void*)hdl + HANDLE_SIZE(file);
     int ret;
     if ((ret = get_norm_path(uri, path, &len)) < 0) {
         SGX_DBG(DBG_E, "Could not normalize path (%s): %s\n", uri, pal_strerror(ret));
@@ -59,32 +54,123 @@ static int file_open(PAL_HANDLE* handle, const char* type, const char* uri, int 
     }
     hdl->file.realpath = (PAL_STR)path;
 
-    sgx_stub_t* stubs;
-    uint64_t total;
-    void* umem;
-    ret = load_trusted_file(hdl, &stubs, &total, create, &umem);
-    if (ret < 0) {
-        SGX_DBG(DBG_E,
-                "Accessing file:%s is denied. (%s) "
-                "This file is not trusted or allowed.\n",
-                hdl->file.realpath, pal_strerror(ret));
-        free(hdl);
-        return ret;
-    }
-    if (stubs && total) {
-        assert(umem);
+    struct protected_file* pf = get_protected_file(path);
+    /* whether to re-initialize the PF */
+    bool pf_create = (create & PAL_CREATE_ALWAYS) || (create & PAL_CREATE_TRY);
+
+    /* try to do the real open */
+    int fd = ocall_open(uri, PAL_ACCESS_TO_LINUX_OPEN(access)  |
+                             PAL_CREATE_TO_LINUX_OPEN(create)  |
+                             PAL_OPTION_TO_LINUX_OPEN(options),
+                        share);
+    if (IS_ERR(fd)) {
+        ret = unix_to_pal_error(ERRNO(fd));
+        goto out;
     }
 
-    hdl->file.stubs  = (PAL_PTR)stubs;
-    hdl->file.total  = total;
-    hdl->file.umem = umem;
+    hdl->file.fd = fd;
+
+    if (pf) {
+        pf_file_mode_t pf_mode = 0;
+        if ((access & PAL_ACCESS_RDWR) == PAL_ACCESS_RDWR)
+            pf_mode = PF_FILE_MODE_READ | PF_FILE_MODE_WRITE;
+        else if ((access & PAL_ACCESS_WRONLY) == PAL_ACCESS_WRONLY)
+            pf_mode = PF_FILE_MODE_WRITE;
+        else
+            pf_mode = PF_FILE_MODE_READ;
+
+        /* disallow opening more than one writable handle to a PF */
+        if (pf_mode & PF_FILE_MODE_WRITE) {
+            if (pf->writable_fd >= 0) {
+                SGX_DBG(DBG_D, "file_open(%s): disallowing concurrent writable handle\n", path);
+                ret = -PAL_ERROR_DENIED;
+                goto out;
+            }
+        }
+
+        /* get real file size */
+        struct stat st;
+        ret = ocall_fstat(fd, &st);
+        if (IS_ERR(ret)) {
+            SGX_DBG(DBG_E, "file_open(%s): fstat failed: %d\n", path, ret);
+            ret = unix_to_pal_error(ERRNO(ret));
+            goto out;
+        }
+
+        ret = -PAL_ERROR_DENIED;
+        pf = load_protected_file(path, (int*)&hdl->file.fd, st.st_size, pf_mode, pf_create, pf);
+        if (pf) {
+            pf->refcount++;
+            if (pf_mode & PF_FILE_MODE_WRITE) {
+                pf->writable_fd = fd;
+            }
+        } else {
+            SGX_DBG(DBG_E, "load_protected_file(%s, %d) failed\n", path, hdl->file.fd);
+            goto out;
+        }
+    } else {
+        sgx_stub_t* stubs;
+        uint64_t total;
+        void* umem;
+        ret = load_trusted_file(hdl, &stubs, &total, create, &umem);
+        if (ret < 0) {
+            SGX_DBG(DBG_E,
+                    "Accessing file:%s is denied. (%s) "
+                    "This file is not trusted or allowed.\n",
+                    hdl->file.realpath, pal_strerror(ret));
+            goto out;
+        }
+
+        if (stubs && total) {
+            assert(umem);
+        }
+
+        hdl->file.stubs = (PAL_PTR)stubs;
+        hdl->file.total = total;
+        hdl->file.umem  = umem;
+    }
 
     *handle = hdl;
-    return 0;
+    ret = 0;
+
+out:
+    if (ret != 0) {
+        if (pf && pf->context && pf->refcount == 0)
+            unload_protected_file(pf);
+
+        free(hdl);
+        if (fd >= 0)
+            ocall_close(fd);
+    }
+    return ret;
+}
+
+static int64_t pf_file_read(struct protected_file* pf, PAL_HANDLE handle, uint64_t offset,
+                            uint64_t count, void* buffer) {
+    int fd = handle->file.fd;
+
+    if (!pf->context) {
+        SGX_DBG(DBG_E, "pf_file_read(PF fd %d): PF not initialized\n", fd);
+        return -PAL_ERROR_BADHANDLE;
+    }
+
+    pf_status_t pfs = pf_read(pf->context, offset, count, buffer);
+
+    if (PF_FAILURE(pfs)) {
+        SGX_DBG(DBG_E, "pf_file_read(PF fd %d): pf_read failed: %d\n", fd, pfs);
+        return -PAL_ERROR_DENIED;
+    }
+
+    return count;
 }
 
 /* 'read' operation for file streams. */
 static int64_t file_read(PAL_HANDLE handle, uint64_t offset, uint64_t count, void* buffer) {
+    struct protected_file* pf = find_protected_file_handle(handle);
+
+    if (pf)
+        return pf_file_read(pf, handle, offset, count, buffer);
+
     int64_t ret;
     sgx_stub_t* stubs = (sgx_stub_t*)handle->file.stubs;
 
@@ -115,8 +201,33 @@ static int64_t file_read(PAL_HANDLE handle, uint64_t offset, uint64_t count, voi
     return end - offset;
 }
 
+
+static int64_t pf_file_write(struct protected_file* pf, PAL_HANDLE handle, uint64_t offset,
+                             uint64_t count, const void* buffer) {
+    int fd = handle->file.fd;
+
+    if (!pf->context) {
+        SGX_DBG(DBG_E, "pf_file_write(PF fd %d): PF not initialized\n", fd);
+        return -PAL_ERROR_BADHANDLE;
+    }
+
+    pf_status_t pf_ret = pf_write(pf->context, offset, count, buffer);
+
+    if (PF_FAILURE(pf_ret)) {
+        SGX_DBG(DBG_E, "pf_file_write(PF fd %d): pf_write failed: %d\n", fd, pf_ret);
+        return -PAL_ERROR_DENIED;
+    }
+
+    return count;
+}
+
 /* 'write' operation for file streams. */
 static int64_t file_write(PAL_HANDLE handle, uint64_t offset, uint64_t count, const void* buffer) {
+    struct protected_file *pf = find_protected_file_handle(handle);
+
+    if (pf)
+        return pf_file_write(pf, handle, offset, count, buffer);
+
     int64_t ret;
     sgx_stub_t* stubs = (sgx_stub_t*)handle->file.stubs;
 
@@ -132,10 +243,36 @@ static int64_t file_write(PAL_HANDLE handle, uint64_t offset, uint64_t count, co
     return -PAL_ERROR_DENIED;
 }
 
+static int pf_file_close(struct protected_file* pf, PAL_HANDLE handle) {
+    int fd = handle->file.fd;
+
+    if (pf->refcount == 0) {
+        SGX_DBG(DBG_E, "pf_file_close(PF fd %d): refcount == 0\n", fd);
+        return -PAL_ERROR_INVAL;
+    }
+
+    pf->refcount--;
+
+    if (pf->writable_fd == fd)
+        pf->writable_fd = -1;
+
+    if (pf->refcount == 0)
+        return unload_protected_file(pf);
+
+    return 0;
+}
+
 /* 'close' operation for file streams. In this case, it will only
    close the file without deleting it. */
 static int file_close(PAL_HANDLE handle) {
     int fd = handle->file.fd;
+    struct protected_file* pf = find_protected_file_handle(handle);
+
+    if (pf) {
+        int ret = pf_file_close(pf, handle);
+        if (ret < 0)
+            return ret;
+    }
 
     if (handle->file.stubs && handle->file.total) {
         /* case of trusted file: the whole file was mmapped in untrusted memory */
@@ -161,8 +298,77 @@ static int file_delete(PAL_HANDLE handle, int access) {
     return IS_ERR(ret) ? unix_to_pal_error(ERRNO(ret)) : ret;
 }
 
+static int pf_file_map(struct protected_file* pf, PAL_HANDLE handle, void** addr, int prot,
+                       uint64_t offset, uint64_t size) {
+    int fd = handle->file.fd;
+
+    if (size == 0)
+        return -PAL_ERROR_INVAL;
+
+    assert(WITHIN_MASK(prot, PAL_PROT_MASK));
+    if ((prot & PAL_PROT_READ) && (prot & PAL_PROT_WRITE)) {
+        SGX_DBG(DBG_E, "pf_file_map(PF fd %d): trying to map with R+W access\n", fd);
+        return -PAL_ERROR_NOTSUPPORT;
+    }
+
+    if (!pf->context) {
+        SGX_DBG(DBG_E, "pf_file_map(PF fd %d): PF not initialized\n", fd);
+        return -PAL_ERROR_BADHANDLE;
+    }
+
+    uint64_t pf_size;
+    pf_status_t pfs = pf_get_size(pf->context, &pf_size);
+    __UNUSED(pfs);
+    assert(PF_SUCCESS(pfs));
+
+    SGX_DBG(DBG_D, "pf_file_map(PF fd %d): pf %p, addr %p, prot %d, offset %lu, size %lu\n",
+            fd, pf, *addr, prot, offset, size);
+
+    /* LibOS always provides preallocated buffer for file maps */
+    assert(*addr);
+
+    if (prot & PAL_PROT_WRITE) {
+        struct pf_map* map = calloc(1, sizeof(*map));
+
+        map->pf     = pf;
+        map->size   = size;
+        map->offset = offset;
+        map->buffer = *addr;
+
+        pf_lock();
+        LISTP_ADD_TAIL(map, &g_pf_map_list, list);
+        pf_unlock();
+    }
+
+    if (prot & PAL_PROT_READ) {
+        /* we don't check this on writes since file size may be extended then */
+        if (offset >= pf_size) {
+            SGX_DBG(DBG_E, "pf_file_map(PF fd %d): offset (%lu) >= file size (%lu)\n",
+                    fd, offset, pf_size);
+            return -PAL_ERROR_INVAL;
+        }
+
+        uint64_t copy_size = MIN(size, pf_size - offset);
+
+        pf_status_t pf_ret = pf_read(pf->context, offset, copy_size, *addr);
+        if (PF_FAILURE(pf_ret)) {
+            SGX_DBG(DBG_E, "pf_file_map(PF fd %d): pf_read failed: %d\n", fd, pf_ret);
+            return -PAL_ERROR_DENIED;
+        }
+        memset(*addr + copy_size, 0, size - copy_size);
+    }
+
+    /* Writes will be flushed to the PF on close. */
+    return 0;
+}
+
 /* 'map' operation for file stream. */
 static int file_map(PAL_HANDLE handle, void** addr, int prot, uint64_t offset, uint64_t size) {
+    struct protected_file* pf = find_protected_file_handle(handle);
+
+    if (pf)
+        return pf_file_map(pf, handle, addr, prot, offset, size);
+
     sgx_stub_t* stubs = (sgx_stub_t*)handle->file.stubs;
     uint64_t total    = handle->file.total;
     void* mem         = *addr;
@@ -229,8 +435,24 @@ static int file_map(PAL_HANDLE handle, void** addr, int prot, uint64_t offset, u
     return 0;
 }
 
+static int64_t pf_file_setlength(struct protected_file *pf, PAL_HANDLE handle, uint64_t length) {
+    int fd = handle->file.fd;
+
+    pf_status_t pfs = pf_set_size(pf->context, length);
+    if (PF_FAILURE(pfs)) {
+        SGX_DBG(DBG_E, "pf_file_setlength(PF fd %d, %lu): pf_set_size returned %d\n",
+                fd, length, pfs);
+        return -PAL_ERROR_DENIED;
+    }
+    return length;
+}
+
 /* 'setlength' operation for file stream. */
 static int64_t file_setlength(PAL_HANDLE handle, uint64_t length) {
+    struct protected_file *pf = find_protected_file_handle(handle);
+    if (pf)
+        return pf_file_setlength(pf, handle, length);
+
     int ret = ocall_ftruncate(handle->file.fd, length);
     if (IS_ERR(ret))
         return unix_to_pal_error(ERRNO(ret));
@@ -241,7 +463,22 @@ static int64_t file_setlength(PAL_HANDLE handle, uint64_t length) {
 
 /* 'flush' operation for file stream. */
 static int file_flush(PAL_HANDLE handle) {
-    ocall_fsync(handle->file.fd);
+    int fd = handle->file.fd;
+    struct protected_file *pf = find_protected_file_handle(handle);
+    if (pf) {
+        int ret = flush_pf_maps(pf, /*buffer=*/NULL, /*remove=*/false);
+        if (ret < 0) {
+            SGX_DBG(DBG_E, "file_flush(PF fd %d): flush_pf_maps returned %d\n", fd, ret);
+            return ret;
+        }
+        pf_status_t pfs = pf_flush(pf->context);
+        if (PF_FAILURE(pfs)) {
+            SGX_DBG(DBG_E, "file_flush(PF fd %d): pf_flush returned %d\n", fd, pfs);
+            return -PAL_ERROR_DENIED;
+        }
+    } else {
+        ocall_fsync(fd);
+    }
     return 0;
 }
 
@@ -272,10 +509,44 @@ static inline void file_attrcopy(PAL_STREAM_ATTR* attr, struct stat* stat) {
     attr->pending_size = stat->st_size;
 }
 
+static int pf_file_attrquery(struct protected_file* pf, int fd_from_attrquery, const char* path,
+                             uint64_t real_size, PAL_STREAM_ATTR* attr) {
+    pf = load_protected_file(path, &fd_from_attrquery, real_size, PAL_PROT_READ, /*create=*/false,
+                             pf);
+    if (!pf) {
+        SGX_DBG(DBG_E, "pf_file_attrquery: load_protected_file(%s, %d) failed\n", path,
+                fd_from_attrquery);
+        /* The call above will fail for PFs that were tampered with or have a wrong path.
+         * glibc kills the process if this fails during directory enumeration, but that
+         * should be fine given the scenario.
+         */
+        return -PAL_ERROR_DENIED;
+    }
+
+    uint64_t size;
+    pf_status_t pfs = pf_get_size(pf->context, &size);
+    __UNUSED(pfs);
+    assert(PF_SUCCESS(pfs));
+    attr->pending_size = size;
+
+    pf_handle_t pf_handle;
+    pfs = pf_get_handle(pf->context, &pf_handle);
+    assert(PF_SUCCESS(pfs));
+
+    if (fd_from_attrquery == *(int*)pf_handle) { /* this is a PF opened just for us, close it */
+        pfs = pf_close(pf->context);
+        pf->context = NULL;
+        assert(PF_SUCCESS(pfs));
+    }
+
+    return 0;
+}
+
 /* 'attrquery' operation for file streams */
 static int file_attrquery(const char* type, const char* uri, PAL_STREAM_ATTR* attr) {
     if (strcmp_static(type, URI_TYPE_FILE) && strcmp_static(type, URI_TYPE_DIR))
         return -PAL_ERROR_INVAL;
+
     /* try to do the real open */
     int fd = ocall_open(uri, 0, 0);
     if (IS_ERR(fd))
@@ -283,14 +554,33 @@ static int file_attrquery(const char* type, const char* uri, PAL_STREAM_ATTR* at
 
     struct stat stat_buf;
     int ret = ocall_fstat(fd, &stat_buf);
-    ocall_close(fd);
 
     /* if it failed, return the right error code */
-    if (IS_ERR(ret))
-        return unix_to_pal_error(ERRNO(ret));
+    if (IS_ERR(ret)) {
+        ret = unix_to_pal_error(ERRNO(ret));
+        goto out;
+    }
 
     file_attrcopy(attr, &stat_buf);
-    return 0;
+
+    char path[URI_MAX];
+    size_t len = URI_MAX;
+    ret = get_norm_path(uri, path, &len);
+    if (ret < 0) {
+        SGX_DBG(DBG_E, "Could not normalize path (%s): %s\n", uri, pal_strerror(ret));
+        goto out;
+    }
+
+    /* For protected files return the data size, not real FS size */
+    struct protected_file* pf = get_protected_file(path);
+    if (pf && attr->handle_type != pal_type_dir)
+        ret = pf_file_attrquery(pf, fd, path, stat_buf.st_size, attr);
+    else
+        ret = 0;
+
+out:
+    ocall_close(fd);
+    return ret;
 }
 
 /* 'attrquerybyhdl' operation for file streams */
@@ -303,6 +593,18 @@ static int file_attrquerybyhdl(PAL_HANDLE handle, PAL_STREAM_ATTR* attr) {
         return unix_to_pal_error(ERRNO(ret));
 
     file_attrcopy(attr, &stat_buf);
+
+    if (attr->handle_type != pal_type_dir) {
+        /* For protected files return the data size, not real FS size */
+        struct protected_file* pf = find_protected_file_handle(handle);
+        if (pf) {
+            uint64_t size;
+            pf_status_t pfs = pf_get_size(pf->context, &size);
+            __UNUSED(pfs);
+            assert(PF_SUCCESS(pfs));
+            attr->pending_size = size;
+        }
+    }
     return 0;
 }
 

--- a/Pal/src/host/Linux-SGX/db_main.c
+++ b/Pal/src/host/Linux-SGX/db_main.c
@@ -17,6 +17,7 @@
 #include "pal_linux.h"
 #include "pal_linux_defs.h"
 #include "pal_security.h"
+#include "protected_files.h"
 
 #include <asm/ioctls.h>
 #include <asm/mman.h>
@@ -395,6 +396,11 @@ void pal_linux_main(char* uptr_args, uint64_t args_size, char* uptr_env, uint64_
 
     if ((rv = init_file_check_policy()) < 0) {
         SGX_DBG(DBG_E, "Failed to load the file check policy: %d\n", rv);
+        ocall_exit(rv, true);
+    }
+
+    if ((rv = init_protected_files()) < 0) {
+        SGX_DBG(DBG_E, "Failed to initialize protected files: %d\n", rv);
         ocall_exit(rv, true);
     }
 

--- a/Pal/src/host/Linux-SGX/db_streams.c
+++ b/Pal/src/host/Linux-SGX/db_streams.c
@@ -80,6 +80,10 @@ void _DkPrintConsole(const void* buf, int size) {
 /* _DkStreamUnmap for internal use. Unmap stream at certain memory address.
    The memory is unmapped as a whole.*/
 int _DkStreamUnmap(void* addr, uint64_t size) {
+    int ret = flush_pf_maps(/*pf=*/NULL, addr, /*remove=*/true);
+    if (ret < 0)
+        return ret;
+
     return free_enclave_pages(addr, size);
 }
 

--- a/Pal/src/host/Linux-SGX/enclave_pf.c
+++ b/Pal/src/host/Linux-SGX/enclave_pf.c
@@ -1,0 +1,613 @@
+/* SPDX-License-Identifier: LGPL-3.0-or-later */
+/* Copyright (C) 2018-2020 Invisible Things Lab
+ *                         Rafal Wojdyla <omeg@invisiblethingslab.com>
+ */
+
+#include <linux/fs.h>
+
+#include "pal_crypto.h"
+#include "pal_internal.h"
+#include "pal_linux.h"
+#include "pal_linux_error.h"
+#include "spinlock.h"
+
+/*
+ * At startup, protected file paths are read from the manifest and the specified files
+ * or directories registered. For supported I/O operations, handlers (in db_files.c)
+ * check if the file is a PF to perform the required operation transparently.
+ *
+ * Since PF's "logical" size is different than the real FS size (and to avoid potential
+ * infinite recursion in FS handlers) we don't use PAL file APIs here, but raw OCALLs.
+ */
+
+/* List of map buffers */
+LISTP_TYPE(pf_map) g_pf_map_list = LISTP_INIT;
+
+/* Callbacks for protected files handling */
+static pf_status_t cb_read(pf_handle_t handle, void* buffer, uint64_t offset, size_t size) {
+    int fd = *(int*)handle;
+    size_t buffer_offset = 0;
+    size_t to_read = size;
+    while (to_read > 0) {
+        ssize_t read = ocall_pread(fd, buffer + buffer_offset, to_read, offset + buffer_offset);
+        if (read == -EINTR)
+            continue;
+
+        if (read < 0) {
+            SGX_DBG(DBG_E, "cb_read(%d, %p, %lu, %lu): read failed: %ld\n",
+                    fd, buffer, offset, size, read);
+            return PF_STATUS_CALLBACK_FAILED;
+        }
+
+        /* EOF is an error condition, we want to read exactly `size` bytes */
+        if (read == 0) {
+            SGX_DBG(DBG_E, "cb_read(%d, %p, %lu, %lu): EOF\n", fd, buffer, offset, size);
+            return PF_STATUS_CALLBACK_FAILED;
+        }
+
+        to_read -= read;
+        buffer_offset += read;
+    }
+    return PF_STATUS_SUCCESS;
+}
+
+static pf_status_t cb_write(pf_handle_t handle, const void* buffer, uint64_t offset, size_t size) {
+    int fd = *(int*)handle;
+    size_t buffer_offset = 0;
+    size_t to_write = size;
+    while (to_write > 0) {
+        ssize_t written = ocall_pwrite(fd, buffer + buffer_offset, to_write,
+                                       offset + buffer_offset);
+        if (written == -EINTR)
+            continue;
+
+        if (written < 0) {
+            SGX_DBG(DBG_E, "cb_write(%d, %p, %lu, %lu): write failed: %ld\n",
+                    fd, buffer, offset, size, written);
+            return PF_STATUS_CALLBACK_FAILED;
+        }
+
+        /* EOF is an error condition, we want to write exactly `size` bytes */
+        if (written == 0) {
+            SGX_DBG(DBG_E, "cb_write(%d, %p, %lu, %lu): EOF\n", fd, buffer, offset, size);
+            return PF_STATUS_CALLBACK_FAILED;
+        }
+
+        to_write -= written;
+        buffer_offset += written;
+    }
+    return PF_STATUS_SUCCESS;
+}
+
+static pf_status_t cb_truncate(pf_handle_t handle, uint64_t size) {
+    int fd = *(int*)handle;
+    int ret = ocall_ftruncate(fd, size);
+    if (IS_ERR(ret)) {
+        SGX_DBG(DBG_E, "cb_truncate(%d, %lu): ocall failed: %d\n", fd, size, ret);
+        return PF_STATUS_CALLBACK_FAILED;
+    }
+    return PF_STATUS_SUCCESS;
+}
+
+#ifdef DEBUG
+static void cb_debug(const char* msg) {
+    SGX_DBG(DBG_D, "%s", msg);
+}
+#endif
+
+static pf_status_t cb_aes_gcm_encrypt(const pf_key_t* key, const pf_iv_t* iv,
+                                      const void* aad, size_t aad_size,
+                                      const void* input, size_t input_size, void* output,
+                                      pf_mac_t* mac) {
+    int ret = lib_AESGCMEncrypt((const uint8_t*)key, sizeof(*key), (const uint8_t*)iv, input,
+                                input_size, aad, aad_size, output, (uint8_t*)mac, sizeof(*mac));
+    if (ret != 0) {
+        SGX_DBG(DBG_E, "lib_AESGCMEncrypt failed: %d\n", ret);
+        return PF_STATUS_CALLBACK_FAILED;
+    }
+    return PF_STATUS_SUCCESS;
+}
+
+static pf_status_t cb_aes_gcm_decrypt(const pf_key_t* key, const pf_iv_t* iv,
+                                      const void* aad, size_t aad_size,
+                                      const void* input, size_t input_size, void* output,
+                                      const pf_mac_t* mac) {
+    int ret = lib_AESGCMDecrypt((const uint8_t*)key, sizeof(*key), (const uint8_t*)iv, input,
+                                input_size, aad, aad_size, output, (const uint8_t*)mac,
+                                sizeof(*mac));
+    if (ret != 0) {
+        SGX_DBG(DBG_E, "lib_AESGCMDecrypt failed: %d\n", ret);
+        return PF_STATUS_CALLBACK_FAILED;
+    }
+    return PF_STATUS_SUCCESS;
+}
+
+static pf_status_t cb_random(uint8_t* buffer, size_t size) {
+    int ret = _DkRandomBitsRead(buffer, size);
+    if (IS_ERR(ret)) {
+        SGX_DBG(DBG_E, "_DkRandomBitsRead failed: %d\n", ret);
+        return PF_STATUS_CALLBACK_FAILED;
+    }
+    return PF_STATUS_SUCCESS;
+}
+
+/* Wrap key for protected files.
+   TODO: In the future, this key should be provisioned after local/remote attestation. */
+static pf_key_t g_pf_wrap_key = {0};
+
+/* Collection of registered protected files */
+static struct protected_file* g_protected_files = NULL;
+
+/* Collection of registered protected directories */
+static struct protected_file* g_protected_dirs = NULL;
+
+/* Lock for operations on global PF structures */
+static spinlock_t g_protected_file_lock = INIT_SPINLOCK_UNLOCKED;
+
+/* Take ownership of the global PF lock */
+void pf_lock(void) {
+    spinlock_lock(&g_protected_file_lock);
+}
+
+/* Release ownership of the global PF lock */
+void pf_unlock(void) {
+    spinlock_unlock(&g_protected_file_lock);
+}
+
+/* Exact match of path in g_protected_files */
+struct protected_file* find_protected_file(const char* path) {
+    struct protected_file* pf = NULL;
+
+    pf_lock();
+    HASH_FIND_STR(g_protected_files, path, pf);
+    pf_unlock();
+    return pf;
+}
+
+/* Find registered pf directory starting with the given path */
+static struct protected_file* find_protected_dir(const char* path) {
+    struct protected_file* pf  = NULL;
+    struct protected_file* tmp = NULL;
+    size_t len = strlen(path);
+
+    pf_lock();
+    // TODO: avoid linear lookup
+    for (tmp = g_protected_dirs; tmp != NULL; tmp = tmp->hh.next) {
+        if (tmp->path_len < len &&
+                !memcmp(tmp->path, path, tmp->path_len) &&
+                (!path[tmp->path_len] || path[tmp->path_len] == '/')) {
+            pf = tmp;
+            break;
+        }
+    }
+
+    pf_unlock();
+    return pf;
+}
+
+/* Find PF by handle */
+struct protected_file* find_protected_file_handle(PAL_HANDLE handle) {
+    char uri[URI_MAX];
+    int uri_len;
+
+    /* TODO: this logic is inefficient, add a PF reference to PAL_HANDLE instead */
+    uri_len = _DkStreamGetName(handle, uri, URI_MAX);
+    if (uri_len < 0)
+        return NULL;
+
+    /* uri is prefixed by "file:", we need path */
+    assert(strstartswith_static(uri, URI_PREFIX_FILE));
+    return find_protected_file(uri + URI_PREFIX_FILE_LEN);
+}
+
+static int register_protected_path(const char* path, struct protected_file** new_pf);
+
+/* Return a registered PF that matches specified path
+   (or the path that is contained in a registered PF directory) */
+struct protected_file* get_protected_file(const char* path) {
+    struct protected_file* pf = find_protected_file(path);
+    if (pf)
+        goto out;
+
+    pf = find_protected_dir(path);
+    if (pf) {
+        /* path not registered but matches registered dir */
+        SGX_DBG(DBG_D, "get_pf: registering new PF '%s' in dir '%s'\n", path, pf->path);
+        int ret = register_protected_path(path, &pf);
+        __UNUSED(ret);
+        assert(ret == 0);
+        /* return newly registered PF */
+    }
+
+out:
+    SGX_DBG(DBG_D, "get_pf(%s) = %p\n", path, pf);
+    return pf;
+}
+
+#define S_ISDIR(m) ((m & 0170000) == 0040000)
+
+static int is_directory(const char* path, bool* is_dir) {
+    int fd = -1;
+    struct stat st;
+
+    *is_dir = false;
+    int ret = ocall_open(path, O_RDONLY, 0);
+    if (IS_ERR(ret)) {
+        /* this can be called on a path without the file existing, assume non-dir for now */
+        ret = 0;
+        goto out;
+    }
+
+    fd = ret;
+    ret = ocall_fstat(fd, &st);
+    if (IS_ERR(ret)) {
+        SGX_DBG(DBG_E, "is_directory(%s): fstat failed: %d\n", path, ret);
+        goto out;
+    }
+
+    if (S_ISDIR(st.st_mode))
+        *is_dir = true;
+
+out:
+    if (fd >= 0) {
+        int rv = ocall_close(fd);
+        if (IS_ERR(rv)) {
+            SGX_DBG(DBG_E, "is_directory(%s): close failed: %d\n", path, rv);
+        }
+    }
+
+    return IS_ERR(ret) ? unix_to_pal_error(ERRNO(ret)) : ret;
+}
+
+/* Register all files from the given directory recursively */
+static int register_protected_dir(const char* path) {
+    int fd = -1;
+    int ret = -PAL_ERROR_NOMEM;
+    size_t bufsize = 1024;
+    void* buf = malloc(bufsize);
+
+    if (!buf)
+        return -PAL_ERROR_NOMEM;
+
+    ret = ocall_open(path, O_RDONLY | O_DIRECTORY, 0);
+    if (IS_ERR(ret)) {
+        SGX_DBG(DBG_E, "register_protected_dir: opening %s failed: %d\n", path, ret);
+        ret = unix_to_pal_error(ERRNO(ret));
+        goto out;
+    }
+    fd = ret;
+
+    size_t path_size = strlen(path) + 1;
+    int returned;
+    do {
+        returned = ocall_getdents(fd, buf, bufsize);
+        if (IS_ERR(returned)) {
+            ret = unix_to_pal_error(ERRNO(returned));
+            SGX_DBG(DBG_E, "register_protected_dir: reading %s failed: %d\n", path, ret);
+            goto out;
+        }
+
+        int pos = 0;
+        struct linux_dirent64* dir;
+
+        while (pos < returned) {
+            dir = (struct linux_dirent64*)((char*)buf + pos);
+
+            if (!strcmp_static(dir->d_name, ".") || !strcmp_static(dir->d_name, ".."))
+                goto next;
+
+            /* register file */
+            size_t sub_path_size = URI_PREFIX_FILE_LEN + path_size + 1 + strlen(dir->d_name);
+            char* sub_path = malloc(sub_path_size);
+            ret = -PAL_ERROR_NOMEM;
+            if (!sub_path)
+                goto out;
+
+            snprintf(sub_path, sub_path_size, URI_PREFIX_FILE "%s/%s", path, dir->d_name);
+            ret = register_protected_path(sub_path, NULL);
+            if (ret != 0) {
+                free(sub_path);
+                goto out;
+            }
+            free(sub_path);
+next:
+            pos += dir->d_reclen;
+        }
+    } while (returned != 0);
+
+    ret = 0;
+out:
+    if (fd >= 0)
+        ocall_close(fd);
+    free(buf);
+    return ret;
+}
+
+/* Register a single PF (if it's a directory, recursively) */
+static int register_protected_path(const char* path, struct protected_file** new_pf) {
+    int ret = -PAL_ERROR_NOMEM;
+    struct protected_file* new = NULL;
+
+    char* normpath = malloc(URI_MAX);
+    if (!normpath)
+        goto out;
+
+    size_t len = URI_MAX;
+    ret = get_norm_path(path, normpath, &len);
+    if (ret < 0) {
+        SGX_DBG(DBG_E, "Couldn't normalize path (%s): %s\n", path, pal_strerror(ret));
+        goto out;
+    }
+
+    /* discard the "file:" prefix */
+    if (strstartswith_static(normpath, URI_PREFIX_FILE))
+        path = normpath + URI_PREFIX_FILE_LEN;
+    else
+        path = normpath;
+
+    if (find_protected_file(path)) {
+        ret = 0;
+        SGX_DBG(DBG_D, "register_protected_path: file %s already registered\n", path);
+        goto out;
+    }
+
+    new = calloc(1, sizeof(*new));
+    if (!new) {
+        ret = -PAL_ERROR_NOMEM;
+        goto out;
+    }
+
+    new->path_len = strlen(path);
+    /* This is never freed but so isn't the whole struct, PFs persist for the whole lifetime
+       of the process. */
+    new->path = malloc(new->path_len + 1);
+    if (!new->path) {
+        ret = -PAL_ERROR_NOMEM;
+        goto out;
+    }
+
+    memcpy(new->path, path, new->path_len + 1);
+    new->refcount = 0;
+    new->writable_fd = -1;
+
+    bool is_dir;
+    ret = is_directory(path, &is_dir);
+    if (ret < 0)
+        goto out;
+
+    SGX_DBG(DBG_D, "register_protected_path: [%s] %s = %p\n", is_dir ? "dir" : "file", path, new);
+
+    if (is_dir)
+        register_protected_dir(path);
+
+    pf_lock();
+
+    if (is_dir) {
+        HASH_ADD_STR(g_protected_dirs, path, new);
+    } else {
+        HASH_ADD_STR(g_protected_files, path, new);
+    }
+
+    pf_unlock();
+
+    if (new_pf)
+        *new_pf = new;
+
+    ret = 0;
+out:
+    free(normpath);
+    if (ret < 0) {
+        if (new)
+            free(new->path);
+        free(new);
+    }
+    return ret;
+}
+
+/* Read PF paths from manifest and register them */
+static int register_protected_files(const char* key_prefix) {
+    char* cfgbuf = NULL;
+    int ret = -PAL_ERROR_DENIED;
+    ssize_t cfgsize = get_config_entries_size(g_pal_state.root_config, key_prefix);
+    if (cfgsize <= 0)
+        goto out;
+
+    cfgbuf = malloc(cfgsize);
+    if (!cfgbuf) {
+        ret = -PAL_ERROR_NOMEM;
+        goto out;
+    }
+
+    int uris_count = get_config_entries(g_pal_state.root_config, key_prefix, cfgbuf, cfgsize);
+    if (uris_count == -PAL_ERROR_INVAL) {
+        ret = -PAL_ERROR_DENIED;
+        goto out;
+    }
+
+    char key[CONFIG_MAX];
+    char uri[CONFIG_MAX];
+    char* key_suffix = cfgbuf;
+
+    for (int i = 0; i < uris_count; i++) {
+        size_t len = strlen(key_suffix);
+        snprintf(key, CONFIG_MAX, "%s.%s", key_prefix, key_suffix);
+        key_suffix += len + 1;
+        len = get_config(g_pal_state.root_config, key, uri, CONFIG_MAX);
+        if (len > 0) {
+            if (!strstartswith_static(uri, URI_PREFIX_FILE)) {
+                SGX_DBG(DBG_E, "Invalid URI [%s]: URIs of protected files must start with '"
+                        URI_PREFIX_FILE "'\n", uri);
+            } else {
+                register_protected_path(uri, NULL);
+            }
+        } else {
+            SGX_DBG(DBG_E, "Invalid PF entry in manifest: '%s'\n", key);
+        }
+    }
+
+    pf_lock();
+    SGX_DBG(DBG_D, "Registered %u protected directories and %u protected files\n",
+            HASH_COUNT(g_protected_dirs), HASH_COUNT(g_protected_files));
+    pf_unlock();
+    ret = 0;
+out:
+    free(cfgbuf);
+    return ret;
+}
+
+#define PF_MANIFEST_KEY_PREFIX "sgx.protected_files_key"
+#define PF_MANIFEST_PATH_PREFIX "sgx.protected_files"
+
+/* Initialize the PF library, register PFs from the manifest */
+int init_protected_files(void) {
+    pf_debug_f debug_callback = NULL;
+
+#ifdef DEBUG
+    debug_callback = cb_debug;
+#endif
+
+    pf_set_callbacks(cb_read, cb_write, cb_truncate, cb_aes_gcm_encrypt, cb_aes_gcm_decrypt,
+                     cb_random, debug_callback);
+
+    /* TODO: development only: get SECRET WRAP KEY FOR PROTECTED FILES from manifest
+       In the future, this key should be provisioned after local/remote attestation. */
+
+    char key_hex[PF_KEY_SIZE * 2 + 1];
+    ssize_t len = get_config(g_pal_state.root_config, PF_MANIFEST_KEY_PREFIX, key_hex,
+                             sizeof(key_hex));
+    if (len <= 0) {
+        if (get_config_entries_size(g_pal_state.root_config, PF_MANIFEST_PATH_PREFIX) > 0) {
+            SGX_DBG(DBG_E, "*** No protected files wrap key specified in the manifest. "
+                    "Protected files will not be available. ***\n");
+        }
+        return 0;
+    }
+
+    if (len != sizeof(key_hex) - 1) {
+        SGX_DBG(DBG_E, "Malformed " PF_MANIFEST_KEY_PREFIX " value in the manifest\n");
+        return -PAL_ERROR_INVAL;
+    }
+
+    memset(g_pf_wrap_key, 0, sizeof(g_pf_wrap_key));
+    for (ssize_t i = 0; i < len; i++) {
+        int8_t val = hex2dec(key_hex[i]);
+        if (val < 0) {
+            SGX_DBG(DBG_E, "Malformed " PF_MANIFEST_KEY_PREFIX " value in the manifest\n");
+            return -PAL_ERROR_INVAL;
+        }
+        g_pf_wrap_key[i/2] = g_pf_wrap_key[i/2] * 16 + (uint8_t)val;
+    }
+
+    if (register_protected_files(PF_MANIFEST_PATH_PREFIX) < 0) {
+        SGX_DBG(DBG_E, PF_MANIFEST_PATH_PREFIX "key not found in manifest, "
+                "protected files will not be available\n");
+    }
+
+    return 0;
+}
+
+/* Open/create a PF */
+static int open_protected_file(const char* path, struct protected_file* pf, pf_handle_t handle,
+                               uint64_t size, pf_file_mode_t mode, bool create) {
+    pf_status_t pfs;
+    pfs = pf_open(handle, path, size, mode, create, &g_pf_wrap_key, &pf->context);
+    if (PF_FAILURE(pfs)) {
+        SGX_DBG(DBG_E, "pf_open(%d, %s) failed: %d\n", *(int*)handle, path, pfs);
+        return -PAL_ERROR_DENIED;
+    }
+    return 0;
+}
+
+/* Prepare a PF for I/O
+   This function registers the PF if path is in a registered PF directory, then
+   calls the appropriate PF function to open/create it (if allowed) */
+struct protected_file* load_protected_file(const char* path, int* fd, uint64_t size,
+                                           pf_file_mode_t mode, bool create,
+                                           struct protected_file* pf) {
+    SGX_DBG(DBG_D, "load_protected_file: %s, fd %d, size %lu, mode %d, create %d, pf %p\n",
+            path, *fd, size, mode, create, pf);
+
+    if (!pf)
+        pf = get_protected_file(path);
+
+    if (pf) {
+        if (!pf->context) {
+            SGX_DBG(DBG_D, "load_protected_file: %s, fd %d: opening new PF %p\n", path, *fd, pf);
+            int ret = open_protected_file(path, pf, (pf_handle_t)fd, size, mode, create);
+            if (ret < 0)
+                return NULL;
+        } else {
+            SGX_DBG(DBG_D, "load_protected_file: %s, fd %d: returning old PF %p\n", path, *fd, pf);
+        }
+    }
+
+    return pf;
+}
+
+/* Flush PF map buffers and optionally remove and free them.
+ * If pf is NULL, process all maps containing given buffer.
+ * If buffer is NULL, process all maps for given pf.
+ * If both pf and buffer are NULL, process all maps for all PFs.
+ */
+int flush_pf_maps(struct protected_file* pf, void* buffer, bool remove) {
+    struct pf_map* map;
+    struct pf_map* tmp;
+    uint64_t pf_size;
+    pf_status_t pfs;
+
+    SGX_DBG(DBG_D, "flush_pf_maps: pf %p, buf %p, remove %d\n", pf, buffer, remove);
+
+    pf_lock();
+    LISTP_FOR_EACH_ENTRY_SAFE(map, tmp, &g_pf_map_list, list) {
+        if (pf && map->pf != pf)
+            continue;
+
+        if (buffer && map->buffer != buffer)
+            continue;
+
+        size_t map_size = map->size;
+        struct protected_file* map_pf = pf ? pf : map->pf;
+
+        pfs = pf_get_size(map_pf->context, &pf_size);
+        assert(PF_SUCCESS(pfs));
+
+        SGX_DBG(DBG_D, "flush_pf_maps: pf %p, buf %p, map size %lu, offset %lu\n",
+                map_pf, map->buffer, map_size, map->offset);
+
+        assert(pf_size >= map->offset);
+        if (map->offset + map_size > pf_size)
+            map_size = pf_size - map->offset;
+
+        if (map_size > 0) {
+            pfs = pf_write(map_pf->context, map->offset, map_size, map->buffer);
+            if (PF_FAILURE(pfs)) {
+                SGX_DBG(DBG_E, "flush_pf_maps: pf_write failed: %d\n", pfs);
+                pf_unlock();
+                return -PAL_ERROR_INVAL;
+            }
+        }
+
+        if (remove) {
+            LISTP_DEL(map, &g_pf_map_list, list);
+            free(map);
+        }
+    }
+
+    pf_unlock();
+    return 0;
+}
+
+/* Flush map buffers and unload/close the PF */
+int unload_protected_file(struct protected_file* pf) {
+    /* flush all pf's maps and delete them */
+    int ret = flush_pf_maps(pf, NULL, true);
+    if (ret < 0)
+        return ret;
+    pf_status_t pfs = pf_close(pf->context);
+    if (PF_FAILURE(pfs)) {
+        SGX_DBG(DBG_E, "unload_protected_file(%p) failed: %d\n", pf, pfs);
+    }
+
+    pf->context = NULL;
+    return 0;
+}

--- a/Pal/src/host/Linux-SGX/pal_linux.h
+++ b/Pal/src/host/Linux-SGX/pal_linux.h
@@ -18,6 +18,8 @@
 #include "sgx_tls.h"
 
 #include "enclave_ocalls.h"
+#include "protected_files.h"
+#include "uthash.h"
 
 #include <linux/mman.h>
 
@@ -146,6 +148,71 @@ int init_enclave_key(void);
 
 void init_untrusted_slab_mgr(void);
 
+/* Used to track map buffers for protected files */
+DEFINE_LIST(pf_map);
+struct pf_map {
+    LIST_TYPE(pf_map) list;
+    struct protected_file* pf;
+    void* buffer;
+    uint64_t size;
+    uint64_t offset; /* offset in PF, needed for write buffers when flushing to the PF */
+};
+DEFINE_LISTP(pf_map);
+
+/* List of PF map buffers; this list is traversed on PF flush (on file close) */
+extern LISTP_TYPE(pf_map) g_pf_map_list;
+
+/* Data of a protected file */
+struct protected_file {
+    UT_hash_handle hh;
+    size_t path_len;
+    char* path;
+    pf_context_t* context; /* NULL until PF is opened */
+    int64_t refcount; /* used for deciding when to call unload_protected_file() */
+    int writable_fd; /* fd of underlying file for writable PF, -1 if no writable handles are open */
+};
+
+/* Initialize the PF library, register PFs from the manifest */
+int init_protected_files(void);
+
+/* Take ownership of the global PF lock */
+void pf_lock(void);
+
+/* Release ownership of the global PF lock */
+void pf_unlock(void);
+
+/* Return a registered PF that matches specified path
+   (or the path is contained in a registered PF directory) */
+struct protected_file* get_protected_file(const char* path);
+
+/* Load and initialize a PF (must be called before any I/O operations)
+ *
+ * path:   normalized host path
+ * fd:     pointer to an opened file descriptor (must point to a valid value for the whole time PF
+ *         is being accessed)
+ * size:   underlying file size (in bytes)
+ * mode:   access mode
+ * create: if true, the PF is being created/truncated
+ * pf:     (optional) PF pointer if already known
+ */
+struct protected_file* load_protected_file(const char* path, int* fd, size_t size,
+                                           pf_file_mode_t mode, bool create,
+                                           struct protected_file* pf);
+
+/* Flush PF map buffers and optionally remove and free them.
+   If pf is NULL, process all maps containing given buffer.
+   If buffer is NULL, process all maps for given pf. */
+int flush_pf_maps(struct protected_file* pf, void* buffer, bool remove);
+
+/* Flush map buffers and unload/close the PF */
+int unload_protected_file(struct protected_file* pf);
+
+/* Find registered PF by path (exact match) */
+struct protected_file* find_protected_file(const char* path);
+
+/* Find protected file by handle (uses handle's path to call find_protected_file) */
+struct protected_file* find_protected_file_handle(PAL_HANDLE handle);
+
 /* exchange and establish a 256-bit session key */
 int _DkStreamKeyExchange(PAL_HANDLE stream, PAL_SESSION_KEY* key);
 
@@ -253,6 +320,13 @@ int sgx_create_process(const char* uri, int nargs, const char** args, int* strea
 #endif
 
 #ifdef IN_ENCLAVE
+#undef uthash_fatal
+#define uthash_fatal(msg) \
+    do { \
+        __UNUSED(msg); \
+        DkProcessExit(-PAL_ERROR_NOMEM); \
+    } while (0)
+
 #define SGX_DBG(class, fmt...) \
     do { if ((class) & DBG_LEVEL) printf(fmt); } while (0)
 #else

--- a/Pal/src/host/Linux-SGX/protected-files/README.rst
+++ b/Pal/src/host/Linux-SGX/protected-files/README.rst
@@ -1,0 +1,65 @@
+===============
+Protected Files
+===============
+
+[TODO: add to RTD]
+Protected files (PF) are a new type of files that can be specified in the manifest (SGX only).
+They are encrypted on disk and transparently decrypted when accessed by Graphene or by application
+running inside Graphene.
+
+Features
+========
+
+- Data is encrypted (confidentiality) and integrity protected (tamper resistance).
+- File swap protection (a PF can only be accessed when in a specific path).
+- Transparency (Graphene application sees PFs as regular files, no need to modify the application).
+
+The following new manifest elements are added::
+
+   sgx.protected_files_key = <16-byte hex value>
+   sgx.protected_files.<name> = file:<host path>
+
+
+Example
+-------
+
+::
+
+   sgx.protected_files.pf_1 = file:tmp/some_file
+   sgx.protected_files.pf_2 = file:tmp/some_dir
+   sgx.protected_files.pf_3 = file:tmp/another_dir/some_file
+
+Paths specifying PF entries can be files or directories. If a directory is specified,
+all existing files/directories within are registered as protected recursively (and are expected
+to be encrypted in the PF format). New files created in a protected directory are automatically
+treated as protected.
+
+Limitations
+-----------
+
+Metadata currently limits PF path size to 512 bytes and filename size to 260 bytes.
+
+NOTE
+----
+
+``sgx.protected_files_key`` specifies the encryption key and is only a temporary implementation.
+This key should be provisioned to the enclave with local/remote attestation in the future.
+
+The ``tools`` directory contains the ``pf_crypt`` utility that converts files to/from the protected
+format.
+
+Internal protected file format in this version was ported from the `SGX SDK
+<https://github.com/intel/linux-sgx/tree/1eaa4551d4b02677eec505684412dc288e6d6361/sdk/protected_fs>`_.
+
+Tests
+=====
+
+Tests in ``LibOS/shim/test/fs`` now contain PF tests too (target is still ``test``).
+Target to run just non-PF tests is ``fs-test``.
+
+TODO
+====
+
+- Truncating protected files is not yet implemented.
+- The recovery file feature is disabled, this needs to be discussed if it's needed in Graphene.
+- Tests for invalid/malformed/corrupted files need to be ported to the new format.

--- a/Pal/src/host/Linux-SGX/protected-files/lru_cache.c
+++ b/Pal/src/host/Linux-SGX/protected-files/lru_cache.c
@@ -1,0 +1,174 @@
+/* SPDX-License-Identifier: LGPL-3.0-or-later */
+/* Copyright (C) 2019-2020 Invisible Things Lab
+ *                         Rafal Wojdyla <omeg@invisiblethingslab.com>
+ * Copyright (C) 2011-2020 Intel Corporation
+ */
+
+/* TODO: add regression tests for this */
+
+#include "lru_cache.h"
+
+#include <assert.h>
+
+#include "api.h"
+#include "list.h"
+#include "uthash.h"
+
+#ifdef IN_PAL
+    #include "pal_linux.h"
+#else
+    #include <stdio.h>
+    #include <stdlib.h>
+#endif
+
+DEFINE_LIST(_lruc_list_node);
+typedef struct _lruc_list_node {
+    LIST_TYPE(_lruc_list_node) list;
+    uint64_t key;
+} lruc_list_node_t;
+DEFINE_LISTP(_lruc_list_node);
+
+typedef struct _lruc_map_node {
+    uint64_t key;
+    void* data;
+    lruc_list_node_t* list_ptr;
+    UT_hash_handle hh;
+} lruc_map_node_t;
+
+struct lruc_context {
+    /* list and map both contain the same objects (list contains keys, map contains actual data).
+     * They're kept in sync so that map is used for fast lookups and list is used for fast LRU.
+     */
+    LISTP_TYPE(_lruc_list_node) list;
+    lruc_map_node_t* map;
+    lruc_list_node_t* current; /* current head of the cache */
+};
+
+lruc_context_t* lruc_create(void) {
+    lruc_context_t* lruc = calloc(1, sizeof(*lruc));
+    if (!lruc)
+        return NULL;
+
+    INIT_LISTP(&lruc->list);
+    lruc->map = NULL;
+    lruc->current = NULL;
+    return lruc;
+}
+
+static lruc_map_node_t* get_map_node(lruc_context_t* lruc, uint64_t key) {
+    lruc_map_node_t* mn = NULL;
+    HASH_FIND(hh, lruc->map, &key, sizeof(key), mn);
+    return mn;
+}
+
+void lruc_destroy(lruc_context_t* lruc) {
+    struct _lruc_list_node* ln;
+    struct _lruc_list_node* tmp;
+    lruc_map_node_t* mn;
+
+    LISTP_FOR_EACH_ENTRY_SAFE(ln, tmp, &lruc->list, list) {
+        mn = get_map_node(lruc, ln->key);
+        if (mn) {
+            HASH_DEL(lruc->map, mn);
+            free(mn);
+        }
+        LISTP_DEL(ln, &lruc->list, list);
+        free(ln);
+    }
+
+    assert(LISTP_EMPTY(&lruc->list));
+    assert(HASH_COUNT(lruc->map) == 0);
+    free(lruc);
+}
+
+bool lruc_add(lruc_context_t* lruc, uint64_t key, void* data) {
+    if (get_map_node(lruc, key))
+        return false;
+
+    lruc_map_node_t* map_node = calloc(1, sizeof(*map_node));
+    if (!map_node)
+        return false;
+
+    lruc_list_node_t* list_node = calloc(1, sizeof(*list_node));
+    if (!list_node) {
+        free(map_node);
+        return false;
+    }
+
+    list_node->key = key;
+    map_node->key = key;
+    LISTP_ADD(list_node, &lruc->list, list);
+    map_node->data = data;
+    map_node->list_ptr = list_node;
+    HASH_ADD(hh, lruc->map, key, sizeof(key), map_node);
+    return true;
+}
+
+void* lruc_find(lruc_context_t* lruc, uint64_t key) {
+    lruc_map_node_t* mn = get_map_node(lruc, key);
+    if (mn)
+        return mn->data;
+    return NULL;
+}
+
+void* lruc_get(lruc_context_t* lruc, uint64_t key) {
+    lruc_map_node_t* mn = get_map_node(lruc, key);
+    if (!mn)
+        return NULL;
+    lruc_list_node_t* ln = mn->list_ptr;
+    assert(ln != NULL);
+    // move node to the front of the list
+    LISTP_DEL(ln, &lruc->list, list);
+    LISTP_ADD(ln, &lruc->list, list);
+    return mn->data;
+}
+
+size_t lruc_size(lruc_context_t* lruc) {
+    return HASH_COUNT(lruc->map);
+}
+
+void* lruc_get_first(lruc_context_t* lruc) {
+    if (LISTP_EMPTY(&lruc->list))
+        return NULL;
+
+    lruc->current = LISTP_FIRST_ENTRY(&lruc->list, /*unused*/0, list);
+    lruc_map_node_t* mn = get_map_node(lruc, lruc->current->key);
+    assert(mn != NULL);
+    return mn->data;
+}
+
+void* lruc_get_next(lruc_context_t* lruc) {
+    if (LISTP_EMPTY(&lruc->list) || !lruc->current)
+        return NULL;
+
+    lruc->current = LISTP_NEXT_ENTRY(lruc->current, &lruc->list, list);
+    if (!lruc->current)
+        return NULL;
+
+    lruc_map_node_t* mn = get_map_node(lruc, lruc->current->key);
+    assert(mn != NULL);
+    return mn->data;
+}
+
+void* lruc_get_last(lruc_context_t* lruc) {
+    if (LISTP_EMPTY(&lruc->list))
+        return NULL;
+
+    lruc_list_node_t* ln = LISTP_LAST_ENTRY(&lruc->list, /*unused*/0, list);
+    lruc_map_node_t* mn = get_map_node(lruc, ln->key);
+    assert(mn != NULL);
+    return mn->data;
+}
+
+void lruc_remove_last(lruc_context_t* lruc) {
+    if (LISTP_EMPTY(&lruc->list))
+        return;
+
+    lruc_list_node_t* ln = LISTP_LAST_ENTRY(&lruc->list, /*unused*/0, list);
+    LISTP_DEL(ln, &lruc->list, list);
+    lruc_map_node_t* mn = get_map_node(lruc, ln->key);
+    assert(mn != NULL);
+    HASH_DEL(lruc->map, mn);
+    free(ln);
+    free(mn);
+}

--- a/Pal/src/host/Linux-SGX/protected-files/lru_cache.h
+++ b/Pal/src/host/Linux-SGX/protected-files/lru_cache.h
@@ -1,0 +1,33 @@
+/* SPDX-License-Identifier: LGPL-3.0-or-later */
+/* Copyright (C) 2019-2020 Invisible Things Lab
+ *                         Rafal Wojdyla <omeg@invisiblethingslab.com>
+ * Copyright (C) 2011-2020 Intel Corporation
+ */
+
+/* Least-recently used cache, used by the protected file implementation for optimizing
+   data and MHT node access */
+
+#ifndef LRU_CACHE_H_
+#define LRU_CACHE_H_
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+struct lruc_context;
+typedef struct lruc_context lruc_context_t;
+
+lruc_context_t* lruc_create(void);
+void lruc_destroy(lruc_context_t* context);
+bool lruc_add(lruc_context_t* context, uint64_t key, void* data); // key must not already exist
+void* lruc_get(lruc_context_t* context, uint64_t key);
+void* lruc_find(lruc_context_t* context, uint64_t key); // only returns the object, does not bump it to the head
+size_t lruc_size(lruc_context_t* context);
+void* lruc_get_first(lruc_context_t* context);
+void* lruc_get_next(lruc_context_t* context);
+void* lruc_get_last(lruc_context_t* context);
+void lruc_remove_last(lruc_context_t* context);
+
+void lruc_test(void);
+
+#endif /* LRU_CACHE_H_ */

--- a/Pal/src/host/Linux-SGX/protected-files/protected_files.c
+++ b/Pal/src/host/Linux-SGX/protected-files/protected_files.c
@@ -1,0 +1,1310 @@
+/* SPDX-License-Identifier: LGPL-3.0-or-later */
+/* Copyright (C) 2019-2020 Invisible Things Lab
+ *                         Rafal Wojdyla <omeg@invisiblethingslab.com>
+ * Copyright (C) 2011-2019 Intel Corporation
+ */
+
+#include "protected_files_internal.h"
+#include "api.h"
+
+#ifndef IN_PAL
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#endif
+
+/* Function for scrubbing sensitive memory buffers.
+ * memset() can be optimized away and memset_s() is not available in PAL.
+ * FIXME: this implementation is inefficient (and used in perf-critical functions),
+ * replace with a better one.
+ * TODO: is this really needed? Intel's implementation uses similar function as "defense in depth".
+ */
+ static void erase_memory(void *buffer, size_t size) {
+    volatile unsigned char *p = buffer;
+    while (size--)
+        *p++ = 0;
+}
+
+/* Host callbacks */
+static pf_read_f     cb_read     = NULL;
+static pf_write_f    cb_write    = NULL;
+static pf_truncate_f cb_truncate = NULL;
+static pf_debug_f    cb_debug    = NULL;
+
+static pf_aes_gcm_encrypt_f cb_aes_gcm_encrypt = NULL;
+static pf_aes_gcm_decrypt_f cb_aes_gcm_decrypt = NULL;
+static pf_random_f          cb_random          = NULL;
+
+#ifdef DEBUG
+#define PF_DEBUG_PRINT_SIZE_MAX 4096
+
+/* Debug print without function name prefix. Implicit param: pf (context pointer). */
+#define __DEBUG_PF(format, ...) \
+    do { \
+        if (cb_debug) { \
+            snprintf(pf->debug_buffer, PF_DEBUG_PRINT_SIZE_MAX, format, ##__VA_ARGS__); \
+            cb_debug(pf->debug_buffer); \
+        } \
+    } while(0)
+
+/* Debug print with function name prefix. Implicit param: pf (context pointer). */
+#define DEBUG_PF(format, ...) \
+    do { \
+        if (cb_debug) { \
+            snprintf(pf->debug_buffer, PF_DEBUG_PRINT_SIZE_MAX, "%s: " format, __FUNCTION__, \
+                     ##__VA_ARGS__); \
+            cb_debug(pf->debug_buffer); \
+        } \
+    } while(0)
+
+#else /* DEBUG */
+#define DEBUG_PF(...)
+#define __DEBUG_PF(...)
+#endif /* DEBUG */
+
+static pf_iv_t g_empty_iv = {0};
+static bool g_initialized = false;
+
+#define METADATA_KEY_NAME     "SGX-PROTECTED-FS-METADATA-KEY"
+#define MAX_LABEL_SIZE        64
+
+static_assert(sizeof(METADATA_KEY_NAME) <= MAX_LABEL_SIZE, "label too long");
+
+#pragma pack(push, 1)
+typedef struct {
+    uint32_t index;
+    char label[MAX_LABEL_SIZE]; // must be NULL terminated
+    pf_keyid_t nonce;
+    uint32_t output_len; // in bits
+} kdf_input_t;
+#pragma pack(pop)
+
+// The key derivation function follow recommendations from NIST Special Publication 800-108:
+// Recommendation for Key Derivation Using Pseudorandom Functions
+// https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-108.pdf
+
+// derive a metadata key from user key (if restore is false, the derived key is randomized)
+static bool ipf_import_metadata_key(pf_context_t* pf, bool restore, pf_key_t* output) {
+    kdf_input_t buf = {0};
+    pf_status_t status;
+
+    buf.index = 1;
+    if (!strcpy_static(buf.label, METADATA_KEY_NAME, MAX_LABEL_SIZE))
+        return false;
+
+    if (!restore) {
+        status = cb_random((uint8_t*)&buf.nonce, sizeof(buf.nonce));
+        if (PF_FAILURE(status)) {
+            pf->last_error = status;
+            return false;
+        }
+    } else {
+        COPY_ARRAY(buf.nonce, pf->file_metadata.plain_part.metadata_key_id);
+    }
+
+    // length of output (128 bits)
+    buf.output_len = 0x80;
+
+    status = cb_aes_gcm_encrypt(&pf->user_kdk_key, &g_empty_iv, &buf, sizeof(buf), NULL, 0, NULL,
+                                output);
+    if (PF_FAILURE(status)) {
+        pf->last_error = status;
+        return false;
+    }
+
+    if (!restore) {
+        COPY_ARRAY(pf->file_metadata.plain_part.metadata_key_id, buf.nonce);
+    }
+
+    erase_memory(&buf, sizeof(buf));
+
+    return true;
+}
+
+static bool ipf_generate_random_key(pf_context_t* pf, pf_key_t* output) {
+    pf_status_t status = cb_random((uint8_t*)output, sizeof(*output));
+    if (PF_FAILURE(status)) {
+        pf->last_error = status;
+        return false;
+    }
+
+    return true;
+}
+
+static bool ipf_generate_random_metadata_key(pf_context_t* pf, pf_key_t* output) {
+    return ipf_import_metadata_key(pf, /*restore=*/false, output);
+}
+
+static bool ipf_restore_current_metadata_key(pf_context_t* pf, pf_key_t* output) {
+    return ipf_import_metadata_key(pf, /*restore=*/true, output);
+}
+
+static bool ipf_init_fields(pf_context_t* pf) {
+#ifdef DEBUG
+    pf->debug_buffer = malloc(PF_DEBUG_PRINT_SIZE_MAX);
+    if (!pf->debug_buffer) {
+        pf->last_error = PF_STATUS_NO_MEMORY;
+        return false;
+    }
+#endif
+    memset(&pf->file_metadata, 0, sizeof(pf->file_metadata));
+    memset(&pf->encrypted_part_plain, 0, sizeof(pf->encrypted_part_plain));
+    memset(&g_empty_iv, 0, sizeof(g_empty_iv));
+    memset(&pf->root_mht, 0, sizeof(pf->root_mht));
+
+    pf->root_mht.type = FILE_MHT_NODE_TYPE;
+    pf->root_mht.physical_node_number = 1;
+    pf->root_mht.node_number = 0;
+    pf->root_mht.new_node = true;
+    pf->root_mht.need_writing = false;
+
+    pf->offset = 0;
+    pf->file = NULL;
+    pf->end_of_file = false;
+    pf->need_writing = false;
+    pf->file_status = PF_STATUS_UNINITIALIZED;
+    pf->last_error = PF_STATUS_SUCCESS;
+    pf->real_file_size = 0;
+
+    pf->cache = lruc_create();
+    return true;
+}
+
+static pf_context_t* ipf_open(const char* path, pf_file_mode_t mode, bool create,
+                              pf_handle_t file, uint64_t real_size, const pf_key_t* kdk_key,
+                              pf_status_t* status) {
+    *status = PF_STATUS_NO_MEMORY;
+    pf_context_t* pf = calloc(1, sizeof(*pf));
+
+    if (!pf)
+        goto out;
+
+    if (!ipf_init_fields(pf))
+        goto out;
+
+    DEBUG_PF("handle: %d, path: '%s', real size: %lu, mode: 0x%x\n",
+             *(int*)file, path, real_size, mode);
+
+    if (kdk_key == NULL) {
+        DEBUG_PF("no key specified\n");
+        pf->last_error = PF_STATUS_INVALID_PARAMETER;
+        goto out;
+    }
+
+    if (path && strlen(path) > PATH_MAX_SIZE - 1) {
+        pf->last_error = PF_STATUS_PATH_TOO_LONG;
+        goto out;
+    }
+
+    // for new file, this value will later be saved in the meta data plain part (init_new_file)
+    // for existing file, we will later compare this value with the value from the file
+    // (init_existing_file)
+    COPY_ARRAY(pf->user_kdk_key, *kdk_key);
+
+    // omeg: we require a canonical full path to file, so no stripping path to filename only
+    // omeg: Intel's implementation opens the file, we get the fd and size from the Graphene handler
+
+    if (!file) {
+        DEBUG_PF("invalid handle\n");
+        pf->last_error = PF_STATUS_INVALID_PARAMETER;
+        goto out;
+    }
+
+    if (real_size % PF_NODE_SIZE != 0) {
+        pf->last_error = PF_STATUS_INVALID_HEADER;
+        goto out;
+    }
+
+    pf->file = file;
+    pf->real_file_size = real_size;
+    pf->mode = mode;
+
+    if (!create) {
+        // existing file
+        if (!ipf_init_existing_file(pf, path))
+            goto out;
+
+    } else {
+        // new file
+        if (!ipf_init_new_file(pf, path))
+            goto out;
+    }
+
+    pf->last_error = pf->file_status = PF_STATUS_SUCCESS;
+    DEBUG_PF("OK (data size %lu)\n", pf->encrypted_part_plain.size);
+
+out:
+    if (pf && PF_FAILURE(pf->last_error)) {
+        DEBUG_PF("failed: %d\n", pf->last_error);
+        free(pf);
+        pf = NULL;
+    }
+
+    if (pf)
+        *status = pf->last_error;
+
+    return pf;
+}
+
+static bool ipf_read_node(pf_context_t* pf, pf_handle_t handle, uint64_t node_number, void* buffer,
+                          uint32_t node_size) {
+    uint64_t offset = node_number * node_size;
+
+    pf_status_t status = cb_read(handle, buffer, offset, node_size);
+    if (PF_FAILURE(status)) {
+        pf->last_error = status;
+        return false;
+    }
+
+    return true;
+}
+
+static bool ipf_write_file(pf_context_t* pf, pf_handle_t handle, uint64_t offset, void* buffer,
+                           uint32_t size) {
+    pf_status_t status = cb_write(handle, buffer, offset, size);
+    if (PF_FAILURE(status)) {
+        pf->last_error = status;
+        return false;
+    }
+
+    return true;
+}
+
+static bool ipf_write_node(pf_context_t* pf, pf_handle_t handle, uint64_t node_number, void* buffer,
+                           uint32_t node_size) {
+    return ipf_write_file(pf, handle, node_number * node_size, buffer, node_size);
+}
+
+static bool ipf_init_existing_file(pf_context_t* pf, const char* path) {
+    pf_status_t status;
+
+    // read meta-data node
+    if (!ipf_read_node(pf, pf->file, /*node_number=*/0, (uint8_t*)&pf->file_metadata,
+                       PF_NODE_SIZE)) {
+        return false;
+    }
+
+    if (pf->file_metadata.plain_part.file_id != PF_FILE_ID) {
+        // such a file exists, but it is not a protected file
+        pf->last_error = PF_STATUS_INVALID_HEADER;
+        return false;
+    }
+
+    if (pf->file_metadata.plain_part.major_version != PF_MAJOR_VERSION) {
+        pf->last_error = PF_STATUS_INVALID_VERSION;
+        return false;
+    }
+
+    pf_key_t key;
+    if (!ipf_restore_current_metadata_key(pf, &key))
+        return false;
+
+    // decrypt the encrypted part of the meta-data
+    status = cb_aes_gcm_decrypt(&key, &g_empty_iv, NULL, 0,
+                                &pf->file_metadata.encrypted_part,
+                                sizeof(pf->file_metadata.encrypted_part),
+                                &pf->encrypted_part_plain,
+                                &pf->file_metadata.plain_part.metadata_gmac);
+    if (PF_FAILURE(status)) {
+        pf->last_error = status;
+        DEBUG_PF("failed to decrypt metadata: %d\n", status);
+        return false;
+    }
+
+    DEBUG_PF("data size %lu\n", pf->encrypted_part_plain.size);
+
+    if (path) {
+        size_t path_len = strlen(pf->encrypted_part_plain.path);
+        if (path_len != strlen(path)
+                || memcmp(path, pf->encrypted_part_plain.path, path_len) != 0) {
+            pf->last_error = PF_STATUS_INVALID_PATH;
+            return false;
+        }
+    }
+
+    if (pf->encrypted_part_plain.size > MD_USER_DATA_SIZE) {
+        // read the root node of the mht
+        if (!ipf_read_node(pf, pf->file, /*node_number=*/1, &pf->root_mht.encrypted.cipher,
+                           PF_NODE_SIZE))
+            return false;
+
+        // this also verifies the root mht gmac against the gmac in the meta-data encrypted part
+        status = cb_aes_gcm_decrypt(&pf->encrypted_part_plain.mht_key, &g_empty_iv,
+                                    NULL, 0, // aad
+                                    &pf->root_mht.encrypted.cipher, PF_NODE_SIZE,
+                                    &pf->root_mht.decrypted.mht,
+                                    &pf->encrypted_part_plain.mht_gmac);
+        if (PF_FAILURE(status)) {
+            pf->last_error = status;
+            return false;
+        }
+
+        pf->root_mht.new_node = false;
+    }
+
+    return true;
+}
+
+static bool ipf_init_new_file(pf_context_t* pf, const char* path) {
+    pf->file_metadata.plain_part.file_id = PF_FILE_ID;
+    pf->file_metadata.plain_part.major_version = PF_MAJOR_VERSION;
+    pf->file_metadata.plain_part.minor_version = PF_MINOR_VERSION;
+
+    // path length is checked in ipf_open()
+    memcpy(pf->encrypted_part_plain.path, path, strlen(path) + 1);
+
+    pf->need_writing = true;
+
+    return true;
+}
+
+static bool ipf_close(pf_context_t* pf) {
+    void* data;
+    bool retval = true;
+
+    if (pf->file_status != PF_STATUS_SUCCESS) {
+        ipf_try_clear_error(pf); // last attempt to fix it
+        retval = false;
+    } else {
+        if (!ipf_internal_flush(pf)) {
+            DEBUG_PF("internal flush failed\n");
+            retval = false;
+        }
+    }
+
+    // omeg: fs close is done by Graphene handler
+    pf->file_status = PF_STATUS_UNINITIALIZED;
+
+    while ((data = lruc_get_last(pf->cache)) != NULL) {
+        file_node_t* file_node = (file_node_t*)data;
+        erase_memory(&file_node->decrypted, sizeof(file_node->decrypted));
+        free(file_node);
+        lruc_remove_last(pf->cache);
+    }
+
+    // scrub first MD_USER_DATA_SIZE of file data and the gmac_key
+    erase_memory(&pf->encrypted_part_plain, sizeof(pf->encrypted_part_plain));
+
+    lruc_destroy(pf->cache);
+
+#ifdef DEBUG
+    free(pf->debug_buffer);
+#endif
+    erase_memory(pf, sizeof(struct pf_context));
+    free(pf);
+
+    return retval;
+}
+
+static bool ipf_internal_flush(pf_context_t* pf) {
+    if (!pf->need_writing) {
+        // no changes at all
+        DEBUG_PF("no need to write\n");
+        return true;
+    }
+
+    if (pf->encrypted_part_plain.size > MD_USER_DATA_SIZE && pf->root_mht.need_writing) {
+        // otherwise it's just one write - the meta-data node
+        if (!ipf_update_all_data_and_mht_nodes(pf)) {
+            // this is something that shouldn't happen, can't fix this...
+            pf->file_status = PF_STATUS_CRYPTO_ERROR;
+            DEBUG_PF("failed to update data nodes\n");
+            return false;
+        }
+    }
+
+    if (!ipf_update_metadata_node(pf)) {
+        // this is something that shouldn't happen, can't fix this...
+        pf->file_status = PF_STATUS_CRYPTO_ERROR;
+        DEBUG_PF("failed to update metadata nodes\n");
+        return false;
+    }
+
+    if (!ipf_write_all_changes_to_disk(pf)) {
+        pf->file_status = PF_STATUS_WRITE_TO_DISK_FAILED;
+
+        DEBUG_PF("failed to write changes to disk\n");
+        return false;
+    }
+
+    pf->need_writing = false;
+
+    return true;
+}
+
+static void swap_nodes(file_node_t** data, size_t idx1, size_t idx2) {
+    file_node_t* tmp = data[idx1];
+    data[idx1] = data[idx2];
+    data[idx2] = tmp;
+}
+
+// TODO: better sort?
+static size_t partition(file_node_t** data, size_t low, size_t high) {
+    assert(low <= high);
+    file_node_t* pivot = data[(low + high) / 2];
+    size_t i = low;
+    size_t j = high;
+
+    while (true) {
+        while (data[i]->node_number < pivot->node_number)
+            i++;
+        while (data[j]->node_number > pivot->node_number)
+            j--;
+        if (i >= j)
+            return j;
+        swap_nodes(data, i, j);
+        i++;
+        j--;
+    }
+}
+
+static void sort_nodes(file_node_t** data, size_t low, size_t high) {
+    if (high - low == 1) {
+        if (data[low]->node_number > data[high]->node_number)
+            swap_nodes(data, low, high);
+        return;
+    }
+    if (low < high) {
+        size_t pi = partition(data, low, high);
+        if (pi > 0)
+            sort_nodes(data, low, pi);
+        sort_nodes(data, pi + 1, high);
+    }
+}
+
+static bool ipf_update_all_data_and_mht_nodes(pf_context_t* pf) {
+    bool ret = false;
+    file_node_t** mht_array = NULL;
+    file_node_t* file_mht_node;
+    pf_status_t status;
+    void* data = lruc_get_first(pf->cache);
+
+    // 1. encrypt the changed data
+    // 2. set the IV+GMAC in the parent MHT
+    // [3. set the need_writing flag for all the parents]
+    while (data != NULL) {
+        if (((file_node_t*)data)->type == FILE_DATA_NODE_TYPE) {
+            file_node_t* data_node = (file_node_t*)data;
+
+            if (data_node->need_writing) {
+
+                gcm_crypto_data_t* gcm_crypto_data = &data_node->parent->decrypted.mht
+                    .data_nodes_crypto[data_node->node_number % ATTACHED_DATA_NODES_COUNT];
+
+                if (!ipf_generate_random_key(pf, &gcm_crypto_data->key))
+                    goto out;
+
+                // encrypt the data, this also saves the gmac of the operation in the mht crypto node
+                status = cb_aes_gcm_encrypt(&gcm_crypto_data->key, &g_empty_iv,
+                                            NULL, 0, // aad
+                                            data_node->decrypted.data.data, PF_NODE_SIZE,
+                                            data_node->encrypted.cipher,
+                                            &gcm_crypto_data->gmac);
+                if (PF_FAILURE(status)) {
+                    pf->last_error = status;
+                    goto out;
+                }
+
+                file_mht_node = data_node->parent;
+#ifdef DEBUG
+                // this loop should do nothing, add it here just to be safe
+                while (file_mht_node->node_number != 0) {
+                    assert(file_mht_node->need_writing == true);
+                    file_mht_node = file_mht_node->parent;
+                }
+#endif
+            }
+        }
+        data = lruc_get_next(pf->cache);
+    }
+
+    size_t dirty_count = 0;
+
+    // count dirty mht nodes
+    data = lruc_get_first(pf->cache);
+    while (data != NULL) {
+        if (((file_node_t*)data)->type == FILE_MHT_NODE_TYPE) {
+            if (((file_node_t*)data)->need_writing)
+                dirty_count++;
+        }
+        data = lruc_get_next(pf->cache);
+    }
+
+    // add all the mht nodes that needs writing to a list
+    mht_array = malloc(dirty_count * sizeof(*mht_array));
+    if (!mht_array) {
+        pf->last_error = PF_STATUS_NO_MEMORY;
+        goto out;
+    }
+
+    data = lruc_get_first(pf->cache);
+    uint64_t dirty_idx = 0;
+    while (data != NULL) {
+        if (((file_node_t*)data)->type == FILE_MHT_NODE_TYPE) {
+            file_mht_node = (file_node_t*)data;
+
+            if (file_mht_node->need_writing)
+                mht_array[dirty_idx++] = file_mht_node;
+        }
+
+        data = lruc_get_next(pf->cache);
+    }
+
+    // sort the list from the last node to the first (bottom layers first)
+    if (dirty_count > 0)
+        sort_nodes(mht_array, 0, dirty_count - 1);
+
+    // update the gmacs in the parents
+    for (dirty_idx = 0; dirty_idx < dirty_count; dirty_idx++) {
+        file_mht_node = mht_array[dirty_idx];
+
+        gcm_crypto_data_t* gcm_crypto_data = &file_mht_node->parent->decrypted.mht
+            .mht_nodes_crypto[(file_mht_node->node_number - 1) % CHILD_MHT_NODES_COUNT];
+
+        if (!ipf_generate_random_key(pf, &gcm_crypto_data->key)) {
+            goto out;
+        }
+
+        status = cb_aes_gcm_encrypt(&gcm_crypto_data->key, &g_empty_iv,
+                                    NULL, 0,
+                                    &file_mht_node->decrypted.mht, PF_NODE_SIZE,
+                                    &file_mht_node->encrypted.cipher,
+                                    &gcm_crypto_data->gmac);
+        if (PF_FAILURE(status)) {
+            pf->last_error = status;
+            goto out;
+        }
+    }
+
+    // update mht root gmac in the meta data node
+    if (!ipf_generate_random_key(pf, &pf->encrypted_part_plain.mht_key))
+        goto out;
+
+    status = cb_aes_gcm_encrypt(&pf->encrypted_part_plain.mht_key, &g_empty_iv,
+                                NULL, 0,
+                                &pf->root_mht.decrypted.mht, PF_NODE_SIZE,
+                                &pf->root_mht.encrypted.cipher,
+                                &pf->encrypted_part_plain.mht_gmac);
+    if (PF_FAILURE(status)) {
+        pf->last_error = status;
+        goto out;
+    }
+
+    ret = true;
+
+out:
+    free(mht_array);
+    return ret;
+}
+
+static bool ipf_update_metadata_node(pf_context_t* pf) {
+    pf_status_t status;
+    pf_key_t key;
+
+    // randomize a new key, saves the key _id_ in the meta data plain part
+    if (!ipf_generate_random_metadata_key(pf, &key)) {
+        // last error already set
+        return false;
+    }
+
+    // encrypt meta data encrypted part, also updates the gmac in the meta data plain part
+    status = cb_aes_gcm_encrypt(&key, &g_empty_iv,
+                                NULL, 0,
+                                &pf->encrypted_part_plain, sizeof(metadata_encrypted_t),
+                                &pf->file_metadata.encrypted_part,
+                                &pf->file_metadata.plain_part.metadata_gmac);
+    if (PF_FAILURE(status)) {
+        pf->last_error = status;
+        return false;
+    }
+
+    return true;
+}
+
+static bool ipf_write_all_changes_to_disk(pf_context_t* pf) {
+    if (pf->encrypted_part_plain.size > MD_USER_DATA_SIZE && pf->root_mht.need_writing) {
+        void* data = NULL;
+        uint8_t* data_to_write;
+        uint64_t node_number;
+        file_node_t* file_node;
+
+        for (data = lruc_get_first(pf->cache); data != NULL; data = lruc_get_next(pf->cache)) {
+            file_node = (file_node_t*)data;
+            if (!file_node->need_writing)
+                continue;
+
+            data_to_write = (uint8_t*)&file_node->encrypted;
+            node_number = file_node->physical_node_number;
+
+            if (!ipf_write_node(pf, pf->file, node_number, data_to_write, PF_NODE_SIZE)) {
+                return false;
+            }
+
+            file_node->need_writing = false;
+            file_node->new_node = false;
+        }
+
+        if (!ipf_write_node(pf, pf->file, /*node_number=*/1, &pf->root_mht.encrypted,
+                            PF_NODE_SIZE)) {
+            return false;
+        }
+
+        pf->root_mht.need_writing = false;
+        pf->root_mht.new_node = false;
+    }
+
+    if (!ipf_write_node(pf, pf->file, /*node_number=*/0, &pf->file_metadata, PF_NODE_SIZE)) {
+        return false;
+    }
+
+    return true;
+}
+
+// seek to a specified file offset from the beginning
+// seek beyond the current size is supported if the file is writable,
+// the file is then extended with zeros (Intel SGX SDK implementation didn't support extending)
+static bool ipf_seek(pf_context_t* pf, uint64_t new_offset) {
+    if (PF_FAILURE(pf->file_status)) {
+        pf->last_error = pf->file_status;
+        return false;
+    }
+
+    bool result = false;
+
+    if (new_offset <= pf->encrypted_part_plain.size) {
+        pf->offset = new_offset;
+        result = true;
+    } else if (pf->mode & PF_FILE_MODE_WRITE) {
+        // need to extend the file
+        result = PF_SUCCESS(pf_set_size(pf, new_offset));
+    }
+
+    if (result)
+        pf->end_of_file = false;
+    else
+        pf->last_error = PF_STATUS_INVALID_PARAMETER;
+
+    return result;
+}
+
+static void ipf_try_clear_error(pf_context_t* pf) {
+    if (pf->file_status == PF_STATUS_UNINITIALIZED ||
+        pf->file_status == PF_STATUS_CRYPTO_ERROR ||
+        pf->file_status == PF_STATUS_CORRUPTED) {
+        // can't fix these...
+        DEBUG_PF("Unrecoverable file status: %d\n", pf->file_status);
+        return;
+    }
+
+    if (pf->file_status == PF_STATUS_FLUSH_ERROR) {
+        if (ipf_internal_flush(pf))
+            pf->file_status = PF_STATUS_SUCCESS;
+    }
+
+    if (pf->file_status == PF_STATUS_WRITE_TO_DISK_FAILED) {
+        if (ipf_write_all_changes_to_disk(pf)) {
+            pf->need_writing = false;
+            pf->file_status = PF_STATUS_SUCCESS;
+        }
+    }
+
+    if (pf->file_status == PF_STATUS_SUCCESS) {
+        pf->last_error = PF_STATUS_SUCCESS;
+        pf->end_of_file = false;
+    }
+}
+
+// memcpy src->dest if src is not NULL, zero dest otherwise
+static void memcpy_or_zero_initialize(void* dest, const void* src, size_t size) {
+    if (src)
+        memcpy(dest, src, size);
+    else
+        memset(dest, 0, size);
+}
+
+// write zeros if `ptr` is NULL
+static size_t ipf_write(pf_context_t* pf, const void* ptr, size_t size) {
+    if (size == 0) {
+        pf->last_error = PF_STATUS_INVALID_PARAMETER;
+        return 0;
+    }
+
+    size_t data_left_to_write = size;
+
+    if (PF_FAILURE(pf->file_status)) {
+        pf->last_error = pf->file_status;
+        DEBUG_PF("bad file status %d\n", pf->last_error);
+        return 0;
+    }
+
+    if (!(pf->mode & PF_FILE_MODE_WRITE)) {
+        pf->last_error = PF_STATUS_INVALID_MODE;
+        DEBUG_PF("File is read-only\n");
+        return 0;
+    }
+
+    const unsigned char* data_to_write = (const unsigned char*)ptr;
+
+    // the first block of user data is written in the meta-data encrypted part
+    if (pf->offset < MD_USER_DATA_SIZE) {
+        // offset is smaller than MD_USER_DATA_SIZE
+        size_t empty_place_left_in_md = MD_USER_DATA_SIZE - (size_t)pf->offset;
+        size_t size_to_write = MIN(data_left_to_write, empty_place_left_in_md);
+
+        memcpy_or_zero_initialize(&pf->encrypted_part_plain.data[pf->offset], data_to_write,
+                                  size_to_write);
+        pf->offset += size_to_write;
+        if (data_to_write)
+            data_to_write += size_to_write;
+        data_left_to_write -= size_to_write;
+
+        if (pf->offset > pf->encrypted_part_plain.size)
+            pf->encrypted_part_plain.size = pf->offset; // file grew, update the new file size
+
+        pf->need_writing = true;
+    }
+
+    while (data_left_to_write > 0) {
+        file_node_t* file_data_node = NULL;
+        // return the data node of the current offset, will read it from disk or create new one
+        // if needed (and also the mht node if needed)
+        file_data_node = ipf_get_data_node(pf);
+        if (file_data_node == NULL) {
+            DEBUG_PF("failed to get data node\n");
+            break;
+        }
+
+        size_t offset_in_node = (size_t)((pf->offset - MD_USER_DATA_SIZE) % PF_NODE_SIZE);
+        size_t empty_place_left_in_node = PF_NODE_SIZE - offset_in_node;
+        size_t size_to_write = MIN(data_left_to_write, empty_place_left_in_node);
+
+        memcpy_or_zero_initialize(&file_data_node->decrypted.data.data[offset_in_node],
+                                  data_to_write, size_to_write);
+        pf->offset += size_to_write;
+        if (data_to_write)
+            data_to_write += size_to_write;
+        data_left_to_write -= size_to_write;
+
+        if (pf->offset > pf->encrypted_part_plain.size) {
+            pf->encrypted_part_plain.size = pf->offset; // file grew, update the new file size
+        }
+
+        if (!file_data_node->need_writing) {
+            file_data_node->need_writing = true;
+            file_node_t* file_mht_node = file_data_node->parent;
+            while (file_mht_node->node_number != 0) {
+                // set all the mht parent nodes as 'need writing'
+                file_mht_node->need_writing = true;
+                file_mht_node = file_mht_node->parent;
+            }
+            pf->root_mht.need_writing = true;
+            pf->need_writing = true;
+        }
+    }
+
+    return size - data_left_to_write;
+}
+
+static size_t ipf_read(pf_context_t* pf, void* ptr, size_t size) {
+    if (ptr == NULL || size == 0)
+        return 0;
+
+    size_t data_left_to_read = size;
+
+    if (PF_FAILURE(pf->file_status)) {
+        pf->last_error = pf->file_status;
+        return 0;
+    }
+
+    if (!(pf->mode & PF_FILE_MODE_READ)) {
+        pf->last_error = PF_STATUS_INVALID_MODE;
+        return 0;
+    }
+
+    if (pf->end_of_file) {
+        // not an error
+        return 0;
+    }
+
+    // this check is not really needed, can go on with the code and it will do nothing until the end,
+    // but it's more 'right' to check it here
+    if (pf->offset == pf->encrypted_part_plain.size) {
+        pf->end_of_file = true;
+        return 0;
+    }
+
+    if (((uint64_t)data_left_to_read) > (uint64_t)(pf->encrypted_part_plain.size - pf->offset)) {
+        // the request is bigger than what's left in the file
+        data_left_to_read = (size_t)(pf->encrypted_part_plain.size - pf->offset);
+    }
+
+    // used at the end to return how much we actually read
+    size_t data_attempted_to_read = data_left_to_read;
+
+    unsigned char* out_buffer = (unsigned char*)ptr;
+
+    // the first block of user data is read from the meta-data encrypted part
+    if (pf->offset < MD_USER_DATA_SIZE) {
+        // offset is smaller than MD_USER_DATA_SIZE
+        size_t data_left_in_md = MD_USER_DATA_SIZE - (size_t)pf->offset;
+        size_t size_to_read = MIN(data_left_to_read, data_left_in_md);
+
+        memcpy(out_buffer, &pf->encrypted_part_plain.data[pf->offset], size_to_read);
+        pf->offset += size_to_read;
+        out_buffer += size_to_read;
+        data_left_to_read -= size_to_read;
+    }
+
+    while (data_left_to_read > 0) {
+        file_node_t* file_data_node = NULL;
+        // return the data node of the current offset, will read it from disk if needed
+        // (and also the mht node if needed)
+        file_data_node = ipf_get_data_node(pf);
+        if (file_data_node == NULL)
+            break;
+
+        size_t offset_in_node = (pf->offset - MD_USER_DATA_SIZE) % PF_NODE_SIZE;
+        size_t data_left_in_node = PF_NODE_SIZE - offset_in_node;
+        size_t size_to_read = MIN(data_left_to_read, data_left_in_node);
+
+        memcpy(out_buffer, &file_data_node->decrypted.data.data[offset_in_node], size_to_read);
+        pf->offset += size_to_read;
+        out_buffer += size_to_read;
+        data_left_to_read -= size_to_read;
+    }
+
+    if (data_left_to_read == 0 && data_attempted_to_read != size) {
+        // user wanted to read more and we had to shrink the request
+        assert(pf->offset == pf->encrypted_part_plain.size);
+        pf->end_of_file = true;
+    }
+
+    return data_attempted_to_read - data_left_to_read;
+}
+
+// this is a very 'specific' function, tied to the architecture of the file layout,
+// returning the node numbers according to the data offset in the file
+static void get_node_numbers(uint64_t offset, uint64_t* mht_node_number, uint64_t* data_node_number,
+                             uint64_t* physical_mht_node_number,
+                             uint64_t* physical_data_node_number) {
+    // physical nodes (file layout):
+    // node 0 - meta data node
+    // node 1 - mht
+    // nodes 2-97 - data (ATTACHED_DATA_NODES_COUNT == 96)
+    // node 98 - mht
+    // node 99-195 - data
+    // etc.
+    uint64_t _physical_mht_node_number;
+    uint64_t _physical_data_node_number;
+
+    // "logical" nodes: sequential index of the corresponding mht/data node in all mht/data nodes
+    uint64_t _mht_node_number;
+    uint64_t _data_node_number;
+
+    assert(offset >= MD_USER_DATA_SIZE);
+
+    _data_node_number = (offset - MD_USER_DATA_SIZE) / PF_NODE_SIZE;
+    _mht_node_number = _data_node_number / ATTACHED_DATA_NODES_COUNT;
+    _physical_data_node_number = _data_node_number
+                                 + 1 // meta data node
+                                 + 1 // mht root
+                                 + _mht_node_number; // number of mht nodes in the middle
+                                 // (the root mht mht_node_number is 0)
+    _physical_mht_node_number = _physical_data_node_number
+                                - _data_node_number % ATTACHED_DATA_NODES_COUNT // now we are at
+                                // the first data node attached to this mht node
+                                - 1; // and now at the mht node itself!
+
+    if (mht_node_number != NULL)
+        *mht_node_number = _mht_node_number;
+    if (data_node_number != NULL)
+        *data_node_number = _data_node_number;
+    if (physical_mht_node_number != NULL)
+        *physical_mht_node_number = _physical_mht_node_number;
+    if (physical_data_node_number != NULL)
+        *physical_data_node_number = _physical_data_node_number;
+}
+
+static file_node_t* ipf_get_data_node(pf_context_t* pf) {
+    file_node_t* file_data_node = NULL;
+
+    if (pf->offset < MD_USER_DATA_SIZE) {
+        pf->last_error = PF_STATUS_UNKNOWN_ERROR;
+        return NULL;
+    }
+
+    if ((pf->offset - MD_USER_DATA_SIZE) % PF_NODE_SIZE == 0
+        && pf->offset == pf->encrypted_part_plain.size) {
+        // new node
+        file_data_node = ipf_append_data_node(pf);
+    } else {
+        // existing node
+        file_data_node = ipf_read_data_node(pf);
+    }
+
+    // bump all the parents mht to reside before the data node in the cache
+    if (file_data_node != NULL) {
+        file_node_t* file_mht_node = file_data_node->parent;
+        while (file_mht_node->node_number != 0) {
+            // bump the mht node to the head of the lru
+            lruc_get(pf->cache, file_mht_node->physical_node_number);
+            file_mht_node = file_mht_node->parent;
+        }
+    }
+
+    // even if we didn't get the required data_node, we might have read other nodes in the process
+    while (lruc_size(pf->cache) > MAX_PAGES_IN_CACHE) {
+        void* data = lruc_get_last(pf->cache);
+        assert(data != NULL);
+        // for production -
+        if (data == NULL) {
+            pf->last_error = PF_STATUS_UNKNOWN_ERROR;
+            return NULL;
+        }
+
+        if (!((file_node_t*)data)->need_writing) {
+            lruc_remove_last(pf->cache);
+
+            // before deleting the memory, need to scrub the plain secrets
+            file_node_t* file_node = (file_node_t*)data;
+            erase_memory(&file_node->decrypted, sizeof(file_node->decrypted));
+            free(file_node);
+        } else {
+            if (!ipf_internal_flush(pf)) {
+                // error, can't flush cache, file status changed to error
+                assert(pf->file_status != PF_STATUS_SUCCESS);
+                if (pf->file_status == PF_STATUS_SUCCESS)
+                    pf->file_status = PF_STATUS_FLUSH_ERROR; // for release set this anyway
+                return NULL; // even if we got the data_node!
+            }
+        }
+    }
+
+    return file_data_node;
+}
+
+static file_node_t* ipf_append_data_node(pf_context_t* pf) {
+    file_node_t* file_mht_node = ipf_get_mht_node(pf);
+    if (file_mht_node == NULL) // some error happened
+        return NULL;
+
+    file_node_t* new_file_data_node = NULL;
+
+    new_file_data_node = calloc(1, sizeof(*new_file_data_node));
+    if (!new_file_data_node) {
+        pf->last_error = PF_STATUS_NO_MEMORY;
+        return NULL;
+    }
+
+    new_file_data_node->type = FILE_DATA_NODE_TYPE;
+    new_file_data_node->new_node = true;
+    new_file_data_node->parent = file_mht_node;
+    get_node_numbers(pf->offset, NULL, &new_file_data_node->node_number, NULL,
+                     &new_file_data_node->physical_node_number);
+
+    if (!lruc_add(pf->cache, new_file_data_node->physical_node_number, new_file_data_node)) {
+        free(new_file_data_node);
+        pf->last_error = PF_STATUS_NO_MEMORY;
+        return NULL;
+    }
+
+    return new_file_data_node;
+}
+
+static file_node_t* ipf_read_data_node(pf_context_t* pf) {
+    uint64_t data_node_number;
+    uint64_t physical_node_number;
+    file_node_t* file_mht_node;
+    pf_status_t status;
+
+    get_node_numbers(pf->offset, NULL, &data_node_number, NULL, &physical_node_number);
+
+    file_node_t* file_data_node = (file_node_t*)lruc_get(pf->cache, physical_node_number);
+    if (file_data_node != NULL)
+        return file_data_node;
+
+    // need to read the data node from the disk
+
+    file_mht_node = ipf_get_mht_node(pf);
+    if (file_mht_node == NULL) // some error happened
+        return NULL;
+
+    file_data_node = calloc(1, sizeof(*file_data_node));
+    if (!file_data_node) {
+        pf->last_error = PF_STATUS_NO_MEMORY;
+        return NULL;
+    }
+
+    file_data_node->type = FILE_DATA_NODE_TYPE;
+    file_data_node->node_number = data_node_number;
+    file_data_node->physical_node_number = physical_node_number;
+    file_data_node->parent = file_mht_node;
+
+    if (!ipf_read_node(pf, pf->file, file_data_node->physical_node_number,
+                       file_data_node->encrypted.cipher, PF_NODE_SIZE)) {
+        free(file_data_node);
+        return NULL;
+    }
+
+    gcm_crypto_data_t* gcm_crypto_data = &file_data_node->parent->decrypted.mht
+        .data_nodes_crypto[file_data_node->node_number % ATTACHED_DATA_NODES_COUNT];
+
+    // this function decrypt the data _and_ checks the integrity of the data against the gmac
+    status = cb_aes_gcm_decrypt(&gcm_crypto_data->key, &g_empty_iv,
+                                NULL, 0,
+                                file_data_node->encrypted.cipher, PF_NODE_SIZE,
+                                file_data_node->decrypted.data.data,
+                                &gcm_crypto_data->gmac);
+
+    if (PF_FAILURE(status)) {
+        free(file_data_node);
+        pf->last_error = status;
+        if (status == PF_STATUS_MAC_MISMATCH)
+            pf->file_status = PF_STATUS_CORRUPTED;
+        return NULL;
+    }
+
+    if (!lruc_add(pf->cache, file_data_node->physical_node_number, file_data_node)) {
+        // scrub the plaintext data
+        erase_memory(&file_data_node->decrypted, sizeof(file_data_node->decrypted));
+        free(file_data_node);
+        pf->last_error = PF_STATUS_NO_MEMORY;
+        return NULL;
+    }
+
+    return file_data_node;
+}
+
+static file_node_t* ipf_get_mht_node(pf_context_t* pf) {
+    file_node_t* file_mht_node;
+    uint64_t mht_node_number;
+    uint64_t physical_mht_node_number;
+
+    if (pf->offset < MD_USER_DATA_SIZE) {
+        pf->last_error = PF_STATUS_UNKNOWN_ERROR;
+        return NULL;
+    }
+
+    get_node_numbers(pf->offset, &mht_node_number, NULL, &physical_mht_node_number, NULL);
+
+    if (mht_node_number == 0)
+        return &pf->root_mht;
+
+    // file is constructed from (ATTACHED_DATA_NODES_COUNT + CHILD_MHT_NODES_COUNT) * PF_NODE_SIZE
+    // bytes per MHT node
+    if ((pf->offset - MD_USER_DATA_SIZE) % (ATTACHED_DATA_NODES_COUNT * PF_NODE_SIZE) == 0 &&
+         pf->offset == pf->encrypted_part_plain.size) {
+        file_mht_node = ipf_append_mht_node(pf, mht_node_number);
+    } else {
+        file_mht_node = ipf_read_mht_node(pf, mht_node_number);
+    }
+
+    return file_mht_node;
+}
+
+static file_node_t* ipf_append_mht_node(pf_context_t* pf, uint64_t mht_node_number) {
+    assert(mht_node_number > 0);
+    file_node_t* parent_file_mht_node =
+        ipf_read_mht_node(pf, (mht_node_number - 1) / CHILD_MHT_NODES_COUNT);
+
+    if (parent_file_mht_node == NULL) // some error happened
+        return NULL;
+
+    uint64_t physical_node_number = 1 + // meta data node
+                                    // the '1' is for the mht node preceding every 96 data nodes
+                                    mht_node_number * (1 + ATTACHED_DATA_NODES_COUNT);
+
+    file_node_t* new_file_mht_node = NULL;
+    new_file_mht_node = calloc(1, sizeof(*new_file_mht_node));
+    if (!new_file_mht_node) {
+        pf->last_error = PF_STATUS_NO_MEMORY;
+        return NULL;
+    }
+
+    new_file_mht_node->type = FILE_MHT_NODE_TYPE;
+    new_file_mht_node->new_node = true;
+    new_file_mht_node->parent = parent_file_mht_node;
+    new_file_mht_node->node_number = mht_node_number;
+    new_file_mht_node->physical_node_number = physical_node_number;
+
+    if (!lruc_add(pf->cache, new_file_mht_node->physical_node_number, new_file_mht_node)) {
+        free(new_file_mht_node);
+        pf->last_error = PF_STATUS_NO_MEMORY;
+        return NULL;
+    }
+
+    return new_file_mht_node;
+}
+
+static file_node_t* ipf_read_mht_node(pf_context_t* pf, uint64_t mht_node_number) {
+    pf_status_t status;
+
+    if (mht_node_number == 0)
+        return &pf->root_mht;
+
+    uint64_t physical_node_number = 1 + // meta data node
+                                    // the '1' is for the mht node preceding every 96 data nodes
+                                    mht_node_number * (1 + ATTACHED_DATA_NODES_COUNT);
+
+    file_node_t* file_mht_node = (file_node_t*)lruc_find(pf->cache, physical_node_number);
+    if (file_mht_node != NULL)
+        return file_mht_node;
+
+    file_node_t* parent_file_mht_node =
+        ipf_read_mht_node(pf, (mht_node_number - 1) / CHILD_MHT_NODES_COUNT);
+
+    if (parent_file_mht_node == NULL) // some error happened
+        return NULL;
+
+    file_mht_node = calloc(1, sizeof(*file_mht_node));
+    if (!file_mht_node) {
+        pf->last_error = PF_STATUS_NO_MEMORY;
+        return NULL;
+    }
+
+    file_mht_node->type = FILE_MHT_NODE_TYPE;
+    file_mht_node->node_number = mht_node_number;
+    file_mht_node->physical_node_number = physical_node_number;
+    file_mht_node->parent = parent_file_mht_node;
+
+    if (!ipf_read_node(pf, pf->file, file_mht_node->physical_node_number,
+                       file_mht_node->encrypted.cipher, PF_NODE_SIZE)) {
+        free(file_mht_node);
+        return NULL;
+    }
+
+    gcm_crypto_data_t* gcm_crypto_data = &file_mht_node->parent->decrypted.mht
+        .mht_nodes_crypto[(file_mht_node->node_number - 1) % CHILD_MHT_NODES_COUNT];
+
+    // this function decrypt the data _and_ checks the integrity of the data against the gmac
+    status = cb_aes_gcm_decrypt(&gcm_crypto_data->key, &g_empty_iv,
+                                NULL, 0,
+                                file_mht_node->encrypted.cipher, PF_NODE_SIZE,
+                                &file_mht_node->decrypted.mht,
+                                &gcm_crypto_data->gmac);
+    if (PF_FAILURE(status)) {
+        free(file_mht_node);
+        pf->last_error = status;
+        if (status == PF_STATUS_MAC_MISMATCH)
+            pf->file_status = PF_STATUS_CORRUPTED;
+        return NULL;
+    }
+
+    if (!lruc_add(pf->cache, file_mht_node->physical_node_number, file_mht_node)) {
+        erase_memory(&file_mht_node->decrypted, sizeof(file_mht_node->decrypted));
+        free(file_mht_node);
+        pf->last_error = PF_STATUS_NO_MEMORY;
+        return NULL;
+    }
+
+    return file_mht_node;
+}
+
+// public API
+
+void pf_set_callbacks(pf_read_f read_f, pf_write_f write_f, pf_truncate_f truncate_f,
+                      pf_aes_gcm_encrypt_f aes_gcm_encrypt_f,
+                      pf_aes_gcm_decrypt_f aes_gcm_decrypt_f, pf_random_f random_f,
+                      pf_debug_f debug_f) {
+    cb_read            = read_f;
+    cb_write           = write_f;
+    cb_truncate        = truncate_f;
+    cb_aes_gcm_encrypt = aes_gcm_encrypt_f;
+    cb_aes_gcm_decrypt = aes_gcm_decrypt_f;
+    cb_random          = random_f;
+    cb_debug           = debug_f;
+    g_initialized      = true;
+}
+
+pf_status_t pf_open(pf_handle_t handle, const char* path, uint64_t underlying_size,
+                    pf_file_mode_t mode, bool create, const pf_key_t* key,
+                    pf_context_t** context) {
+    if (!g_initialized)
+        return PF_STATUS_UNINITIALIZED;
+
+    pf_status_t status;
+    *context = ipf_open(path, mode, create, handle, underlying_size, key, &status);
+    return status;
+}
+
+pf_status_t pf_close(pf_context_t* pf) {
+    if (!g_initialized)
+        return PF_STATUS_UNINITIALIZED;
+
+    if (ipf_close(pf))
+        return PF_STATUS_SUCCESS;
+    return pf->last_error;
+}
+
+pf_status_t pf_get_size(pf_context_t* pf, uint64_t* size) {
+    if (!g_initialized)
+        return PF_STATUS_UNINITIALIZED;
+
+    *size = pf->encrypted_part_plain.size;
+    return PF_STATUS_SUCCESS;
+}
+
+// TODO: file truncation
+pf_status_t pf_set_size(pf_context_t* pf, uint64_t size) {
+    if (!g_initialized)
+        return PF_STATUS_UNINITIALIZED;
+
+    if (!(pf->mode & PF_FILE_MODE_WRITE))
+        return PF_STATUS_INVALID_MODE;
+
+    if (size == pf->encrypted_part_plain.size)
+        return PF_STATUS_SUCCESS;
+
+    if (size > pf->encrypted_part_plain.size) {
+        // extend the file
+        pf->offset = pf->encrypted_part_plain.size;
+        DEBUG_PF("extending the file from %lu to %lu\n", pf->offset, size);
+        if (ipf_write(pf, NULL, size - pf->offset) != size - pf->offset)
+            return pf->last_error;
+
+        return PF_STATUS_SUCCESS;
+    }
+
+    return PF_STATUS_NOT_IMPLEMENTED;
+}
+
+pf_status_t pf_read(pf_context_t* pf, uint64_t offset, size_t size, void* output) {
+    if (!g_initialized)
+        return PF_STATUS_UNINITIALIZED;
+
+    if (!ipf_seek(pf, offset))
+        return pf->last_error;
+
+    if (ipf_read(pf, output, size) != size)
+        return pf->last_error;
+    return PF_STATUS_SUCCESS;
+}
+
+pf_status_t pf_write(pf_context_t* pf, uint64_t offset, size_t size, const void* input) {
+    if (!g_initialized)
+        return PF_STATUS_UNINITIALIZED;
+
+    if (!ipf_seek(pf, offset))
+        return pf->last_error;
+
+    if (ipf_write(pf, input, size) != size)
+        return pf->last_error;
+    return PF_STATUS_SUCCESS;
+}
+
+pf_status_t pf_flush(pf_context_t* pf) {
+    if (!g_initialized)
+        return PF_STATUS_UNINITIALIZED;
+
+    if (!ipf_internal_flush(pf))
+        return pf->last_error;
+    return PF_STATUS_SUCCESS;
+}
+
+pf_status_t pf_get_handle(pf_context_t* pf, pf_handle_t* handle) {
+    if (!g_initialized)
+        return PF_STATUS_UNINITIALIZED;
+
+    *handle = pf->file;
+    return PF_STATUS_SUCCESS;
+}

--- a/Pal/src/host/Linux-SGX/protected-files/protected_files.h
+++ b/Pal/src/host/Linux-SGX/protected-files/protected_files.h
@@ -1,0 +1,254 @@
+/* SPDX-License-Identifier: LGPL-3.0-or-later */
+/* Copyright (C) 2019-2020 Invisible Things Lab
+ *                         Rafal Wojdyla <omeg@invisiblethingslab.com>
+ * Copyright (C) 2011-2019 Intel Corporation
+ */
+
+/* See README.rst for protected files overview */
+
+#ifndef PROTECTED_FILES_H_
+#define PROTECTED_FILES_H_
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+/*! Size of the AES-GCM encryption key */
+#define PF_KEY_SIZE  16
+
+/*! Size of IV for AES-GCM */
+#define PF_IV_SIZE   12
+
+/*! Size of MAC fields */
+#define PF_MAC_SIZE  16
+
+typedef uint8_t pf_iv_t[PF_IV_SIZE];
+typedef uint8_t pf_mac_t[PF_MAC_SIZE];
+typedef uint8_t pf_key_t[PF_KEY_SIZE];
+typedef uint8_t pf_keyid_t[32]; /* key derivation material */
+
+typedef enum _pf_status_t {
+    PF_STATUS_SUCCESS              = 0,
+    PF_STATUS_UNKNOWN_ERROR        = -1,
+    PF_STATUS_UNINITIALIZED        = -2,
+    PF_STATUS_INVALID_PARAMETER    = -3,
+    PF_STATUS_INVALID_MODE         = -4,
+    PF_STATUS_NO_MEMORY            = -5,
+    PF_STATUS_INVALID_VERSION      = -6,
+    PF_STATUS_INVALID_HEADER       = -7,
+    PF_STATUS_INVALID_PATH         = -8,
+    PF_STATUS_MAC_MISMATCH         = -9,
+    PF_STATUS_NOT_IMPLEMENTED      = -10,
+    PF_STATUS_CALLBACK_FAILED      = -11,
+    PF_STATUS_PATH_TOO_LONG        = -12,
+    PF_STATUS_RECOVERY_NEEDED      = -13,
+    PF_STATUS_FLUSH_ERROR          = -14,
+    PF_STATUS_CRYPTO_ERROR         = -15,
+    PF_STATUS_CORRUPTED            = -16,
+    PF_STATUS_WRITE_TO_DISK_FAILED = -17,
+} pf_status_t;
+
+#define PF_SUCCESS(status) ((status) == PF_STATUS_SUCCESS)
+#define PF_FAILURE(status) ((status) != PF_STATUS_SUCCESS)
+
+#define PF_NODE_SIZE 4096U
+
+/*! PF open modes */
+typedef enum _pf_file_mode_t {
+    PF_FILE_MODE_READ  = 1,
+    PF_FILE_MODE_WRITE = 2,
+} pf_file_mode_t;
+
+/*! Opaque file handle type, interpreted by callbacks as necessary */
+typedef void* pf_handle_t;
+
+/*!
+ * \brief File read callback
+ *
+ * \param [in] handle File handle
+ * \param [out] buffer Buffer to read to
+ * \param [in] offset Offset to read from
+ * \param [in] size Number of bytes to read
+ * \return PF status
+ */
+typedef pf_status_t (*pf_read_f)(pf_handle_t handle, void* buffer, uint64_t offset, size_t size);
+
+/*!
+ * \brief File write callback
+ *
+ * \param [in] handle File handle
+ * \param [in] buffer Buffer to write from
+ * \param [in] offset Offset to write to
+ * \param [in] size Number of bytes to write
+ * \return PF status
+ */
+typedef pf_status_t (*pf_write_f)(pf_handle_t handle, const void* buffer, uint64_t offset,
+                                  size_t size);
+
+/*!
+ * \brief File truncate callback
+ *
+ * \param [in] handle File handle
+ * \param [in] size Target file size
+ * \return PF status
+ */
+typedef pf_status_t (*pf_truncate_f)(pf_handle_t handle, uint64_t size);
+
+/*!
+ * \brief Debug print callback
+ *
+ * \param [in] msg Message to print
+ */
+typedef void (*pf_debug_f)(const char* msg);
+
+/*!
+ * \brief AES-GCM encrypt callback
+ *
+ * \param [in] key AES-GCM key
+ * \param [in] iv Initialization vector
+ * \param [in] aad (optional) Additional authenticated data
+ * \param [in] aad_size Size of \a aad in bytes
+ * \param [in] input Plaintext data
+ * \param [in] input_size Size of \a input in bytes
+ * \param [out] output Buffer for encrypted data (size: \a input_size)
+ * \param [out] mac MAC computed for \a input and \a aad
+ * \return PF status
+ */
+typedef pf_status_t (*pf_aes_gcm_encrypt_f)(const pf_key_t* key, const pf_iv_t* iv,
+                                            const void* aad, size_t aad_size,
+                                            const void* input, size_t input_size,
+                                            void* output, pf_mac_t* mac);
+
+/*!
+ * \brief AES-GCM decrypt callback
+ *
+ * \param [in] key AES-GCM key
+ * \param [in] iv Initialization vector
+ * \param [in] aad (optional) Additional authenticated data
+ * \param [in] aad_size Size of \a aad in bytes
+ * \param [in] input Encrypted data
+ * \param [in] input_size Size of \a input in bytes
+ * \param [out] output Buffer for decrypted data (size: \a input_size)
+ * \param [in] mac Expected MAC
+ * \return PF status
+ */
+typedef pf_status_t (*pf_aes_gcm_decrypt_f)(const pf_key_t* key, const pf_iv_t* iv,
+                                            const void* aad, size_t aad_size,
+                                            const void* input, size_t input_size,
+                                            void* output, const pf_mac_t* mac);
+
+/*!
+ * \brief Cryptographic random number generator callback
+ *
+ * \param [out] buffer Buffer to fill with random bytes
+ * \param [in] size Size of \a buffer in bytes
+ * \return PF status
+ */
+typedef pf_status_t (*pf_random_f)(uint8_t* buffer, size_t size);
+
+/*!
+ * \brief Initialize I/O callbacks
+ *
+ * \param [in] read_f File read callback
+ * \param [in] write_f File write callback
+ * \param [in] truncate_f File truncate callback
+ * \param [in] aes_gcm_encrypt_f AES-GCM encrypt callback
+ * \param [in] aes_gcm_decrypt_f AES-GCM decrypt callback
+ * \param [in] random_f Cryptographic random number generator callback
+ * \param [in] debug_f (optional) Debug print callback
+ *
+ * \details Must be called before any actual APIs
+ */
+void pf_set_callbacks(pf_read_f read_f, pf_write_f write_f, pf_truncate_f truncate_f,
+                      pf_aes_gcm_encrypt_f aes_gcm_encrypt_f,
+                      pf_aes_gcm_decrypt_f aes_gcm_decrypt_f, pf_random_f random_f,
+                      pf_debug_f debug_f);
+
+/*! Context representing an open protected file */
+typedef struct pf_context pf_context_t;
+
+/* Public API */
+
+/*!
+ * \brief Open a protected file
+ *
+ * \param [in] handle Open underlying file handle
+ * \param [in] path Path to the file. If NULL and \a create is false, don't check path for validity.
+ * \param [in] underlying_size Underlying file size
+ * \param [in] mode Access mode
+ * \param [in] create Overwrite file contents if true
+ * \param [in] key Wrap key
+ * \param [out] context PF context for later calls
+ * \return PF status
+ */
+pf_status_t pf_open(pf_handle_t handle, const char* path, uint64_t underlying_size,
+                    pf_file_mode_t mode, bool create, const pf_key_t* key, pf_context_t** context);
+
+/*!
+ * \brief Close a protected file and commit all changes to disk
+ *
+ * \param [in] pf PF context
+ * \return PF status
+ */
+pf_status_t pf_close(pf_context_t* pf);
+
+/*!
+ * \brief Read from a protected file
+ *
+ * \param [in] pf PF context
+ * \param [in] offset Data offset to read from
+ * \param [in] size Number of bytes to read
+ * \param [out] output Destination buffer
+ * \return PF status
+ */
+pf_status_t pf_read(pf_context_t* pf, uint64_t offset, size_t size, void* output);
+
+/*!
+ * \brief Write to a protected file
+ *
+ * \param [in] pf PF context
+ * \param [in] offset Data offset to write to
+ * \param [in] size Number of bytes to write
+ * \param [in] input Source buffer
+ * \return PF status
+ */
+pf_status_t pf_write(pf_context_t* pf, uint64_t offset, size_t size, const void* input);
+
+/*!
+ * \brief Get data size of a PF
+ *
+ * \param [in] pf PF context
+ * \param [out] size Data size of \a pf
+ * \return PF status
+ */
+pf_status_t pf_get_size(pf_context_t* pf, uint64_t* size);
+
+/*!
+ * \brief Set data size of a PF
+ *
+ * \param [in] pf PF context
+ * \param [in] size Data size to set
+ * \return PF status
+ * \details If the file is extended, added bytes are zero.
+ *          Truncation is not implemented yet (TODO).
+ */
+pf_status_t pf_set_size(pf_context_t* pf, uint64_t size);
+
+/*!
+ * \brief Get underlying handle of a PF
+ *
+ * \param [in] pf PF context
+ * \param [out] handle Handle to the backing file
+ * \return PF status
+ */
+pf_status_t pf_get_handle(pf_context_t* pf, pf_handle_t* handle);
+
+/*!
+ * \brief Flush any pending data of a protected file to disk
+ *
+ * \param [in] pf PF context
+ * \return PF status
+ */
+pf_status_t pf_flush(pf_context_t* pf);
+
+#endif /* PROTECTED_FILES_H_ */

--- a/Pal/src/host/Linux-SGX/protected-files/protected_files_internal.h
+++ b/Pal/src/host/Linux-SGX/protected-files/protected_files_internal.h
@@ -1,0 +1,181 @@
+/* SPDX-License-Identifier: LGPL-3.0-or-later */
+/* Copyright (C) 2019-2020 Invisible Things Lab
+ *                         Rafal Wojdyla <omeg@invisiblethingslab.com>
+ * Copyright (C) 2011-2019 Intel Corporation
+ */
+
+#ifndef PROTECTED_FILES_INTERNAL_H_
+#define PROTECTED_FILES_INTERNAL_H_
+
+#include <assert.h>
+#include <limits.h>
+
+#include "list.h"
+#include "lru_cache.h"
+#include "protected_files.h"
+
+#define PF_FILE_ID       0x46505f4850415247 /* GRAPH_PF */
+#define PF_MAJOR_VERSION 0x01
+#define PF_MINOR_VERSION 0x00
+
+#pragma pack(push, 1)
+
+typedef struct _metadata_plain {
+    uint64_t   file_id;
+    uint8_t    major_version;
+    uint8_t    minor_version;
+    pf_keyid_t metadata_key_id;
+    pf_mac_t   metadata_gmac; /* GCM mac */
+} metadata_plain_t;
+
+#define PATH_MAX_SIZE          (260 + 512)
+
+// these are all defined as relative to node size, so we can decrease node size in tests
+// and have deeper tree
+#define MD_USER_DATA_SIZE (PF_NODE_SIZE*3/4)  // 3072
+static_assert(MD_USER_DATA_SIZE == 3072, "bad struct size");
+
+typedef struct _metadata_encrypted {
+    char     path[PATH_MAX_SIZE];
+    uint64_t size;
+    pf_key_t mht_key;
+    pf_mac_t mht_gmac;
+    uint8_t  data[MD_USER_DATA_SIZE];
+} metadata_encrypted_t;
+
+typedef uint8_t metadata_encrypted_blob_t[sizeof(metadata_encrypted_t)];
+
+#define METADATA_NODE_SIZE PF_NODE_SIZE
+
+typedef uint8_t metadata_padding_t[METADATA_NODE_SIZE
+    - (sizeof(metadata_plain_t) + sizeof(metadata_encrypted_blob_t))];
+
+typedef struct _metadata_node {
+    metadata_plain_t          plain_part;
+    metadata_encrypted_blob_t encrypted_part;
+    metadata_padding_t        padding;
+} metadata_node_t;
+
+static_assert(sizeof(metadata_node_t) == PF_NODE_SIZE, "sizeof(metadata_node_t)");
+
+typedef struct _data_node_crypto {
+    pf_key_t key;
+    pf_mac_t gmac;
+} gcm_crypto_data_t;
+
+// for PF_NODE_SIZE == 4096, we have 96 attached data nodes and 32 mht child nodes
+// for PF_NODE_SIZE == 2048, we have 48 attached data nodes and 16 mht child nodes
+// for PF_NODE_SIZE == 1024, we have 24 attached data nodes and 8 mht child nodes
+// 3/4 of the node size is dedicated to data nodes
+#define ATTACHED_DATA_NODES_COUNT ((PF_NODE_SIZE/sizeof(gcm_crypto_data_t))*3/4)
+static_assert(ATTACHED_DATA_NODES_COUNT == 96, "ATTACHED_DATA_NODES_COUNT");
+// 1/4 of the node size is dedicated to child mht nodes
+#define CHILD_MHT_NODES_COUNT ((PF_NODE_SIZE/sizeof(gcm_crypto_data_t))*1/4)
+static_assert(CHILD_MHT_NODES_COUNT == 32, "CHILD_MHT_NODES_COUNT");
+
+typedef struct _mht_node {
+    gcm_crypto_data_t data_nodes_crypto[ATTACHED_DATA_NODES_COUNT];
+    gcm_crypto_data_t mht_nodes_crypto[CHILD_MHT_NODES_COUNT];
+} mht_node_t;
+
+static_assert(sizeof(mht_node_t) == PF_NODE_SIZE, "sizeof(mht_node_t)");
+
+typedef struct _data_node {
+    uint8_t data[PF_NODE_SIZE];
+} data_node_t;
+
+static_assert(sizeof(data_node_t) == PF_NODE_SIZE, "sizeof(data_node_t)");
+
+typedef struct _encrypted_node {
+    uint8_t cipher[PF_NODE_SIZE];
+} encrypted_node_t;
+
+static_assert(sizeof(encrypted_node_t) == PF_NODE_SIZE, "sizeof(encrypted_node_t)");
+
+#define MAX_PAGES_IN_CACHE 48
+
+typedef enum {
+    FILE_MHT_NODE_TYPE = 1,
+    FILE_DATA_NODE_TYPE = 2,
+} mht_node_type_e;
+
+// make sure these are the same size
+static_assert(sizeof(mht_node_t) == sizeof(data_node_t),
+              "sizeof(mht_node_t) == sizeof(data_node_t)");
+
+DEFINE_LIST(_file_node);
+typedef struct _file_node {
+    LIST_TYPE(_file_node) list;
+    uint8_t type;
+    uint64_t node_number;
+    struct _file_node* parent;
+    bool need_writing;
+    bool new_node;
+    struct {
+        uint64_t physical_node_number;
+        encrypted_node_t encrypted; // the actual data from the disk
+    };
+    union { // decrypted data
+        mht_node_t mht;
+        data_node_t data;
+    } decrypted;
+} file_node_t;
+DEFINE_LISTP(_file_node);
+
+#pragma pack(pop)
+
+struct pf_context {
+    metadata_node_t file_metadata; // actual data from disk's meta data node
+    pf_status_t last_error;
+    metadata_encrypted_t encrypted_part_plain; // encrypted part of metadata node, decrypted
+    file_node_t root_mht; // the root of the mht is always needed (for files bigger than 3KB)
+    pf_handle_t file;
+    pf_file_mode_t mode;
+    uint64_t offset; // current file position (user's view)
+    bool end_of_file;
+    uint64_t real_file_size;
+    bool need_writing;
+    pf_status_t file_status;
+    pf_key_t user_kdk_key;
+    pf_key_t cur_key;
+    lruc_context_t* cache;
+#ifdef DEBUG
+    char* debug_buffer; // buffer for debug output
+#endif
+};
+
+/* ipf prefix means "Intel protected files", these are functions from the SGX SDK implementation */
+static bool ipf_init_fields(pf_context_t* pf);
+static bool ipf_init_existing_file(pf_context_t* pf, const char* path);
+static bool ipf_init_new_file(pf_context_t* pf, const char* path);
+
+static bool ipf_read_node(pf_context_t* pf, pf_handle_t handle, uint64_t node_number, void* buffer,
+                          uint32_t node_size);
+static bool ipf_write_node(pf_context_t* pf, pf_handle_t handle, uint64_t node_number, void* buffer,
+                           uint32_t node_size);
+
+static bool ipf_import_metadata_key(pf_context_t* pf, bool restore, pf_key_t* output);
+static bool ipf_generate_random_key(pf_context_t* pf, pf_key_t* output);
+static bool ipf_restore_current_metadata_key(pf_context_t* pf, pf_key_t* output);
+
+static file_node_t* ipf_get_data_node(pf_context_t* pf);
+static file_node_t* ipf_read_data_node(pf_context_t* pf);
+static file_node_t* ipf_append_data_node(pf_context_t* pf);
+static file_node_t* ipf_get_mht_node(pf_context_t* pf);
+static file_node_t* ipf_read_mht_node(pf_context_t* pf, uint64_t mht_node_number);
+static file_node_t* ipf_append_mht_node(pf_context_t* pf, uint64_t mht_node_number);
+
+static bool ipf_update_all_data_and_mht_nodes(pf_context_t* pf);
+static bool ipf_update_metadata_node(pf_context_t* pf);
+static bool ipf_write_all_changes_to_disk(pf_context_t* pf);
+static bool ipf_internal_flush(pf_context_t* pf);
+
+static pf_context_t* ipf_open(const char* path, pf_file_mode_t mode, bool create, pf_handle_t file,
+                              size_t real_size, const pf_key_t* kdk_key, pf_status_t* status);
+static bool ipf_close(pf_context_t* pf);
+static size_t ipf_read(pf_context_t* pf, void* ptr, size_t size);
+static size_t ipf_write(pf_context_t* pf, const void* ptr, size_t size);
+static bool ipf_seek(pf_context_t* pf, uint64_t new_offset);
+static void ipf_try_clear_error(pf_context_t* pf);
+
+#endif /* PROTECTED_FILES_INTERNAL_H_ */

--- a/Pal/src/host/Linux-SGX/tools/Makefile
+++ b/Pal/src/host/Linux-SGX/tools/Makefile
@@ -1,4 +1,5 @@
 include ../../../../../Scripts/Makefile.configs
+include ../../../../../Scripts/Makefile.rules
 
 targets = all clean distclean install
 
@@ -10,3 +11,4 @@ $(targets):
 	$(MAKE) -C ias-request $@
 	$(MAKE) -C verify-ias-report $@
 	$(MAKE) -C ra-tls $@
+	$(MAKE) -C pf_crypt $@

--- a/Pal/src/host/Linux-SGX/tools/common/Makefile
+++ b/Pal/src/host/Linux-SGX/tools/common/Makefile
@@ -1,16 +1,21 @@
 include ../../../../../../Scripts/Makefile.configs
+include ../../../../../../Scripts/Makefile.rules
 
+# IN_PAL is defined on 18.04 Jenkins pipeline for some reason, override it since we're NOT in PAL
+CFLAGS := $(filter-out -DIN_PAL, $(CFLAGS))
 CFLAGS += -I../.. \
           -I../../../../../include/lib \
           -I../../../../../lib/crypto/mbedtls/install/include \
           -I../../../../../lib/crypto/mbedtls/crypto/include \
+          -I../../protected-files \
           -DCRYPTO_USE_MBEDTLS \
           -D_POSIX_C_SOURCE=200809L \
           -fPIC
 
 LDFLAGS += -L../../../../../lib/crypto/mbedtls/install/lib
 
-PREFIX ?= /usr/local
+DEFAULT_PREFIX := /usr/local
+PREFIX ?= $(DEFAULT_PREFIX)
 
 .PHONY: all
 all: libsgx_util.so
@@ -35,18 +40,28 @@ cJSON.c cJSON.h: %: cJSON-$(CJSON_VERSION)/%
 
 attestation.o: cJSON.h
 
-libsgx_util.so: attestation.o cJSON.o ias.o util.o
+protected_files.o: ../../protected-files/protected_files.c
+	$(call cmd,cc_o_c)
+
+lru_cache.o: ../../protected-files/lru_cache.c
+	$(call cmd,cc_o_c)
+
+libsgx_util.so: attestation.o cJSON.o ias.o lru_cache.o pf_util.o protected_files.o util.o
 	$(CC) $^ $(LDFLAGS) ../../.lib/crypto/adapters/mbedtls_encoding.o -lmbedcrypto -lcurl -shared -o $@
 
 .PHONY: install
 install:
-	install libsgx_util.so ${PREFIX}/lib
-	install ../../../../../lib/crypto/mbedtls/install/lib/libmbedcrypto.so ${PREFIX}/lib
+	install -D libsgx_util.so -t ${PREFIX}/lib
+	install -D ../../../../../lib/crypto/mbedtls/install/lib/libmbedcrypto.so -t ${PREFIX}/lib
+ifeq ($(PREFIX), $(DEFAULT_PREFIX))
 	ldconfig
+else
+	ldconfig -n ${PREFIX}/lib
+endif
 
 .PHONY: clean
 clean:
-	$(RM) *.gz *.o *.so
+	$(RM) *.d *.gz *.o *.so
 
 .PHONY: distclean
 distclean: clean

--- a/Pal/src/host/Linux-SGX/tools/common/pf_util.c
+++ b/Pal/src/host/Linux-SGX/tools/common/pf_util.c
@@ -1,0 +1,555 @@
+/* SPDX-License-Identifier: LGPL-3.0-or-later */
+/* Copyright (C) 2018-2020 Invisible Things Lab
+ *                         Rafal Wojdyla <omeg@invisiblethingslab.com>
+ */
+
+#define _LARGEFILE64_SOURCE
+
+#include <assert.h>
+#include <dirent.h>
+#include <fcntl.h>
+#include <inttypes.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include <mbedtls/ctr_drbg.h>
+#include <mbedtls/entropy.h>
+#include <mbedtls/gcm.h>
+
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+
+#include "api.h"
+#include "pf_util.h"
+#include "util.h"
+
+/* High-level protected files helper functions. */
+
+/* PF callbacks usable in a standard Linux environment.
+   Assume that pf handle is a pointer to file's fd. */
+
+static pf_status_t linux_read(pf_handle_t handle, void* buffer, uint64_t offset, size_t size) {
+    int fd = *(int*)handle;
+    DBG("linux_read: fd %d, buf %p, offset %zu, size %zu\n", fd, buffer, offset, size);
+    if (lseek64(fd, offset, SEEK_SET) < 0) {
+        ERROR("lseek64 failed: %s\n", strerror(errno));
+        return PF_STATUS_CALLBACK_FAILED;
+    }
+
+    size_t buffer_offset = 0;
+    while (size > 0) {
+        ssize_t ret = read(fd, buffer + buffer_offset, size);
+        if (ret == -EINTR)
+            continue;
+
+        if (ret < 0) {
+            ERROR("read failed: %s\n", strerror(errno));
+            return PF_STATUS_CALLBACK_FAILED;
+        }
+
+        /* EOF is an error condition, we want to read exactly `size` bytes */
+        if (ret == 0) {
+            ERROR("EOF\n");
+            return PF_STATUS_CALLBACK_FAILED;
+        }
+
+        size -= ret;
+        buffer_offset += ret;
+    }
+
+    return PF_STATUS_SUCCESS;
+}
+
+static pf_status_t linux_write(pf_handle_t handle, const void* buffer, uint64_t offset,
+                               size_t size) {
+    int fd = *(int*)handle;
+    DBG("linux_write: fd %d, buf %p, offset %zu, size %zu\n", fd, buffer, offset, size);
+    if (lseek64(fd, offset, SEEK_SET) < 0) {
+        ERROR("lseek64 failed: %s\n", strerror(errno));
+        return PF_STATUS_CALLBACK_FAILED;
+    }
+
+    size_t buffer_offset = 0;
+    while (size > 0) {
+        ssize_t ret = write(fd, buffer + buffer_offset, size);
+        if (ret == -EINTR)
+            continue;
+
+        if (ret < 0) {
+            ERROR("write failed: %s\n", strerror(errno));
+            return PF_STATUS_CALLBACK_FAILED;
+        }
+
+        /* EOF is an error condition, we want to write exactly `size` bytes */
+        if (ret == 0) {
+            ERROR("EOF\n");
+            return PF_STATUS_CALLBACK_FAILED;
+        }
+
+        size -= ret;
+        buffer_offset += ret;
+    }
+    return PF_STATUS_SUCCESS;
+}
+
+static pf_status_t linux_truncate(pf_handle_t handle, uint64_t size) {
+    int fd  = *(int*)handle;
+    DBG("linux_truncate: fd %d, size %zu\n", fd, size);
+    int ret = ftruncate64(fd, size);
+    if (ret < 0) {
+        ERROR("ftruncate64 failed: %s\n", strerror(errno));
+        return PF_STATUS_CALLBACK_FAILED;
+    }
+
+    return PF_STATUS_SUCCESS;
+}
+
+/* Crypto callbacks for mbedTLS */
+
+pf_status_t mbedtls_aes_gcm_encrypt(const pf_key_t* key, const pf_iv_t* iv,
+                                    const void* aad, size_t aad_size,
+                                    const void* input, size_t input_size, void* output,
+                                    pf_mac_t* mac) {
+    pf_status_t status = PF_STATUS_CALLBACK_FAILED;
+
+    mbedtls_gcm_context gcm;
+    mbedtls_gcm_init(&gcm);
+
+    int ret = mbedtls_gcm_setkey(&gcm, MBEDTLS_CIPHER_ID_AES, (const unsigned char*)key,
+                                 PF_KEY_SIZE * 8);
+    if (ret != 0) {
+        ERROR("mbedtls_gcm_setkey failed: %d\n", ret);
+        goto out;
+    }
+
+    ret = mbedtls_gcm_crypt_and_tag(&gcm, MBEDTLS_GCM_ENCRYPT, input_size, (const unsigned char*)iv,
+                                    PF_IV_SIZE, aad, aad_size, input, output, PF_MAC_SIZE,
+                                    (unsigned char*)mac);
+    if (ret != 0) {
+        ERROR("mbedtls_gcm_crypt_and_tag failed: %d\n", ret);
+        goto out;
+    }
+
+    status = PF_STATUS_SUCCESS;
+out:
+    mbedtls_gcm_free(&gcm);
+    return status;
+}
+
+pf_status_t mbedtls_aes_gcm_decrypt(const pf_key_t* key, const pf_iv_t* iv,
+                                    const void* aad, size_t aad_size,
+                                    const void* input, size_t input_size, void* output,
+                                    const pf_mac_t* mac) {
+    pf_status_t status = PF_STATUS_CALLBACK_FAILED;
+
+    mbedtls_gcm_context gcm;
+    mbedtls_gcm_init(&gcm);
+
+    int ret = mbedtls_gcm_setkey(&gcm, MBEDTLS_CIPHER_ID_AES, (const unsigned char*)key,
+                                 PF_KEY_SIZE * 8);
+    if (ret != 0) {
+        ERROR("mbedtls_gcm_setkey failed: %d\n", ret);
+        goto out;
+    }
+
+    ret = mbedtls_gcm_auth_decrypt(&gcm, input_size, (const unsigned char*)iv, PF_IV_SIZE, aad,
+                                   aad_size, (const unsigned char*)mac, PF_MAC_SIZE, input, output);
+    if (ret != 0) {
+        ERROR("mbedtls_gcm_auth_decrypt failed: %d\n", ret);
+        goto out;
+    }
+
+    status = PF_STATUS_SUCCESS;
+out:
+    mbedtls_gcm_free(&gcm);
+    return status;
+}
+
+static mbedtls_ctr_drbg_context g_prng;
+
+static pf_status_t mbedtls_random(uint8_t* buffer, size_t size) {
+    if (mbedtls_ctr_drbg_random(&g_prng, buffer, size) != 0) {
+        ERROR("Failed to get random bytes\n");
+        return PF_STATUS_CALLBACK_FAILED;
+    }
+    return PF_STATUS_SUCCESS;
+}
+
+static int pf_set_linux_callbacks(pf_debug_f debug_f) {
+    mbedtls_entropy_context entropy;
+    const char* prng_tag = "Graphene protected files library";
+
+    /* Initialize mbedTLS CPRNG */
+    mbedtls_entropy_init(&entropy);
+    mbedtls_ctr_drbg_init(&g_prng);
+    int ret = mbedtls_ctr_drbg_seed(&g_prng, mbedtls_entropy_func, &entropy,
+                                    (const unsigned char*)prng_tag, strlen(prng_tag));
+
+    if (ret != 0) {
+        ERROR("Failed to initialize mbedTLS RNG: %d\n", ret);
+        return -1;
+    }
+
+    mbedtls_entropy_free(&entropy);
+
+    pf_set_callbacks(linux_read, linux_write, linux_truncate, mbedtls_aes_gcm_encrypt,
+                     mbedtls_aes_gcm_decrypt, mbedtls_random, debug_f);
+    return 0;
+}
+
+/* Debug print callback for protected files */
+static void cb_debug(const char* msg) {
+    DBG("%s", msg);
+}
+
+/* Initialize protected files for native environment */
+int pf_init(void) {
+    return pf_set_linux_callbacks(cb_debug);
+}
+
+/* Generate random PF key and save it to file */
+int pf_generate_wrap_key(const char* wrap_key_path) {
+    pf_key_t wrap_key;
+
+    int ret = mbedtls_ctr_drbg_random(&g_prng, (unsigned char*)&wrap_key, sizeof(wrap_key));
+    if (ret != 0) {
+        ERROR("Failed to read random bytes: %d\n", ret);
+        return ret;
+    }
+
+    if (write_file(wrap_key_path, sizeof(wrap_key), wrap_key) != 0) {
+        ERROR("Failed to save wrap key\n");
+        return -1;
+    }
+
+    INFO("Wrap key saved to: %s\n", wrap_key_path);
+    return 0;
+}
+
+int load_wrap_key(const char* wrap_key_path, pf_key_t* wrap_key) {
+    int ret = -1;
+    uint64_t size = 0;
+    void* buf = read_file(wrap_key_path, &size, /*buffer=*/NULL);
+
+    if (!buf) {
+        ERROR("Failed to read wrap key\n");
+        goto out;
+    }
+
+    if (size != PF_KEY_SIZE) {
+        ERROR("Wrap key size %zu != %zu\n", size, sizeof(*wrap_key));
+        goto out;
+    }
+
+    memcpy(wrap_key, buf, sizeof(*wrap_key));
+    ret = 0;
+
+out:
+    free(buf);
+    return ret;
+}
+
+/* Convert a single file to the protected format */
+int pf_encrypt_file(const char* input_path, const char* output_path, const pf_key_t* wrap_key) {
+    int ret = -1;
+    int input = -1;
+    int output = -1;
+    pf_context_t* pf = NULL;
+    void* chunk = malloc(PF_NODE_SIZE);
+    if (!chunk) {
+        ERROR("Out of memory\n");
+        goto out;
+    }
+
+    input = open(input_path, O_RDONLY);
+    if (input < 0) {
+        ERROR("Failed to open input file '%s': %s\n", input_path, strerror(errno));
+        goto out;
+    }
+
+    output = open(output_path, O_RDWR|O_CREAT, 0664);
+    if (output < 0) {
+        ERROR("Failed to create output file '%s': %s\n", output_path, strerror(errno));
+        goto out;
+    }
+
+    INFO("Encrypting: %s\n", input_path);
+
+    pf_handle_t handle = (pf_handle_t)&output;
+    pf_status_t pfs = pf_open(handle, output_path, /*size=*/0, PF_FILE_MODE_WRITE, /*create=*/true,
+                              wrap_key, &pf);
+    if (PF_FAILURE(pfs)) {
+        ERROR("Failed to open output PF: %d\n", pfs);
+        goto out;
+    }
+
+    /* Process file contents */
+    uint64_t input_size = get_file_size(input);
+    if (input_size == (uint64_t)-1) {
+        ERROR("Failed to get size of input file '%s': %s\n", input_path, strerror(errno));
+        goto out;
+    }
+
+    uint64_t input_offset = 0;
+
+    while (true) {
+        ssize_t chunk_size = read(input, chunk, PF_NODE_SIZE);
+        if (chunk_size == 0) // EOF
+            break;
+
+        if (chunk_size < 0) {
+            if (errno == -EINTR)
+                continue;
+
+            ERROR("Failed to read file '%s': %s\n", input_path, strerror(errno));
+            goto out;
+        }
+
+        pfs = pf_write(pf, input_offset, chunk_size, chunk);
+        if (PF_FAILURE(pfs)) {
+            ERROR("Failed to write to output PF: %d\n", pfs);
+            goto out;
+        }
+
+        input_offset += chunk_size;
+    }
+
+    ret = 0;
+
+out:
+    if (pf) {
+        if (PF_FAILURE(pf_close(pf))) {
+            ERROR("failed to close PF\n");
+            ret = -1;
+        }
+    }
+
+    free(chunk);
+    if (input >= 0)
+        close(input);
+    if (output >= 0)
+        close(output);
+    return ret;
+}
+
+/* Convert a single file from the protected format */
+int pf_decrypt_file(const char* input_path, const char* output_path, bool verify_path,
+                    const pf_key_t* wrap_key) {
+    int ret = -1;
+    int input = -1;
+    int output = -1;
+    pf_context_t* pf = NULL;
+    void* chunk = malloc(PF_NODE_SIZE);
+    if (!chunk) {
+        ERROR("Out of memory\n");
+        goto out;
+    }
+
+    input = open(input_path, O_RDONLY);
+    if (input < 0) {
+        ERROR("Failed to open input file '%s': %s\n", input_path, strerror(errno));
+        goto out;
+    }
+
+    output = open(output_path, O_RDWR|O_CREAT, 0664);
+    if (output < 0) {
+        ERROR("Failed to create output file '%s': %s\n", output_path, strerror(errno));
+        goto out;
+    }
+
+    INFO("Decrypting: %s\n", input_path);
+
+    /* Get underlying file size */
+    uint64_t input_size = get_file_size(input);
+    if (input_size == (uint64_t)-1) {
+        ERROR("Failed to get size of input file '%s': %s\n", input_path, strerror(errno));
+        goto out;
+    }
+
+    const char* path = verify_path ? input_path : NULL;
+    pf_status_t pfs = pf_open((pf_handle_t)&input, path, input_size, PF_FILE_MODE_READ,
+                              /*create=*/false, wrap_key, &pf);
+    if (PF_FAILURE(pfs)) {
+        ERROR("Opening protected input file failed: %d\n", pfs);
+        goto out;
+    }
+
+    /* Process file contents */
+    uint64_t data_size;
+    pfs = pf_get_size(pf, &data_size);
+    if (PF_FAILURE(pfs)) {
+        ERROR("pf_get_size failed: %d\n", pfs);
+        goto out;
+    }
+
+    if (ftruncate64(output, data_size) < 0) {
+        ERROR("ftruncate64 output file '%s' failed: %s\n", output_path, strerror(errno));
+        goto out;
+    }
+
+    uint64_t input_offset = 0;
+
+    while (true) {
+        assert(input_offset <= data_size);
+        uint64_t chunk_size = MIN(data_size - input_offset, PF_NODE_SIZE);
+        if (chunk_size == 0)
+            break;
+
+        pfs = pf_read(pf, input_offset, chunk_size, chunk);
+        if (PF_FAILURE(pfs)) {
+            ERROR("Read from protected file failed (offset %" PRIu64 ", size %" PRIu64 "): %d\n",
+                  input_offset, chunk_size, pfs);
+            goto out;
+        }
+
+        ssize_t written = write(output, chunk, chunk_size);
+
+        if (written < 0) {
+            if (errno == -EINTR)
+                continue;
+
+            ERROR("Failed to write file '%s': %s\n", output_path, strerror(errno));
+            goto out;
+        }
+
+        input_offset += written;
+    }
+
+    ret = 0;
+
+out:
+    free(chunk);
+    if (pf)
+        pf_close(pf);
+    if (input >= 0)
+        close(input);
+    if (output >= 0)
+        close(output);
+    return ret;
+}
+
+enum processing_mode_t {
+    MODE_ENCRYPT = 1,
+    MODE_DECRYPT = 2,
+};
+
+static int process_files(const char* input_dir, const char* output_dir, const char* wrap_key_path,
+                         enum processing_mode_t mode, bool verify_path) {
+    int ret = -1;
+    pf_key_t wrap_key;
+    struct stat st;
+    char* input_path  = NULL;
+    char* output_path = NULL;
+
+    if (mode != MODE_ENCRYPT && mode != MODE_DECRYPT) {
+        ERROR("Invalid mode: %d\n", mode);
+        goto out;
+    }
+
+    if (mode == MODE_ENCRYPT && verify_path) {
+        ERROR("Path verification can't be on in MODE_ENCRYPT\n");
+        goto out;
+    }
+
+    ret = load_wrap_key(wrap_key_path, &wrap_key);
+    if (ret != 0)
+        goto out;
+
+    if (stat(input_dir, &st) != 0) {
+        ERROR("Failed to stat input path %s: %s\n", input_dir, strerror(errno));
+        goto out;
+    }
+
+    /* single file? */
+    if (S_ISREG(st.st_mode)) {
+        if (mode == MODE_ENCRYPT)
+            return pf_encrypt_file(input_dir, output_dir, &wrap_key);
+        else
+            return pf_decrypt_file(input_dir, output_dir, verify_path, &wrap_key);
+    }
+
+    ret = mkdir(output_dir, S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
+    if (ret != 0 && errno != EEXIST) {
+        ERROR("Failed to create directory %s: %s\n", output_dir, strerror(errno));
+        goto out;
+    }
+
+    /* Process input directory */
+    struct dirent* dir;
+    DIR* dfd = opendir(input_dir);
+    if (!dfd) {
+        ERROR("Failed to open input directory: %s\n", strerror(errno));
+        goto out;
+    }
+
+    size_t input_path_size, output_path_size;
+    while ((dir = readdir(dfd)) != NULL) {
+        if (!strcmp(dir->d_name, "."))
+            continue;
+        if (!strcmp(dir->d_name, ".."))
+            continue;
+
+        input_path_size = strlen(input_dir) + 1 + strlen(dir->d_name) + 1;
+        output_path_size = strlen(output_dir) + 1 + strlen(dir->d_name) + 1;
+
+        input_path = malloc(input_path_size);
+        if (!input_path) {
+            ERROR("No memory\n");
+            goto out;
+        }
+
+        output_path = malloc(output_path_size);
+        if (!output_path) {
+            ERROR("No memory\n");
+            goto out;
+        }
+
+        snprintf(input_path, input_path_size, "%s/%s", input_dir, dir->d_name);
+        snprintf(output_path, output_path_size, "%s/%s", output_dir, dir->d_name);
+
+        if (stat(input_path, &st) != 0) {
+            ERROR("Failed to stat input file %s: %s\n", input_path, strerror(errno));
+            goto out;
+        }
+
+        if (S_ISREG(st.st_mode)) {
+            if (mode == MODE_ENCRYPT)
+                ret = pf_encrypt_file(input_path, output_path, &wrap_key);
+            else
+                ret = pf_decrypt_file(input_path, output_path, verify_path, &wrap_key);
+
+            if (ret != 0)
+                goto out;
+        } else if (S_ISDIR(st.st_mode)) {
+            /* process directory recursively */
+            ret = process_files(input_path, output_path, wrap_key_path, mode, verify_path);
+            if (ret != 0)
+                goto out;
+        } else {
+            INFO("Skipping non-regular file %s\n", input_path);
+        }
+
+        free(input_path);
+        input_path = NULL;
+        free(output_path);
+        output_path = NULL;
+    }
+    ret = 0;
+
+out:
+    free(input_path);
+    free(output_path);
+    return ret;
+}
+
+/* Convert a file or directory (recursively) to the protected format */
+int pf_encrypt_files(const char* input_dir, const char* output_dir, const char* wrap_key_path) {
+    return process_files(input_dir, output_dir, wrap_key_path, MODE_ENCRYPT, false);
+}
+
+/* Convert a file or directory (recursively) from the protected format */
+int pf_decrypt_files(const char* input_dir, const char* output_dir, bool verify_path,
+                     const char* wrap_key_path) {
+    return process_files(input_dir, output_dir, wrap_key_path, MODE_DECRYPT, verify_path);
+}

--- a/Pal/src/host/Linux-SGX/tools/common/pf_util.h
+++ b/Pal/src/host/Linux-SGX/tools/common/pf_util.h
@@ -1,0 +1,50 @@
+/* SPDX-License-Identifier: LGPL-3.0-or-later */
+/* Copyright (C) 2018-2020 Invisible Things Lab
+ *                         Rafal Wojdyla <omeg@invisiblethingslab.com>
+ */
+
+#ifndef PF_UTIL_H
+#define PF_UTIL_H
+
+#include <stdint.h>
+
+#include "protected_files.h"
+
+/* High-level protected files helper functions */
+
+/*! Initialize protected files for native environment */
+int pf_init(void);
+
+/*! Generate random PF key and save it to file */
+int pf_generate_wrap_key(const char* wrap_key_path);
+
+/*! Convert a single file to the protected format */
+int pf_encrypt_file(const char* input_path, const char* output_path, const pf_key_t* wrap_key);
+
+/*! Convert a single file from the protected format */
+int pf_decrypt_file(const char* input_path, const char* output_path, bool verify_path,
+                    const pf_key_t* wrap_key);
+
+/*! Convert a file or directory (recursively) to the protected format */
+int pf_encrypt_files(const char* input_dir, const char* output_dir, const char* wrap_key_path);
+
+/*! Convert a file or directory (recursively) from the protected format */
+int pf_decrypt_files(const char* input_dir, const char* output_dir, bool verify_path,
+                     const char* wrap_key_path);
+
+/*! AES-GCM encrypt */
+pf_status_t mbedtls_aes_gcm_encrypt(const pf_key_t* key, const pf_iv_t* iv,
+                                    const void* aad, size_t aad_size,
+                                    const void* input, size_t input_size, void* output,
+                                    pf_mac_t* mac);
+
+/*! AES-GCM decrypt */
+pf_status_t mbedtls_aes_gcm_decrypt(const pf_key_t* key, const pf_iv_t* iv,
+                                    const void* aad, size_t aad_size,
+                                    const void* input, size_t input_size, void* output,
+                                    const pf_mac_t* mac);
+
+/*! Load PF wrap key from file */
+int load_wrap_key(const char* wrap_key_path, pf_key_t* wrap_key);
+
+#endif

--- a/Pal/src/host/Linux-SGX/tools/common/util.h
+++ b/Pal/src/host/Linux-SGX/tools/common/util.h
@@ -11,7 +11,6 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
-#include <sys/types.h>
 
 /* Miscellaneous helper functions */
 
@@ -46,11 +45,21 @@ endianness_t get_endianness(void);
 /*! Set stdout/stderr descriptors */
 void util_set_fd(int stdout_fd, int stderr_fd);
 
-/*! Get file size, return -1 on error */
-ssize_t get_file_size(int fd);
+/*! Get file size, return (uint64_t)-1 on error */
+uint64_t get_file_size(int fd);
 
-/*! Read whole file, caller should free the buffer */
-uint8_t* read_file(const char* path, ssize_t* size);
+/*!
+ *  \brief Read file contents
+ *
+ *  \param[in]     path   Path to the file.
+ *  \param[in,out] size   On entry, number of bytes to read. 0 means to read the entire file.
+ *                        On exit, number of bytes read. Unchanged on failure.
+ *  \param[in]     buffer Buffer to read data to. If NULL, this function allocates one.
+ *  \return On success, pointer to the data buffer. If \p buffer was NULL, caller should free this.
+ *          On failure, NULL.
+ *  \details If \a buffer is not NULL, \a size must contain valid buffer size.
+ */
+void* read_file(const char* path, size_t* size, void* buffer);
 
 /*! Write buffer to file */
 int write_file(const char* path, size_t size, const void* buffer);

--- a/Pal/src/host/Linux-SGX/tools/ias-request/ias_request.c
+++ b/Pal/src/host/Linux-SGX/tools/ias-request/ias_request.c
@@ -77,8 +77,8 @@ static int report(struct ias_context_t* ias, const char* quote_path, const char*
         goto out;
     }
 
-    ssize_t quote_size;
-    quote_data = read_file(quote_path, &quote_size);
+    size_t quote_size = 0;
+    quote_data = read_file(quote_path, &quote_size, /*buffer=*/NULL);
     if (!quote_data) {
         ERROR("Failed to read quote file '%s'\n", quote_path);
         goto out;

--- a/Pal/src/host/Linux-SGX/tools/is-sgx-available/Makefile
+++ b/Pal/src/host/Linux-SGX/tools/is-sgx-available/Makefile
@@ -5,7 +5,7 @@ all: is_sgx_available
 
 .PHONY: install
 install:
-	install is_sgx_available ${PREFIX}/bin
+	install -D is_sgx_available -t ${PREFIX}/bin
 
 .PHONY: clean
 clean:

--- a/Pal/src/host/Linux-SGX/tools/pf_crypt/.gitignore
+++ b/Pal/src/host/Linux-SGX/tools/pf_crypt/.gitignore
@@ -1,0 +1,1 @@
+/pf_crypt

--- a/Pal/src/host/Linux-SGX/tools/pf_crypt/Makefile
+++ b/Pal/src/host/Linux-SGX/tools/pf_crypt/Makefile
@@ -3,6 +3,7 @@ include ../../../../../../Scripts/Makefile.rules
 
 CFLAGS += -I../.. \
           -I../common \
+          -I../../protected-files \
           -L../common \
           -L../../../../../lib/crypto/mbedtls/install/lib \
           -D_GNU_SOURCE
@@ -11,19 +12,19 @@ LDLIBS += -lsgx_util -lmbedcrypto
 
 PREFIX ?= /usr/local
 
-.PHONY: all
-all: ias_request
-
-ias_request: ias_request.o
+pf_crypt: pf_crypt.o
 	$(call cmd,csingle)
+
+.PHONY: all
+all: pf_crypt
 
 .PHONY: install
 install:
-	install -D ias_request -t ${PREFIX}/bin
+	install -D pf_crypt -t ${PREFIX}/bin
 
 .PHONY: clean
 clean:
-	$(RM) *.o ias_request
+	$(RM) *.o pf_crypt
 
 .PHONY: distclean
 distclean: clean

--- a/Pal/src/host/Linux-SGX/tools/pf_crypt/pf_crypt.c
+++ b/Pal/src/host/Linux-SGX/tools/pf_crypt/pf_crypt.c
@@ -1,0 +1,132 @@
+/* SPDX-License-Identifier: LGPL-3.0-or-later */
+/* Copyright (C) 2018-2020 Invisible Things Lab
+ *                         Rafal Wojdyla <omeg@invisiblethingslab.com>
+ */
+
+#include <getopt.h>
+#include <stdlib.h>
+
+#include "pf_util.h"
+#include "util.h"
+
+/* Command line options */
+struct option g_options[] = {
+    { "input", required_argument, 0, 'i' },
+    { "output", required_argument, 0, 'o' },
+    { "wrap-key", required_argument, 0, 'w' },
+    { "verify", no_argument, 0, 'V' },
+    { "verbose", no_argument, 0, 'v' },
+    { "help", no_argument, 0, 'h' },
+    { 0, 0, 0, 0 }
+};
+
+static void usage(void) {
+    INFO("\nUsage: pf_crypt mode [options]\n");
+    INFO("Available modes:\n");
+    INFO("  gen-key                 Generate and save wrap key to file\n");
+    INFO("  encrypt                 Encrypt plaintext files\n");
+    INFO("  decrypt                 Decrypt encrypted files\n");
+    INFO("\nAvailable general options:\n");
+    INFO("  --help, -h              Display this help\n");
+    INFO("  --verbose, -v           Verbose output\n");
+    INFO("\nAvailable gen-key options:\n");
+    INFO("  --wrap-key, -w PATH     Path to wrap key file\n");
+    INFO("\nAvailable encrypt options:\n");
+    INFO("  --input, -i PATH        Single file or directory with input files to convert\n");
+    INFO("  --output, -o PATH       Single file or directory to write output files to\n");
+    INFO("  --wrap-key, -w PATH     Path to wrap key file, must exist\n");
+    INFO("\nAvailable decrypt options:\n");
+    INFO("  --input, -i PATH        Single file or directory with input files to convert\n");
+    INFO("  --output, -o PATH       Single file or directory to write output files to\n");
+    INFO("  --wrap-key, -w PATH     Path to wrap key file, must exist\n");
+    INFO("  --verify, -V            (optional) Verify that input path matches PF's allowed paths\n");
+}
+
+int main(int argc, char *argv[]) {
+    int ret             = -1;
+    int this_option     = 0;
+    char* input_path    = NULL;
+    char* output_path   = NULL;
+    char* wrap_key_path = NULL;
+    char* mode          = NULL;
+    bool verify         = false;
+
+    while (true) {
+        this_option = getopt_long(argc, argv, "i:o:p:w:Vvh", g_options, NULL);
+        if (this_option == -1)
+            break;
+
+        switch (this_option) {
+            case 'i':
+                input_path = optarg;
+                break;
+            case 'o':
+                output_path = optarg;
+                break;
+            case 'w':
+                wrap_key_path = optarg;
+                break;
+            case 'v':
+                set_verbose(true);
+                break;
+            case 'V':
+                verify = true;
+                break;
+            case 'h':
+                usage();
+                exit(0);
+            default:
+                ERROR("Unknown option: %c\n", this_option);
+                usage();
+        }
+    }
+
+    if (optind >= argc) {
+        ERROR("Mode not specified\n");
+        usage();
+        goto out;
+    }
+
+    if (!wrap_key_path) {
+        ERROR("Wrap key path not specified\n");
+        goto out;
+    }
+
+    if (pf_init() != 0) {
+        ERROR("Failed to initialize protected files\n");
+        goto out;
+    }
+
+    mode = argv[optind];
+
+    switch (mode[0]) {
+    case 'g': /* gen-key */
+        ret = pf_generate_wrap_key(wrap_key_path);
+        break;
+
+    case 'e': /* encrypt */
+        if (!input_path || !output_path) {
+            ERROR("Input or output path not specified\n");
+            usage();
+            goto out;
+        }
+        ret = pf_encrypt_files(input_path, output_path, wrap_key_path);
+        break;
+
+    case 'd': /* decrypt */
+        if (!input_path || !output_path) {
+            ERROR("Input or output path not specified\n");
+            usage();
+            goto out;
+        }
+        ret = pf_decrypt_files(input_path, output_path, verify, wrap_key_path);
+        break;
+
+    default:
+        usage();
+        goto out;
+    }
+
+out:
+    return ret;
+}

--- a/Pal/src/host/Linux-SGX/tools/quote-dump/Makefile
+++ b/Pal/src/host/Linux-SGX/tools/quote-dump/Makefile
@@ -19,7 +19,7 @@ quote_dump: quote_dump.o
 
 .PHONY: install
 install:
-	install quote_dump ${PREFIX}/bin
+	install -D quote_dump -t ${PREFIX}/bin
 
 .PHONY: clean
 clean:

--- a/Pal/src/host/Linux-SGX/tools/quote-dump/quote_dump.c
+++ b/Pal/src/host/Linux-SGX/tools/quote-dump/quote_dump.c
@@ -58,8 +58,8 @@ int main(int argc, char* argv[]) {
 
     const char* path = argv[optind++];
 
-    ssize_t quote_size = 0;
-    uint8_t* quote = read_file(path, &quote_size);
+    size_t quote_size = 0;
+    void* quote = read_file(path, &quote_size, /*buffer=*/NULL);
     if (!quote)
         return -1;
 

--- a/Pal/src/host/Linux-SGX/tools/ra-tls/Makefile
+++ b/Pal/src/host/Linux-SGX/tools/ra-tls/Makefile
@@ -43,3 +43,6 @@ clean:
 
 .PHONY: distclean
 distclean: clean
+
+.PHONY: install
+install: ;

--- a/Pal/src/host/Linux-SGX/tools/verify-ias-report/Makefile
+++ b/Pal/src/host/Linux-SGX/tools/verify-ias-report/Makefile
@@ -19,7 +19,7 @@ verify_ias_report: verify_ias_report.o
 
 .PHONY: install
 install:
-	install verify_ias_report ${PREFIX}/bin
+	install -D verify_ias_report -t ${PREFIX}/bin
 
 .PHONY: clean
 clean:

--- a/Pal/src/host/Linux-SGX/tools/verify-ias-report/verify_ias_report.c
+++ b/Pal/src/host/Linux-SGX/tools/verify-ias-report/verify_ias_report.c
@@ -48,9 +48,9 @@ static void usage(const char* exec) {
 int main(int argc, char* argv[]) {
     int option              = 0;
     char* report_path       = NULL;
-    ssize_t report_size     = 0;
+    size_t report_size      = 0;
     char* sig_path          = NULL;
-    ssize_t sig_size        = 0;
+    size_t sig_size         = 0;
     char* nonce             = NULL;
     bool allow_outdated_tcb = false;
     char* mrsigner          = NULL;
@@ -120,23 +120,23 @@ int main(int argc, char* argv[]) {
         return -1;
     }
 
-    uint8_t* report = read_file(report_path, &report_size);
+    void* report = read_file(report_path, &report_size, /*buffer=*/NULL);
     if (!report) {
         ERROR("Failed to read report file '%s'\n", report_path);
         return -1;
     }
 
-    uint8_t* sig = read_file(sig_path, &sig_size);
+    void* sig = read_file(sig_path, &sig_size, /*buffer=*/NULL);
     if (!sig) {
         ERROR("Failed to read report signature file '%s'\n", sig_path);
         return -1;
     }
 
     char* ias_pubkey = NULL;
-    ssize_t ias_pubkey_size = 0;
+    size_t ias_pubkey_size = 0;
 
     if (ias_pubkey_path) {
-        uint8_t* buf = read_file(ias_pubkey_path, &ias_pubkey_size);
+        void* buf = read_file(ias_pubkey_path, &ias_pubkey_size, /*buffer=*/NULL);
         if (!buf) {
             ERROR("Failed to read IAS pubkey file '%s'\n", ias_pubkey_path);
             return -1;

--- a/Pal/src/host/Linux-common/bogomips.c
+++ b/Pal/src/host/Linux-common/bogomips.c
@@ -27,8 +27,8 @@ static double proc_cpuinfo_atod(const char* s) {
  * This function will return a pointer to the string at the position after the ': '
  * found in that line, NULL otherwise.
  */
-static const char* find_entry_in_cpuinfo(const char* cpuinfo, const char* word) {
-    const char* start = strstr(cpuinfo, word);
+static char* find_entry_in_cpuinfo(const char* cpuinfo, const char* word) {
+    char* start = strstr(cpuinfo, word);
     if (!start)
         return NULL;
 
@@ -43,7 +43,7 @@ static const char* find_entry_in_cpuinfo(const char* cpuinfo, const char* word) 
 }
 
 double get_bogomips_from_cpuinfo_buf(const char* buf) {
-    const char* start = find_entry_in_cpuinfo(buf, "bogomips");
+    char* start = find_entry_in_cpuinfo(buf, "bogomips");
     if (!start)
         return 0.0;
     return proc_cpuinfo_atod(start);

--- a/Scripts/regression.py
+++ b/Scripts/regression.py
@@ -49,6 +49,31 @@ class RegressionTestCase(unittest.TestCase):
 
         return stdout.decode(), stderr.decode()
 
+    def run_native_binary(self, args, timeout=None, libpath=None, **kwds):
+        timeout = (max(self.DEFAULT_TIMEOUT, timeout) if timeout is not None
+            else self.DEFAULT_TIMEOUT)
+
+        my_env = os.environ.copy()
+        if not libpath is None:
+            my_env["LD_LIBRARY_PATH"] = libpath
+
+        with subprocess.Popen(args,
+                stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                env=my_env,
+                preexec_fn=os.setpgrp,
+                **kwds) as process:
+            try:
+                stdout, stderr = process.communicate(timeout=timeout)
+            except subprocess.TimeoutExpired:
+                os.killpg(process.pid, signal.SIGKILL)
+                self.fail('timeout ({} s) expired'.format(timeout))
+
+            if process.returncode:
+                raise subprocess.CalledProcessError(
+                    process.returncode, args, stdout, stderr)
+
+        return stdout.decode(), stderr.decode()
+
     @contextlib.contextmanager
     def expect_returncode(self, returncode):
         if returncode == 0:


### PR DESCRIPTION
<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [x] SGX PAL
- [x] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->
Protected files (PF) are a new type of file that can be specified in
the manifest (SGX only). They are encrypted on disk and transparently
decrypted when accessed by the Graphene payload.

Other features:
- data is integrity protected (tamper resistance)
- file swap protection (a PF can only be accessed when in a specific path)
- transparency (Graphene payload sees PFs as regular files, no need to modify
  the payload)

The following new manifest elements are added:

```
sgx.protected_files_key = <16-byte hex value>
sgx.protected_files.<name> = file:<host path>
```

`sgx.protected_files_key` specifies the encryption key and **is only a temporary
implementation. This key should be provisioned with local/remote attestation
in the future**.

Paths specifying PF entries can be files or directories. If a directory is
specified, all files/directories within are registered as protected
recursively (and are expected to be encrypted in the PF format).

`Linux-SGX/tools` directory contains the `pf_crypt` utility that converts files
to/from the protected format.

Internal protected file format in this version was ported from the SGX SDK:
https://github.com/intel/linux-sgx/tree/master/sdk/protected_fs

TODO:
* Truncating files is not yet implemented.
* The recovery file feature is disabled, this needs to be discussed if it's needed in Graphene.
* Tests for invalid/malformed/corrupted files need to be ported to the new format.

Fixes https://github.com/oscarlab/graphene/issues/1610 (as a side effect).

## How to test this PR? <!-- (if applicable) -->
Tests in `LibOS/shim/test/fs` now contain PF tests too (target is still `test`). Target to run just non-PF tests is `fs-test`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1325)
<!-- Reviewable:end -->
