### PR TITLE
[LibOS] Account for cleanup events when walking list of events - fixes hangs

### DIFF
--- a/LibOS/shim/src/shim_async.c
+++ b/LibOS/shim/src/shim_async.c
@@ -218,6 +218,7 @@ static void shim_async_helper(void* arg) {
 
         struct async_event* tmp;
         struct async_event* n;
+        bool other_event = false;
         LISTP_FOR_EACH_ENTRY_SAFE(tmp, n, &async_list, list) {
             /* repopulate `pals` with IO events and find the next expiring alarm/timer */
             if (tmp->object) {
@@ -258,6 +259,9 @@ static void shim_async_helper(void* arg) {
                     /* use time of the next expiring alarm/timer */
                     next_expire_time = tmp->expire_time;
                 }
+            } else {
+                /* cleanup events do not have an object nor a timeout */
+                other_event = true;
             }
         }
 
@@ -265,7 +269,7 @@ static void shim_async_helper(void* arg) {
         if (next_expire_time) {
             sleep_time  = next_expire_time - now;
             idle_cycles = 0;
-        } else if (pals_cnt) {
+        } else if (pals_cnt || other_event) {
             sleep_time = NO_TIMEOUT;
             idle_cycles = 0;
         } else {


### PR DESCRIPTION
This patch fixes occasional hangs at termination of programs with threads.
These hangs occurred since the async helper thread did not properly account
for installed cleanup events but exited instead due to its idle counter
reaching the limit. This happened occasionally.

When the cleanup function wasn't called, a thread's clear_tid pointer
wasn't reset and the futex wasn't WAKE'ed and then the main thread would
end up WAITing on the futex (which still had the original thread id as its
value) and then never received the WAKE.

This patch fixes #1416

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1419)
<!-- Reviewable:end -->
