### PR TITLE
[LibOS] Refactor implementation of /proc and /dev pseudo-FSs

### DIFF
--- a/LibOS/shim/src/Makefile
+++ b/LibOS/shim/src/Makefile
@@ -44,9 +44,14 @@ objs = \
 	fs/shim_dcache.o \
 	fs/shim_fs.o \
 	fs/shim_fs_hash.o \
+	fs/shim_fs_pseudo.o \
 	fs/shim_namei.o \
 	fs/chroot/fs.o \
 	fs/dev/fs.o \
+	fs/dev/null.o \
+	fs/dev/random.o \
+	fs/dev/std.o \
+	fs/dev/zero.o \
 	fs/eventfd/fs.o \
 	fs/pipe/fs.o \
 	fs/proc/fs.o \

--- a/LibOS/shim/src/fs/chroot/fs.c
+++ b/LibOS/shim/src/fs/chroot/fs.c
@@ -43,8 +43,6 @@
 
 #define URI_MAX_SIZE    STR_SIZE
 
-#define TTY_FILE_MODE   0666
-
 #define FILE_BUFMAP_SIZE (PAL_CB(alloc_align) * 4)
 #define FILE_BUF_SIZE (PAL_CB(alloc_align))
 

--- a/LibOS/shim/src/fs/dev/fs.c
+++ b/LibOS/shim/src/fs/dev/fs.c
@@ -14,395 +14,127 @@
    You should have received a copy of the GNU Lesser General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
 
-/*
- * fs.c
+/*!
+ * \file
  *
- * This file contains codes for implementation of 'dev' filesystem.
+ * This file contains the implementation of `/dev` pseudo-filesystem.
  */
 
-#define __KERNEL__
+#include "shim_fs.h"
 
-#include <asm/fcntl.h>
-#include <asm/mman.h>
-#include <asm/prctl.h>
-#include <asm/unistd.h>
-#include <errno.h>
-#include <linux/fcntl.h>
-#include <linux/stat.h>
+extern const struct pseudo_fs_ops dev_null_fs_ops;
+extern const struct pseudo_fs_ops dev_tty_fs_ops;
+extern const struct pseudo_fs_ops dev_zero_fs_ops;
+extern const struct pseudo_fs_ops dev_random_fs_ops;
+extern const struct pseudo_fs_ops dev_urandom_fs_ops;
+extern const struct pseudo_fs_ops dev_stdin_fs_ops;
+extern const struct pseudo_fs_ops dev_stdout_fs_ops;
+extern const struct pseudo_fs_ops dev_stderr_fs_ops;
 
-#include <pal.h>
-#include <pal_error.h>
-#include <shim_fs.h>
-#include <shim_handle.h>
-#include <shim_internal.h>
-#include <shim_profile.h>
-#include <shim_utils.h>
+static const struct pseudo_dir dev_root_dir = {
+    .size = 8,
+    .ent =  {
+              { .name   = "null",
+                .fs_ops = &dev_null_fs_ops,
+                .type   = LINUX_DT_CHR },
+              { .name   = "tty",
+                .fs_ops = &dev_tty_fs_ops,
+                .type   = LINUX_DT_CHR },
+              { .name   = "zero",
+                .fs_ops = &dev_zero_fs_ops,
+                .type   = LINUX_DT_CHR },
+              { .name   = "random",
+                .fs_ops = &dev_random_fs_ops,
+                .type   = LINUX_DT_CHR },
+              { .name   = "urandom",
+                .fs_ops = &dev_urandom_fs_ops,
+                .type   = LINUX_DT_CHR },
+              { .name   = "stdin",
+                .fs_ops = &dev_stdin_fs_ops,
+                .type   = LINUX_DT_LNK },
+              { .name   = "stdout",
+                .fs_ops = &dev_stdout_fs_ops,
+                .type   = LINUX_DT_LNK },
+              { .name   = "stderr",
+                .fs_ops = &dev_stderr_fs_ops,
+                .type   = LINUX_DT_LNK },
+        },
+};
 
-#define EMPTY_DEV_OPS     \
-    {                     \
-        .open     = NULL, \
-        .close    = NULL, \
-        .read     = NULL, \
-        .write    = NULL, \
-        .flush    = NULL, \
-        .seek     = NULL, \
-        .truncate = NULL, \
-        .mode     = NULL, \
-        .stat     = NULL, \
-        .hstat    = NULL, \
-    }
+static const struct pseudo_fs_ops dev_root_fs = {
+    .open = &pseudo_dir_open,
+    .mode = &pseudo_dir_mode,
+    .stat = &pseudo_dir_stat,
+};
 
-#define DEV_INO_BASE 1025
-
-static ssize_t dev_null_read(struct shim_handle* hdl, void* buf, size_t count) {
-    // Arguments for compatibility
-    __UNUSED(hdl);
-    __UNUSED(buf);
-    __UNUSED(count);
-
-    return 0;
-}
-
-static ssize_t dev_zero_read(struct shim_handle* hdl, void* buf, size_t count) {
-    // Argument for compatibility
-    __UNUSED(hdl);
-
-    memset(buf, 0, count);
-    return count;
-}
-
-static ssize_t dev_null_write(struct shim_handle* hdl, const void* buf, size_t count) {
-    // Arguments for compatibility
-    __UNUSED(hdl);
-    __UNUSED(buf);
-    __UNUSED(count);
-
-    return count;
-}
-
-static int dev_null_mode(const char* name, mode_t* mode) {
-    __UNUSED(name);  // We know it is /dev/null
-
-    *mode = 0666 | S_IFCHR;
-    return 0;
-}
-
-static int dev_null_stat(const char* name, struct stat* stat) {
-    __UNUSED(name);  // We know it is /dev/null
-
-    stat->st_mode    = 0666 | S_IFCHR;
-    stat->st_uid     = 0;
-    stat->st_gid     = 0;
-    stat->st_size    = 0;
-    stat->st_blksize = 0;
-    return 0;
-}
-
-static int dev_null_hstat(struct shim_handle* hdl, struct stat* stat) {
-    __UNUSED(hdl);  // We know it is /dev/null
-
-    stat->st_mode    = 0666 | S_IFCHR;
-    stat->st_uid     = 0;
-    stat->st_gid     = 0;
-    stat->st_size    = 0;
-    stat->st_blksize = 0;
-    return 0;
-}
-
-static int dev_null_truncate(struct shim_handle* hdl, uint64_t size) {
-    // Arguments for compatibility
-    __UNUSED(hdl);
-    __UNUSED(size);
-
-    return 0;
-}
-
-static int dev_random_mode(const char* name, mode_t* mode) {
-    __UNUSED(name);  // We know it is /dev/random
-
-    *mode = 0666 | S_IFCHR;
-    return 0;
-}
-
-static ssize_t dev_urandom_read(struct shim_handle* hdl, void* buf, size_t count) {
-    __UNUSED(hdl);
-    ssize_t ret = DkRandomBitsRead(buf, count);
-
-    if (ret < 0)
-        return -convert_pal_errno(-ret);
-    return count;
-}
-
-static ssize_t dev_random_read(struct shim_handle* hdl, void* buf, size_t count) {
-    return dev_urandom_read(hdl, buf, count);
-}
-
-static int dev_random_stat(const char* name, struct stat* stat) {
-    __UNUSED(name);  // we know it is /dev/random
-
-    stat->st_mode    = 0666 | S_IFCHR;
-    stat->st_uid     = 0;
-    stat->st_gid     = 0;
-    stat->st_size    = 0;
-    stat->st_blksize = 0;
-    return 0;
-}
-
-static int dev_random_hstat(struct shim_handle* hdl, struct stat* stat) {
-    __UNUSED(hdl);  // pseudo-device
-
-    stat->st_mode    = 0444 | S_IFCHR;
-    stat->st_uid     = 0;
-    stat->st_gid     = 0;
-    stat->st_size    = 0;
-    stat->st_blksize = 0;
-    return 0;
-}
-
-static int search_dev_driver(const char* name, struct shim_dev_ops* ops) {
-    if (!strcmp_static(name, "null") || !strcmp_static(name, "tty")) {
-        if (ops)
-            ops->read = &dev_null_read;
-    null_dev:
-        if (ops) {
-            ops->write    = &dev_null_write;
-            ops->truncate = &dev_null_truncate;
-            ops->mode     = &dev_null_mode;
-            ops->stat     = &dev_null_stat;
-            ops->hstat    = &dev_null_hstat;
-        }
-        return 0;
-    }
-
-    if (!strcmp_static(name, "zero")) {
-        if (ops)
-            ops->read = &dev_zero_read;
-        goto null_dev;
-    }
-
-    if (!strcmp_static(name, "random")) {
-        if (ops)
-            ops->read = &dev_random_read;
-    random_dev:
-        if (ops) {
-            ops->mode  = &dev_random_mode;
-            ops->stat  = &dev_random_stat;
-            ops->hstat = &dev_random_hstat;
-        }
-        return 0;
-    }
-
-    if (!strcmp_static(name, "urandom")) {
-        if (ops)
-            ops->read = &dev_urandom_read;
-        goto random_dev;
-    }
-
-    if (!strcmp_static(name, "stdin") || !strcmp_static(name, "stdout") ||
-        !strcmp_static(name, "stderr"))
-        return -EISLINK;
-
-    return -ENOENT;
-}
-
-static int dev_mount(const char* uri, void** mount_data) {
-    // Arguments for compatibility
-    __UNUSED(uri);
-    __UNUSED(mount_data);
-
-    /* do nothing */
-    return 0;
-}
-
-static int dev_unmount(void* mount_data) {
-    // Arguments for compatibility
-    __UNUSED(mount_data);
-
-    /* do nothing */
-    return 0;
-}
+static const struct pseudo_ent dev_root_ent = {
+    .name   = "",
+    .fs_ops = &dev_root_fs,
+    .dir    = &dev_root_dir,
+};
 
 static int dev_open(struct shim_handle* hdl, struct shim_dentry* dent, int flags) {
-    struct shim_dev_ops ops_buf = EMPTY_DEV_OPS;
-    int ret                     = search_dev_driver(qstrgetstr(&dent->rel_path), &ops_buf);
-
-    if (ret < 0)
-        return ret;
-
-    hdl->type     = TYPE_DEV;
-    hdl->flags    = flags & ~O_ACCMODE;
-    hdl->acc_mode = ACC_MODE(flags & O_ACCMODE);
-
-    memcpy(&hdl->info.dev.dev_ops, &ops_buf, sizeof(struct shim_dev_ops));
-
-    if (!ops_buf.read && (hdl->acc_mode & MAY_READ))
-        return -EACCES;
-
-    if (!ops_buf.write && (hdl->acc_mode & MAY_WRITE))
-        return -EACCES;
-
-    if (ops_buf.open)
-        return ops_buf.open(hdl, qstrgetstr(&dent->rel_path), flags);
-
-    return 0;
+    return pseudo_open(hdl, dent, flags, &dev_root_ent);
 }
 
 static int dev_lookup(struct shim_dentry* dent) {
-    if (qstrempty(&dent->rel_path)) {
-        dent->state |= DENTRY_ISDIRECTORY;
-        dent->ino = DEV_INO_BASE;
-        return 0;
-    }
-
-    /* we don't care about forced or not */
-    return search_dev_driver(qstrgetstr(&dent->rel_path), NULL);
+    return pseudo_lookup(dent, &dev_root_ent);
 }
 
 static int dev_mode(struct shim_dentry* dent, mode_t* mode) {
-    if (qstrempty(&dent->rel_path)) {
-        dent->ino = DEV_INO_BASE;
-        *mode     = 0555 | S_IFDIR;
-        return 0;
-    }
-
-    /* we don't care about forced or not */
-    struct shim_dev_ops ops_buf = EMPTY_DEV_OPS;
-    int ret                     = search_dev_driver(qstrgetstr(&dent->rel_path), &ops_buf);
-
-    if (ret < 0)
-        return ret;
-
-    return ops_buf.mode(qstrgetstr(&dent->rel_path), mode);
+    return pseudo_mode(dent, mode, &dev_root_ent);
 }
 
