### PR TITLE
[LibOS,Pal] Force intermediate process to wait for child after execve()

### DIFF
--- a/LibOS/shim/src/shim_init.c
+++ b/LibOS/shim/src/shim_init.c
@@ -1140,6 +1140,12 @@ noreturn void shim_clean_and_exit(int exit_code) {
     shim_stdio = NULL;
     debug("process %u exited with status %d\n", cur_process.vmid & 0xFFFF, cur_process.exit_code);
     MASTER_LOCK();
+
+    if (cur_process.exit_code == PAL_WAIT_FOR_CHILDREN_EXIT) {
+        /* user application specified magic exit code; this should be an extremely rare case */
+        debug("exit status collides with Graphene-internal magic status; changed to 1\n");
+        cur_process.exit_code = 1;
+    }
     DkProcessExit(cur_process.exit_code);
 }
 

--- a/LibOS/shim/src/sys/shim_exec.c
+++ b/LibOS/shim/src/sys/shim_exec.c
@@ -521,14 +521,14 @@ reopen:
         return ret;
     }
 
-    /* This "temporary" process must die quietly, not sending any messages to not confuse the parent
-     * and the execve'ed child */
+    /* this "temporary" process must die quietly, not sending any messages to not confuse the parent
+     * and the execve'ed child, but it must still be around until the child finally exits (because
+     * its parent in turn may wait on it, e.g., `bash -c ls`) */
     debug(
-        "Temporary process %u exited after emulating execve (by forking new process to replace this"
-        " one)\n",
-        cur_process.vmid & 0xFFFF);
+        "Temporary process %u is exiting after emulating execve (by forking new process to replace"
+        " this one); will wait for forked process to exit...\n", cur_process.vmid & 0xFFFF);
     MASTER_LOCK();
-    DkProcessExit(0);
+    DkProcessExit(PAL_WAIT_FOR_CHILDREN_EXIT);
 
     return 0;
 }

--- a/Pal/include/pal/pal.h
+++ b/Pal/include/pal/pal.h
@@ -388,6 +388,17 @@ DkVirtualMemoryProtect (PAL_PTR addr, PAL_NUM size, PAL_FLG prot);
 PAL_HANDLE
 DkProcessCreate (PAL_STR uri, PAL_STR * args);
 
+
+/*!
+ * \brief Magic exit code that instructs the exiting process to wait for its children
+ *
+ * Required for a corner case when the parent exec's the child in a new Graphene process: for
+ * correctness, the parent cannot immediately exit since it may have a parent that waits on it.
+ * If an application by coincidence picks this magic number as its exit code, it is changed to
+ * another exit code so as to not confuse the PAL code.
+ */
+#define PAL_WAIT_FOR_CHILDREN_EXIT (1024 * 1024)
+
 noreturn void
 DkProcessExit (PAL_NUM exitCode);
 

--- a/Pal/src/host/Linux-SGX/sgx_enclave.c
+++ b/Pal/src/host/Linux-SGX/sgx_enclave.c
@@ -1,18 +1,19 @@
-#include "ocall_types.h"
 #include "ecall_types.h"
-#include "sgx_internal.h"
-#include "sgx_enclave.h"
-#include "pal_security.h"
+#include "ocall_types.h"
 #include "pal_linux_error.h"
+#include "pal_security.h"
+#include "sgx_enclave.h"
+#include "sgx_internal.h"
 
-#include <asm/mman.h>
+#include <asm/errno.h>
 #include <asm/ioctls.h>
+#include <asm/mman.h>
 #include <asm/socket.h>
 #include <linux/fs.h>
 #include <linux/in.h>
 #include <linux/in6.h>
 #include <math.h>
-#include <asm/errno.h>
+#include <sys/wait.h>
 
 #define ODEBUG(code, ms) do {} while (0)
 
