### PR TITLE
[Pal/{lib,Linux-SGX}] Put mbedTLS TLS-context init logic in critical section

### DIFF
--- a/Pal/include/lib/pal_crypto.h
+++ b/Pal/include/lib/pal_crypto.h
@@ -137,6 +137,7 @@ int lib_SSLInit(LIB_SSL_CONTEXT* ssl_ctx, int stream_fd, bool is_server,
                 ssize_t (*pal_send_cb)(int fd, const void* buf, size_t len),
                 const uint8_t* buf_load_ssl_ctx, size_t buf_size);
 int lib_SSLFree(LIB_SSL_CONTEXT* ssl_ctx);
+int lib_SSLHandshake(LIB_SSL_CONTEXT* ssl_ctx);
 int lib_SSLRead(LIB_SSL_CONTEXT* ssl_ctx, uint8_t* buf, size_t len);
 int lib_SSLWrite(LIB_SSL_CONTEXT* ssl_ctx, const uint8_t* buf, size_t len);
 int lib_SSLSave(LIB_SSL_CONTEXT* ssl_ctx, uint8_t* buf, size_t len, size_t* olen);

--- a/Pal/src/host/Linux-SGX/db_pipes.c
+++ b/Pal/src/host/Linux-SGX/db_pipes.c
@@ -90,11 +90,13 @@ int thread_handshake_func(void* param) {
 
     int ret = _DkStreamSecureInit(handle, handle->pipe.is_server, &handle->pipe.session_key,
                                   (LIB_SSL_CONTEXT**)&handle->pipe.ssl_ctx, NULL, 0);
-    if (ret < 0)
-        return ret;
+    if (ret < 0) {
+        SGX_DBG(DBG_E, "Failed to initialize secure pipe %s: %d\n", handle->pipe.name.str, ret);
+        _DkProcessExit(1);
+    }
 
     __atomic_store_n(&handle->pipe.handshake_done, 1, __ATOMIC_RELEASE);
-    return ret;
+    return 0;
 }
 
 /*!


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

mbedTLS configuration used in Graphene is not thread-safe (because this would require the use of a threading library like pthread which is not possible in the LibOS/Pal layers). However, some mbedTLS functions use shared state, in particular TLS context initialization functions. This led to data races during encrypted-pipe creation, since it requires two threads performing a TLS handshake. This PR adds spinlocks to protect the racy mbedTLS logic.

## How to test this PR? <!-- (if applicable) -->

All tests must pass. I tested for ~1 hour with:
```
echo "= PAL pipe ="; while [ $? -eq 0 ]; do SGX=1 ~/graphene/Runtime/pal_loader ./Pipe; done
echo "= LibOS pipe ="; while [ $? -eq 0 ]; do SGX=1 ./pal_loader ./pipe; done
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1427)
<!-- Reviewable:end -->
