### PR TITLE
[Pal] Introduce DkAttestationReport() API for local report retrieval

### DIFF
--- a/Documentation/pal/host-abi.rst
+++ b/Documentation/pal/host-abi.rst
@@ -379,7 +379,7 @@ The ABI includes seven assorted calls to get wall clock time, generate
 cryptographically-strong random bits, flush portions of instruction caches,
 increment and decrement the reference counts on objects shared between threads,
 to coordinate threads with the security monitor during process serialization,
-and to obtain an attestation quote.
+and to obtain an attestation report and quote.
 
 .. doxygenfunction:: DkSystemTimeQuery
    :project: pal
@@ -400,6 +400,9 @@ and to obtain an attestation quote.
    :project: pal
 
 .. doxygenenum:: PAL_CPUID_WORD
+   :project: pal
+
+.. doxygenfunction:: DkAttestationReport
    :project: pal
 
 .. doxygenfunction:: DkAttestationQuote

--- a/Pal/include/pal/pal.h
+++ b/Pal/include/pal/pal.h
@@ -919,21 +919,56 @@ PAL_BOL
 DkCpuIdRetrieve(PAL_IDX leaf, PAL_IDX subleaf, PAL_IDX values[PAL_CPUID_WORD_NUM]);
 
 /*!
- * \brief Obtain the attestation quote with `report_data` embedded into it.
+ * \brief Obtain the attestation report (local) with `user_report_data` embedded into it.
  *
- * Currently, works only for Linux-SGX PAL, where `report_data` is a 64B blob and `quote` is an
- * SGX quote obtained from the Quoting Enclave via AESM service.
+ * Currently, works only for Linux-SGX PAL, where `user_report_data` is a blob of exactly 64B,
+ * `target_info` is an SGX target_info struct of exactly 512B, and `report` is an SGX report
+ * obtained via the EREPORT instruction (exactly 432B). If `target_info` contains all zeros,
+ * then this function additionally returns this enclave's target info in `target_info`. Useful
+ * for local attestation.
  *
- * \param[in]     report_data       Report data with arbitrary contents (typically uniquely
- *                                  identifies this Graphene instance). Must be a 64B buffer
- *                                  in case of SGX PAL.
- * \param[in]     report_data_size  Size in bytes of report data. Must be 64 in case of SGX PAL.
- * \param[out]    quote             Attestation quote with report data embedded.
- * \param[in,out] quote_size        Caller specifies maximum size allocated for `quote`; on return,
- *                                  contains actual size of `quote`.
+ * The caller may specify `*user_report_data_size`, `*target_info_size`, and `*report_size` as 0
+ * and other fields as NULL to get PAL-enforced sizes of these three structs.
+ *
+ * \param[in]     user_report_data       Report data with arbitrary contents (typically uniquely
+ *                                       identifies this Graphene instance). Must be a 64B buffer
+ *                                       in case of SGX PAL.
+ * \param[in,out] user_report_data_size  Caller specifies size of `user_report_data`; on return,
+ *                                       contains PAL-enforced size of `user_report_data` (64B in
+ *                                       case of SGX PAL).
+ * \param[in,out] target_info            Target info of target enclave for attestation. If it
+ *                                       contains all zeros, it is populated with this enclave's
+ *                                       target info. Must be a 512B buffer in case of SGX PAL.
+ * \param[in,out] target_info_size       Caller specifies size of `target_info`; on return,
+ *                                       contains PAL-enforced size of `target_info` (512B in case
+ *                                       of SGX PAL).
+ * \param[out]    report                 Attestation report with `user_report_data` embedded,
+ *                                       targeted for an enclave with provided `target_info`. Must
+ *                                       be a 432B buffer in case of SGX PAL.
+ * \param[in,out] report_size            Caller specifies size of `report`; on return, contains
+ *                                       PAL-enforced size of `report` (432B in case of SGX PAL).
  */
