### PR TITLE
[Makefile] fix Makefile.Host

### DIFF
--- a/Scripts/Makefile.Host
+++ b/Scripts/Makefile.Host
@@ -13,11 +13,11 @@ endif
 endif
 
 ifeq ($(SGX_RUN),1)
-	$(error "SGX_RUN has been removed. Always set SGX=1 if building for SGX and use the 'sgx-tokens' make target to build launch/EINIT tokens")
+$(error "SGX_RUN has been removed. Always set SGX=1 if building for SGX and use the 'sgx-tokens' make target to build launch/EINIT tokens")
 endif
 
 ifeq ($(SGX),1)
-	PAL_HOST := $(patsubst %-SGX,%,$(PAL_HOST))-SGX
+PAL_HOST := $(patsubst %-SGX,%,$(PAL_HOST))-SGX
 endif
 
 ifeq ($(findstring $(PAL_HOST),$(all_hosts)),)


### PR DESCRIPTION
remove leading tab to fix the following error with SGX_RUN=1
> Scripts//Makefile.Host:16: *** recipe commences before first target. Stop.

<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [x] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->


## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1352)
<!-- Reviewable:end -->
