### PR TITLE
[Pal/Linux-SGX] Make quote struct the same as in SGX SDK

### DIFF
--- a/Pal/src/host/Linux-SGX/enclave_platform.c
+++ b/Pal/src/host/Linux-SGX/enclave_platform.c
@@ -597,12 +597,13 @@ int sgx_verify_platform(sgx_spid_t* spid, const char* subkey, sgx_quote_nonce_t*
         goto failed;
     }
 
-    SGX_DBG(DBG_S, "Quote:\n");
-    SGX_DBG(DBG_S, "  version:    %04x\n", ias_quote->body.version);
-    SGX_DBG(DBG_S, "  sigtype:    %04x\n", ias_quote->body.sigtype);
-    SGX_DBG(DBG_S, "  gid:        %08x\n", ias_quote->body.gid);
-    SGX_DBG(DBG_S, "  isvsvn qe:  %08x\n", ias_quote->body.isvsvn_qe);
-    SGX_DBG(DBG_S, "  isvsvn pce: %08x\n", ias_quote->body.isvsvn_pce);
+    SGX_DBG(DBG_S, "IAS quote:\n");
+    SGX_DBG(DBG_S, "  version:       %04x\n", ias_quote->version);
+    SGX_DBG(DBG_S, "  sign_type:     %04x\n", ias_quote->sign_type);
+    SGX_DBG(DBG_S, "  epid_group_id: %02x%02x%02x%02x\n", ias_quote->epid_group_id[3],
+            ias_quote->epid_group_id[2], ias_quote->epid_group_id[1], ias_quote->epid_group_id[0]);
+    SGX_DBG(DBG_S, "  qe_svn:        %08x\n", ias_quote->qe_svn);
+    SGX_DBG(DBG_S, "  pce_svn:       %08x\n", ias_quote->pce_svn);
 
     SGX_DBG(DBG_S, "IAS report: %s\n", attestation.ias_report);
     SGX_DBG(DBG_S, "  status:    %s\n", ias_status);
@@ -624,8 +625,7 @@ int sgx_verify_platform(sgx_spid_t* spid, const char* subkey, sgx_quote_nonce_t*
     }
 
     // Check if the quote matches the IAS report
-    if (memcmp(&ias_quote->body, &attestation.quote->body, sizeof(sgx_quote_body_t)) ||
-        memcmp(&ias_quote->report_body, &report.body, sizeof(sgx_report_body_t))) {
+    if (memcmp(ias_quote, attestation.quote, SGX_QUOTE_BODY_SIZE)) {
         SGX_DBG(DBG_E, "IAS returned the wrong quote\n");
         goto failed;
     }

--- a/Pal/src/host/Linux-SGX/sgx_attest.h
+++ b/Pal/src/host/Linux-SGX/sgx_attest.h
@@ -22,21 +22,28 @@
 
 #include "sgx_arch.h"
 
-typedef struct {
-    uint16_t version;
-    uint16_t sigtype;
-    uint32_t gid;
-    uint16_t isvsvn_qe;
-    uint16_t isvsvn_pce;
-    uint8_t reserved[4];
-    uint8_t base[32];
-} __attribute__((packed)) sgx_quote_body_t;
+#pragma pack(push, 1)
 
-typedef struct {
-    sgx_quote_body_t body;
+typedef uint8_t sgx_epid_group_id_t[4];
+
+typedef struct _sgx_basename_t {
+    uint8_t name[32];
+} sgx_basename_t;
+
+typedef struct _sgx_quote_t {
+    uint16_t version;
+    uint16_t sign_type;
+    sgx_epid_group_id_t epid_group_id;
+    sgx_isv_svn_t qe_svn;
+    sgx_isv_svn_t pce_svn;
+    uint32_t xeid;
+    sgx_basename_t basename;
     sgx_report_body_t report_body;
-    uint32_t sig_len;
-} __attribute__((packed)) sgx_quote_t;
+    uint32_t signature_len;
+    uint8_t signature[];
+} sgx_quote_t;
+
+#define SGX_QUOTE_BODY_SIZE (offsetof(sgx_quote_t, signature_len))
 
 typedef uint8_t sgx_spid_t[16];
 typedef uint8_t sgx_quote_nonce_t[16];
@@ -62,7 +69,7 @@ typedef struct {
     size_t       ias_sig_len;
     char*        ias_certs;
     size_t       ias_certs_len;
-} __attribute__((packed)) sgx_attestation_t;
+} sgx_attestation_t;
 
 int sgx_verify_platform(sgx_spid_t* spid, const char* subkey, sgx_quote_nonce_t* nonce,
                         sgx_report_data_t* report_data, bool linkable,
@@ -71,5 +78,7 @@ int sgx_verify_platform(sgx_spid_t* spid, const char* subkey, sgx_quote_nonce_t*
                         char** ret_ias_timestamp);
 
 #define HTTPS_REQUEST_MAX_LENGTH 256
+
+#pragma pack(pop)
 
 #endif /* SGX_ATTEST_H */

--- a/Pal/src/host/Linux-SGX/sgx_platform.c
+++ b/Pal/src/host/Linux-SGX/sgx_platform.c
@@ -156,7 +156,7 @@ failed:
 int contact_intel_attest_service(const char* subkey, const sgx_quote_nonce_t* nonce,
                                  const sgx_quote_t* quote, sgx_attestation_t* attestation) {
 
-    size_t quote_len = sizeof(sgx_quote_t) + quote->sig_len;
+    size_t quote_len = sizeof(sgx_quote_t) + quote->signature_len;
     size_t quote_str_len;
     lib_Base64Encode((uint8_t*)quote, quote_len, NULL, &quote_str_len);
     char* quote_str = __alloca(quote_str_len);


### PR DESCRIPTION
## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [x] SGX PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->

This PR makes `sgx_quote_t` definition compatible with the SGX SDK.

## How to test this PR? <!-- (if applicable) -->

Attestation test must pass.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1368)
<!-- Reviewable:end -->