@@ -20,6 +21,28 @@ static long sgx_ocall_exit(void* pms)
 {
     ms_ocall_exit_t * ms = (ms_ocall_exit_t *) pms;
     ODEBUG(OCALL_EXIT, NULL);
+
+    if (ms->ms_is_exitgroup && ms->ms_exitcode == PAL_WAIT_FOR_CHILDREN_EXIT) {
+        /* this is a "temporary" process exiting after execve'ing a child process: it must still
+         * be around until the child finally exits (because its parent in turn may wait on it) */
+        SGX_DBG(DBG_I, "Temporary process exits after emulating execve, wait for child to exit\n");
+
+        int wstatus;
+        int ret = INLINE_SYSCALL(wait4, 4, /*any child*/-1, &wstatus, /*options=*/0, /*rusage=*/NULL);
+        if (IS_ERR(ret)) {
+            /* it's too late to recover from errors, just log it and set some reasonable exit code */
+            SGX_DBG(DBG_I, "Temporary process waited for child to exit but received error %d\n", ret);
+            ms->ms_exitcode = ECHILD;
+        } else {
+            /* Linux expects 0..127 for normal termination and 128..255 for signal termination */
+            if (WIFEXITED(wstatus))
+                ms->ms_exitcode = WEXITSTATUS(wstatus);
+            else if (WIFSIGNALED(wstatus))
+                ms->ms_exitcode = 128 + WTERMSIG(wstatus);
+            else
+                ms->ms_exitcode = ECHILD;
+        }
+    }
 
     if (ms->ms_exitcode != (int) ((uint8_t) ms->ms_exitcode)) {
         SGX_DBG(DBG_E, "Saturation error in exit code %d, getting rounded down to %u\n",

--- a/Pal/src/host/Linux/db_process.c
+++ b/Pal/src/host/Linux/db_process.c
@@ -43,6 +43,7 @@ typedef __kernel_pid_t pid_t;
 #include <linux/time.h>
 #include <linux/types.h>
 #include <sys/socket.h>
+#include <sys/wait.h>
 
 static inline int create_process_handle (PAL_HANDLE * parent,
                                          PAL_HANDLE * child)
@@ -422,6 +423,25 @@ no_data:
 
 noreturn void _DkProcessExit (int exitcode)
 {
+    if (exitcode == PAL_WAIT_FOR_CHILDREN_EXIT) {
+        /* this is a "temporary" process exiting after execve'ing a child process: it must still
+         * be around until the child finally exits (because its parent in turn may wait on it) */
+        int wstatus;
+        int ret = INLINE_SYSCALL(wait4, 4, /*any child*/-1, &wstatus, /*options=*/0, /*rusage=*/NULL);
+        if (IS_ERR(ret)) {
+            /* it's too late to recover from errors, just set some reasonable exit code */
+            exitcode = ECHILD;
+        } else {
+            /* Linux expects 0..127 for normal termination and 128..255 for signal termination */
+            if (WIFEXITED(wstatus))
+                exitcode = WEXITSTATUS(wstatus);
+            else if (WIFSIGNALED(wstatus))
+                exitcode = 128 + WTERMSIG(wstatus);
+            else
+                exitcode = ECHILD;
+        }
+    }
+
     INLINE_SYSCALL(exit_group, 1, exitcode);
     while (true) {
         /* nothing */;


### PR DESCRIPTION
## Affected components

- [ ] README and global configuration
- [x] Linux PAL
- [x] SGX PAL
- [ ] Common PAL code
- [x] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->

Previously, Graphene emulated execve() by silently terminating the intermediate process and creating a new child one. For example, `bash -c ls` would spawn a new Graphene process with `ls` and exit the unnecessary "intermediate" process `bash`. This deviation from standard execve() behavior resulted in the host shell becoming detached from the Graphene process.

This commit simply forces this intermediate process to wait() until the child terminates. This way the host shell stays attached, and all timings and pipes behave correctly.

Fixes #1364. Also see #1181.

The corresponding PR in graphene-tests is https://github.com/oscarlab/graphene-tests/pull/77.

## How to test this PR? <!-- (if applicable) -->

Bash example (in graphene-tests) was updated to remove `sleep 1`. Note that without this PR, removing `sleep 1` would result in failing check.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1370)
<!-- Reviewable:end -->
