### PR TITLE
[Linux-SGX] tools: Fix debug builds

### DIFF
--- a/Pal/src/host/Linux-SGX/tools/common/attestation.c
+++ b/Pal/src/host/Linux-SGX/tools/common/attestation.c
@@ -37,6 +37,12 @@ const char* g_ias_public_key_pem =
 "tQIDAQAB\n"
 "-----END PUBLIC KEY-----\n";
 
+// Copied from Graphene's api.h.
+// TODO: Remove after Graphene's C utils get refactored into a separate module/header (we can't
+// include it here, because these SGX tools should be independent of Graphene).
+#define IS_ALIGNED_POW2(val, alignment)     (((val) & ((alignment) - 1)) == 0)
+#define IS_ALIGNED_PTR_POW2(val, alignment) IS_ALIGNED_POW2((uintptr_t)(val), alignment)
+
 // TODO: decode some known values (flags etc)
 void display_report_body(const sgx_report_body_t* body) {
     INFO(" cpu_svn          : ");


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

#1406 accidentally broke debug builds with SGX PAL. This was possible because unfortunately we don't test this configuration on Jenkins. This PR fixes this regression.

## How to test this PR? <!-- (if applicable) -->

Just build with `SGX=1 DEBUG=1`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1409)
<!-- Reviewable:end -->
