### PR TITLE
[LibOS,Pal] Support Glibc logic of line-buffered/fully-buffered STDOUT

### DIFF
--- a/Pal/include/pal/pal.h
+++ b/Pal/include/pal/pal.h
@@ -341,6 +341,11 @@ typedef struct PAL_CONTROL_ {
 
     PAL_CPU_INFO cpu_info; /*!< CPU information (only required ones) */
     PAL_MEM_INFO mem_info; /*!< memory information (only required ones) */
+
+    /*
+     * Misc
+     */
+    PAL_BOL is_stdout_tty; /*!< STDOUT is TTY (app prints to term) or non-TTY (to pipe/file) */
 } PAL_CONTROL;
 
 #define pal_control (*pal_control_addr())

--- a/Pal/src/db_main.c
+++ b/Pal/src/db_main.c
@@ -395,6 +395,7 @@ noreturn void pal_main (
     __pal_control.host_type          = XSTRINGIFY(HOST_TYPE);
     __pal_control.process_id         = _DkGetProcessId();
     __pal_control.host_id            = _DkGetHostId();
+    __pal_control.is_stdout_tty      = _DkIsStdoutTty();
     __pal_control.manifest_handle    = manifest_handle;
     __pal_control.executable         = exec_uri;
     __pal_control.parent_process     = parent_process;

--- a/Pal/src/host/Linux-SGX/db_main.c
+++ b/Pal/src/host/Linux-SGX/db_main.c
@@ -82,6 +82,11 @@ PAL_NUM _DkGetHostId (void)
     return 0;
 }
 
+PAL_BOL _DkIsStdoutTty(void) {
+    /* is_stdout_tty is initialized in untrusted runtime during enclave creation and buffered */
+    return pal_sec.is_stdout_tty;
+}
+
 #include "elf-x86_64.h"
 #include "dynamic_link.h"
 #include <asm/errno.h>
@@ -272,6 +277,7 @@ void pal_linux_main(char * uptr_args, uint64_t args_size,
 
     COPY_ARRAY(pal_sec.pipe_prefix, sec_info.pipe_prefix);
     pal_sec.qe_targetinfo = sec_info.qe_targetinfo;
+    pal_sec.is_stdout_tty = sec_info.is_stdout_tty;
 #ifdef DEBUG
     pal_sec.in_gdb = sec_info.in_gdb;
 #endif

--- a/Pal/src/host/Linux-SGX/pal_security.h
+++ b/Pal/src/host/Linux-SGX/pal_security.h
@@ -52,6 +52,9 @@ struct pal_sec {
     /* Need to pass in the number of cores */
     PAL_NUM         num_cpus;
 
+    /* STDOUT is TTY (app prints to term) or non-TTY (app prints to pipe/file) */
+    PAL_BOL         is_stdout_tty;
+
 #ifdef DEBUG
     PAL_BOL         in_gdb;
 #endif

--- a/Pal/src/host/Linux/db_main.c
+++ b/Pal/src/host/Linux/db_main.c
@@ -37,6 +37,7 @@
 #include <asm/mman.h>
 #include <elf/elf.h>
 #include <sysdeps/generic/ldsodefs.h>
+#include <termios.h>
 
 /* At the begining of entry point, rsp starts at argc, then argvs,
    envps and auxvs. Here we store rsp to rdi, so it will not be
@@ -186,6 +187,18 @@ PAL_NUM _DkGetProcessId (void)
 PAL_NUM _DkGetHostId (void)
 {
     return 0;
+}
+
+PAL_BOL _DkIsStdoutTty(void) {
+    struct termios term;
+    int ret = INLINE_SYSCALL(ioctl, 3, STDOUT_FILENO, TCGETS, &term);
+    if (IS_ERR(ret)) {
+        /* mark STDOUT as not TTY (app writes to pipe/file); Glibc considers it fully-buffered */
+        return false;
+    }
+
+    /* mark STDOUT as TTY (app writes to terminal); Glibc considers it line-buffered */
+    return true;
 }
 
 #include "dynamic_link.h"

--- a/Pal/src/host/Skeleton/db_main.c
+++ b/Pal/src/host/Skeleton/db_main.c
@@ -62,7 +62,6 @@ PAL_BOL _DkIsStdoutTty(void) {
 }
 
 int _DkGetCPUInfo (PAL_CPU_INFO * ci)
-int _DkGetCPUInfo (PAL_CPU_INFO * ci)
 {
     /* needs to be implemented */
     return 0;

--- a/Pal/src/host/Skeleton/db_main.c
+++ b/Pal/src/host/Skeleton/db_main.c
@@ -56,6 +56,12 @@ PAL_NUM _DkGetHostId (void)
     return 0;
 }
 
+PAL_BOL _DkIsStdoutTty(void) {
+    /* mark STDOUT as not TTY (app writes to pipe/file); Glibc considers it fully-buffered */
+    return false;
+}
+
+int _DkGetCPUInfo (PAL_CPU_INFO * ci)
 int _DkGetCPUInfo (PAL_CPU_INFO * ci)
 {
     /* needs to be implemented */

--- a/Pal/src/pal_internal.h
+++ b/Pal/src/pal_internal.h
@@ -219,6 +219,7 @@ void _DkGetAvailableUserAddressRange (PAL_PTR * start, PAL_PTR * end, PAL_PTR * 
 bool _DkCheckMemoryMappable (const void * addr, size_t size);
 PAL_NUM _DkGetProcessId (void);
 PAL_NUM _DkGetHostId (void);
+PAL_BOL _DkIsStdoutTty(void);
 unsigned long _DkMemoryQuota (void);
 unsigned long _DkMemoryAvailableQuota (void);
 // Returns 0 on success, negative PAL code on failure


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Glibc has special handling of STDOUT: it checks whether STDOUT is TTY (app writes to a terminal) or non-TTY (app writes to a pipe/file) and makes STDOUT line-buffered or fully-buffered respectively. Glibc uses a trick with IOCTL(TCGETS) to find out whether it is TTY or non-TTY. Previously, Graphene always returned `-EINVAL` on this IOCTL, so STDOUT in Graphene was always fully-buffered. This inconsistency led to e.g. `close(STDOUT)` without printing out buffered strings.

This PR fixes this by propagating info on TTY/non-TTY from the host.

## How to test this PR? <!-- (if applicable) -->

Unfortunately, I didn't find a way to test it in our LibOS tests. Our PyTest framework redirects STDOUT to a pipe (no surprises here), so STDOUT is always detected to be non-TTY and thus fully-buffered. I didn't come up with a way to force PyTest to make STDOUT line-buffered.

One can manually test it though. Just add `close(STDOUT_FILENO)` to `shared_object.c` LibOS test and run. The original app will output `Hello World`; old Graphene will not output anything; and Graphene with this patch will correctly output `Hello World`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1423)
<!-- Reviewable:end -->
