### PR TITLE
[Pal/Linux-SGX] Remove PAL_ALLOC_INTERNAL and pal_vmas array

### DIFF
--- a/Documentation/oldwiki/PAL-Host-ABI.md
+++ b/Documentation/oldwiki/PAL-Host-ABI.md
@@ -176,7 +176,6 @@ positive number, aligned at the allocation alignment.
 
     /* Memory Allocation Flags */
     #define PAL_ALLOC_RESERVE     0x0001   /* Only reserve the memory */
-    #define PAL_ALLOC_INTERNAL    0x8000   /* Allocate for PAL */
 
 `prot` can be a combination of the following flags:
 

--- a/Pal/include/pal/pal.h
+++ b/Pal/include/pal/pal.h
@@ -348,10 +348,6 @@ PAL_CONTROL * pal_control_addr (void);
 /* Memory Allocation Flags */
 #define PAL_ALLOC_RESERVE     0x0001   /* Only reserve the memory */
 
-#ifdef IN_PAL
-#define PAL_ALLOC_INTERNAL    0x8000
-#endif
-
 /* Memory Protection Flags */
 #define PAL_PROT_NONE       0x0     /* 0x0 Page can not be accessed. */
 #define PAL_PROT_READ       0x1     /* 0x1 Page can be read. */

--- a/Pal/src/host/Linux-SGX/db_memory.c
+++ b/Pal/src/host/Linux-SGX/db_memory.c
@@ -35,15 +35,6 @@
 
 #include "enclave_pages.h"
 
-/* TODO: Having VMAs in an array is extremely inefficient */
-#define PAL_VMA_MAX 64
-static struct pal_vma {
-    void * top, * bottom;
-} pal_vmas[PAL_VMA_MAX];
-
-static uint32_t pal_nvmas = 0;
-static spinlock_t pal_vma_lock = INIT_SPINLOCK_UNLOCKED;
-
 bool _DkCheckMemoryMappable (const void * addr, size_t size)
 {
     if (addr < DATA_END && addr + size > TEXT_START) {
@@ -51,28 +42,17 @@ bool _DkCheckMemoryMappable (const void * addr, size_t size)
         return true;
     }
 
-    spinlock_lock(&pal_vma_lock);
-
-    for (uint32_t i = 0 ; i < pal_nvmas ; i++)
-        if (addr < pal_vmas[i].top && addr + size > pal_vmas[i].bottom) {
-            spinlock_unlock(&pal_vma_lock);
-            printf("address %p-%p is not mappable\n", addr, addr + size);
-            return true;
-        }
-
-    spinlock_unlock(&pal_vma_lock);
     return false;
 }
 
 int _DkVirtualMemoryAlloc (void ** paddr, uint64_t size, int alloc_type, int prot)
 {
+    __UNUSED(alloc_type);
+
     if (!WITHIN_MASK(prot, PAL_PROT_MASK))
         return -PAL_ERROR_INVAL;
 
     void * addr = *paddr, * mem;
-
-    if ((alloc_type & PAL_ALLOC_INTERNAL) && addr)
-        return -PAL_ERROR_INVAL;
 
     if (size == 0)
         __asm__ volatile ("int $3");
@@ -87,24 +67,6 @@ int _DkVirtualMemoryAlloc (void ** paddr, uint64_t size, int alloc_type, int pro
         return -PAL_ERROR_INVAL; // `addr` was unaligned.
     }
 
-    if (alloc_type & PAL_ALLOC_INTERNAL) {
-        spinlock_lock(&pal_vma_lock);
-        if (pal_nvmas >= PAL_VMA_MAX) {
-            spinlock_unlock(&pal_vma_lock);
-            SGX_DBG(DBG_E, "Pal is out of VMAs (current limit on VMAs PAL_VMA_MAX = %d)!\n",
-                    PAL_VMA_MAX);
-            free_pages(mem, size);
-            return -PAL_ERROR_NOMEM;
-        }
-
-        pal_vmas[pal_nvmas].bottom = mem;
-        pal_vmas[pal_nvmas].top = mem + size;
-        pal_nvmas++;
-        spinlock_unlock(&pal_vma_lock);
-
-        SGX_DBG(DBG_M, "pal allocated %p-%p for internal use\n", mem, mem + size);
-    }
-
     memset(mem, 0, size);
 
     *paddr = mem;
@@ -115,25 +77,6 @@ int _DkVirtualMemoryFree (void * addr, uint64_t size)
 {
     if (sgx_is_completely_within_enclave(addr, size)) {
         free_pages(addr, size);
-
-        /* check if it is internal PAL memory and remove this VMA from pal_vmas if yes */
-        spinlock_lock(&pal_vma_lock);
-        for (uint32_t i = 0; i < pal_nvmas; i++) {
-            if (addr == pal_vmas[i].bottom) {
-                /* TODO: currently assume that internal PAL memory is freed at same granularity as
-                 *       was allocated in _DkVirtualMemoryAlloc(); may be false in general case */
-                assert(addr + size == pal_vmas[i].top);
-
-                for (uint32_t j = i; j < pal_nvmas - 1; j++) {
-                    pal_vmas[j].bottom = pal_vmas[j + 1].bottom;
-                    pal_vmas[j].top    = pal_vmas[j + 1].top;
-                }
-
-                pal_nvmas--;
-                break;
-            }
-        }
-        spinlock_unlock(&pal_vma_lock);
     } else {
         /* Possible to have untrusted mapping. Simply unmap
            the memory outside the enclave */

--- a/Pal/src/slab.c
+++ b/Pal/src/slab.c
@@ -59,7 +59,7 @@ static inline void* __malloc(int size) {
     }
 #endif
 
-    _DkVirtualMemoryAlloc(&addr, size, PAL_ALLOC_INTERNAL, PAL_PROT_READ | PAL_PROT_WRITE);
+    _DkVirtualMemoryAlloc(&addr, size, /*alloc_type=*/0, PAL_PROT_READ | PAL_PROT_WRITE);
     return addr;
 }
 


### PR DESCRIPTION
<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [x] SGX PAL
- [x] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->

Previously, Graphene kept track of memory regions allocated inside PAL via `PAL_ALLOC_INTERNAL` flag. The `pal_vmas` array with 64 VMAs was used for bookkeeping. This limit led to out-of-PAL-memory errors for bigger applications, e.g., for huge numbers of trusted files.

This bookkeeping is not needed, since this is already covered by SGX-specific page allocation in `enclave_pages.c`.

## How to test this PR? <!-- (if applicable) -->

All tests must pass.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1361)
<!-- Reviewable:end -->
