### PR TITLE
[Pal/Linux-SGX] resolve race condition to use ustack for ocall and AEX

### DIFF
--- a/LibOS/shim/test/ltp/ltp-sgx.cfg
+++ b/LibOS/shim/test/ltp/ltp-sgx.cfg
@@ -1853,7 +1853,6 @@ skip = yes
 skip = yes
 
 [mprotect04]
-timeout = 60
 skip = yes
 
 [mq_notify01]

--- a/LibOS/shim/test/ltp/ltp.cfg
+++ b/LibOS/shim/test/ltp/ltp.cfg
@@ -1439,6 +1439,10 @@ must-pass =
 [mmap01]
 skip = yes
 
+# uses siglongjmp() from exception handler back into normal execution; not supported by Graphene
+[mmap05]
+skip = yes
+
 [mmap06]
 skip = yes
 
@@ -1446,6 +1450,10 @@ skip = yes
 skip = yes
 
 [mmap12]
+skip = yes
+
+# uses siglongjmp() from exception handler back into normal execution; not supported by Graphene
+[mmap13]
 skip = yes
 
 [mmap14]
@@ -1521,8 +1529,9 @@ skip = yes
 must-pass =
     2
 
+# uses siglongjmp() from exception handler back into normal execution; not supported by Graphene
 [mprotect04]
-timeout = 40
+skip = yes
 
 [mq_notify01]
 skip = yes

--- a/Pal/regression/Exception.c
+++ b/Pal/regression/Exception.c
@@ -6,10 +6,18 @@
 #include "pal.h"
 #include "pal_debug.h"
 
