### PR TITLE
[LibOS,Pal] Replace 32-bit pipeid with 256-bit pipe name

### DIFF
--- a/LibOS/shim/include/shim_handle.h
+++ b/LibOS/shim/include/shim_handle.h
@@ -127,11 +127,7 @@ struct shim_dev_handle {
 };
 
 struct shim_pipe_handle {
-#if USE_SIMPLE_PIPE == 1
-    struct shim_handle* pair;
-#else
-    IDTYPE pipeid;
-#endif
+    char name[PIPE_URI_SIZE];
 };
 
 #define SOCK_STREAM   1
@@ -163,10 +159,6 @@ enum shim_sock_state {
     SOCK_SHUTDOWN,
 };
 
-struct shim_unix_data {
-    unsigned int pipeid;
-};
-
 struct shim_sock_handle {
     int domain;
     int sock_type;
@@ -190,8 +182,7 @@ struct shim_sock_handle {
         // UNIX addr
         struct addr_unix {
             struct shim_dentry* dentry;
-            unsigned int pipeid;
-            struct shim_unix_data* data;
+            char name[PIPE_URI_SIZE];
         } un;
     } addr;
 

--- a/LibOS/shim/include/shim_internal.h
+++ b/LibOS/shim/include/shim_internal.h
@@ -827,10 +827,4 @@ static_always_inline void * current_stack(void)
 # error "Unsupported architecture"
 #endif /* __x86_64__ */
 
-static inline IDTYPE hashtype_to_idtype(HASHTYPE hash) {
-    static_assert(sizeof(HASHTYPE) == 8, "Unsupported HASHTYPE size");
-    static_assert(sizeof(IDTYPE) == 4, "Unsupported IDTYPE size");
-    return ((IDTYPE)hash) ^ ((IDTYPE)(hash >> 32));
-}
-
 #endif /* _PAL_INTERNAL_H_ */

--- a/LibOS/shim/include/shim_types.h
+++ b/LibOS/shim/include/shim_types.h
@@ -515,4 +515,7 @@ struct shim_qstr {
     struct shim_str * oflow;
 };
 
+/* maximum length of pipe/FIFO name (should be less than Linux sockaddr_un.sun_path = 108) */
+#define PIPE_URI_SIZE 96
+
 #endif /* _SHIM_TYPES_H_ */

--- a/LibOS/shim/include/shim_utils.h
+++ b/LibOS/shim/include/shim_utils.h
@@ -206,8 +206,7 @@ void append_r_debug(const char* uri, void* addr, void* dyn_addr);
 void clean_link_map_list(void);
 
 /* create unique files/pipes */
-#define PIPE_URI_SIZE 40
-int create_pipe(IDTYPE* pipeid, char* uri, size_t size, PAL_HANDLE* hdl, struct shim_qstr* qstr,
+int create_pipe(char* name, char* uri, size_t size, PAL_HANDLE* hdl, struct shim_qstr* qstr,
                 bool use_vmid_for_name);
 int create_dir(const char* prefix, char* path, size_t size, struct shim_handle** hdl);
 int create_file(const char* prefix, char* path, size_t size, struct shim_handle** hdl);

--- a/LibOS/shim/src/shim_init.c
+++ b/LibOS/shim/src/shim_init.c
@@ -33,9 +33,10 @@
 #include <shim_profile.h>
 #include <shim_vdso.h>
 
-#include <pal.h>
-#include <pal_debug.h>
-#include <pal_error.h>
+#include "hex.h"
+#include "pal.h"
+#include "pal_debug.h"
+#include "pal_error.h"
 
 #include <sys/mman.h>
 #include <asm/unistd.h>
@@ -807,69 +808,85 @@ static int create_unique (int (*mkname) (char *, size_t, void *),
     }
 }
 
-static int name_pipe_rand (char * uri, size_t size, void * id)
-{
-    IDTYPE pipeid;
-    size_t len;
-    int ret = DkRandomBitsRead(&pipeid, sizeof(pipeid));
+static int get_256b_random_hex_string(char* buf, size_t size) {
+    char random[32];  /* 256-bit random value, sufficiently crypto secure */
+
+    if (size < sizeof(random) * 2 + 1)
+        return -ENOMEM;
+
+    int ret = DkRandomBitsRead(&random, sizeof(random));
     if (ret < 0)
         return -convert_pal_errno(-ret);
-    debug("creating pipe: " URI_PREFIX_PIPE_SRV "%u\n", pipeid);
-    if ((len = snprintf(uri, size, URI_PREFIX_PIPE_SRV "%u", pipeid)) >= size)
-        return -ERANGE;
-    *((IDTYPE *)id) = pipeid;
-    return len;
-}
 
-static int name_pipe_vmid (char * uri, size_t size, void * id)
-{
-    IDTYPE pipeid = cur_process.vmid;
-    size_t len;
-    debug("creating pipe: " URI_PREFIX_PIPE_SRV "%u\n", pipeid);
-    if ((len = snprintf(uri, size, URI_PREFIX_PIPE_SRV "%u", pipeid)) >= size)
-        return -ERANGE;
-    *((IDTYPE *)id) = pipeid;
-    return len;
-}
-
-static int open_pipe (const char * uri, void * obj)
-{
-    PAL_HANDLE pipe = DkStreamOpen(uri, 0, 0, 0, 0);
-    if (!pipe)
-        return PAL_NATIVE_ERRNO == PAL_ERROR_STREAMEXIST ? 1 :
-            -PAL_ERRNO;
-    if (obj)
-        *((PAL_HANDLE *) obj) = pipe;
-    else
-        DkObjectClose(pipe);
+    BYTES2HEXSTR(random, buf, size);
     return 0;
 }
 
-static int pipe_addr (char * uri, size_t size, const void * id,
-                      struct shim_qstr * qstr)
-{
-    IDTYPE pipeid = *((IDTYPE *) id);
-    size_t len;
-    if ((len = snprintf(uri, size, URI_PREFIX_PIPE "%u", pipeid)) == size)
+static int name_pipe_rand(char* uri, size_t uri_size, void* name) {
+    char pipename[PIPE_URI_SIZE];
+
+    int ret = get_256b_random_hex_string(pipename, sizeof(pipename));
+    if (ret < 0)
+        return ret;
+
+    debug("creating pipe: " URI_PREFIX_PIPE_SRV "%s\n", pipename);
+    size_t len = snprintf(uri, uri_size, URI_PREFIX_PIPE_SRV "%s", pipename);
+    if (len >= uri_size)
         return -ERANGE;
+
+    memcpy(name, pipename, sizeof(pipename));
+    return len;
+}
+
+static int name_pipe_vmid(char* uri, size_t uri_size, void* name) {
+    char pipename[PIPE_URI_SIZE];
+
+    size_t len = snprintf(pipename, sizeof(pipename), "%u", cur_process.vmid);
+    if (len >= sizeof(pipename))
+        return -ERANGE;
+
+    debug("creating pipe: " URI_PREFIX_PIPE_SRV "%s\n", pipename);
+    len = snprintf(uri, uri_size, URI_PREFIX_PIPE_SRV "%s", pipename);
+    if (len >= uri_size)
+        return -ERANGE;
+
+    memcpy(name, pipename, sizeof(pipename));
+    return len;
+}
+
+static int open_pipe(const char* uri, void* obj) {
+    assert(obj);
+
+    PAL_HANDLE pipe = DkStreamOpen(uri, 0, 0, 0, 0);
+    if (!pipe)
+        return PAL_NATIVE_ERRNO == PAL_ERROR_STREAMEXIST ? 1 : -PAL_ERRNO;
+
+    PAL_HANDLE* pal_hdl = (PAL_HANDLE*)obj;
+    *pal_hdl = pipe;
+    return 0;
+}
+
+static int pipe_addr(char* uri, size_t size, const void* name, struct shim_qstr* qstr) {
+    char* pipename = (char*)name;
+
+    size_t len = snprintf(uri, size, URI_PREFIX_PIPE "%s", pipename);
+    if (len >= size)
+        return -ERANGE;
+
     if (qstr)
         qstrsetstr(qstr, uri, len);
     return len;
 }
 
-int create_pipe (IDTYPE * id, char * uri, size_t size, PAL_HANDLE * hdl,
-                 struct shim_qstr * qstr, bool use_vmid_for_name)
-{
-    IDTYPE pipeid;
-    int ret;
-    if (use_vmid_for_name)
-        ret = create_unique(&name_pipe_vmid, &open_pipe, &pipe_addr,
-                            uri, size, &pipeid, hdl, qstr);
-    else
-        ret = create_unique(&name_pipe_rand, &open_pipe, &pipe_addr,
-                            uri, size, &pipeid, hdl, qstr);
-    if (ret > 0 && id)
-        *id = pipeid;
+int create_pipe(char* name, char* uri, size_t size, PAL_HANDLE* hdl, struct shim_qstr* qstr,
+                bool use_vmid_for_name) {
+    char pipename[PIPE_URI_SIZE];
+
+    int ret = create_unique(use_vmid_for_name ? &name_pipe_vmid : &name_pipe_rand, &open_pipe,
+                            &pipe_addr, uri, size, &pipename, hdl, qstr);
+    if (ret > 0 && name) {
+        memcpy(name, pipename, sizeof(pipename));
+    }
     return ret;
 }
 

--- a/Pal/include/lib/hex.h
+++ b/Pal/include/lib/hex.h
@@ -36,7 +36,7 @@
 static inline __attribute__((always_inline))
 char * __bytes2hexstr(void * hex, size_t size, char *str, size_t len)
 {
-    static char * ch = "0123456789abcdef";
+    static const char* ch = "0123456789abcdef";
     __UNUSED(len);
     assert(len >= size * 2 + 1);
 

--- a/Pal/include/pal/pal.h
+++ b/Pal/include/pal/pal.h
@@ -56,6 +56,9 @@ typedef bool          PAL_BOL;
  * since it is 3, across all host kernels. */
 #define MAX_FDS 3
 
+/* maximum length of pipe/FIFO name (should be less than Linux sockaddr_un.sun_path = 108) */
+#define PIPE_NAME_MAX 96
+
 #ifdef IN_PAL
 #include <atomic.h>
 typedef struct atomic_int PAL_REF;
@@ -516,9 +519,9 @@ enum PAL_OPTION {
  * * `%file:...`, `dir:...`: Files or directories on the host file system. If #PAL_CREATE_TRY is
  *   given in `create` flags, the file/directory will be created.
  * * `dev:...`: Open a device as a stream. For example, `dev:tty` represents the standard I/O.
- * * `pipe.srv:<ID>`, `pipe:<ID>`, `pipe:`: Open a byte stream that can be used for RPC between
- *   processes. Pipes are located by numeric IDs. The server side of a pipe can accept any number
- *   of connections. If `pipe:` is given as the URI, it will open an anonymous bidirectional pipe.
+ * * `pipe.srv:<name>`, `pipe:<name>`, `pipe:`: Open a byte stream that can be used for RPC between
+ *   processes. The server side of a pipe can accept any number of connections. If `pipe:` is given
+ *   as the URI (i.e., without a name), it will open an anonymous bidirectional pipe.
  * * `tcp.srv:<ADDR>:<PORT>`, `tcp:<ADDR>:<PORT>`: Open a TCP socket to listen or connect to
  *   a remote TCP socket.
  * * `udp.srv:<ADDR>:<PORT>`, `udp:<ADDR>:<PORT>`: Open a UDP socket to listen or connect to

--- a/Pal/src/host/Linux-SGX/db_pipes.c
+++ b/Pal/src/host/Linux-SGX/db_pipes.c
@@ -38,8 +38,8 @@ typedef __kernel_pid_t pid_t;
 #include <linux/types.h>
 #include <linux/un.h>
 
-static int pipe_addr(int pipeid, struct sockaddr_un* addr) {
-    /* use abstract UNIX sockets for pipes, with name format "@/graphene/12345678" */
+static int pipe_addr(const char* name, struct sockaddr_un* addr) {
+    /* use abstract UNIX sockets for pipes, with name format "@/graphene/<pipename>" */
     addr->sun_family = AF_UNIX;
     memset(addr->sun_path, 0, sizeof(addr->sun_path));
 
@@ -48,29 +48,29 @@ static int pipe_addr(int pipeid, struct sockaddr_un* addr) {
     size_t size = sizeof(addr->sun_path) - 1;
 
     /* pipe_prefix already contains a slash at the end, so not needed in the format string */
-    int ret = snprintf(str, size, "%s%08x", pal_sec.pipe_prefix, pipeid);
+    int ret = snprintf(str, size, "%s%s", pal_sec.pipe_prefix, name);
     return ret >= 0 && (size_t)ret < size ? 0 : -EINVAL;
 }
 
 /*!
  * \brief Create a listening abstract UNIX socket as preparation for connecting two ends of a pipe.
  *
- * An abstract UNIX socket with name "@/graphene/<pipeid>" is opened for listening. A corresponding
+ * An abstract UNIX socket with name "@/graphene/<pipename>" is opened for listening. A corresponding
  * PAL handle with type `pipesrv` is created. This PAL handle typically serves only as an
  * intermediate step to connect two ends of the pipe (`pipecli` and `pipe`). As soon as the other
  * end of the pipe connects to this listening socket, a new accepted socket and the corresponding
  * PAL handle are created, and this `pipesrv` handle can be closed.
  *
  * \param[out] handle  PAL handle of type `pipesrv` with abstract UNIX socket opened for listening.
- * \param[in]  pipeid  Integer uniquely identifying the pipe.
+ * \param[in]  name    String uniquely identifying the pipe.
  * \param[in]  options May contain PAL_OPTION_NONBLOCK.
  * \return             0 on success, negative PAL error code otherwise.
  */
-static int pipe_listen(PAL_HANDLE* handle, PAL_NUM pipeid, int options) {
+static int pipe_listen(PAL_HANDLE* handle, const char* name, int options) {
     int ret;
 
     struct sockaddr_un addr;
-    ret = pipe_addr(pipeid, &addr);
+    ret = pipe_addr(name, &addr);
     if (IS_ERR(ret))
         return -PAL_ERROR_DENIED;
 
@@ -92,8 +92,8 @@ static int pipe_listen(PAL_HANDLE* handle, PAL_NUM pipeid, int options) {
     SET_HANDLE_TYPE(hdl, pipesrv);
     HANDLE_HDR(hdl)->flags |= RFD(0);  /* cannot write to a listening socket */
     hdl->pipe.fd            = ret;
-    hdl->pipe.pipeid        = pipeid;
     hdl->pipe.nonblocking   = options & PAL_OPTION_NONBLOCK ? PAL_TRUE : PAL_FALSE;
+    memcpy(&hdl->pipe.name.str, name, sizeof(hdl->pipe.name.str));
 
     *handle = hdl;
     return 0;
@@ -133,8 +133,8 @@ static int pipe_waitforclient(PAL_HANDLE handle, PAL_HANDLE* client) {
     SET_HANDLE_TYPE(clnt, pipecli);
     HANDLE_HDR(clnt)->flags |= RFD(0) | WFD(0);
     clnt->pipe.fd            = ret;
+    clnt->pipe.name          = handle->pipe.name;
     clnt->pipe.nonblocking   = PAL_FALSE; /* FIXME: must set nonblocking based on `handle` value */
-    clnt->pipe.pipeid        = handle->pipe.pipeid;
 
     *client = clnt;
     return 0;
@@ -144,20 +144,20 @@ static int pipe_waitforclient(PAL_HANDLE handle, PAL_HANDLE* client) {
  * \brief Connect to the other end of the pipe and create PAL handle for our end of the pipe.
  *
  * This function connects to the other end of the pipe, represented as an abstract UNIX socket
- * "@/graphene/<pipeid>" opened for listening. When the connection succeeds, a new `pipe` PAL handle
+ * "@/graphene/<pipename>" opened for listening. When the connection succeeds, a new `pipe` PAL handle
  * is created with the corresponding underlying socket and is returned in `handle`. The other end of
  * the pipe is typically of type `pipecli`.
  *
  * \param[out] handle  PAL handle of type `pipe` with abstract UNIX socket connected to another end.
- * \param[in]  pipeid  Integer uniquely identifying the pipe.
+ * \param[in]  name    String uniquely identifying the pipe.
  * \param[in]  options May contain PAL_OPTION_NONBLOCK.
  * \return             0 on success, negative PAL error code otherwise.
  */
-static int pipe_connect(PAL_HANDLE* handle, PAL_NUM pipeid, int options) {
+static int pipe_connect(PAL_HANDLE* handle, const char* name, int options) {
     int ret;
 
     struct sockaddr_un addr;
-    ret = pipe_addr(pipeid, &addr);
+    ret = pipe_addr(name, &addr);
     if (IS_ERR(ret))
         return -PAL_ERROR_DENIED;
 
@@ -180,8 +180,8 @@ static int pipe_connect(PAL_HANDLE* handle, PAL_NUM pipeid, int options) {
     SET_HANDLE_TYPE(hdl, pipe);
     HANDLE_HDR(hdl)->flags |= RFD(0) | WFD(0);
     hdl->pipe.fd            = ret;
-    hdl->pipe.pipeid        = pipeid;
     hdl->pipe.nonblocking   = (options & PAL_OPTION_NONBLOCK) ? PAL_TRUE : PAL_FALSE;
+    memcpy(&hdl->pipe.name.str, name, sizeof(hdl->pipe.name.str));
 
     *handle = hdl;
     return 0;
@@ -233,17 +233,15 @@ static int pipe_private(PAL_HANDLE* handle, int options) {
  *                                               ends of an anonymous pipe).
  *
  * - `type` is URI_TYPE_PIPE_SRV: create `pipesrv` handle (intermediate listening socket) with
- *                                name in the form of "@/graphene/<pipeid>" where pipeid is
- *                                derived from `uri` via strtol(). Caller is expected to call
- *                                pipe_waitforclient() afterwards.
+ *                                name in the form of "@/graphene/<uri>". Caller is expected to
+ *                                call pipe_waitforclient() afterwards.
  *
  * - `type` is URI_TYPE_PIPE: create `pipe` handle (connecting socket) with name in the form of
- *                            "@/graphene/<pipeid>" where pipeid is derived from `uri` via
- *                            strtol().
+ *                            "@/graphene/<uri>".
  *
  * \param[out] handle  Created PAL handle of type `pipeprv`, `pipesrv`, or `pipe`.
  * \param[in]  type    Can be URI_TYPE_PIPE or URI_TYPE_PIPE_SRV.
- * \param[in]  uri     Content is either NUL (for anonymous pipe) or an integer denoting pipeid.
+ * \param[in]  uri     Content is either NUL (for anonymous pipe) or a string with pipe name.
  * \param[in]  access  Not used.
  * \param[in]  share   Not used.
  * \param[in]  create  Not used.
@@ -259,17 +257,14 @@ static int pipe_open(PAL_HANDLE* handle, const char* type, const char* uri, int 
     if (!strcmp_static(type, URI_TYPE_PIPE) && !*uri)
         return pipe_private(handle, options);
 
-    char* endptr;
-    PAL_NUM pipeid = strtol(uri, &endptr, 10);
-
-    if (*endptr)
+    if (strlen(uri) + 1 > PIPE_NAME_MAX)
         return -PAL_ERROR_INVAL;
 
     if (!strcmp_static(type, URI_TYPE_PIPE_SRV))
-        return pipe_listen(handle, pipeid, options);
+        return pipe_listen(handle, uri, options);
 
     if (!strcmp_static(type, URI_TYPE_PIPE))
-        return pipe_connect(handle, pipeid, options);
+        return pipe_connect(handle, uri, options);
 
     return -PAL_ERROR_INVAL;
 }
@@ -487,7 +482,7 @@ static int pipe_attrsetbyhdl(PAL_HANDLE handle, PAL_STREAM_ATTR* attr) {
 /*!
  * \brief Retrieve full URI of PAL handle.
  *
- * Full URI is composed of the type and pipeid: "<type>:<pipeid>".
+ * Full URI is composed of the type and pipe name: "<type>:<pipename>".
  *
  * \param[in]  handle  PAL handle of type `pipeprv`, `pipesrv`, `pipecli`, or `pipe`.
  * \param[out] buffer  User-supplied buffer to write URI to.
@@ -524,7 +519,7 @@ static int pipe_getname(PAL_HANDLE handle, char* buffer, size_t count) {
     buffer += prefix_len + 1;
     count -= prefix_len + 1;
 
-    ret = snprintf(buffer, count, "%lu\n", handle->pipe.pipeid);
+    ret = snprintf(buffer, count, "%s\n", handle->pipe.name.str);
     if (buffer[ret - 1] != '\n') {
         memset(buffer, 0, count);
         return -PAL_ERROR_OVERFLOW;

--- a/Pal/src/host/Linux-SGX/pal_host.h
+++ b/Pal/src/host/Linux-SGX/pal_host.h
@@ -71,6 +71,10 @@ struct pal_handle_thread {
     void * param;
 };
 
+typedef struct {
+    char str[PIPE_NAME_MAX];
+} PAL_PIPE_NAME;
+
 /* RPC streams are encrypted with 256-bit AES keys */
 typedef uint8_t PAL_SESSION_KEY[32];
 
@@ -98,7 +102,7 @@ typedef struct pal_handle
 
         struct {
             PAL_IDX fd;
-            PAL_NUM pipeid;
+            PAL_PIPE_NAME name;
             PAL_BOL nonblocking;
         } pipe;
 

--- a/Pal/src/host/Linux/pal_host.h
+++ b/Pal/src/host/Linux/pal_host.h
@@ -59,6 +59,10 @@ typedef struct {
     PAL_HDR hdr;
 } PAL_RESERVED_HDR;
 
+typedef struct {
+    char str[PIPE_NAME_MAX];
+} PAL_PIPE_NAME;
+
 typedef struct pal_handle
 {
     /* TSAI: Here we define the internal types of PAL_HANDLE
@@ -86,7 +90,7 @@ typedef struct pal_handle
 
         struct {
             PAL_IDX fd;
-            PAL_NUM pipeid;
+            PAL_PIPE_NAME name;
             PAL_BOL nonblocking;
         } pipe;
 

--- a/Pal/src/host/Linux/pal_linux.h
+++ b/Pal/src/host/Linux/pal_linux.h
@@ -44,8 +44,6 @@
 #define ERRNO INTERNAL_SYSCALL_ERRNO
 #define ERRNO_P INTERNAL_SYSCALL_ERRNO_P
 
-#define GRAPHENE_UNIX_PREFIX_FMT       "/graphene/%016lx"
-
 struct timespec;
 struct timeval;
 

--- a/Pal/src/host/Linux/pal_security.h
+++ b/Pal/src/host/Linux/pal_security.h
@@ -62,9 +62,6 @@ extern struct pal_sec {
     unsigned int process_id;
     int random_device;
 
-    /* pipes and sockets */
-    unsigned long pipe_prefix_id;
-
     /* for debugger */
     void (*_dl_debug_state)(void);
     struct r_debug* _r_debug;

--- a/Pal/src/host/Skeleton/db_pipes.c
+++ b/Pal/src/host/Skeleton/db_pipes.c
@@ -27,7 +27,7 @@
 #include "pal_error.h"
 #include "pal_internal.h"
 
-static int pipe_listen(PAL_HANDLE* handle, PAL_NUM pipeid, int create) {
+static int pipe_listen(PAL_HANDLE* handle, const char* name, int options) {
     return -PAL_ERROR_NOTIMPLEMENTED;
 }
 
@@ -35,41 +35,27 @@ static int pipe_waitforclient(PAL_HANDLE handle, PAL_HANDLE* client) {
     return -PAL_ERROR_NOTIMPLEMENTED;
 }
 
-static int pipe_connect(PAL_HANDLE* handle, PAL_NUM pipeid, PAL_IDX connid, int create) {
+static int pipe_connect(PAL_HANDLE* handle, const char* name, int options) {
     return -PAL_ERROR_NOTIMPLEMENTED;
 }
 
-static int pipe_private(PAL_HANDLE* handle) {
+static int pipe_private(PAL_HANDLE* handle, int options) {
     return -PAL_ERROR_NOTIMPLEMENTED;
 }
 
-/* 'open' operation of pipe stream. For each pipe stream, it is identified by a decimal number in
-   URI. There could be two types: pipe and pipe.srv. They behave pretty much the same, except they
-   are two ends of the pipe. */
 static int pipe_open(PAL_HANDLE* handle, const char* type, const char* uri, int access, int share,
                      int create, int options) {
     if (!strcmp_static(type, URI_TYPE_PIPE) && !*uri)
-        return pipe_private(handle);
+        return pipe_private(handle, options);
 
-    char* endptr;
-    PAL_NUM pipeid = strtol(uri, &endptr, 10);
-    PAL_IDX connid = 0;
-
-    if (*endptr == ':') {
-        if (create & PAL_CREATE_TRY)
-            return -PAL_ERROR_INVAL;
-
-        connid = strtol(endptr + 1, &endptr, 10);
-    }
-
-    if (*endptr)
+    if (strlen(uri) + 1 > PIPE_NAME_MAX)
         return -PAL_ERROR_INVAL;
 
     if (!strcmp_static(type, URI_TYPE_PIPE_SRV))
-        return pipe_listen(handle, pipeid, create);
+        return pipe_listen(handle, uri, options);
 
     if (!strcmp_static(type, URI_TYPE_PIPE))
-        return pipe_connect(handle, pipeid, connid, create);
+        return pipe_connect(handle, uri, options);
 
     return -PAL_ERROR_INVAL;
 }


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Previously, Graphene used the notation "pipe:<uint32_t>" to emulate pipes, socketpairs, and UNIX domain sockets. In particular, pipes and socketpairs received random integer IDs, and sockets received deterministic integer IDs. However, 32-bit IDs are bad for crypto. This commit changes pipe IDs (pipeid) from `uint32_t` to `char[96]` that can hold a 256-bit random sequence sufficient for crypto.

This is a prerequisite for #1400.

## How to test this PR? <!-- (if applicable) -->

All tests must pass. If you do smth like `strace -ff Runtime/pal_loader Pal/regression/Pipe`, you'll see much longer names now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1407)
<!-- Reviewable:end -->