-PAL_BOL DkAttestationQuote(PAL_PTR report_data, PAL_NUM report_data_size, PAL_PTR quote,
-                           PAL_NUM* quote_size);
+PAL_BOL DkAttestationReport(PAL_PTR user_report_data, PAL_NUM* user_report_data_size,
+                            PAL_PTR target_info, PAL_NUM* target_info_size,
+                            PAL_PTR report, PAL_NUM* report_size);
+
+/*!
+ * \brief Obtain the attestation quote with `user_report_data` embedded into it.
+ *
+ * Currently, works only for Linux-SGX PAL, where `user_report_data` is a blob of exactly 64B
+ * and `quote` is an SGX quote obtained from Quoting Enclave via AESM service.
+ *
+ * \param[in]     user_report_data       Report data with arbitrary contents (typically uniquely
+ *                                       identifies this Graphene instance). Must be a 64B buffer
+ *                                       in case of SGX PAL.
+ * \param[in]     user_report_data_size  Size in bytes of `user_report_data`. Must be exactly 64B
+ *                                       in case of SGX PAL.
+ * \param[out]    quote                  Attestation quote with `user_report_data` embedded.
+ * \param[in,out] quote_size             Caller specifies maximum size allocated for `quote`; on
+ *                                       return, contains actual size of obtained quote.
+ */
+PAL_BOL DkAttestationQuote(PAL_PTR user_report_data, PAL_NUM user_report_data_size,
+                           PAL_PTR quote, PAL_NUM* quote_size);
 
 #ifdef __GNUC__
 # define symbol_version_default(real, name, version) \

--- a/Pal/regression/.gitignore
+++ b/Pal/regression/.gitignore
@@ -8,8 +8,9 @@
 /.cache
 /..Bootstrap
 /AtomicMath
-avl_tree_test
+/AttestationReport
 /AvxDisable
+/avl_tree_test
 /Bootstrap
 /Bootstrap2
 /Bootstrap3

--- a/Pal/regression/AttestationReport.c
+++ b/Pal/regression/AttestationReport.c
@@ -1,0 +1,76 @@
+#include "api.h"
+#include "pal.h"
+#include "pal_debug.h"
+#include "sgx_arch.h"
+
+int main(int argc, char** argv) {
+    bool ret;
+
+    size_t user_report_data_size;
+    size_t target_info_size;
+    size_t report_size;
+    ret = DkAttestationReport(/*user_report_data=*/NULL, &user_report_data_size,
+                              /*target_info=*/NULL, &target_info_size,
+                              /*report=*/NULL, &report_size);
+    if (!ret) {
+        pal_printf("ERROR: DkAttestationReport() to get sizes of SGX structs failed\n");
+        return -1;
+    }
+
+    if (user_report_data_size != sizeof(sgx_report_data_t)) {
+        pal_printf("ERROR: DkAttestationReport() returned incorrect user_report_data size\n");
+        return -1;
+    }
+
+    if (target_info_size != sizeof(sgx_target_info_t)) {
+        pal_printf("ERROR: DkAttestationReport() returned incorrect target_info size\n");
+        return -1;
+    }
+
+    if (report_size != sizeof(sgx_report_t)) {
+        pal_printf("ERROR: DkAttestationReport() returned incorrect report size\n");
+        return -1;
+    }
+
+    pal_printf("user_report_data_size = %lu, target_info_size = %lu, report_size = %lu\n",
+               user_report_data_size, target_info_size, report_size);
+
+    char user_report_data[user_report_data_size];
+    char target_info[target_info_size];
+    char report[report_size];
+
+    memset(&user_report_data, 'A', sizeof(user_report_data));
+    memset(&target_info, 0, sizeof(target_info));
+    memset(&report, 0, sizeof(report));
+
+    ret = DkAttestationReport(&user_report_data, &user_report_data_size,
+                              &target_info, &target_info_size,
+                              &report, &report_size);
+    if (!ret) {
+        pal_printf("ERROR: DkAttestationReport() to get SGX report failed\n");
+        return -1;
+    }
+
+    sgx_report_t* sgx_report = (sgx_report_t*)&report;
+    if (memcmp(&sgx_report->body.report_data.d, &user_report_data,
+           sizeof(sgx_report->body.report_data.d))) {
+        pal_printf("ERROR: DkAttestationReport() returned SGX report with wrong report_data\n");
+        return -1;
+    }
+
+    char zerobuf[report_size];
+    memset(&zerobuf, 0, sizeof(zerobuf));
+
+    if (memcmp(&sgx_report->body.reserved1, &zerobuf, sizeof(sgx_report->body.reserved1)) ||
+        memcmp(&sgx_report->body.reserved2, &zerobuf, sizeof(sgx_report->body.reserved2)) ||
+        memcmp(&sgx_report->body.reserved3, &zerobuf, sizeof(sgx_report->body.reserved3)) ||
+        memcmp(&sgx_report->body.reserved4, &zerobuf, sizeof(sgx_report->body.reserved4)))
+    {
+        pal_printf("ERROR: DkAttestationReport() returned SGX report with non-zero reserved "
+                   "fields\n");
+        return -1;
+    }
+
+    pal_printf("Success\n");
+    return 0;
+}

