### PR TITLE
[SGX] Add standalone SGX utilities

### DIFF
--- a/Documentation/conf.py
+++ b/Documentation/conf.py
@@ -145,6 +145,10 @@ html_static_path = ['_static']
 # (source start file, name, description, authors, manual section).
 man_pages = [
     ('manpages/pal_loader', 'pal_loader', 'FIXME Loader', [author], 1),
+    ('manpages/is_sgx_available', 'is_sgx_available', 'Check SGX compatibility', [author], 1),
+    ('manpages/quote_dump', 'quote_dump', 'Display SGX quote', [author], 1),
+    ('manpages/ias_request', 'ias_request', 'Submit Intel Attestation Service request', [author], 1),
+    ('manpages/verify_ias_report', 'verify_ias_report', 'Verify Intel Attestation Service report', [author], 1),
 ]
 
 # barf if a page is not included

--- a/Documentation/manpages/ias_request.rst
+++ b/Documentation/manpages/ias_request.rst
@@ -1,0 +1,94 @@
+.. program:: ias_request
+
+==================================================================
+:program:`ias_request` -- Submit Intel Attestation Service request
+==================================================================
+
+Synopsis
+========
+
+:command:`ias_request` *COMMAND* [*OPTION*]...
+
+Description
+===========
+
+`ias_request` submits requests to Intel Attestation Service (IAS).
+Possible commands are retrieving EPID signature revocation list and verifying
+attestation evidence for an SGX enclave quote.
+
+Command line arguments
+======================
+
+General options
+---------------
+
+.. option:: -h, --help
+
+   Display usage.
+
+.. option:: -v, --verbose
+
+   Print more information.
+
+.. option:: -m, --msb
+
+   Print/parse hex strings in big-endian order.
+
+.. option:: -k, --api-key
+
+   IAS API key.
+
+Commands
+--------
+
+.. option:: sigrl
+
+   Retrieve signature revocation list for a given EPID group.
+
+   Possible ``sigrl`` options:
+
+   .. option:: -g, --gid
+
+      EPID group id (hex string).
+
+   .. option:: -i, --sigrl-path
+
+      Path to save retrieved SigRL to.
+
+   .. option:: -S, --sigrl-url
+
+      URL for the IAS SigRL endpoint (optional).
+
+.. option:: report
+
+   Verify attestation evidence (quote).
+
+   Possible ``report`` options:
+
+   .. option:: -q, --quote-path
+
+      Path to quote to submit.
+
+   .. option:: -r, --report-path
+
+      Path to save IAS report to.
+
+   .. option:: -s, --sig-path
+
+      Path to save IAS report's signature to.
+
+   .. option:: -n, --nonce
+
+      Nonce to use (optional).
+
+   .. option:: -c, --cert-path
+
+      Path to save IAS certificate to (optional).
+
+   .. option:: -a, --advisory-path
+
+      Path to save IAS security advisories to (optional).
+
+   .. option:: -R, --report-url
+
+      URL for the IAS attestation report endpoint (optional).

--- a/Documentation/manpages/is_sgx_available.rst
+++ b/Documentation/manpages/is_sgx_available.rst
@@ -1,0 +1,42 @@
+.. program:: is_sgx_available
+
+======================================================================
+:program:`is_sgx_available` -- Check environment for SGX compatibility
+======================================================================
+
+Synopsis
+========
+
+:command:`is_sgx_available` [--quiet]
+
+Description
+===========
+
+`is_sgx_available` checks the CPU and operating system for :term:`SGX`
+compatibility. A detailed report is printed unless suppressed by the
+:option:`--quiet` option.
+
+Command line arguments
+======================
+
+.. option:: --quiet
+
+   Suppress displaying detailed report. See exit status for the result.
+
+Exit status
+===========
+
+0
+   SGX version 1 is available and ready
+
+1
+   No CPU cupport
+
+2
+   No BIOS support
+
+3
+   SGX Platform Software (:term:`PSW`) is not installed
+
+4
+   The ``aesmd`` :term:`PSW` daemon is not running

--- a/Documentation/manpages/quote_dump.rst
+++ b/Documentation/manpages/quote_dump.rst
@@ -1,0 +1,27 @@
+.. program:: quote_dump
+
+====================================================
+:program:`quote_dump` -- Display SGX quote structure
+====================================================
+
+Synopsis
+========
+
+:command:`quote_dump` [*OPTION*]... *FILE*
+
+Description
+===========
+
+`quote_dump` displays internal structure of an :term:`SGX` quote contained
+in *FILE*.
+
+Command line arguments
+======================
+
+.. option:: -h, --help
+
+   Display usage.
+
+.. option:: -m, --msb
+
+   Print hex strings in big-endian order.

--- a/Documentation/manpages/verify_ias_report.rst
+++ b/Documentation/manpages/verify_ias_report.rst
@@ -1,0 +1,72 @@
+.. program:: verify_ias_report
+
+========================================================================
+:program:`verify_ias_report` -- Submit Intel Attestation Service request
+========================================================================
+
+Synopsis
+========
+
+:command:`verify_ias_report` [*OPTION*]...
+
+Description
+===========
+
+`verify_ias_report` verifies attestation report retrieved from the Intel
+Attestation Service (using ``ias_request`` for example). It also verifies
+that the quote contained in the IAS report contains expected values.
+
+Command line arguments
+======================
+
+.. option:: -h, --help
+
+   Display usage.
+
+.. option:: -v, --verbose
+
+   Print more information.
+
+.. option:: -m, --msb
+
+   Print/parse hex strings in big-endian order.
+
+.. option:: -r, --report-path
+
+   IAS report to verify.
+
+.. option:: -s, --sig-path
+
+   Path to the IAS report's signature.
+
+.. option:: -o, --allow-outdated-tcb
+
+   Treat IAS status GROUP_OUT_OF_DATE as OK.
+
+.. option:: -n, --nonce
+
+   Nonce that's expected in the report (optional).
+
+.. option:: -S, --mr-signer
+
+   Expected mr_signer field (hex string, optional).
+
+.. option:: -E, --mr-enclave
+
+   Expected mr_enclave field (hex string, optional).
+
+.. option:: -R, --report-data
+
+   Expected report_data field (hex string, optional).
+
+.. option:: -P, --isv-prod-id
+
+   Expected isv_prod_id field (hex string, optional).
+
+.. option:: -V, --isv-svn
+
+   Expected isv_svn field (hex string, optional).
+
+.. option:: -i, --ias-pubkey
+
+   Path to IAS public RSA key (PEM format, optional).

--- a/LICENSE.addendum.txt
+++ b/LICENSE.addendum.txt
@@ -12,8 +12,10 @@ RSA's MD5 algorithm (LibOS/shim/src/utils/md5.c) - RSA custom attribution licens
 
 Internet Software Consortium (permissive license): Pal/lib/network/inet_pton.c
 
