### PR TITLE
[LibOS] Add attestation pseudo-filesystem under /dev/attestation

### DIFF
--- a/LibOS/shim/src/Makefile
+++ b/LibOS/shim/src/Makefile
@@ -47,6 +47,7 @@ objs = \
 	fs/shim_fs_pseudo.o \
 	fs/shim_namei.o \
 	fs/chroot/fs.o \
+	fs/dev/attestation.o \
 	fs/dev/fs.o \
 	fs/dev/null.o \
 	fs/dev/random.o \

--- a/LibOS/shim/src/fs/dev/attestation.c
+++ b/LibOS/shim/src/fs/dev/attestation.c
@@ -1,0 +1,498 @@
+/* Copyright (C) 2020 Intel Labs
+   This file is part of Graphene Library OS.
+
+   Graphene Library OS is free software: you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public License
+   as published by the Free Software Foundation, either version 3 of the
+   License, or (at your option) any later version.
+
+   Graphene Library OS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
+
+/*!
+ * \file
+ *
+ * This file contains the implementation of local- and remote-attestation logic implemented via
+ * `/dev/attestation/{user_report_data, target_info, my_target_info, report, quote}` pseudo-files.
+ *
+ * The attestation logic uses DkAttestationReport() and DkAttestationQuote() and is generic enough
+ * to support attestation flows similar to Intel SGX. Currently only SGX attestation is used.
+ *
+ * This pseudo-FS interface is not thread-safe. It is the responsibility of the application to
+ * correctly synchronize concurrent accesses to the pseudo-files. We expect attestation flows to
+ * be generally single-threaded and therefore do not introduce synchronization here.
+ */
+
+#include "shim_fs.h"
+
+/* user_report_data, target_info and quote are opaque blobs of predefined maximum sizes. Currently
+ * these sizes are overapproximations of SGX requirements (report_data is 64B, target_info is
+ * 512B, quote is about 1024B). */
+#define USER_REPORT_DATA_MAX_SIZE 256
+#define TARGET_INFO_MAX_SIZE 1024
+#define QUOTE_MAX_SIZE 2048
+
+static char g_user_report_data[USER_REPORT_DATA_MAX_SIZE] = {0};
+static size_t g_user_report_data_size = 0;
+
+static char g_target_info[TARGET_INFO_MAX_SIZE] = {0};
+static size_t g_target_info_size = 0;
+
+static size_t g_report_size = 0;
+
+
+static int init_attestation_struct_sizes(void) {
+    if (g_user_report_data_size && g_target_info_size && g_report_size) {
+        /* already initialized, nothing to do here */
+        return 0;
+    }
+
+    int ret = DkAttestationReport(/*user_report_data=*/NULL, &g_user_report_data_size,
+                                  /*target_info=*/NULL, &g_target_info_size,
+                                  /*report=*/NULL, &g_report_size);
+    if (ret < 0)
+        return -EACCES;
+
+    assert(g_user_report_data_size && g_user_report_data_size <= sizeof(g_user_report_data));
+    assert(g_target_info_size && g_target_info_size <= sizeof(g_target_info));
+    assert(g_report_size);
+    return 0;
+}
+
+static int dev_attestation_readonly_mode(const char* name, mode_t* mode) {
+    __UNUSED(name);
+    *mode = FILE_R_MODE | S_IFREG;
+    return 0;
+}
+
+static int dev_attestation_readwrite_mode(const char* name, mode_t* mode) {
+    __UNUSED(name);
+    *mode = FILE_RW_MODE | S_IFREG;
+    return 0;
+}
+
+static int dev_attestation_readonly_stat(const char* name, struct stat* buf) {
+    __UNUSED(name);
+    memset(buf, 0, sizeof(*buf));
+    buf->st_dev  = 1;    /* dummy ID of device containing file */
+    buf->st_ino  = 1;    /* dummy inode number */
+    buf->st_mode = FILE_R_MODE | S_IFREG;
+    return 0;
+}
+
+static int dev_attestation_readwrite_stat(const char* name, struct stat* buf) {
+    __UNUSED(name);
+    memset(buf, 0, sizeof(*buf));
+    buf->st_dev  = 1;    /* dummy ID of device containing file */
+    buf->st_ino  = 1;    /* dummy inode number */
+    buf->st_mode = FILE_RW_MODE | S_IFREG;
+    return 0;
+}
+
+/* callback for str FS; copies contents of `/dev/attestation/user_report_data` file in the
+ * global `g_user_report_data` struct on file close */
+static int user_report_data_modify(struct shim_handle* hdl) {
+    assert(g_user_report_data_size);
+    memcpy(&g_user_report_data, hdl->info.str.data->str, g_user_report_data_size);
+    return 0;
+}
+
+/* callback for str FS; copies contents of `/dev/attestation/target_info` file in the global
+ * `g_target_info` struct on file close */
+static int target_info_modify(struct shim_handle* hdl) {
+    assert(g_target_info_size);
+    memcpy(&g_target_info, hdl->info.str.data->str, g_target_info_size);
+    return 0;
+}
+
+/*!
+ * \brief Modify/obtain user-defined report data used in `report` and `quote` pseudo-files.
+ *
+ * This file `/dev/attestation/user_report_data` can be opened for read and write. Typically, it is
+ * opened and written into before opening and reading from `/dev/attestation/report` or
+ * `/dev/attestation/quote` files, so they can use the user-provided report data blob.
+ *
+ * In case of SGX, user report data can be an arbitrary string of size 64B.
+ */
+static int dev_attestation_user_report_data_open(struct shim_handle* hdl, const char* name,
+                                                 int flags) {
+    __UNUSED(name);
+    __UNUSED(flags);
+
+    if (strcmp_static(PAL_CB(host_type), "Linux-SGX")) {
+        /* this pseudo-file is only available with Linux-SGX */
+        return -EACCES;
+    }
+
+    if (init_attestation_struct_sizes() < 0)
+        return -EACCES;
+
+    struct shim_str_data* data = calloc(1, sizeof(*data));
+    if (!data)
+        return -ENOMEM;
+
+    char* data_str_userreportdata = calloc(1, g_user_report_data_size);
+    if (!data_str_userreportdata) {
+        free(data);
+        return -ENOMEM;
+    }
+
+    memcpy(data_str_userreportdata, &g_user_report_data, g_user_report_data_size);
+
+    data->str      = data_str_userreportdata;
+    data->buf_size = g_user_report_data_size;
+    data->modify   = &user_report_data_modify; /* invoked when file is closed */
+
+    hdl->type          = TYPE_STR;
+    hdl->acc_mode      = MAY_WRITE | MAY_READ;
+    hdl->info.str.data = data;
+    hdl->info.str.ptr  = data_str_userreportdata;
+    return 0;
+}
+
+/*!
+ * \brief Modify/obtain target info used in `report` and `quote` pseudo-files.
+ *
+ * This file `/dev/attestation/target_info` can be opened for read and write. Typically, it is
+ * opened and written into before opening and reading from `/dev/attestation/report` or
+ * `/dev/attestation/quote` files, so they can use the provided target info.
+ *
+ * In case of SGX, target info is an opaque blob of size 512B.
+ */
+static int dev_attestation_target_info_open(struct shim_handle* hdl, const char* name, int flags) {
+    __UNUSED(name);
+    __UNUSED(flags);
+
+    if (strcmp_static(PAL_CB(host_type), "Linux-SGX")) {
+        /* this pseudo-file is only available with Linux-SGX */
+        return -EACCES;
+    }
+
+    if (init_attestation_struct_sizes() < 0)
+        return -EACCES;
+
+    struct shim_str_data* data = calloc(1, sizeof(*data));
+    if (!data)
+        return -ENOMEM;
+
+    char* data_str_ti = calloc(1, g_target_info_size);
+    if (!data_str_ti) {
+        free(data);
+        return -ENOMEM;
+    }
+
+    memcpy(data_str_ti, &g_target_info, g_target_info_size);
+
+    data->str      = data_str_ti;
+    data->buf_size = g_target_info_size;
+    data->modify   = &target_info_modify; /* invoked when file is closed */
+
+    hdl->type          = TYPE_STR;
+    hdl->acc_mode      = MAY_WRITE | MAY_READ;
+    hdl->info.str.data = data;
+    hdl->info.str.ptr  = data_str_ti;
+    return 0;
+}
+
+/*!
+ * \brief Obtain this enclave's target info via DkAttestationReport().
+ *
+ * This file `/dev/attestation/my_target_info` can be opened for read and will contain the
+ * target info of this enclave. The resulting target info blob can be passed to another enclave
+ * as part of the local attestation flow.
+ *
+ * In case of SGX, target info is an opaque blob of size 512B.
+ */
+static int dev_attestation_my_target_info_open(struct shim_handle* hdl, const char* name, int flags) {
+    __UNUSED(name);
+    int ret;
+
+    char* user_report_data     = NULL;
+    char* target_info          = NULL;
+    struct shim_str_data* data = NULL;
+
+    if (strcmp_static(PAL_CB(host_type), "Linux-SGX")) {
+        /* this pseudo-file is only available with Linux-SGX */
+        return -EACCES;
+    }
+
+    if (init_attestation_struct_sizes() < 0)
+        return -EACCES;
+
+    if (flags & (O_WRONLY | O_RDWR))
+        return -EACCES;
+
+    size_t user_report_data_size = g_user_report_data_size;
+    size_t target_info_size      = g_target_info_size;
+    size_t report_size           = g_report_size;
+
+    user_report_data = calloc(1, user_report_data_size);
+    if (!user_report_data) {
+        ret = -ENOMEM;
+        goto out;
+    }
+
+    target_info = calloc(1, target_info_size);
+    if (!target_info) {
+        ret = -ENOMEM;
+        goto out;
+    }
+
+    /* below invocation returns this enclave's target info because we zeroed out (via calloc)
+     * target_info: it's a hint to function to update target_info with this enclave's info */
+    ret = DkAttestationReport(user_report_data, &user_report_data_size,
+                              target_info, &target_info_size,
+                              /*report=*/NULL, &report_size);
+    if (ret < 0) {
+        ret = -EACCES;
+        goto out;
+    }
+
+    /* sanity checks: returned struct sizes must be the same as previously obtained ones */
+    assert(user_report_data_size == g_user_report_data_size);
+    assert(target_info_size == g_target_info_size);
+    assert(report_size == g_report_size);
+
+    data = calloc(1, sizeof(*data));
+    if (!data) {
+        ret = -ENOMEM;
+        goto out;
+    }
+
+    data->str       = target_info;
+    data->buf_size  = target_info_size;
+    data->len       = target_info_size;
+
+    hdl->type          = TYPE_STR;
+    hdl->acc_mode      = MAY_READ;
+    hdl->info.str.data = data;
+    hdl->info.str.ptr  = target_info;
+
+    ret = 0;
+out:
+    if (ret < 0) {
+        free(target_info);
+        free(data);
+    }
+    free(user_report_data);
+    return ret;
+}
+
+/*!
+ * \brief Obtain report via DkAttestationReport() with previously populated user_report_data
+ *        and target_info.
+ *
+ * Before opening `/dev/attestation/report` for read, user_report_data must be written into
+ * `/dev/attestation/user_report_data` and target info must be written into
+ * `/dev/attestation/target_info`. Otherwise the obtained report will contain incorrect or
+ * stale user_report_data and target_info.
+ *
+ * In case of SGX, report is a locally obtained EREPORT struct of size 432B.
+ */
+static int dev_attestation_report_open(struct shim_handle* hdl, const char* name, int flags) {
+    __UNUSED(name);
+    int ret;
+
+    char* report               = NULL;
+    struct shim_str_data* data = NULL;
+    char* data_str_report      = NULL;
+
+    if (strcmp_static(PAL_CB(host_type), "Linux-SGX")) {
+        /* this pseudo-file is only available with Linux-SGX */
+        return -EACCES;
+    }
+
+    if (!g_target_info_size || !g_user_report_data_size || !g_report_size)
+        return -EACCES;
+
+    if (flags & (O_WRONLY | O_RDWR))
+        return -EACCES;
+
+    report = calloc(1, g_report_size);
+    if (!report) {
+        ret = -ENOMEM;
+        goto out;
+    }
+
+    ret = DkAttestationReport(&g_user_report_data, &g_user_report_data_size,
+                              &g_target_info, &g_target_info_size,
+                              report, &g_report_size);
+    if (ret < 0) {
+        ret = -EACCES;
+        goto out;
+    }
+
+    data = calloc(1, sizeof(*data));
+    if (!data) {
+        ret = -ENOMEM;
+        goto out;
+    }
+
+    data_str_report = calloc(1, g_report_size);
+    if (!data_str_report) {
+        ret = -ENOMEM;
+        goto out;
+    }
+
+    memcpy(data_str_report, report, g_report_size);
+
+    data->str      = data_str_report;
+    data->buf_size = g_report_size;
+    data->len      = g_report_size;
+
+    hdl->type          = TYPE_STR;
+    hdl->acc_mode      = MAY_READ;
+    hdl->info.str.data = data;
+    hdl->info.str.ptr  = data_str_report;
+
+    ret = 0;
+out:
+    if (ret < 0) {
+        free(data_str_report);
+        free(data);
+    }
+    free(report);
+    return ret;
+}
+
+/*!
+ * \brief Obtain quote by communicating with the outside-of-enclave service.
+ *
+ * Before opening `/dev/attestation/quote` for read, user_report_data must be written into
+ * `/dev/attestation/user_report_data`. Otherwise the obtained quote will contain incorrect or
+ * stale user_report_data. The resulting quote can be passed to another enclave or service as
+ * part of the remote attestation flow.
+ *
+ * Note that this file doesn't depend on contents of files `/dev/attestation/target_info` and
+ * `/dev/attestation/my_target_info`. This is because the quote always embeds target info of
+ * the current enclave.
+ *
+ * In case of SGX, the obtained quote is the SGX quote created by the Quoting Enclave.
+ */
+static int dev_attestation_quote_open(struct shim_handle* hdl, const char* name, int flags) {
+    __UNUSED(name);
+    int ret;
+
+    uint8_t* quote             = NULL;
+    char* data_str_quote       = NULL;
+    struct shim_str_data* data = NULL;
+
+    if (strcmp_static(PAL_CB(host_type), "Linux-SGX")) {
+        /* this pseudo-file is only available with Linux-SGX */
+        return -EACCES;
+    }
+
+    if (!g_user_report_data_size)
+        return -EACCES;
+
+    if (flags & (O_WRONLY | O_RDWR))
+        return -EACCES;
+
+    size_t quote_size = QUOTE_MAX_SIZE;
+    quote = calloc(1, quote_size);
+    if (!quote) {
+        ret = -ENOMEM;
+        goto out;
+    }
+
+    ret = DkAttestationQuote(&g_user_report_data, g_user_report_data_size,
+                             quote, &quote_size);
+    if (ret < 0) {
+        ret = -EACCES;
+        goto out;
+    }
+
+    data = calloc(1, sizeof(*data));
+    if (!data) {
+        ret = -ENOMEM;
+        goto out;
+    }
+
+    data_str_quote = calloc(1, quote_size);
+    if (!data_str_quote) {
+        ret = -ENOMEM;
+        goto out;
+    }
+
+    memcpy(data_str_quote, quote, quote_size);
+
+    data->str       = data_str_quote;
+    data->buf_size  = quote_size;
+    data->len       = quote_size;
+
+    hdl->type          = TYPE_STR;
+    hdl->acc_mode      = MAY_READ;
+    hdl->info.str.data = data;
+    hdl->info.str.ptr  = data_str_quote;
+
+    ret = 0;
+out:
+    if (ret < 0) {
+        free(data_str_quote);
+        free(data);
+    }
+    free(quote);
+    return ret;
+}
+
+static struct pseudo_fs_ops dev_attestation_user_report_data_fs_ops = {
+    .open = &dev_attestation_user_report_data_open,
+    .mode = &dev_attestation_readwrite_mode,
+    .stat = &dev_attestation_readwrite_stat,
+};
+
+static struct pseudo_fs_ops dev_attestation_target_info_fs_ops = {
+    .open = &dev_attestation_target_info_open,
+    .mode = &dev_attestation_readwrite_mode,
+    .stat = &dev_attestation_readwrite_stat,
+};
+
+static struct pseudo_fs_ops dev_attestation_my_target_info_fs_ops = {
+    .open = &dev_attestation_my_target_info_open,
+    .mode = &dev_attestation_readonly_mode,
+    .stat = &dev_attestation_readonly_stat,
+};
+
+static struct pseudo_fs_ops dev_attestation_report_fs_ops = {
+    .open = &dev_attestation_report_open,
+    .mode = &dev_attestation_readonly_mode,
+    .stat = &dev_attestation_readonly_stat,
+};
+
+static struct pseudo_fs_ops dev_attestation_quote_fs_ops = {
+    .open = &dev_attestation_quote_open,
+    .mode = &dev_attestation_readonly_mode,
+    .stat = &dev_attestation_readonly_stat,
+};
+
+struct pseudo_fs_ops dev_attestation_fs_ops = {
+    .open = &pseudo_dir_open,
+    .mode = &pseudo_dir_mode,
+    .stat = &pseudo_dir_stat,
+};
+
+struct pseudo_dir dev_attestation_dir = {
+    .size = 5,
+    .ent  = {
+              { .name   = "user_report_data",
+                .fs_ops = &dev_attestation_user_report_data_fs_ops,
+                .type   = LINUX_DT_REG },
+              { .name   = "target_info",
+                .fs_ops = &dev_attestation_target_info_fs_ops,
+                .type   = LINUX_DT_REG },
+              { .name   = "my_target_info",
+                .fs_ops = &dev_attestation_my_target_info_fs_ops,
+                .type   = LINUX_DT_REG },
+              { .name   = "report",
+                .fs_ops = &dev_attestation_report_fs_ops,
+                .type   = LINUX_DT_REG },
+              { .name   = "quote",
+                .fs_ops = &dev_attestation_quote_fs_ops,
+                .type   = LINUX_DT_REG },
+            }
+};