-static int dev_flush(struct shim_handle* hdl) {
-    if (!hdl->info.dev.dev_ops.flush)
-        return 0;
-
-    return hdl->info.dev.dev_ops.flush(hdl);
+static int dev_readdir(struct shim_dentry* dent, struct shim_dirent** dirent) {
+    return pseudo_readdir(dent, dirent, &dev_root_ent);
 }
 
-static int dev_close(struct shim_handle* hdl) {
-    if (!hdl->info.dev.dev_ops.close)
-        return 0;
+static int dev_stat(struct shim_dentry* dent, struct stat* buf) {
+    return pseudo_stat(dent, buf, &dev_root_ent);
+}
 
-    return hdl->info.dev.dev_ops.close(hdl);
+static int dev_hstat(struct shim_handle* hdl, struct stat* buf) {
+    return pseudo_hstat(hdl, buf, &dev_root_ent);
+}
+
+static int dev_follow_link(struct shim_dentry* dent, struct shim_qstr* link) {
+    return pseudo_follow_link(dent, link, &dev_root_ent);
 }
 
 static ssize_t dev_read(struct shim_handle* hdl, void* buf, size_t count) {
     if (!hdl->info.dev.dev_ops.read)
         return -EACCES;
-
     return hdl->info.dev.dev_ops.read(hdl, buf, count);
 }
 
 static ssize_t dev_write(struct shim_handle* hdl, const void* buf, size_t count) {
     if (!hdl->info.dev.dev_ops.write)
         return -EACCES;
-
     return hdl->info.dev.dev_ops.write(hdl, buf, count);
 }
 
 static off_t dev_seek(struct shim_handle* hdl, off_t offset, int wence) {
     if (!hdl->info.dev.dev_ops.seek)
         return -EACCES;
-
     return hdl->info.dev.dev_ops.seek(hdl, offset, wence);
 }
 
 static int dev_truncate(struct shim_handle* hdl, off_t len) {
     if (!hdl->info.dev.dev_ops.truncate)
         return -EACCES;
-
     return hdl->info.dev.dev_ops.truncate(hdl, len);
 }
 
-static int dev_readdir(struct shim_dentry* dent, struct shim_dirent** dirent) {
-    if (!qstrempty(&dent->rel_path)) {
-        struct shim_dev_ops ops_buf = EMPTY_DEV_OPS;
-        int ret                     = search_dev_driver(qstrgetstr(&dent->rel_path), &ops_buf);
-
-        if (ret < 0 && ret != -EISLINK)
-            return ret;
-
-        return -ENOTDIR;
-    }
-
-    struct shim_dirent *buf, *ptr;
-    int buf_size = MAX_PATH;
-
-retry:
-    buf     = malloc(buf_size);
-    *dirent = ptr = buf;
-    struct shim_dirent** last = dirent;
-
-#define COPY_ENTRY(devname, devtype)                                 \
-    do {                                                             \
-        int name_len = strlen(devname);                              \
-                                                                     \
-        if ((void*)(ptr + 1) + name_len + 1 > (void*)buf + buf_size) \
-            goto nomem;                                              \
-                                                                     \
-        ptr->next = (void*)(ptr + 1) + name_len + 1;                 \
-        ptr->ino  = 1;                                               \
-        ptr->type = (devtype);                                       \
-        memcpy(ptr->name, (devname), name_len + 1);                  \
-        last = &ptr->next;                                           \
-        ptr  = ptr->next;                                            \
-    } while (0)
-
-    COPY_ENTRY("null", LINUX_DT_CHR);
-    COPY_ENTRY("zero", LINUX_DT_CHR);
-    COPY_ENTRY("stdin", LINUX_DT_LNK);
-    COPY_ENTRY("stdout", LINUX_DT_LNK);
-    COPY_ENTRY("stderr", LINUX_DT_LNK);
-#undef COPY_ENTRY
-
-    *last = NULL;
-    return 0;
-
-nomem:
-    buf_size *= 2;
-    free(buf);
-    goto retry;
+static int dev_flush(struct shim_handle* hdl) {
+    if (!hdl->info.dev.dev_ops.flush)
+        return 0;
+    return hdl->info.dev.dev_ops.flush(hdl);
 }
 
-static int dev_stat(struct shim_dentry* dent, struct stat* buf) {
-    if (qstrempty(&dent->rel_path)) {
-        buf->st_dev     = DEV_INO_BASE;
-        buf->st_ino     = DEV_INO_BASE;
-        buf->st_mode    = 0777 | S_IFDIR;
-        buf->st_size    = 4096;
-        buf->st_blksize = 4096;
+static int dev_close(struct shim_handle* hdl) {
+    if (!hdl->info.dev.dev_ops.close)
         return 0;
-    }
-
-    struct shim_dev_ops ops_buf = EMPTY_DEV_OPS;
-    int ret                     = search_dev_driver(qstrgetstr(&dent->rel_path), &ops_buf);
-
-    if (ret < 0 && ret != -EISLINK)
-        return ret;
-
-    if (ret == -EISLINK) {
-        buf->st_dev     = DEV_INO_BASE;
-        buf->st_ino     = DEV_INO_BASE;
-        buf->st_mode    = 0777 | S_IFLNK;
-        buf->st_size    = 0;
-        buf->st_blksize = 0;
-        return 0;
-    }
-
-    buf->st_dev = DEV_INO_BASE;
-    buf->st_ino = DEV_INO_BASE;
-
-    return ops_buf.stat ? ops_buf.stat(qstrgetstr(&dent->rel_path), buf) : -EACCES;
-}
-
-static int dev_hstat(struct shim_handle* hdl, struct stat* buf) {
-    if (!hdl->info.dev.dev_ops.hstat)
-        return -EACCES;
-
-    return hdl->info.dev.dev_ops.hstat(hdl, buf);
+    return hdl->info.dev.dev_ops.close(hdl);
 }
 
 static off_t dev_poll(struct shim_handle* hdl, int poll_type) {
@@ -418,49 +150,17 @@ static off_t dev_poll(struct shim_handle* hdl, int poll_type) {
     return ret;
 }
 
-static int dev_follow_link(struct shim_dentry* dent, struct shim_qstr* link) {
-    const char* name = qstrgetstr(&dent->rel_path);
-
-    if (!strcmp_static(name, "stdin")) {
-        qstrsetstr(link, "/proc/self/0", static_strlen("/proc/self/0"));
-        return 0;
-    } else if (!strcmp_static(name, "stdout")) {
-        qstrsetstr(link, "/proc/self/1", static_strlen("/proc/self/1"));
-        return 0;
-    } else if (!strcmp_static(name, "stderr")) {
-        qstrsetstr(link, "/proc/self/2", static_strlen("/proc/self/2"));
-        return 0;
-    }
-
-    if (!strcmp_static(name, "null") || !strcmp_static(name, "zero"))
-        return -ENOTLINK;
-
-    return -ENOENT;
-}
-
 int dev_update_dev_ops(struct shim_handle* hdl) {
-    int ret;
-    char buf[STR_SIZE];
-    size_t bufsize = sizeof(buf);
-    struct shim_dev_ops ops_buf = EMPTY_DEV_OPS;
+    struct shim_dentry* dent = hdl->dentry;
+    assert(dent);
 
-    assert(hdl && hdl->type == TYPE_DEV);
-
-    ret = get_base_name(qstrgetstr(&hdl->path), buf, &bufsize);
-    if (ret < 0)
-        return -ENOENT;
-
-    ret = search_dev_driver(buf, &ops_buf);
-    if (ret < 0)
-        return ret;
-
-    memcpy(&hdl->info.dev.dev_ops, &ops_buf, sizeof(ops_buf));
-    return 0;
+    /* simply reopen pseudo-file, this will update dev_ops function pointers to correct values */
+    return pseudo_open(hdl, dent, /*flags=*/0, &dev_root_ent);
 }
 
 struct shim_fs_ops dev_fs_ops = {
-    .mount    = &dev_mount,
-    .unmount  = &dev_unmount,
+    .mount    = &pseudo_mount,
+    .unmount  = &pseudo_unmount,
     .flush    = &dev_flush,
     .close    = &dev_close,
     .read     = &dev_read,

--- a/LibOS/shim/src/fs/dev/null.c
+++ b/LibOS/shim/src/fs/dev/null.c
@@ -1,0 +1,90 @@
+/* Copyright (C) 2020 Intel Labs
+   This file is part of Graphene Library OS.
+
+   Graphene Library OS is free software: you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public License
+   as published by the Free Software Foundation, either version 3 of the
+   License, or (at your option) any later version.
+
+   Graphene Library OS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
+
+/*!
+ * \file
+ *
+ * This file contains the implementation of `/dev/null` and `/dev/tty` pseudo-files.
+ */
+
+#include "shim_fs.h"
+
+static ssize_t dev_null_read(struct shim_handle* hdl, void* buf, size_t count) {
+    __UNUSED(hdl);
+    __UNUSED(buf);
+    __UNUSED(count);
+    return 0;
+}
+
+static ssize_t dev_null_write(struct shim_handle* hdl, const void* buf, size_t count) {
+    __UNUSED(hdl);
+    __UNUSED(buf);
+    __UNUSED(count);
+    return count;
+}
+
+static int dev_null_truncate(struct shim_handle* hdl, uint64_t size) {
+    __UNUSED(hdl);
+    __UNUSED(size);
+    return 0;
+}
+
+static int dev_null_mode(const char* name, mode_t* mode) {
+    __UNUSED(name);
+    *mode = FILE_RW_MODE | S_IFCHR;
+    return 0;
+}
+
+static int dev_null_stat(const char* name, struct stat* buf) {
+    __UNUSED(name);
+    memset(buf, 0, sizeof(*buf));
+
+    buf->st_mode = FILE_RW_MODE | S_IFCHR;
+    return 0;
+}
+
+static int dev_null_hstat(struct shim_handle* hdl, struct stat* buf) {
+    __UNUSED(hdl);
+    return dev_null_stat(/*name=*/NULL, buf);
+}
+
+static int dev_null_open(struct shim_handle* hdl, const char* name, int flags) {
+    __UNUSED(name);
+    __UNUSED(flags);
+
+    struct shim_dev_ops ops = {.read     = &dev_null_read,
+                               .write    = &dev_null_write,
+                               .truncate = &dev_null_truncate,
+                               .mode     = &dev_null_mode,
+                               .stat     = &dev_null_stat,
+                               .hstat    = &dev_null_hstat};
+
+    memcpy(&hdl->info.dev.dev_ops, &ops, sizeof(ops));
+    return 0;
+}
+
+struct pseudo_fs_ops dev_null_fs_ops = {
+    .open = &dev_null_open,
+    .mode = &dev_null_mode,
+    .stat = &dev_null_stat,
+};
+
+/* /dev/tty is exactly the same as /dev/null in Graphene, so it has the same operations */
+struct pseudo_fs_ops dev_tty_fs_ops = {
+    .open = &dev_null_open,
+    .mode = &dev_null_mode,
+    .stat = &dev_null_stat,
+};

--- a/LibOS/shim/src/fs/dev/random.c
+++ b/LibOS/shim/src/fs/dev/random.c
@@ -1,0 +1,86 @@
+/* Copyright (C) 2020 Intel Labs
+   This file is part of Graphene Library OS.
+
+   Graphene Library OS is free software: you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public License
+   as published by the Free Software Foundation, either version 3 of the
+   License, or (at your option) any later version.
+
+   Graphene Library OS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
+
+/*!
+ * \file
+ *
+ * This file contains the implementation of `/dev/random` and `/dev/urandom` pseudo-files.
+ */
+
+#include "shim_fs.h"
+
+static ssize_t dev_random_read(struct shim_handle* hdl, void* buf, size_t count) {
+    __UNUSED(hdl);
+    ssize_t ret = DkRandomBitsRead(buf, count);
+
+    if (ret < 0)
+        return -convert_pal_errno(-ret);
+    return count;
+}
+
+static ssize_t dev_random_write(struct shim_handle* hdl, const void* buf, size_t count) {
+    /* writes in /dev/random add entropy in normal Linux, but not implemented in Graphene */
+    __UNUSED(hdl);
+    __UNUSED(buf);
+    __UNUSED(count);
+    return count;
+}
+
+static int dev_random_mode(const char* name, mode_t* mode) {
+    __UNUSED(name);
+    *mode = FILE_RW_MODE | S_IFCHR;
+    return 0;
+}
+
+static int dev_random_stat(const char* name, struct stat* buf) {
+    __UNUSED(name);
+    memset(buf, 0, sizeof(*buf));
+
+    buf->st_mode = FILE_RW_MODE | S_IFCHR;
+    return 0;
+}
+
+static int dev_random_hstat(struct shim_handle* hdl, struct stat* buf) {
+    __UNUSED(hdl);
+    return dev_random_stat(/*name=*/NULL, buf);
+}
+
+static int dev_random_open(struct shim_handle* hdl, const char* name, int flags) {
+    __UNUSED(name);
+    __UNUSED(flags);
+
+    struct shim_dev_ops ops = {.read     = &dev_random_read,
+                               .write    = &dev_random_write,
+                               .mode     = &dev_random_mode,
+                               .stat     = &dev_random_stat,
+                               .hstat    = &dev_random_hstat};
+
+    memcpy(&hdl->info.dev.dev_ops, &ops, sizeof(ops));
+    return 0;
+}
+
+struct pseudo_fs_ops dev_random_fs_ops = {
+    .open = &dev_random_open,
+    .mode = &dev_random_mode,
+    .stat = &dev_random_stat,
+};
+
+/* /dev/urandom is exactly the same as /dev/random, so it has the same operations */
+struct pseudo_fs_ops dev_urandom_fs_ops = {
+    .open = &dev_random_open,
+    .mode = &dev_random_mode,
+    .stat = &dev_random_stat,
+};

--- a/LibOS/shim/src/fs/dev/std.c
+++ b/LibOS/shim/src/fs/dev/std.c
@@ -1,0 +1,83 @@
+/* Copyright (C) 2020 Intel Labs
+   This file is part of Graphene Library OS.
+
+   Graphene Library OS is free software: you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public License
+   as published by the Free Software Foundation, either version 3 of the
+   License, or (at your option) any later version.
+
+   Graphene Library OS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
+
+/*!
+ * \file
+ *
+ * This file contains the implementation of `/dev/stdin`, `/dev/stdout`, `/dev/stderr` pseudo-files.
+ */
+
+#include "shim_fs.h"
+
+static int dev_std_mode(const char* name, mode_t* mode) {
+    __UNUSED(name);
+    *mode = FILE_RW_MODE | S_IFCHR;
+    return 0;
+}
+
+static int dev_std_stat(const char* name, struct stat* buf) {
+    __UNUSED(name);
+    memset(buf, 0, sizeof(*buf));
+
+    buf->st_mode    = FILE_RW_MODE | S_IFLNK;
+    return 0;
+}
+
+static int dev_std_open(struct shim_handle* hdl, const char* name, int flags) {
+    __UNUSED(hdl);
+    __UNUSED(name);
+    __UNUSED(flags);
+    return 0;
+}
+
+static int dev_stdin_follow_link(const char* name, struct shim_qstr* link) {
+    __UNUSED(name);
+    qstrsetstr(link, "/proc/self/fd/0", static_strlen("/proc/self/fd/0"));
+    return 0;
+}
+
+static int dev_stdout_follow_link(const char* name, struct shim_qstr* link) {
+    __UNUSED(name);
+    qstrsetstr(link, "/proc/self/fd/1", static_strlen("/proc/self/fd/1"));
+    return 0;
+}
+
+static int dev_stderr_follow_link(const char* name, struct shim_qstr* link) {
+    __UNUSED(name);
+    qstrsetstr(link, "/proc/self/fd/2", static_strlen("/proc/self/fd/2"));
+    return 0;
+}
+
+struct pseudo_fs_ops dev_stdin_fs_ops = {
+    .open = &dev_std_open,
+    .mode = &dev_std_mode,
+    .stat = &dev_std_stat,
+    .follow_link = &dev_stdin_follow_link,
+};
+
+struct pseudo_fs_ops dev_stdout_fs_ops = {
+    .open = &dev_std_open,
+    .mode = &dev_std_mode,
+    .stat = &dev_std_stat,
+    .follow_link = &dev_stdout_follow_link,
+};
+
+struct pseudo_fs_ops dev_stderr_fs_ops = {
+    .open = &dev_std_open,
+    .mode = &dev_std_mode,
+    .stat = &dev_std_stat,
+    .follow_link = &dev_stderr_follow_link,
+};

--- a/LibOS/shim/src/fs/dev/zero.c
+++ b/LibOS/shim/src/fs/dev/zero.c
@@ -1,0 +1,82 @@
+/* Copyright (C) 2020 Intel Labs
+   This file is part of Graphene Library OS.
+
+   Graphene Library OS is free software: you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public License
+   as published by the Free Software Foundation, either version 3 of the
+   License, or (at your option) any later version.
+
+   Graphene Library OS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
+
+/*!
+ * \file
+ *
+ * This file contains the implementation of `/dev/zero` pseudo-file.
+ */
+
+#include "shim_fs.h"
+
+static ssize_t dev_zero_read(struct shim_handle* hdl, void* buf, size_t count) {
+    __UNUSED(hdl);
+    memset(buf, 0, count);
+    return count;
+}
+
+static ssize_t dev_zero_write(struct shim_handle* hdl, const void* buf, size_t count) {
+    __UNUSED(hdl);
+    __UNUSED(buf);
+    __UNUSED(count);
+    return count;
+}
+
+static int dev_zero_truncate(struct shim_handle* hdl, uint64_t size) {
+    __UNUSED(hdl);
+    __UNUSED(size);
+    return 0;
+}
+
+static int dev_zero_mode(const char* name, mode_t* mode) {
+    __UNUSED(name);
+    *mode = FILE_RW_MODE | S_IFCHR;
+    return 0;
+}
+
+static int dev_zero_stat(const char* name, struct stat* buf) {
+    __UNUSED(name);
+    memset(buf, 0, sizeof(*buf));
+
+    buf->st_mode = FILE_RW_MODE | S_IFCHR;
+    return 0;
+}
+
+static int dev_zero_hstat(struct shim_handle* hdl, struct stat* buf) {
+    __UNUSED(hdl);
+    return dev_zero_stat(/*name=*/NULL, buf);
+}
+
+static int dev_zero_open(struct shim_handle* hdl, const char* name, int flags) {
+    __UNUSED(name);
+    __UNUSED(flags);
+
+    struct shim_dev_ops ops = {.read     = &dev_zero_read,
+                               .write    = &dev_zero_write,
+                               .truncate = &dev_zero_truncate,
+                               .mode     = &dev_zero_mode,
+                               .stat     = &dev_zero_stat,
+                               .hstat    = &dev_zero_hstat};
+
+    memcpy(&hdl->info.dev.dev_ops, &ops, sizeof(ops));
+    return 0;
+}
+
+struct pseudo_fs_ops dev_zero_fs_ops = {
+    .open = &dev_zero_open,
+    .mode = &dev_zero_mode,
+    .stat = &dev_zero_stat,
+};

--- a/LibOS/shim/src/fs/proc/fs.c
+++ b/LibOS/shim/src/fs/proc/fs.c
@@ -14,372 +14,90 @@
    You should have received a copy of the GNU Lesser General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
 
-/*
- * fs.c
+/*!
+ * \file
  *
- * This file contains codes for implementation of 'proc' filesystem.
+ * This file contains the implementation of `/proc` pseudo-filesystem.
  */
 
-#define __KERNEL__
+#include "shim_fs.h"
 
-#include <asm/fcntl.h>
-#include <asm/mman.h>
-#include <asm/prctl.h>
-#include <asm/unistd.h>
-#include <errno.h>
-#include <linux/fcntl.h>
-#include <linux/stat.h>
+extern const struct pseudo_name_ops nm_thread;
+extern const struct pseudo_fs_ops fs_thread;
+extern const struct pseudo_dir dir_thread;
 
-#include <pal.h>
-#include <pal_error.h>
-#include <shim_fs.h>
-#include <shim_handle.h>
-#include <shim_internal.h>
-#include <shim_thread.h>
-#include <shim_utils.h>
+extern const struct pseudo_name_ops nm_ipc_thread;
+extern const struct pseudo_fs_ops fs_ipc_thread;
+extern const struct pseudo_dir dir_ipc_thread;
 
-extern const struct proc_nm_ops nm_thread;
-extern const struct proc_fs_ops fs_thread;
-extern const struct proc_dir dir_thread;
-extern const struct proc_nm_ops nm_ipc_thread;
-extern const struct proc_fs_ops fs_ipc_thread;
-extern const struct proc_dir dir_ipc_thread;
-extern const struct proc_fs_ops fs_meminfo;
-extern const struct proc_fs_ops fs_cpuinfo;
+extern const struct pseudo_fs_ops fs_meminfo;
 
-const struct proc_dir proc_root = {
+extern const struct pseudo_fs_ops fs_cpuinfo;
+
+static const struct pseudo_dir proc_root_dir = {
     .size = 5,
-    .ent =
-        {
-            {
-                .name   = "self",
+    .ent  = {
+              { .name   = "self",
                 .fs_ops = &fs_thread,
-                .dir    = &dir_thread,
-            },
-            {
-                .nm_ops = &nm_thread,
-                .fs_ops = &fs_thread,
-                .dir    = &dir_thread,
-            },
-            {
-                .nm_ops = &nm_ipc_thread,
-                .fs_ops = &fs_ipc_thread,
-                .dir    = &dir_ipc_thread,
-            },
-            {
-                .name   = "meminfo",
+                .dir    = &dir_thread },
+              { .name_ops = &nm_thread,
+                .fs_ops   = &fs_thread,
+                .dir      = &dir_thread },
+              { .name_ops = &nm_ipc_thread,
+                .fs_ops   = &fs_ipc_thread,
+                .dir      = &dir_ipc_thread },
+              { .name   = "meminfo",
                 .fs_ops = &fs_meminfo,
-            },
-            {
-                .name   = "cpuinfo",
+                .type   = LINUX_DT_REG },
+              { .name   = "cpuinfo",
                 .fs_ops = &fs_cpuinfo,
-            },
-        },
+                .type   = LINUX_DT_REG },
+            }
 };
 
-#define PROC_INO_BASE 1
-
-static int proc_root_mode(const char* name, mode_t* mode) {
-    __UNUSED(name);  // We know this is /proc
-    *mode = 0555;
-    return 0;
-}
-
-static int proc_root_stat(const char* name, struct stat* buf) {
-    __UNUSED(name);  // We know this is /proc
-    memset(buf, 0, sizeof(struct stat));
-
-    buf->st_dev = buf->st_ino = 1;
-    buf->st_mode              = 0555 | S_IFDIR;
-    buf->st_uid               = 0;
-    buf->st_gid               = 0;
-    buf->st_size              = 4096;
-
-    return 0;
-}
-
-static int proc_root_open(struct shim_handle* hdl, const char* name, int flags) {
-    __UNUSED(hdl);   // this is a placeholder function
-    __UNUSED(name);  // We know this is /proc
-
-    if (flags & (O_WRONLY | O_RDWR))
-        return -EISDIR;
-
-    // Don't really need to do any work here, but keeping as a placeholder,
-    // just in case.
-
-    return 0;
-}
-
-struct proc_fs_ops fs_proc_root = {
-    .open = &proc_root_open,
-    .mode = &proc_root_mode,
-    .stat = &proc_root_stat,
+static const struct pseudo_fs_ops proc_root_fs = {
+    .open = &pseudo_dir_open,
+    .mode = &pseudo_dir_mode,
+    .stat = &pseudo_dir_stat,
 };
 
-const struct proc_ent proc_root_ent = {
+static const struct pseudo_ent proc_root_ent = {
     .name   = "",
-    .fs_ops = &fs_proc_root,
-    .dir    = &proc_root,
+    .fs_ops = &proc_root_fs,
+    .dir    = &proc_root_dir,
 };
-
-static inline int token_len(const char* str, const char** next_str) {
-    const char* t = str;
-
-    while (*t && *t != '/') {
-        t++;
-    }
-
-    if (next_str)
-        *next_str = *t ? t + 1 : NULL;
-
-    return t - str;
-}
-
-static int proc_match_name(const char* trim_name, const struct proc_ent** found_ent) {
-    if (!trim_name || !trim_name[0]) {
-        *found_ent = &proc_root_ent;
-        return 0;
-    }
-
-    const char* token          = trim_name;
-    const char* next_token     = NULL;
-    const struct proc_dir* dir = &proc_root;
-    const struct proc_ent* ent = NULL;
-
-    if (*token == '/')
-        token++;
-
-    while (token) {
-        int tlen = token_len(token, &next_token);
-
-        for (ent = dir->ent; ent < dir->ent + dir->size; ent++) {
-            if (ent->name && !memcmp(ent->name, token, tlen))
-                break;
-
-            if (ent->nm_ops && ent->nm_ops->match_name && ent->nm_ops->match_name(trim_name))
-                break;
-        }
-
-        if (ent == dir->ent + dir->size) {
-            /* couldn't find any entry corresponding to token */
-            return -ENOENT;
-        }
-
-        if (!next_token) {
-            /* found the entry, break out of the while loop */
-            break;
-        }
-
-        if (!ent->dir) {
-            /* still have tokens left, but current entry doesn't have subdirs/files */
-            return -ENOENT;
-        }
-
-        dir   = ent->dir;
-        token = next_token;
-    }
-
-    *found_ent = ent;
-    return 0;
-}
 
 static int proc_mode(struct shim_dentry* dent, mode_t* mode) {
-    if (qstrempty(&dent->rel_path)) {
-        dent->ino = PROC_INO_BASE;
-        *mode     = 0555 | S_IFDIR;
-        return 0;
-    }
-
-    /* don't care about forced or not */
-    const char* rel_path = qstrgetstr(&dent->rel_path);
-    const struct proc_ent* ent;
-    int ret = proc_match_name(rel_path, &ent);
-
-    if (ret < 0)
-        return ret;
-
-    if (!ent->fs_ops || !ent->fs_ops->mode)
-        return -EACCES;
-
-    return ent->fs_ops->mode(rel_path, mode);
+    return pseudo_mode(dent, mode, &proc_root_ent);
 }
 
 static int proc_lookup(struct shim_dentry* dent) {
-    if (qstrempty(&dent->rel_path)) {
-        dent->ino = PROC_INO_BASE;
-        dent->state |= DENTRY_ISDIRECTORY;
-        return 0;
-    }
-
-    /* don't care about forced or not */
-    const struct proc_ent* ent = NULL;
-    int ret                    = proc_match_name(qstrgetstr(&dent->rel_path), &ent);
-
-    if (!ret && ent->dir)
-        dent->state |= DENTRY_ISDIRECTORY;
-
-    if (ent && ent->fs_ops && ent->fs_ops->follow_link)
-        dent->state |= DENTRY_ISLINK;
-
-    return ret;
-}
-
-static int proc_mount(const char* uri, void** mount_data) {
-    // Arguments for compatibility with other FSes
-    __UNUSED(uri);
-    __UNUSED(mount_data);
-    /* do nothing */
-    return 0;
-}
-
-static int proc_unmount(void* mount_data) {
-    // Arguments for compatibility with other FSes
-    __UNUSED(mount_data);
-    /* do nothing */
-    return 0;
+    return pseudo_lookup(dent, &proc_root_ent);
 }
 
 static int proc_open(struct shim_handle* hdl, struct shim_dentry* dent, int flags) {
-    const char* rel_path = qstrgetstr(&dent->rel_path);
-
-    if (flags & (O_CREAT | O_EXCL))
-        return -EACCES;
-
-    const struct proc_ent* ent;
-    int ret;
-
-    if ((ret = proc_match_name(rel_path, &ent)) < 0)
-        return ret;
-
-    if (!ent->fs_ops || !ent->fs_ops->open)
-        return -EACCES;
-
-    hdl->flags = flags;
-
-    return ent->fs_ops->open(hdl, rel_path, flags);
+    return pseudo_open(hdl, dent, flags, &proc_root_ent);
 }
 
 static int proc_readdir(struct shim_dentry* dent, struct shim_dirent** dirent) {
-    const char* rel_path = qstrgetstr(&dent->rel_path);
-    const struct proc_ent* ent;
-    int ret;
-
-    if ((ret = proc_match_name(rel_path, &ent)) < 0)
-        return ret;
-
-    if (!ent->dir)
-        return -ENOTDIR;
-
-    const struct proc_dir* dir = ent->dir;
-
-    HASHTYPE self_hash = hash_path(rel_path, dent->rel_path.len);
-    HASHTYPE new_hash;
-    struct shim_dirent* buf;
-    struct shim_dirent* ptr;
-    int buf_size = MAX_PATH;
-
-retry:
-    buf     = malloc(buf_size);
-    *dirent = ptr             = buf;
-    struct shim_dirent** last = dirent;
-
-    for (const struct proc_ent* tmp = dir->ent; tmp < dir->ent + dir->size; tmp++) {
-        if (tmp->name) {
-            int name_len = strlen(tmp->name);
-
-            if ((void*)(ptr + 1) + name_len + 1 > (void*)buf + buf_size)
-                goto enlarge;
-
-            new_hash = rehash_name(self_hash, tmp->name, name_len);
-
-            ptr->next = (void*)(ptr + 1) + name_len + 1;
-            ptr->ino  = new_hash;
-            ptr->type =
-                tmp->dir ? LINUX_DT_DIR
-                         : (tmp->fs_ops && tmp->fs_ops->follow_link ? LINUX_DT_LNK : LINUX_DT_REG);
-            memcpy(ptr->name, tmp->name, name_len + 1);
-            last = &ptr->next;
-            ptr  = *last;
-            continue;
-        }
-
-        if (tmp->nm_ops && tmp->nm_ops->list_name) {
-            struct shim_dirent* d = ptr;
-            int ret = tmp->nm_ops->list_name(rel_path, &ptr, (void*)buf + buf_size - (void*)ptr);
-
-            if (ret == -ENOBUFS)
-                goto enlarge;
-
-            if (ret < 0)
-                ptr = d;
-            else
-                for (; d && d != ptr; d = d->next) {
-                    last = &d->next;
-                }
-            continue;
-        }
-    }
-
-    *last = NULL;
-    if (!(*dirent))
-        free(buf);
-    return 0;
-
-enlarge:
-    buf_size *= 2;
-    free(buf);
-    goto retry;
+    return pseudo_readdir(dent, dirent, &proc_root_ent);
 }
 
 static int proc_stat(struct shim_dentry* dent, struct stat* buf) {
-    const char* rel_path = qstrgetstr(&dent->rel_path);
-    const struct proc_ent* ent;
-    int ret;
-
-    if ((ret = proc_match_name(rel_path, &ent)) < 0)
-        return ret;
-
-    if (!ent->fs_ops || !ent->fs_ops->stat)
-        return -EACCES;
-
-    return ent->fs_ops->stat(rel_path, buf);
-}
-
-static int proc_follow_link(struct shim_dentry* dent, struct shim_qstr* link) {
-    const char* rel_path = qstrgetstr(&dent->rel_path);
-    const struct proc_ent* ent;
-    int ret;
-
-    if ((ret = proc_match_name(rel_path, &ent)) < 0)
-        return ret;
-
-    if (!ent->fs_ops || !ent->fs_ops->follow_link)
-        return -EINVAL;
-
-    return ent->fs_ops->follow_link(rel_path, link);
+    return pseudo_stat(dent, buf, &proc_root_ent);
 }
 
 static int proc_hstat(struct shim_handle* hdl, struct stat* buf) {
-    struct shim_dentry* dent = hdl->dentry;
-    assert(dent);
+    return pseudo_hstat(hdl, buf, &proc_root_ent);
+}
 
-    const char* rel_path = qstrgetstr(&dent->rel_path);
-    const struct proc_ent* ent;
-    int ret;
-
-    if ((ret = proc_match_name(rel_path, &ent)) < 0)
-        return ret;
-
-    if (!ent->fs_ops || !ent->fs_ops->stat)
-        return -EACCES;
-
-    return ent->fs_ops->stat(rel_path, buf);
+static int proc_follow_link(struct shim_dentry* dent, struct shim_qstr* link) {
+    return pseudo_follow_link(dent, link, &proc_root_ent);
 }
 
 struct shim_fs_ops proc_fs_ops = {
-    .mount   = &proc_mount,
-    .unmount = &proc_unmount,
+    .mount   = &pseudo_mount,
+    .unmount = &pseudo_unmount,
     .close   = &str_close,
     .read    = &str_read,
     .write   = &str_write,

--- a/LibOS/shim/src/fs/proc/ipc-thread.c
+++ b/LibOS/shim/src/fs/proc/ipc-thread.c
@@ -171,7 +171,7 @@ static int proc_ipc_thread_link_follow_link(const char* name, struct shim_qstr* 
     return find_ipc_thread_link(name, link, NULL);
 }
 
-static const struct proc_fs_ops fs_ipc_thread_link = {
+static const struct pseudo_fs_ops fs_ipc_thread_link = {
     .open        = &proc_ipc_thread_link_open,
     .mode        = &proc_ipc_thread_link_mode,
     .stat        = &proc_ipc_thread_link_stat,
@@ -332,7 +332,7 @@ static int proc_list_ipc_thread(const char* name, struct shim_dirent** buf, int 
             ;
 
         if ((void*)(ptr + 1) + l + 1 > buf_end) {
-            ret = -ENOBUFS;
+            ret = -ENOMEM;
             goto err;
         }
 
@@ -365,31 +365,27 @@ err:
     return ret;
 }
 
-const struct proc_nm_ops nm_ipc_thread = {
+const struct pseudo_name_ops nm_ipc_thread = {
     .match_name = &proc_match_ipc_thread,
     .list_name  = &proc_list_ipc_thread,
 };
 
-const struct proc_fs_ops fs_ipc_thread = {
+const struct pseudo_fs_ops fs_ipc_thread = {
     .mode = &proc_ipc_thread_dir_mode,
     .stat = &proc_ipc_thread_dir_stat,
 };
 
-const struct proc_dir dir_ipc_thread = {
-    .size = 0,
-    .ent =
-        {
-            {
-                .name   = "cwd",
+const struct pseudo_dir dir_ipc_thread = {
+    .size = 3,
+    .ent  = {
+              { .name   = "cwd",
                 .fs_ops = &fs_ipc_thread_link,
-            },
-            {
-                .name   = "exe",
+                .type   = LINUX_DT_LNK },
+              { .name   = "exe",
                 .fs_ops = &fs_ipc_thread_link,
-            },
-            {
-                .name   = "root",
+                .type   = LINUX_DT_LNK },
+              { .name   = "root",
                 .fs_ops = &fs_ipc_thread_link,
-            },
-        },
+                .type   = LINUX_DT_LNK },
+        }
 };

--- a/LibOS/shim/src/fs/shim_fs_pseudo.c
+++ b/LibOS/shim/src/fs/shim_fs_pseudo.c
@@ -1,0 +1,349 @@
+/* Copyright (C) 2014 Stony Brook University
+ * Copyright (C) 2020 Intel Labs
+   This file is part of Graphene Library OS.
+
+   Graphene Library OS is free software: you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public License
+   as published by the Free Software Foundation, either version 3 of the
+   License, or (at your option) any later version.
+
+   Graphene Library OS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
+
+/*!
+ * \file
+ *
+ * This file contains common code for pseudo-filesystems (e.g., /dev and /proc).
+ */
+
+#include "shim_fs.h"
+
+/*!
+ * \brief Find entry corresponding to path, starting from \p root_ent.
+ *
+ * Generic function for pseudo-filesystems. Example usage for the `/proc` FS is
+ * `pseudo_findent("/proc/3/cwd", proc_root_ent, &cwd_ent_for_third_thread)`.
+ *
+ * \param[in]  path       Path to the requested entry.
+ * \param[in]  root_ent   Root entry to start search from (e.g., `proc_root_ent`).
+ * \param[out] found_ent  Pointer to found entry.
+ * \return                0 if entry was found, negative Linux error code otherwise.
+ */
+static int pseudo_findent(const char* path, const struct pseudo_ent* root_ent,
+                          const struct pseudo_ent** found_ent) {
+    assert(path);
+
+    size_t token_len       = 0;
+    const char* token      = path;
+    const char* next_token = NULL;
+    const struct pseudo_ent* ent = root_ent;
+
+    while (*token == '/')
+        token++;
+
+    while (token && *token) {
+        char* slash_ptr = strchr(token, '/');
+        if (!slash_ptr) {
+            next_token = NULL;
+            token_len  = strlen(token);
+        } else {
+            next_token = slash_ptr + 1; /* set it past '/' */
+            token_len  = slash_ptr - token;
+        }
+
+        const struct pseudo_dir* dir = ent->dir;
+
+        for (ent = dir->ent; ent < dir->ent + dir->size; ent++) {
+            if (ent->name && !memcmp(ent->name, token, token_len)) {
+                /* directory entry has a hardcoded name that matches current token: found ent */
+                break;
+            }
+
+            if (ent->name_ops && ent->name_ops->match_name && ent->name_ops->match_name(token)) {
+                /* directory entry has a calculated at runtime name (via match_name) that matches
+                 * current token: found ent */
+                break;
+            }
+        }
+
+        if (ent == dir->ent + dir->size) {
+            /* traversed all entries in directory but couldn't find entry matching the token */
+            return -ENOENT;
+        }
+
+        if (!ent->dir && next_token) {
+            /* still tokens left (subdirs left), but current entry doesn't have subdirs/files */
+            return -ENOENT;
+        }
+
+        token = next_token;
+    }
+
+    *found_ent = ent;
+    return 0;
+}
+
+/*! Populate supplied buffer with dirents (see pseudo_readdir() for details). */
+static int populate_dirent(const char* path, const struct pseudo_dir* dir, struct shim_dirent* buf,
+                           size_t buf_size) {
+    if (!dir->size)
+        return 0;
+
+    HASHTYPE dir_hash = hash_path(path, strlen(path));
+
+    struct shim_dirent* dirent_in_buf = buf;
+    size_t total_size = 0;
+
+    for (const struct pseudo_ent* ent = dir->ent; ent < dir->ent + dir->size; ent++) {
+        if (ent->name) {
+            /* directory entry has a hardcoded name */
+            size_t name_size   = strlen(ent->name) + 1;
+            size_t dirent_size = sizeof(struct shim_dirent) + name_size;
+
+            total_size += dirent_size;
+            if (total_size > buf_size)
+                return -ENOMEM;
+
+            memcpy(dirent_in_buf->name, ent->name, name_size);
+            dirent_in_buf->next = (void*)dirent_in_buf + dirent_size;
+            dirent_in_buf->ino  = rehash_name(dir_hash, ent->name, name_size - 1);
+            dirent_in_buf->type = ent->dir ? LINUX_DT_DIR : ent->type;
+
+            dirent_in_buf  = dirent_in_buf->next;
+        } else if (ent->name_ops && ent->name_ops->list_name) {
+            /* directory entry has a list of entries calculated at runtime (via list_name) */
+            struct shim_dirent* old_dirent_in_buf = dirent_in_buf;
+            int ret = ent->name_ops->list_name(path, &dirent_in_buf, buf_size - total_size);
+            if (ret < 0)
+                return ret;
+
+            /* dirent_in_buf now contains the address past all added entries */
+            total_size += (void*)dirent_in_buf - (void*)old_dirent_in_buf;
+        }
+    }
+
+    /* above logic set the last dirent's `next` to point past the buffer, find this last dirent
+     * and unset its `next` */
+    dirent_in_buf = buf;
+    while ((void*)dirent_in_buf->next < (void*)buf + total_size)
+        dirent_in_buf = dirent_in_buf->next;
+
+    dirent_in_buf->next = NULL;
+    return 0;
+}
+
+/*! Generic callback to mount a pseudo-filesystem. */
+int pseudo_mount(const char* uri, void** mount_data) {
+    __UNUSED(uri);
+    __UNUSED(mount_data);
+    return 0;
+}
+
+/*! Generic callback to unmount a pseudo-filesystem. */
+int pseudo_unmount(void* mount_data) {
+    __UNUSED(mount_data);
+    return 0;
+}
+
+/*! Generic callback to obtain mode of a directory in a pseudo-filesystem. */
+int pseudo_dir_mode(const char* name, mode_t* mode) {
+    __UNUSED(name);
+    *mode = DIR_RX_MODE | S_IFDIR;
+    return 0;
+}
+
+/*! Generic callback to obtain stat of a directory in a pseudo-filesystem. */
+int pseudo_dir_stat(const char* name, struct stat* buf) {
+    __UNUSED(name);
+    memset(buf, 0, sizeof(*buf));
+
+    buf->st_dev     = 1;    /* dummy ID of device containing file */
+    buf->st_ino     = 1;    /* dummy inode number */
+    buf->st_size    = 4096; /* dummy total size, in bytes */
+    buf->st_blksize = 4096; /* dummy bulk size, in bytes */
+    buf->st_mode    = DIR_RX_MODE | S_IFDIR;
+    return 0;
+}
+
+/*! Generic callback to open a directory in a pseudo-filesystem. */
+int pseudo_dir_open(struct shim_handle* hdl, const char* name, int flags) {
+    __UNUSED(name);
+
+    if (flags & (O_WRONLY | O_RDWR)) {
+        /* cannot write in pseudo-directory */
+        return -EISDIR;
+    }
+
+    if (*name == '\0') {
+        hdl->type     = TYPE_DIR;
+        hdl->flags    = flags & ~O_ACCMODE;
+        hdl->acc_mode = 0;
+    }
+
+    /* pseudo-dirs are emulated completely in LibOS, so nothing to open */
+    return 0;
+}
+
+/*! Generic callback to obtain a mode of an entry in a pseudo-filesystem. */
+int pseudo_mode(struct shim_dentry* dent, mode_t* mode, const struct pseudo_ent* root_ent) {
+    if (qstrempty(&dent->rel_path)) {
+        /* root of pseudo-FS */
+        return pseudo_dir_mode(/*name=*/NULL, mode);
+    }
+
+    const char* rel_path = qstrgetstr(&dent->rel_path);
+    const struct pseudo_ent* ent = NULL;
+
+    int ret = pseudo_findent(rel_path, root_ent, &ent);
+    if (ret < 0)
+        return ret;
+
+    if (!ent->fs_ops || !ent->fs_ops->mode)
+        return -EACCES;
+
+    return ent->fs_ops->mode(rel_path, mode);
+}
+
+/*! Generic callback to check if an entry exists in a pseudo-filesystem (and populate \p dent). */
+int pseudo_lookup(struct shim_dentry* dent, const struct pseudo_ent* root_ent) {
+    if (qstrempty(&dent->rel_path)) {
+        /* root of pseudo-FS */
+        dent->ino    = 1;
+        dent->state |= DENTRY_ISDIRECTORY;
+        return 0;
+    }
+
+    const char* rel_path = qstrgetstr(&dent->rel_path);
+    const struct pseudo_ent* ent = NULL;
+
+    int ret = pseudo_findent(rel_path, root_ent, &ent);
+    if (ret < 0)
+        return ret;
+
+    if (ent->dir)
+        dent->state |= DENTRY_ISDIRECTORY;
+
+    if (ent->fs_ops && ent->fs_ops->follow_link)
+        dent->state |= DENTRY_ISLINK;
+
+    return 0;
+}
+
+/*! Generic callback to open an entry in a pseudo-filesystem (and populate \p hdl). */
+int pseudo_open(struct shim_handle* hdl, struct shim_dentry* dent, int flags,
+                const struct pseudo_ent* root_ent) {
+    const char* rel_path = qstrgetstr(&dent->rel_path);
+    const struct pseudo_ent* ent = NULL;
+
+    int ret = pseudo_findent(rel_path, root_ent, &ent);
+    if (ret < 0)
+        return ret;
+
+    if (!ent->fs_ops || !ent->fs_ops->open)
+        return -EACCES;
+
+    hdl->type     = ent->dir ? TYPE_DIR : (ent->type == LINUX_DT_CHR ? TYPE_DEV : TYPE_FILE);
+    hdl->flags    = flags & ~O_ACCMODE;
+    hdl->acc_mode = ACC_MODE(flags & O_ACCMODE);
+
+    return ent->fs_ops->open(hdl, rel_path, flags);
+}
+
+/*!
+ * \brief Create and populate buffer with dirents.
+ *
+ * Generic function for pseudo-filesystems. Example usage for the `/proc` FS is
+ * `pseudo_readdir("/proc/3", &dirents_of_third_thread, proc_root_ent)` -- this
+ * returns a dirent list with "root", "cwd", "exe", "fd", etc.
+ *
+ * \param[in]  dent       Dentry with path to the requested directory.
+ * \param[out] dirent     Pointer to newly created buffer with dirents.
+ * \param[in]  root_ent   Root entry to start search from (e.g., `proc_root_ent`).
+ * \return                0 if populated the buffer, negative Linux error code otherwise.
+ */
+int pseudo_readdir(struct shim_dentry* dent, struct shim_dirent** dirent,
+                   const struct pseudo_ent* root_ent) {
+    int ret;
+    const char* path = qstrgetstr(&dent->rel_path);
+    const struct pseudo_ent* ent = NULL;
+
+    ret = pseudo_findent(path, root_ent, &ent);
+    if (ret < 0)
+        return ret;
+
+    if (!ent->dir)
+        return -ENOTDIR;
+
+    struct shim_dirent* buf;
+    size_t buf_size = MAX_PATH;
+
+    while (true) {
+        buf = malloc(buf_size);
+
+        ret = populate_dirent(path, ent->dir, buf, buf_size);
+        if (!ret) {
+            /* successfully listed all entries */
+            break;
+        } else if (ret == -ENOMEM) {
+            /* reallocate bigger buffer and try again */
+            free(buf);
+            buf_size *= 2;
+            continue;
+        } else {
+            /* unrecoverable error */
+            free(buf);
+            return ret;
+        }
+    }
+
+    *dirent = buf;
+    return 0;
+}
+
+/*! Generic callback to obtain stat of an entry in a pseudo-filesystem. */
+int pseudo_stat(struct shim_dentry* dent, struct stat* buf, const struct pseudo_ent* root_ent) {
+    if (qstrempty(&dent->rel_path)) {
+        /* root of pseudo-FS */
+        return pseudo_dir_stat(/*name=*/NULL, buf);
+    }
+
+    const char* rel_path = qstrgetstr(&dent->rel_path);
+    const struct pseudo_ent* ent = NULL;
+
+    int ret = pseudo_findent(rel_path, root_ent, &ent);
+    if (ret < 0)
+        return ret;
+
+    if (!ent->fs_ops || !ent->fs_ops->stat)
+        return -EACCES;
+
+    return ent->fs_ops->stat(rel_path, buf);
+}
+
+/*! Generic callback to obtain stat of an entry in a pseudo-filesystem via its open \p hdl. */
+int pseudo_hstat(struct shim_handle* hdl, struct stat* buf, const struct pseudo_ent* root_ent) {
+    struct shim_dentry* dent = hdl->dentry;
+    assert(dent);
+    return pseudo_stat(dent, buf, root_ent);
+}
+
+/*! Generic callback to obtain a target string of a link entry in a pseudo-filesystem. */
+int pseudo_follow_link(struct shim_dentry* dent, struct shim_qstr* link,
+                       const struct pseudo_ent* root_ent) {
+    const char* rel_path = qstrgetstr(&dent->rel_path);
+    const struct pseudo_ent* ent = NULL;
+
+    int ret = pseudo_findent(rel_path, root_ent, &ent);
+    if (ret < 0)
+        return ret;
+
+    if (!ent->fs_ops || !ent->fs_ops->follow_link)
+        return -ENOTLINK;
+
+    return ent->fs_ops->follow_link(rel_path, link);
+}

--- a/LibOS/shim/src/fs/shim_namei.c
+++ b/LibOS/shim/src/fs/shim_namei.c
@@ -391,7 +391,12 @@ int __path_lookupat (struct shim_dentry * start, const char * path, int flags,
                         struct shim_dentry * root;
                         // not sure how to deal with this case if cur_thread isn't defined
                         assert(cur_thread);
+
+                        /* FIXME: below logic assumes that target file is under chroot; this misses
+                         *        cases like `/dev/stdin` which is a link to `/proc/self/fd/0`
+                         *        (i.e., Graphene currently fails if target is under pseudo-FS) */
                         root = cur_thread->root;
+
                         /*XXX: Check out path_reacquire here? */
                         // my_dent's refcount was incremented by lookup_dentry above,
                         // we need to not leak it here

--- a/LibOS/shim/test/regression/.gitignore
+++ b/LibOS/shim/test/regression/.gitignore
@@ -12,6 +12,7 @@
 /bootstrap_pie
 /bootstrap_static
 /cpuid
+/dev
 /epoll_wait_timeout
 /eventfd
 /exec

--- a/LibOS/shim/test/regression/Makefile
+++ b/LibOS/shim/test/regression/Makefile
@@ -5,6 +5,7 @@ c_executables = \
 	bootstrap_pie \
 	bootstrap_static \
 	cpuid \
+	dev \
 	epoll_wait_timeout \
 	eventfd \
 	exec \
@@ -114,6 +115,7 @@ CFLAGS-eventfd = -pthread
 CFLAGS-futex_bitset = -pthread
 CFLAGS-futex_requeue = -pthread
 CFLAGS-futex_wake_op = -pthread
+CFLAGS-proc = -pthread
 CFLAGS-spinlock += -I$(PALDIR)/../include/lib -pthread
 CFLAGS-sigprocmask += -pthread
 

--- a/LibOS/shim/test/regression/dev.c
+++ b/LibOS/shim/test/regression/dev.c
@@ -1,0 +1,126 @@
+#include <dirent.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+int main(int argc, char** argv) {
+    int ret;
+    FILE* f;
+    DIR* dir;
+    struct dirent* dirent;
+    char buf[64];
+
+    /* sanity checks that incorrect invocations return errors */
+    f = fopen("/dummy-pseudo-fs", "r");
+    if (f != NULL || errno != ENOENT) {
+        perror("(sanity check) fopen of dummy non-existing pseudo-FS did not fail with ENOENT");
+        return 1;
+    }
+
+    f = fopen("/dev", "r+");
+    if (f != NULL || errno != EISDIR) {
+        perror("(sanity check) fopen of /dev did not fail with EISDIR");
+        return 1;
+    }
+
+    f = fopen("/dev/dummy", "r");
+    if (f != NULL || errno != ENOENT) {
+        perror("(sanity check) fopen of /dev/dummy (non-existing file) did not fail with ENOENT");
+        return 1;
+    }
+
+    printf("===== Contents of /dev\n");
+    dir = opendir("/dev");
+    if (!dir) {
+        perror("opendir /dev");
+        return 1;
+    }
+
+    errno = 0;
+    while ((dirent = readdir(dir))) {
+        printf("/dev/%s\n", dirent->d_name);
+    }
+    if (errno) {
+        perror("readdir /dev");
+        return 1;
+    }
+
+    ret = closedir(dir);
+    if (ret < 0) {
+        perror("closedir /dev");
+        return 1;
+    }
+
+    printf("===== Read from /dev/urandom\n");
+    f = fopen("/dev/urandom", "r");
+    if (!f) {
+        perror("fopen /dev/urandom");
+        return 1;
+    }
+
+    memset(buf, 0, sizeof(buf));
+    ret = fread(buf, 1, sizeof(buf), f);
+    if (ferror(f)) {
+        perror("fread /dev/urandom");
+        return 1;
+    }
+
+    printf("Four bytes from /dev/urandom: %x:%x:%x:%x\n", buf[0], buf[1], buf[2], buf[3]);
+
+    ret = fclose(f);
+    if (ret) {
+        perror("fclose /dev/urandom");
+        return 1;
+    }
+
+    printf("===== Write to /dev/null\n");
+    f = fopen("/dev/null", "w");
+    if (!f) {
+        perror("fopen /dev/null");
+        return 1;
+    }
+
+    ret = fwrite(buf, 1, sizeof(buf), f);
+    if (ret < sizeof(buf)) {
+        perror("fwrite /dev/null");
+        return 1;
+    }
+
+    ret = fclose(f);
+    if (ret) {
+        perror("fclose /dev/null");
+        return 1;
+    }
+
+#if 0
+    /* `/dev/stdout` is a link to `/proc/self/fd/1`; Graphene currently fails, see #1387 */
+
+    printf("===== Write to /dev/stdout\n");
+    f = fopen("/dev/stdout", "w");
+    if (!f) {
+        perror("fopen /dev/stdout");
+        return 1;
+    }
+
+    sprintf(buf, "%s\n", "Hello World written to stdout!");
+    size_t towrite = strlen(buf) + 1;
+    ret = fwrite(buf, 1, towrite, f);
+    if (ret < towrite) {
+        perror("fwrite /dev/stdout");
+        return 1;
+    }
+
+    ret = fclose(f);
+    if (ret) {
+        perror("fclose /dev/stdout");
+        return 1;
+    }
+#endif
+
+    return 0;
+}

--- a/LibOS/shim/test/regression/proc.c
+++ b/LibOS/shim/test/regression/proc.c
@@ -1,54 +1,202 @@
 #include <dirent.h>
+#include <errno.h>
 #include <fcntl.h>
+#include <pthread.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <sys/wait.h>
 #include <unistd.h>
 
-int main(int argc, char** argv) {
-    struct dirent* dirent;
-    DIR* dir;
+void* fn(void* arg) {
+    /* not to consume CPU, each thread simply sleeps */
+    sleep(10000);
+    return NULL;
+}
 
+int main(int argc, char** argv) {
+    pthread_t thread[3];
+    int ret;
+    FILE* f;
+    DIR* dir;
+    struct dirent* dirent;
+    char buf[4096];
+
+    /* create three threads so we have some info in /proc/[pid] */
+    for (int j = 0; j < 3; j++) {
+        pthread_create(&thread[j], NULL, fn, NULL);
+    }
+
+    /* sanity checks that incorrect invocations return errors */
+    f = fopen("/dummy-pseudo-fs", "r");
+    if (f != NULL || errno != ENOENT) {
+        perror("(sanity check) fopen of dummy non-existing pseudo-FS did not fail with ENOENT");
+        return 1;
+    }
+
+    f = fopen("/proc", "r+");
+    if (f != NULL || errno != EISDIR) {
+        perror("(sanity check) fopen of /proc did not fail with EISDIR");
+        return 1;
+    }
+
+    f = fopen("/proc/1", "r+");
+    if (f != NULL || errno != EISDIR) {
+        perror("(sanity check) fopen of /proc/1 did not fail with EISDIR");
+        return 1;
+    }
+
+    f = fopen("/proc/2/cwd", "w");
+    if (f != NULL || errno != EISDIR) {
+        perror("(sanity check) fopen of /proc/2/cwd in write mode did not fail with EISDIR");
+        return 1;
+    }
+
+    f = fopen("/proc/3/maps", "r+");
+    if (f != NULL || errno != EACCES) {
+        perror("(sanity check) fopen of /proc/3/maps in read-write mode did not fail with EACCES");
+        return 1;
+    }
+
+    f = fopen("/proc/self/dummy", "r");
+    if (f != NULL || errno != ENOENT) {
+        perror("(sanity check) fopen of /proc/self/dummy (non-existing file) did not fail with ENOENT");
+        return 1;
+    }
+
+    /* at this point, we must have /proc/1, /proc/2, /proc/3, /proc/4 */
+    printf("===== Contents of /proc/1\n");
     dir = opendir("/proc/1");
     if (!dir) {
         perror("opendir /proc/1");
-        exit(1);
+        return 1;
     }
+
+    errno = 0;
     while ((dirent = readdir(dir))) {
         printf("/proc/1/%s\n", dirent->d_name);
     }
-    closedir(dir);
-
-    // Children end up inheriting junk if we don't flush here.
-    fflush(stdout);
-
-/* This code tickles a bug in exit/wait for PIDs/IPC; created an issue (#532), will revisit after 
- * landing some related IPC fixes that are pending. */
-#if 0
-    for (int i = 0 ; i < 3 ; i++) {
-        pid_t pid = fork();
-
-        if (pid < 0) {
-            perror("fork");
-            exit(1);
-        }
-
-        if (pid) {
-            waitpid(pid, NULL, 0);
-            exit(0);
-        }
+    if (errno) {
+        perror("readdir /proc/1");
+        return 1;
     }
-#endif
 
+    ret = closedir(dir);
+    if (ret < 0) {
+        perror("closedir /proc/1");
+        return 1;
+    }
+
+    printf("===== Contents of /proc/self\n");
+    dir = opendir("/proc/self");
+    if (!dir) {
+        perror("opendir /proc/self");
+        return 1;
+    }
+
+    errno = 0;
+    while ((dirent = readdir(dir))) {
+        printf("/proc/self/%s\n", dirent->d_name);
+    }
+    if (errno) {
+        perror("readdir /proc/self");
+        return 1;
+    }
+
+    ret = closedir(dir);
+    if (ret < 0) {
+        perror("closedir /proc/self");
+        return 1;
+    }
+
+    printf("===== Contents of /proc\n");
     dir = opendir("/proc");
     if (!dir) {
         perror("opendir /proc");
-        exit(1);
+        return 1;
     }
+
+    errno = 0;
     while ((dirent = readdir(dir))) {
         printf("/proc/%s\n", dirent->d_name);
     }
-    closedir(dir);
+    if (errno) {
+        perror("readdir /proc");
+        return 1;
+    }
+
+    ret = closedir(dir);
+    if (ret < 0) {
+        perror("closedir /proc");
+        return 1;
+    }
+
+    /* this outputs all files in this current dir: a good test of realloced getdents buffer */
+    printf("===== Contents of /proc/2/cwd\n");
+    dir = opendir("/proc/2/cwd");
+    if (!dir) {
+        perror("opendir /proc/2/cwd");
+        return 1;
+    }
+
+    errno = 0;
+    while ((dirent = readdir(dir))) {
+        printf("/proc/2/cwd/%s\n", dirent->d_name);
+    }
+    if (errno) {
+        perror("readdir /proc/2/cwd");
+        return 1;
+    }
+
+    ret = closedir(dir);
+    if (ret < 0) {
+        perror("closedir /proc/2/cwd");
+        return 1;
+    }
+
+    printf("===== Contents of /proc/3/maps\n");
+    f = fopen("/proc/3/maps", "r");
+    if (!f) {
+        perror("fopen /proc/3/maps");
+        return 1;
+    }
+
+    memset(buf, 0, sizeof(buf));
+    ret = fread(buf, 1, sizeof(buf), f);
+    if (ferror(f)) {
+        perror("fread /proc/3/maps");
+        return 1;
+    }
+
+    printf("%s\n", buf);
+
+    ret = fclose(f);
+    if (ret) {
+        perror("fclose /proc/3/maps");
+        return 1;
+    }
+
+    printf("===== Contents of /proc/cpuinfo\n");
+    f = fopen("/proc/cpuinfo", "r");
+    if (!f) {
+        perror("fopen /proc/cpuinfo");
+        return 1;
+    }
+
+    memset(buf, 0, sizeof(buf));
+    ret = fread(buf, 1, sizeof(buf), f);
+    if (ferror(f)) {
+        perror("fread /proc/cpuinfo");
+        return 1;
+    }
+
+    printf("%s\n", buf);
+
+    ret = fclose(f);
+    if (ret) {
+        perror("fclose /proc/cpuinfo");
+        return 1;
+    }
 
     return 0;
 }

--- a/LibOS/shim/test/regression/test_libos.py
+++ b/LibOS/shim/test/regression/test_libos.py
@@ -381,26 +381,47 @@ class TC_31_SyscallSGX(RegressionTestCase):
         self.assertIn('Hello world', stdout)
 
 class TC_40_FileSystem(RegressionTestCase):
-    def test_000_base(self):
+    def test_000_proc(self):
         stdout, _ = self.run_binary(['proc'])
-
-        # Base /proc files present
         self.assertIn('/proc/1/..', stdout)
         self.assertIn('/proc/1/cwd', stdout)
         self.assertIn('/proc/1/exe', stdout)
         self.assertIn('/proc/1/root', stdout)
         self.assertIn('/proc/1/fd', stdout)
         self.assertIn('/proc/1/maps', stdout)
+        self.assertIn('/proc/self/..', stdout)
+        self.assertIn('/proc/self/cwd', stdout)
+        self.assertIn('/proc/self/exe', stdout)
+        self.assertIn('/proc/self/root', stdout)
+        self.assertIn('/proc/self/fd', stdout)
+        self.assertIn('/proc/self/maps', stdout)
         self.assertIn('/proc/.', stdout)
         self.assertIn('/proc/1', stdout)
+        self.assertIn('/proc/2', stdout)
+        self.assertIn('/proc/3', stdout)
+        self.assertIn('/proc/4', stdout)
         self.assertIn('/proc/self', stdout)
         self.assertIn('/proc/meminfo', stdout)
         self.assertIn('/proc/cpuinfo', stdout)
+        self.assertIn('/proc/2/cwd/proc.c', stdout)
+        self.assertIn('/lib/libpthread.so', stdout)
+        self.assertIn('stack', stdout)
+        self.assertIn('vendor_id', stdout)
+
+    def test_001_dev(self):
+        stdout, _ = self.run_binary(['dev'])
+        self.assertIn('/dev/.', stdout)
+        self.assertIn('/dev/null', stdout)
+        self.assertIn('/dev/zero', stdout)
+        self.assertIn('/dev/random', stdout)
+        self.assertIn('/dev/urandom', stdout)
+        self.assertIn('/dev/stdin', stdout)
+        self.assertIn('/dev/stdout', stdout)
+        self.assertIn('/dev/stderr', stdout)
+        self.assertIn('Four bytes from /dev/urandom', stdout)
 
     def test_010_path(self):
         stdout, _ = self.run_binary(['proc-path'])
-
-        # Base /proc path present
         self.assertIn('proc path test success', stdout)
 
     def test_020_cpuinfo(self):


### PR DESCRIPTION
## Description of the changes: <!-- (reasons and measures) -->

Previously, `/proc` and `/dev` pseudo-filesystems were implemented in completely different ways. This PR introduces a set of generic functions for all pseudo-FSs (based on previous implementation of `/proc`) and refactors both `/proc` and `/dev` to use these functions.

This PR also expands a LibOS test `proc` to cover more cases and pseudo-files, as well as introduces a new LibOS test `dev`. Several bugs in pseudo-FSs were detected and fixed in the process.

Also bug https://github.com/oscarlab/graphene/issues/1387 was found while working on this PR. This PR however does *not* fix it, merely circumvents it.

## How to test this PR? <!-- (if applicable) -->

LibOS test `proc` was significantly expanded. New LibOS test `dev` was added.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1388)
<!-- Reviewable:end -->