--- a/Pal/regression/Makefile
+++ b/Pal/regression/Makefile
@@ -11,8 +11,9 @@ preloads = \
 executables = \
 	..Bootstrap \
 	AtomicMath \
-	avl_tree_test \
+	AttestationReport \
 	AvxDisable \
+	avl_tree_test \
 	Bootstrap \
 	Bootstrap2 \
 	Bootstrap3 \
@@ -102,6 +103,7 @@ crt_init-recurse:
 
 CFLAGS-AvxDisable += -mavx
 CFLAGS-Pie = -fPIC -pie
+CFLAGS-AttestationReport = -I../src/host/Linux-SGX
 
 # workaround: File.manifest.template has strange reference
 # to ../regression/File

--- a/Pal/regression/test_pal.py
+++ b/Pal/regression/test_pal.py
@@ -696,3 +696,11 @@ class TC_40_AVXDisable(RegressionTestCase):
         # Disable AVX bit in XFRM
         _, stderr = self.run_binary(['AvxDisable'])
         self.assertIn('Illegal instruction executed in enclave', stderr)
+
+
+@unittest.skipUnless(HAS_SGX, 'This test is only meaningful on SGX PAL')
+class TC_50_Attestation(RegressionTestCase):
+    def test_000_attestation_report(self):
+        _, stderr = self.run_binary(['AttestationReport'])
+        self.assertNotIn('ERROR', stderr)
+        self.assertIn('Success', stderr)

--- a/Pal/src/db_misc.c
+++ b/Pal/src/db_misc.c
@@ -106,11 +106,25 @@ DkCpuIdRetrieve(PAL_IDX leaf, PAL_IDX subleaf, PAL_IDX values[4]) {
     LEAVE_PAL_CALL_RETURN(PAL_TRUE);
 }
 
