### PR TITLE
[Pal/Linux-SGX] Introduce sgx_get_quote() OCALL

### DIFF
--- a/Pal/src/host/Linux-SGX/ecall_types.h
+++ b/Pal/src/host/Linux-SGX/ecall_types.h
@@ -1,3 +1,5 @@
+#include <stddef.h>
+
 enum {
     ECALL_ENCLAVE_START = 0,
     ECALL_THREAD_START,

--- a/Pal/src/host/Linux-SGX/enclave_ocalls.c
+++ b/Pal/src/host/Linux-SGX/enclave_ocalls.c
@@ -2,12 +2,14 @@
  * This is for enclave to make ocalls to untrusted runtime.
  */
 
-#include "pal_linux.h"
-#include "pal_internal.h"
-#include "pal_debug.h"
+#include "ecall_types.h"
 #include "enclave_ocalls.h"
 #include "ocall_types.h"
-#include "ecall_types.h"
+#include "pal_debug.h"
+#include "pal_internal.h"
+#include "pal_linux.h"
+#include "sgx_attest.h"
+
 #include <api.h>
 #include <asm/errno.h>
 
@@ -1296,6 +1298,70 @@ int ocall_eventfd (unsigned int initval, int flags)
 
     retval = sgx_ocall(OCALL_EVENTFD, ms);
 
+    sgx_reset_ustack();
+    return retval;
+}
+
+int ocall_get_quote(const sgx_spid_t* spid, bool linkable, const sgx_report_t* report,
+                    const sgx_quote_nonce_t* nonce, char** quote, size_t* quote_len) {
+    int retval;
+    char* buf  = NULL;
+
+    ms_ocall_get_quote_t* ms = sgx_alloc_on_ustack(sizeof(*ms));
+    if (!ms) {
+        retval = -ENOMEM;
+        goto out;
+    }
+
+    memcpy(&ms->ms_spid, spid, sizeof(*spid));
+    memcpy(&ms->ms_report, report, sizeof(*report));
+    memcpy(&ms->ms_nonce, nonce, sizeof(*nonce));
+    ms->ms_linkable = linkable;
+
+    retval = sgx_ocall(OCALL_GET_QUOTE, ms);
+
+    if (!IS_ERR(retval)) {
+        ms_ocall_get_quote_t ms_copied;
+        if (!sgx_copy_to_enclave(&ms_copied, sizeof(ms_copied), ms, sizeof(*ms))) {
+            retval = -EACCES;
+            goto out;
+        }
+
+        /* copy each field inside and free the out-of-enclave buffers */
+        if (ms_copied.ms_quote) {
+            size_t len = ms_copied.ms_quote_len;
+            if (len > SGX_QUOTE_MAX_SIZE) {
+                retval = -EACCES;
+                goto out;
+            }
+
+            buf = malloc(len);
+            if (!buf) {
+                retval = -ENOMEM;
+                goto out;
+            }
+
+            if (!sgx_copy_to_enclave(buf, len, ms_copied.ms_quote, len)) {
+                retval = -EACCES;
+                goto out;
+            }
+
+            /* for calling ocall_munmap_untrusted(), need to reset the untrusted stack */
+            sgx_reset_ustack();
+
+            retval = ocall_munmap_untrusted(ms_copied.ms_quote, ALLOC_ALIGN_UP(len));
+            if (IS_ERR(retval)) {
+                goto out;
+            }
+
+            *quote     = buf;
+            *quote_len = len;
+        }
+    }
+
+out:
+    if (IS_ERR(retval))
+        free(buf);
     sgx_reset_ustack();
     return retval;
 }

--- a/Pal/src/host/Linux-SGX/enclave_ocalls.h
+++ b/Pal/src/host/Linux-SGX/enclave_ocalls.h
@@ -100,3 +100,20 @@ int ocall_get_attestation(const sgx_spid_t* spid, const char* subkey, bool linka
                           sgx_attestation_t* attestation);
 int ocall_eventfd (unsigned int initval, int flags);
 
+/*!
+ * \brief Execute untrusted code in PAL to obtain a quote from the Quoting Enclave.
+ *
+ * The obtained quote is not validated in any way (i.e., this function does not check whether the
+ * returned quote corresponds to this enclave or whether its contents make sense).
+ *
+ * \param[in]  spid       Software provider ID (SPID).
+ * \param[in]  linkable   Quote type (linkable vs unlinkable).
+ * \param[in]  report     Enclave report to be sent to the Quoting Enclave.
+ * \param[in]  nonce      16B nonce to be included in the quote for freshness.
+ * \param[out] quote      Quote returned by the Quoting Enclave (allocated via malloc() in this
+ *                        function; the caller gets the ownership of the quote).
+ * \param[out] quote_len  Length of the quote returned by the Quoting Enclave.
+ * \return                0 on success, negative Linux error code otherwise.
+ */
+int ocall_get_quote(const sgx_spid_t* spid, bool linkable, const sgx_report_t* report,
+                    const sgx_quote_nonce_t* nonce, char** quote, size_t* quote_len);

--- a/Pal/src/host/Linux-SGX/ocall_types.h
+++ b/Pal/src/host/Linux-SGX/ocall_types.h
@@ -59,6 +59,7 @@ enum {
     OCALL_LOAD_DEBUG,
     OCALL_GET_ATTESTATION,
     OCALL_EVENTFD,
+    OCALL_GET_QUOTE,
     OCALL_NR,
 };
 
@@ -279,5 +280,14 @@ typedef struct {
     unsigned int ms_initval;
     int          ms_flags;
 } ms_ocall_eventfd_t;
