### PR TITLE
[LibOS] test/apps: Add PyTorch example

### DIFF
--- a/.ci/run-pylint
+++ b/.ci/run-pylint
@@ -16,6 +16,7 @@ find . -name \*.py \
     -and -not -path ./LibOS/glibc-\?.\?\?/\* \
     -and -not -path ./LibOS/shim/test/apps/ltp/opt/\* \
     -and -not -path ./LibOS/shim/test/apps/ltp/src/\* \
+    -and -not -path ./LibOS/shim/test/apps/pytorch/\* \
 | sed 's/./\\&/g' \
 | xargs "${PYLINT}" "$@" \
     Pal/src/host/Linux-SGX/signer/pal-sgx-get-token \


### PR DESCRIPTION

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->

This PR adds a PyTorch example. The corresponding PR is https://github.com/oscarlab/graphene-tests/pull/66.

## How to test this PR? <!-- (if applicable) -->

Since PyTorch installation is huge (~1GB on hard drive and 4GB of enclave size), we don't test in Jenkins. However, this was tested on several machines with Ubuntu 16.04/18.04.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1356)
<!-- Reviewable:end -->
