### PR TITLE
[Linux-SGX] tools: improve APIs to simplify usage in libraries

### DIFF
--- a/Pal/src/host/Linux-SGX/tools/common/attestation.c
+++ b/Pal/src/host/Linux-SGX/tools/common/attestation.c
@@ -339,8 +339,8 @@ int verify_quote(const void* quote_data, size_t quote_size, const char* mr_signe
                 HEXDUMP(body->mr_signer);
                 ERROR("Expected mr_signer:\n");
                 HEXDUMP(expected_mr);
-                goto out;
             }
+            goto out;
         }
 
         DBG("Quote: mr_signer OK\n");
@@ -361,8 +361,8 @@ int verify_quote(const void* quote_data, size_t quote_size, const char* mr_signe
                 HEXDUMP(body->mr_enclave);
                 ERROR("Expected mr_enclave:\n");
                 HEXDUMP(expected_mr);
-                goto out;
             }
+            goto out;
         }
 
         DBG("Quote: mr_enclave OK\n");
@@ -421,6 +421,7 @@ int verify_quote(const void* quote_data, size_t quote_size, const char* mr_signe
                 ERROR("Expected report_data:\n");
                 HEXDUMP(rd);
             }
+            goto out;
         }
 
         DBG("Quote: report_data OK\n");

--- a/Pal/src/host/Linux-SGX/tools/common/attestation.h
+++ b/Pal/src/host/Linux-SGX/tools/common/attestation.h
@@ -47,36 +47,49 @@ void display_report_body(const sgx_report_body_t* body);
  *  \param[in] ias_sig_b64_size   Size of \a ias_sig_b64 in bytes.
  *  \param[in] allow_outdated_tcb Treat IAS status GROUP_OUT_OF_DATE as OK.
  *  \param[in] nonce              (Optional) Nonce that's expected in the report.
- *  \param[in] mr_signer          (Optional) Expected mr_signer quote field (hex string).
- *  \param[in] mr_enclave         (Optional) Expected mr_enclave quote field (hex string).
- *  \param[in] isv_prod_id        (Optional) Expected isv_prod_id quote field (decimal string).
- *  \param[in] isv_svn            (Optional) Expected isv_svn quote field (decimal string).
- *  \param[in] report_data        (Optional) Expected report_data quote field (hex string).
+ *  \param[in] mr_signer          (Optional) Expected mr_signer quote field.
+ *  \param[in] mr_enclave         (Optional) Expected mr_enclave quote field.
+ *  \param[in] isv_prod_id        (Optional) Expected isv_prod_id quote field.
+ *  \param[in] isv_svn            (Optional) Expected isv_svn quote field.
+ *  \param[in] report_data        (Optional) Expected report_data quote field.
  *  \param[in] ias_pub_key_pem    (Optional) IAS public RSA key (PEM format, NULL-terminated).
  *                                If not specified, a hardcoded Intel's key is used.
