### PR TITLE
[SGX PAL] pal_sgx_sign.py: UTF-8 characters in trusted file URIs

### DIFF
--- a/Pal/src/host/Linux-SGX/signer/pal_sgx_sign.py
+++ b/Pal/src/host/Linux-SGX/signer/pal_sgx_sign.py
@@ -59,7 +59,7 @@ def parse_size(value):
 def read_manifest(filename):
     manifest = dict()
     manifest_layout = []
-    with open(filename, "r") as file:
+    with open(filename, "r", encoding="utf-8") as file:
         for line in file:
             if line == "":
                 manifest_layout.append((None, None))
@@ -129,7 +129,7 @@ def output_manifest(filename, manifest, manifest_layout):
                 if line != '':
                     line += ' '
                 line += comment
-            file.write(line)
+            file.write(str(line.encode("utf-8")))
             file.write('\n')
 
         file.write('\n')
@@ -212,7 +212,7 @@ def resolve_uri(uri, check_exist=True):
         target = os.path.normpath(uri[len('file:'):])
     else:
         target = os.path.normpath(uri)
-    if check_exist and not os.path.exists(target):
+    if check_exist and not os.path.exists(target.encode("utf-8")):
         raise Exception(
             'Cannot resolve ' + orig_uri + ' or the file does not exist.')
     return target
@@ -228,7 +228,7 @@ def resolve_manifest_uri(manifest_path, uri):
 
 def get_checksum(filename):
     digest = hashlib.sha256()
-    with open(filename, 'rb') as file:
+    with open(filename.encode("utf-8"), 'rb') as file:
         digest.update(file.read())
     return digest.digest()
 
@@ -857,7 +857,7 @@ def main_sign(args):
     print("Trusted files:")
     for key, val in get_trusted_files(manifest, args).items():
         (uri, _, checksum) = val
-        print("    %s %s" % (checksum, uri))
+        print("    %s %s" % (checksum, uri.encode("utf-8")))
         manifest['sgx.trusted_checksum.' + key] = checksum
 
     print("Trusted children:")


### PR DESCRIPTION
## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [x] SGX PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes 

Updated pal_sgx_sign.py to allow trusted files to include UTF-8 characters. As suggested in https://github.com/oscarlab/graphene/issues/1337, the pal_sgx_sign.py fails to generate a signature for an application with a trusted filename including UTF-8 characters.

These changes are only concerned about the pal_sgx_sign.py and not about the actual initialization of Graphene. As a result, Graphene fails during the initialization of a manifest file with UTF-8 characters in trusted file URIs. 

## How to test this PR? 

1) Create a file with a UTF-8 character in its name (i.e. ♥♥♥.txt)
2) Create a manifest file including
```
sgx.trusted_file.love = file:♥♥♥.txt
```
3) Run pal_sgx_sign.py 
```
graphene/Pal/src/Host/Linux-SGX/signer/pal-sgx-sign 
    -libpal graphene/Runtime/libpal-Linux-SGX.so 
    -key graphene/Pal/src/Host/Linux-SGX/signer/enclave-key.pem 
    -output app.manifest.sgx
    -manifest app.manifest 
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1355)
<!-- Reviewable:end -->
