### PR TITLE
[LibOS] Fix header import order issue

### DIFF
--- a/LibOS/shim/src/fs/dev/fs.c
+++ b/LibOS/shim/src/fs/dev/fs.c
@@ -20,12 +20,16 @@
  * This file contains codes for implementation of 'dev' filesystem.
  */
 
+#define __KERNEL__
+
 #include <asm/fcntl.h>
 #include <asm/mman.h>
 #include <asm/prctl.h>
 #include <asm/unistd.h>
 #include <errno.h>
 #include <linux/fcntl.h>
+#include <linux/stat.h>
+
 #include <pal.h>
 #include <pal_error.h>
 #include <shim_fs.h>
@@ -33,10 +37,6 @@
 #include <shim_internal.h>
 #include <shim_profile.h>
 #include <shim_utils.h>
-
-// TODO: For some reason S_IF* macros are missing if this file is included before our headers. We
-// should investigate and fix this behavior.
-#include <linux/stat.h>
 
 #define EMPTY_DEV_OPS     \
     {                     \

--- a/LibOS/shim/src/fs/pipe/fs.c
+++ b/LibOS/shim/src/fs/pipe/fs.c
@@ -20,12 +20,16 @@
  * This file contains codes for implementation of 'pipe' filesystem.
  */
 
+#define __KERNEL__
+
 #include <asm/fcntl.h>
 #include <asm/mman.h>
 #include <asm/prctl.h>
 #include <asm/unistd.h>
 #include <errno.h>
 #include <linux/fcntl.h>
+#include <linux/stat.h>
+
 #include <pal.h>
 #include <pal_debug.h>
 #include <pal_error.h>
@@ -34,10 +38,6 @@
 #include <shim_internal.h>
 #include <shim_profile.h>
 #include <shim_thread.h>
-
-// TODO: For some reason S_I{R,W}USR macros are missing if this file is included before our headers.
-// We should investigate and fix this behavior.
-#include <linux/stat.h>
 
 static ssize_t pipe_read(struct shim_handle* hdl, void* buf, size_t count) {
     PAL_NUM bytes = DkStreamRead(hdl->pal_handle, 0, count, buf, NULL, 0);

--- a/LibOS/shim/src/fs/proc/fs.c
+++ b/LibOS/shim/src/fs/proc/fs.c
@@ -20,12 +20,16 @@
  * This file contains codes for implementation of 'proc' filesystem.
  */
 
+#define __KERNEL__
+
 #include <asm/fcntl.h>
 #include <asm/mman.h>
 #include <asm/prctl.h>
 #include <asm/unistd.h>
 #include <errno.h>
 #include <linux/fcntl.h>
+#include <linux/stat.h>
+
 #include <pal.h>
 #include <pal_error.h>
 #include <shim_fs.h>
@@ -33,10 +37,6 @@
 #include <shim_internal.h>
 #include <shim_thread.h>
 #include <shim_utils.h>
-
-// TODO: For some reason S_IF* macros are missing if this file is included before our headers. We
-// should investigate and fix this behavior.
-#include <linux/stat.h>
 
 extern const struct proc_nm_ops nm_thread;
 extern const struct proc_fs_ops fs_thread;

--- a/LibOS/shim/src/fs/proc/info.c
+++ b/LibOS/shim/src/fs/proc/info.c
@@ -1,17 +1,17 @@
+#define __KERNEL__
+
 #include <asm/fcntl.h>
 #include <asm/mman.h>
 #include <asm/prctl.h>
 #include <asm/unistd.h>
 #include <errno.h>
 #include <linux/fcntl.h>
+#include <linux/stat.h>
+
 #include <pal.h>
 #include <pal_error.h>
 #include <shim_fs.h>
 #include <shim_internal.h>
-
-// TODO: For some reason S_IF* macros are missing if this file is included before our headers. We
-// should investigate and fix this behavior.
-#include <linux/stat.h>
 
 static int proc_info_mode(const char* name, mode_t* mode) {
     // The path is implicitly set by calling this function

--- a/LibOS/shim/src/fs/proc/ipc-thread.c
+++ b/LibOS/shim/src/fs/proc/ipc-thread.c
@@ -1,9 +1,13 @@
+#define __KERNEL__
+
 #include <asm/fcntl.h>
 #include <asm/mman.h>
 #include <asm/prctl.h>
 #include <asm/unistd.h>
 #include <errno.h>
 #include <linux/fcntl.h>
+#include <linux/stat.h>
+
 #include <pal.h>
 #include <pal_error.h>
 #include <shim_fs.h>
@@ -13,10 +17,6 @@
 #include <shim_table.h>
 #include <shim_thread.h>
 #include <shim_utils.h>
-
-// TODO: For some reason S_IF* macros are missing if this file is included before our headers. We
-// should investigate and fix this behavior.
-#include <linux/stat.h>
 
 static int parse_ipc_thread_name(const char* name, IDTYPE* pidptr, const char** next,
                                  size_t* next_len, const char** nextnext) {

--- a/LibOS/shim/src/fs/proc/thread.c
+++ b/LibOS/shim/src/fs/proc/thread.c
@@ -1,9 +1,13 @@
+#define __KERNEL__
+
 #include <asm/fcntl.h>
 #include <asm/mman.h>
 #include <asm/prctl.h>
 #include <asm/unistd.h>
 #include <errno.h>
 #include <linux/fcntl.h>
+#include <linux/stat.h>
+
 #include <pal.h>
 #include <pal_error.h>
 #include <shim_fs.h>
@@ -12,10 +16,6 @@
 #include <shim_table.h>
 #include <shim_thread.h>
 #include <shim_utils.h>
-
-// TODO: For some reason S_IF* macros are missing if this file is included before our headers. We
-// should investigate and fix this behavior.
-#include <linux/stat.h>
 
 static int parse_thread_name(const char* name, IDTYPE* pidptr, const char** next, size_t* next_len,
                              const char** nextnext) {

--- a/LibOS/shim/src/fs/shim_namei.c
+++ b/LibOS/shim/src/fs/shim_namei.c
@@ -22,21 +22,18 @@
  * directory cache.
  */
 
+#include <asm/fcntl.h>
+#include <linux/fcntl.h>
+#include <linux/stat.h>
 #include <stdbool.h>
 
-#include <shim_internal.h>
-#include <shim_utils.h>
-#include <shim_thread.h>
-#include <shim_handle.h>
-#include <shim_fs.h>
-#include <shim_profile.h>
-
 #include <pal.h>
-
-#include <linux/stat.h>
-#include <linux/fcntl.h>
-
-#include <asm/fcntl.h>
+#include <shim_fs.h>
+#include <shim_handle.h>
+#include <shim_internal.h>
+#include <shim_profile.h>
+#include <shim_thread.h>
+#include <shim_utils.h>
 
 /* Advances a char pointer (string) past any repeated slashes and returns the result.
  * Must be a null-terminated string. */

--- a/LibOS/shim/src/fs/socket/fs.c
+++ b/LibOS/shim/src/fs/socket/fs.c
@@ -20,21 +20,21 @@
  * This file contains codes for implementation of 'socket' filesystem.
  */
 
+#define __KERNEL__
+
 #include <asm/fcntl.h>
 #include <asm/mman.h>
 #include <asm/prctl.h>
 #include <asm/unistd.h>
 #include <errno.h>
 #include <linux/fcntl.h>
+#include <linux/stat.h>
+
 #include <pal.h>
 #include <pal_error.h>
 #include <shim_fs.h>
 #include <shim_internal.h>
 #include <shim_profile.h>
-
-// TODO: For some reason S_IF* macros are missing if this file is included before our headers. We
-// should investigate and fix this behavior.
-#include <linux/stat.h>
 
 static int socket_close(struct shim_handle* hdl) {
     /* XXX: Shouldn't this do something? */

--- a/LibOS/shim/src/sys/shim_fs.c
+++ b/LibOS/shim/src/sys/shim_fs.c
@@ -22,9 +22,12 @@
  * "sendfile".
  */
 
+#define __KERNEL__
+
 #include <asm/mman.h>
 #include <errno.h>
 #include <linux/fcntl.h>
+#include <linux/stat.h>
 
 #include <pal.h>
 #include <pal_error.h>
@@ -34,10 +37,6 @@
 #include <shim_table.h>
 #include <shim_thread.h>
 #include <shim_utils.h>
-
-/* FIXME(mkow): for some reason it must be included last, otherwise S_IFREG is not being
- * defined inside (sic!). */
-#include <linux/stat.h>
 
 /* The kernel would look up the parent directory, and remove the child from the inode. But we are
  * working with the PAL, so we open the file, truncate and close it. */


### PR DESCRIPTION
<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->
Some defines (e.g. `S_IFREG`) where missing if some includes where moved around (e.g. `linux/stat.h`) - this PR fixes it.

## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1349)
<!-- Reviewable:end -->