+ *  \param[in] expected_as_str    If true, then all expected SGX fields are treated as hex and
+ *                                decimal strings. Otherwise, they are treated as raw bytes.
+ *
+ *  If \a expected_as_str is true, then \a mr_signer, \a mr_enclave and \a report_data are treated
+ *  as hex strings, and \a isv_prod_id and a isv_svn are treated as decimal strings. This is
+ *  convenient for command-line utilities.
  *
  *  \return 0 on successful verification, negative value on error.
  */
 int verify_ias_report(const uint8_t* ias_report, size_t ias_report_size, uint8_t* ias_sig_b64,
                       size_t ias_sig_b64_size, bool allow_outdated_tcb, const char* nonce,
                       const char* mrsigner, const char* mrenclave, const char* isv_prod_id,
-                      const char* isv_svn, const char* report_data, const char* ias_pub_key_pem);
+                      const char* isv_svn, const char* report_data, const char* ias_pub_key_pem,
+                      bool expected_as_str);
 
 /*!
  *  \brief Verify that the provided SGX quote contains expected values.
  *
- *  \param[in] quote_data  Quote to verify.
- *  \param[in] quote_size  Size of \a quote_data in bytes.
- *  \param[in] mr_signer   (Optional) Expected mr_signer quote field (hex string).
- *  \param[in] mr_enclave  (Optional) Expected mr_enclave quote field (hex string).
- *  \param[in] isv_prod_id (Optional) Expected isv_prod_id quote field (decimal string).
- *  \param[in] isv_svn     (Optional) Expected isv_svn quote field (decimal string).
- *  \param[in] report_data (Optional) Expected report_data quote field (hex string).
+ *  \param[in] quote_data      Quote to verify.
+ *  \param[in] quote_size      Size of \a quote_data in bytes.
+ *  \param[in] mr_signer       (Optional) Expected mr_signer quote field.
+ *  \param[in] mr_enclave      (Optional) Expected mr_enclave quote field.
+ *  \param[in] isv_prod_id     (Optional) Expected isv_prod_id quote field.
+ *  \param[in] isv_svn         (Optional) Expected isv_svn quote field.
+ *  \param[in] report_data     (Optional) Expected report_data quote field.
+ *  \param[in] expected_as_str If true, then all expected SGX fields are treated as hex and
+ *                             decimal strings. Otherwise, they are treated as raw bytes.
+ *
+ *  If \a expected_as_str is true, then \a mr_signer, \a mr_enclave and \a report_data are treated
+ *  as hex strings, and \a isv_prod_id and a isv_svn are treated as decimal strings. This is
+ *  convenient for command-line utilities.
  *
  *  \return 0 on successful verification, negative value on error.
  */
 int verify_quote(const void* quote_data, size_t quote_size, const char* mr_signer,
                  const char* mr_enclave, const char* isv_prod_id, const char* isv_svn,
-                 const char* report_data);
+                 const char* report_data, bool expected_as_str);
 
 #endif /* ATTESTATION_H */

--- a/Pal/src/host/Linux-SGX/tools/common/ias.c
+++ b/Pal/src/host/Linux-SGX/tools/common/ias.c
@@ -366,10 +366,9 @@ out:
     return ret;
 }
 
