### PR TITLE
[Pal] Introduce DkAttestationQuote() API for quote retrieval

### DIFF
--- a/Documentation/pal/host-abi.rst
+++ b/Documentation/pal/host-abi.rst
@@ -378,8 +378,8 @@ Miscellaneous
 The ABI includes seven assorted calls to get wall clock time, generate
 cryptographically-strong random bits, flush portions of instruction caches,
 increment and decrement the reference counts on objects shared between threads,
-and to coordinate threads with the security monitor during process
-serialization.
+to coordinate threads with the security monitor during process serialization,
+and to obtain an attestation quote.
 
 .. doxygenfunction:: DkSystemTimeQuery
    :project: pal
@@ -400,4 +400,7 @@ serialization.
    :project: pal
 
 .. doxygenenum:: PAL_CPUID_WORD
+   :project: pal
+
+.. doxygenfunction:: DkAttestationQuote
    :project: pal

--- a/Pal/include/pal/pal.h
+++ b/Pal/include/pal/pal.h
@@ -925,6 +925,23 @@ enum PAL_CPUID_WORD {
 PAL_BOL
 DkCpuIdRetrieve(PAL_IDX leaf, PAL_IDX subleaf, PAL_IDX values[PAL_CPUID_WORD_NUM]);
 
+/*!
+ * \brief Obtain the attestation quote with `report_data` embedded into it.
+ *
+ * Currently, works only for Linux-SGX PAL, where `report_data` is a 64B blob and `quote` is an
+ * SGX quote obtained from the Quoting Enclave via AESM service.
+ *
+ * \param[in]     report_data       Report data with arbitrary contents (typically uniquely
+ *                                  identifies this Graphene instance). Must be a 64B buffer
+ *                                  in case of SGX PAL.
+ * \param[in]     report_data_size  Size in bytes of report data. Must be 64 in case of SGX PAL.
+ * \param[out]    quote             Attestation quote with report data embedded.
+ * \param[in,out] quote_size        Caller specifies maximum size allocated for `quote`; on return,
+ *                                  contains actual size of `quote`.
+ */
+PAL_BOL DkAttestationQuote(PAL_PTR report_data, PAL_NUM report_data_size, PAL_PTR quote,
+                           PAL_NUM* quote_size);
+
 #ifdef __GNUC__
 # define symbol_version_default(real, name, version) \
     __asm__ (".symver " #real "," #name "@@" #version "\n")

--- a/Pal/src/db_misc.c
+++ b/Pal/src/db_misc.c
@@ -105,3 +105,15 @@ DkCpuIdRetrieve(PAL_IDX leaf, PAL_IDX subleaf, PAL_IDX values[4]) {
 
     LEAVE_PAL_CALL_RETURN(PAL_TRUE);
 }
+
+PAL_BOL DkAttestationQuote(PAL_PTR report_data, PAL_NUM report_data_size, PAL_PTR quote,
+                           PAL_NUM* quote_size) {
+    ENTER_PAL_CALL(DkAttestationQuote);
+
+    int ret = _DkAttestationQuote(report_data, report_data_size, quote, quote_size);
+    if (ret < 0) {
+        _DkRaiseFailure(-ret);
+        LEAVE_PAL_CALL_RETURN(PAL_FALSE);
+    }
+    LEAVE_PAL_CALL_RETURN(PAL_TRUE);
+}

--- a/Pal/src/host/Linux/db_misc.c
+++ b/Pal/src/host/Linux/db_misc.c
@@ -231,3 +231,12 @@ int _DkCpuIdRetrieve(unsigned int leaf, unsigned int subleaf, unsigned int value
     cpuid(leaf, subleaf, values);
     return 0;
 }
+
+int _DkAttestationQuote(PAL_PTR report_data, PAL_NUM report_data_size, PAL_PTR quote,
+                        PAL_NUM* quote_size) {
+    __UNUSED(report_data);
+    __UNUSED(report_data_size);
+    __UNUSED(quote);
+    __UNUSED(quote_size);
+    return -PAL_ERROR_NOTIMPLEMENTED;
+}

--- a/Pal/src/host/Skeleton/db_misc.c
+++ b/Pal/src/host/Skeleton/db_misc.c
@@ -62,3 +62,12 @@ int _DkInstructionCacheFlush(const void* addr, int size) {
 int _DkCpuIdRetrieve(unsigned int leaf, unsigned int subleaf, unsigned int values[4]) {
     return -PAL_ERROR_NOTIMPLEMENTED;
 }
+
+int _DkAttestationQuote(PAL_PTR report_data, PAL_NUM report_data_size, PAL_PTR quote,
+                        PAL_NUM* quote_size) {
+    __UNUSED(report_data);
+    __UNUSED(report_data_size);
+    __UNUSED(quote);
+    __UNUSED(quote_size);
+    return -PAL_ERROR_NOTIMPLEMENTED;
+}

--- a/Pal/src/pal-symbols
+++ b/Pal/src/pal-symbols
@@ -44,6 +44,7 @@ DkStreamAttributesSetByHandle
 DkMemoryAvailableQuota
 DkDebugAttachBinary
 DkDebugDetachBinary
+DkAttestationQuote
 pal_printf
 pal_control_addr
 pal_strerror

--- a/Pal/src/pal_internal.h
+++ b/Pal/src/pal_internal.h
@@ -355,6 +355,8 @@ int _DkSegmentRegisterSet (int reg, const void * addr);
 int _DkSegmentRegisterGet (int reg, void ** addr);
 int _DkInstructionCacheFlush (const void * addr, int size);
 int _DkCpuIdRetrieve (unsigned int leaf, unsigned int subleaf, unsigned int values[4]);
+int _DkAttestationQuote(PAL_PTR report_data, PAL_NUM report_data_size, PAL_PTR quote,
+                        PAL_NUM* quote_size);
 
 #define INIT_FAIL(exitcode, reason)                                     \
     do {                                                                \


### PR DESCRIPTION
## Description of the changes: <!-- (reasons and measures) -->

New `DkAttestationQuote()` API retrieves the attestation quote from the underlying host-OS attestation mechanism. Currently, it is implemented only for Linux-SGX PAL and stubbed for all other PALs. The Linux-SGX implementation retrieves the SGX quote via `sgx_get_quote()` which communicates with the Quoting Enclave via AESM service. The caller of this new API may forward the obtained quote to the remote user for remote attestation.

This is a part of Remote Attestation PRs. Based on and supersedes #1284. Also see issue #1365.

A follow-up PR will introduce the pseudo-FS interface to actually use this API.

## How to test this PR? <!-- (if applicable) -->

All tests must pass. No new tests are added (will be in a follow-up PR).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1383)
<!-- Reviewable:end -->