--- a/LibOS/shim/test/regression/.gitignore
+++ b/LibOS/shim/test/regression/.gitignore
@@ -7,6 +7,7 @@
 /.cache
 /abort
 /abort_multithread
+/attestation
 /bootstrap
 /bootstrap-c++
 /bootstrap_pie

--- a/LibOS/shim/test/regression/Makefile
+++ b/LibOS/shim/test/regression/Makefile
@@ -1,6 +1,7 @@
 c_executables = \
 	abort \
 	abort_multithread \
+	attestation \
 	bootstrap \
 	bootstrap_pie \
 	bootstrap_static \
@@ -65,6 +66,7 @@ cxx_executables = bootstrap-c++
 
 manifests = \
 	manifest \
+	attestation.manifest \
 	echo.manifest \
 	eventfd.manifest \
 	exec_victim.manifest \
@@ -101,6 +103,10 @@ target = \
 
 clean-extra += clean-tmp
 
+extra_rules = \
+	-e 's:\$$(RA_CLIENT_SPID):$(if $(RA_CLIENT_SPID),$(RA_CLIENT_SPID),AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA):g' \
+	-e 's:\$$(RA_CLIENT_LINKABLE):$(if $(RA_CLIENT_LINKABLE),$(RA_CLIENT_LINKABLE),0):g'
+
 include ../../../../Scripts/Makefile.configs
 include ../../../../Scripts/Makefile.manifest
 include ../../../../Scripts/Makefile.Test