-int ias_verify_quote(struct ias_context_t* context, const void* quote, size_t quote_size,
-                     const char* nonce, const char* report_path, const char* sig_path,
-                     const char* cert_path, const char* advisory_path) {
-    struct ias_request_resp ias_resp = { 0 };
+/*! Send request to IAS and save response in \a ias_resp; caller is responsible for its cleanup */
+static int ias_send_request(struct ias_context_t* context, struct ias_request_resp* ias_resp,
+                            const void* quote, size_t quote_size, const char* nonce) {
     int ret = -1;
     long response_code;
     char* quote_b64 = NULL;
@@ -430,11 +429,11 @@ int ias_verify_quote(struct ias_context_t* context, const void* quote, size_t qu
         goto out;
 
     /* place to store result */
-    curl_ret = curl_easy_setopt(context->curl, CURLOPT_HEADERDATA, &ias_resp);
+    curl_ret = curl_easy_setopt(context->curl, CURLOPT_HEADERDATA, ias_resp);
     if (CURL_FAIL("set CURLOPT_HEADERDATA", curl_ret))
         goto out;
 
-    curl_ret = curl_easy_setopt(context->curl, CURLOPT_WRITEDATA, &ias_resp);
+    curl_ret = curl_easy_setopt(context->curl, CURLOPT_WRITEDATA, ias_resp);
     if (CURL_FAIL("set CURLOPT_WRITEDATA", curl_ret))
         goto out;
 
@@ -454,9 +453,31 @@ int ias_verify_quote(struct ias_context_t* context, const void* quote, size_t qu
 
     DBG("IAS response: %ld\n", response_code);
 
-    if (!ias_resp.signature || !ias_resp.data) {
+    if (!ias_resp->signature || !ias_resp->data) {
         /* XXX should it be fatal? */
         ERROR("IAS response: missing headers or data\n");
+        goto out;
+    }
+
+    ret = 0;
+
+out:
+    /* cleanup */
+    free(quote_b64);
+    free(quote_json);
+
+    return ret;
+}
+
+int ias_verify_quote(struct ias_context_t* context, const void* quote, size_t quote_size,
+                     const char* nonce, const char* report_path, const char* sig_path,
+                     const char* cert_path, const char* advisory_path) {
+    int ret;
+    struct ias_request_resp ias_resp = { 0 };
+
+    ret = ias_send_request(context, &ias_resp, quote, quote_size, nonce);
+    if (ret < 0) {
+        ERROR("Failed to send request to IAS and receive its response\n");
         goto out;
     }
 
@@ -531,8 +552,125 @@ out:
     free(ias_resp.advisory_url);
     free(ias_resp.advisory_ids);
     free(ias_resp.data);
-    free(quote_b64);
-    free(quote_json);
+
+    return ret;
+}
+
+int ias_verify_quote_raw(struct ias_context_t* context, const void* quote, size_t quote_size,
+                         const char* nonce, char** report_data_ptr, size_t* report_data_size,
+                         char** sig_data_ptr, size_t* sig_data_size, char** cert_data_ptr,
+                         size_t* cert_data_size, char** advisory_data_ptr,
+                         size_t* advisory_data_size) {
+    int ret;
+    struct ias_request_resp ias_resp = { 0 };
+
+    char* report_data   = NULL;
+    char* sig_data      = NULL;
+    char* cert_data     = NULL;
+    char* advisory_data = NULL;
+
+    ret = ias_send_request(context, &ias_resp, quote, quote_size, nonce);
+    if (ret < 0) {
+        ERROR("Failed to send request to IAS and receive its response\n");
+        goto out;
+    }
+
+    /* body_callback and header_callback always add terminating \0, but
+     * don't count it in respective resp_data->*_size, finalize the process
+     */
+    ias_resp.data_size++;
+    ias_resp.signature_size++;
+
+    ret = -1;
+
+    if (report_data_ptr) {
+        assert(report_data_size);
+
+        report_data = malloc(ias_resp.data_size);
+        if (!report_data) {
+            ERROR("Failed to allocate memory for IAS report\n");
+            goto out;
+        }
+        memcpy(report_data, ias_resp.data, ias_resp.data_size);
+
+        *report_data_ptr  = report_data;
+        *report_data_size = ias_resp.data_size;
+    }
+
+    if (sig_data_ptr) {
+        assert(sig_data_size);
+
+        sig_data = malloc(ias_resp.signature_size);
+        if (!sig_data) {
+            ERROR("Failed to allocate memory for IAS signature\n");
+            goto out;
+        }
+        memcpy(sig_data, ias_resp.signature, ias_resp.signature_size);
+
+        *sig_data_ptr  = sig_data;
+        *sig_data_size = ias_resp.signature_size;
+    }
+
+    if (cert_data_ptr) {
+        assert(cert_data_size);
+
+        urldecode(ias_resp.certificate, ias_resp.certificate);
+        ias_resp.certificate_size = strlen(ias_resp.certificate) + 1;
+
+        cert_data = malloc(ias_resp.certificate_size);
+        if (!cert_data) {
+            ERROR("Failed to allocate memory for IAS certificate\n");
+            goto out;
+        }
+        memcpy(cert_data, ias_resp.certificate, ias_resp.certificate_size);
+
+        *cert_data_ptr  = cert_data;
+        *cert_data_size = ias_resp.certificate_size;
+    }
+
+    if (advisory_data_ptr) {
+        assert(advisory_data_size);
+
+        *advisory_data_ptr  = NULL;
+        *advisory_data_size = 0;
+
+        if (ias_resp.advisory_url_size > 0 || ias_resp.advisory_ids_size > 0) {
+            size_t dummy_size_t_int;
+            if (__builtin_add_overflow(ias_resp.advisory_url_size, ias_resp.advisory_ids_size,
+                    &dummy_size_t_int)) {
+                ERROR("Sum of sizes of IAS advisory URL and advisory IDs overflows\n");
+                goto out;
+            }
+            advisory_data = malloc(ias_resp.advisory_url_size + ias_resp.advisory_ids_size);
+            if (!advisory_data) {
+                ERROR("Failed to allocate memory for IAS advisory URL and IDs\n");
+                goto out;
+            }
+            memcpy(advisory_data, ias_resp.advisory_url, ias_resp.advisory_url_size);
+            memcpy(advisory_data + ias_resp.advisory_url_size, ias_resp.advisory_ids,
+                   ias_resp.advisory_ids_size);
+
+            *advisory_data_ptr  = advisory_data;
+            *advisory_data_size = ias_resp.advisory_url_size + ias_resp.advisory_ids_size;
+        }
+    }
+
+    ret = 0;
+
+out:
+    /* cleanup */
+    free(ias_resp.signature);
+    free(ias_resp.certificate);
+    free(ias_resp.advisory_url);
+    free(ias_resp.advisory_ids);
+    free(ias_resp.data);
+
+    if (ret < 0) {
+        free(report_data);
+        free(sig_data);
+        free(cert_data);
+        free(advisory_data);
+    }
 
     return ret;
 }

--- a/Pal/src/host/Linux-SGX/tools/common/ias.h
+++ b/Pal/src/host/Linux-SGX/tools/common/ias.h
@@ -59,12 +59,15 @@ int ias_get_sigrl(struct ias_context_t* context, uint8_t gid[4], size_t* sigrl_s
  * \param[in] context       IAS context returned by ias_init().
  * \param[in] quote         Binary quote data blob.
  * \param[in] quote_size    Size of \a quote.
- * \param[in] nonce         (Optional) Nonce to send with the IAS request (maximum size: 32 bytes).
+ * \param[in] nonce         (Optional) Nonce string to send with the IAS request (max 32 chars).
  * \param[in] report_path   (Optional) File to save IAS report to.
  * \param[in] sig_path      (Optional) File to save IAS report's signature to.
  * \param[in] cert_path     (Optional) File to save IAS certificate to.
  * \param[in] advisory_path (Optional) File to save IAS security advisories to.
  * \return 0 on success, -1 otherwise.
+ *
+ *  This version of the function is convenient for command-line utilities. To get raw IAS contents,
+ *  use ias_verify_quote_raw().
  *
  * \details Sends quote to the "Verify Attestation Evidence" IAS endpoint.
  */
@@ -72,4 +75,33 @@ int ias_verify_quote(struct ias_context_t* context, const void* quote, size_t qu
                      const char* nonce, const char* report_path, const char* sig_path,
                      const char* cert_path, const char* advisory_path);
 
+/*!
+ * \brief Send quote to IAS for verification (same as ias_verify_quote() but not saving to files).
+ *
+ * \param[in] context             IAS context returned by ias_init().
+ * \param[in] quote               Binary quote data blob.
+ * \param[in] quote_size          Size of \a quote.
+ * \param[in] nonce               (Optional) Nonce string to send with IAS request (max 32 chars).
+ * \param[out] report_data_ptr    (Optional) Pointer to allocated IAS report.
+ * \param[out] report_data_size   (Optional) Size of allocated IAS report.
+ * \param[out] sig_data_ptr       (Optional) Pointer to allocated IAS report's signature.
+ * \param[out] sig_data_size      (Optional) Size of allocated IAS report's signature.
+ * \param[out] cert_data_ptr      (Optional) Pointer to allocated IAS certificate.
+ * \param[out] cert_data_size     (Optional) Size of allocated IAS certificate.
+ * \param[out] advisory_data_ptr  (Optional) Pointer to allocated IAS security advisories.
+ * \param[out] advisory_data_size (Optional) Size of allocated IAS security advisories.
+ * \return 0 on success, -1 otherwise.
+ *
+ *  This version of the function is convenient for library usage. This function allocates buffers
+ *  for IAS contents and passes them to caller via \a report_data_ptr, \a sig_data_ptr,
+ *  \a cert_data_ptr and \a advisory_data_ptr. The caller is responsible for freeing them.
+ *  To save IAS contents to files, use ias_verify_quote().
+ *
+ * \details Sends quote to the "Verify Attestation Evidence" IAS endpoint.
+ */
+int ias_verify_quote_raw(struct ias_context_t* context, const void* quote, size_t quote_size,
+                         const char* nonce, char** report_data_ptr, size_t* report_data_size,
+                         char** sig_data_ptr, size_t* sig_data_size, char** cert_data_ptr,
+                         size_t* cert_data_size, char** advisory_data_ptr,
+                         size_t* advisory_data_size);
 #endif /* _IAS_H */

--- a/Pal/src/host/Linux-SGX/tools/common/util.c
+++ b/Pal/src/host/Linux-SGX/tools/common/util.c
@@ -147,6 +147,27 @@ void util_set_fd(int stdout_fd, int stderr_fd) {
     g_stderr_fd = stderr_fd;
 }
 
+/* Print memory as hex in buffer */
+int hexdump_mem_to_buffer(const void* data, size_t size, char* buffer, size_t buffer_size) {
+    uint8_t* ptr = (uint8_t*)data;
+
+    if (buffer_size < size * 2 + 1) {
+        ERROR("Insufficiently large buffer to dump data as hex string\n");
+        return -1;
+    }
+
+    for (size_t i = 0; i < size; i++) {
+        if (g_endianness == ENDIAN_LSB) {
+            sprintf(buffer + i * 2, "%02x", ptr[i]);
+        } else {
+            sprintf(buffer + i * 2, "%02x", ptr[size - i - 1]);
+        }
+    }
+
+    buffer[size * 2] = 0; /* end of string */
+    return 0;
+}
+
 /* Print memory as hex */
 void hexdump_mem(const void* data, size_t size) {
     uint8_t* ptr = (uint8_t*)data;

--- a/Pal/src/host/Linux-SGX/tools/common/util.h
+++ b/Pal/src/host/Linux-SGX/tools/common/util.h
@@ -67,6 +67,9 @@ int write_file(const char* path, size_t size, const void* buffer);
 /*! Append buffer to file */
 int append_file(const char* path, size_t size, const void* buffer);
 
+/*! Print memory as hex to buffer */
+int hexdump_mem_to_buffer(const void* data, size_t size, char* buffer, size_t buffer_size);
+
 /*! Print memory as hex */
 void hexdump_mem(const void* data, size_t size);
 

--- a/Pal/src/host/Linux-SGX/tools/verify-ias-report/verify_ias_report.c
+++ b/Pal/src/host/Linux-SGX/tools/verify-ias-report/verify_ias_report.c
@@ -164,7 +164,8 @@ int main(int argc, char* argv[]) {
     }
 
     int ret = verify_ias_report(report, report_size, sig, sig_size, allow_outdated_tcb, nonce,
-                                mrsigner, mrenclave, isv_prod_id, isv_svn, report_data, ias_pubkey);
+                                mrsigner, mrenclave, isv_prod_id, isv_svn, report_data, ias_pubkey,
+                                /*expected_as_str=*/true);
 
     return ret;
 }


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Previously, APIs `verify_ias_report()`, `verify_quote()`, `ias_verify_quote()` used hex/decimal strings as arguments and saved IAS response contents to files. This is not convenient for library usage.

This PR allows to pass raw-data arguments to `verify_ias_report()` and `verify_quote()`, as well as adds `ias_verify_quote_raw()` to output IAS response contents in memory.

## How to test this PR? <!-- (if applicable) -->

Old interfaces are tested as usual. A follow-up PR on RA-TLS will test the new interfaces.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1426)
<!-- Reviewable:end -->
