### PR TITLE
[Pal] Fix memory corruption introduced by #1320

### DIFF
--- a/Pal/src/host/Linux-SGX/enclave_ocalls.c
+++ b/Pal/src/host/Linux-SGX/enclave_ocalls.c
@@ -109,7 +109,7 @@ int ocall_munmap_untrusted (const void * mem, uint64_t size)
 static int ocall_mmap_untrusted_cache(uint64_t size, void** mem, bool* need_munmap) {
     *need_munmap = false;
     struct untrusted_area* cache = &get_tcb_trts()->untrusted_area_cache;
-    int in_use = 0;
+    uint64_t in_use = 0;
     if (!__atomic_compare_exchange_n(&cache->in_use, &in_use, 1, false, __ATOMIC_RELAXED, __ATOMIC_RELAXED)) {
         /* AEX signal handling case: cache is in use, so make explicit mmap/munmap */
         int retval = ocall_mmap_untrusted(-1, 0, size, PROT_READ | PROT_WRITE, mem);


### PR DESCRIPTION
## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [X] SGX PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->

#1320 introduced a memory corruption where `__atomic_compare_exchange_n` read a 64-bit value into a 32-bit variable. See https://reviewable.io/reviews/oscarlab/graphene/1320#-M1IhbFd7WaTSxNBCI00.

Yes, GCC seems to be really terrible at type checking in builtins...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1354)
<!-- Reviewable:end -->
