### PR TITLE
LibOS: Prevent signal handler from disappearing due to SA_RESETHAND

### DIFF
--- a/LibOS/shim/test/regression/.gitignore
+++ b/LibOS/shim/test/regression/.gitignore
@@ -56,6 +56,7 @@
 /select
 /shared_object
 /sigaltstack
+/sighandler_reset
 /sigprocmask
 /spinlock
 /stat_invalid_args

--- a/LibOS/shim/test/regression/Makefile
+++ b/LibOS/shim/test/regression/Makefile
@@ -47,6 +47,7 @@ c_executables = \
 	select \
 	shared_object \
 	sigaltstack \
+	sighandler_reset \
 	sigprocmask \
 	spinlock \
 	stat_invalid_args \

--- a/LibOS/shim/test/regression/sighandler_reset.c
+++ b/LibOS/shim/test/regression/sighandler_reset.c
@@ -1,0 +1,51 @@
+#define _XOPEN_SOURCE 700
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <unistd.h>
+#include <signal.h>
+#include <sys/signal.h>
+#include <sys/wait.h>
+
+static int count = 0;
+
+void handler(int signum) {
+    printf("Got signal %d\n", signum);
+    fflush(stdout);
+    count++;
+}
+
+int main() {
+
+    struct sigaction action;
+    action.sa_handler = handler;
+    action.sa_flags = SA_RESETHAND; // one shot
+
+    int ret = sigaction(SIGCHLD, &action, NULL);
+    if (ret < 0) {
+        fprintf(stderr, "sigaction failed\n");
+        return 1;
+    }
+
+    int pid = fork();
+    if (pid < 0) {
+        fprintf(stderr, "fork failed\n");
+        return 1;
+    }
+
+    if (pid == 0) {
+        /* child signals parent -- only 1 must go through */
+        kill(getppid(), SIGCHLD);
+        kill(getppid(), SIGCHLD);
+        exit(0);
+    }
+
+    wait(NULL);
+
+    printf("Handler was invoked %d time(s).\n", count);
+
+    if (count != 1)
+        return 1;
+
+    return 0;
+}

--- a/LibOS/shim/test/regression/test_libos.py
+++ b/LibOS/shim/test/regression/test_libos.py
@@ -369,6 +369,11 @@ class TC_30_Syscall(RegressionTestCase):
         # Scheduling Syscalls Test
         self.assertIn('Test completed successfully', stdout)
 
+    def test_090_sighandler_reset(self):
+        stdout, _ = self.run_binary(['sighandler_reset'])
+        self.assertIn('Got signal 17', stdout)
+        self.assertIn('Handler was invoked 1 time(s).', stdout)
+
 @unittest.skipUnless(HAS_SGX,
     'This test is only meaningful on SGX PAL because only SGX catches raw '
     'syscalls and redirects to Graphene\'s LibOS. If we will add seccomp to '


### PR DESCRIPTION
This patch prevents a signal handler that has the SA_RESETHAND flag set
from disappearing when a signal is appended. We do this by passing an
additional boolean to the __get_sighandler() function that allows us to
control whether the signal handler may be reset or not. It is only
desirable to reset the signal handler if an actual invocation of the
handler function occurs, not when only asking 'where is the handler?'

I noticed signals not being handled anymore while porting Graphene to PowerPC64.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1401)
<!-- Reviewable:end -->
