### PR TITLE
[Pal/lib] Build in-Graphene mbedTLS crypto lib with minimal config

### DIFF
--- a/Pal/lib/Makefile
+++ b/Pal/lib/Makefile
@@ -79,9 +79,11 @@ crypto/mbedtls/CMakeLists.txt: crypto/$(MBEDTLS_SRC) crypto/$(MBEDCRYPTO_SRC)
 	mkdir crypto/mbedtls/install
 	cd crypto/mbedtls && ./scripts/config.pl set MBEDTLS_CMAC_C && make SHARED=1 DESTDIR=install install .
 	$(RM) crypto/mbedtls/include/mbedtls/config.h
+	$(RM) crypto/mbedtls/crypto/include/mbedtls/config.h
 
 crypto/mbedtls/include/mbedtls/config.h: crypto/config.h crypto/mbedtls/CMakeLists.txt
 	cp crypto/config.h crypto/mbedtls/include/mbedtls
+	cp crypto/config.h crypto/mbedtls/crypto/include/mbedtls
 
 crypto/mbedtls/crypto/library/aes.c: crypto/mbedtls/CMakeLists.txt crypto/mbedtls/include/mbedtls/config.h
 $(filter-out crypto/mbedtls/crypto/library/aes.c,$(patsubst %.o,%.c,$(crypto_mbedtls_library_objs))): crypto/mbedtls/crypto/library/aes.c


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Graphene now moved to mbedTLS version 2.21.0. This new version decouples the crypto functionality in a separate lib (libmbedcrypto). This separate lib has its C code and headers under mbedtls/crypto subdirectory. Previously, we forgot to copy our in-Graphene minimal config `config.h` into this new subdirectory. This meant that the crypto lib was built with a default and bloated configuration, not needed for our Graphene purposes. This commit fixes this.

## How to test this PR? <!-- (if applicable) -->

Check out `graphene/Pal/lib/crypto/mbedtls/crypto/include/mbedtls/config.h` after Graphene build. It must contain our minimal configuration.