### PR TITLE
[LibOS] regression: Workaround for #1408

### DIFF
--- a/LibOS/shim/test/ltp/manifest.template
+++ b/LibOS/shim/test/ltp/manifest.template
@@ -25,6 +25,8 @@ fs.mount.tmp.type = chroot
 fs.mount.tmp.path = /tmp
 fs.mount.tmp.uri = file:/tmp
 
+# The line below may be causing problems on SGX, see
+# https://github.com/oscarlab/graphene/issues/1408.
 sys.brk.size = 32M
 sys.stack.size = 4M
 

--- a/LibOS/shim/test/regression/exec_victim.manifest.template
+++ b/LibOS/shim/test/regression/exec_victim.manifest.template
@@ -11,9 +11,6 @@ fs.mount.bin.type = chroot
 fs.mount.bin.path = /bin
 fs.mount.bin.uri = file:/bin
 
-sys.brk.size = 32M
-sys.stack.size = 4M
-
 # sgx-related
 sgx.trusted_files.ld = file:../../../../Runtime/ld-linux-x86-64.so.2
 sgx.trusted_files.libc = file:../../../../Runtime/libc.so.6

--- a/LibOS/shim/test/regression/proc-path.manifest.template
+++ b/LibOS/shim/test/regression/proc-path.manifest.template
@@ -11,9 +11,6 @@ fs.mount.bin.type = chroot
 fs.mount.bin.path = /bin
 fs.mount.bin.uri = file:/bin
 
-sys.brk.size = 32M
-sys.stack.size = 4M
-
 # sgx-related
 sgx.trusted_files.ld = file:../../../../Runtime/ld-linux-x86-64.so.2
 sgx.trusted_files.libc = file:../../../../Runtime/libc.so.6


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Because of https://github.com/oscarlab/graphene/issues/1408 (Elf relocations do not work correctly for small base addresses) a few tests were crashing from time to time on Linux-SGX. This workaround stabilizes them until we fix the bug.

## How to test this PR? <!-- (if applicable) -->

Large brk limit seems to trigger this bug from time to time (for `proc-path` about 15 runs are needed). I ran `proc-path` and `exec` 300 times on this path and they didn't crash anymore.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1410)
<!-- Reviewable:end -->