+
+typedef struct {
+    sgx_spid_t        ms_spid;
+    bool              ms_linkable;
+    sgx_report_t      ms_report;
+    sgx_quote_nonce_t ms_nonce;
+    char*             ms_quote;
+    size_t            ms_quote_len;
+} ms_ocall_get_quote_t;
 
 #pragma pack(pop)

--- a/Pal/src/host/Linux-SGX/sgx_attest.h
+++ b/Pal/src/host/Linux-SGX/sgx_attest.h
@@ -55,6 +55,26 @@ enum {
 
 #define SGX_QUOTE_MAX_SIZE 2048
 
+/*!
+ * \brief Obtain SGX Quote from the Quoting Enclave (communicate via AESM).
+ *
+ * First create enclave report (sgx_report_t) with target info of the Quoting Enclave, and
+ * then call out of the enclave to request the corresponding Quote from the Quoting Enclave.
+ * Communication is done via AESM service, in the form of protobuf request/response messages.
+ *
+ * \param[in]  spid         Software provider ID (SPID).
+ * \param[in]  nonce        16B nonce to be included in the quote for freshness.
+ * \param[in]  report_data  64B bytestring to be included in the report and the quote.
+ * \param[in]  linkable     Quote type (linkable vs unlinkable).
+ * \param[out] quote        Quote returned by the Quoting Enclave (allocated via malloc() in this
+ *                          function; the caller gets the ownership of the quote).
+ * \param[out] quote_len    Length of the quote returned by the Quoting Enclave.
+ * \return                  0 on success, negative PAL error code otherwise.
+ */
+int sgx_get_quote(const sgx_spid_t* spid, const sgx_quote_nonce_t* nonce,
+                  const sgx_report_data_t* report_data, bool linkable,
+                  char** quote, size_t* quote_len);
+
 #define IAS_REPORT_URL "https://api.trustedservices.intel.com/sgx/dev/attestation/v3/report"
 
 int init_trusted_platform(void);

--- a/Pal/src/host/Linux-SGX/sgx_enclave.c
+++ b/Pal/src/host/Linux-SGX/sgx_enclave.c
@@ -618,6 +618,13 @@ static long sgx_ocall_get_attestation(void* pms) {
                                    &ms->ms_nonce, &ms->ms_attestation);
 }
 
+static long sgx_ocall_get_quote(void* pms) {
+    ms_ocall_get_quote_t* ms = (ms_ocall_get_quote_t*)pms;
+    ODEBUG(OCALL_GET_QUOTE, ms);
+    return retrieve_quote(&ms->ms_spid, ms->ms_linkable, &ms->ms_report, &ms->ms_nonce,
+                          &ms->ms_quote, &ms->ms_quote_len);
+}
+
 sgx_ocall_fn_t ocall_table[OCALL_NR] = {
         [OCALL_EXIT]             = sgx_ocall_exit,
         [OCALL_MMAP_UNTRUSTED]   = sgx_ocall_mmap_untrusted,
@@ -657,6 +664,7 @@ sgx_ocall_fn_t ocall_table[OCALL_NR] = {
         [OCALL_LOAD_DEBUG]       = sgx_ocall_load_debug,
         [OCALL_GET_ATTESTATION]  = sgx_ocall_get_attestation,
         [OCALL_EVENTFD]          = sgx_ocall_eventfd,
+        [OCALL_GET_QUOTE]        = sgx_ocall_get_quote,
     };
 
 #define EDEBUG(code, ms) do {} while (0)

--- a/Pal/src/host/Linux-SGX/sgx_internal.h
+++ b/Pal/src/host/Linux-SGX/sgx_internal.h
@@ -111,6 +111,21 @@ int retrieve_verified_quote(const sgx_spid_t* spid, const char* subkey, bool lin
                             const sgx_report_t* report, const sgx_quote_nonce_t* nonce,
                             sgx_attestation_t* attestation);
 
+/*!
+ * \brief Obtain SGX Quote from the Quoting Enclave (communicate via AESM).
+ *
+ * \param[in]  spid       Software provider ID (SPID).
+ * \param[in]  linkable   Quote type (linkable vs unlinkable).
+ * \param[in]  report     Enclave report to convert into a quote.
+ * \param[in]  nonce      16B nonce to be included in the quote for freshness.
+ * \param[out] quote      Quote returned by the Quoting Enclave (allocated via mmap() in this
+ *                        function; the caller gets the ownership of the quote).
+ * \param[out] quote_len  Length of the quote returned by the Quoting Enclave.
+ * \return                0 on success, negative Linux error code otherwise.
+ */
+int retrieve_quote(const sgx_spid_t* spid, bool linkable, const sgx_report_t* report,
+                   const sgx_quote_nonce_t* nonce, char** quote, size_t* quote_len);
+
 int init_enclave(sgx_arch_secs_t * secs,
                  sgx_arch_enclave_css_t * sigstruct,
                  sgx_arch_token_t * token);


### PR DESCRIPTION
## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [x] SGX PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->

New `sgx_get_quote()` OCALL allows to retrieve the SGX Quote from the Quoting Enclave. The retrieved quote is based on this enclave's SGX report and corresponds to this enclave. The caller of this OCALL may forward the quote to the remote user for remote attestation. A follow-up commit will introduce the actual callers.

This PR is the second in the series of Remote Attestation PRs (re-worked #1284). Also see issue #1365.

It is better to merge it after #1366 (but not necessary).

## How to test this PR? <!-- (if applicable) -->

All tests must pass. Technically, this PR has no tests (the changes introduced here are dead code by themselves) since it is only a prerequisite for the follow-up PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1367)
<!-- Reviewable:end -->
