### PR TITLE
[LibOS] Disable signals in critical section in shim_futex.c

### DIFF
--- a/LibOS/shim/include/shim_internal.h
+++ b/LibOS/shim/include/shim_internal.h
@@ -36,10 +36,10 @@
 
 #include <api.h>
 #include <assert.h>
-#include <shim_types.h>
-#include <shim_defs.h>
 #include <atomic.h>
+#include <shim_defs.h>
 #include <shim_tcb.h>
+#include <shim_types.h>
 
 noreturn void shim_clean_and_exit(int exit_code);
 


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://graphene.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes: <!-- (reasons and measures) -->
If a thread was killed during critical section in our futexes implementation, it would not release a global lock (`g_futex_list_lock`). Later, at program exit, one thread would call `release_clear_child_id` which would hang trying to acquire that lock.
This PR disables all signals when inside the critical section in `shim_futex.c`.

## How to test this PR? <!-- (if applicable) -->
I was able to trigger this bug running blender example, with SGX and no debug - without this patch hitting a bug once in ~10 runs (hang after blender exit).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1393)
<!-- Reviewable:end -->