@@ -120,6 +126,11 @@ CFLAGS-futex_wake_op = -pthread
 CFLAGS-proc = -pthread
 CFLAGS-spinlock += -I$(PALDIR)/../include/lib -pthread
 CFLAGS-sigprocmask += -pthread
+
+CFLAGS-attestation += -I$(PALDIR)/../lib/crypto/mbedtls/crypto/include \
+                      -I$(PALDIR)/host/Linux-SGX \
+                      -I$(PALDIR)/../include/pal
+LDLIBS-attestation += $(PALDIR)/../lib/crypto/mbedtls/install/lib/libmbedcrypto.a
 
 %: %.c
 	$(call cmd,csingle)

--- a/LibOS/shim/test/regression/attestation.c
+++ b/LibOS/shim/test/regression/attestation.c
@@ -1,0 +1,278 @@
+/* Attestation API test. Only works for SGX PAL. */
+
+#include <ctype.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <mbedtls/base64.h>
+#include <mbedtls/cmac.h>
+
+#include "sgx_api.h"
+#include "sgx_arch.h"
+#include "sgx_attest.h"
+
+char user_report_data_str[] = "This is user-provided report data";
+
+enum { SUCCESS = 0, FAILURE = -1 };
+
+ssize_t rw_file(const char* path, char* buf, size_t bytes, bool do_write) {
+    ssize_t rv = 0;
+    ssize_t ret = 0;
+
+    int fd = open(path, do_write ? O_WRONLY : O_RDONLY);
+    if (fd < 0) {
+        fprintf(stderr, "opening %s failed\n", path);
+        return fd;
+    }
+
+    while (bytes > rv) {
+        if (do_write)
+            ret = write(fd, buf + rv, bytes - rv);
+        else
+            ret = read(fd, buf + rv, bytes - rv);
+
+        if (ret > 0) {
+            rv += ret;
+        } else if (ret == 0) {
+            /* end of file */
+            if (rv == 0)
+                fprintf(stderr, "%s failed: unexpected end of file\n", do_write ? "write" : "read");
+            break;
+        } else {
+            if (ret < 0 && (errno == EAGAIN || errno == EINTR)) {
+                continue;
+            } else {
+                fprintf(stderr, "%s failed: %s\n", do_write ? "write" : "read", strerror(errno));
+                goto out;
+            }
+        }
+    }
+
+out:
+    if (ret < 0) {
+        /* error path */
+        close(fd);
+        return ret;
+    }
+
+    ret = close(fd);
+    if (ret < 0) {
+        fprintf(stderr, "closing %s failed\n", path);
+        return ret;
+    }
+    return rv;
+}
+
+/*!
+ * \brief Verify the signature on `report`.
+ *
+ * If verification succeeds, it means the enclave which produced `report` runs on same platform
+ * as the enclave executing this function.
+ *
+ * \return 0 if signature verification succeeded, -1 otherwise.
+ */
+static int verify_report_mac(sgx_report_t* report) {
+    int ret;
+
+    /* setup key request structure */
+    __sgx_mem_aligned sgx_key_request_t key_request;
+    memset(&key_request, 0, sizeof(key_request));
+    key_request.key_name = REPORT_KEY;
+    memcpy(&key_request.key_id, &report->key_id, sizeof(key_request.key_id));
+
+    /* retrieve key via EGETKEY instruction leaf */
+    __sgx_mem_aligned uint8_t key[128/8];
+    memset(key, 0, sizeof(key));
+    sgx_getkey(&key_request, (sgx_key_128bit_t*)key);
+
+    /* calculate message authentication code (MAC) over report body;
+     * signature is calculated over part of report BEFORE the key_id field */
+    sgx_mac_t mac = {0};
+    const int bits_per_byte = 8;
+    const mbedtls_cipher_info_t* cipher_info =
+        mbedtls_cipher_info_from_type(MBEDTLS_CIPHER_AES_128_ECB);
+    ret = mbedtls_cipher_cmac(cipher_info, key, sizeof(key) * bits_per_byte,
+                              (const unsigned char*)report, offsetof(sgx_report_t, key_id),
+                              (uint8_t*)&mac);
+    if (ret) {
+        fprintf(stderr, "MAC calculation over report body failed: %d (mbedtls error code)\n", ret);
+        return FAILURE;
+    }
+
+    /* compare calculated MAC against MAC sent with report */
+    ret = memcmp(&mac, report->mac, sizeof(mac));
+    if (ret) {
+        fprintf(stderr, "MAC comparison failed\n");
+        return FAILURE;
+    }
+
+    return SUCCESS;
+}
+
+/*!
+ * \brief Test local attestation interface.
+ *
+ * Perform the following steps in order:
+ *   1. read `my_target_info` file
+ *   2. write data from `my_target_info` to `target_info` file
+ *   3. write some custom data to `user_report_data` file
+ *   4. read `report` file
+ *   5. verify data read from `report`
+ *
+ * \return 0 if the test succeeded, -1 otherwise.
+ */
+static int test_local_attestation(void) {
+    ssize_t bytes;
+
+    /* 1. read `my_target_info` file */
+    sgx_target_info_t target_info;
+    bytes = rw_file("/dev/attestation/my_target_info", (char*)&target_info, sizeof(target_info),
+                    /*do_write=*/false);
+    if (bytes != sizeof(target_info)) {
+        /* error is already printed by rw_file() */
+        return FAILURE;
+    }
+
+    /* 2. write data from `my_target_info` to `target_info` file */
+    bytes = rw_file("/dev/attestation/target_info", (char*)&target_info, sizeof(target_info),
+                    /*do_write=*/true);
+    if (bytes != sizeof(target_info)) {
+        /* error is already printed by rw_file() */
+        return FAILURE;
+    }
+
+    /* 3. write some custom data to `user_report_data` file */
+    sgx_report_data_t user_report_data = {0};
+    static_assert(sizeof(user_report_data) >= sizeof(user_report_data_str),
+                  "insufficient size of user_report_data");
+
+    memcpy((void*)&user_report_data, (void*)user_report_data_str, sizeof(user_report_data_str));
+
+    bytes = rw_file("/dev/attestation/user_report_data", (char*)&user_report_data,
+                    sizeof(user_report_data), /*do_write=*/true);
+    if (bytes != sizeof(user_report_data)) {
+        /* error is already printed by rw_file() */
+        return FAILURE;
+    }
+
+    /* 4. read `report` file */
+    sgx_report_t report;
+    bytes = rw_file("/dev/attestation/report", (char*)&report, sizeof(report), /*do_write=*/false);
+    if (bytes != sizeof(report)) {
+        /* error is already printed by rw_file() */
+        return FAILURE;
+    }
+
+    /* 5. verify data read from `report` */
+    return verify_report_mac(&report);
+}
+
+/* This currently does not include 'quote'. Since the quote interface does not implement caching,
+ * we do not want to have 10^5 interactions with the quoting service (would take too long). */
+static const char* paths[] = {
+    "/dev/attestation/user_report_data",
+    "/dev/attestation/target_info",
+    "/dev/attestation/my_target_info",
+    "/dev/attestation/report",
+};
+
+/*!
+ * \brief Test resource leaks in the attestation pseudo filesystem.
+ *
+ * Perform the following steps 100,000 times:
+ *   1. open one of the /dev/attestation files
+ *   2. close this file
+ *
+ * \return 0 if the test succeeded, -1 otherwise.
+ */
+static int test_resource_leak(void) {
+    /* repeatedly open()/close() pseudo-files to hopefully uncover resource leaks */
+    for (int j = 0; j < sizeof(paths) / sizeof(&paths[0]); j++) {
+        for (int i = 0; i < 100000; i++) {
+            int fd = open(paths[j], O_RDONLY);
+            if (fd < 0) {
+                fprintf(stderr, "opening %s failed: %s\n", paths[j], strerror(errno));
+                return FAILURE;
+            }
+
+            int ret = close(fd);
+            if (ret < 0) {
+                fprintf(stderr, "closing %s failed: %s\n", paths[j], strerror(errno));
+                return FAILURE;
+            }
+        }
+    }
+    return SUCCESS;
+}
+
+/*!
+ * \brief Test quote interface (currently SGX quote obtained from the Quoting Enclave).
+ *
+ * Perform the following steps in order:
+ *   1. write some custom data to `user_report_data` file
+ *   2. read `quote` file
+ *   3. verify report data read from `quote`
+ *
+ * \return 0 if the test succeeds, -1 otherwise.
+ */
+static int test_quote_interface(void) {
+    ssize_t bytes;
+
+    /* 1. write some custom data to `user_report_data` file */
+    sgx_report_data_t user_report_data = {0};
+    static_assert(sizeof(user_report_data) >= sizeof(user_report_data_str),
+                  "insufficient size of user_report_data");
+
+    memcpy((void*)&user_report_data, (void*)user_report_data_str, sizeof(user_report_data_str));
+
+    bytes = rw_file("/dev/attestation/user_report_data", (char*)&user_report_data,
+                    sizeof(user_report_data), /*do_write=*/true);
+    if (bytes != sizeof(user_report_data)) {
+        /* error is already printed by rw_file() */
+        return FAILURE;
+    }
+
+    /* 2. read `quote` file */
+    uint8_t quote[SGX_QUOTE_MAX_SIZE];
+    bytes = rw_file("/dev/attestation/quote", (char*)&quote, sizeof(quote), /*do_write=*/false);
+    if (bytes < 0) {
+        /* error is already printed by rw_file() */
+        return FAILURE;
+    }
+
+    /* 3. verify report data read from `quote` */
+    if (bytes < sizeof(sgx_quote_t)) {
+        fprintf(stderr, "obtained SGX quote is too small: %ldB (must be at least %ldB)\n",
+                bytes, sizeof(sgx_quote_t));
+        return FAILURE;
+    }
+
+    sgx_quote_t* typed_quote = (sgx_quote_t*)quote;
+    int ret = memcmp(typed_quote->report_body.report_data.d, user_report_data.d,
+                     sizeof(user_report_data));
+    if (ret) {
+        fprintf(stderr, "comparison of report data in SGX quote failed\n");
+        return FAILURE;
+    }
+
+    return SUCCESS;
+}
+
+int main(int argc, char** argv) {
+    if (argc == 1) {
+        /* for debugging, we skip this test by adding any command-line arg */
+        printf("Test resource leaks in attestation filesystem... %s\n",
+               test_resource_leak() == SUCCESS ? "SUCCESS" : "FAIL");
+    }
+
+    printf("Test local attestation... %s\n",
+           test_local_attestation() == SUCCESS ? "SUCCESS" : "FAIL");
+    printf("Test quote interface... %s\n",
+           test_quote_interface() == SUCCESS ? "SUCCESS" : "FAIL");
+    return 0;
+}