+static void* get_stack(void) {
+    void* stack;
+    __asm__ volatile("mov %%rsp, %0" : "=r"(stack) :: "memory");
+    return stack;
+}
+
 void handler1 (PAL_PTR event, PAL_NUM arg, PAL_CONTEXT * context)
 {
     pal_printf("Arithmetic Exception Handler 1: 0x%08lx, rip = 0x%08lx\n",
                arg, context->rip);
+
+    pal_printf("Stack in handler: %p\n", get_stack());
 
     while (*(unsigned char *) context->rip != 0x90)
         context->rip++;
@@ -108,6 +116,8 @@ static void red_zone_test(void) {
 int main (void)
 {
     volatile long i;
+
+    pal_printf("Stack in main: %p\n", get_stack());
 
     DkSetExceptionHandler(handler1, PAL_EVENT_ARITHMETIC_ERROR);
     i = 0;

--- a/Pal/regression/test_pal.py
+++ b/Pal/regression/test_pal.py
@@ -314,8 +314,24 @@ class TC_02_Symbols(RegressionTestCase):
             self.assertNotEqual(value, 0, 'symbol {} has value 0'.format(k))
 
 class TC_10_Exception(RegressionTestCase):
+    def is_altstack_different_from_main_stack(self, output):
+        mainstack = 0
+        altstack  = 0
+        for line in output.splitlines():
+            if line.startswith('Stack in main:'):
+                mainstack = int(line.split(':')[1], 0)
+            elif line.startswith('Stack in handler:'):
+                altstack = int(line.split(':')[1], 0)
+
+        # handler stack cannot be "close" to the main stack
+        if abs(mainstack - altstack) < 8192:
+            return False
+        return True
+
     def test_000_exception(self):
         _, stderr = self.run_binary(['Exception'])
+
+        self.assertTrue(self.is_altstack_different_from_main_stack(stderr))
 
         # Exception Handling (Div-by-Zero)
         self.assertIn('Arithmetic Exception Handler', stderr)

--- a/Pal/src/host/Linux-SGX/enclave_entry.S
+++ b/Pal/src/host/Linux-SGX/enclave_entry.S
@@ -62,8 +62,7 @@ enclave_entry:
 	# RDI - ECALL number
 	# RSI - pointer to ecall arguments
 	# RDX - exit target
-	# RCX (former RSP) - The untrusted stack
-	# R8  - enclave base
+	# RCX - enclave base
 
 	cmpq $ECALL_THREAD_RESET, %rdi
 	je .Lhandle_thread_reset
@@ -79,10 +78,7 @@ enclave_entry:
 
 	# calculate enclave base = RBX (trusted) - %gs:SGX_TCS_OFFSET
 	subq %gs:SGX_TCS_OFFSET, %rbx
-	movq %rbx, %r8
-
-	# push untrusted stack address to RCX
-	movq %rsp, %rcx
+	movq %rbx, %rcx
 
 	# switch to enclave stack: enclave base + %gs:SGX_INITIAL_STACK_OFFSET
 	addq %gs:SGX_INITIAL_STACK_OFFSET, %rbx
@@ -91,6 +87,7 @@ enclave_entry:
 	# clear the rest of register states
 	xorq %rax, %rax
 	xorq %rbx, %rbx
+	xorq %r8, %r8
 	xorq %r9,  %r9
 	xorq %r10, %r10
 	xorq %r11, %r11

--- a/Pal/src/host/Linux-SGX/pal_linux_defs.h
+++ b/Pal/src/host/Linux-SGX/pal_linux_defs.h
@@ -2,7 +2,7 @@
 #define PAL_LINUX_DEFS_H
 
 #define THREAD_STACK_SIZE (PRESET_PAGESIZE * 512)  /* 2MB untrusted stack */
-#define ALT_STACK_SIZE    PRESET_PAGESIZE
+#define ALT_STACK_SIZE    (PRESET_PAGESIZE * 16)   /* 64KB untrusted signal stack */
 #define RPC_STACK_SIZE    (PRESET_PAGESIZE * 2)
 
 #define ENCLAVE_HIGH_ADDRESS    0x800000000

--- a/Pal/src/host/Linux-SGX/sgx_exception.c
+++ b/Pal/src/host/Linux-SGX/sgx_exception.c
@@ -85,7 +85,7 @@ int set_sighandler (int * sigs, int nsig, void * handler)
 {
     struct sigaction action;
     action.sa_handler = (void (*)(int)) handler;
-    action.sa_flags = SA_SIGINFO;
+    action.sa_flags = SA_SIGINFO | SA_ONSTACK;
 
 #if !defined(__i386__)
     action.sa_flags |= SA_RESTORER;

--- a/Pal/src/host/Linux-SGX/sgx_thread.c
+++ b/Pal/src/host/Linux-SGX/sgx_thread.c
@@ -102,14 +102,11 @@ int pal_thread_init(void* tcbptr) {
     }
 
     if (tcb->alt_stack) {
-        /* align stack to 16 bytes */
-        void* alt_stack = ALIGN_DOWN_PTR(tcb, 16);
-        assert(alt_stack > tcb->alt_stack);
-        stack_t ss;
-        ss.ss_sp    = alt_stack;
-        ss.ss_flags = 0;
-        ss.ss_size  = alt_stack - tcb->alt_stack;
-
+        stack_t ss = {
+            .ss_sp    = tcb->alt_stack,
+            .ss_flags = 0,
+            .ss_size  = ALT_STACK_SIZE - sizeof(*tcb)
+        };
         ret = INLINE_SYSCALL(sigaltstack, 2, &ss, NULL);
         if (IS_ERR(ret)) {
             ret = -EPERM;

--- a/Pal/src/host/Linux/db_exception.c
+++ b/Pal/src/host/Linux/db_exception.c
@@ -89,7 +89,7 @@ int set_sighandler (int * sigs, int nsig, void * handler)
 
     if (handler) {
         action.sa_handler = (void (*)(int)) handler;
-        action.sa_flags = SA_SIGINFO;
+        action.sa_flags = SA_SIGINFO | SA_ONSTACK;
 #if !defined(__i386__)
         action.sa_flags |= SA_RESTORER;
         action.sa_restorer = __restore_rt;

--- a/Pal/src/host/Linux/db_threading.c
+++ b/Pal/src/host/Linux/db_threading.c
@@ -110,13 +110,11 @@ int pal_thread_init (void * tcbptr)
         return -ERRNO(ret);
 
     if (tcb->alt_stack) {
-        // Align stack to 16 bytes
-        void* alt_stack_top = ALIGN_DOWN_PTR(tcb, 16);
-        assert(alt_stack_top > tcb->alt_stack);
-        stack_t ss;
-        ss.ss_sp    = alt_stack_top;
-        ss.ss_flags = 0;
-        ss.ss_size  = alt_stack_top - tcb->alt_stack;
+        stack_t ss = {
+            .ss_sp    = tcb->alt_stack,
+            .ss_flags = 0,
+            .ss_size  = ALT_STACK_SIZE - sizeof(*tcb),
+        };
 
         ret = INLINE_SYSCALL(sigaltstack, 2, &ss, NULL);
         if (IS_ERR(ret))

--- a/Pal/src/host/Linux/pal_linux_defs.h
+++ b/Pal/src/host/Linux/pal_linux_defs.h
@@ -3,8 +3,8 @@
 
 #define USER_ADDRESS_LOWEST 0x10000
 
-#define THREAD_STACK_SIZE (PRESET_PAGESIZE * 2)
-#define ALT_STACK_SIZE    PRESET_PAGESIZE
+#define THREAD_STACK_SIZE (PRESET_PAGESIZE * 2)   /* 8KB initial stack (grows automatically) */
+#define ALT_STACK_SIZE    (PRESET_PAGESIZE * 16)  /* 64KB signal stack */
 
 #define USE_VSYSCALL_GETTIME 0
 #define USE_VDSO_GETTIME     1


### PR DESCRIPTION
Untrusted stack is used for ocall. The argument is allocated by subtracting
from untrusted stack. which is managed by enclave_tls::ustack.
On the other hand, for AEX, GPR::ursp is used. As result the area below
the untrusted stack can be clobbered by signal handler in untrusted code.

Use sgx_pal_gpr_t::ursp instead of enclave_tls::ustack to manage the argument
for ocall so that signal handler for AEX doesn't clobber them.
I guess that the reason why this doesn't matter much is, usually the size
of argument is less than red zone (128 bytes). So the signal frame doesn't
overlap with it.

(Other option is, allocate dedicated stack for ocall.)

Closes #527. Closes #1025. Fixes #486.

<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [x] SGX PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->


## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1326)
<!-- Reviewable:end -->
