### PR TITLE
[Pal/Linux-SGX] Assorted SGX-related fixups

### DIFF
--- a/Pal/src/host/Linux-SGX/db_main.c
+++ b/Pal/src/host/Linux-SGX/db_main.c
@@ -277,7 +277,7 @@ void pal_linux_main(char * uptr_args, uint64_t args_size,
     pal_sec.cargo_fd  = sec_info.cargo_fd;
 
     COPY_ARRAY(pal_sec.pipe_prefix, sec_info.pipe_prefix);
-    pal_sec.aesm_targetinfo = sec_info.aesm_targetinfo;
+    pal_sec.qe_targetinfo = sec_info.qe_targetinfo;
 #ifdef DEBUG
     pal_sec.in_gdb = sec_info.in_gdb;
 #endif

--- a/Pal/src/host/Linux-SGX/enclave_platform.c
+++ b/Pal/src/host/Linux-SGX/enclave_platform.c
@@ -417,7 +417,7 @@ int sgx_verify_platform(sgx_spid_t* spid, const char* subkey, sgx_quote_nonce_t*
     SGX_DBG(DBG_S, "  nonce: %s\n", ALLOCA_BYTES2HEXSTR(*nonce));
 
     __sgx_mem_aligned sgx_report_t report;
-    __sgx_mem_aligned sgx_target_info_t targetinfo = pal_sec.aesm_targetinfo;
+    __sgx_mem_aligned sgx_target_info_t targetinfo = pal_sec.qe_targetinfo;
 
     int ret = sgx_report(&targetinfo, report_data, &report);
     if (ret) {

--- a/Pal/src/host/Linux-SGX/pal_linux.h
+++ b/Pal/src/host/Linux-SGX/pal_linux.h
@@ -18,6 +18,7 @@
 #define PAL_LINUX_H
 
 #include "api.h"
+#include "assert.h"
 #include "pal.h"
 #include "pal_crypto.h"
 #include "pal_defs.h"
@@ -169,12 +170,27 @@ extern struct pal_enclave_state {
     uint64_t        enclave_id;         // Unique identifier for authentication
     sgx_sign_data_t enclave_data;       // Reserved for signing other data
 } __attribute__((packed)) pal_enclave_state;
+static_assert(sizeof(pal_enclave_state) == sizeof(sgx_report_data_t), "incorrect struct size");
 
 /*
  * sgx_verify_report: verify a CPU-signed report from another local enclave
  * @report: the buffer storing the report to verify
  */
 int sgx_verify_report(sgx_report_t* report);
+
+
+/*!
+ * \brief Obtain a CPU-signed report for local attestation.
+ *
+ * Caller must align all parameters to 512 bytes (cf. `__sgx_mem_aligned`).
+ *
+ * \param[in]  target_info  Information on the target enclave.
+ * \param[in]  data         User-specified data to be included in the report.
+ * \param[out] report       Output buffer to store the report.
+ * \return                  0 on success, negative error code otherwise.
+ */
+int sgx_get_report(const sgx_target_info_t* target_info, const sgx_report_data_t* data,
+                   sgx_report_t* report);
 
 typedef int (*check_mr_enclave_t)(PAL_HANDLE, sgx_measurement_t*, struct pal_enclave_state*);
 

--- a/Pal/src/host/Linux-SGX/pal_security.h
+++ b/Pal/src/host/Linux-SGX/pal_security.h
@@ -28,7 +28,7 @@ struct pal_sec {
     PAL_IDX         ppid, pid, uid, gid;
 
     /* enclave information */
-    sgx_target_info_t  aesm_targetinfo;
+    sgx_target_info_t  qe_targetinfo;
     sgx_measurement_t  mr_enclave;
     sgx_measurement_t  mr_signer;
     sgx_attributes_t   enclave_attributes;

--- a/Pal/src/host/Linux-SGX/sgx_api.h
+++ b/Pal/src/host/Linux-SGX/sgx_api.h
@@ -36,9 +36,8 @@ uint64_t sgx_copy_to_enclave(const void* ptr, uint64_t maxsize, const void* uptr
  * sgx_report:
  * Generate SGX hardware signed report.
  */
-static inline int sgx_report (sgx_target_info_t * targetinfo,
-                              void * reportdata, sgx_report_t * report)
-{
+static inline int sgx_report(const sgx_target_info_t* targetinfo,
+                             const void* reportdata, sgx_report_t* report) {
     __asm__ volatile(
         ENCLU "\n"
         :: "a"(EREPORT), "b"(targetinfo), "c"(reportdata), "d"(report)

--- a/Pal/src/host/Linux-SGX/sgx_arch.h
+++ b/Pal/src/host/Linux-SGX/sgx_arch.h
@@ -294,18 +294,22 @@ typedef struct _sgx_report_data_t {
 #define __sgx_mem_aligned __attribute__((aligned(512)))
 
 typedef struct _report_body_t {
-    sgx_cpu_svn_t     cpu_svn;
-    sgx_misc_select_t misc_select;
-    uint8_t           reserved1[28];
-    sgx_attributes_t  attributes;
-    sgx_measurement_t mr_enclave;
-    uint8_t           reserved2[32];
-    sgx_measurement_t mr_signer;
-    uint8_t           reserved3[96];
-    sgx_prod_id_t     isv_prod_id;
-    sgx_isv_svn_t     isv_svn;
-    uint8_t           reserved4[60];
-    sgx_report_data_t report_data;
+    sgx_cpu_svn_t        cpu_svn;
+    sgx_misc_select_t    misc_select;
+    uint8_t              reserved1[12];
+    sgx_isvext_prod_id_t isv_ext_prod_id;
+    sgx_attributes_t     attributes;
+    sgx_measurement_t    mr_enclave;
+    uint8_t              reserved2[32];
+    sgx_measurement_t    mr_signer;
+    uint8_t              reserved3[32];
+    sgx_config_id_t      config_id;
+    sgx_prod_id_t        isv_prod_id;
+    sgx_isv_svn_t        isv_svn;
+    sgx_config_svn_t     config_svn;
+    uint8_t              reserved4[42];
+    sgx_isvfamily_id_t   isv_family_id;
+    sgx_report_data_t    report_data;
 } sgx_report_body_t;
 
 typedef struct _report_t {

--- a/Pal/src/host/Linux-SGX/sgx_internal.h
+++ b/Pal/src/host/Linux-SGX/sgx_internal.h
@@ -99,7 +99,13 @@ int add_pages_to_enclave(sgx_arch_secs_t * secs,
                          bool skip_eextend,
                          const char * comment);
 
-int init_aesm_targetinfo(sgx_target_info_t* aesm_targetinfo);
+/*!
+ * \brief Retrieve Quoting Enclave's sgx_target_info_t by talking to AESMD.
+ *
+ * \param[out] qe_targetinfo  Retrieved Quoting Enclave's target info.
+ * \return                    0 on success, negative error code otherwise.
+ */
+int init_quoting_enclave_targetinfo(sgx_target_info_t* qe_targetinfo);
 
 int retrieve_verified_quote(const sgx_spid_t* spid, const char* subkey, bool linkable,
                             const sgx_report_t* report, const sgx_quote_nonce_t* nonce,

--- a/Pal/src/host/Linux-SGX/sgx_main.c
+++ b/Pal/src/host/Linux-SGX/sgx_main.c
@@ -900,8 +900,8 @@ static int load_enclave (struct pal_enclave * enclave,
         return ret;
 
     if (get_config(enclave->config, "sgx.ra_client_key", cfgbuf, sizeof(cfgbuf)) > 0) {
-        /* initialize communication with AESM enclave only if app requests remote attestation */
-        ret = init_aesm_targetinfo(&pal_sec->aesm_targetinfo);
+        /* initialize communication with Quoting Enclave only if app requests remote attestation */
+        ret = init_quoting_enclave_targetinfo(&pal_sec->qe_targetinfo);
         if (ret < 0)
             return ret;
     }

--- a/Pal/src/host/Linux-SGX/sgx_platform.c
+++ b/Pal/src/host/Linux-SGX/sgx_platform.c
@@ -109,9 +109,7 @@ err:
     return -ERRNO(ret);
 }
 
-// Retrieve the targetinfo for the AESM enclave for generating the local attestation report.
-int init_aesm_targetinfo(sgx_target_info_t* aesm_targetinfo) {
-
+int init_quoting_enclave_targetinfo(sgx_target_info_t* qe_target_info) {
     Request req = REQUEST__INIT;
     Request__InitQuoteRequest initreq = REQUEST__INIT_QUOTE_REQUEST__INIT;
     req.initquotereq = &initreq;
@@ -133,12 +131,12 @@ int init_aesm_targetinfo(sgx_target_info_t* aesm_targetinfo) {
         goto failed;
     }
 
-    if (r->targetinfo.len != sizeof(*aesm_targetinfo)) {
-        SGX_DBG(DBG_E, "aesm_service returned invalid target info\n");
+    if (r->targetinfo.len != sizeof(*qe_target_info)) {
+        SGX_DBG(DBG_E, "Quoting Enclave returned invalid target info\n");
         goto failed;
     }
 
-    memcpy(aesm_targetinfo, r->targetinfo.data, sizeof(*aesm_targetinfo));
+    memcpy(qe_target_info, r->targetinfo.data, sizeof(*qe_target_info));
     ret = 0;
 failed:
     response__free_unpacked(res, NULL);


### PR DESCRIPTION
## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [x] SGX PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->

Summary of commits in this PR:

- [Pal/Linux-SGX] Rename aesm_targetinfo to qe_targetinfo.
- [Pal/Linux-SGX] sgx_arch.h: Update sgx_report_body_t struct
- [Pal/Linux-SGX] sgx_api.h: Improve comments and fix formatting
- [Pal/Linux-SGX] Introduce generic sgx_get_report() and fix formatting

This PR is the first in the series of Remote Attestation PRs (re-worked #1284). Also see issue #1365.

## How to test this PR? <!-- (if applicable) -->

All tests must pass. This PR is only formatting/renaming.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1366)
<!-- Reviewable:end -->
