### PR TITLE
Argument-passing-related cleanup

### DIFF
--- a/Pal/include/lib/api.h
+++ b/Pal/include/lib/api.h
@@ -30,13 +30,6 @@ typedef ptrdiff_t ssize_t;
 
 /* Macros */
 
-#ifndef likely
-# define likely(x)	__builtin_expect((!!(x)),1)
-#endif
-#ifndef unlikely
-# define unlikely(x)	__builtin_expect((!!(x)),0)
-#endif
-
 #ifndef MIN
 #define MIN(a,b) \
    ({ __typeof__(a) _a = (a); \

--- a/Pal/lib/graphene/path.c
+++ b/Pal/lib/graphene/path.c
@@ -65,12 +65,13 @@ static inline bool find_prev_slash_offset(const char* path, size_t* offset) {
 
 /*
  * Before calling this function *size_ptr should hold the size of buf.
- * After returning it holds number of bytes actually written to it (excluding the ending '\0').
+ * After returning it holds number of bytes actually written to it (excluding the ending '\0'). This
+ * number is never greater than the size of the input path.
  */
 int get_norm_path(const char* path, char* buf, size_t* size_ptr) {
-    if (!path || !buf || !size_ptr) {
-        return -PAL_ERROR_INVAL;
-    }
+    assert(path && buf && size_ptr);
+    size_t path_size = strlen(path) + 1;
+    __UNUSED(path_size);  // used only for an assert at the end
 
     size_t size = *size_ptr;
     if (!size) {
@@ -145,6 +146,7 @@ int get_norm_path(const char* path, char* buf, size_t* size_ptr) {
     buf[offset] = '\0';
 
     *size_ptr = ret_size + offset;
+    assert(*size_ptr <= path_size);
 
     return 0;
 }

--- a/Pal/regression/normalize_path.c
+++ b/Pal/regression/normalize_path.c
@@ -3,6 +3,12 @@
 #include "pal_defs.h"
 #include "pal_error.h"
 
+// Required for asserts inside get_norm_path().
+noreturn void __abort(void) {
+    warn("ABORTED\n");
+    DkProcessExit(1);
+}
+
 static const char* get_norm_path_cases[][2] = {
     {"/", "/"},
     {"/a/b/c", "/a/b/c"},

--- a/Pal/src/db_main.c
+++ b/Pal/src/db_main.c
@@ -207,17 +207,15 @@ static int loader_filter (const char * key, int len)
 }
 
 /* 'pal_main' must be called by the host-specific bootloader */
-noreturn void pal_main (
+noreturn void pal_main(
         PAL_NUM    instance_id,      /* current instance id */
         PAL_HANDLE manifest_handle,  /* manifest handle if opened */
         PAL_HANDLE exec_handle,      /* executable handle if opened */
         PAL_PTR    exec_loaded_addr, /* executable addr if loaded */
         PAL_HANDLE parent_process,   /* parent process if it's a child */
         PAL_HANDLE first_thread,     /* first thread handle */
-        PAL_STR *  arguments,        /* application arguments */
-        PAL_STR *  environments      /* environment variables */
-    )
-{
+        PAL_STR*   arguments,        /* application arguments */
+        PAL_STR*   environments      /* environment variables */) {
     pal_state.instance_id = instance_id;
     pal_state.alloc_align = _DkGetAllocationAlignment();
     assert(IS_POWER_OF_2(pal_state.alloc_align));

--- a/Pal/src/db_main.c
+++ b/Pal/src/db_main.c
@@ -351,10 +351,10 @@ noreturn void pal_main (
     /* must be an ELF */
     if (exec_handle) {
         if (exec_loaded_addr) {
-            if (check_elf_magic(exec_loaded_addr, sizeof(ElfW(Ehdr))))
+            if (!has_elf_magic(exec_loaded_addr, sizeof(ElfW(Ehdr))))
                 INIT_FAIL(PAL_ERROR_INVAL, "executable is not an ELF binary");
         } else {
-            if (check_elf_object(exec_handle) < 0)
+            if (!is_elf_object(exec_handle))
                 INIT_FAIL(PAL_ERROR_INVAL, "executable is not an ELF binary");
         }
     }

--- a/Pal/src/db_rtld.c
+++ b/Pal/src/db_rtld.c
@@ -23,6 +23,8 @@
  * Library.
  */
 
+#include <stdbool.h>
+
 #include "pal_defs.h"
 #include "pal.h"
 #include "pal_internal.h"
@@ -427,37 +429,17 @@ postmap:
     return l;
 }
 
-int check_elf_magic (const void* header, size_t len)
-{
-#define ELF_MAGIC_SIZE EI_CLASS
-    if (len < ELF_MAGIC_SIZE)
-        return -PAL_ERROR_INVAL;
-
-    ElfW(Ehdr) * ehdr = (ElfW(Ehdr) *) header;
-
-    static const unsigned char expected[EI_CLASS] =
-    {
-        [EI_MAG0] = ELFMAG0,
-        [EI_MAG1] = ELFMAG1,
-        [EI_MAG2] = ELFMAG2,
-        [EI_MAG3] = ELFMAG3,
-    };
-
-    /* See whether the ELF header is what we expect.  */
-    if (memcmp(ehdr->e_ident, expected, ELF_MAGIC_SIZE) != 0)
-        return -PAL_ERROR_INVAL;
-
-    return 0;
+bool has_elf_magic(const void* header, size_t len) {
+    return len >= SELFMAG && !memcmp(header, ELFMAG, SELFMAG);
 }
 
-int check_elf_object (PAL_HANDLE handle)
-{
-    unsigned char buffer[ELF_MAGIC_SIZE];
+bool is_elf_object(PAL_HANDLE handle) {
+    unsigned char buffer[SELFMAG];
     int64_t len = _DkStreamRead(handle, 0, sizeof(buffer), buffer, NULL, 0);
 
     if (len < 0)
-        return len;
-    return check_elf_magic(buffer, len);
+        return false;
+    return has_elf_magic(buffer, len);
 }
 
 void free_elf_object (struct link_map * map)

--- a/Pal/src/db_rtld.c
+++ b/Pal/src/db_rtld.c
@@ -455,7 +455,7 @@ int check_elf_object (PAL_HANDLE handle)
     unsigned char buffer[ELF_MAGIC_SIZE];
     int64_t len = _DkStreamRead(handle, 0, sizeof(buffer), buffer, NULL, 0);
 
-    if (__builtin_expect(len < 0, 0))
+    if (len < 0)
         return len;
     return check_elf_magic(buffer, len);
 }

--- a/Pal/src/db_streams.c
+++ b/Pal/src/db_streams.c
@@ -150,16 +150,14 @@ static int parse_stream_uri(const char** uri, char** prefix, struct handle_ops**
     return 0;
 }
 
-/* _DkStreamOpen for internal use. Open stream based on uri.
-   access/share/create/options are the same flags defined for
-   DkStreamOpen. */
+/* _DkStreamOpen for internal use. Open stream based on uri. access/share/create/options are the
+ * same flags defined for DkStreamOpen. */
 int _DkStreamOpen(PAL_HANDLE* handle, const char* uri, int access, int share, int create,
                   int options) {
     struct handle_ops* ops = NULL;
-    char* type             = NULL;
+    char* type = NULL;
 
     int ret = parse_stream_uri(&uri, &type, &ops);
-
     if (ret < 0)
         return ret;
 

--- a/Pal/src/host/Linux-SGX/pal_security.h
+++ b/Pal/src/host/Linux-SGX/pal_security.h
@@ -68,6 +68,4 @@ extern struct pal_sec pal_sec;
 #define GRAPHENE_TEMPDIR        "/tmp/graphene"
 #define GRAPHENE_PIPEDIR        (GRAPHENE_TEMPDIR "/pipes")
 
-#define PROC_INIT_FD    255
-
 #endif /* PAL_SECURITY_H */

--- a/Pal/src/host/Linux-SGX/sgx_internal.h
+++ b/Pal/src/host/Linux-SGX/sgx_internal.h
@@ -148,7 +148,7 @@ void thread_exit(int status);
 uint64_t sgx_edbgrd (void * addr);
 void sgx_edbgwr (void * addr, uint64_t data);
 
-int sgx_init_child_process (struct pal_sec * pal_sec);
+int sgx_init_child_process(int parent_pipe_fd, struct pal_sec* pal_sec);
 int sgx_signal_setup (void);
 int block_signals (bool block, const int * sigs, int nsig);
 int block_async_signals (bool block);

--- a/Pal/src/host/Linux/db_main.c
+++ b/Pal/src/host/Linux/db_main.c
@@ -297,7 +297,7 @@ void pal_linux_main (void * args)
     }
     file->file.realpath = path;
 
-    if (!check_elf_object(file)) {
+    if (is_elf_object(file)) {
         exec = file;
         goto done_init;
     }

--- a/Pal/src/host/Linux/db_process.c
+++ b/Pal/src/host/Linux/db_process.c
@@ -127,9 +127,7 @@ struct proc_args {
  * NOTE: more tricks may be needed to prevent unexpected optimization for
  * future compiler.
  */
-static int __attribute_noinline
-child_process (struct proc_param * proc_param)
-{
+static int __attribute_noinline child_process(struct proc_param* proc_param) {
     int ret = ARCH_VFORK();
     if (ret)
         return ret;
@@ -154,9 +152,7 @@ failed:
     return -PAL_ERROR_DENIED;
 }
 
-int _DkProcessCreate (PAL_HANDLE * handle, const char * uri, const char ** args)
-{
-
+int _DkProcessCreate(PAL_HANDLE* handle, const char* uri, const char** args) {
     PAL_HANDLE exec = NULL;
     PAL_HANDLE parent_handle = NULL, child_handle = NULL;
     int ret;
@@ -177,7 +173,7 @@ int _DkProcessCreate (PAL_HANDLE * handle, const char * uri, const char ** args)
          * tell its address to forked process.
          */
         size_t len;
-        const char * file_uri = URI_PREFIX_FILE;
+        const char* file_uri = URI_PREFIX_FILE;
         if (exec_map && exec_map->l_name &&
             (len = strlen(uri)) >= URI_PREFIX_FILE_LEN && !memcmp(uri, file_uri, URI_PREFIX_FILE_LEN) &&
             /* skip "file:"*/
@@ -187,7 +183,7 @@ int _DkProcessCreate (PAL_HANDLE * handle, const char * uri, const char ** args)
             exec->file.map_start = (PAL_PTR)exec_map->l_map_start;
     }
 
-    /* step 2: create parant and child process handle */
+    /* step 2: create parent and child process handle */
 
     struct proc_param param;
     ret = create_process_handle(&parent_handle, &child_handle);
@@ -198,12 +194,12 @@ int _DkProcessCreate (PAL_HANDLE * handle, const char * uri, const char ** args)
     param.exec = exec;
     param.manifest = pal_state.manifest_handle;
 
-    /* step 3: compose process parameter */
+    /* step 3: compose process parameters */
 
     size_t parent_datasz = 0, exec_datasz = 0, manifest_datasz = 0;
-    void * parent_data = NULL;
-    void * exec_data = NULL;
-    void * manifest_data = NULL;
+    void* parent_data = NULL;
+    void* exec_data = NULL;
+    void* manifest_data = NULL;
 
     ret = handle_serialize(parent_handle, &parent_data);
     if (ret < 0)
@@ -230,7 +226,7 @@ int _DkProcessCreate (PAL_HANDLE * handle, const char * uri, const char ** args)
     }
 
     size_t datasz = parent_datasz + exec_datasz + manifest_datasz;
-    struct proc_args * proc_args = __alloca(sizeof(struct proc_args) + datasz);
+    struct proc_args* proc_args = __alloca(sizeof(struct proc_args) + datasz);
 
     proc_args->parent_process_id = linux_state.parent_process_id;
     memcpy(&proc_args->pal_sec, &pal_sec, sizeof(struct pal_sec));
@@ -238,7 +234,7 @@ int _DkProcessCreate (PAL_HANDLE * handle, const char * uri, const char ** args)
     proc_args->pal_sec._r_debug = NULL;
     proc_args->memory_quota = linux_state.memory_quota;
 
-    void * data = (void *) (proc_args + 1);
+    void* data = (void*)(proc_args + 1);
 
     memcpy(data, parent_data, parent_datasz);
     data += (proc_args->parent_data_size = parent_datasz);
@@ -366,7 +362,7 @@ void init_child_process (PAL_HANDLE * parent_handle,
     PAL_HANDLE parent = NULL;
     ret = handle_deserialize(&parent, data, proc_args->parent_data_size);
     if (ret < 0)
-        INIT_FAIL(-ret, "cannot deseilaize parent process handle");
+        INIT_FAIL(-ret, "cannot deserialize parent process handle");
     data += proc_args->parent_data_size;
     *parent_handle = parent;
 

--- a/Pal/src/host/Linux/db_process.c
+++ b/Pal/src/host/Linux/db_process.c
@@ -167,7 +167,7 @@ int _DkProcessCreate (PAL_HANDLE * handle, const char * uri, const char ** args)
         if ((ret = _DkStreamOpen(&exec, uri, PAL_ACCESS_RDONLY, 0, 0, 0)) < 0)
             return ret;
 
-        if (check_elf_object(exec) < 0) {
+        if (!is_elf_object(exec)) {
             ret = -PAL_ERROR_INVAL;
             goto out;
         }

--- a/Pal/src/host/Linux/pal_linux.h
+++ b/Pal/src/host/Linux/pal_linux.h
@@ -157,8 +157,8 @@ int handle_deserialize (PAL_HANDLE * handle, const void * data, int size);
 
 bool stataccess (struct stat * stats, int acc);
 
-void init_child_process (PAL_HANDLE * parent, PAL_HANDLE * exec,
-                         PAL_HANDLE * manifest);
+void init_child_process(int parent_pipe_fd, PAL_HANDLE* parent, PAL_HANDLE* exec,
+                        PAL_HANDLE* manifest);
 
 void cpuid (unsigned int leaf, unsigned int subleaf,
             unsigned int words[]);
@@ -197,8 +197,7 @@ typedef struct pal_tcb_linux {
     };
 } PAL_TCB_LINUX;
 
-noreturn void pal_linux_main (void * args);
-int pal_thread_init (void * tcbptr);
+int pal_thread_init(void* tcbptr);
 
 static inline PAL_TCB_LINUX * get_tcb_linux (void)
 {

--- a/Pal/src/host/Linux/pal_security.h
+++ b/Pal/src/host/Linux/pal_security.h
@@ -67,8 +67,6 @@ extern struct pal_sec {
     struct r_debug* _r_debug;
 } pal_sec;
 
-#define PROC_INIT_FD 255
-
 #define RANDGEN_DEVICE "/dev/urandom"
 
 #endif /* PAL_SECURITY_H */

--- a/Pal/src/pal_internal.h
+++ b/Pal/src/pal_internal.h
@@ -321,8 +321,8 @@ int _DkAttestationQuote(PAL_PTR user_report_data, PAL_NUM user_report_data_size,
 #define DEFAULT_OBJECT_EXEC_ADDR ((void*)0x00400000)
 enum object_type { OBJECT_RTLD, OBJECT_EXEC, OBJECT_PRELOAD, OBJECT_EXTERNAL };
 
-int check_elf_magic (const void* header, size_t len);
-int check_elf_object (PAL_HANDLE handle);
+bool has_elf_magic(const void* header, size_t len);
+bool is_elf_object(PAL_HANDLE handle);
 int load_elf_object (const char * uri, enum object_type type);
 int load_elf_object_by_handle (PAL_HANDLE handle, enum object_type type);
 int add_elf_object(void * addr, PAL_HANDLE handle, int type);

--- a/Pal/src/pal_internal.h
+++ b/Pal/src/pal_internal.h
@@ -309,12 +309,11 @@ int _DkAttestationReport(PAL_PTR user_report_data, PAL_NUM* user_report_data_siz
 int _DkAttestationQuote(PAL_PTR user_report_data, PAL_NUM user_report_data_size,
                         PAL_PTR quote, PAL_NUM* quote_size);
 
-#define INIT_FAIL(exitcode, reason)                                     \
-    do {                                                                \
-        printf("PAL failed at " __FILE__  ":%s:%u (exitcode = %u, reason=%s)\n", \
-               __FUNCTION__, (unsigned int)__LINE__,                    \
-               (unsigned int) (exitcode), (const char *) (reason));     \
-        _DkProcessExit(exitcode);                                       \
+#define INIT_FAIL(exitcode, reason)                                                     \
+    do {                                                                                \
+        printf("PAL failed at " __FILE__  ":%s:%u (exitcode = %u, reason=%s)\n",        \
+               __FUNCTION__, (unsigned int)__LINE__, (unsigned int)(exitcode), reason); \
+        _DkProcessExit(exitcode);                                                       \
     } while (0)
 
 /* function and definition for loading binaries */

--- a/Runtime/pal_loader
+++ b/Runtime/pal_loader
@@ -79,13 +79,18 @@ do
 	break
 done
 
+if [ "$MANIFEST" == "" ]; then
+	echo "Usage: $0 [<executable_path>|<manifest_path>] <args>..."
+	exit 1
+fi
+
 if [ ! -f "$PAL_CMD" ]; then
-	echo "$PAL_CMD is not built, or security mode is not supported"
+	echo "$PAL_CMD is not built"
 	exit 1
 fi
 
 if [ ${#PREFIX[@]} -eq 0 ]; then
-    exec "$PAL_CMD" "$MANIFEST" "$@"
+    exec "$PAL_CMD" init "$MANIFEST" "$@"
 else
-    exec "${PREFIX[@]}" "$PAL_CMD" "$MANIFEST" "$@"
+    exec "${PREFIX[@]}" "$PAL_CMD" init "$MANIFEST" "$@"
 fi

--- a/Scripts/regression.py
+++ b/Scripts/regression.py
@@ -32,7 +32,7 @@ class RegressionTestCase(unittest.TestCase):
         if not pathlib.Path(loader).exists():
             self.skipTest('loader ({}) not found'.format(loader))
 
-        with subprocess.Popen([loader, *args],
+        with subprocess.Popen([loader, 'init', *args],
                 stdout=subprocess.PIPE, stderr=subprocess.PIPE,
                 preexec_fn=os.setpgrp,
                 **kwds) as process:


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

While preparing protected argv/env PR it turned out that everything around argv passing is in a terrible state. This is the first PR in a series which will try to untangle this mess.

The biggest change in this PR is refactoring main functions and interfaces of PAL binaries. Now they take an explicit argument informing them in which mode they start (initial process vs child) and in the latter case, fd number with a pipe to the parent. Previously this differentiation was done by checking a magic fd number.

Reviewing commit-by-commit is recommended.

## How to test this PR? <!-- (if applicable) -->

Jenkins.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1428)
<!-- Reviewable:end -->
