### PR TITLE
[Pal/Linux-SGX] Remove support for Intel SGX drivers version 1.8-

### DIFF
--- a/.ci/prfilter
+++ b/.ci/prfilter
@@ -44,7 +44,6 @@ THE_BIG_LIST_OF_NAUGHTY_FILES = list(map(pathlib.Path, [
     'LibOS/shim/test/apps/python-simple/run-tests.sh',
     'LibOS/shim/test/native',
     'Pal/src/host/Linux-SGX/debugger/gdb',
-    'Pal/src/host/Linux-SGX/sgx-driver/load.sh',
     'Scripts/list-all-graphene.sh',
     'Scripts/memusg',
     '.ci/run-pylint',

--- a/.ci/run-shellcheck
+++ b/.ci/run-shellcheck
@@ -10,7 +10,6 @@ shellcheck "$@" \
     LibOS/shim/test/apps/python-simple/run-tests.sh \
     LibOS/shim/test/native/*.sh \
     Pal/src/host/Linux-SGX/debugger/gdb \
-    Pal/src/host/Linux-SGX/sgx-driver/load.sh \
     Runtime/pal_loader \
     Scripts/clean-check \
     Scripts/clean-check-prepare \

--- a/Documentation/oldwiki/Graphene-SGX-Quick-Start.md
+++ b/Documentation/oldwiki/Graphene-SGX-Quick-Start.md
@@ -33,7 +33,7 @@ The first command should list `isgx` and the second command should list the proc
     cd $GRAPHENE_DIR/Pal/src/host/Linux-SGX/sgx-driver
     make
     # the console will prompt you for the path of the Intel SGX driver code
-    sudo ./load.sh
+    sudo insmod gsgx.ko
 
 ### 5. Build Graphene-SGX
 

--- a/Documentation/oldwiki/Introduction-to-Graphene-SGX.md
+++ b/Documentation/oldwiki/Introduction-to-Graphene-SGX.md
@@ -94,7 +94,7 @@ following commands to build the driver:
     cd Pal/src/host/Linux-SGX/sgx-driver
     make
     # the console will prompt you for the path of the Intel SGX driver code
-    sudo ./load.sh
+    sudo insmod gsgx.ko
 
 If the Graphene SGX driver is successfully installed, and the Intel SDK aesmd service is up and
 running (see [here](https://github.com/01org/linux-sgx#start-or-stop-aesmd-service) for more

--- a/Documentation/oldwiki/Introduction-to-Graphene.md
+++ b/Documentation/oldwiki/Introduction-to-Graphene.md
@@ -129,7 +129,7 @@ To make Graphene aware of the SGX driver, run the following commands:
     cd Pal/src/host/Linux-SGX/sgx-driver
     make
     # the console will prompt you for the path of the Intel SGX driver code
-    sudo ./load.sh
+    sudo insmod gsgx.ko
 
 #### Build Graphene for SGX
 

--- a/Pal/src/host/Linux-SGX/Makefile
+++ b/Pal/src/host/Linux-SGX/Makefile
@@ -61,7 +61,7 @@ urts-asm-objs = sgx_entry.o
 graphene_lib = .lib/graphene-lib.a
 
 .PHONY: all
-all: sgx-driver/isgx_version.h $(host_files)
+all: sgx-driver/sgx.h $(host_files)
 
 libpal-Linux-SGX.a: $(enclave-objs) $(enclave-asm-objs)
 	$(call cmd,ar_a_o)
@@ -114,7 +114,7 @@ debugger/sgx_gdb.so: debugger/sgx_gdb.c
 
 enclave_entry.o sgx_entry.o: asm-offsets.h
 
-sgx-driver/isgx_version.h:
+sgx-driver/sgx.h:
 	$(MAKE) -C sgx-driver $(notdir $@)
 
 ifeq ($(filter %clean,$(MAKECMDGOALS)),)

--- a/README.rst
+++ b/README.rst
@@ -115,7 +115,7 @@ Prerequisites
       cd Pal/src/host/Linux-SGX/sgx-driver
       make
       # The console will be prompted to ask for the path of Intel SGX driver code
-      sudo ./load.sh
+      sudo insmod gsgx.ko
       sudo sysctl vm.mmap_min_addr = 0
 
    We note that this last command is a tempoarary work-around for some issues with the Intel SGX


### PR DESCRIPTION
<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [x] SGX PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->

Previously, Graphene SGX driver tried to stay compatible with Intel SGX drivers of versions 1.8 and lower. This inflated GSGX driver codebase significantly. Given that Intel SGX driver v1.8 was released in 2017, we can deprecate it and only allow drivers v1.9+ (including DCAP driver).

Corresponding PR is https://github.com/oscarlab/graphene-sgx-driver/pull/12.

## How to test this PR? <!-- (if applicable) -->

All tests must pass.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1328)
<!-- Reviewable:end -->
