### PR TITLE
[Pal/Linux-SGX] Encrypt all pipes/socketpairs with TLS-PSK

### DIFF
--- a/LibOS/shim/test/regression/.gitignore
+++ b/LibOS/shim/test/regression/.gitignore
@@ -44,6 +44,7 @@
 /mprotect_file_fork
 /multi_pthread
 /openmp
+/pipe
 /poll
 /poll_many_types
 /ppoll

--- a/LibOS/shim/test/regression/Makefile
+++ b/LibOS/shim/test/regression/Makefile
@@ -35,6 +35,7 @@ c_executables = \
 	mprotect_file_fork \
 	multi_pthread \
 	openmp \
+	pipe \
 	poll \
 	poll_many_types \
 	ppoll \

--- a/LibOS/shim/test/regression/pipe.c
+++ b/LibOS/shim/test/regression/pipe.c
@@ -1,0 +1,47 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+int main(int argc, char** argv) {
+    int pipefds[2];
+    char buffer[1024];
+    size_t bufsize = sizeof(buffer);
+
+    if (pipe(pipefds) < 0) {
+        perror("pipe error");
+        return 1;
+    }
+
+    int pid = fork();
+
+    if (pid < 0) {
+        perror("fork error");
+        return 1;
+    } else if (pid == 0) {
+        /* client */
+        close(pipefds[1]);
+
+        if (read(pipefds[0], &buffer, bufsize) < 0) {
+            perror("read error");
+            return 1;
+        }
+        buffer[bufsize - 1] = '\0';
+
+        printf("read on pipe: %s\n", buffer);
+    } else {
+        /* server */
+        close(pipefds[0]);
+
+        snprintf(buffer, bufsize, "Hello from write end of pipe!");
+        if (write(pipefds[1], &buffer, strlen(buffer) + 1) < 0) {
+            perror("write error");
+            return 1;
+        }
+
+        wait(NULL); /* wait for child termination, just for sanity */
+    }
+
+    return 0;
+}

--- a/LibOS/shim/test/regression/test_libos.py
+++ b/LibOS/shim/test/regression/test_libos.py
@@ -480,6 +480,10 @@ class TC_80_Socket(RegressionTestCase):
         self.assertIn('pselect() on write event returned 1 file descriptors', stdout)
         self.assertIn('pselect() on read event returned 1 file descriptors', stdout)
 
+    def test_090_pipe(self):
+        stdout, _ = self.run_binary(['pipe'], timeout=60)
+        self.assertIn('read on pipe: Hello from write end of pipe!', stdout)
+
     def test_100_socket_unix(self):
         stdout, _ = self.run_binary(['unix'])
         self.assertIn('Data: This is packet 0', stdout)

--- a/Pal/include/lib/pal_crypto.h
+++ b/Pal/include/lib/pal_crypto.h
@@ -134,8 +134,10 @@ int lib_Base64Decode(const char *src, size_t slen, uint8_t* dst, size_t* dlen);
 int lib_SSLInit(LIB_SSL_CONTEXT* ssl_ctx, int stream_fd, bool is_server,
                 const uint8_t* psk, size_t psk_size,
                 ssize_t (*pal_recv_cb)(int fd, void* buf, size_t len),
-                ssize_t (*pal_send_cb)(int fd, const void* buf, size_t len));
+                ssize_t (*pal_send_cb)(int fd, const void* buf, size_t len),
+                const uint8_t* buf_load_ssl_ctx, size_t buf_size);
 int lib_SSLFree(LIB_SSL_CONTEXT* ssl_ctx);
 int lib_SSLRead(LIB_SSL_CONTEXT* ssl_ctx, uint8_t* buf, size_t len);
 int lib_SSLWrite(LIB_SSL_CONTEXT* ssl_ctx, const uint8_t* buf, size_t len);
+int lib_SSLSave(LIB_SSL_CONTEXT* ssl_ctx, uint8_t* buf, size_t len, size_t* olen);
 #endif

