### PR TITLE
[LibOS,Pal/{Linux, Linux-SGX}] Add bogomips to /proc/cpuinfo

### DIFF
--- a/Pal/include/host/Linux-common/bogomips.h
+++ b/Pal/include/host/Linux-common/bogomips.h
@@ -1,0 +1,8 @@
+#ifndef BOGOMIPS_H
+#define BOGOMIPS_H
+
+double get_bogomips_from_cpuinfo_buf(const char* buf, size_t size);
+double sanitize_bogomips_value(double);
+
+#endif // BOGOMIPS_H
+

--- a/Pal/include/lib/api.h
+++ b/Pal/include/lib/api.h
@@ -186,7 +186,8 @@ void fprintfmt (int (*_fputch)(void *, int, void *), void * f, void * putdat,
 void vfprintfmt (int (*_fputch)(void *, int, void *), void * f, void * putdat,
                  const char * fmt, va_list ap) __attribute__((format(printf, 4, 0)));
 
-int snprintf (char * buf, size_t n, const char * fmt, ...) __attribute__((format(printf, 3, 4)));
+int vsnprintf(char* buf, size_t n, const char* fmt, va_list ap);
+int snprintf(char* buf, size_t n, const char* fmt, ...) __attribute__((format(printf, 3, 4)));
 
 /* Miscelleneous */
 

--- a/Pal/include/pal/pal.h
+++ b/Pal/include/pal/pal.h
@@ -270,6 +270,7 @@ typedef struct {
     PAL_NUM cpu_family;
     PAL_NUM cpu_model;
     PAL_NUM cpu_stepping;
+    double  cpu_bogomips;
     PAL_STR cpu_flags;
 } PAL_CPU_INFO;
 

--- a/Pal/lib/stdlib/printfmt.c
+++ b/Pal/lib/stdlib/printfmt.c
@@ -266,7 +266,8 @@ void fprintfmt(int (*_fputch)(void*, int, void*), void* f, void* putdat, const c
 }
 
 struct sprintbuf {
-    int cnt, max;
+    size_t cnt;
+    size_t max;
     char* buf;
 };
 
@@ -280,7 +281,7 @@ static int sprintputch(void* f, int ch, struct sprintbuf* b) {
     return 0;
 }
 
-static int vsprintf(char* buf, int n, const char* fmt, va_list ap) {
+int vsnprintf(char* buf, size_t n, const char* fmt, va_list ap) {
     struct sprintbuf b = {0, n, buf};
 
     if (!buf || n < 1)
@@ -301,7 +302,7 @@ int snprintf(char* buf, size_t n, const char* fmt, ...) {
     int rc;
 
     va_start(ap, fmt);
-    rc = vsprintf(buf, n, fmt, ap);
+    rc = vsnprintf(buf, n, fmt, ap);
     va_end(ap);
 
     return rc;

--- a/Pal/src/host/Linux-SGX/Makefile
+++ b/Pal/src/host/Linux-SGX/Makefile
@@ -7,6 +7,7 @@ ias_cert_file = quote/$(notdir $(ias_cert_url))
 
 CFLAGS += -I. -Iinclude -I../.. -I../../../include -I../../../include/pal \
 	-I../../../lib/crypto/mbedtls/include -I../../../include/host/Linux-SGX \
+	-I../../../include/host/Linux-common \
 	-I../../../include/lib -Isgx-driver
 ASFLAGS += -I. -I../.. -I../../../include
 
@@ -15,6 +16,8 @@ host_files = libpal-Linux-SGX.a pal-sgx debugger/sgx_gdb.so pal.map generated_of
 defs	= -DIN_PAL -DPAL_DIR=$(PAL_DIR) -DRUNTIME_DIR=$(RUNTIME_DIR)
 CFLAGS += $(defs)
 ASFLAGS += $(defs)
+
+commons_objs = bogomips.o
 
 enclave-objs = \
 	db_devices.o \
@@ -39,7 +42,8 @@ enclave-objs = \
 	enclave_pages.o \
 	enclave_platform.o \
 	enclave_untrusted.o \
-	enclave_xstate.o
+	enclave_xstate.o \
+	$(commons_objs)
 
 enclave-asm-objs = enclave_entry.o
 
@@ -74,6 +78,9 @@ $(patsubst %.o,%.s,$(enclave-asm-objs)): ASFLAGS += -DIN_ENCLAVE
 
 $(urts-objs): quote/aesm.pb-c.h
 $(enclave-objs): quote/generated-cacert.h
+
+$(commons_objs): %.o: ../Linux-common/%.c
+	$(call cmd,cc_o_c)
 
 %.o: %.c
 	$(call cmd,cc_o_c)

--- a/Pal/src/host/Linux-SGX/db_main.c
+++ b/Pal/src/host/Linux-SGX/db_main.c
@@ -21,18 +21,19 @@
  * processes environment, arguments and manifest.
  */
 
-#include "pal_defs.h"
-#include "pal_linux_defs.h"
+#include "api.h"
+#include "bogomips.h"
 #include "pal.h"
+#include "pal_debug.h"
+#include "pal_defs.h"
+#include "pal_error.h"
 #include "pal_internal.h"
 #include "pal_linux.h"
-#include "pal_debug.h"
-#include "pal_error.h"
+#include "pal_linux_defs.h"
 #include "pal_security.h"
-#include "api.h"
 
-#include <asm/mman.h>
 #include <asm/ioctls.h>
+#include <asm/mman.h>
 #include <elf/elf.h>
 #include <sysdeps/generic/ldsodefs.h>
 
@@ -490,6 +491,24 @@ static char * cpu_flags[]
           "pbe",    // "pending break event"
         };
 
+static double get_bogomips(void) {
+    int fd = -1;
+    char buf[0x800] = { 0 };
+
+    fd = ocall_open("/proc/cpuinfo", O_RDONLY, 0);
+    if (fd < 0) {
+        return 0.0;
+    }
+
+    /* Although the whole file might not fit in this size, the first cpu description should. */
+    int x = ocall_read(fd, buf, sizeof(buf) - 1);
+    ocall_close(fd);
+    if (x < 0) {
+        return 0.0;
+    }
+
+    return sanitize_bogomips_value(get_bogomips_from_cpuinfo_buf(buf, sizeof(buf)));
+}
 
 int _DkGetCPUInfo (PAL_CPU_INFO * ci)
 {
@@ -557,5 +576,11 @@ int _DkGetCPUInfo (PAL_CPU_INFO * ci)
 
     flags[flen ? flen - 1 : 0] = 0;
     ci->cpu_flags = flags;
+
+    ci->cpu_bogomips = get_bogomips();
+    if (ci->cpu_bogomips == 0.0) {
+        SGX_DBG(DBG_E, "Warning: bogomips could not be retrieved, passing 0.0 to the application\n");
+    }
+
     return rv;
 }

--- a/Pal/src/host/Linux-common/bogomips.c
+++ b/Pal/src/host/Linux-common/bogomips.c
@@ -1,0 +1,71 @@
+#include "api.h"
+#include "bogomips.h"
+
+/* This version is too dumb to be shared by the whole repository and should be removed once we get
+ * a proper stdlib (like musl). */
+static double proc_cpuinfo_atod(const char* s) {
+    double ret = 0.0;
+    char* end = NULL;
+    double base, fractional;
+
+    base = strtol(s, &end, 10);
+
+    if (*end == '.') {
+        s = end + 1;
+        fractional = strtol(s, &end, 10);
+        while (s != end) {
+            fractional /= 10.0;
+            s++;
+        }
+        ret = base + fractional;
+    }
+
+    return ret;
+}
+
+double get_bogomips_from_cpuinfo_buf(const char* buf, size_t size) {
+    /* We could use strstr if graphene had one. */
+    /* Each prefix of the word "bogomips" occurs only once in the whole word, hence this works. */
+    const char* const word = "bogomips";
+    const size_t word_size = strlen(word);
+    size_t i = 0,
+           j = 0;
+
+    if (word_size > size) {
+        return 0.0;
+    }
+
+    while (i < size - word_size && buf[i]) {
+        j = 0;
+        while (j < word_size && buf[i + j] == word[j]) {
+            j++;
+        }
+
+        if (j) {
+            i += j;
+        } else {
+            i += 1;
+        }
+
+        if (j == word_size) {
+            /* buf is null-terminated, so no need to check size. word does not contain neither
+             * spaces nor tabs, hence we can forward global index `i`, even if we do not return
+             * here. */
+            while (buf[i] == ' ' || buf[i] == '\t') {
+                i++;
+            }
+            if (buf[i] == ':') {
+                return proc_cpuinfo_atod(&buf[i + 1]);
+            }
+        }
+    }
+
+    return 0.0;
+}
+
+double sanitize_bogomips_value(double v) {
+    if (!__builtin_isnormal(v) || v < 0.0) {
+        return 0.0;
+    }
+    return v;
+}

--- a/Pal/src/host/Linux/Makefile
+++ b/Pal/src/host/Linux/Makefile
@@ -2,8 +2,8 @@ include ../../../../Scripts/Makefile.configs
 include Makefile.am
 
 CFLAGS	+= -I. -Iinclude -I../.. -I../../../include -I../../../include/pal \
-	   -I../../../include/host/Linux -I../../../include/lib \
-	   -I../../../linux-kernel/graphene
+	-I../../../include/host/Linux -I../../../include/lib \
+	-I../../../include/host/Linux-common
 ASFLAGS += -I. -Iinclude -I../.. -I../../../include
 
 host_files = libpal-Linux.a pal.map
@@ -11,6 +11,9 @@ host_files = libpal-Linux.a pal.map
 defs	= -DIN_PAL -DPAL_DIR=$(PAL_DIR) -DRUNTIME_DIR=$(RUNTIME_DIR)
 CFLAGS += $(defs)
 ASFLAGS += $(defs)
+
+commons_objs = bogomips.o
+
 objs = \
 	clone-x86_64.o \
 	db_devices.o \
@@ -28,7 +31,8 @@ objs = \
 	db_rtld.o \
 	db_sockets.o \
 	db_streams.o \
-	db_threading.o
+	db_threading.o \
+	$(commons_objs)
 
 graphene_lib = .lib/graphene-lib.a
 
@@ -37,6 +41,9 @@ all: $(host_files)
 
 libpal-Linux.a: $(objs) $(graphene_lib)
 	$(call cmd,ar_a_o)
+
+$(commons_objs): %.o: ../Linux-common/%.c
+	$(call cmd,cc_o_c)
 
 %.o: %.c
 	$(call cmd,cc_o_c)

--- a/Pal/src/host/Linux/db_main.c
+++ b/Pal/src/host/Linux/db_main.c
@@ -21,19 +21,20 @@
  * processes environment, arguments and manifest.
  */
 
-#include "pal_defs.h"
-#include "pal_linux_defs.h"
+#include "api.h"
+#include "bogomips.h"
 #include "pal.h"
+#include "pal_debug.h"
+#include "pal_defs.h"
+#include "pal_error.h"
 #include "pal_internal.h"
 #include "pal_linux.h"
-#include "pal_debug.h"
-#include "pal_error.h"
+#include "pal_linux_defs.h"
 #include "pal_security.h"
-#include "api.h"
 
-#include <asm/mman.h>
-#include <asm/ioctls.h>
 #include <asm/errno.h>
+#include <asm/ioctls.h>
+#include <asm/mman.h>
 #include <elf/elf.h>
 #include <sysdeps/generic/ldsodefs.h>
 
@@ -432,6 +433,25 @@ int get_cpu_count(void) {
     return cpu_count;
 }
 
+static double get_bogomips(void) {
+    int fd = -1;
+    char buf[0x800] = { 0 };
+
+    fd = INLINE_SYSCALL(open, 2, "/proc/cpuinfo", O_RDONLY);
+    if (fd < 0) {
+        return 0.0;
+    }
+
+    /* Although the whole file might not fit in this size, the first cpu description should. */
+    long x = INLINE_SYSCALL(read, 3, fd, buf, sizeof(buf) - 1);
+    INLINE_SYSCALL(close, 1, fd);
+    if (x < 0) {
+        return 0.0;
+    }
+
+    return sanitize_bogomips_value(get_bogomips_from_cpuinfo_buf(buf, sizeof(buf)));
+}
+
 int _DkGetCPUInfo (PAL_CPU_INFO * ci)
 {
     unsigned int words[PAL_CPUID_WORD_NUM];
@@ -503,5 +523,11 @@ int _DkGetCPUInfo (PAL_CPU_INFO * ci)
 
     flags[flen ? flen - 1 : 0] = 0;
     ci->cpu_flags = flags;
+
+    ci->cpu_bogomips = get_bogomips();
+    if (ci->cpu_bogomips == 0.0) {
+        printf("Warning: bogomips could not be retrieved, passing 0.0 to the application\n");
+    }
+
     return rv;
 }


### PR DESCRIPTION
<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->
This PR adds bogomips entry to `/proc/cpuinfo`, which is used by some applications (e.g. blender).
Additionally this introduces code shared between PAL-Linux and PAL-Linux-SGX which is first step in removing copy-pasted code in them.

## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1348)
<!-- Reviewable:end -->