-MIT JOS (mix of MIT and BSD licenses:
+MIT JOS (mix of MIT and BSD licenses):
 * Pal/lib/stdlib/printfmt.c
+
+cJSON - MIT
 
 A number of files taken from other C libraries:
 * musl - MIT

--- a/Pal/lib/Makefile
+++ b/Pal/lib/Makefile
@@ -77,7 +77,7 @@ crypto/mbedtls/CMakeLists.txt: crypto/$(MBEDTLS_SRC) crypto/$(MBEDCRYPTO_SRC)
 	mv crypto/mbed-crypto-mbedcrypto-$(MBEDCRYPTO_VERSION) crypto/mbedtls
 	mv crypto/mbedtls/mbed-crypto-mbedcrypto-3.1.0 crypto/mbedtls/crypto
 	mkdir crypto/mbedtls/install
-	cd crypto/mbedtls && ./scripts/config.pl set MBEDTLS_CMAC_C && make DESTDIR=install install .
+	cd crypto/mbedtls && ./scripts/config.pl set MBEDTLS_CMAC_C && make SHARED=1 DESTDIR=install install .
 	$(RM) crypto/mbedtls/include/mbedtls/config.h
 
 crypto/mbedtls/include/mbedtls/config.h: crypto/config.h crypto/mbedtls/CMakeLists.txt

--- a/Pal/src/host/Linux-SGX/sgx_arch.h
+++ b/Pal/src/host/Linux-SGX/sgx_arch.h
@@ -21,6 +21,7 @@
 
 #ifndef __ASSEMBLER__
 
+#include <stddef.h>
 #include <stdint.h>
 
 #include "assert.h"

--- a/Pal/src/host/Linux-SGX/sgx_attest.h
+++ b/Pal/src/host/Linux-SGX/sgx_attest.h
@@ -18,6 +18,7 @@
 #ifndef SGX_ATTEST_H
 #define SGX_ATTEST_H
 
+#include <stdbool.h>
 #include <stdint.h>
 
 #include "sgx_arch.h"

--- a/Pal/src/host/Linux-SGX/tools/Makefile
+++ b/Pal/src/host/Linux-SGX/tools/Makefile
@@ -1,0 +1,11 @@
+include ../../../../../Scripts/Makefile.configs
+
+targets = all clean distclean install
+
+.PHONY: $(targets)
+$(targets):
+	$(MAKE) -C common $@
+	$(MAKE) -C is-sgx-available $@
+	$(MAKE) -C quote-dump $@
+	$(MAKE) -C ias-request $@
+	$(MAKE) -C verify-ias-report $@

--- a/Pal/src/host/Linux-SGX/tools/README.rst
+++ b/Pal/src/host/Linux-SGX/tools/README.rst
@@ -88,11 +88,11 @@ and for verifying attestation evidence (enclave quote)::
                                 https://api.trustedservices.intel.com/sgx/dev/attestation/v3/sigrl)
     Available report options:
       --quote-path, -q PATH     Path to quote to submit
-      --nonce, -n STRING        Nonce to use (optional)
       --report-path, -r PATH    Path to save IAS report to
       --sig-path, -s PATH       Path to save IAS report's signature to
+      --nonce, -n STRING        Nonce to use (optional)
       --cert-path, -c PATH      Path to save IAS certificate to (optional)
-      --advisory-path, -a PATH  Path to save IAS advisories to (optional)
+      --advisory-path, -a PATH  Path to save IAS security advisories to (optional)
       --report-url, -R URL      URL for the IAS attestation report endpoint (default:
                                 https://api.trustedservices.intel.com/sgx/dev/attestation/v3/report)
 
@@ -133,8 +133,8 @@ that the quote from the report contains expected values::
       --sig-path, -s PATH       Path to the IAS report's signature
       --allow-outdated-tcb, -o  Treat IAS status GROUP_OUT_OF_DATE as OK
       --nonce, -n STRING        Nonce that's expected in the report (optional)
-      --mr-signer, -S STRING    Expected quote MRSIGNER (hex string, optional)
-      --mr-enclave, -E STRING   Expected quote MRENCLAVE (hex string, optional)
+      --mr-signer, -S STRING    Expected mr_signer field (hex string, optional)
+      --mr-enclave, -E STRING   Expected mr_enclave field (hex string, optional)
       --report-data, -R STRING  Expected report_data field (hex string, optional)
       --isv-prod-id, -P NUMBER  Expected isv_prod_id field (uint16_t, optional)
       --isv-svn, -V NUMBER      Expected isv_svn field (uint16_t, optional)

--- a/Pal/src/host/Linux-SGX/tools/README.rst
+++ b/Pal/src/host/Linux-SGX/tools/README.rst
@@ -1,0 +1,160 @@
+SGX tools
+=========
+
+
+SGX availability checker
+------------------------
+
+Example output::
+
+    > ./is_sgx_available/is_sgx_available
+    SGX supported by CPU: true
+    SGX1 (ECREATE, EENTER, ...): true
+    SGX2 (EAUG, EACCEPT, EMODPR, ...): false
+    Flexible Launch Control (IA32_SGXPUBKEYHASH{0..3} MSRs): false
+    SGX extensions for virtualizers (EINCVIRTCHILD, EDECVIRTCHILD, ESETCONTEXT): false
+    Extensions for concurrent memory management (ETRACKC, ELDBC, ELDUC, ERDINFO): false
+    Max enclave size (32-bit): 0x80000000
+    Max enclave size (64-bit): 0x1000000000
+    EPC size: 0x5d80000
+    SGX driver loaded: true
+    SGX PSW/libsgx installed: true
+    AESMD running: false
+
+The program terminates successfully if all SGX1 components are detected and running, otherwise
+the program exits with an error code (see the source code for possible values).
+To suppress printing output use the --quiet argument.
+
+
+SGX quote dump
+--------------
+
+Displays internal structure of an SGX quote::
+
+    Usage: quote_dump [options] <quote path>
+    Available options:
+      --help, -h  Display this help
+      --msb, -m   Display hex strings in big-endian order
+
+    $ quote_dump -m gr.quote
+    version           : 0002
+    sign_type         : 0001
+    epid_group_id     : 00000aef
+    qe_svn            : 0007
+    pce_svn           : 0006
+    xeid              : 00000000
+    basename          : 0000000000000000000000000000000094b929a21f249e5eccb9a5fa33fa5a65
+    report_body       :
+     cpu_svn          : 000000000000000000000201ffff0e08
+     misc_select      : 00000000
+     reserved1        : 000000000000000000000000
+     isv_ext_prod_id  : 00000000000000000000000000000000
+     attributes.flags : 0000000000000007
+     attributes.xfrm  : 000000000000001f
+     mr_enclave       : 4d69102c40401f40a54eb156601be73fb7605db0601845580f036fd284b7b303
+     reserved2        : 0000000000000000000000000000000000000000000000000000000000000000
+     mr_signer        : 14b284525c45c4f526bf1535d05bd88aa73b9e184464f2d97be3dabc0d187b57
+     reserved3        : 0000000000000000000000000000000000000000000000000000000000000000
+     config_id        : 00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+     isv_prod_id      : 0000
+     isv_svn          : 0000
+     config_svn       : 0000
+     reserved4        : 000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+     isv_family_id    : 00000000000000000000000000000000
+     report_data      : 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000004ba476e321e12c720000000000000001
+    signature_len     : 680 (0x2a8)
+    signature         : 2e13c6a3...
+
+
+Intel Attestation Service submitter
+-----------------------------------
+
+Submits requests to Intel Attestation Service (IAS) for retrieving EPID signature revocation lists
+and for verifying attestation evidence (enclave quote)::
+
+    Usage: ias_request <request> [options]
+    Available requests:
+      sigrl                     Retrieve signature revocation list for a given EPID group
+      report                    Verify attestation evidence (quote)
+    Available general options:
+      --help, -h                Display this help
+      --verbose, -v             Enable verbose output
+      --msb, -m                 Print/parse hex strings in big-endian order
+      --api-key, -k STRING      IAS API key
+    Available sigrl options:
+      --gid, -g STRING          EPID group ID (hex string)
+      --sigrl-path, -i PATH     Path to save SigRL to
+      --sigrl-url, -S URL       URL for the IAS SigRL endpoint (default:
+                                https://api.trustedservices.intel.com/sgx/dev/attestation/v3/sigrl)
+    Available report options:
+      --quote-path, -q PATH     Path to quote to submit
+      --nonce, -n STRING        Nonce to use (optional)
+      --report-path, -r PATH    Path to save IAS report to
+      --sig-path, -s PATH       Path to save IAS report's signature to
+      --cert-path, -c PATH      Path to save IAS certificate to (optional)
+      --advisory-path, -a PATH  Path to save IAS advisories to (optional)
+      --report-url, -R URL      URL for the IAS attestation report endpoint (default:
+                                https://api.trustedservices.intel.com/sgx/dev/attestation/v3/report)
+
+Example SigRL retrieval::
+
+    $ ias_request sigrl -k $IAS_API_KEY -g ef0a0000 -i sigrl
+    No SigRL for given EPID group ID ef0a0000
+
+Example quote verification::
+
+    $ ias_request report -k $IAS_API_KEY -q gr.quote -r ias.report -s ias.sig -c ias.cert -a ias.adv -v
+    Verbose output enabled
+    IAS request:
+    {"isvEnclaveQuote":"AgABAO8..."}
+    [...snip curl output...]
+    IAS response: 200
+    IAS report saved to: ias.report
+    IAS report signature saved to: ias.sig
+    IAS certificate saved to: ias.cert
+    IAS advisory saved to: ias.adv
+    IAS submission successful
+    $ cat ias.report
+    {"id":"205146415611480061439763344693868541328","timestamp":"2020-03-20T10:48:32.353294","version":3,"epidPseudonym":"Itmg0 [...]","isvEnclaveQuoteStatus":"GROUP_OUT_OF_DATE" [...]}
+
+
+Intel Attestation Report verifier
+---------------------------------
+
+Verifies attestation report retrieved from IAS (using ``ias_request`` for example). Also verifies
+that the quote from the report contains expected values::
+
+    Usage: verify_ias_report [options]
+    Available options:
+      --help, -h                Display this help
+      --verbose, -v             Enable verbose output
+      --msb, -m                 Print/parse hex strings in big-endian order
+      --report-path, -r PATH    Path to the IAS report
+      --sig-path, -s PATH       Path to the IAS report's signature
+      --allow-outdated-tcb, -o  Treat IAS status GROUP_OUT_OF_DATE as OK
+      --nonce, -n STRING        Nonce that's expected in the report (optional)
+      --mr-signer, -S STRING    Expected quote MRSIGNER (hex string, optional)
+      --mr-enclave, -E STRING   Expected quote MRENCLAVE (hex string, optional)
+      --report-data, -R STRING  Expected report_data field (hex string, optional)
+      --isv-prod-id, -P NUMBER  Expected isv_prod_id field (uint16_t, optional)
+      --isv-svn, -V NUMBER      Expected isv_svn field (uint16_t, optional)
+      --ias-pubkey, -i PATH     Path to IAS public RSA key (PEM format, optional)
+
+Example report verification with all options enabled::
+
+    $ verify_ias_report -v -m -r rp -s sp -i ias.pem -o -n thisisnonce -S 14b284525c45c4f526bf1535d05bd88aa73b9e184464f2d97be3dabc0d187b57 -E 4d69102c40401f40a54eb156601be73fb7605db0601845580f036fd284b7b303 -R 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000004ba476e321e12c720000000000000001 -P 0 -V 0
+    Verbose output enabled
+    Endianness set to MSB
+    Using IAS public key from file 'ias.pem'
+    IAS key: RSA, 2048 bits
+    Decoded IAS signature size: 256 bytes
+    IAS report: signature verified correctly
+    IAS report: allowing quote status GROUP_OUT_OF_DATE
+    IAS report: nonce OK
+    IAS report: quote decoded, size 432 bytes
+    [...quote dump...]
+    Quote: mr_signer OK
+    Quote: mr_enclave OK
+    Quote: isv_prod_id OK
+    Quote: isv_svn OK
+    Quote: report_data OK

--- a/Pal/src/host/Linux-SGX/tools/common/Makefile
+++ b/Pal/src/host/Linux-SGX/tools/common/Makefile
@@ -1,0 +1,47 @@
+include ../../../../../../Scripts/Makefile.configs
+
+CFLAGS += -I../.. \
+          -I../../../../../include/lib \
+          -I../../../../../lib/crypto/mbedtls/install/include \
+          -I../../../../../lib/crypto/mbedtls/crypto/include \
+          -DCRYPTO_USE_MBEDTLS \
+          -D_POSIX_C_SOURCE=200809L \
+          -fPIC
+
+LDFLAGS += -L../../../../../lib/crypto/mbedtls/install/lib
+
+PREFIX ?= /usr/local
+
+.PHONY: all
+all: libsgx_util.so
+
+CJSON_VERSION ?= 1.7.12
+CJSON_SRC ?= v$(CJSON_VERSION).tar.gz
+CJSON_URI ?= https://github.com/DaveGamble/cJSON/archive/
+CJSON_CHECKSUM ?= 760687665ab41a5cff9c40b1053c19572bcdaadef1194e5cba1b5e6f824686e7
+DOWNLOAD_SCRIPT := ../../../../../../Scripts/download
+
+cJSON.c cJSON.h:
+	$(DOWNLOAD_SCRIPT) --output $(CJSON_SRC) --url $(CJSON_URI)/$(CJSON_SRC) --sha256 $(CJSON_CHECKSUM)
+	tar -mxzf $(CJSON_SRC)
+	cp cJSON-$(CJSON_VERSION)/cJSON.c .
+	cp cJSON-$(CJSON_VERSION)/cJSON.h .
+
+attestation.o: cJSON.h
+
+libsgx_util.so: attestation.o cJSON.o ias.o util.o
+	$(CC) $^ $(LDFLAGS) ../../.lib/crypto/adapters/mbedtls_encoding.o -lmbedcrypto -lcurl -shared -o $@
+
+.PHONY: install
+install:
+	install libsgx_util.so ${PREFIX}/lib
+	install ../../../../../lib/crypto/mbedtls/install/lib/libmbedcrypto.so ${PREFIX}/lib
+	ldconfig
+
+.PHONY: clean
+clean:
+	$(RM) *.gz *.o *.so
+
+.PHONY: distclean
+distclean: clean
+	$(RM) -r cJSON-$(CJSON_VERSION) cJSON.c cJSON.h

--- a/Pal/src/host/Linux-SGX/tools/common/attestation.c
+++ b/Pal/src/host/Linux-SGX/tools/common/attestation.c
@@ -1,0 +1,402 @@
+/* Copyright (C) 2018-2020 Invisible Things Lab
+                           Rafal Wojdyla <omeg@invisiblethingslab.com>
+   This file is part of Graphene Library OS.
+   Graphene Library OS is free software: you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public License
+   as published by the Free Software Foundation, either version 3 of the
+   License, or (at your option) any later version.
+   Graphene Library OS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Lesser General Public License for more details.
+   You should have received a copy of the GNU Lesser General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
+
+#include <mbedtls/md.h>
+#include <mbedtls/pk.h>
+#include <stdalign.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "api.h"
+#include "attestation.h"
+#include "cJSON.h"
+#include "pal_crypto.h"
+#include "sgx_arch.h"
+#include "sgx_attest.h"
+#include "util.h"
+
+/*! This is the public RSA key of the IAS (PEM). It's used to verify IAS report signatures. */
+const char* g_ias_public_key_pem =
+"-----BEGIN PUBLIC KEY-----\n"
+"MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAqXot4OZuphR8nudFrAFi\n"
+"aGxxkgma/Es/BA+tbeCTUR106AL1ENcWA4FX3K+E9BBL0/7X5rj5nIgX/R/1ubhk\n"
+"KWw9gfqPG3KeAtIdcv/uTO1yXv50vqaPvE1CRChvzdS/ZEBqQ5oVvLTPZ3VEicQj\n"
+"lytKgN9cLnxbwtuvLUK7eyRPfJW/ksddOzP8VBBniolYnRCD2jrMRZ8nBM2ZWYwn\n"
+"XnwYeOAHV+W9tOhAImwRwKF/95yAsVwd21ryHMJBcGH70qLagZ7Ttyt++qO/6+KA\n"
+"XJuKwZqjRlEtSEz8gZQeFfVYgcwSfo96oSMAzVr7V0L6HSDLRnpb6xxmbPdqNol4\n"
+"tQIDAQAB\n"
+"-----END PUBLIC KEY-----\n";
+
+// TODO: decode some known values (flags etc)
+void display_report_body(const sgx_report_body_t* body) {
+    INFO(" cpu_svn          : ");
+    HEXDUMP(body->cpu_svn);
+    INFO(" misc_select      : ");
+    HEXDUMP(body->misc_select);
+    INFO(" reserved1        : ");
+    HEXDUMP(body->reserved1);
+    INFO(" isv_ext_prod_id  : ");
+    HEXDUMP(body->isv_ext_prod_id);
+    INFO(" attributes.flags : ");
+    HEXDUMP(body->attributes.flags);
+    INFO(" attributes.xfrm  : ");
+    HEXDUMP(body->attributes.xfrm);
+    INFO(" mr_enclave       : ");
+    HEXDUMP(body->mr_enclave);
+    INFO(" reserved2        : ");
+    HEXDUMP(body->reserved2);
+    INFO(" mr_signer        : ");
+    HEXDUMP(body->mr_signer);
+    INFO(" reserved3        : ");
+    HEXDUMP(body->reserved3);
+    INFO(" config_id        : ");
+    HEXDUMP(body->config_id);
+    INFO(" isv_prod_id      : ");
+    HEXDUMP(body->isv_prod_id);
+    INFO(" isv_svn          : ");
+    HEXDUMP(body->isv_svn);
+    INFO(" config_svn       : ");
+    HEXDUMP(body->config_svn);
+    INFO(" reserved4        : ");
+    HEXDUMP(body->reserved4);
+    INFO(" isv_family_id    : ");
+    HEXDUMP(body->isv_family_id);
+    INFO(" report_data      : ");
+    HEXDUMP(body->report_data);
+}
+
+void display_quote(const void* quote_data, size_t quote_size) {
+    if (quote_size < offsetof(sgx_quote_t, signature_len)) {
+        ERROR("Quote size too small\n");
+        return;
+    }
+
+    assert(IS_ALIGNED_PTR_POW2(quote_data, alignof(sgx_quote_t)));
+    sgx_quote_t* quote = (sgx_quote_t*)quote_data;
+    INFO("version           : ");
+    HEXDUMP(quote->version);
+    INFO("sign_type         : ");
+    HEXDUMP(quote->sign_type);
+    INFO("epid_group_id     : ");
+    HEXDUMP(quote->epid_group_id);
+    INFO("qe_svn            : ");
+    HEXDUMP(quote->qe_svn);
+    INFO("pce_svn           : ");
+    HEXDUMP(quote->pce_svn);
+    INFO("xeid              : ");
+    HEXDUMP(quote->xeid);
+    INFO("basename          : ");
+    HEXDUMP(quote->basename);
+    INFO("report_body       :\n");
+    display_report_body(&quote->report_body);
+
+    // quotes from IAS reports are missing signature fields
+    if (quote_size >= sizeof(sgx_quote_t)) {
+        INFO("signature_len     : %d (0x%x)\n", quote->signature_len, quote->signature_len);
+    }
+
+    if (quote_size >= sizeof(sgx_quote_t) + quote->signature_len) {
+        INFO("signature         : ");
+        hexdump_mem(&quote->signature, quote->signature_len);
+        INFO("\n");
+    }
+}
+
+int verify_ias_report(const uint8_t* ias_report, size_t ias_report_size, uint8_t* ias_sig_b64,
+                      size_t ias_sig_b64_size, bool allow_outdated_tcb, const char* nonce,
+                      const char* mrsigner, const char* mrenclave, const char* isv_prod_id,
+                      const char* isv_svn, const char* report_data, const char* ias_pub_key_pem) {
+    mbedtls_pk_context ias_pub_key;
+    int ret = -1;
+    uint8_t* ias_sig = NULL;
+    uint8_t* report_quote = NULL;
+    cJSON* json = NULL;
+
+    // Load the IAS public key
+    mbedtls_pk_init(&ias_pub_key);
+
+    if (!ias_pub_key_pem)
+        ias_pub_key_pem = g_ias_public_key_pem;
+
+    ret = mbedtls_pk_parse_public_key(&ias_pub_key, (const unsigned char*)ias_pub_key_pem,
+                                      strlen(ias_pub_key_pem) + 1);
+    if (ret != 0) {
+        ERROR("Failed to parse IAS public key: %d\n", ret);
+        goto out;
+    }
+
+    DBG("IAS key: %s, %zu bits\n", mbedtls_pk_get_name(&ias_pub_key),
+        mbedtls_pk_get_bitlen(&ias_pub_key));
+
+    if (!mbedtls_pk_can_do(&ias_pub_key, MBEDTLS_PK_RSA)) {
+        ret = -1;
+        ERROR("IAS public key is not an RSA key\n");
+        goto out;
+    }
+
+    size_t ias_sig_size = 0;
+
+    // Drop trailing newlines
+    if (ias_sig_b64_size == 0) {
+        ret = -1;
+        ERROR("Invalid signature size\n");
+        goto out;
+    }
+
+    while (ias_sig_b64[ias_sig_b64_size - 1] == '\n' || ias_sig_b64[ias_sig_b64_size - 1] == '\r')
+        ias_sig_b64[--ias_sig_b64_size] = '\0';
+
+    ret = lib_Base64Decode((const char*)ias_sig_b64, ias_sig_b64_size, NULL, &ias_sig_size);
+    if (ret != 0) {
+        ERROR("Failed to base64-decode IAS signature\n");
+        goto out;
+    }
+
+    ias_sig = malloc(ias_sig_size);
+    if (!ias_sig) {
+        ret = -1;
+        ERROR("No memory\n");
+        goto out;
+    }
+
+    ret = lib_Base64Decode((const char*)ias_sig_b64, ias_sig_b64_size, ias_sig, &ias_sig_size);
+    if (ret != 0) {
+        ERROR("Failed to base64-decode IAS signature\n");
+        goto out;
+    }
+
+    DBG("Decoded IAS signature size: %zu bytes\n", ias_sig_size);
+
+    // Calculate report hash
+    uint8_t report_hash[32];
+    ret = mbedtls_md(mbedtls_md_info_from_type(MBEDTLS_MD_SHA256), (const unsigned char*)ias_report,
+                     ias_report_size, report_hash);
+    if (ret != 0) {
+        ERROR("Failed to compute IAS report hash: %d\n", ret);
+        goto out;
+    }
+
+    // Verify signature
+    ret = mbedtls_pk_verify(&ias_pub_key, MBEDTLS_MD_SHA256, (const unsigned char*)report_hash,
+                            sizeof(report_hash), ias_sig, ias_sig_size);
+    if (ret != 0) {
+        ERROR("Failed to verify IAS report signature: %d\n", ret);
+        goto out;
+    }
+
+    INFO("IAS report: signature verified correctly\n");
+
+    // Check quote status
+    ret = -1;
+    json = cJSON_Parse((const char*)ias_report);
+    if (!json) {
+        ERROR("Failed to parse IAS report\n");
+        goto out;
+    }
+
+    cJSON* node = cJSON_GetObjectItem(json, "isvEnclaveQuoteStatus");
+    if (!node) {
+        ERROR("IAS report: failed to read quote status\n");
+        goto out;
+    }
+
+    if (node->type != cJSON_String) {
+        ERROR("IAS report: quote status is not a string\n");
+        goto out;
+    }
+
+    if (strcmp("OK", node->valuestring) == 0) {
+        ret = 0;
+        INFO("IAS report: quote status OK\n");
+    } else if (allow_outdated_tcb && strcmp("GROUP_OUT_OF_DATE", node->valuestring) == 0) {
+        ret = 0;
+        INFO("IAS report: allowing quote status GROUP_OUT_OF_DATE\n");
+    }
+
+    if (ret != 0) {
+        ERROR("IAS report: quote status is not OK (%s)\n", node->valuestring);
+        goto out;
+    }
+
+    ret = -1;
+    // Verify nonce if required
+    if (nonce) {
+        cJSON* node = cJSON_GetObjectItem(json, "nonce");
+        if (!node) {
+            ERROR("IAS report: failed to read nonce\n");
+            goto out;
+        }
+
+        if (node->type != cJSON_String) {
+            ERROR("IAS report: nonce is not a string\n");
+            goto out;
+        }
+
+        if (strcmp(nonce, node->valuestring) != 0) {
+            ERROR("IAS report: invalid nonce '%s', expected '%s'\n", node->valuestring, nonce);
+            goto out;
+        }
+
+        DBG("IAS report: nonce OK\n");
+    }
+
+    // Extract quote from the report
+    node = cJSON_GetObjectItem(json, "isvEnclaveQuoteBody");
+    if (!node) {
+        ERROR("IAS report: failed to get quote\n");
+        goto out;
+    }
+
+    if (node->type != cJSON_String) {
+        ERROR("IAS report: quote is not a string\n");
+        goto out;
+    }
+
+    size_t quote_size = 0;
+    ret = lib_Base64Decode(node->valuestring, strlen(node->valuestring), NULL, &quote_size);
+    if (ret != 0) {
+        ERROR("IAS report: failed to decode report quote\n");
+        goto out;
+    }
+
+    report_quote = malloc(quote_size);
+    if (!report_quote) {
+        ret = -1;
+        ERROR("No memory\n");
+        goto out;
+    }
+
+    ret = lib_Base64Decode(node->valuestring, strlen(node->valuestring), report_quote, &quote_size);
+    if (ret != 0) {
+        ERROR("IAS report: failed to decode report quote\n");
+        goto out;
+    }
+
+    DBG("IAS report: quote decoded, size %zu bytes\n", quote_size);
+    ret = verify_quote(report_quote, quote_size, mrsigner, mrenclave, isv_prod_id, isv_svn,
+                       report_data);
+
+out:
+    if (json)
+        cJSON_Delete(json);
+    mbedtls_pk_free(&ias_pub_key);
+    free(report_quote);
+    free(ias_sig);
+    return ret ? -1 : 0;
+}
+
+int verify_quote(const void* quote_data, size_t quote_size, const char* mr_signer,
+                 const char* mr_enclave, const char* isv_prod_id, const char* isv_svn,
+                 const char* report_data) {
+    int ret = -1;
+
+    assert(IS_ALIGNED_PTR_POW2(quote_data, alignof(sgx_quote_t)));
+    sgx_quote_t* quote = (sgx_quote_t*)quote_data;
+
+    // Quote contained in the IAS report doesn't contain signature_len and signature fields
+    // Reject any smaller quotes as invalid
+    size_t ias_quote_size = offsetof(sgx_quote_t, signature_len);
+    if (quote_size < ias_quote_size) {
+        ERROR("Quote: Bad size %zu < %zu\n", quote_size, ias_quote_size);
+        goto out;
+    }
+
+    if (get_verbose())
+        display_quote(quote_data, quote_size);
+
+    sgx_report_body_t* body = &quote->report_body;
+
+    sgx_measurement_t expected_mr;
+    if (mr_signer) {
+        if (parse_hex(mr_signer, &expected_mr, sizeof(expected_mr)) != 0)
+            goto out;
+
+        if (memcmp(&body->mr_signer, &expected_mr, sizeof(expected_mr)) != 0) {
+            ERROR("Quote: mr_signer doesn't match the expected value\n");
+            if (get_verbose()) {
+                ERROR("Quote mr_signer:\n");
+                HEXDUMP(body->mr_signer);
+                ERROR("Expected mr_signer:\n");
+                HEXDUMP(expected_mr);
+                goto out;
+            }
+        }
+
+        DBG("Quote: mr_signer OK\n");
+    }
+
+    if (mr_enclave) {
+        if (parse_hex(mr_enclave, &expected_mr, sizeof(expected_mr)) != 0)
+            goto out;
+
+        if (memcmp(&body->mr_enclave, &expected_mr, sizeof(expected_mr)) != 0) {
+            ERROR("Quote: mr_enclave doesn't match the expected value\n");
+            if (get_verbose()) {
+                ERROR("Quote mr_enclave:\n");
+                HEXDUMP(body->mr_enclave);
+                ERROR("Expected mr_enclave:\n");
+                HEXDUMP(expected_mr);
+                goto out;
+            }
+        }
+
+        DBG("Quote: mr_enclave OK\n");
+    }
+
+    // Product ID must match, security version must be greater or equal
+    if (isv_prod_id) {
+        sgx_prod_id_t prod_id = strtoul(isv_prod_id, NULL, 10);
+
+        if (body->isv_prod_id != prod_id) {
+            ERROR("Quote: invalid isv_prod_id (%u, expected %u)\n", body->isv_prod_id, prod_id);
+            goto out;
+        }
+
+        DBG("Quote: isv_prod_id OK\n");
+    }
+
+    if (isv_svn) {
+        sgx_isv_svn_t svn = strtoul(isv_svn, NULL, 10);
+
+        if (body->isv_svn < svn) {
+            ERROR("Quote: invalid isv_svn (%u < expected %u)\n", body->isv_svn, svn);
+            goto out;
+        }
+
+        DBG("Quote: isv_svn OK\n");
+    }
+
+    if (report_data) {
+        sgx_report_data_t rd;
+        if (parse_hex(report_data, &rd, sizeof(rd)) != 0)
+            goto out;
+
+        if (memcmp(&body->report_data, &rd, sizeof(rd)) != 0) {
+            ERROR("Quote: report_data doesn't match the expected value\n");
+            if (get_verbose()) {
+                ERROR("Quote report_data:\n");
+                HEXDUMP(body->report_data);
+                ERROR("Expected report_data:\n");
+                HEXDUMP(rd);
+            }
+        }
+
+        DBG("Quote: report_data OK\n");
+    }
+
+    ret = 0;
+    // TODO: KSS support (isv_ext_prod_id, config_id, config_svn, isv_family_id)
+out:
+    return ret;
+}

--- a/Pal/src/host/Linux-SGX/tools/common/attestation.h
+++ b/Pal/src/host/Linux-SGX/tools/common/attestation.h
@@ -1,0 +1,82 @@
+/* Copyright (C) 2018-2020 Invisible Things Lab
+                           Rafal Wojdyla <omeg@invisiblethingslab.com>
+   This file is part of Graphene Library OS.
+   Graphene Library OS is free software: you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public License
+   as published by the Free Software Foundation, either version 3 of the
+   License, or (at your option) any later version.
+   Graphene Library OS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Lesser General Public License for more details.
+   You should have received a copy of the GNU Lesser General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
+
+#ifndef ATTESTATION_H
+#define ATTESTATION_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "sgx_arch.h"
+
+/*!
+ *  \brief Display internal SGX quote structure.
+ *
+ *  \param[in] quote_data Buffer with quote data. This can be a full quote (sgx_quote_t)
+ *                        or a quote from IAS attestation report (which is missing signature
+ *                        fields).
+ *  \param[in] quote_size Size of \a quote_data in bytes.
+ */
+void display_quote(const void* quote_data, size_t quote_size);
+
+/*!
+ *  \brief Display internal SGX report body structure (sgx_report_body_t).
+ *
+ *  \param[in] body Buffer with report body data.
+ */
+void display_report_body(const sgx_report_body_t* body);
+
+/*!
+ *  \brief Verify IAS attestation report. Also verify that the quote contained in IAS report
+ *         is valid and matches expected values.
+ *
+ *  \param[in] ias_report         IAS attestation verification report.
+ *  \param[in] ias_report_size    Size of \a ias_report in bytes.
+ *  \param[in] ias_sig_b64        IAS report signature (base64-encoded as returned by IAS).
+ *  \param[in] ias_sig_b64_size   Size of \a ias_sig_b64 in bytes.
+ *  \param[in] allow_outdated_tcb Treat IAS status GROUP_OUT_OF_DATE as OK.
+ *  \param[in] nonce              (Optional) Nonce that's expected in the report.
+ *  \param[in] mr_signer          (Optional) Expected mr_signer quote field (hex string).
+ *  \param[in] mr_enclave         (Optional) Expected mr_enclave quote field (hex string).
+ *  \param[in] isv_prod_id        (Optional) Expected isv_prod_id quote field (decimal string).
+ *  \param[in] isv_svn            (Optional) Expected isv_svn quote field (decimal string).
+ *  \param[in] report_data        (Optional) Expected report_data quote field (hex string).
+ *  \param[in] ias_pub_key_pem    (Optional) IAS public RSA key (PEM format, NULL-terminated).
+ *                                If not specified, a hardcoded Intel's key is used.
+ *
+ *  \return 0 on successful verification, negative value on error.
+ */
+int verify_ias_report(const uint8_t* ias_report, size_t ias_report_size, uint8_t* ias_sig_b64,
+                      size_t ias_sig_b64_size, bool allow_outdated_tcb, const char* nonce,
+                      const char* mrsigner, const char* mrenclave, const char* isv_prod_id,
+                      const char* isv_svn, const char* report_data, const char* ias_pub_key_pem);
+
+/*!
+ *  \brief Verify that the provided SGX quote contains expected values.
+ *
+ *  \param[in] quote_data  Quote to verify.
+ *  \param[in] quote_size  Size of \a quote_data in bytes.
+ *  \param[in] mr_signer   (Optional) Expected mr_signer quote field (hex string).
+ *  \param[in] mr_enclave  (Optional) Expected mr_enclave quote field (hex string).
+ *  \param[in] isv_prod_id (Optional) Expected isv_prod_id quote field (decimal string).
+ *  \param[in] isv_svn     (Optional) Expected isv_svn quote field (decimal string).
+ *  \param[in] report_data (Optional) Expected report_data quote field (hex string).
+ *
+ *  \return 0 on successful verification, negative value on error.
+ */
+int verify_quote(const void* quote_data, size_t quote_size, const char* mr_signer,
+                 const char* mr_enclave, const char* isv_prod_id, const char* isv_svn,
+                 const char* report_data);
+
+#endif /* ATTESTATION_H */

--- a/Pal/src/host/Linux-SGX/tools/common/ias.c
+++ b/Pal/src/host/Linux-SGX/tools/common/ias.c
@@ -1,0 +1,536 @@
+/* Copyright (C) 2018-2020 Invisible Things Lab
+                           Rafal Wojdyla <omeg@invisiblethingslab.com>
+   This file is part of Graphene Library OS.
+   Graphene Library OS is free software: you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public License
+   as published by the Free Software Foundation, either version 3 of the
+   License, or (at your option) any later version.
+   Graphene Library OS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Lesser General Public License for more details.
+   You should have received a copy of the GNU Lesser General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
+
+#include <assert.h>
+#include <ctype.h>
+#include <curl/curl.h>
+#include <errno.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <strings.h>
+
+#include "pal_crypto.h"
+#include "util.h"
+
+#define CURL_FAIL(action, ret)                                                     \
+    (((ret) == CURLE_OK) ? false :                                                 \
+        ({                                                                         \
+            ERROR("curl call (%s) failed: %s\n", action, curl_easy_strerror(ret)); \
+            true;                                                                  \
+        }))
+
+/*! Context used in ias_*() calls */
+struct ias_context_t {
+    CURL* curl;                 /*!< CURL context for this session */
+    const char* ias_verify_url; /*!< URL for IAS attestation verification API */
+    const char* ias_sigrl_url;  /*!< URL for IAS "Retrieve SigRL" API */
+    struct curl_slist* headers; /*!< Request headers sent to IAS */
+};
+
+/*! IAS response with attestation evidence or signature revocation list */
+struct ias_request_resp {
+    char* signature;          /*!< X-IASReport-Signature data, NULL terminated string */
+    size_t signature_size;    /*!< size of \a signature string */
+    char* certificate;        /*!< x-iasreport-signing-certificate data, NULL terminated string */
+    size_t certificate_size;  /*!< size of \a certificate string */
+    char* advisory_url;       /*!< Advisory-URL data, NULL terminated string */
+    size_t advisory_url_size; /*!< size of \a advisory_url string */
+    char* advisory_ids;       /*!< Advisory-IDs data, NULL terminated string */
+    size_t advisory_ids_size; /*!< size of \a advisory_ids string */
+    char* data;               /*!< response data */
+    size_t data_size;         /*!< size of \a data field */
+};
+
+/*!
+ *  \brief Decode %-sequences ("URL encoding")
+ *
+ *  \param[in]  src NULL-terminated URL-encoded input.
+ *  \param[out] dst Buffer to write decoded output to. Can be the same as \a src.
+ */
+void urldecode(const char* src, char* dst) {
+    char a, b;
+    while (*src) {
+        if (*src == '%' && (a = src[1]) && (b = src[2]) && isxdigit(a) && isxdigit(b)) {
+            if (a >= 'a')
+                a -= 'a'-'A';
+
+            if (a >= 'A')
+                a -= ('A' - 10);
+            else
+                a -= '0';
+
+            if (b >= 'a')
+                b -= 'a'-'A';
+
+            if (b >= 'A')
+                b -= ('A' - 10);
+            else
+                b -= '0';
+
+            *dst++ = 16 * a + b;
+            src += 3;
+        } else if (*src == '+') {
+            *dst++ = ' ';
+            src++;
+        } else {
+            *dst++ = *src++;
+        }
+    }
+    *dst++ = '\0';
+}
+
+/*!
+ * \brief Parse response headers to get report signature and other metadata.
+ *
+ * \param[in] buffer  Single HTTP header.
+ * \param[in] size    Together with \a count a size of \a buffer.
+ * \param[in] count   Size of \a buffer, in \a size units.
+ * \param[in] context User data pointer (ias_request_resp).
+ * \return \a size * \a count
+ *
+ * \details See cURL documentation at
+ *          https://curl.haxx.se/libcurl/c/CURLOPT_HEADERFUNCTION.html
+ */
+static size_t header_callback(char* buffer, size_t size, size_t count, void* context) {
+    const char* sig_hdr = "x-iasreport-signature: "; // header containing IAS signature
+    const char* cert_hdr = "x-iasreport-signing-certificate: "; // header containing IAS certificate
+    const char* adv_url_hdr = "Advisory-URL: "; // header containing URL to IAS security advisories
+    const char* adv_ids_hdr = "Advisory-IDs: "; // header containing security advisory IDs
+    size_t total_size = size * count;
+    struct ias_request_resp* resp_data = context;
+    char** save_to;
+    size_t* save_to_size;
+    size_t hdr_len;
+
+    assert(context);
+
+    if (!strncasecmp(buffer, sig_hdr, strlen(sig_hdr))) {
+        save_to = &resp_data->signature;
+        save_to_size = &resp_data->signature_size;
+        hdr_len = strlen(sig_hdr);
+    } else if (!strncasecmp(buffer, cert_hdr, strlen(cert_hdr))) {
+        save_to = &resp_data->certificate;
+        save_to_size = &resp_data->certificate_size;
+        hdr_len = strlen(cert_hdr);
+    } else if (!strncasecmp(buffer, adv_url_hdr, strlen(adv_url_hdr))) {
+        save_to = &resp_data->advisory_url;
+        save_to_size = &resp_data->advisory_url_size;
+        hdr_len = strlen(adv_url_hdr);
+    } else if (!strncasecmp(buffer, adv_ids_hdr, strlen(adv_ids_hdr))) {
+        save_to = &resp_data->advisory_ids;
+        save_to_size = &resp_data->advisory_ids_size;
+        hdr_len = strlen(adv_ids_hdr);
+    } else {
+        /* don't save */
+        return total_size;
+    }
+
+    /* keep only last value */
+    if (*save_to) {
+        free(*save_to);
+    }
+    *save_to = strndup(buffer + hdr_len, total_size - hdr_len);
+
+    if (!*save_to) {
+        ERROR("Out of memory\n");
+        exit(-ENOMEM); // no way to gracefully recover
+    }
+    *save_to_size = total_size - hdr_len;
+
+    /* drop already stored data - seeing headers after some data means it's additional response
+     * - store only the last one */
+    if (resp_data->data) {
+        free(resp_data->data);
+        resp_data->data = NULL;
+        resp_data->data_size = 0;
+    }
+
+    return total_size;
+}
+
+/*!
+ * \brief Add HTTP body chunk to internal buffer.
+ *
+ * \param[in] buffer  Chunk containing HTTP body.
+ * \param[in] size    Together with \a count a size of \a buffer.
+ * \param[in] count   Size of \a buffer, in \a size units.
+ * \param[in] context User data pointer (ias_request_resp).
+ * \return \a size * \a count
+ *
+ * \details See cURL documentation at
+ *          https://curl.haxx.se/libcurl/c/CURLOPT_WRITEFUNCTION.html
+ */
+static size_t body_callback(char* buffer, size_t size, size_t count, void* context) {
+    size_t total_size = size * count;
+    struct ias_request_resp* resp_data = context;
+
+    assert(context);
+
+    /* make space for the data, plus terminating \0 */
+    resp_data->data = realloc(resp_data->data, resp_data->data_size + total_size + 1);
+    if (!resp_data->data) {
+        ERROR("Out of memory\n");
+        exit(-ENOMEM); // no way to gracefully recover
+    }
+
+    /* append the data (buffer) to resp_data->data */
+    memcpy(resp_data->data + resp_data->data_size, buffer, total_size);
+    resp_data->data_size += total_size;
+
+    /* add terminating \0, but don't count it in resp_data->data_size to ease appending next chunk */
+    resp_data->data[resp_data->data_size] = '\0';
+
+    return total_size;
+}
+
+struct ias_context_t* ias_init(const char* ias_api_key, const char* ias_verify_url,
+                               const char* ias_sigrl_url) {
+    int ret = -1;
+    struct ias_context_t* context = NULL;
+    const char* api_key_hdr_start = "Ocp-Apim-Subscription-Key: ";
+    char* api_key_hdr = NULL;
+    size_t api_key_hdr_size;
+
+    // can be called multiple times
+    CURLcode curl_ret = curl_global_init(CURL_GLOBAL_ALL);
+    if (CURL_FAIL("global cURL init", curl_ret))
+        goto out;
+
+    context = calloc(1, sizeof(*context));
+    if (!context)
+        goto out;
+
+    context->curl = curl_easy_init();
+    if (!context->curl || !ias_api_key)
+        goto out;
+
+    api_key_hdr_size = strlen(api_key_hdr_start) + strlen(ias_api_key) + 1;
+    api_key_hdr = malloc(api_key_hdr_size);
+    if (!api_key_hdr)
+        goto out;
+    snprintf(api_key_hdr, api_key_hdr_size, "%s%s", api_key_hdr_start, ias_api_key);
+
+    // set IAS URLs
+    context->ias_verify_url = ias_verify_url;
+    context->ias_sigrl_url = ias_sigrl_url;
+
+    if (get_verbose())
+        curl_easy_setopt(context->curl, CURLOPT_VERBOSE, 1L);
+
+    // IAS requires TLS 1.2 minimum
+    curl_ret = curl_easy_setopt(context->curl, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1_2);
+    if (CURL_FAIL("set CURLOPT_SSLVERSION", curl_ret))
+        goto out;
+
+    curl_ret = curl_easy_setopt(context->curl, CURLOPT_SSL_VERIFYPEER, 1L);
+    if (CURL_FAIL("set CURLOPT_SSL_VERIFYPEER", curl_ret))
+        goto out;
+
+    // set IAS API key in headers
+    context->headers = curl_slist_append(context->headers, api_key_hdr);
+
+    // set Content-Type header (required)
+    context->headers = curl_slist_append(context->headers, "Content-Type: application/json");
+    curl_ret = curl_easy_setopt(context->curl, CURLOPT_HTTPHEADER, context->headers);
+    if (CURL_FAIL("set CURLOPT_HTTPHEADER", curl_ret))
+        goto out;
+
+    // callbacks to store response and headers (headers contain IAS report signature)
+    curl_ret = curl_easy_setopt(context->curl, CURLOPT_HEADERFUNCTION, header_callback);
+    if (CURL_FAIL("set CURLOPT_HEADERFUNCTION", curl_ret))
+        goto out;
+
+    curl_ret = curl_easy_setopt(context->curl, CURLOPT_WRITEFUNCTION, body_callback);
+    if (CURL_FAIL("set CURLOPT_WRITEFUNCTION", curl_ret))
+        goto out;
+
+    ret = 0;
+out:
+    free(api_key_hdr);
+    if (ret != 0) {
+        free(context);
+        context = NULL;
+    }
+
+    return context;
+}
+
+void ias_cleanup(struct ias_context_t* context) {
+    assert(context);
+
+    if (context->headers)
+        curl_slist_free_all(context->headers);
+
+    curl_easy_cleanup(context->curl);
+    free(context);
+
+    // every curl_global_init() must have a corresponding curl_global_cleanup()
+    curl_global_cleanup();
+}
+
+int ias_get_sigrl(struct ias_context_t* context, uint8_t gid[4], size_t* sigrl_size, void** sigrl) {
+    struct ias_request_resp* ias_resp = NULL;
+    int ret = -1;
+    long response_code;
+    char* url = NULL;
+    size_t url_size = 0;
+    CURLcode curl_ret;
+
+    ias_resp = calloc(1, sizeof(*ias_resp));
+    if (!ias_resp)
+        goto out;
+
+    /* format request URL */
+    url_size = strlen(context->ias_sigrl_url) + 1 + 8 + 1; /* slash, 8 chars for gid, NULL */
+    url = malloc(url_size);
+    if (!url)
+        goto out;
+
+    /* gid must be big-endian */
+    snprintf(url, url_size, "%s/%02x%02x%02x%02x", context->ias_sigrl_url, gid[3], gid[2],
+             gid[1], gid[0]);
+
+    DBG("IAS URL: %s\n", url);
+
+    curl_ret = curl_easy_setopt(context->curl, CURLOPT_URL, url);
+    if (CURL_FAIL("set CURLOPT_URL", curl_ret))
+        goto out;
+
+    /* disable POST for curl */
+    curl_ret = curl_easy_setopt(context->curl, CURLOPT_POST, 0L);
+    if (CURL_FAIL("set CURLOPT_POST", curl_ret))
+        goto out;
+
+    /* place to store result */
+    curl_ret = curl_easy_setopt(context->curl, CURLOPT_HEADERDATA, ias_resp);
+    if (CURL_FAIL("set CURLOPT_HEADERDATA", curl_ret))
+        goto out;
+
+    curl_ret = curl_easy_setopt(context->curl, CURLOPT_WRITEDATA, ias_resp);
+    if (CURL_FAIL("set CURLOPT_WRITEDATA", curl_ret))
+        goto out;
+
+    /* perform the request, callbacks will store result in ias_resp */
+    curl_ret = curl_easy_perform(context->curl);
+    if (CURL_FAIL("SigRL IAS request", curl_ret))
+        goto out;
+
+    curl_ret = curl_easy_getinfo(context->curl, CURLINFO_RESPONSE_CODE, &response_code);
+    if (CURL_FAIL("get response", curl_ret))
+        goto out;
+
+    if (response_code != 200) {
+        ERROR("SigRL IAS request failed: code %ld\n", response_code);
+        goto out;
+    }
+
+    /* SigRL is base64-encoded, decode if not empty. */
+    *sigrl_size = 0;
+    if (ias_resp->data) {
+        lib_Base64Decode(ias_resp->data, strlen(ias_resp->data), NULL, sigrl_size);
+        *sigrl = malloc(*sigrl_size);
+        if (!*sigrl) {
+            ERROR("No memory\n");
+            goto out;
+        }
+
+        lib_Base64Decode(ias_resp->data, strlen(ias_resp->data), *sigrl, sigrl_size);
+        if (!*sigrl_size) {
+            ERROR("Failed to base64-decode SigRL\n");
+            goto out;
+        }
+    }
+    ret = 0;
+
+out:
+    free(url);
+    if (ias_resp) {
+        free(ias_resp->data);
+        free(ias_resp);
+    }
+
+    return ret;
+}
+
+int ias_verify_quote(struct ias_context_t* context, const void* quote, size_t quote_size,
+                     const char* nonce, const char* report_path, const char* sig_path,
+                     const char* cert_path, const char* advisory_path) {
+    struct ias_request_resp ias_resp = { 0 };
+    int ret = -1;
+    long response_code;
+    char* quote_b64 = NULL;
+    size_t quote_b64_size = 0;
+    char* quote_json = NULL;
+    size_t quote_json_size = 0;
+    const char* json_fmt = nonce ? "{\"isvEnclaveQuote\":\"%s\",\"nonce\":\"%s\"}" :
+                                   "{\"isvEnclaveQuote\":\"%s\"}";
+
+    if (nonce && strlen(nonce) > 32) {
+        ERROR("Nonce too long\n");
+        goto out;
+    }
+
+    /* get needed base64 buffer size */
+    ret = lib_Base64Encode(quote, quote_size, NULL, &quote_b64_size);
+    if (ret < 0) {
+        ERROR("Failed to base64 encode the quote\n");
+        goto out;
+    }
+
+    quote_b64 = malloc(quote_b64_size);
+    ret = lib_Base64Encode(quote, quote_size, quote_b64, &quote_b64_size);
+    if (ret < 0) {
+        ERROR("Failed to base64 encode the quote\n");
+        goto out;
+    }
+
+    /* this is not exactly accurate but should always be enough for the json string */
+    quote_json_size = quote_b64_size + strlen(json_fmt);
+    if (nonce)
+        quote_json_size += strlen(nonce);
+
+    quote_json = malloc(quote_json_size);
+    if (!quote_json) {
+        ERROR("Failed to allocate memory for IAS request\n");
+        goto out;
+    }
+
+    if (nonce)
+        snprintf(quote_json, quote_json_size, json_fmt, quote_b64, nonce);
+    else
+        snprintf(quote_json, quote_json_size, json_fmt, quote_b64);
+
+    DBG("IAS request:\n%s\n", quote_json);
+
+    CURLcode curl_ret;
+    ret = -1;
+
+    /* request URL */
+    curl_ret = curl_easy_setopt(context->curl, CURLOPT_URL, context->ias_verify_url);
+    if (CURL_FAIL("set CURLOPT_URL", curl_ret))
+        goto out;
+
+    /* request data */
+    curl_ret = curl_easy_setopt(context->curl, CURLOPT_POSTFIELDS, quote_json);
+    if (CURL_FAIL("set CURLOPT_POSTFIELDS", curl_ret))
+        goto out;
+
+    /* place to store result */
+    curl_ret = curl_easy_setopt(context->curl, CURLOPT_HEADERDATA, &ias_resp);
+    if (CURL_FAIL("set CURLOPT_HEADERDATA", curl_ret))
+        goto out;
+
+    curl_ret = curl_easy_setopt(context->curl, CURLOPT_WRITEDATA, &ias_resp);
+    if (CURL_FAIL("set CURLOPT_WRITEDATA", curl_ret))
+        goto out;
+
+    /* perform the request, callbacks will store result in ias_resp */
+    curl_ret = curl_easy_perform(context->curl);
+    if (CURL_FAIL("Attestation IAS request", curl_ret))
+        goto out;
+
+    curl_ret = curl_easy_getinfo(context->curl, CURLINFO_RESPONSE_CODE, &response_code);
+    if (CURL_FAIL("get response", curl_ret))
+        goto out;
+
+    if (response_code != 200) {
+        ERROR("Attestation IAS request failed: code %ld\n", response_code);
+        goto out;
+    }
+
+    DBG("IAS response: %ld\n", response_code);
+
+    if (!ias_resp.signature || !ias_resp.data) {
+        /* XXX should it be fatal? */
+        ERROR("IAS response: missing headers or data\n");
+        goto out;
+    }
+
+    if (report_path) {
+        ret = write_file(report_path, ias_resp.data_size, ias_resp.data);
+        if (ret != 0) {
+            ERROR("Failed to write IAS report to %s: %s\n", report_path, strerror(errno));
+            goto out;
+        }
+        DBG("IAS report saved to: %s\n", report_path);
+    }
+
+    if (sig_path) {
+        ret = write_file(sig_path, ias_resp.signature_size, ias_resp.signature);
+        if (ret != 0) {
+            ERROR("Failed to write IAS signature to %s: %s\n", sig_path, strerror(errno));
+            goto out;
+        }
+        DBG("IAS report signature saved to: %s\n", sig_path);
+    }
+
+    if (cert_path) {
+        urldecode(ias_resp.certificate, ias_resp.certificate);
+        ias_resp.certificate_size = strlen(ias_resp.certificate);
+        ret = write_file(cert_path, ias_resp.certificate_size, ias_resp.certificate);
+        if (ret != 0) {
+            ERROR("Failed to write IAS certificate to %s: %s\n", cert_path, strerror(errno));
+            goto out;
+        }
+        DBG("IAS certificate saved to: %s\n", cert_path);
+    }
+
+    if (advisory_path) {
+        ret = remove(advisory_path);
+        if (ret != 0 && errno != ENOENT) {
+            ERROR("Failed to overwrite %s: %s\n", advisory_path, strerror(errno));
+            goto out;
+        }
+
+        if (ias_resp.advisory_url_size > 0) {
+            ret = append_file(advisory_path, ias_resp.advisory_url_size, ias_resp.advisory_url);
+            if (ret != 0) {
+                ERROR("Failed to write IAS advisory URL to %s: %s\n", advisory_path,
+                      strerror(errno));
+                goto out;
+            }
+        }
+
+        if (ias_resp.advisory_ids_size > 0) {
+            ret = append_file(advisory_path, ias_resp.advisory_ids_size, ias_resp.advisory_ids);
+            if (ret != 0) {
+                ERROR("Failed to write IAS advisory IDs to %s: %s\n", advisory_path,
+                      strerror(errno));
+                goto out;
+            }
+        }
+        DBG("IAS advisory saved to: %s\n", advisory_path);
+    }
+
+    /* body_callback and header_callback always add terminating \0, but
+     * don't count it in respective resp_data->*_size, finalize the process
+     */
+    ias_resp.data_size++;
+    ias_resp.signature_size++;
+
+    ret = 0;
+
+out:
+    /* cleanup */
+    free(ias_resp.signature);
+    free(ias_resp.certificate);
+    free(ias_resp.advisory_url);
+    free(ias_resp.advisory_ids);
+    free(ias_resp.data);
+    free(quote_b64);
+    free(quote_json);
+
+    return ret;
+}

--- a/Pal/src/host/Linux-SGX/tools/common/ias.h
+++ b/Pal/src/host/Linux-SGX/tools/common/ias.h
@@ -1,0 +1,75 @@
+/* Copyright (C) 2018-2020 Invisible Things Lab
+                           Rafal Wojdyla <omeg@invisiblethingslab.com>
+   This file is part of Graphene Library OS.
+   Graphene Library OS is free software: you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public License
+   as published by the Free Software Foundation, either version 3 of the
+   License, or (at your option) any later version.
+   Graphene Library OS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Lesser General Public License for more details.
+   You should have received a copy of the GNU Lesser General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
+
+#ifndef _IAS_H
+#define _IAS_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+/*! Context used in ias_*() calls. */
+struct ias_context_t;
+
+/*!
+ * \brief Create and initialize context used for IAS communication.
+ *
+ * \param[in] ias_api_key    API key for IAS access.
+ * \param[in] ias_verify_url URL for IAS attestation verification API.
+ * \param[in] ias_sigrl_url  URL for IAS "Retrieve SigRL" API.
+ * \return Context to be used in further ias_* calls or NULL on failure.
+ *
+ * \details Should be called once, before handling any request.
+ */
+struct ias_context_t* ias_init(const char* ias_api_key, const char* ias_verify_url,
+                               const char* ias_sigrl_url);
+
+/*!
+ * \brief Clean up and free context used for IAS communication.
+ *
+ * \param[in] context IAS context returned by ias_init().
+ * \details Should be called once, after serving last request.
+ */
+void ias_cleanup(struct ias_context_t* context);
+
+/*!
+ * \brief Get the signature revocation list for a given EPID group.
+ *
+ * \param[in]  context    IAS context returned by ias_init().
+ * \param[in]  gid        EPID group ID to get SigRL for.
+ * \param[out] sigrl_size Size of the SigRL (may be 0).
+ * \param[out] sigrl      SigRL data, needs to be freed by the caller.
+ * \return 0 on success, -1 otherwise.
+ */
+int ias_get_sigrl(struct ias_context_t* context, uint8_t gid[4], size_t* sigrl_size, void** sigrl);
+
+/*!
+ * \brief Send quote to IAS for verification.
+ *
+ * \param[in] context       IAS context returned by ias_init().
+ * \param[in] quote         Binary quote data blob.
+ * \param[in] quote_size    Size of \a quote.
+ * \param[in] nonce         (Optional) Nonce to send with the IAS request (maximum size: 32 bytes).
+ * \param[in] report_path   (Optional) File to save IAS report to.
+ * \param[in] sig_path      (Optional) File to save IAS report's signature to.
+ * \param[in] cert_path     (Optional) File to save IAS certificate to.
+ * \param[in] advisory_path (Optional) File to save IAS security advisories to.
+ * \return 0 on success, -1 otherwise.
+ *
+ * \details Sends quote to the "Verify Attestation Evidence" IAS endpoint.
+ */
+int ias_verify_quote(struct ias_context_t* context, const void* quote, size_t quote_size,
+                     const char* nonce, const char* report_path, const char* sig_path,
+                     const char* cert_path, const char* advisory_path);
+
+#endif /* _IAS_H */

--- a/Pal/src/host/Linux-SGX/tools/common/util.c
+++ b/Pal/src/host/Linux-SGX/tools/common/util.c
@@ -1,0 +1,192 @@
+/* Copyright (C) 2018-2020 Invisible Things Lab
+                           Rafal Wojdyla <omeg@invisiblethingslab.com>
+   This file is part of Graphene Library OS.
+   Graphene Library OS is free software: you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public License
+   as published by the Free Software Foundation, either version 3 of the
+   License, or (at your option) any later version.
+   Graphene Library OS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Lesser General Public License for more details.
+   You should have received a copy of the GNU Lesser General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
+
+#include <ctype.h>
+#include <stdlib.h>
+#include <sys/stat.h>
+#include "util.h"
+
+/*! Console stdout fd */
+int g_stdout_fd = 1;
+
+/*! Console stderr fd */
+int g_stderr_fd = 2;
+
+/*! Verbosity level */
+bool g_verbose = false;
+
+/*! Endianness for hex strings */
+endianness_t g_endianness = ENDIAN_LSB;
+
+void set_verbose(bool verbose) {
+    g_verbose = verbose;
+    if (verbose)
+        DBG("Verbose output enabled\n");
+    else
+        DBG("Verbose output disabled\n");
+}
+
+bool get_verbose() {
+    return g_verbose;
+}
+
+void set_endianness(endianness_t endianness) {
+    g_endianness = endianness;
+    if (g_verbose) {
+        if (endianness == ENDIAN_LSB)
+            DBG("Endianness set to LSB\n");
+        else
+            DBG("Endianness set to MSB\n");
+    }
+}
+
+endianness_t get_endianness(void) {
+    return g_endianness;
+}
+
+/* return -1 on error */
+ssize_t get_file_size(int fd) {
+    struct stat st;
+
+    if (fstat(fd, &st) != 0)
+        return -1;
+
+    return st.st_size;
+}
+
+/* Read whole file, caller should free the buffer */
+uint8_t* read_file(const char* path, ssize_t* size) {
+    FILE* f = NULL;
+    uint8_t* buf = NULL;
+
+    f = fopen(path, "rb");
+    if (!f) {
+        ERROR("Failed to open file '%s' for reading: %s\n", path, strerror(errno));
+        goto out;
+    }
+
+    *size = get_file_size(fileno(f));
+    if (*size == -1) {
+        ERROR("Failed to get size of file '%s': %s\n", path, strerror(errno));
+        goto out;
+    }
+
+    buf = (uint8_t*)malloc(*size);
+    if (!buf) {
+        ERROR("No memory\n");
+        goto out;
+    }
+
+    if (fread(buf, *size, 1, f) != 1) {
+        ERROR("Failed to read file '%s'\n", path);
+        free(buf);
+        buf = NULL;
+    }
+
+out:
+    if (f)
+        fclose(f);
+
+    return buf;
+}
+
+static int write_file_internal(const char* path, size_t size, const void* buffer, bool append) {
+    FILE* f = NULL;
+    int status;
+
+    if (append)
+        f = fopen(path, "ab");
+    else
+        f = fopen(path, "wb");
+
+    if (!f) {
+        ERROR("Failed to open file '%s' for writing: %s\n", path, strerror(errno));
+        goto out;
+    }
+
+    if (size > 0 && buffer) {
+        if (fwrite(buffer, size, 1, f) != 1) {
+            ERROR("Failed to write file '%s': %s\n", path, strerror(errno));
+            goto out;
+        }
+    }
+
+    errno = 0;
+
+out:
+    status = errno;
+    if (f)
+        fclose(f);
+    return status;
+}
+
+/* Write buffer to file */
+int write_file(const char* path, size_t size, const void* buffer) {
+    return write_file_internal(path, size, buffer, false);
+}
+
+/* Append buffer to file */
+int append_file(const char* path, size_t size, const void* buffer) {
+    return write_file_internal(path, size, buffer, true);
+}
+
+/* Set stdout/stderr descriptors */
+void util_set_fd(int stdout_fd, int stderr_fd) {
+    g_stdout_fd = stdout_fd;
+    g_stderr_fd = stderr_fd;
+}
+
+/* Print memory as hex */
+void hexdump_mem(const void* data, size_t size) {
+    uint8_t* ptr = (uint8_t*)data;
+
+    for (size_t i = 0; i < size; i++) {
+        if (g_endianness == ENDIAN_LSB) {
+            INFO("%02x", ptr[i]);
+        } else {
+            INFO("%02x", ptr[size - i - 1]);
+        }
+    }
+
+    INFO("\n");
+}
+
+/* Parse hex string to buffer */
+int parse_hex(const char* hex, void* buffer, size_t buffer_size) {
+    if (!hex || !buffer || buffer_size == 0)
+        return -1;
+
+    if (strlen(hex) != buffer_size * 2) {
+        ERROR("Invalid hex string (%s) length\n", hex);
+        return -1;
+    }
+
+    for (size_t i = 0; i < buffer_size; i++) {
+        if (!isxdigit(hex[i * 2]) || !isxdigit(hex[i * 2 + 1])) {
+            ERROR("Invalid hex string '%s'\n", hex);
+            return -1;
+        }
+
+        if (g_endianness == ENDIAN_LSB)
+            sscanf(hex + i * 2, "%02hhx", &((uint8_t*)buffer)[i]);
+        else
+            sscanf(hex + i * 2, "%02hhx", &((uint8_t*)buffer)[buffer_size - i - 1]);
+    }
+    return 0;
+}
+
+/* For PAL's assert compatibility */
+void __abort() {
+    ERROR("exiting\n");
+}

--- a/Pal/src/host/Linux-SGX/tools/common/util.h
+++ b/Pal/src/host/Linux-SGX/tools/common/util.h
@@ -1,0 +1,84 @@
+/* Copyright (C) 2018-2020 Invisible Things Lab
+                           Rafal Wojdyla <omeg@invisiblethingslab.com>
+   This file is part of Graphene Library OS.
+   Graphene Library OS is free software: you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public License
+   as published by the Free Software Foundation, either version 3 of the
+   License, or (at your option) any later version.
+   Graphene Library OS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Lesser General Public License for more details.
+   You should have received a copy of the GNU Lesser General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
+
+#ifndef UTIL_H
+#define UTIL_H
+
+#include <errno.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/types.h>
+
+/* Miscellaneous helper functions */
+
+/*! Order of bytes for hex strings (display and parsing) */
+typedef enum _endianness_t {
+    ENDIAN_LSB,
+    ENDIAN_MSB,
+} endianness_t;
+
+extern int g_stdout_fd;
+extern int g_stderr_fd;
+extern bool g_verbose;
+extern endianness_t g_endianness;
+
+/* Print functions */
+#define DBG(fmt, ...)   do { if (g_verbose) dprintf(g_stdout_fd, fmt, ##__VA_ARGS__); } while (0)
+#define INFO(fmt, ...)  do { dprintf(g_stdout_fd, fmt, ##__VA_ARGS__); } while (0)
+#define ERROR(fmt, ...) do { dprintf(g_stderr_fd, "%s: " fmt, __FUNCTION__, ##__VA_ARGS__); } while (0)
+
+/*! Set verbosity level */
+void set_verbose(bool verbose);
+
+/*! Get verbosity level */
+bool get_verbose();
+
+/*! Set endianness for hex strings */
+void set_endianness(endianness_t endianness);
+
+/*! Get endianness for hex strings */
+endianness_t get_endianness(void);
+
+/*! Set stdout/stderr descriptors */
+void util_set_fd(int stdout_fd, int stderr_fd);
+
+/*! Get file size, return -1 on error */
+ssize_t get_file_size(int fd);
+
+/*! Read whole file, caller should free the buffer */
+uint8_t* read_file(const char* path, ssize_t* size);
+
+/*! Write buffer to file */
+int write_file(const char* path, size_t size, const void* buffer);
+
+/*! Append buffer to file */
+int append_file(const char* path, size_t size, const void* buffer);
+
+/*! Print memory as hex */
+void hexdump_mem(const void* data, size_t size);
+
+/*! Print variable as hex */
+#define HEXDUMP(x) hexdump_mem((const void*)&(x), sizeof(x))
+
+/*! Parse hex string to buffer */
+int parse_hex(const char* hex, void* buffer, size_t buffer_size);
+
+/* For PAL's assert compatibility */
+#ifndef warn
+#define warn ERROR
+#endif
+
+#endif /* UTIL_H */

--- a/Pal/src/host/Linux-SGX/tools/ias-request/.gitignore
+++ b/Pal/src/host/Linux-SGX/tools/ias-request/.gitignore
@@ -1,0 +1,1 @@
+/ias_request

--- a/Pal/src/host/Linux-SGX/tools/ias-request/Makefile
+++ b/Pal/src/host/Linux-SGX/tools/ias-request/Makefile
@@ -1,0 +1,28 @@
+include ../../../../../../Scripts/Makefile.configs
+include ../../../../../../Scripts/Makefile.rules
+
+CFLAGS += -I../.. \
+          -I../common \
+          -L../common \
+          -D_GNU_SOURCE
+
+LDLIBS += -lsgx_util
+
+PREFIX ?= /usr/local
+
+.PHONY: all
+all: ias_request
+
+ias_request: ias_request.o
+	$(call cmd,csingle)
+
+.PHONY: install
+install:
+	install ias_request ${PREFIX}/bin
+
+.PHONY: clean
+clean:
+	$(RM) *.o ias_request
+
+.PHONY: distclean
+distclean: clean

--- a/Pal/src/host/Linux-SGX/tools/ias-request/ias_request.c
+++ b/Pal/src/host/Linux-SGX/tools/ias-request/ias_request.c
@@ -66,11 +66,11 @@ void usage(const char* exec) {
          "                            %s)\n", IAS_URL_SIGRL);
     INFO("Available report options:\n");
     INFO("  --quote-path, -q PATH     Path to quote to submit\n");
-    INFO("  --nonce, -n STRING        Nonce to use (optional)\n");
     INFO("  --report-path, -r PATH    Path to save IAS report to\n");
     INFO("  --sig-path, -s PATH       Path to save IAS report's signature to\n");
+    INFO("  --nonce, -n STRING        Nonce to use (optional)\n");
     INFO("  --cert-path, -c PATH      Path to save IAS certificate to (optional)\n");
-    INFO("  --advisory-path, -a PATH  Path to save IAS advisories to (optional)\n");
+    INFO("  --advisory-path, -a PATH  Path to save IAS security advisories to (optional)\n");
     INFO("  --report-url, -R URL      URL for the IAS attestation report endpoint (default:\n"
          "                            %s)\n", IAS_URL_REPORT);
 }

--- a/Pal/src/host/Linux-SGX/tools/ias-request/ias_request.c
+++ b/Pal/src/host/Linux-SGX/tools/ias-request/ias_request.c
@@ -1,0 +1,253 @@
+/* Copyright (C) 2020 Invisible Things Lab
+                      Rafal Wojdyla <omeg@invisiblethingslab.com>
+   This file is part of Graphene Library OS.
+   Graphene Library OS is free software: you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public License
+   as published by the Free Software Foundation, either version 3 of the
+   License, or (at your option) any later version.
+   Graphene Library OS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Lesser General Public License for more details.
+   You should have received a copy of the GNU Lesser General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
+
+#include <errno.h>
+#include <getopt.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "ias.h"
+#include "sgx_arch.h"
+#include "sgx_attest.h"
+#include "util.h"
+
+/** Default base URL for IAS API endpoints. Remove "/dev" for production environment. */
+#define IAS_URL_BASE "https://api.trustedservices.intel.com/sgx/dev"
+
+/** Default URL for IAS "verify attestation evidence" API endpoint. */
+#define IAS_URL_REPORT IAS_URL_BASE "/attestation/v3/report"
+
+/** Default URL for IAS "Retrieve SigRL" API endpoint. EPID group id is added at the end. */
+#define IAS_URL_SIGRL IAS_URL_BASE "/attestation/v3/sigrl"
+
+struct option g_options[] = {
+    { "help", no_argument, 0, 'h' },
+    { "verbose", no_argument, 0, 'v' },
+    { "msb", no_argument, 0, 'm' },
+    { "quote-path", required_argument, 0, 'q' },
+    { "api-key", required_argument, 0, 'k' },
+    { "nonce", required_argument, 0, 'n' },
+    { "report-path", required_argument, 0, 'r' },
+    { "sig-path", required_argument, 0, 's' },
+    { "cert-path", required_argument, 0, 'c' },
+    { "advisory-path", required_argument, 0, 'a' },
+    { "gid", required_argument, 0, 'g' },
+    { "sigrl-path", required_argument, 0, 'i' },
+    { "report-url", required_argument, 0, 'R' },
+    { "sigrl-url", required_argument, 0, 'S' },
+    { 0, 0, 0, 0 }
+};
+
+void usage(const char* exec) {
+    INFO("Usage: %s <request> [options]\n", exec);
+    INFO("Available requests:\n");
+    INFO("  sigrl                     Retrieve signature revocation list for a given EPID group\n");
+    INFO("  report                    Verify attestation evidence (quote)\n");
+    INFO("Available general options:\n");
+    INFO("  --help, -h                Display this help\n");
+    INFO("  --verbose, -v             Enable verbose output\n");
+    INFO("  --msb, -m                 Print/parse hex strings in big-endian order\n");
+    INFO("  --api-key, -k STRING      IAS API key\n");
+    INFO("Available sigrl options:\n");
+    INFO("  --gid, -g STRING          EPID group ID (hex string)\n");
+    INFO("  --sigrl-path, -i PATH     Path to save SigRL to\n");
+    INFO("  --sigrl-url, -S URL       URL for the IAS SigRL endpoint (default:\n"
+         "                            %s)\n", IAS_URL_SIGRL);
+    INFO("Available report options:\n");
+    INFO("  --quote-path, -q PATH     Path to quote to submit\n");
+    INFO("  --nonce, -n STRING        Nonce to use (optional)\n");
+    INFO("  --report-path, -r PATH    Path to save IAS report to\n");
+    INFO("  --sig-path, -s PATH       Path to save IAS report's signature to\n");
+    INFO("  --cert-path, -c PATH      Path to save IAS certificate to (optional)\n");
+    INFO("  --advisory-path, -a PATH  Path to save IAS advisories to (optional)\n");
+    INFO("  --report-url, -R URL      URL for the IAS attestation report endpoint (default:\n"
+         "                            %s)\n", IAS_URL_REPORT);
+}
+
+int report(struct ias_context_t* ias, const char* quote_path, const char* nonce,
+           const char* report_path, const char* sig_path, const char* cert_path,
+           const char* advisory_path) {
+    int ret = -1;
+    void* quote_data = NULL;
+
+    if (!quote_path) {
+        ERROR("Quote path not specified\n");
+        goto out;
+    }
+
+    ssize_t quote_size;
+    quote_data = read_file(quote_path, &quote_size);
+    if (!quote_data) {
+        ERROR("Failed to read quote file '%s'\n", quote_path);
+        goto out;
+    }
+
+    if (quote_size < sizeof(sgx_quote_t)) {
+        ERROR("Quote is too small\n");
+        goto out;
+    }
+
+    sgx_quote_t* quote = (sgx_quote_t*)quote_data;
+    if (quote_size < sizeof(sgx_quote_t) + quote->signature_len) {
+        ERROR("Quote is too small\n");
+        goto out;
+    }
+    quote_size = sizeof(sgx_quote_t) + quote->signature_len;
+
+    ret = ias_verify_quote(ias, quote_data, quote_size, nonce, report_path, sig_path, cert_path,
+                           advisory_path);
+    if (ret != 0) {
+        ERROR("Failed to submit quote to IAS\n");
+        goto out;
+    }
+
+    INFO("IAS submission successful\n");
+out:
+    free(quote_data);
+    return ret;
+}
+
+int sigrl(struct ias_context_t* ias, const char* gid_str, const char* sigrl_path) {
+    uint8_t gid[4];
+
+    if (parse_hex(gid_str, gid, sizeof(gid)) != 0) {
+        ERROR("Invalid EPID group ID\n");
+        return -1;
+    }
+
+    size_t sigrl_size = 0;
+    void* sigrl = NULL;
+    int ret = ias_get_sigrl(ias, gid, &sigrl_size, &sigrl);
+    if (ret == 0) {
+        if (sigrl_size == 0) {
+            INFO("No SigRL for given EPID group ID %s\n", gid_str);
+        } else {
+            DBG("SigRL size: %zu\n", sigrl_size);
+            ret = write_file(sigrl_path, sigrl_size, sigrl);
+        }
+    }
+    free(sigrl);
+    return ret;
+}
+
+int main(int argc, char* argv[]) {
+    int option          = 0;
+    char* mode          = NULL;
+    char* quote_path    = NULL;
+    char* api_key       = NULL;
+    char* nonce         = NULL;
+    char* report_path   = NULL;
+    char* sig_path      = NULL;
+    char* cert_path     = NULL;
+    char* advisory_path = NULL;
+    char* gid           = NULL;
+    char* sigrl_path    = NULL;
+    char* report_url    = IAS_URL_REPORT;
+    char* sigrl_url     = IAS_URL_SIGRL;
+    endianness_t endian = ENDIAN_LSB;
+
+    // parse command line
+    while (true) {
+        option = getopt_long(argc, argv, "hvmq:k:n:r:s:c:a:g:i:R:S:", g_options, NULL);
+        if (option == -1)
+            break;
+
+        switch (option) {
+            case 'h':
+                usage(argv[0]);
+                return 0;
+            case 'v':
+                set_verbose(true);
+                break;
+            case 'm':
+                endian = ENDIAN_MSB;
+                break;
+            case 'q':
+                quote_path = optarg;
+                break;
+            case 'k':
+                api_key = optarg;
+                break;
+            case 'n':
+                nonce = optarg;
+                break;
+            case 'r':
+                report_path = optarg;
+                break;
+            case 's':
+                sig_path = optarg;
+                break;
+            case 'c':
+                cert_path = optarg;
+                break;
+            case 'a':
+                advisory_path = optarg;
+                break;
+            case 'g':
+                gid = optarg;
+                break;
+            case 'i':
+                sigrl_path = optarg;
+                break;
+            case 'R':
+                report_url = optarg;
+                break;
+            case 'S':
+                sigrl_url = optarg;
+                break;
+            default:
+                usage(argv[0]);
+                return -1;
+        }
+    }
+
+    set_endianness(endian);
+
+    if (optind >= argc) {
+        ERROR("Request not specified\n");
+        usage(argv[0]);
+        return -1;
+    }
+
+    mode = argv[optind++];
+
+    if (!api_key) {
+        ERROR("API key not specified\n");
+        return -1;
+    }
+
+    struct ias_context_t* ias = ias_init(api_key, report_url, sigrl_url);
+    if (!ias) {
+        ERROR("Failed to initialize IAS library\n");
+        return -1;
+    }
+
+    if (mode[0] == 'r') {
+        if (!report_path || !sig_path) {
+            ERROR("Report or signature path not specified\n");
+            return -1;
+        }
+        return report(ias, quote_path, nonce, report_path, sig_path, cert_path, advisory_path);
+    } else if (mode[0] == 's') {
+        if (!sigrl_path) {
+            ERROR("SigRL path not specified\n");
+            return -1;
+        }
+        return sigrl(ias, gid, sigrl_path);
+    }
+
+    ERROR("Invalid request\n");
+    usage(argv[0]);
+    return -1;
+}

--- a/Pal/src/host/Linux-SGX/tools/is-sgx-available/.gitignore
+++ b/Pal/src/host/Linux-SGX/tools/is-sgx-available/.gitignore
@@ -1,0 +1,1 @@
+/is_sgx_available

--- a/Pal/src/host/Linux-SGX/tools/is-sgx-available/Makefile
+++ b/Pal/src/host/Linux-SGX/tools/is-sgx-available/Makefile
@@ -1,0 +1,18 @@
+PREFIX ?= /usr/local
+
+.PHONY: all
+all: is_sgx_available
+
+.PHONY: install
+install:
+	install is_sgx_available ${PREFIX}/bin
+
+.PHONY: clean
+clean:
+	$(RM) is_sgx_available
+
+.PHONY: distclean
+distclean: clean
+
+is_sgx_available: is_sgx_available.cpp
+	g++ -O2 -std=c++14 -DNDEBUG -Wall -Wextra -Wno-multichar -masm=intel $< -o $@

--- a/Pal/src/host/Linux-SGX/tools/is-sgx-available/is_sgx_available.cpp
+++ b/Pal/src/host/Linux-SGX/tools/is-sgx-available/is_sgx_available.cpp
@@ -1,0 +1,245 @@
+/* Copyright (C) 2018-2020 Invisible Things Lab
+                           Michal Kowalczyk <mkow@invisiblethingslab.com>
+   This file is part of Graphene Library OS.
+   Graphene Library OS is free software: you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public License
+   as published by the Free Software Foundation, either version 3 of the
+   License, or (at your option) any later version.
+   Graphene Library OS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Lesser General Public License for more details.
+   You should have received a copy of the GNU Lesser General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
+
+#include <cinttypes>
+#include <cstdint>
+#include <cstring>
+#include <exception>
+#include <iostream>
+#include <sys/stat.h>
+
+enum ExitCodes {
+    SUCCESS = 0,
+    NO_CPU_SUPPORT = 1,
+    NO_BIOS_SUPPORT = 2,
+    PSW_NOT_INSTALLED = 3,
+    AESMD_NOT_RUNNING = 4 // This is a separate exit code, because AESMD tends
+                          // to die spontaneously.
+};
+
+bool file_exists(const char* path) {
+    struct stat statbuf;
+    return stat(path, &statbuf) == 0;
+}
+
+void cpuid(uint32_t leaf, uint32_t subleaf, uint32_t* eax, uint32_t* ebx,
+           uint32_t* ecx, uint32_t* edx) {
+    unsigned long eax_, ebx_, ecx_, edx_;
+    __asm__ ("cpuid\n"
+        : "=a" (eax_), "=b" (ebx_), "=c" (ecx_), "=d" (edx_)
+        : "0" (leaf), "2" (subleaf));
+    if (eax) *eax = (eax_ & 0xFFFFFFFF);
+    if (ebx) *ebx = (ebx_ & 0xFFFFFFFF);
+    if (ecx) *ecx = (ecx_ & 0xFFFFFFFF);
+    if (edx) *edx = (edx_ & 0xFFFFFFFF);
+}
+
+static bool is_cpuid_supported() {
+    // Checks whether (R/E)FLAGS.ID is writable (bit 21).
+    uint64_t write_diff;
+    __asm__ (
+        "pushf\n"
+
+        "pushf\n"
+        "xor qword ptr [rsp], (1<<21)\n"
+        "popf\n"
+        "pushf\n"
+        "pop %0\n"
+        "xor %0, [rsp]\n"
+
+        "popf\n"
+        : "=r" (write_diff)
+    );
+    return write_diff;
+}
+
+// 2**exp with saturation for unsigned types.
+template<class T> T saturating_exp2(T exp) {
+    // Protect against UB.
+    if (exp >= sizeof(T)*8)
+        return ~(T)0;
+    // No overflow.
+    return (T)1 << exp;
+}
+
+class SgxCpuChecker {
+    bool cpuid_supported_ = false;
+    bool is_intel_cpu_ = false;
+    bool sgx_supported_ = false;
+    bool sgx1_supported_ = false;
+    bool sgx2_supported_ = false;
+    bool flc_supported_ = false;
+    bool sgx_virt_supported_ = false;
+    bool sgx_mem_concurrency_supported_ = false;
+    bool cet_supported_ = false;
+    bool kss_supported_ = false;
+    uint64_t maximum_enclave_size_x86_ = false;
+    uint64_t maximum_enclave_size_x64_ = false;
+    uint64_t epc_region_size_ = 0;
+
+public:
+    explicit SgxCpuChecker() {
+        uint32_t cpuid_max_leaf_value;
+        uint32_t cpuid_0_ebx;
+        uint32_t cpuid_0_ecx;
+        uint32_t cpuid_0_edx;
+
+        uint32_t cpuid_7_0_eax;
+        uint32_t cpuid_7_0_ebx;
+        uint32_t cpuid_7_0_ecx;
+        uint32_t cpuid_7_0_edx;
+        // Used only if sgx_supported().
+        uint32_t cpuid_12_0_eax;
+        uint32_t cpuid_12_0_ebx;
+        uint32_t cpuid_12_0_ecx;
+        uint32_t cpuid_12_0_edx;
+        uint32_t cpuid_12_1_eax;
+        uint32_t cpuid_12_1_ebx;
+        uint32_t cpuid_12_1_ecx;
+        uint32_t cpuid_12_1_edx;
+
+        cpuid_supported_ = is_cpuid_supported();
+        if (!cpuid_supported_)
+            return;
+        cpuid(0, 0, &cpuid_max_leaf_value, &cpuid_0_ebx, &cpuid_0_ecx, &cpuid_0_edx);
+        is_intel_cpu_ = cpuid_0_ebx == __builtin_bswap32('Genu')
+                     && cpuid_0_edx == __builtin_bswap32('ineI')
+                     && cpuid_0_ecx == __builtin_bswap32('ntel');
+        if (!is_intel_cpu_ || cpuid_max_leaf_value < 7)
+            return;
+        // See chapter 36.7 in Intel SDM vol.3
+        cpuid(7, 0, &cpuid_7_0_eax, &cpuid_7_0_ebx, &cpuid_7_0_ecx, &cpuid_7_0_edx);
+        sgx_supported_ = cpuid_7_0_ebx & (1 << 2);
+        if (!sgx_supported_ || cpuid_max_leaf_value < 0x12)
+            return;
+        flc_supported_ = cpuid_7_0_ecx & (1 << 30);
+        cpuid(0x12, 0, &cpuid_12_0_eax, &cpuid_12_0_ebx, &cpuid_12_0_ecx, &cpuid_12_0_edx);
+        cpuid(0x12, 1, &cpuid_12_1_eax, &cpuid_12_1_ebx, &cpuid_12_1_ecx, &cpuid_12_1_edx);
+        sgx1_supported_ = cpuid_12_0_eax & (1 << 0);
+        sgx2_supported_ = cpuid_12_0_eax & (1 << 1);
+        sgx_virt_supported_ = cpuid_12_0_eax & (1 << 5);
+        sgx_mem_concurrency_supported_ = cpuid_12_0_eax & (1 << 6);
+        cet_supported_ = cpuid_12_1_eax & (1 << 6);
+        kss_supported_ = cpuid_12_1_eax & (1 << 7);
+        maximum_enclave_size_x86_ = saturating_exp2<uint64_t>(cpuid_12_0_edx & 0xFF);
+        maximum_enclave_size_x64_ = saturating_exp2<uint64_t>((cpuid_12_0_edx >> 8) & 0xFF);
+        // Check if there's any EPC region allocated by BIOS
+        for (uint32_t subleaf = 2; subleaf >= 2; subleaf++) {
+            uint32_t eax, ebx, ecx, edx;
+            cpuid(0x12, subleaf, &eax, &ebx, &ecx, &edx);
+            auto type = eax & 0xF;
+            if (!type)
+                break;
+            if (type == 1) {
+                // EAX and EBX report the physical address of the base of the EPC region,
+                // but we only care about the EPC size
+                if (ecx & 0xFFFFF000 || edx & 0xFFFFF) {
+                    epc_region_size_ += ecx & 0xFFFFF000;
+                    epc_region_size_ += (uint64_t)(edx & 0xFFFFF) << 32;
+                }
+            }
+        }
+    }
+
+    bool cpuid_supported() const { return cpuid_supported_; }
+    bool is_intel_cpu() const { return is_intel_cpu_; }
+    bool sgx_supported() const { return sgx_supported_; }
+    bool sgx1_supported() const { return sgx1_supported_; }
+    // SGX2 enclave dynamic memory management (EDMM) support (EAUG, EACCEPT, EMODPR, ...)
+    bool sgx2_supported() const { return sgx2_supported_; }
+    // Flexible Launch Control support (IA32_SGXPUBKEYHASH{0..3} MSRs)
+    bool flc_supported() const { return flc_supported_; }
+    // Extensions for virtualizers (EINCVIRTCHILD, EDECVIRTCHILD, ESETCONTEXT).
+    bool sgx_virt_supported() const { return sgx_virt_supported_; }
+    // Extensions for concurrent memory management (ETRACKC, ERDINFO, ELDBC, ELDUC).
+    bool sgx_mem_concurrency_supported() const { return sgx_mem_concurrency_supported_; }
+    // CET enclave attributes support (See Table 37-5 in the SDM)
+    bool cet_supported() const { return cet_supported_; }
+    // Key separation and sharing (KSS) support (CONFIGID, CONFIGSVN, ISVEXTPRODID, ISVFAMILYID report fields)
+    bool kss_supported() const { return kss_supported_; }
+    uint64_t maximum_enclave_size_x86() const { return maximum_enclave_size_x86_; }
+    uint64_t maximum_enclave_size_x64() const { return maximum_enclave_size_x64_; }
+    uint64_t epc_region_size() const { return epc_region_size_; }
+};
+
+bool sgx_driver_loaded() {
+    // /dev/isgx is for LKM version, /dev/sgx is for in-kernel support.
+    return file_exists("/dev/isgx") || file_exists("/dev/sgx");
+}
+
+bool psw_installed() {
+    bool aesmd_installed = file_exists("/etc/aesmd.conf");
+    return sgx_driver_loaded() && aesmd_installed;
+}
+
+bool aesmd_running() {
+    return file_exists("/var/run/aesmd/aesm.socket");
+}
+
+void print_detailed_info(const SgxCpuChecker& cpu_checker) {
+    if (!cpu_checker.cpuid_supported()) {
+        puts("`cpuid` instruction not available");
+        return;
+    }
+    if (!cpu_checker.is_intel_cpu()) {
+        puts("Not an Intel CPU");
+        return;
+    }
+    auto bool2str = [](bool b){ return b ? "true" : "false"; };
+    auto sgx_supported = cpu_checker.sgx_supported();
+    printf("SGX supported by CPU: %s\n", bool2str(sgx_supported));
+    if (!sgx_supported)
+        return;
+    printf("SGX1 (ECREATE, EENTER, ...): %s\n", bool2str(cpu_checker.sgx1_supported()));
+    printf("SGX2 (EAUG, EACCEPT, EMODPR, ...): %s\n", bool2str(cpu_checker.sgx2_supported()));
+    printf("Flexible Launch Control (IA32_SGXPUBKEYHASH{0..3} MSRs): %s\n",
+           bool2str(cpu_checker.flc_supported()));
+    printf("SGX extensions for virtualizers (EINCVIRTCHILD, EDECVIRTCHILD, ESETCONTEXT): %s\n",
+           bool2str(cpu_checker.sgx_virt_supported()));
+    printf("Extensions for concurrent memory management (ETRACKC, ELDBC, ELDUC, ERDINFO): %s\n",
+           bool2str(cpu_checker.sgx_mem_concurrency_supported()));
+    printf("CET enclave attributes support (See Table 37-5 in the SDM): %s\n",
+           bool2str(cpu_checker.cet_supported()));
+    printf("Key separation and sharing (KSS) support (CONFIGID, CONFIGSVN, ISVEXTPRODID, "
+           "ISVFAMILYID report fields): %s\n", bool2str(cpu_checker.kss_supported()));
+    printf("Max enclave size (32-bit): 0x%" PRIx64 "\n", cpu_checker.maximum_enclave_size_x86());
+    printf("Max enclave size (64-bit): 0x%" PRIx64 "\n", cpu_checker.maximum_enclave_size_x64());
+    printf("EPC size: 0x%" PRIx64 "\n", cpu_checker.epc_region_size());
+    printf("SGX driver loaded: %s\n", bool2str(sgx_driver_loaded()));
+    printf("SGX PSW/libsgx installed: %s\n", bool2str(psw_installed()));
+    printf("AESMD running: %s\n", bool2str(aesmd_running()));
+}
+
+int main(int argc, char* argv[]) {
+    bool quiet = (argc >= 2) && !strcmp(argv[1], "--quiet");
+
+    SgxCpuChecker cpu_checker;
+    if (!quiet)
+        print_detailed_info(cpu_checker);
+
+    if (!cpu_checker.cpuid_supported() || !cpu_checker.is_intel_cpu()
+        || !cpu_checker.sgx_supported() || (!cpu_checker.sgx1_supported()
+                                            && !cpu_checker.sgx2_supported()))
+        return ExitCodes::NO_CPU_SUPPORT;
+    // We currently fail also when only one from 32/64 bit modes is available.
+    if (cpu_checker.maximum_enclave_size_x86() == 0
+        || cpu_checker.maximum_enclave_size_x64() == 0
+        || cpu_checker.epc_region_size() == 0)
+        return ExitCodes::NO_BIOS_SUPPORT;
+    if (!psw_installed())
+        return ExitCodes::PSW_NOT_INSTALLED;
+    if (!aesmd_running())
+        return ExitCodes::AESMD_NOT_RUNNING;
+    return ExitCodes::SUCCESS;
+}

--- a/Pal/src/host/Linux-SGX/tools/quote-dump/.gitignore
+++ b/Pal/src/host/Linux-SGX/tools/quote-dump/.gitignore
@@ -1,0 +1,1 @@
+/quote_dump

--- a/Pal/src/host/Linux-SGX/tools/quote-dump/Makefile
+++ b/Pal/src/host/Linux-SGX/tools/quote-dump/Makefile
@@ -1,0 +1,28 @@
+include ../../../../../../Scripts/Makefile.configs
+include ../../../../../../Scripts/Makefile.rules
+
+CFLAGS += -I../.. \
+          -I../common \
+          -L../common \
+          -D_GNU_SOURCE
+
+LDLIBS += -lsgx_util
+
+PREFIX ?= /usr/local
+
+.PHONY: all
+all: quote_dump
+
+quote_dump: quote_dump.o
+	$(call cmd,csingle)
+
+.PHONY: install
+install:
+	install quote_dump ${PREFIX}/bin
+
+.PHONY: clean
+clean:
+	$(RM) *.o quote_dump
+
+.PHONY: distclean
+distclean: clean

--- a/Pal/src/host/Linux-SGX/tools/quote-dump/quote_dump.c
+++ b/Pal/src/host/Linux-SGX/tools/quote-dump/quote_dump.c
@@ -1,0 +1,78 @@
+/* Copyright (C) 2018-2020 Invisible Things Lab
+                           Rafal Wojdyla <omeg@invisiblethingslab.com>
+   This file is part of Graphene Library OS.
+   Graphene Library OS is free software: you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public License
+   as published by the Free Software Foundation, either version 3 of the
+   License, or (at your option) any later version.
+   Graphene Library OS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Lesser General Public License for more details.
+   You should have received a copy of the GNU Lesser General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
+
+#include <getopt.h>
+#include <stdlib.h>
+
+#include "attestation.h"
+#include "util.h"
+
+struct option g_options[] = {
+    { "help", no_argument, 0, 'h' },
+    { "msb", no_argument, 0, 'm' },
+    { 0, 0, 0, 0 }
+};
+
+void usage(const char* exec) {
+    INFO("Usage: %s [options] <quote path>\n", exec);
+    INFO("Available options:\n");
+    INFO("  --help, -h  Display this help\n");
+    INFO("  --msb, -m   Display hex strings in big-endian order\n");
+}
+
+int main(int argc, char* argv[]) {
+    if (argc < 2) {
+        usage(argv[0]);
+        return -1;
+    }
+
+    endianness_t endian = ENDIAN_LSB;
+
+    int option = 0;
+    // parse command line
+    while (true) {
+        option = getopt_long(argc, argv, "hm", g_options, NULL);
+        if (option == -1)
+            break;
+
+        switch (option) {
+            case 'h':
+                usage(argv[0]);
+                return 0;
+            case 'm':
+                endian = ENDIAN_MSB;
+                break;
+            default:
+                usage(argv[0]);
+                return -1;
+        }
+    }
+
+    if (optind >= argc) {
+        ERROR("Quote path not specified\n");
+        usage(argv[0]);
+        return -1;
+    }
+
+    const char* path = argv[optind++];
+
+    ssize_t quote_size = 0;
+    uint8_t* quote = read_file(path, &quote_size);
+    if (!quote)
+        return -1;
+
+    set_endianness(endian);
+    display_quote(quote, quote_size);
+    return 0;
+}

--- a/Pal/src/host/Linux-SGX/tools/verify-ias-report/.gitignore
+++ b/Pal/src/host/Linux-SGX/tools/verify-ias-report/.gitignore
@@ -1,0 +1,1 @@
+/verify_ias_report

--- a/Pal/src/host/Linux-SGX/tools/verify-ias-report/Makefile
+++ b/Pal/src/host/Linux-SGX/tools/verify-ias-report/Makefile
@@ -1,0 +1,28 @@
+include ../../../../../../Scripts/Makefile.configs
+include ../../../../../../Scripts/Makefile.rules
+
+CFLAGS += -I../.. \
+          -I../common \
+          -L../common \
+          -D_GNU_SOURCE
+
+LDLIBS += -lsgx_util
+
+PREFIX ?= /usr/local
+
+.PHONY: all
+all: verify_ias_report
+
+verify_ias_report: verify_ias_report.o
+	$(call cmd,csingle)
+
+.PHONY: install
+install:
+	install verify_ias_report ${PREFIX}/bin
+
+.PHONY: clean
+clean:
+	$(RM) *.o verify_ias_report
+
+.PHONY: distclean
+distclean: clean

--- a/Pal/src/host/Linux-SGX/tools/verify-ias-report/verify_ias_report.c
+++ b/Pal/src/host/Linux-SGX/tools/verify-ias-report/verify_ias_report.c
@@ -46,8 +46,8 @@ void usage(const char* exec) {
     INFO("  --sig-path, -s PATH       Path to the IAS report's signature\n");
     INFO("  --allow-outdated-tcb, -o  Treat IAS status GROUP_OUT_OF_DATE as OK\n");
     INFO("  --nonce, -n STRING        Nonce that's expected in the report (optional)\n");
-    INFO("  --mr-signer, -S STRING    Expected quote MRSIGNER (hex string, optional)\n");
-    INFO("  --mr-enclave, -E STRING   Expected quote MRENCLAVE (hex string, optional)\n");
+    INFO("  --mr-signer, -S STRING    Expected mr_signer field (hex string, optional)\n");
+    INFO("  --mr-enclave, -E STRING   Expected mr_enclave field (hex string, optional)\n");
     INFO("  --report-data, -R STRING  Expected report_data field (hex string, optional)\n");
     INFO("  --isv-prod-id, -P NUMBER  Expected isv_prod_id field (uint16_t, optional)\n");
     INFO("  --isv-svn, -V NUMBER      Expected isv_svn field (uint16_t, optional)\n");

--- a/Pal/src/host/Linux-SGX/tools/verify-ias-report/verify_ias_report.c
+++ b/Pal/src/host/Linux-SGX/tools/verify-ias-report/verify_ias_report.c
@@ -1,0 +1,170 @@
+/* Copyright (C) 2018-2020 Invisible Things Lab
+                           Rafal Wojdyla <omeg@invisiblethingslab.com>
+   This file is part of Graphene Library OS.
+   Graphene Library OS is free software: you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public License
+   as published by the Free Software Foundation, either version 3 of the
+   License, or (at your option) any later version.
+   Graphene Library OS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Lesser General Public License for more details.
+   You should have received a copy of the GNU Lesser General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
+
+#include <getopt.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "attestation.h"
+#include "util.h"
+
+struct option g_options[] = {
+    { "help", no_argument, 0, 'h' },
+    { "verbose", no_argument, 0, 'v' },
+    { "msb", no_argument, 0, 'm' },
+    { "report-path", required_argument, 0, 'r' },
+    { "sig-path", required_argument, 0, 's' },
+    { "allow-outdated-tcb", no_argument, 0, 'o' },
+    { "nonce", required_argument, 0, 'n' },
+    { "mr-signer", required_argument, 0, 'S' },
+    { "mr-enclave", required_argument, 0, 'E' },
+    { "report-data", required_argument, 0, 'R' },
+    { "isv-prod-id", required_argument, 0, 'P' },
+    { "isv-svn", required_argument, 0, 'S' },
+    { "ias-pubkey", required_argument, 0, 'i' },
+    { 0, 0, 0, 0 }
+};
+
+void usage(const char* exec) {
+    INFO("Usage: %s [options]\n", exec);
+    INFO("Available options:\n");
+    INFO("  --help, -h                Display this help\n");
+    INFO("  --verbose, -v             Enable verbose output\n");
+    INFO("  --msb, -m                 Print/parse hex strings in big-endian order\n");
+    INFO("  --report-path, -r PATH    Path to the IAS report\n");
+    INFO("  --sig-path, -s PATH       Path to the IAS report's signature\n");
+    INFO("  --allow-outdated-tcb, -o  Treat IAS status GROUP_OUT_OF_DATE as OK\n");
+    INFO("  --nonce, -n STRING        Nonce that's expected in the report (optional)\n");
+    INFO("  --mr-signer, -S STRING    Expected quote MRSIGNER (hex string, optional)\n");
+    INFO("  --mr-enclave, -E STRING   Expected quote MRENCLAVE (hex string, optional)\n");
+    INFO("  --report-data, -R STRING  Expected report_data field (hex string, optional)\n");
+    INFO("  --isv-prod-id, -P NUMBER  Expected isv_prod_id field (uint16_t, optional)\n");
+    INFO("  --isv-svn, -V NUMBER      Expected isv_svn field (uint16_t, optional)\n");
+    INFO("  --ias-pubkey, -i PATH     Path to IAS public RSA key (PEM format, optional)\n");
+}
+
+int main(int argc, char* argv[]) {
+    int option              = 0;
+    char* report_path       = NULL;
+    ssize_t report_size     = 0;
+    char* sig_path          = NULL;
+    ssize_t sig_size        = 0;
+    char* nonce             = NULL;
+    bool allow_outdated_tcb = false;
+    char* mrsigner          = NULL;
+    char* mrenclave         = NULL;
+    char* report_data       = NULL;
+    char* isv_prod_id       = NULL;
+    char* isv_svn           = NULL;
+    char* ias_pubkey_path   = NULL;
+    endianness_t endian     = ENDIAN_LSB;
+
+    // parse command line
+    while (true) {
+        option = getopt_long(argc, argv, "hvmr:s:on:S:E:R:P:V:i:", g_options, NULL);
+        if (option == -1)
+            break;
+
+        switch (option) {
+            case 'h':
+                usage(argv[0]);
+                return 0;
+            case 'v':
+                set_verbose(true);
+                break;
+            case 'm':
+                endian = ENDIAN_MSB;
+                break;
+            case 'r':
+                report_path = optarg;
+                break;
+            case 's':
+                sig_path = optarg;
+                break;
+            case 'o':
+                allow_outdated_tcb = true;
+                break;
+            case 'n':
+                nonce = optarg;
+                break;
+            case 'S':
+                mrsigner = optarg;
+                break;
+            case 'E':
+                mrenclave = optarg;
+                break;
+            case 'R':
+                report_data = optarg;
+                break;
+            case 'P':
+                isv_prod_id = optarg;
+                break;
+            case 'V':
+                isv_svn = optarg;
+                break;
+            case 'i':
+                ias_pubkey_path = optarg;
+                break;
+            default:
+                usage(argv[0]);
+                return -1;
+        }
+    }
+
+    set_endianness(endian);
+
+    if (!report_path || !sig_path) {
+        usage(argv[0]);
+        return -1;
+    }
+
+    uint8_t* report = read_file(report_path, &report_size);
+    if (!report) {
+        ERROR("Failed to read report file '%s'\n", report_path);
+        return -1;
+    }
+
+    uint8_t* sig = read_file(sig_path, &sig_size);
+    if (!sig) {
+        ERROR("Failed to read report signature file '%s'\n", sig_path);
+        return -1;
+    }
+
+    char* ias_pubkey = NULL;
+    ssize_t ias_pubkey_size = 0;
+
+    if (ias_pubkey_path) {
+        uint8_t* buf = read_file(ias_pubkey_path, &ias_pubkey_size);
+        if (!buf) {
+            ERROR("Failed to read IAS pubkey file '%s'\n", ias_pubkey_path);
+            return -1;
+        }
+
+        // Need to add NULL terminator
+        ias_pubkey = calloc(1, ias_pubkey_size + 1);
+        if (!ias_pubkey) {
+            ERROR("No memory\n");
+            return -1;
+        }
+
+        memcpy(ias_pubkey, buf, ias_pubkey_size);
+        free(buf);
+        DBG("Using IAS public key from file '%s'\n", ias_pubkey_path);
+    }
+
+    int ret = verify_ias_report(report, report_size, sig, sig_size, allow_outdated_tcb, nonce,
+                                mrsigner, mrenclave, isv_prod_id, isv_svn, report_data, ias_pubkey);
+
+    return ret;
+}


### PR DESCRIPTION
<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [ ] Linux PAL
- [ ] SGX PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->
Added standalone (non-graphene) SGX utilities:
- `is_sgx_available` for checking environment for SGX compatibility
- `quote_dump` for displaying internal quote structure
- `ias_request` for sending IAS requests (SigRL retrieval and quote verification)
- `verify_ias_report` for verifying IAS attestation reports (and quote contents)
- `libsgx_util.so` shared library with functionality of these tools (see `.h` files)
- run `make install` to install tools and the library

## How to test this PR? <!-- (if applicable) -->
Run the tools.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1371)
<!-- Reviewable:end -->