-PAL_BOL DkAttestationQuote(PAL_PTR report_data, PAL_NUM report_data_size, PAL_PTR quote,
-                           PAL_NUM* quote_size) {
+PAL_BOL DkAttestationReport(PAL_PTR user_report_data, PAL_NUM* user_report_data_size,
+                            PAL_PTR target_info, PAL_NUM* target_info_size,
+                            PAL_PTR report, PAL_NUM* report_size) {
+    ENTER_PAL_CALL(DkAttestationReport);
+
+    int ret = _DkAttestationReport(user_report_data, user_report_data_size, target_info,
+                                   target_info_size, report, report_size);
+    if (ret < 0) {
+        _DkRaiseFailure(-ret);
+        LEAVE_PAL_CALL_RETURN(PAL_FALSE);
+    }
+    LEAVE_PAL_CALL_RETURN(PAL_TRUE);
+}
+
+PAL_BOL DkAttestationQuote(PAL_PTR user_report_data, PAL_NUM user_report_data_size,
+                           PAL_PTR quote, PAL_NUM* quote_size) {
     ENTER_PAL_CALL(DkAttestationQuote);
 
-    int ret = _DkAttestationQuote(report_data, report_data_size, quote, quote_size);
+    int ret = _DkAttestationQuote(user_report_data, user_report_data_size, quote, quote_size);
     if (ret < 0) {
         _DkRaiseFailure(-ret);
         LEAVE_PAL_CALL_RETURN(PAL_FALSE);

--- a/Pal/src/host/Linux-SGX/db_misc.c
+++ b/Pal/src/host/Linux-SGX/db_misc.c
@@ -297,9 +297,66 @@ int _DkCpuIdRetrieve(unsigned int leaf, unsigned int subleaf, unsigned int value
     return 0;
 }
 
-int _DkAttestationQuote(const PAL_PTR report_data, PAL_NUM report_data_size, PAL_PTR quote,
-                        PAL_NUM* quote_size) {
-    if (report_data_size != sizeof(sgx_report_data_t))
+int _DkAttestationReport(PAL_PTR user_report_data, PAL_NUM* user_report_data_size,
+                         PAL_PTR target_info, PAL_NUM* target_info_size,
+                         PAL_PTR report, PAL_NUM* report_size) {
+    __sgx_mem_aligned sgx_report_data_t stack_report_data = {0};
+    __sgx_mem_aligned sgx_target_info_t stack_target_info = {0};
+    __sgx_mem_aligned sgx_report_t stack_report           = {0};
+
+    if (!user_report_data_size || !target_info_size || !report_size)
+        return -PAL_ERROR_INVAL;
+
+    if (*user_report_data_size != sizeof(stack_report_data) ||
+        *target_info_size != sizeof(stack_target_info) || *report_size != sizeof(stack_report)) {
+        /* inform the caller of SGX sizes for user_report_data, target_info, and report */
+        goto out;
+    }
+
+    if (!user_report_data || !target_info) {
+        /* cannot produce report without user_report_data or target_info */
+        goto out;
+    }
+
+    bool populate_target_info = false;
+    if (!memcmp(target_info, &stack_target_info, sizeof(stack_target_info))) {
+        /* caller supplied all-zero target_info, wants to get this enclave's target info */
+        populate_target_info = true;
+    }
+
+    memcpy(&stack_report_data, user_report_data, sizeof(stack_report_data));
+    memcpy(&stack_target_info, target_info, sizeof(stack_target_info));
+
+    int ret = sgx_report(&stack_target_info, &stack_report_data, &stack_report);
+    if (ret < 0) {
+        /* caller already provided reasonable sizes, so just error out without updating them */
+        return -PAL_ERROR_INVAL;
+    }
+
+    if (populate_target_info) {
+        sgx_target_info_t* ti = (sgx_target_info_t*)target_info;
+        memcpy(&ti->attributes, &stack_report.body.attributes, sizeof(ti->attributes));
+        memcpy(&ti->config_id, &stack_report.body.config_id, sizeof(ti->config_id));
+        memcpy(&ti->config_svn, &stack_report.body.config_svn, sizeof(ti->config_svn));
+        memcpy(&ti->misc_select, &stack_report.body.misc_select, sizeof(ti->misc_select));
+        memcpy(&ti->mr_enclave, &stack_report.body.mr_enclave, sizeof(ti->mr_enclave));
+    }
+
+    if (report) {
+        /* report may be NULL if caller only wants to know the size of target_info and/or report */
+        memcpy(report, &stack_report, sizeof(stack_report));
+    }
+
+out:
+    *user_report_data_size = sizeof(stack_report_data);
+    *target_info_size      = sizeof(stack_target_info);
+    *report_size           = sizeof(stack_report);
+    return 0;
+}
+
+int _DkAttestationQuote(const PAL_PTR user_report_data, PAL_NUM user_report_data_size,
+                        PAL_PTR quote, PAL_NUM* quote_size) {
+    if (user_report_data_size != sizeof(sgx_report_data_t))
         return -PAL_ERROR_INVAL;
 
     char spid_hex[sizeof(sgx_spid_t) * 2 + 1];
@@ -338,7 +395,7 @@ int _DkAttestationQuote(const PAL_PTR report_data, PAL_NUM report_data_size, PAL
     char* pal_quote       = NULL;
     size_t pal_quote_size = 0;
 
-    ret = sgx_get_quote(&spid, &nonce, report_data, linkable, &pal_quote, &pal_quote_size);
+    ret = sgx_get_quote(&spid, &nonce, user_report_data, linkable, &pal_quote, &pal_quote_size);
     if (ret < 0)
         return ret;
 

--- a/Pal/src/host/Linux/db_misc.c
+++ b/Pal/src/host/Linux/db_misc.c
@@ -232,10 +232,22 @@ int _DkCpuIdRetrieve(unsigned int leaf, unsigned int subleaf, unsigned int value
     return 0;
 }
 
-int _DkAttestationQuote(PAL_PTR report_data, PAL_NUM report_data_size, PAL_PTR quote,
-                        PAL_NUM* quote_size) {
-    __UNUSED(report_data);
-    __UNUSED(report_data_size);
+int _DkAttestationReport(PAL_PTR user_report_data, PAL_NUM* user_report_data_size,
+                         PAL_PTR target_info, PAL_NUM* target_info_size,
+                         PAL_PTR report, PAL_NUM* report_size) {
+    __UNUSED(user_report_data);
+    __UNUSED(user_report_data_size);
+    __UNUSED(target_info);
+    __UNUSED(target_info_size);
+    __UNUSED(report);
+    __UNUSED(report_size);
+    return -PAL_ERROR_NOTIMPLEMENTED;
+}
+
+int _DkAttestationQuote(PAL_PTR user_report_data, PAL_NUM user_report_data_size,
+                        PAL_PTR quote, PAL_NUM* quote_size) {
+    __UNUSED(user_report_data);
+    __UNUSED(user_report_data_size);
     __UNUSED(quote);
     __UNUSED(quote_size);
     return -PAL_ERROR_NOTIMPLEMENTED;

--- a/Pal/src/host/Skeleton/db_misc.c
+++ b/Pal/src/host/Skeleton/db_misc.c
@@ -63,10 +63,22 @@ int _DkCpuIdRetrieve(unsigned int leaf, unsigned int subleaf, unsigned int value
     return -PAL_ERROR_NOTIMPLEMENTED;
 }
 
-int _DkAttestationQuote(PAL_PTR report_data, PAL_NUM report_data_size, PAL_PTR quote,
-                        PAL_NUM* quote_size) {
-    __UNUSED(report_data);
-    __UNUSED(report_data_size);
+int _DkAttestationReport(PAL_PTR user_report_data, PAL_NUM* user_report_data_size,
+                         PAL_PTR target_info, PAL_NUM* target_info_size,
+                         PAL_PTR report, PAL_NUM* report_size) {
+    __UNUSED(user_report_data);
+    __UNUSED(user_report_data_size);
+    __UNUSED(target_info);
+    __UNUSED(target_info_size);
+    __UNUSED(report);
+    __UNUSED(report_size);
+    return -PAL_ERROR_NOTIMPLEMENTED;
+}
+
+int _DkAttestationQuote(PAL_PTR user_report_data, PAL_NUM user_report_data_size,
+                        PAL_PTR quote, PAL_NUM* quote_size) {
+    __UNUSED(user_report_data);
+    __UNUSED(user_report_data_size);
     __UNUSED(quote);
     __UNUSED(quote_size);
     return -PAL_ERROR_NOTIMPLEMENTED;

--- a/Pal/src/pal-symbols
+++ b/Pal/src/pal-symbols
@@ -43,6 +43,7 @@ DkStreamAttributesSetByHandle
 DkMemoryAvailableQuota
 DkDebugAttachBinary
 DkDebugDetachBinary
+DkAttestationReport
 DkAttestationQuote
 pal_printf
 pal_control_addr

--- a/Pal/src/pal_internal.h
+++ b/Pal/src/pal_internal.h
@@ -303,8 +303,11 @@ int _DkSegmentRegisterSet (int reg, const void * addr);
 int _DkSegmentRegisterGet (int reg, void ** addr);
 int _DkInstructionCacheFlush (const void * addr, int size);
 int _DkCpuIdRetrieve (unsigned int leaf, unsigned int subleaf, unsigned int values[4]);
-int _DkAttestationQuote(PAL_PTR report_data, PAL_NUM report_data_size, PAL_PTR quote,
-                        PAL_NUM* quote_size);
+int _DkAttestationReport(PAL_PTR user_report_data, PAL_NUM* user_report_data_size,
+                         PAL_PTR target_info, PAL_NUM* target_info_size,
+                         PAL_PTR report, PAL_NUM* report_size);
+int _DkAttestationQuote(PAL_PTR user_report_data, PAL_NUM user_report_data_size,
+                        PAL_PTR quote, PAL_NUM* quote_size);
 
 #define INIT_FAIL(exitcode, reason)                                     \
     do {                                                                \


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

New `DkAttestationReport()` API retrieves the attestation report (local) from the local attestation mechanism. Currently, it is implemented only for Linux-SGX PAL and stubbed for all other PALs. The Linux-SGX implementation retrieves the SGX report via EREPORT instruction.

The caller of this new API may learn sizes of report_data, target_info, and report structs. The caller may also obtain current target info. Finally, the caller may obtain the report for use in local attestation.

This PR is a prerequisite for pseudo-FS PR (currently #1392, but I may close that one and open a new one since changes will be pretty significant).

## How to test this PR? <!-- (if applicable) -->

All tests must pass. No new tests are added (will be in a follow-up PR on pseudo-FS).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1411)
<!-- Reviewable:end -->