--- a/Pal/lib/Makefile
+++ b/Pal/lib/Makefile
@@ -76,6 +76,7 @@ crypto/mbedtls/CMakeLists.txt: crypto/$(MBEDTLS_SRC) crypto/$(MBEDCRYPTO_SRC)
 	$(RM) -r crypto/mbedtls/crypto
 	mv crypto/mbed-crypto-mbedcrypto-$(MBEDCRYPTO_VERSION) crypto/mbedtls
 	mv crypto/mbedtls/mbed-crypto-mbedcrypto-3.1.0 crypto/mbedtls/crypto
+	cd crypto/mbedtls && patch -p1 < ../mbedtls-$(MBEDTLS_VERSION).diff || exit 255
 	mkdir crypto/mbedtls/install
 	cd crypto/mbedtls && ./scripts/config.pl set MBEDTLS_CMAC_C && make CFLAGS="" SHARED=1 DESTDIR=install install .
 	$(RM) crypto/mbedtls/include/mbedtls/config.h

--- a/Pal/lib/crypto/mbedtls-2.21.0.diff
+++ b/Pal/lib/crypto/mbedtls-2.21.0.diff
@@ -1,0 +1,94 @@
+# A similar fix will be merged to a future version of mbedTLS, please track
+# progress via issue https://github.com/ARMmbed/mbedtls/issues/3141.
+
+diff --git a/library/ssl_tls.c b/library/ssl_tls.c
+index 63bc5c8..a850c36 100644
+--- a/library/ssl_tls.c
++++ b/library/ssl_tls.c
+@@ -5951,12 +5951,14 @@ int mbedtls_ssl_context_save( mbedtls_ssl_context *ssl,
+         MBEDTLS_SSL_DEBUG_MSG( 1, ( "There is pending outgoing data" ) );
+         return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
+     }
++#if 0
+     /* Protocol must be DLTS, not TLS */
+     if( ssl->conf->transport != MBEDTLS_SSL_TRANSPORT_DATAGRAM )
+     {
+         MBEDTLS_SSL_DEBUG_MSG( 1, ( "Only DTLS is supported" ) );
+         return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
+     }
++#endif
+     /* Version must be 1.2 */
+     if( ssl->major_ver != MBEDTLS_SSL_MAJOR_VERSION_3 )
+     {
+@@ -6125,6 +6127,16 @@ int mbedtls_ssl_context_save( mbedtls_ssl_context *ssl,
+     }
+ #endif /* MBEDTLS_SSL_ALPN */
+ 
++    if( ssl->conf->transport == MBEDTLS_SSL_TRANSPORT_STREAM )
++    {
++        used += 8;
++        if( used <= buf_len )
++        {
++            memcpy( p, ssl->in_ctr, 8 );
++            p += 8;
++        }
++    }
++
+     /*
+      * Done
+      */
+@@ -6135,7 +6147,19 @@ int mbedtls_ssl_context_save( mbedtls_ssl_context *ssl,
+ 
+     MBEDTLS_SSL_DEBUG_BUF( 4, "saved context", buf, used );
+ 
++#if 0
++    /* At the moment of fork (when we call this function to serialize the TLS
++     * context and send to the child), we don't know (1) whether the child
++     * process will use it at all -- maybe both TLS endpoints will be used by
++     * the parent process, and (2) which TLS endpoint will be closed and which
++     * endpoint will be used. Thus, we must not reset the session since it may
++     * be continued to be used.
++     * Currently we are relying on the application to be "sane" and not use
++     * the same endpoint in two different processes. */
+     return( mbedtls_ssl_session_reset_int( ssl, 0 ) );
++#else
++    return( 0 );
++#endif
+ }
+ 
+ /*
+@@ -6191,7 +6215,10 @@ static int ssl_context_load( mbedtls_ssl_context *ssl,
+      * We can't check that the config matches the initial one, but we can at
+      * least check it matches the requirements for serializing.
+      */
++#if 0
+     if( ssl->conf->transport != MBEDTLS_SSL_TRANSPORT_DATAGRAM ||
++#else
++    if(
+         ssl->conf->max_major_ver < MBEDTLS_SSL_MAJOR_VERSION_3 ||
+         ssl->conf->min_major_ver > MBEDTLS_SSL_MAJOR_VERSION_3 ||
+         ssl->conf->max_minor_ver < MBEDTLS_SSL_MINOR_VERSION_3 ||
+@@ -6203,6 +6230,7 @@ static int ssl_context_load( mbedtls_ssl_context *ssl,
+     {
+         return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
+     }
++#endif
+ 
+     MBEDTLS_SSL_DEBUG_BUF( 4, "context to load", buf, len );
+ 
+@@ -6422,6 +6450,15 @@ static int ssl_context_load( mbedtls_ssl_context *ssl,
+     ssl->in_epoch = 1;
+ #endif
+ 
++    if( ssl->conf->transport == MBEDTLS_SSL_TRANSPORT_STREAM )
++    {
++        if( (size_t)( end - p ) < 8 )
++            return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
++
++        memcpy( ssl->in_ctr, p, 8 );
++        p += 8;
++    }
++
+     /* mbedtls_ssl_reset() leaves the handshake sub-structure allocated,
+      * which we don't want - otherwise we'd end up freeing the wrong transform
+      * by calling mbedtls_ssl_handshake_wrapup_free_hs_transform()

--- a/Pal/regression/SendHandle.c
+++ b/Pal/regression/SendHandle.c
@@ -6,17 +6,15 @@ int main(int argc, char** argv) {
     PAL_HANDLE handles[3];
 
     if (argc == 2 && !memcmp(argv[1], "Child", 6)) {
-        for (int i = 0; i < 3; i++) {
-            handles[i] = DkReceiveHandle(pal_control.parent_process);
-            if (handles[i])
-                pal_printf("Receive Handle OK\n");
-        }
-
         char buffer[20];
 
         for (int i = 0; i < 3; i++) {
-            if (!handles[i])
+            handles[i] = DkReceiveHandle(pal_control.parent_process);
+            if (handles[i]) {
+                pal_printf("Receive Handle OK\n");
+            } else {
                 continue;
+            }
 
             memset(buffer, 0, 20);
 

--- a/Pal/src/host/Linux-SGX/db_pipes.c
+++ b/Pal/src/host/Linux-SGX/db_pipes.c
@@ -23,6 +23,7 @@
 
 #include "api.h"
 #include "pal.h"
+#include "pal_crypto.h"
 #include "pal_debug.h"
 #include "pal_defs.h"
 #include "pal_error.h"
@@ -50,6 +51,50 @@ static int pipe_addr(const char* name, struct sockaddr_un* addr) {
     /* pipe_prefix already contains a slash at the end, so not needed in the format string */
     int ret = snprintf(str, size, "%s%s", pal_sec.pipe_prefix, name);
     return ret >= 0 && (size_t)ret < size ? 0 : -EINVAL;
+}
+
+static int pipe_session_key(PAL_PIPE_NAME* name, PAL_SESSION_KEY* session_key) {
+    /* use SHA256 as a KDF; session key is KDF(g_master_key || pipe_name) */
+    int ret;
+    LIB_SHA256_CONTEXT sha;
+
+    ret = lib_SHA256Init(&sha);
+    if (ret < 0)
+        goto fail;
+
+    ret = lib_SHA256Update(&sha, (uint8_t*)&g_master_key, sizeof(g_master_key));
+    if (ret < 0)
+        goto fail;
+
+    ret = lib_SHA256Update(&sha, (uint8_t*)name->str, sizeof(name->str));
+    if (ret < 0)
+        goto fail;
+
+    ret = lib_SHA256Final(&sha, (uint8_t*)session_key);
+    if (ret < 0)
+        goto fail;
+
+    return 0;
+fail:
+    SGX_DBG(DBG_E, "Failed to derive the pre-shared key for pipe %s: %d\n", name->str, ret);
+    return ret;
+}
+
+int thread_handshake_func(void* param) {
+    PAL_HANDLE handle = (PAL_HANDLE)param;
+
+    assert(handle);
+    assert(IS_HANDLE_TYPE(handle, pipe));
+    assert(!handle->pipe.ssl_ctx);
+    assert(!handle->pipe.handshake_done);
+
+    int ret = _DkStreamSecureInit(handle, handle->pipe.is_server, &handle->pipe.session_key,
+                                  (LIB_SSL_CONTEXT**)&handle->pipe.ssl_ctx, NULL, 0);
+    if (ret < 0)
+        return ret;
+
+    __atomic_store_n(&handle->pipe.handshake_done, 1, __ATOMIC_RELEASE);
+    return ret;
 }
 
 /*!
@@ -93,7 +138,16 @@ static int pipe_listen(PAL_HANDLE* handle, const char* name, int options) {
     HANDLE_HDR(hdl)->flags |= RFD(0);  /* cannot write to a listening socket */
     hdl->pipe.fd            = ret;
     hdl->pipe.nonblocking   = options & PAL_OPTION_NONBLOCK ? PAL_TRUE : PAL_FALSE;
-    memcpy(&hdl->pipe.name.str, name, sizeof(hdl->pipe.name.str));
+
+    /* padding with zeros is because the whole buffer is used in key derivation */
+    memset(&hdl->pipe.name.str, 0, sizeof(hdl->pipe.name.str));
+    memcpy(&hdl->pipe.name.str, name, strlen(name) + 1);
+
+    /* pipesrv handle is only intermediate so it doesn't need SSL context or session key */
+    hdl->pipe.ssl_ctx        = NULL;
+    hdl->pipe.is_server      = false;
+    hdl->pipe.handshake_done = 1;  /* pipesrv doesn't do any handshake so consider it done */
+    memset(hdl->pipe.session_key, 0, sizeof(hdl->pipe.session_key));
 
     *handle = hdl;
     return 0;
@@ -135,6 +189,28 @@ static int pipe_waitforclient(PAL_HANDLE handle, PAL_HANDLE* client) {
     clnt->pipe.fd            = ret;
     clnt->pipe.name          = handle->pipe.name;
     clnt->pipe.nonblocking   = PAL_FALSE; /* FIXME: must set nonblocking based on `handle` value */
+
+    /* create the SSL pre-shared key for this end of the pipe; note that SSL context is initialized
+     * lazily on first read/write on this pipe */
+    clnt->pipe.ssl_ctx        = NULL;
+    clnt->pipe.is_server      = false;
+    clnt->pipe.handshake_done = 0;
+
+    ret = pipe_session_key(&clnt->pipe.name, &clnt->pipe.session_key);
+    if (IS_ERR(ret)) {
+        ocall_close(clnt->pipe.fd);
+        free(clnt);
+        return -PAL_ERROR_DENIED;
+    }
+
+    ret = _DkStreamSecureInit(clnt, clnt->pipe.is_server, &clnt->pipe.session_key,
+                              (LIB_SSL_CONTEXT**)&clnt->pipe.ssl_ctx, NULL, 0);
+    if (ret < 0) {
+        ocall_close(clnt->pipe.fd);
+        free(clnt);
+        return ret;
+    }
+    __atomic_store_n(&clnt->pipe.handshake_done, 1, __ATOMIC_RELEASE);
 
     *client = clnt;
     return 0;
@@ -181,7 +257,33 @@ static int pipe_connect(PAL_HANDLE* handle, const char* name, int options) {
     HANDLE_HDR(hdl)->flags |= RFD(0) | WFD(0);
     hdl->pipe.fd            = ret;
     hdl->pipe.nonblocking   = (options & PAL_OPTION_NONBLOCK) ? PAL_TRUE : PAL_FALSE;
-    memcpy(&hdl->pipe.name.str, name, sizeof(hdl->pipe.name.str));
+
+    /* padding with zeros is because the whole buffer is used in key derivation */
+    memset(&hdl->pipe.name.str, 0, sizeof(hdl->pipe.name.str));
+    memcpy(&hdl->pipe.name.str, name, strlen(name) + 1);
+
+    /* create the SSL pre-shared key for this end of the pipe and initialize SSL context */
+    ret = pipe_session_key(&hdl->pipe.name, &hdl->pipe.session_key);
+    if (IS_ERR(ret)) {
+        ocall_close(hdl->pipe.fd);
+        free(hdl);
+        return -PAL_ERROR_DENIED;
+    }
+
+    hdl->pipe.ssl_ctx        = NULL;
+    hdl->pipe.is_server      = true;
+    hdl->pipe.handshake_done = 0;
+
+    /* create a helper thread to initialize the SSL context (by performing SSL handshake);
+     * we need a separate thread because the underlying handshake implementation is blocking
+     * and assumes that client and server are two parallel entities (e.g., two threads) */
+    PAL_HANDLE thread_hdl;
+    ret = _DkThreadCreate(&thread_hdl, thread_handshake_func, /*param=*/hdl);
+    if (IS_ERR(ret)) {
+        ocall_close(hdl->pipe.fd);
+        free(hdl);
+        return -PAL_ERROR_DENIED;
+    }
 
     *handle = hdl;
     return 0;
@@ -192,7 +294,7 @@ static int pipe_connect(PAL_HANDLE* handle, const char* name, int options) {
  *
  * This function creates a PAL handle of type `pipeprv` (anonymous pipe). In contrast to other types
  * of pipes, `pipeprv` encapsulates both ends of the pipe, backed by a host-level socketpair. This
- * type of pipe is typically reserved for internal PAL uses, not for LibOS emulation.
+ * type of pipe is typically reserved for internal LibOS usages, e.g. events (see `create_event()`).
  *
  * \param[out] handle  PAL handle of type `pipeprv` backed by a host-level socketpair.
  * \param[in]  options May contain PAL_OPTION_NONBLOCK.
@@ -219,6 +321,9 @@ static int pipe_private(PAL_HANDLE* handle, int options) {
     hdl->pipeprv.fds[0]      = fds[0];
     hdl->pipeprv.fds[1]      = fds[1];
     hdl->pipeprv.nonblocking = (options & PAL_OPTION_NONBLOCK) ? PAL_TRUE : PAL_FALSE;
+
+    /* pipeprv handle is currently used only for LibOS event emulation and does not send any real
+     * messages (only dummy bytes to trigger events), so it doesn't need SSL context or key */
 
     *handle = hdl;
     return 0;
@@ -286,11 +391,22 @@ static int64_t pipe_read(PAL_HANDLE handle, uint64_t offset, uint64_t len, void*
         !IS_HANDLE_TYPE(handle, pipe))
         return -PAL_ERROR_NOTCONNECTION;
 
-    int fd = IS_HANDLE_TYPE(handle, pipeprv) ? handle->pipeprv.fds[0] : handle->pipe.fd;
+    ssize_t bytes;
+    if (IS_HANDLE_TYPE(handle, pipeprv)) {
+        /* pipeprv are currently not encrypted, see pipe_private() */
+        bytes = ocall_recv(handle->pipeprv.fds[0], buffer, len, NULL, NULL, NULL, NULL);
+        if (IS_ERR(bytes))
+            return unix_to_pal_error(ERRNO(bytes));
+    } else {
+        /* normal pipe, use a secure session (should be already initialized) */
+        while (!__atomic_load_n(&handle->pipe.handshake_done, __ATOMIC_ACQUIRE))
+            __asm__ volatile ("pause");
 
-    ssize_t bytes = ocall_recv(fd, buffer, len, NULL, NULL, NULL, NULL);
-    if (IS_ERR(bytes))
-        return unix_to_pal_error(ERRNO(bytes));
+        if (!handle->pipe.ssl_ctx)
+            return -PAL_ERROR_NOTCONNECTION;
+
+        bytes = _DkStreamSecureRead(handle->pipe.ssl_ctx, buffer, len);
+    }
 
     if (!bytes)
         return -PAL_ERROR_ENDOFSTREAM;
@@ -315,11 +431,22 @@ static int64_t pipe_write(PAL_HANDLE handle, uint64_t offset, uint64_t len, cons
         !IS_HANDLE_TYPE(handle, pipe))
         return -PAL_ERROR_NOTCONNECTION;
 
-    int fd = IS_HANDLE_TYPE(handle, pipeprv) ? handle->pipeprv.fds[1] : handle->pipe.fd;
+    ssize_t bytes;
+    if (IS_HANDLE_TYPE(handle, pipeprv)) {
+        /* pipeprv are currently not encrypted, see pipe_private() */
+        bytes = ocall_send(handle->pipeprv.fds[1], buffer, len, NULL, 0, NULL, 0);
+        if (IS_ERR(bytes))
+            return unix_to_pal_error(ERRNO(bytes));
+    } else {
+        /* normal pipe, use a secure session (should be already initialized) */
+        while (!__atomic_load_n(&handle->pipe.handshake_done, __ATOMIC_ACQUIRE))
+            __asm__ volatile ("pause");
 
-    ssize_t bytes = ocall_send(fd, buffer, len, NULL, 0, NULL, 0);
-    if (IS_ERR(bytes))
-        return unix_to_pal_error(ERRNO(bytes));
+        if (!handle->pipe.ssl_ctx)
+            return -PAL_ERROR_NOTCONNECTION;
+
+        bytes = _DkStreamSecureWrite(handle->pipe.ssl_ctx, buffer, len);
+    }
 
     return bytes;
 }
@@ -341,6 +468,13 @@ static int pipe_close(PAL_HANDLE handle) {
             handle->pipeprv.fds[1] = PAL_IDX_POISON;
         }
     } else if (handle->pipe.fd != PAL_IDX_POISON) {
+        while (!__atomic_load_n(&handle->pipe.handshake_done, __ATOMIC_ACQUIRE))
+            __asm__ volatile ("pause");
+
+        if (handle->pipe.ssl_ctx) {
+            _DkStreamSecureFree((LIB_SSL_CONTEXT*)handle->pipe.ssl_ctx);
+            handle->pipe.ssl_ctx = NULL;
+        }
         ocall_close(handle->pipe.fd);
         handle->pipe.fd = PAL_IDX_POISON;
     }

--- a/Pal/src/host/Linux-SGX/db_process.c
+++ b/Pal/src/host/Linux-SGX/db_process.c
@@ -287,8 +287,14 @@ int _DkProcessCreate (PAL_HANDLE * handle, const char * uri, const char ** args)
         goto failed;
 
     ret = _DkStreamSecureInit(child, /*is_server=*/true, &child->process.session_key,
-                              (LIB_SSL_CONTEXT**)&child->process.ssl_ctx);
+                              (LIB_SSL_CONTEXT**)&child->process.ssl_ctx, NULL, 0);
     if (ret < 0)
+        goto failed;
+
+    /* securely send the master key to child in the newly established SSL session */
+    ret = _DkStreamSecureWrite(child->process.ssl_ctx, (uint8_t*)&g_master_key,
+                               sizeof(g_master_key));
+    if (ret != sizeof(g_master_key))
         goto failed;
 
     *handle = child;
@@ -341,8 +347,14 @@ int init_child_process (PAL_HANDLE * parent_handle)
         return ret;
 
     ret = _DkStreamSecureInit(parent, /*is_server=*/false, &parent->process.session_key,
-                              (LIB_SSL_CONTEXT**)&parent->process.ssl_ctx);
+                              (LIB_SSL_CONTEXT**)&parent->process.ssl_ctx, NULL, 0);
     if (ret < 0)
+        return ret;
+
+    /* securely receive the master key from parent in the newly established SSL session */
+    ret = _DkStreamSecureRead(parent->process.ssl_ctx, (uint8_t*)&g_master_key,
+                              sizeof(g_master_key));
+    if (ret != sizeof(g_master_key))
         return ret;
 
     *parent_handle = parent;

--- a/Pal/src/host/Linux-SGX/enclave_framework.c
+++ b/Pal/src/host/Linux-SGX/enclave_framework.c
@@ -1303,11 +1303,14 @@ out:
 }
 
 int _DkStreamSecureInit(PAL_HANDLE stream, bool is_server, PAL_SESSION_KEY* session_key,
-                        LIB_SSL_CONTEXT** out_ssl_ctx) {
+                        LIB_SSL_CONTEXT** out_ssl_ctx, const uint8_t* buf_load_ssl_ctx,
+                        size_t buf_size) {
     int stream_fd;
 
     if (IS_HANDLE_TYPE(stream, process))
         stream_fd = stream->process.stream;
+    else if (IS_HANDLE_TYPE(stream, pipe) || IS_HANDLE_TYPE(stream, pipecli))
+        stream_fd = stream->pipe.fd;
     else
         return -PAL_ERROR_BADHANDLE;
 
@@ -1318,7 +1321,7 @@ int _DkStreamSecureInit(PAL_HANDLE stream, bool is_server, PAL_SESSION_KEY* sess
 
     int ret = lib_SSLInit(ssl_ctx, stream_fd, is_server,
                           (const uint8_t*)session_key, sizeof(*session_key),
-                          ocall_read, ocall_write);
+                          ocall_read, ocall_write, buf_load_ssl_ctx, buf_size);
 
     if (ret != 0) {
         free(ssl_ctx);
@@ -1341,4 +1344,32 @@ int _DkStreamSecureRead(LIB_SSL_CONTEXT* ssl_ctx, uint8_t* buf, size_t len) {
 
 int _DkStreamSecureWrite(LIB_SSL_CONTEXT* ssl_ctx, const uint8_t* buf, size_t len) {
     return lib_SSLWrite(ssl_ctx, buf, len);
+}
+
+int _DkStreamSecureSave(LIB_SSL_CONTEXT* ssl_ctx, const uint8_t** obuf, size_t* olen) {
+    assert(obuf);
+    assert(olen);
+
+    int ret;
+
+    /* figure out the required buffer size */
+    ret = lib_SSLSave(ssl_ctx, NULL, 0, olen);
+    if (ret != 0 && ret != -PAL_ERROR_NOMEM)
+        return ret;
+
+    /* create the required buffer */
+    size_t len   = *olen;
+    uint8_t* buf = malloc(len);
+    if (!buf)
+        return -PAL_ERROR_NOMEM;
+
+    /* now have buffer with sufficient size to save serialized context */
+    ret = lib_SSLSave(ssl_ctx, buf, len, olen);
+    if (ret != 0 || len != *olen) {
+        free(buf);
+        return -PAL_ERROR_DENIED;
+    }
+
+    *obuf = buf;
+    return 0;
 }

--- a/Pal/src/host/Linux-SGX/pal_host.h
+++ b/Pal/src/host/Linux-SGX/pal_host.h
@@ -104,6 +104,10 @@ typedef struct pal_handle
             PAL_IDX fd;
             PAL_PIPE_NAME name;
             PAL_BOL nonblocking;
+            PAL_BOL is_server;
+            PAL_SESSION_KEY session_key;
+            PAL_NUM handshake_done;
+            void* ssl_ctx;
         } pipe;
 
         struct {

--- a/Pal/src/host/Linux-SGX/pal_linux.h
+++ b/Pal/src/host/Linux-SGX/pal_linux.h
@@ -164,6 +164,10 @@ int _DkStreamKeyExchange(PAL_HANDLE stream, PAL_SESSION_KEY* key);
 
 typedef uint8_t sgx_sign_data_t[48];
 
+/* master key for all enclaves of one application, populated by the first enclave and inherited by
+ * all other enclaves (children, their children, etc.); used as master key in pipes' encryption */
+extern PAL_SESSION_KEY g_master_key;
+
 /* enclave state used for generating report */
 extern struct pal_enclave_state {
     uint64_t        enclave_flags;      // Reserved for flags
@@ -208,10 +212,12 @@ int _DkStreamReportRespond(PAL_HANDLE stream, sgx_sign_data_t* data,
                            check_mr_enclave_t check_mr_enclave);
 
 int _DkStreamSecureInit(PAL_HANDLE stream, bool is_server, PAL_SESSION_KEY* session_key,
-                        LIB_SSL_CONTEXT** out_ssl_ctx);
+                        LIB_SSL_CONTEXT** out_ssl_ctx, const uint8_t* buf_load_ssl_ctx,
+                        size_t buf_size);
 int _DkStreamSecureFree(LIB_SSL_CONTEXT* ssl_ctx);
 int _DkStreamSecureRead(LIB_SSL_CONTEXT* ssl_ctx, uint8_t* buf, size_t len);
 int _DkStreamSecureWrite(LIB_SSL_CONTEXT* ssl_ctx, const uint8_t* buf, size_t len);
+int _DkStreamSecureSave(LIB_SSL_CONTEXT* ssl_ctx, const uint8_t** obuf, size_t* olen);
 
 #include "sgx_arch.h"
 

--- a/Pal/src/host/Linux/db_pipes.c
+++ b/Pal/src/host/Linux/db_pipes.c
@@ -104,7 +104,10 @@ static int pipe_listen(PAL_HANDLE* handle, const char* name, int options) {
     HANDLE_HDR(hdl)->flags |= RFD(0);  /* cannot write to a listening socket */
     hdl->pipe.fd            = fd;
     hdl->pipe.nonblocking   = options & PAL_OPTION_NONBLOCK ? PAL_TRUE : PAL_FALSE;
-    memcpy(&hdl->pipe.name.str, name, sizeof(hdl->pipe.name.str));
+
+    /* padding with zeros is for uniformity with other PALs (in particular, Linux-SGX) */
+    memset(&hdl->pipe.name.str, 0, sizeof(hdl->pipe.name.str));
+    memcpy(&hdl->pipe.name.str, name, strlen(name) + 1);
 
     *handle = hdl;
     return 0;
@@ -193,7 +196,10 @@ static int pipe_connect(PAL_HANDLE* handle, const char* name, int options) {
     HANDLE_HDR(hdl)->flags |= RFD(0) | WFD(0);
     hdl->pipe.fd            = fd;
     hdl->pipe.nonblocking   = (options & PAL_OPTION_NONBLOCK) ? PAL_TRUE : PAL_FALSE;
-    memcpy(&hdl->pipe.name.str, name, sizeof(hdl->pipe.name.str));
+
+    /* padding with zeros is for uniformity with other PALs (in particular, Linux-SGX) */
+    memset(&hdl->pipe.name.str, 0, sizeof(hdl->pipe.name.str));
+    memcpy(&hdl->pipe.name.str, name, strlen(name) + 1);
 
     *handle = hdl;
     return 0;


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Previously, Linux-SGX PAL did not encrypt pipe/socketpair communication (only process checkpoint send/receive was encrypted). This PR encrypts all pipe/socketpair IPC between threads of
the same enclave and between enclave processes. In particular, all offsprings of the "first" enclave inherit the same master key and derive IPC session keys from this master key based on pipe ID. When two pipe/socketpair endpoints are first created, they establish a TLS-PSK session via intra-enclave handshake (requires a spawn of an intermediate enclave thread). During clone/fork/exec, endpoints' TLS contexts are serialized and sent to the child that deserializes them (using `mbedtls_ssl_context_{save,load}` functions).

Note that multicast pipes (with more than two communicating entities) are not supported since TLS protocol doesn't support it.

This commit modifies the PAL `SendHandle` test to correctly test pipe communication, as well as adds the LibOS `pipe` test.

Fixes #1235. See it for details.

It is better to merge #1399 before this one.


## How to test this PR? <!-- (if applicable) -->

PAL `SendHandle` test and LibOS `pipe` test are modified/added. All other tests also must work correctly. You can test that pipe communication is indeed encrypted like this: `SGX=1 strace -ff -s 500 ./pal_loader ./pipe`. Without this PR, you will send send/recv syscalls with plaintext "Hello from write end". With this PR, these syscalls will send encrypted TLS messages.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1400)
<!-- Reviewable:end -->