--- a/LibOS/shim/test/regression/attestation.manifest.template
+++ b/LibOS/shim/test/regression/attestation.manifest.template
@@ -1,0 +1,21 @@
+loader.preload = file:$(SHIMPATH)
+loader.env.LD_LIBRARY_PATH = /lib
+loader.debug_type = none
+loader.syscall_symbol = syscalldb
+
+fs.mount.lib.type = chroot
+fs.mount.lib.path = /lib
+fs.mount.lib.uri = file:$(LIBCDIR)
+
+fs.mount.bin.type = chroot
+fs.mount.bin.path = /bin
+fs.mount.bin.uri = file:/bin
+
+# sgx-related
+sgx.trusted_files.ld = file:$(LIBCDIR)/ld-linux-x86-64.so.2
+sgx.trusted_files.libc = file:$(LIBCDIR)/libc.so.6
+sgx.trusted_files.libdl = file:$(LIBCDIR)/libdl.so.2
+sgx.trusted_files.libm = file:$(LIBCDIR)/libm.so.6
+
+sgx.ra_client_spid = $(RA_CLIENT_SPID)
+sgx.ra_client_linkable = $(RA_CLIENT_LINKABLE)

--- a/LibOS/shim/test/regression/test_libos.py
+++ b/LibOS/shim/test/regression/test_libos.py
@@ -207,6 +207,15 @@ class TC_03_FileCheckPolicy(RegressionTestCase):
         self.assertNotIn('Allowing access to an unknown file due to file_check_policy settings: file:trusted_testfile', stderr)
         self.assertIn('file_check_policy succeeded', stdout)
 
