### PR TITLE
[LibOS] return error on munmap()/mprotect() for outside of user address

### DIFF
--- a/LibOS/shim/src/sys/shim_mmap.c
+++ b/LibOS/shim/src/sys/shim_mmap.c
@@ -35,9 +35,8 @@
 DEFINE_PROFILE_OCCURENCE(mmap, memory);
 
 static bool completely_within_user_address(void* addr, size_t length) {
-    /* the caller already tested access_ok() */
-    return /* access_ok(addr, length) && */
-        PAL_CB(user_address.start) <= addr && addr + length <= PAL_CB(user_address.end);
+    /* the caller already tested access_ok(), so we can safely perform addr + length */
+    return PAL_CB(user_address.start) <= addr && addr + length <= PAL_CB(user_address.end);
 }
 
 void* shim_do_mmap(void* addr, size_t length, int prot, int flags, int fd, off_t offset) {


### PR DESCRIPTION
So far only mmap() checks it. munmap()/mprotect() also should do.

<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->


## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1344)
<!-- Reviewable:end -->
