### PR TITLE
[LibOS] Multiple fixes for dup* syscalls

### DIFF
--- a/LibOS/shim/include/shim_handle.h
+++ b/LibOS/shim/include/shim_handle.h
@@ -409,8 +409,8 @@ struct shim_handle* get_fd_handle(FDTYPE fd, int* flags, struct shim_handle_map*
  * Creates mapping for the given handle to a new file descriptor which is then returned.
  * Uses the lowest, non-negative available number for the new fd.
  */
-int set_new_fd_handle(struct shim_handle* hdl, int flags, struct shim_handle_map* map);
-int set_new_fd_handle_by_fd(FDTYPE fd, struct shim_handle* hdl, int flags,
+int set_new_fd_handle(struct shim_handle* hdl, int fd_flags, struct shim_handle_map* map);
+int set_new_fd_handle_by_fd(FDTYPE fd, struct shim_handle* hdl, int fd_flags,
                             struct shim_handle_map* map);
 struct shim_handle* __detach_fd_handle(struct shim_fd_handle* fd, int* flags,
                                        struct shim_handle_map* map);

--- a/LibOS/shim/include/shim_table.h
+++ b/LibOS/shim/include/shim_table.h
@@ -353,8 +353,8 @@ int shim_do_sched_yield(void);
 void* shim_do_mremap(void* addr, size_t old_len, size_t new_len, int flags, void* new_addr);
 int shim_do_msync(void* start, size_t len, int flags);
 int shim_do_mincore(void* start, size_t len, unsigned char* vec);
-int shim_do_dup(int fd);
-int shim_do_dup2(int oldfd, int newfd);
+int shim_do_dup(unsigned int fd);
+int shim_do_dup2(unsigned int oldfd, unsigned int newfd);
 int shim_do_pause(void);
 int shim_do_nanosleep(const struct __kernel_timespec* rqtp, struct __kernel_timespec* rmtp);
 int shim_do_getitimer(int which, struct __kernel_itimerval* value);
@@ -486,7 +486,7 @@ int shim_do_get_robust_list(pid_t pid, struct robust_list_head** head, size_t* l
 int shim_do_epoll_pwait(int epfd, struct __kernel_epoll_event* events, int maxevents,
                         int timeout_ms, const __sigset_t* sigmask, size_t sigsetsize);
 int shim_do_accept4(int sockfd, struct sockaddr* addr, socklen_t* addrlen, int flags);
-int shim_do_dup3(int oldfd, int newfd, int flags);
+int shim_do_dup3(unsigned int oldfd, unsigned int newfd, int flags);
 int shim_do_epoll_create1(int flags);
 int shim_do_pipe2(int* fildes, int flags);
 ssize_t shim_do_recvmmsg(int sockfd, struct mmsghdr* msg, size_t vlen, int flags,
@@ -541,8 +541,8 @@ int shim_madvise(void* start, size_t len, int behavior);
 int shim_shmget(key_t key, size_t size, int shmflg);
 void* shim_shmat(int shmid, const void* shmaddr, int shmflg);
 int shim_shmctl(int shmid, int cmd, struct shmid_ds* buf);
-int shim_dup(int fd);
-int shim_dup2(int oldfd, int newfd);
+int shim_dup(unsigned int fd);
+int shim_dup2(unsigned int oldfd, unsigned int newfd);
 int shim_pause(void);
 int shim_nanosleep(const struct __kernel_timespec* rqtp, struct __kernel_timespec* rmtp);
 int shim_getitimer(int which, struct __kernel_itimerval* value);
@@ -806,7 +806,7 @@ int shim_accept4(int sockfd, struct sockaddr* addr, socklen_t* addrlen, int flag
 int shim_signalfd4(int ufd, __sigset_t* user_mask, size_t sizemask, int flags);
 int shim_eventfd2(unsigned int count, int flags);
 int shim_epoll_create1(int flags);
-int shim_dup3(int oldfd, int newfd, int flags);
+int shim_dup3(unsigned int oldfd, unsigned int newfd, int flags);
 int shim_pipe2(int* fildes, int flags);
 int shim_inotify_init1(int flags);
 int shim_preadv(unsigned long fd, const struct iovec* vec, unsigned long vlen, unsigned long pos_l,

--- a/LibOS/shim/src/shim_syscalls.c
+++ b/LibOS/shim/src/shim_syscalls.c
@@ -224,10 +224,10 @@ SHIM_SYSCALL_PASSTHROUGH(shmat, 3, void*, int, shmid, const void*, shmaddr, int,
 SHIM_SYSCALL_PASSTHROUGH(shmctl, 3, int, int, shmid, int, cmd, struct shmid_ds*, buf)
 
 /* dup: sys/shim_dup.c */
-DEFINE_SHIM_SYSCALL(dup, 1, shim_do_dup, int, int, fd)
+DEFINE_SHIM_SYSCALL(dup, 1, shim_do_dup, int, unsigned int, fd)
 
 /* dup2: sys/shim_dup.c */
-DEFINE_SHIM_SYSCALL(dup2, 2, shim_do_dup2, int, int, oldfd, int, newfd)
+DEFINE_SHIM_SYSCALL(dup2, 2, shim_do_dup2, int, unsigned int, oldfd, unsigned int, newfd)
 
 /* pause: sys/shim_sleep.c */
 DEFINE_SHIM_SYSCALL(pause, 0, shim_do_pause, int)
@@ -989,7 +989,8 @@ DEFINE_SHIM_SYSCALL (eventfd2, 2, shim_do_eventfd2, int, unsigned int, count, in
 DEFINE_SHIM_SYSCALL(epoll_create1, 1, shim_do_epoll_create1, int, int, flags)
 
 /* dup3: sys/shim_dup.c */
-DEFINE_SHIM_SYSCALL(dup3, 3, shim_do_dup3, int, int, oldfd, int, newfd, int, flags)
+DEFINE_SHIM_SYSCALL(dup3, 3, shim_do_dup3, int, unsigned int, oldfd, unsigned int, newfd, int,
+                    flags)
 
 /* pipe2: sys/shim_pipe.c */
 DEFINE_SHIM_SYSCALL(pipe2, 2, shim_do_pipe2, int, int*, fildes, int, flags)

--- a/LibOS/shim/test/ltp/ltp.cfg
+++ b/LibOS/shim/test/ltp/ltp.cfg
@@ -248,19 +248,11 @@ skip = yes
 [dup05]
 skip = yes
 
-[dup06]
-skip = yes
-
 [dup07]
 must-pass =
     1
     2
     3
-
-[dup201]
-must-pass =
-    1
-    2
 
 [dup202]
 must-pass =
@@ -268,16 +260,7 @@ must-pass =
     2
     3
 
-[dup204]
-timeout = 40
-
-[dup205]
-skip = yes
-
 [dup3_01]
-skip = yes
-
-[dup3_02]
 skip = yes
 
 # complex test, not all of its checking is implemented in Graphene

--- a/LibOS/shim/test/ltp/ltp.cfg
+++ b/LibOS/shim/test/ltp/ltp.cfg
@@ -260,9 +260,6 @@ must-pass =
     2
     3
 
-[dup3_01]
-skip = yes
-
 # complex test, not all of its checking is implemented in Graphene
 [epoll01]
 skip = yes


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Fixes:
* Correct syscall argument signess,
* Correct invalid arg handling (e.g. previously negative fd caused memory corruption inside LibOS),
* Correct handling of O_CLOEXEC flag,
* Checking `RLIMIT_NOFILE` when enlarging fd array.

Some of those issues were randomly triggered by an unrelated PR #1412 - seems that `dup201` was always crashing after the first two tests, but because it was marked as "selectively passing" only those two tests were checked and the return code wasn't checked.

## How to test this PR? <!-- (if applicable) -->

Run LTP on the newly enabled tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1413)
<!-- Reviewable:end -->