+@unittest.skipUnless(HAS_SGX,
+    'This test is only meaningful on SGX PAL because only SGX supports attestation.')
+class TC_04_Attestation(RegressionTestCase):
+    def test_000_attestation(self):
+        stdout, _ = self.run_binary(['attestation'], timeout=60)
+        self.assertIn("Test resource leaks in attestation filesystem... SUCCESS", stdout)
+        self.assertIn("Test local attestation... SUCCESS", stdout)
+        self.assertIn("Test quote interface... SUCCESS", stdout)
+
 class TC_30_Syscall(RegressionTestCase):
     def test_000_getcwd(self):
         stdout, _ = self.run_binary(['getcwd'])

--- a/Pal/src/host/Linux-SGX/sgx_attest.h
+++ b/Pal/src/host/Linux-SGX/sgx_attest.h
@@ -54,6 +54,7 @@ enum {
     SGX_LINKABLE_SIGNATURE
 };
 
+/* typical SGX quotes are around 1K in size, overapproximate to 2K */
 #define SGX_QUOTE_MAX_SIZE 2048
 
 /*!

--- a/Pal/src/host/Linux-SGX/sgx_platform.c
+++ b/Pal/src/host/Linux-SGX/sgx_platform.c
@@ -194,7 +194,7 @@ int retrieve_quote(const sgx_spid_t* spid, bool linkable, const sgx_report_t* re
         goto out;
     }
 
-    memcpy(*quote, r->quote.data, actual_quote_size);
+    memcpy(mmapped, r->quote.data, actual_quote_size);
 
     *quote = mmapped;
     *quote_len = actual_quote_size;


### PR DESCRIPTION
## Description of the changes: <!-- (reasons and measures) -->

This PR adds a new subdirectory in the `/dev` pseudo-FS and new pseudo-files to allow applications and helper libraries on top of Graphene to perform attestation. The currently exposed  primitives are tailored to the Intel SGX local and remote EPID attestation. App developer writes attestation logic against this pseudo-FS interface by opening and reading/writing the following files:

- `/dev/attestation/report_data`: write SGX report data used in `report` and `quote` pseudo-files
- `/dev/attestation/target_info`: write SGX target info used in `report` and `quote` pseudo-files
- `/dev/attestation/my_target_info`: read this enclave's target info
- `/dev/attestation/report`: read SGX report
- `/dev/attestation/quote`: read SGX quote

~~**Depends on https://github.com/oscarlab/graphene/pull/1388.** (That PR is the first commit here, so to check this PR, review only the second commit.)~~

Closes #1284. This is the last PR in this series on Remote Attestation.

Closes #1365.

## How to test this PR? <!-- (if applicable) -->

This PR also adds a corresponding LibOS test `attestation`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1392)
<!-- Reviewable:end -->
