### PR TITLE
[Pal/lib] fix slabmgr initialization

### DIFF
--- a/Pal/include/lib/slabmgr.h
+++ b/Pal/include/lib/slabmgr.h
@@ -251,7 +251,7 @@ static inline SLAB_MGR create_slab_mgr(void) {
         mgr->size[i] = 0;
         __set_free_slab_area(area, mgr, i);
 
-        addr += __MAX_MEM_SIZE(slab_levels[i], STARTUP_SIZE);
+        addr += __MAX_MEM_SIZE(slab_levels[i], size);
     }
 
     return mgr;
@@ -269,7 +269,7 @@ static inline void destroy_slab_mgr(SLAB_MGR mgr) {
                 system_free(area, __MAX_MEM_SIZE(slab_levels[i], area->size));
         }
 
-        addr += __MAX_MEM_SIZE(slab_levels[i], STARTUP_SIZE);
+        addr += __MAX_MEM_SIZE(slab_levels[i], area->size);
     }
 
     system_free(mgr, addr - (void*)mgr);


### PR DESCRIPTION
the size was wrongly calculated STARTUP_SIZE. which should be size.

<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [x] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->


## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1334)
<!-- Reviewable:end -->
