### PR TITLE
[Pal/{Linux,Linux-SGX}] Remove cargo host-level file descriptor

### DIFF
--- a/Pal/src/host/Linux-SGX/db_main.c
+++ b/Pal/src/host/Linux-SGX/db_main.c
@@ -274,7 +274,6 @@ void pal_linux_main(char * uptr_args, uint64_t args_size,
     pal_sec.manifest_name[sizeof(pal_sec.manifest_name) - 1] = '\0';
 
     pal_sec.stream_fd = sec_info.stream_fd;
-    pal_sec.cargo_fd  = sec_info.cargo_fd;
 
     COPY_ARRAY(pal_sec.pipe_prefix, sec_info.pipe_prefix);
     pal_sec.qe_targetinfo = sec_info.qe_targetinfo;

--- a/Pal/src/host/Linux-SGX/db_streams.c
+++ b/Pal/src/host/Linux-SGX/db_streams.c
@@ -281,7 +281,7 @@ int _DkSendHandle(PAL_HANDLE hdl, PAL_HANDLE cargo) {
             fds[nfds++] = cargo->generic.fds[i];
         }
 
-    int ch = hdl->process.cargo;
+    int ch = hdl->process.stream;
     ssize_t ret;
     ret    = ocall_send(ch, &hdl_hdr, sizeof(struct hdl_header), NULL, 0, NULL, 0);
 
@@ -313,7 +313,7 @@ int _DkReceiveHandle(PAL_HANDLE hdl, PAL_HANDLE* cargo) {
     if (!IS_HANDLE_TYPE(hdl, process))
         return -PAL_ERROR_BADHANDLE;
 
-    int ch = hdl->process.cargo;
+    int ch = hdl->process.stream;
 
     ssize_t ret = ocall_recv(ch, &hdl_hdr, sizeof(struct hdl_header), NULL, NULL, NULL, NULL);
 

--- a/Pal/src/host/Linux-SGX/enclave_ocalls.c
+++ b/Pal/src/host/Linux-SGX/enclave_ocalls.c
@@ -640,8 +640,7 @@ int ocall_clone_thread (void)
     return sgx_ocall(OCALL_CLONE_THREAD, dummy);
 }
 
-int ocall_create_process(const char* uri, int nargs, const char** args, int* stream_fd,
-                         int* cargo_fd, unsigned int* pid) {
+int ocall_create_process(const char* uri, int nargs, const char** args, int* stream_fd, unsigned int* pid) {
     int retval = 0;
     int ulen = uri ? strlen(uri) + 1 : 0;
     ms_ocall_create_process_t * ms;
@@ -677,8 +676,6 @@ int ocall_create_process(const char* uri, int nargs, const char** args, int* str
             *pid = ms->ms_pid;
         if (stream_fd)
             *stream_fd = ms->ms_stream_fd;
-        if (cargo_fd)
-            *cargo_fd = ms->ms_cargo_fd;
     }
 
     sgx_reset_ustack(old_ustack);

--- a/Pal/src/host/Linux-SGX/enclave_ocalls.h
+++ b/Pal/src/host/Linux-SGX/enclave_ocalls.h
@@ -76,8 +76,7 @@ int ocall_resume_thread (void * tcs);
 
 int ocall_clone_thread (void);
 
-int ocall_create_process(const char* uri, int nargs, const char** args, int* stream_fd,
-                         int* cargo_fd, unsigned int* pid);
+int ocall_create_process(const char* uri, int nargs, const char** args, int* stream_fd, unsigned int* pid);
 
 int ocall_futex(int* uaddr, int op, int val, int64_t timeout_us);
 

--- a/Pal/src/host/Linux-SGX/ocall_types.h
+++ b/Pal/src/host/Linux-SGX/ocall_types.h
@@ -165,7 +165,6 @@ typedef struct {
     unsigned int ms_pid;
     const char * ms_uri;
     int ms_stream_fd;
-    int ms_cargo_fd;
     int ms_nargs;
     const char * ms_args[];
 } ms_ocall_create_process_t;

--- a/Pal/src/host/Linux-SGX/pal_host.h
+++ b/Pal/src/host/Linux-SGX/pal_host.h
@@ -146,7 +146,6 @@ typedef struct pal_handle
 
         struct {
             PAL_IDX stream;
-            PAL_IDX cargo;
             PAL_IDX pid;
             PAL_BOL nonblocking;
             PAL_SESSION_KEY session_key;

--- a/Pal/src/host/Linux-SGX/pal_linux.h
+++ b/Pal/src/host/Linux-SGX/pal_linux.h
@@ -227,7 +227,7 @@ extern struct pal_enclave_config {
 
 #else
 
-int sgx_create_process(const char* uri, int nargs, const char** args, int* stream_fd, int* cargo_fd);
+int sgx_create_process(const char* uri, int nargs, const char** args, int* stream_fd);
 
 #ifdef DEBUG
 # ifndef SIGCHLD

--- a/Pal/src/host/Linux-SGX/pal_security.h
+++ b/Pal/src/host/Linux-SGX/pal_security.h
@@ -43,9 +43,8 @@ struct pal_sec {
 
     PAL_SEC_STR     manifest_name;
 
-    /* child's stream and cargo FDs created and sent over by parent */
+    /* child's stream FD created and sent over by parent */
     PAL_IDX         stream_fd;
-    PAL_IDX         cargo_fd;
 
     /* additional information */
     PAL_SEC_STR     pipe_prefix;

--- a/Pal/src/host/Linux-SGX/sgx_enclave.c
+++ b/Pal/src/host/Linux-SGX/sgx_enclave.c
@@ -261,8 +261,7 @@ static long sgx_ocall_create_process(void * pms)
 {
     ms_ocall_create_process_t * ms = (ms_ocall_create_process_t *) pms;
     ODEBUG(OCALL_CREATE_PROCESS, ms);
-    long ret = sgx_create_process(ms->ms_uri, ms->ms_nargs, ms->ms_args,
-                                  &ms->ms_stream_fd, &ms->ms_cargo_fd);
+    long ret = sgx_create_process(ms->ms_uri, ms->ms_nargs, ms->ms_args, &ms->ms_stream_fd);
     if (ret < 0)
         return ret;
     ms->ms_pid = ret;

--- a/Pal/src/host/Linux/db_process.c
+++ b/Pal/src/host/Linux/db_process.c
@@ -35,6 +35,7 @@
 #include "pal_linux_defs.h"
 #include "pal_rtld.h"
 #include "pal_security.h"
+
 typedef __kernel_pid_t pid_t;
 #include <asm/errno.h>
 #include <asm/fcntl.h>
@@ -45,16 +46,15 @@ typedef __kernel_pid_t pid_t;
 #include <sys/socket.h>
 #include <sys/wait.h>
 
-static inline int create_process_handle (PAL_HANDLE * parent,
-                                         PAL_HANDLE * child)
-{
-    PAL_HANDLE phdl = NULL, chdl = NULL;
-    int fds[4] = { -1, -1, -1, -1 };
+static inline int create_process_handle(PAL_HANDLE* parent, PAL_HANDLE* child) {
+    PAL_HANDLE phdl = NULL;
+    PAL_HANDLE chdl = NULL;
+    int fds[2] = {-1, -1};
     int socktype = SOCK_STREAM | SOCK_CLOEXEC;
     int ret;
 
-    if (IS_ERR((ret = INLINE_SYSCALL(socketpair, 4, AF_UNIX, socktype, 0, &fds[0]))) ||
-        IS_ERR((ret = INLINE_SYSCALL(socketpair, 4, AF_UNIX, socktype, 0, &fds[2])))) {
+    ret = INLINE_SYSCALL(socketpair, 4, AF_UNIX, socktype, 0, fds);
+    if (IS_ERR(ret)) {
         ret = -PAL_ERROR_DENIED;
         goto out;
     }
@@ -66,9 +66,8 @@ static inline int create_process_handle (PAL_HANDLE * parent,
     }
 
     SET_HANDLE_TYPE(phdl, process);
-    HANDLE_HDR(phdl)->flags |= RFD(0)|WFD(0)|RFD(1)|WFD(1);
+    HANDLE_HDR(phdl)->flags  |= RFD(0)|WFD(0);
     phdl->process.stream      = fds[0];
-    phdl->process.cargo       = fds[2];
     phdl->process.pid         = linux_state.pid;
     phdl->process.nonblocking = PAL_FALSE;
 
@@ -79,9 +78,8 @@ static inline int create_process_handle (PAL_HANDLE * parent,
     }
 
     SET_HANDLE_TYPE(chdl, process);
-    HANDLE_HDR(chdl)->flags |= RFD(0)|WFD(0)|RFD(1)|WFD(1);
+    HANDLE_HDR(chdl)->flags |= RFD(0)|WFD(0);
     chdl->process.stream      = fds[1];
-    chdl->process.cargo       = fds[3];
     chdl->process.pid         = 0; /* unknown yet */
     chdl->process.nonblocking = PAL_FALSE;
 
@@ -90,13 +88,12 @@ static inline int create_process_handle (PAL_HANDLE * parent,
     ret = 0;
 out:
     if (ret < 0) {
-        if (phdl)
-            _DkObjectClose(phdl);
-        if (chdl)
-            _DkObjectClose(chdl);
-        for (int i = 0; i < 4; i++)
-            if (fds[i] != -1)
-                INLINE_SYSCALL(close, 1, fds[i]);
+        free(phdl);
+        free(chdl);
+        if (fds[0] != -1)
+            INLINE_SYSCALL(close, 1, fds[0]);
+        if (fds[1] != -1)
+            INLINE_SYSCALL(close, 1, fds[1]);
     }
     return ret;
 }
@@ -105,7 +102,7 @@ struct proc_param {
     PAL_HANDLE parent;
     PAL_HANDLE exec;
     PAL_HANDLE manifest;
-    const char ** argv;
+    const char** argv;
 };
 
 struct proc_args {
@@ -498,11 +495,6 @@ static int proc_close (PAL_HANDLE handle)
         handle->process.stream = PAL_IDX_POISON;
     }
 
-    if (handle->process.cargo != PAL_IDX_POISON) {
-        INLINE_SYSCALL(close, 1, handle->process.cargo);
-        handle->process.cargo = PAL_IDX_POISON;
-    }
-
     return 0;
 }
 
@@ -525,9 +517,6 @@ static int proc_delete (PAL_HANDLE handle, int access)
 
     if (handle->process.stream != PAL_IDX_POISON)
         INLINE_SYSCALL(shutdown, 2, handle->process.stream, shutdown);
-
-    if (handle->process.cargo != PAL_IDX_POISON)
-        INLINE_SYSCALL(shutdown, 2, handle->process.cargo, shutdown);
 
     return 0;
 }

--- a/Pal/src/host/Linux/db_streams.c
+++ b/Pal/src/host/Linux/db_streams.c
@@ -282,7 +282,7 @@ int _DkSendHandle(PAL_HANDLE hdl, PAL_HANDLE cargo) {
 
     // ~ Initialize common parameter formessage passing
     // Channel between parent and child
-    int ch = hdl->process.cargo;
+    int ch = hdl->process.stream;
 
     // Declare variables required for sending the message
     struct msghdr hdr;     // message header
@@ -361,7 +361,7 @@ int _DkReceiveHandle(PAL_HANDLE hdl, PAL_HANDLE* cargo) {
 
     // ~ Initialize common parameter for message passing
     // Channel between parent and child
-    int ch = hdl->process.cargo;
+    int ch = hdl->process.stream;
 
     struct msghdr hdr;
     struct iovec iov[1];

--- a/Pal/src/host/Linux/pal_host.h
+++ b/Pal/src/host/Linux/pal_host.h
@@ -135,7 +135,6 @@ typedef struct pal_handle
 
         struct {
             PAL_IDX stream;
-            PAL_IDX cargo;
             PAL_IDX pid;
             PAL_BOL nonblocking;
         } process;


### PR DESCRIPTION
## Affected components

- [ ] README and global configuration
- [x] Linux PAL
- [x] SGX PAL
- [x] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

## Description of the changes <!-- (reasons and measures) -->

In process-type PAL handle, there were two underlying host FDs: `stream` and `cargo`/`cargo_fd`. The first one was used to send the checkpoint and other messages between parent and child, whereas
the second one was used to send PAL handles via cmsg ancillary data Linux mechanism. In reality, `cargo`/`cargo_fd` can be replaced with `stream` in all scenarios. This PR does that.

This commit is a prerequisite for Encrypted IPC. See also https://github.com/oscarlab/graphene/pull/1377 and https://github.com/oscarlab/graphene/issues/1235.

## How to test this PR? <!-- (if applicable) -->

All tests must pass.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1378)
<!-- Reviewable:end -->
