### PR TITLE
[LibOS] Introduce test for system() and fix bug with Glibc 2.31

### DIFF
--- a/LibOS/shim/src/sys/shim_exec.c
+++ b/LibOS/shim/src/sys/shim_exec.c
@@ -112,11 +112,14 @@ noreturn static void __shim_do_execve_rtld(struct execve_rtld_arg* __arg) {
     UPDATE_PROFILE_INTERVAL();
 
     DkVirtualMemoryFree(old_stack, old_stack_top - old_stack);
-    DkVirtualMemoryFree(old_stack_red, old_stack - old_stack_red);
-
-    if (bkeep_munmap(old_stack, old_stack_top - old_stack, 0) < 0 ||
-        bkeep_munmap(old_stack_red, old_stack - old_stack_red, 0) < 0)
+    if (bkeep_munmap(old_stack, old_stack_top - old_stack, 0) < 0)
         BUG();
+
+    if (old_stack - old_stack_red > 0) {
+        DkVirtualMemoryFree(old_stack_red, old_stack - old_stack_red);
+        if (bkeep_munmap(old_stack_red, old_stack - old_stack_red, 0) < 0)
+            BUG();
+    }
 
     remove_loaded_libraries();
     clean_link_map_list();

--- a/LibOS/shim/test/regression/.gitignore
+++ b/LibOS/shim/test/regression/.gitignore
@@ -60,6 +60,7 @@
 /stat_invalid_args
 /str_close_leak
 /syscall
+/system
 /testfile
 /tmp
 /tcp_ipv6_v6only

--- a/LibOS/shim/test/regression/Makefile
+++ b/LibOS/shim/test/regression/Makefile
@@ -51,6 +51,7 @@ c_executables = \
 	stat_invalid_args \
 	str_close_leak \
 	syscall \
+	system \
 	tcp_ipv6_v6only \
 	tcp_msg_peek \
 	udp \
@@ -61,6 +62,7 @@ cxx_executables = bootstrap-c++
 
 manifests = \
 	manifest \
+	echo.manifest \
 	eventfd.manifest \
 	exec_victim.manifest \
 	exit_group.manifest \
@@ -78,14 +80,17 @@ manifests = \
 	multi_pthread_exitless.manifest \
 	openmp.manifest \
 	proc-path.manifest \
+	sh.manifest \
 	shared_object.manifest
 
 exec_target = \
 	$(c_executables) \
 	$(cxx_executables) \
-	file_check_policy_strict.manifest \
+	echo.manifest \
 	file_check_policy_allow_all_but_log.manifest \
-	multi_pthread_exitless.manifest
+	file_check_policy_strict.manifest \
+	multi_pthread_exitless.manifest \
+	sh.manifest
 
 target = \
 	$(exec_target) \

--- a/LibOS/shim/test/regression/echo.manifest.template
+++ b/LibOS/shim/test/regression/echo.manifest.template
@@ -1,3 +1,6 @@
+loader.exec = file:/bin/echo
+loader.execname = file:echo
+
 loader.preload = file:../../src/libsysdb.so
 loader.env.LD_LIBRARY_PATH = /lib:/lib/x86_64-linux-gnu:/usr/lib/x86_64-linux-gnu
 loader.debug_type = none
@@ -19,29 +22,7 @@ fs.mount.bin.type = chroot
 fs.mount.bin.path = /bin
 fs.mount.bin.uri = file:/bin
 
-# allow to bind on port 8000
-net.rules.1 = 127.0.0.1:8000:0.0.0.0:0-65535
-# allow to connect to port 8000
-net.rules.2 = 0.0.0.0:0-65535:127.0.0.1:8000
-
 sgx.trusted_files.ld = file:../../../../Runtime/ld-linux-x86-64.so.2
 sgx.trusted_files.libc = file:../../../../Runtime/libc.so.6
-sgx.trusted_files.libdl = file:../../../../Runtime/libdl.so.2
-sgx.trusted_files.libm = file:../../../../Runtime/libm.so.6
-sgx.trusted_files.libpthread = file:../../../../Runtime/libpthread.so.0
-sgx.trusted_files.libgcc_s = file:/lib/x86_64-linux-gnu/libgcc_s.so.1
-sgx.trusted_files.libstdcxx = file:/usr/lib/x86_64-linux-gnu/libstdc++.so.6
-
-sgx.trusted_files.victim = file:exec_victim
-sgx.trusted_children.victim = file:exec_victim.sig
-
-sgx.allow_file_creation = 1
-
-sgx.allowed_files.tmp_dir = file:tmp/
-
-sgx.thread_num = 6
 
 sgx.static_address = 1
-
-sgx.trusted_files.sh = file:/bin/sh
-sgx.trusted_children.sh = file:sh.sig

--- a/LibOS/shim/test/regression/eventfd.manifest.template
+++ b/LibOS/shim/test/regression/eventfd.manifest.template
@@ -14,3 +14,5 @@ sgx.trusted_files.libc = file:../../../../Runtime/libc.so.6
 sgx.trusted_files.libdl = file:../../../../Runtime/libdl.so.2
 sgx.trusted_files.libm = file:../../../../Runtime/libm.so.6
 sgx.trusted_files.libpthread = file:../../../../Runtime/libpthread.so.0
+
+sgx.static_address = 1

--- a/LibOS/shim/test/regression/exec_victim.manifest.template
+++ b/LibOS/shim/test/regression/exec_victim.manifest.template
@@ -17,3 +17,5 @@ sys.stack.size = 4M
 # sgx-related
 sgx.trusted_files.ld = file:../../../../Runtime/ld-linux-x86-64.so.2
 sgx.trusted_files.libc = file:../../../../Runtime/libc.so.6
+
+sgx.static_address = 1

--- a/LibOS/shim/test/regression/exit_group.manifest.template
+++ b/LibOS/shim/test/regression/exit_group.manifest.template
@@ -13,3 +13,5 @@ sgx.trusted_files.libpthread = file:../../../../Runtime/libpthread.so.0
 
 # Test uses 5 threads plus Graphene has up to two internal threads.
 sgx.thread_num = 7
+
+sgx.static_address = 1

--- a/LibOS/shim/test/regression/file_check_policy_allow_all_but_log.manifest.template
+++ b/LibOS/shim/test/regression/file_check_policy_allow_all_but_log.manifest.template
@@ -15,3 +15,5 @@ sgx.trusted_files.ld = file:$(LIBCDIR)/ld-linux-x86-64.so.2
 sgx.trusted_files.libc = file:$(LIBCDIR)/libc.so.6
 
 sgx.trusted_files.test = file:trusted_testfile
+
+sgx.static_address = 1

--- a/LibOS/shim/test/regression/file_check_policy_strict.manifest.template
+++ b/LibOS/shim/test/regression/file_check_policy_strict.manifest.template
@@ -15,3 +15,5 @@ sgx.trusted_files.ld = file:$(LIBCDIR)/ld-linux-x86-64.so.2
 sgx.trusted_files.libc = file:$(LIBCDIR)/libc.so.6
 
 sgx.trusted_files.test = file:trusted_testfile
+
+sgx.static_address = 1

--- a/LibOS/shim/test/regression/futex_bitset.manifest.template
+++ b/LibOS/shim/test/regression/futex_bitset.manifest.template
@@ -20,3 +20,5 @@ sgx.trusted_files.ld = file:../../../../Runtime/ld-linux-x86-64.so.2
 sgx.trusted_files.libc = file:../../../../Runtime/libc.so.6
 sgx.trusted_files.libpthread = file:../../../../Runtime/libpthread.so.0
 sgx.thread_num = 16
+
+sgx.static_address = 1

--- a/LibOS/shim/test/regression/futex_requeue.manifest.template
+++ b/LibOS/shim/test/regression/futex_requeue.manifest.template
@@ -15,3 +15,5 @@ sgx.trusted_files.ld = file:../../../../Runtime/ld-linux-x86-64.so.2
 sgx.trusted_files.libc = file:../../../../Runtime/libc.so.6
 sgx.trusted_files.libpthread = file:../../../../Runtime/libpthread.so.0
 sgx.thread_num = 16
+
+sgx.static_address = 1

--- a/LibOS/shim/test/regression/futex_wake_op.manifest.template
+++ b/LibOS/shim/test/regression/futex_wake_op.manifest.template
@@ -15,3 +15,5 @@ sgx.trusted_files.ld = file:../../../../Runtime/ld-linux-x86-64.so.2
 sgx.trusted_files.libc = file:../../../../Runtime/libc.so.6
 sgx.trusted_files.libpthread = file:../../../../Runtime/libpthread.so.0
 sgx.thread_num = 16
+
+sgx.static_address = 1

--- a/LibOS/shim/test/regression/getdents.manifest.template
+++ b/LibOS/shim/test/regression/getdents.manifest.template
@@ -10,3 +10,5 @@ sgx.trusted_files.ld = file:$(LIBCDIR)/ld-linux-x86-64.so.2
 sgx.trusted_files.libc = file:$(LIBCDIR)/libc.so.6
 
 sgx.allowed_files.test = file:root
+
+sgx.static_address = 1

--- a/LibOS/shim/test/regression/host_root_fs.manifest.template
+++ b/LibOS/shim/test/regression/host_root_fs.manifest.template
@@ -14,3 +14,5 @@ fs.mount.graphene_lib.uri = file:../../../../Runtime
 sgx.trusted_files.ld = file:../../../../Runtime/ld-linux-x86-64.so.2
 sgx.trusted_files.libc = file:../../../../Runtime/libc.so.6
 sgx.trusted_files.libdl = file:../../../../Runtime/libdl.so.2
+
+sgx.static_address = 1

--- a/LibOS/shim/test/regression/init_fail.manifest.template
+++ b/LibOS/shim/test/regression/init_fail.manifest.template
@@ -14,3 +14,4 @@ fs.mount.test.uri = file:I_DONT_EXIST
 sgx.trusted_files.ld = file:$(LIBCDIR)/ld-linux-x86-64.so.2
 sgx.trusted_files.libc = file:$(LIBCDIR)/libc.so.6
 
+sgx.static_address = 1

--- a/LibOS/shim/test/regression/large-mmap.manifest.template
+++ b/LibOS/shim/test/regression/large-mmap.manifest.template
@@ -22,3 +22,5 @@ sgx.trusted_files.libc = file:../../../../Runtime/libc.so.6
 sgx.allowed_files.testfile = file:testfile
 
 sgx.enclave_size = 8G
+
+sgx.static_address = 1

--- a/LibOS/shim/test/regression/mmap-file.manifest.template
+++ b/LibOS/shim/test/regression/mmap-file.manifest.template
@@ -20,3 +20,5 @@ sgx.trusted_files.ld = file:../../../../Runtime/ld-linux-x86-64.so.2
 sgx.trusted_files.libc = file:../../../../Runtime/libc.so.6
 
 sgx.allowed_files.testfile = file:testfile
+
+sgx.static_address = 1

--- a/LibOS/shim/test/regression/multi_pthread.manifest.template
+++ b/LibOS/shim/test/regression/multi_pthread.manifest.template
@@ -13,3 +13,5 @@ sgx.trusted_files.libpthread = file:../../../../Runtime/libpthread.so.0
 
 # app runs with 4 parallel threads + Graphene has couple internal threads
 sgx.thread_num = 8
+
+sgx.static_address = 1

--- a/LibOS/shim/test/regression/multi_pthread_exitless.manifest.template
+++ b/LibOS/shim/test/regression/multi_pthread_exitless.manifest.template
@@ -17,3 +17,5 @@ sgx.trusted_files.libpthread = file:../../../../Runtime/libpthread.so.0
 # app runs with 4 parallel threads + Graphene has couple internal threads
 sgx.thread_num = 8
 sgx.rpc_thread_num = 8
+
+sgx.static_address = 1

--- a/LibOS/shim/test/regression/openmp.manifest.template
+++ b/LibOS/shim/test/regression/openmp.manifest.template
@@ -22,3 +22,5 @@ sgx.trusted_files.libc = file:../../../../Runtime/libc.so.6
 sgx.trusted_files.libpthread = file:../../../../Runtime/libpthread.so.0
 sgx.trusted_files.libdl = file:../../../../Runtime/libdl.so.2
 sgx.trusted_files.libgomp = file:/usr/lib/x86_64-linux-gnu/libgomp.so.1
+
+sgx.static_address = 1

--- a/LibOS/shim/test/regression/proc-path.manifest.template
+++ b/LibOS/shim/test/regression/proc-path.manifest.template
@@ -17,3 +17,5 @@ sys.stack.size = 4M
 # sgx-related
 sgx.trusted_files.ld = file:../../../../Runtime/ld-linux-x86-64.so.2
 sgx.trusted_files.libc = file:../../../../Runtime/libc.so.6
+
+sgx.static_address = 1

--- a/LibOS/shim/test/regression/sh.manifest.template
+++ b/LibOS/shim/test/regression/sh.manifest.template
@@ -1,3 +1,6 @@
+loader.exec = file:/bin/sh
+loader.execname = file:sh
+
 loader.preload = file:../../src/libsysdb.so
 loader.env.LD_LIBRARY_PATH = /lib:/lib/x86_64-linux-gnu:/usr/lib/x86_64-linux-gnu
 loader.debug_type = none
@@ -19,29 +22,10 @@ fs.mount.bin.type = chroot
 fs.mount.bin.path = /bin
 fs.mount.bin.uri = file:/bin
 
-# allow to bind on port 8000
-net.rules.1 = 127.0.0.1:8000:0.0.0.0:0-65535
-# allow to connect to port 8000
-net.rules.2 = 0.0.0.0:0-65535:127.0.0.1:8000
-
 sgx.trusted_files.ld = file:../../../../Runtime/ld-linux-x86-64.so.2
 sgx.trusted_files.libc = file:../../../../Runtime/libc.so.6
-sgx.trusted_files.libdl = file:../../../../Runtime/libdl.so.2
-sgx.trusted_files.libm = file:../../../../Runtime/libm.so.6
-sgx.trusted_files.libpthread = file:../../../../Runtime/libpthread.so.0
-sgx.trusted_files.libgcc_s = file:/lib/x86_64-linux-gnu/libgcc_s.so.1
-sgx.trusted_files.libstdcxx = file:/usr/lib/x86_64-linux-gnu/libstdc++.so.6
 
-sgx.trusted_files.victim = file:exec_victim
-sgx.trusted_children.victim = file:exec_victim.sig
-
-sgx.allow_file_creation = 1
-
-sgx.allowed_files.tmp_dir = file:tmp/
-
-sgx.thread_num = 6
+sgx.trusted_files.echo = file:/bin/echo
+sgx.trusted_children.echo = file:echo.sig
 
 sgx.static_address = 1
-
-sgx.trusted_files.sh = file:/bin/sh
-sgx.trusted_children.sh = file:sh.sig

--- a/LibOS/shim/test/regression/shared_object.manifest.template
+++ b/LibOS/shim/test/regression/shared_object.manifest.template
@@ -9,3 +9,4 @@ fs.mount.lib.uri = file:$(LIBCDIR)
 sgx.trusted_files.ld = file:$(LIBCDIR)/ld-linux-x86-64.so.2
 sgx.trusted_files.libc = file:$(LIBCDIR)/libc.so.6
 
+sgx.static_address = 1

--- a/LibOS/shim/test/regression/system.c
+++ b/LibOS/shim/test/regression/system.c
@@ -1,0 +1,12 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+int main(int argc, char const *argv[]) {
+    int ret = system("echo hello from system");
+    if (ret) {
+        /* something went wrong with system() execution */
+        return 1;
+    }
+
+    return 0;
+}

--- a/LibOS/shim/test/regression/test_libos.py
+++ b/LibOS/shim/test/regression/test_libos.py
@@ -99,6 +99,10 @@ class TC_01_Bootstrap(RegressionTestCase):
         self.assertIn('child exited with status: 0', stdout)
         self.assertIn('test completed successfully', stdout)
 
+    def test_204_system(self):
+        stdout, _ = self.run_binary(['system'], timeout=60)
+        self.assertIn('hello from system', stdout)
+
     def test_210_exec_invalid_args(self):
         stdout, _ = self.run_binary(['exec_invalid_args'])
 


### PR DESCRIPTION
## Description of the changes: <!-- (reasons and measures) -->

Glibc 2.31 implements system() POSIX function call via a combination of `clone(CLONE_VM|CLONE_VFORK|SIGCHLD, <child_stack_addr>, ...)` and `execve()`. This special case was not supported by Graphene. Moreover, Glibc 2.31 allocates a child stack and puts some variables on this child stack. After clone, the child process tries to access these variables on the child stack. However, previously Graphene always assumed that the child process returns on the same (parent) stack. Therefore, restored RSP in the child did not point to the child stack but to the parent stack, which triggered segfaults in Glibc.

This PR fixes this by temporarily rewiring the current thread (the one issuing `clone(VFORK, ...)`) so that it points to the provided child stack, and then rewiring it back to the original parent stack after the clone (in the parent process). The child process will resume execution with the correct child stack.
To test this bugfix, a LibOS test for `system()` is introduced. Also, all LibOS tests are forced to start enclaves at address 0x0. This removes checkpointing issues on mixes of PIE- and non-PIE executables (in particular, this happens in the `system()` test).

Fixes #1381. See detailed description of the bug there.

See #1380 regarding the need for `sgx.static_address = 1`.

## How to test this PR? <!-- (if applicable) -->

New `system` LibOS regression test is added. It fails on previous Graphene with Glibc 2.31 and succeeds with this PR with Glibc 2.31 (i.e., on Ubuntu 18.04+).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1384)
<!-- Reviewable:end -->
