### PR TITLE
[Pal/{Linux,Linux-SGX}] Refactor _DkSendHandle() and _DkReceiveHandle() and encrypt

### DIFF
--- a/Pal/src/host/Linux-SGX/db_streams.c
+++ b/Pal/src/host/Linux-SGX/db_streams.c
@@ -21,9 +21,8 @@
  * streams.
  */
 
-#include <linux/types.h>
-
 #include "api.h"
+#include "enclave_pages.h"
 #include "pal.h"
 #include "pal_debug.h"
 #include "pal_defs.h"
@@ -32,6 +31,7 @@
 #include "pal_linux.h"
 #include "pal_linux_defs.h"
 #include "pal_linux_error.h"
+
 typedef __kernel_pid_t pid_t;
 #include <asm/fcntl.h>
 #include <asm/poll.h>
@@ -42,12 +42,27 @@ typedef __kernel_pid_t pid_t;
 #include <linux/msg.h>
 #include <linux/socket.h>
 #include <linux/stat.h>
+#include <linux/types.h>
 #include <linux/wait.h>
 
-#include "enclave_pages.h"
+#define DUMMYPAYLOAD "dummypayload"
+#define DUMMYPAYLOADSIZE (sizeof(DUMMYPAYLOAD))
 
-void _DkPrintConsole(const void* buf, int size) {
-    ocall_write(2 /*stderr*/, buf, size);
+struct hdl_header {
+    uint8_t fds;       /* bitmask of host file descriptors corresponding to PAL handle */
+    size_t  data_size; /* total size of serialized PAL handle */
+};
+static_assert((sizeof(((struct hdl_header*)0)->fds) * 8) >= MAX_FDS, "insufficient fds size");
+
+static size_t addr_size(const struct sockaddr* addr) {
+    switch (addr->sa_family) {
+        case AF_INET:
+            return sizeof(struct sockaddr_in);
+        case AF_INET6:
+            return sizeof(struct sockaddr_in6);
+        default:
+            return 0;
+    }
 }
 
 bool stataccess(struct stat* stat, int acc) {
@@ -70,33 +85,24 @@ out:
     return (mode & acc);
 }
 
+void _DkPrintConsole(const void* buf, int size) {
+    ocall_write(2 /*stderr*/, buf, size);
+}
+
 /* _DkStreamUnmap for internal use. Unmap stream at certain memory address.
    The memory is unmapped as a whole.*/
 int _DkStreamUnmap(void* addr, uint64_t size) {
     return free_enclave_pages(addr, size);
 }
 
-static size_t addr_size(const struct sockaddr* addr) {
-    switch (addr->sa_family) {
-        case AF_INET:
-            return sizeof(struct sockaddr_in);
-        case AF_INET6:
-            return sizeof(struct sockaddr_in6);
-        default:
-            return 0;
-    }
-}
-
-int handle_serialize(PAL_HANDLE handle, void** data) {
-    int hdlsz = handle_size(handle);
+static ssize_t handle_serialize(PAL_HANDLE handle, void** data) {
     const void* d1;
     const void* d2;
-    int dsz1 = 0, dsz2 = 0;
+    size_t dsz1 = 0;
+    size_t dsz2 = 0;
 
-    // ~ Check cargo PAL_HANDLE - is allowed to be sent (White List checking
-    // of cargo type)
-    // ~ Also, Initialize common parameter formessage passing
-    // Channel between parent and child
+    /* find fields to serialize (depends on the handle type) and assign them to d1/d2; note that
+     * no handle type has more than two such fields, and some have none at all */
     switch (PAL_GET_TYPE(handle)) {
         case pal_type_file:
             d1   = handle->file.realpath;
@@ -106,6 +112,7 @@ int handle_serialize(PAL_HANDLE handle, void** data) {
         case pal_type_pipesrv:
         case pal_type_pipecli:
         case pal_type_pipeprv:
+            /* pipes have no fields to serialize */
             break;
         case pal_type_dev:
             if (handle->dev.realpath) {
@@ -133,252 +140,230 @@ int handle_serialize(PAL_HANDLE handle, void** data) {
             }
             break;
         case pal_type_process:
+            /* do not send ssl_ctx to child */
+            break;
         case pal_type_eventfd:
             break;
         default:
             return -PAL_ERROR_INVAL;
     }
 
+    size_t hdlsz = handle_size(handle);
     void* buffer = malloc(hdlsz + dsz1 + dsz2);
     if (!buffer)
         return -PAL_ERROR_NOMEM;
 
+    /* copy into buffer all handle fields and then serialized fields */
     memcpy(buffer, handle, hdlsz);
     if (dsz1)
         memcpy(buffer + hdlsz, d1, dsz1);
     if (dsz2)
         memcpy(buffer + hdlsz + dsz1, d2, dsz2);
 
-    if (PAL_GET_TYPE(handle) == pal_type_process) {
-        /* must not leak session key and SSL context -> zero them */
-        memset(buffer + offsetof(struct pal_handle, process.session_key), 0, sizeof(handle->process.session_key));
-        memset(buffer + offsetof(struct pal_handle, process.ssl_ctx), 0, sizeof(handle->process.ssl_ctx));
-    }
-
     *data = buffer;
     return hdlsz + dsz1 + dsz2;
 }
 
-int handle_deserialize(PAL_HANDLE* handle, const void* data, int size) {
-    PAL_HANDLE hdl_data = (void*)data, hdl = NULL;
-    int hdlsz = handle_size(hdl_data), ret = -PAL_ERROR_NOMEM;
+static int handle_deserialize(PAL_HANDLE* handle, const void* data, size_t size) {
+    PAL_HANDLE hdl = malloc(size);
+    if (!hdl)
+        return -PAL_ERROR_NOMEM;
 
-    data += hdlsz;
-    size -= hdlsz;
+    memcpy(hdl, data, size);
+    size_t hdlsz = handle_size(hdl);
 
-    // recreate PAL_HANDLE based on type
-    switch (PAL_GET_TYPE(hdl_data)) {
-        case pal_type_file: {
-            int l = strlen((const char*)data) + 1;
-            hdl   = malloc(hdlsz + l);
-            if (!hdl)
-                break;
-            memcpy(hdl, hdl_data, hdlsz);
-            memcpy((void*)hdl + hdlsz, data, l);
-            hdl->file.realpath = (PAL_STR)hdl + hdlsz;
+    /* update handle fields to point to correct contents (located right after handle itself) */
+    switch (PAL_GET_TYPE(hdl)) {
+        case pal_type_file:
+            hdl->file.realpath = hdl->file.realpath ? (PAL_STR)hdl + hdlsz : NULL;
             hdl->file.stubs    = (PAL_PTR)NULL;
             break;
-        }
         case pal_type_pipe:
         case pal_type_pipesrv:
         case pal_type_pipecli:
         case pal_type_pipeprv:
-            hdl = malloc_copy(hdl_data, hdlsz);
             break;
-        case pal_type_dev: {
-            int l = hdl_data->dev.realpath ? strlen((const char*)data) + 1 : 0;
-            hdl   = malloc(hdlsz + l);
-            if (!hdl)
-                break;
-            memcpy(hdl, hdl_data, hdlsz);
-            if (l) {
-                memcpy((void*)hdl + hdlsz, data, l);
-                hdl->dev.realpath = (void*)hdl + hdlsz;
-            }
+        case pal_type_dev:
+            hdl->dev.realpath = hdl->dev.realpath ? (PAL_STR)hdl + hdlsz : NULL;
             break;
-        }
-        case pal_type_dir: {
-            int l = hdl_data->dir.realpath ? strlen((const char*)data) + 1 : 0;
-            hdl   = malloc(hdlsz + l);
-            if (!hdl)
-                break;
-            memcpy(hdl, hdl_data, hdlsz);
-            if (l) {
-                memcpy((void*)hdl + hdlsz, data, l);
-                hdl->dir.realpath = (void*)hdl + hdlsz;
-            }
+        case pal_type_dir:
+            hdl->dir.realpath = hdl->dir.realpath ? (PAL_STR)hdl + hdlsz : NULL;
             break;
-        }
         case pal_type_tcp:
         case pal_type_tcpsrv:
         case pal_type_udp:
         case pal_type_udpsrv: {
-            int s1 = 0, s2 = 0;
-            if (hdl_data->sock.bind)
-                s1 = addr_size(data);
-            if (hdl_data->sock.conn)
-                s2 = addr_size(data + s1);
-            hdl = malloc(hdlsz + s1 + s2);
-            if (!hdl)
-                break;
-            memcpy(hdl, hdl_data, hdlsz);
-            if (s1) {
-                memcpy((void*)hdl + hdlsz, data, s1);
+            size_t s1 = hdl->sock.bind ? addr_size((PAL_PTR)hdl + hdlsz) : 0;
+            size_t s2 = hdl->sock.conn ? addr_size((PAL_PTR)hdl + hdlsz + s1) : 0;
+            if (s1)
                 hdl->sock.bind = (PAL_PTR)hdl + hdlsz;
-            }
-            if (s2) {
-                memcpy((void*)hdl + hdlsz + s1, data + s1, s2);
+            if (s2)
                 hdl->sock.conn = (PAL_PTR)hdl + hdlsz + s2;
-            }
             break;
         }
         case pal_type_process:
+            /* child doesn't need to know ssl_ctx of other processes */
+            hdl->process.ssl_ctx = NULL;
+            break;
         case pal_type_eventfd:
-            hdl = malloc_copy(hdl_data, hdlsz);
             break;
         default:
             return -PAL_ERROR_BADHANDLE;
-    }
-
-    if (!hdl)
-        return ret;
-
-    if (PAL_GET_TYPE(hdl) == pal_type_process) {
-        /* must not have leaked session key and SSL context, verify */
-        static PAL_SESSION_KEY zero_session_key;
-        __UNUSED(zero_session_key); /* otherwise GCC with Release build complains */
-
-        assert(memcmp(hdl->process.session_key, zero_session_key, sizeof(zero_session_key)) == 0);
-        assert(hdl->process.ssl_ctx == 0);
     }
 
     *handle = hdl;
     return 0;
 }
 
-// Header for DkSendHandle and DkRecvHandle
-struct hdl_header {
-    unsigned short fds : (MAX_FDS);
-    unsigned short data_size : (16 - (MAX_FDS));
-};
-
-/* _DkSendHandle for internal use. Send a Pal Handle over the given
-   process handle. Return 1 if success else return negative error code */
+/*!
+ * \brief Send `cargo` handle to a process identified via `hdl` handle.
+ *
+ * If `hdl` has an SSL context (i.e., its stream is encrypted), then `cargo` is sent encrypted.
+ *
+ * \param[in] hdl    Process stream on which to send `cargo`.
+ * \param[in] cargo  Arbitrary handle to serialize and send on `hdl`.
+ * \return           0 on success, negative PAL error code otherwise.
+ */
 int _DkSendHandle(PAL_HANDLE hdl, PAL_HANDLE cargo) {
-    struct hdl_header hdl_hdr;
-    void* hdl_data;
-    int data_size = handle_serialize(cargo, &hdl_data);
-    if (data_size < 0)
-        return data_size;
+    if (!IS_HANDLE_TYPE(hdl, process))
+        return -PAL_ERROR_BADHANDLE;
 
-    hdl_hdr.fds       = 0;
-    hdl_hdr.data_size = data_size;
-    unsigned int fds[MAX_FDS];
-    unsigned int nfds = 0;
+    /* serialize cargo handle into a blob hdl_data */
+    void* hdl_data = NULL;
+    ssize_t hdl_data_size = handle_serialize(cargo, &hdl_data);
+    if (hdl_data_size < 0)
+        return hdl_data_size;
+
+    ssize_t ret;
+    struct hdl_header hdl_hdr = {.fds = 0, .data_size = hdl_data_size};
+    int fd = hdl->process.stream;
+
+    /* apply bitmask of FDs-to-transfer to hdl_hdr.fds and populate `fds` with these FDs */
+    int fds[MAX_FDS];
+    int nfds = 0;
     for (int i = 0; i < MAX_FDS; i++)
         if (HANDLE_HDR(cargo)->flags & (RFD(i) | WFD(i))) {
             hdl_hdr.fds |= 1U << i;
             fds[nfds++] = cargo->generic.fds[i];
         }
 
-    int ch = hdl->process.stream;
-    ssize_t ret;
-    ret    = ocall_send(ch, &hdl_hdr, sizeof(struct hdl_header), NULL, 0, NULL, 0);
-
+    /* first send hdl_hdr so the recipient knows how many FDs were transferred + how large is cargo */
+    ret = ocall_send(fd, &hdl_hdr, sizeof(struct hdl_header), NULL, 0, NULL, 0);
     if (IS_ERR(ret)) {
         free(hdl_data);
         return unix_to_pal_error(ERRNO(ret));
     }
 
-    uint64_t fds_size = nfds * sizeof(unsigned int);
-    char cbuf[sizeof(struct cmsghdr) + fds_size];
+    /* construct ancillary data of FDs-to-transfer in a control message */
+    size_t fds_size = nfds * sizeof(int);
+    char control_buf[sizeof(struct cmsghdr) + fds_size];
 
-    struct cmsghdr* chdr = (struct cmsghdr*)cbuf;
-    chdr->cmsg_level = SOL_SOCKET;
-    chdr->cmsg_type = SCM_RIGHTS;
-    chdr->cmsg_len = CMSG_LEN(fds_size);
-    memcpy(CMSG_DATA(chdr), fds, fds_size);
+    struct cmsghdr* control_hdr = (struct cmsghdr*)control_buf;
+    control_hdr->cmsg_level     = SOL_SOCKET;
+    control_hdr->cmsg_type      = SCM_RIGHTS;
+    control_hdr->cmsg_len       = CMSG_LEN(fds_size);
+    memcpy(CMSG_DATA(control_hdr), fds, fds_size);
 
-    ret = ocall_send(ch, hdl_data, hdl_hdr.data_size, NULL, 0, chdr, chdr->cmsg_len);
+    /* next send FDs-to-transfer as ancillary data */
+    ret = ocall_send(fd, DUMMYPAYLOAD, DUMMYPAYLOADSIZE, NULL, 0, control_hdr, control_hdr->cmsg_len);
+    if (IS_ERR(ret)) {
+        free(hdl_data);
+        return unix_to_pal_error(ERRNO(ret));
+    }
+
+    /* finally send the serialized cargo as payload (possibly encrypted) */
+    if (hdl->process.ssl_ctx) {
+        ret = _DkStreamSecureWrite(hdl->process.ssl_ctx, (uint8_t*)hdl_data, hdl_hdr.data_size);
+    } else {
+        ret = ocall_write(fd, hdl_data, hdl_hdr.data_size);
+        ret = IS_ERR(ret) ? unix_to_pal_error(ERRNO(ret)) : ret;
+    }
 
     free(hdl_data);
-    return IS_ERR(ret) ? unix_to_pal_error(ERRNO(ret)) : 0;
+    return IS_ERR(ret) ? ret : 0;
 }
 
-/* _DkRecvHandle for internal use. Receive and return a PAL_HANDLE over the
-   given PAL_HANDLE else return negative value. */
+/*!
+ * \brief Receive `cargo` handle from a process identified via `hdl` handle.
+ *
+ * If `hdl` has an SSL context (i.e., its stream is encrypted), then `cargo` is sent encrypted.
+ *
+ * \param[in] hdl    Process stream on which to receive `cargo`.
+ * \param[in] cargo  Arbitrary handle to receive on `hdl` and deserialize.
+ * \return           0 on success, negative PAL error code otherwise.
+ */
 int _DkReceiveHandle(PAL_HANDLE hdl, PAL_HANDLE* cargo) {
-    struct hdl_header hdl_hdr;
-
     if (!IS_HANDLE_TYPE(hdl, process))
         return -PAL_ERROR_BADHANDLE;
 
-    int ch = hdl->process.stream;
+    ssize_t ret;
+    struct hdl_header hdl_hdr;
+    int fd = hdl->process.stream;
 
-    ssize_t ret = ocall_recv(ch, &hdl_hdr, sizeof(struct hdl_header), NULL, NULL, NULL, NULL);
-
+    /* first receive hdl_hdr so that we know how many FDs were transferred + how large is cargo */
+    ret = ocall_recv(fd, &hdl_hdr, sizeof(hdl_hdr), NULL, NULL, NULL, NULL);
     if (IS_ERR(ret))
         return unix_to_pal_error(ERRNO(ret));
 
-    if ((size_t)ret < sizeof(struct hdl_header)) {
-        /*
-         * This code block is just in case to cover all the possibilities
-         * to shield Iago attack.
-         * We know that the file descriptor is an unix domain socket with
-         * blocking mode and that the sender, _DkSendHandle() above, sends the
-         * header with single sendmsg syscall by ocall_send() which
-         * transfers a message atomically.
-         *
-         * read size == 0: return error for the caller to try again.
-         *                 It should result in EINTR.
-         *
-         * read size > 0: return error for the caller to give up this file
-         *                descriptor.
-         *                If the header can't be send atomically for some
-         *                reason, the sender should get EMSGSIZE.
-         */
+    if ((size_t)ret != sizeof(hdl_hdr)) {
+        /* This check is to shield from a Iago attack. We know that ocall_send() in _DkSendHandle()
+         * transfers the message atomically, and that our ocall_recv() receives it atomically. So
+         * the only valid values for ret must be zero or the size of the header. */
         if (!ret)
             return -PAL_ERROR_TRYAGAIN;
         return -PAL_ERROR_DENIED;
     }
 
-    uint32_t nfds = 0;
+    /* prepare control-message buffer to receive ancillary data of FDs-to-transfer */
+    int nfds = 0;
     for (int i = 0; i < MAX_FDS; i++)
         if (hdl_hdr.fds & (1U << i))
             nfds++;
 
-    uint64_t fds_size  = nfds * sizeof(unsigned int);
-    uint64_t cbuf_size = sizeof(struct cmsghdr) + fds_size;
+    size_t control_buf_size = sizeof(struct cmsghdr) + nfds * sizeof(int);
+    char control_buf[control_buf_size];
 
-    char buffer[hdl_hdr.data_size];
-    char cbuf[cbuf_size];
-    ret = ocall_recv(ch, buffer, hdl_hdr.data_size, NULL, NULL, cbuf, &cbuf_size);
-
+    /* next receive FDs-to-transfer as ancillary data */
+    char dummypayload[DUMMYPAYLOADSIZE];
+    ret = ocall_recv(fd, dummypayload, DUMMYPAYLOADSIZE, NULL, NULL, control_buf, &control_buf_size);
     if (IS_ERR(ret))
         return unix_to_pal_error(ERRNO(ret));
 
-    nfds = 0;
-    uint32_t fds[fds_size];
-    struct cmsghdr* chdr = (struct cmsghdr*)cbuf;
-    if (chdr->cmsg_type == SCM_RIGHTS) {
-        nfds = (chdr->cmsg_len - sizeof(struct cmsghdr)) / sizeof(int);
-        memcpy(fds, CMSG_DATA(chdr), nfds * sizeof(int));
-    }
+    /* finally receive the serialized cargo as payload (possibly encrypted) */
+    char hdl_data[hdl_hdr.data_size];
 
-    PAL_HANDLE handle = NULL;
-    ret               = handle_deserialize(&handle, buffer, hdl_hdr.data_size);
-    if (ret < 0)
+    if (hdl->process.ssl_ctx) {
+        ret = _DkStreamSecureRead(hdl->process.ssl_ctx, (uint8_t*)hdl_data, hdl_hdr.data_size);
+    } else {
+        ret = ocall_read(fd, hdl_data, hdl_hdr.data_size);
+        ret = IS_ERR(ret) ? unix_to_pal_error(ERRNO(ret)) : ret;
+    }
+    if (IS_ERR(ret))
         return ret;
 
-    uint32_t n = 0;
-    for (uint32_t i = 0; i < MAX_FDS; i++)
+    /* deserialize cargo handle from a blob hdl_data */
+    PAL_HANDLE handle = NULL;
+    ret = handle_deserialize(&handle, hdl_data, hdl_hdr.data_size);
+    if (IS_ERR(ret))
+        return ret;
+
+    /* restore cargo handle's FDs from the received FDs-to-transfer */
+    struct cmsghdr* control_hdr = (struct cmsghdr*)control_buf;
+    if (!control_hdr || control_hdr->cmsg_type != SCM_RIGHTS)
+        return -PAL_ERROR_DENIED;
+
+    int fds_idx = 0;
+    int* fds = (int*)CMSG_DATA(control_hdr);
+
+    for (int i = 0; i < MAX_FDS; i++) {
         if (hdl_hdr.fds & (1U << i)) {
-            if (n < nfds) {
-                handle->generic.fds[i] = fds[n++];
+            if (fds_idx < nfds) {
+                handle->generic.fds[i] = fds[fds_idx++];
             } else {
                 HANDLE_HDR(handle)->flags &= ~(RFD(i) | WFD(i));
             }
         }
+    }
 
     *cargo = handle;
     return 0;

--- a/Pal/src/host/Linux/db_streams.c
+++ b/Pal/src/host/Linux/db_streams.c
@@ -21,8 +21,6 @@
  * streams.
  */
 
-#include <linux/types.h>
-
 #include "api.h"
 #include "pal.h"
 #include "pal_debug.h"
@@ -31,6 +29,7 @@
 #include "pal_internal.h"
 #include "pal_linux.h"
 #include "pal_linux_defs.h"
+
 typedef __kernel_pid_t pid_t;
 #include <asm/errno.h>
 #include <asm/fcntl.h>
@@ -38,13 +37,27 @@ typedef __kernel_pid_t pid_t;
 #include <asm/socket.h>
 #include <linux/msg.h>
 #include <linux/socket.h>
+#include <linux/types.h>
 #include <linux/wait.h>
 #include <netinet/in.h>
 #include <sys/signal.h>
 #include <sys/socket.h>
 
-void _DkPrintConsole(const void* buf, int size) {
-    INLINE_SYSCALL(write, 3, 2, buf, size);
+struct hdl_header {
+    uint8_t fds;       /* bitmask of host file descriptors corresponding to PAL handle */
+    size_t  data_size; /* total size of serialized PAL handle */
+};
+static_assert((sizeof(((struct hdl_header*)0)->fds) * 8) >= MAX_FDS, "insufficient fds size");
+
+static size_t addr_size(const struct sockaddr* addr) {
+    switch (addr->sa_family) {
+        case AF_INET:
+            return sizeof(struct sockaddr_in);
+        case AF_INET6:
+            return sizeof(struct sockaddr_in6);
+        default:
+            return 0;
+    }
 }
 
 bool stataccess(struct stat* stat, int acc) {
@@ -79,6 +92,10 @@ int handle_set_cloexec(PAL_HANDLE handle, bool enable) {
     return 0;
 }
 
+void _DkPrintConsole(const void* buf, int size) {
+    INLINE_SYSCALL(write, 3, 2 /*stderr*/, buf, size);
+}
+
 /* _DkStreamUnmap for internal use. Unmap stream at certain memory address.
    The memory is unmapped as a whole.*/
 int _DkStreamUnmap(void* addr, uint64_t size) {
@@ -91,27 +108,14 @@ int _DkStreamUnmap(void* addr, uint64_t size) {
     return 0;
 }
 
-static size_t addr_size(const struct sockaddr* addr) {
-    switch (addr->sa_family) {
-        case AF_INET:
-            return sizeof(struct sockaddr_in);
-        case AF_INET6:
-            return sizeof(struct sockaddr_in6);
-        default:
-            return 0;
-    }
-}
-
 int handle_serialize(PAL_HANDLE handle, void** data) {
-    int hdlsz = handle_size(handle);
     const void* d1;
     const void* d2;
-    int dsz1 = 0, dsz2 = 0;
+    size_t dsz1 = 0;
+    size_t dsz2 = 0;
 
-    // ~ Check cargo PAL_HANDLE - is allowed to be sent (White List checking
-    // of cargo type)
-    // ~ Also, Initialize common parameter formessage passing
-    // Channel between parent and child
+    /* find fields to serialize (depends on the handle type) and assign them to d1/d2; note that
+     * no handle type has more than two such fields, and some have none at all */
     switch (PAL_GET_TYPE(handle)) {
         case pal_type_file:
             d1   = handle->file.realpath;
@@ -121,6 +125,7 @@ int handle_serialize(PAL_HANDLE handle, void** data) {
         case pal_type_pipesrv:
         case pal_type_pipecli:
         case pal_type_pipeprv:
+            /* pipes have no fields to serialize */
             break;
         case pal_type_dev:
             if (handle->dev.realpath) {
@@ -154,10 +159,12 @@ int handle_serialize(PAL_HANDLE handle, void** data) {
             return -PAL_ERROR_INVAL;
     }
 
+    size_t hdlsz = handle_size(handle);
     void* buffer = malloc(hdlsz + dsz1 + dsz2);
     if (!buffer)
         return -PAL_ERROR_NOMEM;
 
+    /* copy into buffer all handle fields and then serialized fields */
     memcpy(buffer, handle, hdlsz);
     if (dsz1)
         memcpy(buffer + hdlsz, d1, dsz1);
@@ -169,109 +176,74 @@ int handle_serialize(PAL_HANDLE handle, void** data) {
 }
 
 int handle_deserialize(PAL_HANDLE* handle, const void* data, int size) {
-    PAL_HANDLE hdl_data = (void*)data, hdl = NULL;
-    int hdlsz = handle_size(hdl_data), ret = -PAL_ERROR_NOMEM;
+    PAL_HANDLE hdl = malloc(size);
+    if (!hdl)
+        return -PAL_ERROR_NOMEM;
 
-    data += hdlsz;
-    size -= hdlsz;
+    memcpy(hdl, data, size);
+    size_t hdlsz = handle_size(hdl);
 
-    // recreate PAL_HANDLE based on type
-    switch (PAL_GET_TYPE(hdl_data)) {
-        case pal_type_file: {
-            int l = strlen((const char*)data) + 1;
-            hdl   = malloc(hdlsz + l);
-            if (!hdl)
-                break;
-            memcpy(hdl, hdl_data, hdlsz);
-            memcpy((void*)hdl + hdlsz, data, l);
-            hdl->file.realpath = (void*)hdl + hdlsz;
+    /* update handle fields to point to correct contents (located right after handle itself) */
+    switch (PAL_GET_TYPE(hdl)) {
+        case pal_type_file:
+            hdl->file.realpath = hdl->file.realpath ? (PAL_STR)hdl + hdlsz : NULL;
             break;
-        }
         case pal_type_pipe:
         case pal_type_pipesrv:
         case pal_type_pipecli:
         case pal_type_pipeprv:
-            hdl = malloc_copy(hdl_data, hdlsz);
             break;
-        case pal_type_dev: {
-            int l = hdl_data->dev.realpath ? strlen((const char*)data) + 1 : 0;
-            hdl   = malloc(hdlsz + l);
-            if (!hdl)
-                break;
-            memcpy(hdl, hdl_data, hdlsz);
-            if (l) {
-                memcpy((void*)hdl + hdlsz, data, l);
-                hdl->dev.realpath = (void*)hdl + hdlsz;
-            }
+        case pal_type_dev:
+            hdl->dev.realpath = hdl->dev.realpath ? (PAL_STR)hdl + hdlsz : NULL;
             break;
-        }
-        case pal_type_dir: {
-            int l = hdl_data->dir.realpath ? strlen((const char*)data) + 1 : 0;
-            hdl   = malloc(hdlsz + l);
-            if (!hdl)
-                break;
-            memcpy(hdl, hdl_data, hdlsz);
-            if (l) {
-                memcpy((void*)hdl + hdlsz, data, l);
-                hdl->dir.realpath = (void*)hdl + hdlsz;
-            }
+        case pal_type_dir:
+            hdl->dir.realpath = hdl->dir.realpath ? (PAL_STR)hdl + hdlsz : NULL;
             break;
-        }
         case pal_type_tcp:
         case pal_type_tcpsrv:
         case pal_type_udp:
         case pal_type_udpsrv: {
-            int s1 = 0, s2 = 0;
-            if (hdl_data->sock.bind)
-                s1 = addr_size((const struct sockaddr*)data);
-            if (hdl_data->sock.conn)
-                s2 = addr_size((const struct sockaddr*)(data + s1));
-            hdl = malloc(hdlsz + s1 + s2);
-            if (!hdl)
-                break;
-            memcpy(hdl, hdl_data, hdlsz);
-            if (s1) {
-                memcpy((void*)hdl + hdlsz, data, s1);
+            size_t s1 = hdl->sock.bind ? addr_size((PAL_PTR)hdl + hdlsz) : 0;
+            size_t s2 = hdl->sock.conn ? addr_size((PAL_PTR)hdl + hdlsz + s1) : 0;
+            if (s1)
                 hdl->sock.bind = (PAL_PTR)hdl + hdlsz;
-            }
-            if (s2) {
-                memcpy((void*)hdl + hdlsz + s1, data + s1, s2);
+            if (s2)
                 hdl->sock.conn = (PAL_PTR)hdl + hdlsz + s2;
-            }
             break;
         }
         case pal_type_process:
         case pal_type_eventfd:
-            hdl = malloc_copy(hdl_data, hdlsz);
             break;
         default:
             return -PAL_ERROR_BADHANDLE;
     }
 
-    if (!hdl)
-        return ret;
-
     *handle = hdl;
     return 0;
 }
 
-// Header for DkSendHandle and DkRecvHandle
-struct hdl_header {
-    unsigned short fds : (MAX_FDS);
-    unsigned short data_size : (16 - (MAX_FDS));
-};
-
-/* _DkSendHandle for internal use. Send a Pal Handle over the given
-   process handle. Return 1 if success else return negative error code */
+/*!
+ * \brief Send `cargo` handle to a process identified via `hdl` handle.
+ *
+ * \param[in] hdl    Process stream on which to send `cargo`.
+ * \param[in] cargo  Arbitrary handle to serialize and send on `hdl`.
+ * \return           0 on success, negative PAL error code otherwise.
+ */
 int _DkSendHandle(PAL_HANDLE hdl, PAL_HANDLE cargo) {
-    struct hdl_header hdl_hdr;
-    void* hdl_data;
-    int ret = handle_serialize(cargo, &hdl_data);
-    if (ret < 0)
-        return ret;
+    if (!IS_HANDLE_TYPE(hdl, process))
+        return -PAL_ERROR_BADHANDLE;
 
-    hdl_hdr.fds       = 0;
-    hdl_hdr.data_size = ret;
+    /* serialize cargo handle into a blob hdl_data */
+    void* hdl_data = NULL;
+    ssize_t hdl_data_size = handle_serialize(cargo, &hdl_data);
+    if (hdl_data_size < 0)
+        return hdl_data_size;
+
+    ssize_t ret;
+    struct hdl_header hdl_hdr = {.fds = 0, .data_size = hdl_data_size};
+    int fd = hdl->process.stream;
+
+    /* apply bitmask of FDs-to-transfer to hdl_hdr.fds and populate `fds` with these FDs */
     int fds[MAX_FDS];
     int nfds = 0;
     for (int i = 0; i < MAX_FDS; i++)
@@ -280,171 +252,132 @@ int _DkSendHandle(PAL_HANDLE hdl, PAL_HANDLE cargo) {
             fds[nfds++] = cargo->generic.fds[i];
         }
 
-    // ~ Initialize common parameter formessage passing
-    // Channel between parent and child
-    int ch = hdl->process.stream;
-
-    // Declare variables required for sending the message
-    struct msghdr hdr;     // message header
-    struct cmsghdr* chdr;  // control message header
-    struct iovec iov[1];   // IO Vector
-
-    iov[0].iov_base    = &hdl_hdr;
-    iov[0].iov_len     = sizeof(struct hdl_header);
-    hdr.msg_name       = NULL;
-    hdr.msg_namelen    = 0;
-    hdr.msg_iov        = iov;
-    hdr.msg_iovlen     = 1;
-    hdr.msg_control    = NULL;
-    hdr.msg_controllen = 0;
-    hdr.msg_flags      = 0;
-
-    ret = INLINE_SYSCALL(sendmsg, 3, ch, &hdr, MSG_NOSIGNAL);
-
-    // Unlock is error
-    if (IS_ERR(ret)) {
-        free(hdl_data);
-        return -PAL_ERROR_DENIED;
-    }
-
-    /* Message Body Composition:
-       IOVEC[0]: PAL_HANDLE
-       IOVEC[1..n]: Additional handle member follow
-       Control Message: file descriptors */
-
-    // Control message buffer with added space for 2 fds (ie. max size
-    // that it will have)
-    char cbuf[sizeof(struct cmsghdr) + MAX_FDS * sizeof(int)];
-
-    // Initialize iovec[0] with struct PAL_HANDLE
-    iov[0].iov_base = hdl_data;
-    iov[0].iov_len  = hdl_hdr.data_size;
-
-    hdr.msg_iov        = iov;
-    hdr.msg_iovlen     = 1;
-    hdr.msg_control    = cbuf;  // Control Message Buffer
-    hdr.msg_controllen = sizeof(cbuf);
-
-    // Fill control message infomation for the file descriptors
-    // Check hdr.msg_controllen >= sizeof(struct cmsghdr) to point to
-    // cbuf, which is redundant based on the above code as we have
-    // statically allocated memory.
-    // or (struct cmsghdr*) cbuf
-    chdr             = CMSG_FIRSTHDR(&hdr);  // Pointer to msg_control
-    chdr->cmsg_level = SOL_SOCKET;           // Originating Protocol
-    chdr->cmsg_type  = SCM_RIGHTS;           // Protocol Specific Type
-    // Length of control message = sizeof(struct cmsghdr) + nfds
-    chdr->cmsg_len = CMSG_LEN(sizeof(int) * nfds);
-
-    // Copy the fds below control header
-    memcpy(CMSG_DATA(chdr), fds, sizeof(int) * nfds);
-
-    // Also, Update main header with control message length (duplicate)
-    hdr.msg_controllen = chdr->cmsg_len;
-
-    //  Send message
-    ret = INLINE_SYSCALL(sendmsg, 3, ch, &hdr, 0);
-
-    free(hdl_data);
-    return IS_ERR(ret) ? -PAL_ERROR_DENIED : 0;
-}
-
-/* _DkRecvHandle for internal use. Receive and return a PAL_HANDLE over the
-   given PAL_HANDLE else return negative value. */
-int _DkReceiveHandle(PAL_HANDLE hdl, PAL_HANDLE* cargo) {
-    struct hdl_header hdl_hdr;
-
-    // ~ Check connection PAL_HANDLE - is of process type for sending handle
-    // else fail
-    if (!IS_HANDLE_TYPE(hdl, process))
-        return -PAL_ERROR_BADHANDLE;
-
-    // ~ Initialize common parameter for message passing
-    // Channel between parent and child
-    int ch = hdl->process.stream;
-
-    struct msghdr hdr;
+    /* first send hdl_hdr so the recipient knows how many FDs were transferred + how large is cargo */
+    struct msghdr message_hdr = {0};
     struct iovec iov[1];
 
     iov[0].iov_base    = &hdl_hdr;
-    iov[0].iov_len     = sizeof(struct hdl_header);
-    hdr.msg_name       = NULL;
-    hdr.msg_namelen    = 0;
-    hdr.msg_iov        = iov;
-    hdr.msg_iovlen     = 1;
-    hdr.msg_control    = NULL;
-    hdr.msg_controllen = 0;
-    hdr.msg_flags      = 0;
+    iov[0].iov_len     = sizeof(hdl_hdr);
+    message_hdr.msg_iov    = iov;
+    message_hdr.msg_iovlen = 1;
 
-    int ret = INLINE_SYSCALL(recvmsg, 3, ch, &hdr, 0);
+    ret = INLINE_SYSCALL(sendmsg, 3, fd, &message_hdr, MSG_NOSIGNAL);
+    if (IS_ERR(ret)) {
+        free(hdl_data);
+        return unix_to_pal_error(ERRNO(ret));
+    }
+
+    /* construct ancillary data of FDs-to-transfer in a control message */
+    char control_buf[sizeof(struct cmsghdr) + MAX_FDS * sizeof(int)];
+    message_hdr.msg_control    = control_buf;
+    message_hdr.msg_controllen = sizeof(control_buf);
+
+    struct cmsghdr* control_hdr = CMSG_FIRSTHDR(&message_hdr);
+    control_hdr->cmsg_level = SOL_SOCKET;
+    control_hdr->cmsg_type  = SCM_RIGHTS;
+    control_hdr->cmsg_len   = CMSG_LEN(sizeof(int) * nfds);
+    memcpy(CMSG_DATA(control_hdr), fds, sizeof(int) * nfds);
+
+    message_hdr.msg_controllen = control_hdr->cmsg_len;
+
+    /* finally send the serialized cargo as payload and FDs-to-transfer as ancillary data */
+    iov[0].iov_base = hdl_data;
+    iov[0].iov_len  = hdl_data_size;
+    message_hdr.msg_iov    = iov;
+    message_hdr.msg_iovlen = 1;
+
+    ret = INLINE_SYSCALL(sendmsg, 3, fd, &message_hdr, 0);
+    if (IS_ERR(ret)) {
+        free(hdl_data);
+        return unix_to_pal_error(ERRNO(ret));
+    }
+
+    free(hdl_data);
+    return IS_ERR(ret) ? unix_to_pal_error(ERRNO(ret)) : 0;
+}
+
+/*!
+ * \brief Receive `cargo` handle from a process identified via `hdl` handle.
+ *
+ * \param[in] hdl    Process stream on which to receive `cargo`.
+ * \param[in] cargo  Arbitrary handle to receive on `hdl` and deserialize.
+ * \return           0 on success, negative PAL error code otherwise.
+ */
+int _DkReceiveHandle(PAL_HANDLE hdl, PAL_HANDLE* cargo) {
+    if (!IS_HANDLE_TYPE(hdl, process))
+        return -PAL_ERROR_BADHANDLE;
+
+    ssize_t ret;
+    struct hdl_header hdl_hdr;
+    int fd = hdl->process.stream;
+
+    /* first receive hdl_hdr so that we know how many FDs were transferred + how large is cargo */
+    struct msghdr message_hdr = {0};
+    struct iovec iov[1];
+
+    iov[0].iov_base = &hdl_hdr;
+    iov[0].iov_len  = sizeof(hdl_hdr);
+    message_hdr.msg_iov    = iov;
+    message_hdr.msg_iovlen = 1;
+
+    ret = INLINE_SYSCALL(recvmsg, 3, fd, &message_hdr, 0);
     if (IS_ERR(ret))
         return unix_to_pal_error(ERRNO(ret));
-    if ((size_t)ret < sizeof(struct hdl_header)) {
-        /*
-         * This code block is just in case to cover all the possibilities.
-         * We know that the file descriptor is an unix domain socket with
-         * blocking mode and that the sender, _DkSendHandle() above, sends the
-         * header with single sendmsg syscall which transfers message atomically.
-         *
-         * read size == 0: return error for the caller to try again.
-         *                 It should result in EINTR.
-         *
-         * read size > 0: return error for the caller to give up this file
-         *                descriptor.
-         *                If the header can't be send atomically for some
-         *                reason, the sender should get EMSGSIZE.
-         */
+
+    if ((size_t)ret != sizeof(hdl_hdr)) {
+        /* This check is to shield from a Iago attack. We know that sendmsg() in _DkSendHandle()
+         * transfers the message atomically, and that our recvmsg() receives it atomically. So
+         * the only valid values for ret must be zero or the size of the header. */
         if (!ret)
             return -PAL_ERROR_TRYAGAIN;
         return -PAL_ERROR_DENIED;
     }
 
-    // initialize variables to get body
-    void* buffer = __alloca(hdl_hdr.data_size);
-    size_t nfds  = 0;
-
+    /* prepare control-message buffer to receive ancillary data of FDs-to-transfer */
+    int nfds = 0;
     for (int i = 0; i < MAX_FDS; i++)
         if (hdl_hdr.fds & (1U << i))
             nfds++;
 
-    // receive PAL_HANDLE contents in the body
-    char cbuf[sizeof(struct cmsghdr) + nfds * sizeof(int)];
+    char control_buf[sizeof(struct cmsghdr) + nfds * sizeof(int)];
+    message_hdr.msg_control    = control_buf;
+    message_hdr.msg_controllen = sizeof(control_buf);
 
-    // initialize iovec[0] with struct PAL_HANDLE
-    iov[0].iov_base = buffer;
+    /* finally receive the serialized cargo as payload and FDs-to-transfer as ancillary data */
+    char hdl_data[hdl_hdr.data_size];
+
+    iov[0].iov_base = hdl_data;
     iov[0].iov_len  = hdl_hdr.data_size;
+    message_hdr.msg_iov    = iov;
+    message_hdr.msg_iovlen = 1;
 
-    // set message header values
-    hdr.msg_iov        = iov;
-    hdr.msg_iovlen     = 1;
-    hdr.msg_control    = cbuf;
-    hdr.msg_controllen = sizeof(struct cmsghdr) + sizeof(int) * nfds;
+    ret = INLINE_SYSCALL(recvmsg, 3, fd, &message_hdr, 0);
+    if (IS_ERR(ret))
+        return unix_to_pal_error(ERRNO(ret));
 
-    ret = INLINE_SYSCALL(recvmsg, 3, ch, &hdr, 0);
-
-    // if error was returned
-    if (IS_ERR(ret) && ERRNO(ret) != EINTR && ERRNO(ret) != ERESTART)
-        return -ERRNO(ret);
-
-    struct cmsghdr* chdr = CMSG_FIRSTHDR(&hdr);
-    if (!chdr || chdr->cmsg_type != SCM_RIGHTS)
-        return -PAL_ERROR_INVAL;
-
+    /* deserialize cargo handle from a blob hdl_data */
     PAL_HANDLE handle = NULL;
-    ret               = handle_deserialize(&handle, buffer, hdl_hdr.data_size);
-    if (ret < 0)
+    ret = handle_deserialize(&handle, hdl_data, hdl_hdr.data_size);
+    if (IS_ERR(ret))
         return ret;
 
-    int total_fds = (hdr.msg_controllen - sizeof(struct cmsghdr)) / sizeof(int);
-    int n         = 0;
-    for (int i = 0; i < MAX_FDS; i++)
+    /* restore cargo handle's FDs from the received FDs-to-transfer */
+    struct cmsghdr* control_hdr = CMSG_FIRSTHDR(&message_hdr);
+    if (!control_hdr || control_hdr->cmsg_type != SCM_RIGHTS)
+        return -PAL_ERROR_DENIED;
+
+    int fds_idx = 0;
+    int* fds = (int*)CMSG_DATA(control_hdr);
+
+    for (int i = 0; i < MAX_FDS; i++) {
         if (hdl_hdr.fds & (1U << i)) {
-            if (n < total_fds) {
-                handle->generic.fds[i] = ((int*)CMSG_DATA(chdr))[n++];
+            if (fds_idx < nfds) {
+                handle->generic.fds[i] = fds[fds_idx++];
             } else {
                 HANDLE_HDR(handle)->flags &= ~(RFD(i) | WFD(i));
             }
         }
+    }
 
     *cargo = handle;
     return 0;


### PR DESCRIPTION
<!-- Please fill in the following form before submitting this PR and ensure that your code follows our [coding style guideline](../blob/master/CODESTYLE.md). -->

## Affected components

- [ ] README and global configuration
- [x] Linux PAL
- [x] SGX PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->

This PR contains two commits dealing with `_DkSendHandle()` and `_DkReceiveHandle()` -- the first function serializes a given PAL handle and sends to the child process, the second function receives this serialized PAL handle and deserializes it.

- [Pal/{Linux,Linux-SGX}] Refactor _DkSendHandle() and _DkReceiveHandle(). In Graphene, these two functions are used to serialize the PAL handle and send it on a process stream (socketpair) to another (usually child) process, and vice versa. This commit simply refactors their code without any logic changes.

- [Pal/Linux-SGX] Encrypt messages in _DkSendHandle()/_DkReceiveHandle(). Previously, _DkSendHandle() and _DkReceiveHandle() of Linux-SGX PAL sent serialized PAL handles (with their metadata like paths, socket addresses, etc.) in plaintext via ocall_send(). This forced us to explicitly zero out sensitive metadata like session keys. This commit uses _DkStreamSecure{Write,Read}() to encrypt these messages, and we don't need to worry about leaking sensitive metadata.

UPDATE: Rebasing was way too complex with two commits, so I squashed them into one.

This commit is a prerequisite for Encrypted IPC. See also https://github.com/oscarlab/graphene/pull/1378 and https://github.com/oscarlab/graphene/issues/1235.

## How to test this PR? <!-- (if applicable) -->

All tests must pass. You can do something like `SGX=1 strace -ff ~/graphene/Runtime/pal_loader SendHandle` in PAL regression tests and observe that serialized-PAL-handle messages are encrypted now and sent via TLS.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1377)
<!-- Reviewable:end -->
