### PR TITLE
Docker integration via Graphene Shielded Containers 

### DIFF
--- a/Documentation/conf.py
+++ b/Documentation/conf.py
@@ -145,6 +145,7 @@ html_static_path = ['_static']
 # (source start file, name, description, authors, manual section).
 man_pages = [
     ('manpages/pal_loader', 'pal_loader', 'FIXME Loader', [author], 1),
+    ('manpages/gsc', 'gsc', 'Graphene Shielded Containers', [author], 1),
     ('manpages/is_sgx_available', 'is_sgx_available', 'Check SGX compatibility', [author], 1),
     ('manpages/quote_dump', 'quote_dump', 'Display SGX quote', [author], 1),
     ('manpages/ias_request', 'ias_request', 'Submit Intel Attestation Service request', [author], 1),

--- a/Documentation/manpages/gsc.rst
+++ b/Documentation/manpages/gsc.rst
@@ -1,0 +1,477 @@
+.. program:: gsc
+
+==============================================
+:program:`gsc` -- Graphene Shielded Containers
+==============================================
+
+.. warning::
+    GSC is still under development and must not be used in production! Please
+    see `issue #1520 <https://github.com/oscarlab/graphene/issues/1520>`__ for a
+    description of missing features and security caveats.
+
+Synopsis
+========
+
+:command:`gsc` *COMMAND* [*OPTIONS*] ...
+
+Description
+===========
+
+Docker containers are widely used to deploy applications in the cloud. Using
+Graphene Shielded Containers (GSC) we provide the infrastructure to deploy Docker
+containers protected by Intel SGX enclaves using the Graphene Library OS.
+
+The :program:`gsc` tool transforms a Docker image into a new image
+(called ``gsc-<image-name>``) which includes the Graphene Library OS, manifest
+files, Intel SGX related information, and executes the application inside an
+Intel SGX enclave using the Graphene Library OS. It follows the common Docker
+approach to first build an image and subsequently run a container of an image.
+At first a Docker image has to be graphenized via the :command:`gsc build`
+command. When the graphenized image should run within an Intel SGX enclave, the
+image has to be signed via a :command:`gsc sign-image` command. Subsequently,
+the image can be run using :command:`docker run`.
+
+Prerequisites
+=============
+
+The installation descriptions of prerequisites are for Ubuntu 18.04 and may
+differ when using a different Ubuntu version or Linux distribution.
+
+Software packages
+-----------------
+
+Please install the ``docker.io``, ``python3``, ``python3-pip`` packages. In
+addition, install the Docker client python package via pip. GSC requires Python
+3.6 or later.
+
+.. code-block:: sh
+
+   sudo apt install docker.io python3 python3-pip
+   pip3 install docker pyyaml jinja2
+
+Kernel modules and services
+---------------------------
+
+To run Intel SGX applications, please install the following kernel driver and
+services.
+
+- `Intel SGX driver <https://github.com/intel/linux-sgx-driver>`__
+- `Intel SGX SDK <https://01.org/intel-software-guard-extensions/downloads>`__
+- `Graphene SGX Driver (kernel module) <https://github.com/oscarlab/graphene-sgx-driver>`__
+
+Host configuration
+------------------
+
+To create Docker images, the user must have access to Docker daemon.
+
+.. warning::
+    Please use this step with caution. By granting the user access to the Docker
+    group, the user may acquire root privileges via :command:`docker run`. You
+    could also run commands as root.
+
+.. code-block:: sh
+
+   sudo adduser $USER docker
+
+Create a configuration file called :file:`config.yaml`. Please see the
+documentation on configuration options below and use the
+:file:`config.yaml.template` as reference.
+
+Command line arguments
+======================
+
+.. option:: --help
+
+   Display usage.
+
+.. program:: gsc-build
+
+:command:`gsc build` -- build graphenized image
+-----------------------------------------------
+
+Builds an unsigned graphenized Docker image of an application image called
+``gsc-<IMAGE-NAME>-unsigned``.
+
+Synopsis:
+
+:command:`gsc build` [*OPTIONS*] <*IMAGE-NAME*> <*APP1.MANIFEST*> [<*APP2.MANIFEST*> ... <*APPN.MANIFEST*>]
+
+.. option:: -d
+
+   Compile Graphene with debug flags and debug output
+
+.. option:: -L
+
+   Compile Graphene with Linux PAL in addition to Linux-SGX PAL
+
+.. option:: -G
+
+   Build Graphene only and ignore the application image (useful for Graphene
+   development, irrelevant for end users of GSC)
+
+.. option:: --insecure-args
+
+   Allow untrusted arguments to be specified at :command:`docker run`. Otherwise
+   any arguments specified during :command:`docker run` are ignored.
+
+.. option:: -nc
+
+   Disable Docker's caches during :command:`gsc build`. This builds the
+   unsigned graphenized image from scratch.
+
+.. option:: --rm
+
+   Remove intermediate Docker images created by :command:`gsc build`, if the
+   image build is successful.
+
+.. option:: IMAGE-NAME
+
+   Name of the application Docker image
+
+.. option:: APP1.MANIFEST
+
+   Application-specific manifest file for the executable entrypoint of the
+   Docker image
+
+.. option:: APPN.MANIFEST
+
+   Application-specific Manifest for the n-th application
+
+
+.. program:: gsc-sign-image
+
+:command:`gsc sign-image` -- signs a graphenized image
+------------------------------------------------------
+
+Signs the enclave of an unsigned graphenized Docker image and creates a new
+Docker image called ``gsc-<IMAGE-NAME>``. :command:`gsc sign-image` always
+removes intermediate Docker images, if successful or not, to ensure the removal
+of the signing key in intermediate Docker images.
+
+Synopsis:
+
+:command:`gsc sign-image` [*OPTIONS*] <*IMAGE-NAME*> <*KEY-FILE*>
+
+.. option:: IMAGE-NAME
+
+   Name of the application Docker image
+
+.. option:: KEY-FILE
+
+   Used to sign the Intel SGX enclave
+
+
+Using Graphene's trusted command line arguments
+-----------------------------------------------
+
+Most applications aren't designed to run with attacker-controlled arguments.
+Allowing an attacker to control application arguments can break the security of
+the resulting enclave.
+
+:command:`gsc build` uses the existing Docker image's entrypoint and cmd fields
+to identify the trusted arguments. These arguments are stored in
+:file:`trusted_argv`. This file is only generated when :option:`--insecure-args
+<gsc-build --insecure-args>` is *not* specified. As a result any arguments
+specified during :command:`docker run` are ignored.
+
+To be able to provide arguments at runtime, the image build has to enable this
+via the option :option:`--insecure-args <gsc-build --insecure-args>`.
+
+Application-specific manifest files
+-----------------------------------
+
+Each application loaded by Graphene requires a separate manifest file.
+:program:`gsc` semi-automatically generates these manifest files. It generates a
+list of trusted files, assumes values for the number of stacks and memory size,
+and generates the chain of trusted children (see below for details). To allow
+specializing each application manifest, :program:`gsc` allows the user to
+augment each generated manifest. In particular, this allows to add additional
+trusted or allowed files and specify a particular enclave size or number of
+Thread Control Structures (TCS).
+
+:program:`gsc` allows application-specific manifest files to be empty or not to
+exist. In this case :program:`gsc` generates a generic manifest file.
+
+Docker images starting multiple applications
+--------------------------------------------
+
+Depending on the use case, a Docker container may execute multiple applications.
+The Docker image defines the entrypoint application which could fork additional
+applications. A common pattern in Docker images executes an entrypoint script
+which calls a set of applications. In Graphene the manifest of a parent
+application has to specify all trusted children that might be forked.
+
+We define the parent-child relationship by overestimating the set of possible
+children. Multiple applications are specified as arguments to :program:`gsc`.
+The example below creates a Docker image with three applications. Based on the
+specified chain of applications, :program:`gsc` generates parent-child
+relationships between application ``appi`` and all applications after it in
+the chain (``> appi``). This overestimates the set of trusted children and may
+not map to the actual partent-child relationship. In the example below ``app1``
+may call ``app2`` or ``app3``, and ``app2`` may call ``app3``, but ``app2`` may
+*not* call ``app1``, and ``app3`` may *not* call ``app1`` or ``app2``.
+
+.. code-block:: sh
+
+   gsc build image app1.manifest app2.manifest app3.manifest
+
+Stages of building graphenized SGX Docker images
+------------------------------------------------
+
+The build process of a graphenized Docker image from image ``<image-name>``
+follows four main stages and produces an image named ``gsc-<image-name>``.
+:command:`gsc build` generates the first two stages (building Graphene and
+graphenizing the base image) and :command:`gsc sign-image` generates the last
+two stages (signing the Intel SGX enclave and generating the final Docker
+image).
+
+Building Graphene
+^^^^^^^^^^^^^^^^^
+
+The first stage compiles Graphene based on the provided configuration (see
+:file:`config.yaml`) which includes the distribution (e.g., Ubuntu 18.04) and the
+Intel SGX driver details.
+
+Graphenizing the base image
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The second stage copies the important Graphene artifacts (e.g., the runtime and
+signer tool) from the first stage. It then prepares image-specific variables
+such as the executable path and the library path, and scans the entire image to
+generate a list of trusted files. GSC excludes files and paths starting with
+:file:`/boot`, :file:`/dev`, :file:`/proc`, :file:`/var`, :file:`/sys` and
+:file:`/etc/rc`, since checksums are required which either don't exist or may
+vary across different deployment machines. GSC combines these variables and list
+of trusted files to a new manifest file. In a last step the entrypoint is
+changed to launch the :file:`apploader.sh` script which generates an Intel SGX
+token and starts the :program:`pal-Linux-SGX` loader. The generated image
+(``gsc-<image-name>-unsigned``) cannot successfully load an Intel SGX enclave,
+since essential files and the signing of the enclave are missing.
+
+Signing the Intel SGX enclave
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The third stage uses Graphene's signer tool to generate SIGSTRUCT files for SGX
+enclave initialization. This tool also generates an SGX-specific manifest files.
+The required signing key is provided by the user via the :command:`gsc
+sign-image` command and copied into this Docker build stage.
+
+Generating a signed graphenized Docker image
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The last stage combines the graphenized Docker image with the signed enclave and
+manifest files. Therefore it copies the SIGSTRUCT files and the SGX-specific
+manifest file from the previous stage into the graphenized Docker image from the
+second stage. The resulting image is called `gsc-<image-name>` and includes all
+necessary files to start an Intel SGX enclave.
+
+Configuration
+=============
+
+GSC is configured via a configuration file called :file:`config.yaml` with the
+following parameters. A template configuration file is provided in
+:file:`config.yaml.template`.
+
+.. describe:: Distro
+
+   Defines Linux distribution to be used to build Graphene in. Currently the
+   only supported value is ``ubuntu18.04``.
+
+.. describe:: Graphene.Repository
+
+   Source repository of Graphene. Default value:
+   `https://github.com/oscarlab/graphene.git
+   <https://github.com/oscarlab/graphene.git>`__
+
+.. describe:: Graphene.Branch
+
+   Use this branch of the repository. Default value: master
+
+.. describe:: SGXDriver.Repository
+
+   Source repository of the Intel SGX driver. Default value:
+   `https://github.com/01org/linux-sgx-driver.git
+   <https://github.com/01org/linux-sgx-driver.git>`__
+
+.. describe:: SGXDriver.Branch
+
+   Use this branch of the repository. Default value: sgx_driver_1.9
+
+Run graphenized Docker images
+=============================
+
+Execute :command:`docker run` command via Docker CLI and provide gsgx and
+isgx/sgx device, and the PSW/AESM socket. Additional Docker options and
+application arguments may be supplied to the :command:`docker run` command.
+
+.. warning::
+   Forwarding devices to a container lowers security of the host. GSC should
+   never be used as a sandbox for applications (i.e. it only shields the app
+   from the host but not vice versa).
+
+.. program:: docker
+
+:command:`docker run` --device=/dev/gsgx --device=/dev/isgx -v /var/run/aesmd/aesm.socket:/var/run/aesmd/aesm.socket [*OPTIONS*] gsc-<*IMAGE-NAME*> [<*ARGUMENTS*>]
+
+.. option:: OPTIONS
+
+   :command:`docker run` options. Common options include ``-it`` (interactive
+   with terminal) or ``-d`` (detached). Please see
+   `Docker manual <https://docs.docker.com/engine/reference/commandline/run/>`__
+   for details.
+
+.. option:: IMAGE-NAME
+
+   Name of original image (without GSC build).
+
+.. option:: ARGUMENTS
+
+   Application arguments to be supplied to the application launching inside the
+   Docker container and Graphene. Such arguments may only be provided when
+   :option:`--insecure-args <gsc-build --insecure-args>` was specified during
+   :command:`gsc build`.
+
+
+Execute with Linux PAL instead of Linux-SGX PAL
+-----------------------------------------------
+
+When specifying :option:`-L <gsc-build -L>`  during GSC :command:`gsc build`,
+you may select the Linux PAL at Docker run time instead of the Linux-SGX PAL by
+specifying the environment variable :envvar:`GSC_PAL` as an option to the
+:command:`docker run` command. When using the Linux PAL, it is not necessary to
+sign the image via a :command:`gsc sign-image` command.
+
+.. envvar:: GSC_PAL
+
+   Specifies the pal loader
+
+.. code-block:: sh
+
+   docker run ... --env GSC_PAL=Linux gsc-<image-name> ...
+
+Example
+=======
+
+The :file:`test` folder in :file:`Tools/gsc` describes how to graphenize Docker
+images and test them with sample inputs. The samples include Ubuntu-based Docker
+images of Bash, Python, nodejs, Numpy, and Pytorch.
+
+.. warning::
+   All test images rely on insecure arguments to be able to set test-specific
+   arguments to each application. These images are not intended for production
+   environments.
+
+The example below shows how to graphenize the public Docker image of Python3.
+This example assumes that all prerequisites are installed and configured.
+
+#. Pull public Python image from Dockerhub:
+
+   .. code-block:: sh
+
+      docker pull python
+
+#. Create a configuration file:
+
+   .. code-block:: sh
+
+      cd Tools/gsc
+      cp config.yaml.template config.yaml
+      # Adopt config.yaml to the installed Intel SGX driver and desired Graphene
+      # repository.
+
+#. Graphenize the Python image using :command:`gsc build`:
+
+   .. code-block:: sh
+
+      ./gsc build --insecure-args python test/ubuntu18.04-python3.manifest
+
+#. Sign the graphenized Docker image using :command:`gsc sign-image`:
+
+   .. code-block:: sh
+
+      # Generate signing key (if you don't already have a key)
+      openssl genrsa -3 -out enclave-key.pem 3072
+      # Sign graphenized Docker image with the key
+      ./gsc sign-image python enclave-key.pem
+
+#. Test the graphenized Docker image:
+
+   .. code-block:: sh
+
+      docker run --device=/dev/gsgx --device=/dev/*sgx \
+         -v /var/run/aesmd/aesm.socket:/var/run/aesmd/aesm.socket \
+         gsc-python -c 'print("HelloWorld!")'
+
+Limitations
+===========
+
+This document focuses on the most important limitations of GSC.
+`Issue #1520 <https://github.com/oscarlab/graphene/issues/1520>`__ provides the
+complete list of known limitations and serves as a discussion board for
+workarounds.
+
+Dependency on Ubuntu 18.04
+--------------------------
+
+Docker images not based on Ubuntu 18.04 may not be compatible with GSC. GSC
+relies on Graphene to execute Linux applications inside Intel SGX enclaves and
+the installation of prerequisites depends on package manager and package
+repositories.
+
+GSC can simply be extended to support other distributions by providing a
+template for this distribution in :file:`Tools/gsc/templates`.
+
+Trusted data in Docker volumes
+------------------------------
+
+Data mounted as Docker volumes at runtime is not included in the general search
+for trusted files during the image build. As a result, Graphene denies access to
+these files, since they are neither allowed nor trusted files. This will likely
+break applications using files stored in Docker volumes.
+
+Workaround
+^^^^^^^^^^
+
+   Trusted files can be added to image-specific manifest file (first argument to
+   :command:`gsc build` command) at build time. This workaround does not allow
+   these files to change between build and run, or over multiple runs. This only
+   provides integrity for files and not confidentiality.
+
+Allowing dynamic file contents via Graphene protected files
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+   Once protected files are supported by Graphene, Docker volumes could include
+   protected files. As a result Graphene can open these protected files without
+   knowing the exact contents as long as the protected file was configured in
+   the application-specific manifest. The complete and secure use of protected
+   files may require additional steps.
+
+Integration of Docker Secrets
+-----------------------------
+
+Docker Secrets are automatically pulled by Docker and the results are stored
+either in environment variables or mounted as files. GSC is currently unaware of
+such files and hence, cannot mark them trusted. Similar to trusted data, these
+files may be added to the application-specific manifest.
+
+Access to files in excluded paths
+---------------------------------
+
+The manifest generation excludes all files and paths starting with
+:file:`/boot`, :file:`/dev`, :file:`/proc`, :file:`/var`, :file:`/sys`, and
+:file:`/etc/rc` from the list of trusted files. If your application
+relies on some files in these directories, you must manually add them to the
+application-specific manifest::
+
+   sgx.trusted_file.some_special_file_unique_name=file:PATH_TO_FILE
+   or
+   sgx.allowed_file.some_special_file_unique_name=file:PATH_TO_FILE
+
+Docker images with non-executables as entrypoint
+------------------------------------------------
+
+Docker images may contain a script entrypoint which is not an ELF executable.
+:program:`gsc` fails to recognize such entrypoints and fails during the image
+build. A workaround relies on creating an image from the application image which
+has an entrypoint of the script interpreter with the script as an argument. This
+allows :program:`gsc` to start the interpreter instead of the script.

--- a/Jenkinsfiles/Linux-SGX-gsc
+++ b/Jenkinsfiles/Linux-SGX-gsc
@@ -1,0 +1,63 @@
+pipeline {
+        agent { label 'sgx_bionic' }
+        stages {
+                stage('Build') {
+                    steps {
+                        sh '''
+                            cd Tools/gsc/test
+                            # Jenkins may automatically merge master into submitted commit (but
+                            # maybe not): choose the original submitted commit for GSC (third
+                            # commit in below git-log output if merged or first commit if not
+                            # merged)
+                            export COMMIT=`git log --pretty="%H %P" -n 1 | awk '{if(!$3) \
+                                                                {print $1} else {print $3}}'`
+                            make TESTCASES=python3 DISTRIBUTIONS="ubuntu18.04" \
+                                 IMAGE_SUFFIX=-${COMMIT} GRAPHENE_BRANCH=${COMMIT}
+                        '''
+                    }
+                }
+                stage('Test') {
+                    steps {
+                        sh '''
+                            cd Tools/gsc/test
+                            # Jenkins may automatically merge master into submitted commit (but
+                            # maybe not): choose the original submitted commit for GSC (third
+                            # commit in below git-log output if merged or first commit if not merged)
+                            export COMMIT=`git log --pretty="%H %P" -n 1 | awk '{if(!$3) \
+                                                                {print $1} else {print $3}}'`
+                            make test MAXTESTNUM=2 TESTCASES=python3 \
+                                      DISTRIBUTIONS="ubuntu18.04" IMAGE_SUFFIX=-${COMMIT}
+                        '''
+                    }
+                }
+                stage('Deploy') {
+                    steps {
+                        sh 'echo Deploying code'
+                    }
+                }
+        }
+        post {
+                success {
+                        echo 'Deployment successful'
+                }
+                failure {
+                        echo 'Failure while on the pipeline'
+                }
+                unstable {
+                        echo 'Pipeline marked as "unstable"'
+                }
+                always {
+                    sh '''
+                        cd Tools/gsc/test
+                        # Jenkins may automatically merge master into submitted commit (but
+                        # maybe not): choose the original submitted commit for GSC (third
+                        # commit in below git-log output if merged or first commit if not merged)
+                        export COMMIT=`git log --pretty="%H %P" -n 1 | awk '{if(!$3) \
+                                                            {print $1} else {print $3}}'`
+                        make clean TESTCASES=python3 \
+                                      DISTRIBUTIONS="ubuntu18.04" IMAGE_SUFFIX=-${COMMIT}
+                        docker image prune -f
+                    '''
+                }
+        }
+}

--- a/README.rst
+++ b/README.rst
@@ -93,6 +93,11 @@ For the full documentation of the Graphene manifest syntax, see the `Graphene
 documentation
 <https://graphene.readthedocs.io/en/latest/manifest-syntax.html>`__.
 
+Automatically running applications via Graphene Shielded Containers (GSC)
+-------------------------------------------------------------------------
+
+Applications deployed as Docker images may be graphenized via the `gsc tool
+<https://graphene.readthedocs.io/en/latest/manpages/gsc.html>`__.
 
 Graphene is *not a production-ready software* (yet)
 ===================================================
@@ -102,7 +107,6 @@ more reliable piece of software. The most important problems (which include
 major security issues) are tracked in
 `#1544 (Production blockers) <https://github.com/oscarlab/graphene/issues/1544>`__.
 You should read it before installing and using Graphene.
-
 
 Getting help
 ============
@@ -121,13 +125,6 @@ Deprecated Code
 ===============
 
 We have some branches with legacy code (use at your own risk).
-
-Docker support
---------------
-
-We are actively working on adding a proper Docker support. You can find the old
-and deprecated implementation on `DEPRECATED/gsc
-<https://github.com/oscarlab/graphene/tree/DEPRECATED/gsc>`__ branch.
 
 Build with Kernel-Level Sandboxing
 ----------------------------------

--- a/Tools/gsc/.gitignore
+++ b/Tools/gsc/.gitignore
@@ -1,0 +1,2 @@
+gsc-*/
+config.yaml

--- a/Tools/gsc/config.yaml.template
+++ b/Tools/gsc/config.yaml.template
@@ -1,0 +1,7 @@
+Distro: "ubuntu18.04"
+Graphene:
+    Repository: "https://github.com/oscarlab/graphene.git"
+    Branch: "master"
+SGXDriver:
+    Repository: "https://github.com/01org/linux-sgx-driver.git"
+    Branch: "sgx_driver_1.9"

--- a/Tools/gsc/finalize_manifests.py
+++ b/Tools/gsc/finalize_manifests.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-3.0-or-later
+# Copyright (C) 2020 Intel Corp.
+#                    Anjo Vahldiek-Oberwagner <anjo.lucas.vahldiek-oberwagner@intel.com>
+
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+import jinja2
+
+def is_ascii(chars):
+    return all(ord(c) < 128 for c in chars)
+
+def generate_trusted_files(root_dir):
+    cwd = os.getcwd() if os.getcwd() != '/' else ''
+    # Exclude files and paths from list of trusted files
+    excluded_paths_regex = (r'^/('
+                                r'boot/.*'
+                                r'|dev/.*'
+                                r'|etc/rc(\d|.)\.d/.*'
+                                r'|proc/.*'
+                                r'|sys/.*'
+                                r'|var/.*)'
+                            f'|^{cwd}/('
+                                r'.*\.manifest'
+                                r'|finalize_manifests\.py'
+                                r'|sign_manifests\.py)$')
+    exclude_re = re.compile(excluded_paths_regex)
+    num_trusted = 0
+    trusted_files = ''
+    script_file = os.path.basename(__file__)
+
+    for root, _, files in os.walk(root_dir, followlinks=False):
+        for file in files:
+            filename = os.path.join(root, file)
+            if  (not exclude_re.match(filename)
+                # The check for ascii-only characters is required, since the manifest syntax does
+                # not support other encodings (e.g., UTF-8).
+                and is_ascii(filename)
+                and os.path.isfile(filename)
+                and filename != script_file):
+                trusted_files += f'sgx.trusted_files.file{num_trusted} = file:{filename}\n'
+                num_trusted += 1
+
+    print(f'Found {num_trusted} files in \'{root_dir}\'.')
+
+    return trusted_files
+
+def generate_library_paths():
+    ld_paths = subprocess.check_output('ldconfig -v',
+                                       stderr=subprocess.PIPE, shell=True).decode().splitlines()
+
+    # Library paths start without whitespace. Libraries found under a path start with an
+    # indentation.
+    ld_paths = (line for line in ld_paths if not re.match(r'(^\s)', line))
+
+    ld_library_paths = os.getenv('LD_LIBRARY_PATH')
+
+    return ''.join(ld_paths) + (ld_library_paths[1:] if ld_library_paths is not None else '')
+
+def get_binary_path(executable):
+    path = subprocess.check_output(f'which {executable}',
+                                   stderr=subprocess.STDOUT, shell=True).decode()
+    return path.replace('\n', '')
+
+argparser = argparse.ArgumentParser()
+argparser.add_argument('directory', default='/',
+    help='Search the directory tree from this root for files and generate list of trusted files')
+argparser.add_argument('manifests',
+    nargs='+',
+    help='Application-specific manifest files. The first manifest will be used for the entry '
+         'point of the docker image. If file does not exist, manifest will be generated '
+         'without application-specific values.')
+
+def main(args=None):
+    args = argparser.parse_args(args[1:])
+
+    if not os.path.isdir(args.directory):
+        argparser.error(f'Could not find directory {args.directory}.')
+
+    trusted_files = generate_trusted_files(args.directory)
+    library_paths = generate_library_paths()
+    env_path = os.getenv('PATH')
+
+    print(f'LD_LIBRARY_PATH = \'{library_paths}\'\nPATH = \'{env_path}\'.')
+
+    env = jinja2.Environment(loader=jinja2.FileSystemLoader('.'))
+    env.globals.update({
+                        'library_paths': library_paths,
+                        'env_path': env_path
+                        })
+
+    trusted_signatures = []
+
+    # To deal with multi-process applications, we allow multiple manifest files to be specified.
+    # User must specify manifest files in the order of parent to child. Here we reverse the list
+    # of manifests to include the signature files of children in the parent. The actual signatures
+    # are generated during 'gsc sign-image' command in a second step.
+    for manifest in reversed(args.manifests):
+        print(f'{manifest}:')
+
+        executable = manifest[:manifest.rfind('.manifest')] if (
+            manifest.rfind('.manifest') != -1) else manifest
+        binary_path = get_binary_path(executable)
+
+        print(f'\tSetting exec file to \'{binary_path}\'.')
+
+        # Write final manifest file with trusted files and children
+        rendered_manifest = env.get_template(manifest).render(binary_path=binary_path)
+        with open(manifest, 'w') as manifest_file:
+            manifest_file.write('\n'.join((rendered_manifest,
+                                trusted_files,
+                                '\n'.join(trusted_signatures),
+                                '\n')))
+
+        print(f'\tWrote {manifest}.')
+
+        trusted_signatures.append(f'sgx.trusted_children.child{len(trusted_signatures)}'
+                                  f' = file:{executable}.sig')
+
+        with open('signing_order.txt', 'a+') as sig_order:
+            print(manifest, file=sig_order)
+
+if __name__ == '__main__':
+    main(sys.argv)

--- a/Tools/gsc/gsc
+++ b/Tools/gsc/gsc
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-3.0-or-later
+# Copyright (C) 2020 Intel Corp.
+#                    Anjo Vahldiek-Oberwagner <anjo.lucas.vahldiek-oberwagner@intel.com>
+
+import sys
+import os
+
+sys.path.insert(0, os.path.dirname(__file__))
+from gsc import main # pylint: disable=import-error,wrong-import-position
+
+sys.exit(main(sys.argv))

--- a/Tools/gsc/gsc.py
+++ b/Tools/gsc/gsc.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-3.0-or-later
+# Copyright (C) 2020 Intel Corp.
+#                    Anjo Vahldiek-Oberwagner <anjo.lucas.vahldiek-oberwagner@intel.com>
+
+import argparse
+import os
+import json
+import re
+import pathlib
+import shutil
+import sys
+import jinja2
+import docker
+import yaml
+
+def gsc_image_name(name):
+    return f'gsc-{name}'
+
+def gsc_unsigned_image_name(name):
+    return f'gsc-{name}-unsigned'
+
+def load_config(file):
+    if not os.path.exists(file):
+        print('Please create file named \'config.yaml\' based on the template configuration '
+              'file called \'config.yaml.template\'.')
+        sys.exit(1)
+
+    with open(file) as config_file:
+        return yaml.safe_load(config_file)
+
+# Generate manifest from a template (see template/manifest.template) based on the binary name.
+# The generated manifest is only partially completed. Later, during the docker build it is
+# finished by adding the list of trusted files, the path to the binary, and LD_LIBRARY_PATH.
+def generate_manifest(image, env, user_manifest, binary):
+    user_mf = ''
+    if os.path.exists(user_manifest):
+        with open(user_manifest, 'r') as user_manifest_file:
+            user_mf = user_manifest_file.read()
+
+    manifest_path = (pathlib.Path(gsc_image_name(image)) / binary).with_suffix('.manifest')
+    with open(manifest_path, 'w') as app_manifest:
+        app_manifest.write(env.get_template('manifest.template').render(binary=binary))
+        app_manifest.write('\n')
+        app_manifest.write(user_mf)
+        app_manifest.write('\n')
+
+# Generate app loader script which generates the SGX token and starts the Graphene PAL loader with
+# the manifest as an input (see template/apploader.template).
+def generate_app_loader(image, env, binary):
+    apploader_path = (pathlib.Path(gsc_image_name(image)) / 'apploader').with_suffix('.sh')
+    with open(apploader_path, 'w') as apploader:
+        apploader.write(env.get_template('apploader.template').render(binary=binary))
+
+# Generate a dockerfile that compiles Graphene and includes the application image. This dockerfile
+# is generated from a template (templates/Dockerfile.$distro.build.template). It follows a docker
+# multistage build with two stages. The first stage compiles Graphene for the specified
+# distribution. The second stage builds the final image based on the previously built Graphene and
+# the base image.
+def generate_dockerfile(image, env, binary):
+    dockerfile_path = (pathlib.Path(gsc_image_name(image)) / 'Dockerfile.build')
+    with open(dockerfile_path, 'w') as dockerfile:
+        dockerfile.write(env.get_template(
+            f'Dockerfile.{env.globals["Distro"]}.build.template').render(binary=binary))
+
+def prepare_build_context(image, user_manifests, env, binary):
+    # create directory for image specific files
+    os.makedirs(f'gsc-{image}', exist_ok=True)
+
+    # generate dockerfile to build graphenized docker image
+    generate_dockerfile(image, env, binary)
+
+    # generate app specific loader script
+    generate_app_loader(image, env, binary)
+
+    # generate manifest stub for this app
+    generate_manifest(image, env, user_manifests[0], binary)
+
+    for user_manifest in user_manifests[1:]:
+        generate_manifest(image, env, user_manifest,
+            user_manifest[user_manifest.rfind('/') + 1 : user_manifest.rfind('.manifest')])
+
+    fm_path = (pathlib.Path(gsc_image_name(image)) / 'finalize_manifests').with_suffix('.py')
+    shutil.copyfile('finalize_manifests.py', fm_path)
+    sm_path = (pathlib.Path(gsc_image_name(image)) / 'sign_manifests').with_suffix('.py')
+    shutil.copyfile('sign_manifests.py', sm_path)
+
+def extract_binary_cmd_from_image_config(config):
+    entrypoint = config['Entrypoint'] or []
+    num_starting_entrypoint_items = len(entrypoint)
+    cmd = config['Cmd'] or []
+
+    # Some Docker images only use the optional CMD and have an empty entrypoint
+    # GSC has to make it explicit to prepare scripts and Intel SGX signatures
+    entrypoint.extend(cmd)
+
+    if len(entrypoint) == 0:
+        print('Could not find the entrypoint binary to the application image.')
+        sys.exit(1)
+
+    # Set binary to first executable in entrypoint
+    binary = os.path.basename(entrypoint[0])
+
+    # Check if we have fixed binary arguments as part of entrypoint
+    if num_starting_entrypoint_items > 1:
+        last_bin_arg = num_starting_entrypoint_items
+        escaped_args = [s.replace('\\', '\\\\').replace('"', '\\"')
+                        for s in entrypoint[1:last_bin_arg]]
+        binary_arguments = '"' + '", "'.join(escaped_args) + '"'
+    else:
+        last_bin_arg = 0
+        binary_arguments = ''
+
+    # Place the remaining optional arguments previously specified as command, in the
+    # new command. This is necessary, since the first element of the command may be the
+    # binary of the resulting image.
+    cmd = entrypoint[last_bin_arg + 1 : ] if len(entrypoint) > last_bin_arg + 1 else ''
+    cmd = [s.replace('\\', '\\\\').replace('"', '\\"') for s in cmd]
+
+    return binary, binary_arguments, cmd
+
+def extract_working_dir(image):
+    working_dir = image.attrs['Config']['WorkingDir']
+    if working_dir == '':
+        working_dir = '/'
+    elif working_dir[-1] != '/':
+        working_dir = working_dir + '/'
+
+    return working_dir
+
+def prepare_env(base_image, image, args, user_manifests):
+    env = jinja2.Environment(loader=jinja2.FileSystemLoader('templates/'))
+
+    env.globals.update(vars(args))
+    config = load_config('config.yaml')
+    env.globals.update(config)
+
+    # Image names follow the format distro/package:tag
+    image_re = re.match(r'([^:]*)(:?)(.*)', image[image.rfind('/')+1:])
+
+    # Extract binary and command from base_image
+    binary, binary_arguments, cmd = extract_binary_cmd_from_image_config(
+        base_image.attrs['Config'])
+
+    working_dir = extract_working_dir(base_image)
+
+    env.globals.update({
+            'app_image': image,
+            'app': image_re.group(1),
+            'binary_arguments': binary_arguments,
+            'cmd': cmd,
+            'working_dir': working_dir,
+            'user_manifests': ' '.join([os.path.basename(manifest)
+                                       for manifest in user_manifests[1:]])
+            })
+
+    return env, binary
+
+def get_docker_image(docker_socket, image):
+    try:
+        docker_image = docker_socket.images.get(image)
+        return docker_image
+
+    except (docker.errors.ImageNotFound, docker.errors.APIError):
+        return None
+
+def build_docker_image(path, name, dockerfile, **kwargs):
+    docker_api = docker.APIClient(base_url='unix://var/run/docker.sock')
+    # Docker build returns stream of json output
+    stream = docker_api.build(path=path,
+                              tag=name,
+                              dockerfile=dockerfile,
+                              **kwargs)
+
+    # Print continuously the stream of output by docker build
+    for chunk in stream:
+        json_output = json.loads(chunk.decode(sys.stdout.encoding
+                                    if sys.stdout.encoding is not None else 'UTF-8'))
+        if 'stream' in json_output:
+            for line in json_output['stream'].splitlines():
+                print(line)
+
+# Build graphenized docker image. args has to follow [<options>] <base_image> <app.manifest>
+# [<app2.manifest> ...].
+def gsc_build(args):
+    image = args.image
+    user_manifests = args.manifests
+
+    docker_socket = docker.from_env()
+
+    if get_docker_image(docker_socket, gsc_image_name(image)) is not None:
+        print(f'Image {gsc_image_name(image)} already exists, no gsc build required.')
+        sys.exit(0)
+
+    base_image = get_docker_image(docker_socket, image)
+    if base_image is None:
+        print(f'Unable to find base image {image}')
+        sys.exit(1)
+
+    print(f'Building graphenized image from base image {image}')
+
+    env, binary = prepare_env(base_image, image, args, user_manifests)
+
+    prepare_build_context(image, user_manifests, env, binary)
+
+    build_docker_image(gsc_image_name(image), gsc_unsigned_image_name(image), 'Dockerfile.build',
+                       rm=args.rm, nocache=args.no_cache)
+
+    # Check if docker build failed
+    if get_docker_image(docker_socket, gsc_unsigned_image_name(image)) is None:
+        print(f'Failed to build graphenized image for {image}')
+        sys.exit(1)
+
+    print(f'Successfully graphenized docker image {image} into docker image '
+          f'{gsc_unsigned_image_name(image)}')
+
+def generate_dockerfile_sign_manifests(image, env):
+
+    dockerfile_path = (pathlib.Path(gsc_image_name(image)) / 'Dockerfile.sign_manifests')
+    with open(dockerfile_path, 'w') as dockerfile:
+        dockerfile.write(env.get_template(
+            f'Dockerfile.{env.globals["Distro"]}.sign_manifests.template')
+            .render(image=gsc_unsigned_image_name(image)))
+
+def gsc_sign_image(args):
+
+    image = args.image
+    key = args.key
+
+    docker_socket = docker.from_env()
+
+    gsc_image = get_docker_image(docker_socket, gsc_unsigned_image_name(image))
+    if gsc_image is None:
+        print(f'Could not find graphenized Docker image of {image}.\n'
+              f'Please make sure to build the graphenized image first by using gsc build command.')
+        sys.exit(1)
+
+    env = jinja2.Environment(loader=jinja2.FileSystemLoader('templates/'))
+    config = load_config('config.yaml')
+    env.globals.update(config)
+    env.globals.update({'working_dir': extract_working_dir(gsc_image)})
+
+    generate_dockerfile_sign_manifests(image, env)
+
+    fk_path = (pathlib.Path(gsc_image_name(image)) / 'gsc-signer-key').with_suffix('.pem')
+    shutil.copyfile(os.path.abspath(key), fk_path)
+
+    try:
+        # We force the removal of intermediate Docker images to not leave the signing
+        # key in a Docker container.
+        build_docker_image(gsc_image_name(image), gsc_image_name(image),
+                           'Dockerfile.sign_manifests', forcerm=True)
+
+    finally:
+        # Remove key file from the temporary folder
+        os.remove(fk_path)
+
+        # Check if docker build failed
+        if get_docker_image(docker_socket, gsc_image_name(image)) is None:
+            print(f'Failed to sign graphenized image for {image}')
+            sys.exit(1)
+
+        print(f'Successfully signed docker image {gsc_unsigned_image_name(image)} into docker '
+              f'image {gsc_image_name(image)}.')
+
+argparser = argparse.ArgumentParser()
+subcommands = argparser.add_subparsers(metavar='<command>')
+subcommands.required = True
+sub_build = subcommands.add_parser('build', help="Build graphenized Docker image")
+sub_build.set_defaults(command=gsc_build)
+sub_build.add_argument('-d', '--debug', action='store_true',
+    help='Compile Graphene with debug flags and output.')
+sub_build.add_argument('-L', '--linux', action='store_true',
+    help='Compile Graphene with Linux PAL in addition to Linux-SGX PAL.')
+sub_build.add_argument('-G', '--graphene', action='store_true',
+    help='Build Graphene only and ignore the application image (useful for Graphene development, '
+         'irrelevant for end users of GSC).')
+sub_build.add_argument('--insecure-args', action='store_true',
+    help='Allow to specify untrusted arguments during Docker run. '
+         'Otherwise arguments are ignored.')
+sub_build.add_argument('-nc', '--no-cache', action='store_true',
+    help='Build graphenized Docker image without any cached images.')
+sub_build.add_argument('--rm', action='store_true',
+    help='Remove intermediate Docker images when build is successful.')
+sub_build.add_argument('image',
+    help='Name of the application Docker image.')
+sub_build.add_argument('manifests',
+    nargs='+',
+    help='Application-specific manifest files. The first manifest will be used for the entry '
+         'point of the Docker image.')
+
+sub_sign = subcommands.add_parser('sign-image', help="Sign graphenized Docker image")
+sub_sign.set_defaults(command=gsc_sign_image)
+sub_sign.add_argument('image',
+    help='Name of the application Docker image.')
+sub_sign.add_argument('key',
+    help='Key for signing the image.')
+
+def main(args):
+    args = argparser.parse_args()
+    return args.command(args)

--- a/Tools/gsc/sign_manifests.py
+++ b/Tools/gsc/sign_manifests.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-3.0-or-later
+# Copyright (C) 2020 Intel Corp.
+#                    Anjo Vahldiek-Oberwagner <anjo.lucas.vahldiek-oberwagner@intel.com>
+
+import os
+import sys
+import subprocess
+import argparse
+
+def generate_signature(manifest):
+    sign_process = subprocess.Popen([
+        '/graphene/signer/pal-sgx-sign',
+        '-libpal', '/graphene/Runtime/libpal-Linux-SGX.so',
+        '-key', '/gsc-signer-key.pem',
+        '-output', f'{manifest}.sgx',
+        '-manifest', manifest
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=os.environ.update({'PYTHONDONTWRITEBYTECODE':'1'}))
+
+    _, err = sign_process.communicate()
+
+    if (sign_process.returncode != 0
+        or not os.path.exists(os.path.join('./', manifest + '.sgx'))
+        or not os.path.exists(os.path.join('./', manifest[:manifest.rfind('.manifest')] + '.sig'))):
+        print(err.decode())
+        print('Finalize manifests failed due to pal-sgx-sign failure.')
+        sys.exit(1)
+
+# Iterate over manifest file to find enclave size definition and return it
+def extract_enclave_size(manifest):
+    with open(manifest, 'r') as file:
+        for line in file:
+            if not line.strip().startswith('sgx.enclave_size'):
+                continue
+
+            tokens = line.split('=')
+            if len(tokens) != 2:
+                continue
+            return tokens[1].strip()
+
+    return '0M'
+
+argparser = argparse.ArgumentParser()
+argparser.add_argument('signing_order', default='signing_order.txt',
+    help='File specifying the order in which manifest should be signed. '
+         'Default: signing_order.txt')
+
+def main(args=None):
+    args = argparser.parse_args(args[1:])
+
+    print('Signing manifests:')
+
+    sig_order_file = args.signing_order
+    if not os.path.exists(sig_order_file):
+        print(f'Failed to generate signatures, since image misses {sig_order_file}.')
+
+    # To deal with multi-process applications, we sign the application manifests in the order
+    # specified by finalize_manifests.py. The order is stored in a temporary file called
+    # signature_order.txt.
+    with open(sig_order_file, 'r') as sig_order:
+        manifest_files = sig_order.read().splitlines()
+        for manifest in manifest_files:
+            generate_signature(manifest)
+
+            print(f'\t{manifest}')
+
+        # In case multiple manifest files were generated, ensure that their enclave sizes are
+        # compatible
+        if len(manifest_files) > 1:
+            main_encl_size = extract_enclave_size(manifest_files[0] + '.sgx')
+            for manifest in manifest_files:
+                if main_encl_size != extract_enclave_size(manifest + '.sgx'):
+                    print('Error: Detected a child manifest with an enclave size different than '
+                          'its parent.')
+                    sys.exit(1)
+
+if __name__ == '__main__':
+    main(sys.argv)

--- a/Tools/gsc/templates/Dockerfile.ubuntu18.04.build.template
+++ b/Tools/gsc/templates/Dockerfile.ubuntu18.04.build.template
@@ -1,0 +1,106 @@
+FROM ubuntu:18.04 AS graphene
+
+# Add steps here to set up dependencies
+RUN env DEBIAN_FRONTEND=noninteractive apt-get update \
+    && env DEBIAN_FRONTEND=noninteractive apt-get install -y \
+        autoconf \
+        bison \
+        build-essential \
+        coreutils \
+        gawk \
+        git \
+        libcurl4-openssl-dev \
+        libprotobuf-c-dev \
+        protobuf-c-compiler \
+        python3-protobuf \
+        wget
+
+# Clone graphene
+RUN git clone {{Graphene.Repository}} /graphene
+
+# Init submodules
+RUN cd /graphene \
+    && git fetch origin {{Graphene.Branch}} \
+    && git checkout origin/{{Graphene.Branch}} \
+    && git submodule update --init -- Pal/src/host/Linux-SGX/sgx-driver/
+
+# Create SGX driver for header files
+RUN cd /graphene/Pal/src/host/Linux-SGX/sgx-driver \
+    && git clone {{SGXDriver.Repository}} linux-sgx-driver \
+    && cd linux-sgx-driver \
+    && git checkout {{SGXDriver.Branch}}
+
+# Build Graphene-SGX
+RUN cd /graphene && ISGX_DRIVER_PATH=/graphene/Pal/src/host/Linux-SGX/sgx-driver/linux-sgx-driver \
+    make -s -j4 SGX=1 {% if debug %} DEBUG=1 {% endif %} WERROR=1 \
+    {% if linux %} && make -s -j4 WERROR=1 {% if debug %} DEBUG=1 {% endif %} {% else %} && true {%endif %}
+
+# Translate runtime symlinks to files
+RUN for f in $(find /graphene/Runtime -type l); do cp --remove-destination $(readlink $f) $f; done
+
+# Finished building Graphene
+
+{% if not graphene %}
+
+# Integrate Graphene into the app image
+# This file is used in a multistage docker build process, in which the previous image is named "graphene"
+FROM {{app_image}}
+
+# Update any packages
+RUN apt-get update \
+    && env DEBIAN_FRONTEND=noninteractive apt-get install -y \
+        python3 \
+        python3-pip \
+        python3-protobuf \
+        libprotobuf-c-dev \
+        binutils \
+        openssl \
+    && python3 -B -m pip install protobuf jinja2
+
+{% if debug %}
+# Install GDB and related tools when Debug is enabled
+RUN env DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    gdb \
+    less \
+    strace \
+    vim
+{% endif %}
+
+# Copy Graphene runtime and signer tools to /graphene
+RUN mkdir -p /graphene \
+    && mkdir -p /graphene/Runtime \
+    && mkdir -p /graphene/signer \
+    && mkdir -p /graphene/Tools \
+    && mkdir -p /graphene/Pal/src
+COPY --from=graphene /graphene/Runtime/ /graphene/Runtime
+COPY --from=graphene /graphene/Pal/src/host/Linux-SGX/signer/aesm_pb2.py /graphene/signer
+COPY --from=graphene /graphene/Pal/src/host/Linux-SGX/signer/pal-sgx-get-token /graphene/signer
+COPY --from=graphene /graphene/Pal/src/host/Linux-SGX/signer/pal-sgx-sign /graphene/signer
+COPY --from=graphene /graphene/Pal/src/host/Linux-SGX/signer/pal_sgx_sign.py /graphene/signer
+COPY --from=graphene /graphene/Pal/src/host/Linux-SGX/generated_offsets.py /graphene/signer/
+COPY --from=graphene /graphene/Tools/argv_serializer /graphene/Tools
+{% if debug %}
+COPY --from=graphene /graphene/Pal/src/host/Linux-SGX/debugger/sgx_gdb.so /graphene/Runtime
+COPY --from=graphene /graphene/Pal/src/host/Linux-SGX/debugger/pal-gdb.py /graphene/Runtime
+{% endif %}
+
+# Copy template scripts and manifests
+COPY apploader.sh ./
+COPY *.manifest ./
+COPY *.py ./
+
+{% if not insecure_args %}
+# Generate trusted arguments
+RUN /graphene/Tools/argv_serializer {{binary}} {{binary_arguments}} "{{"\" \"".join(cmd)}}" > trusted_argv
+{% endif %}
+
+# Mark apploader.sh executable, finalize manifests, and remove intermediate scripts
+RUN chmod u+x apploader.sh \
+    && python3 -B finalize_manifests.py / {{binary}}.manifest {{user_manifests}} \
+    && rm -f finalize_manifests.py
+
+# Define default command
+ENTRYPOINT ["/bin/sh", "./apploader.sh"]
+CMD [{% if insecure_args %} "{{'", "'.join(cmd)}}" {% endif %}]
+
+{% endif %}

--- a/Tools/gsc/templates/Dockerfile.ubuntu18.04.sign_manifests.template
+++ b/Tools/gsc/templates/Dockerfile.ubuntu18.04.sign_manifests.template
@@ -1,0 +1,14 @@
+# We sign the image in a multi-stage build to ensure that the signing key is never part of the
+# final image.
+FROM {{image}} as unsigned_image
+
+COPY gsc-signer-key.pem /gsc-signer-key.pem
+
+RUN python3 -B sign_manifests.py signing_order.txt
+
+FROM {{image}}
+
+COPY --from=unsigned_image {{working_dir}}*.sig ./
+COPY --from=unsigned_image {{working_dir}}*.sgx ./
+
+RUN rm signing_order.txt sign_manifests.py /graphene/signer/pal-sgx-sign /graphene/signer/pal_sgx_sign.py

--- a/Tools/gsc/templates/apploader.template
+++ b/Tools/gsc/templates/apploader.template
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+set -ex
+
+# Generate EINITOKEN for all applications
+for manifest in {{binary}}.manifest {{user_manifests}}
+do
+    # Remove .manifest from file
+    executable=${manifest%.manifest}
+    /graphene/signer/pal-sgx-get-token -output ${executable}.token -sig ${executable}.sig
+done
+
+# Run the application with arguments given to it
+if [ -z "$GSC_PAL" ]
+then
+    SGX=1 /graphene/Runtime/pal-Linux-SGX init {{binary}}.manifest.sgx {% if insecure_args %} {{binary_arguments}} "${@}" {% endif %}
+else
+    /graphene/Runtime/pal-$GSC_PAL init {{binary}}.manifest {{binary_arguments}} "${@}"
+fi

--- a/Tools/gsc/templates/manifest.template
+++ b/Tools/gsc/templates/manifest.template
@@ -1,0 +1,32 @@
+loader.preload = file:/graphene/Runtime/libsysdb.so
+
+# Get path of binary
+loader.exec = file:{{"{{binary_path}}"}}
+loader.execname = {{binary}}
+loader.env.LD_LIBRARY_PATH = /graphene/Runtime:{{"{{library_paths}}"}}
+loader.env.PATH = {{"{{env_path}}"}}
+loader.debug_type = {% if debug %} inline {% else %} none {% endif %}
+
+fs.root.type = chroot
+fs.root.path = /
+fs.root.uri = file:/
+
+# With fs.root Graphene's working directory is '/', setting fs.start_dir changes the
+# working directory to the desired location
+fs.start_dir = {{working_dir}}
+
+# Start at static addresses (otherwise breaks when static and PIE executables are used)
+sgx.static_address = 1
+
+{% if insecure_args %}
+# !! INSECURE !! Allow passing command-line arguments from the host without validation
+# Most Docker images rely on runtime arguments and hence, a more general technique is required.
+# The issue is documented for future release of GSC in issue #1520.
+# https://github.com/oscarlab/graphene/issues/1520
+loader.insecure__use_cmdline_argv = 1
+{% else %}
+loader.argv_src_file = file:trusted_argv
+sgx.trusted_files.trusted_argv = file:trusted_argv
+{% endif %}
+
+# All trusted files and the user defined manifest specifications should be after this line

--- a/Tools/gsc/test/Makefile
+++ b/Tools/gsc/test/Makefile
@@ -1,0 +1,174 @@
+TESTCASES ?= python3 hello-world nodejs bash numpy pytorch
+DISTRIBUTIONS ?= ubuntu18.04
+DOCKER_BUILD_FLAGS ?= --rm --no-cache
+GSC_BUILD_FLAGS ?= --rm --no-cache
+TESTS = $(foreach D,$(DISTRIBUTIONS),$(foreach T,$(TESTCASES),$D-$T))
+MAXTESTNUM ?= 11
+KEY_FILE ?= ../enclave-key.pem
+ifeq ($(wildcard /dev/isgx), )
+	SGX_DEVICE = sgx
+else
+	SGX_DEVICE = isgx
+endif
+DEVICES_VOLUMES = --device=/dev/gsgx --device=/dev/${SGX_DEVICE} -v /var/run/aesmd/aesm.socket:/var/run/aesmd/aesm.socket
+
+IMAGE_SUFFIX ?=
+
+.PHONY: all
+all: $(KEY_FILE) $(TESTS)
+	for d in $(DISTRIBUTIONS); do \
+		sed -e 's/\"Distro\": \".*\"/\"Distro\": \"'$${d}'\"/' \
+			../config.yaml.template > ../config.yaml; \
+		$(MAKE) $(addprefix gsc-$${d}-, $(TESTCASES)) || exit 1; \
+	done
+
+$(KEY_FILE):
+	openssl genrsa -3 -out $(KEY_FILE) 3072
+
+.PRECIOUS: %: %.dockerfile
+%: %.dockerfile
+	echo "Building base image $@.dockerfile..."
+	docker build $(DOCKER_BUILD_FLAGS) -t $(addsuffix $(IMAGE_SUFFIX), $@) -f $@.dockerfile ../../../Examples
+	touch $@
+
+.PRECIOUS: gsc-%-bash
+gsc-%-bash: %-bash
+	echo "Building graphenized image $@..."
+	cd .. && ./gsc build --insecure-args $(GSC_BUILD_FLAGS) $(addsuffix $(IMAGE_SUFFIX), $*-bash) $(addprefix test/, bash.manifest ls.manifest)
+	cd .. && ./gsc sign-image $(addsuffix $(IMAGE_SUFFIX), $*-bash) $(notdir $(KEY_FILE))
+	touch $@
+
+.PRECIOUS: gsc-%-python3
+gsc-%-python3: %-python3 %-python3.manifest
+	echo "Building graphenized image $@..."
+	cd .. && ./gsc build --insecure-args $(GSC_BUILD_FLAGS) $(addsuffix $(IMAGE_SUFFIX), $*-python3) $(addprefix test/, $*-python3.manifest sh.manifest ls.manifest)
+	cd .. && ./gsc sign-image $(addsuffix $(IMAGE_SUFFIX), $*-python3) $(notdir $(KEY_FILE))
+	touch $@
+
+.PRECIOUS: gsc-%-pytorch
+gsc-%-pytorch: %-pytorch %-pytorch.manifest
+	echo "Building graphenized image $@..."
+	cd .. && ./gsc build --insecure-args $(GSC_BUILD_FLAGS) $(addsuffix $(IMAGE_SUFFIX), $*-pytorch) $(addprefix test/, $*-pytorch.manifest sh.manifest uname.manifest)
+	cd .. && ./gsc sign-image $(addsuffix $(IMAGE_SUFFIX), $*-pytorch) $(notdir $(KEY_FILE))
+	touch $@
+
+.PRECIOUS: gsc-%
+gsc-%: %
+	echo "Building graphenized image $@..."
+	cd .. && ./gsc build --insecure-args $(BUILD_FLAGS) $(addsuffix $(IMAGE_SUFFIX), $*) test/$(*:gsc-%=%).manifest
+	cd .. && ./gsc sign-image $(addsuffix $(IMAGE_SUFFIX), $*) $(notdir $(KEY_FILE))
+	touch $@
+
+.PHONY: test
+test: $(addprefix test-distro-, $(DISTRIBUTIONS))
+	echo "[SUCCESS] Completed all GSC test cases"
+
+.PHONY: test-distro-%
+test-distro-%:
+	echo "Testing $*."
+	for t in $(shell seq 1 $(MAXTESTNUM)); do \
+		printf "$${t}/$(MAXTESTNUM): "; \
+		$(MAKE) test-$${t}-$* || exit 1; \
+		printf "[SUCCESS]\\n"; \
+	done
+	echo "Successfully finished testing $*."
+
+.PHONY: test-1-%
+test-1-%: gsc-%-python3
+	docker run $(DEVICES_VOLUMES) $(addsuffix $(IMAGE_SUFFIX), gsc-$*-python3) -c 'print("HelloWorld!")' >out 2>/dev/null
+	grep -q "HelloWorld!" out
+	$(RM) out
+
+.PHONY: test-2-%
+test-2-%: gsc-%-python3
+	docker run $(DEVICES_VOLUMES) $(addsuffix $(IMAGE_SUFFIX), gsc-$*-python3) /graphene/Examples/scripts/helloworld.py >out 2>&1
+	grep -q "Hello World" out
+	$(RM) out
+
+.PHONY: test-3-%
+test-3-%: gsc-%-python3
+	docker run $(DEVICES_VOLUMES) $(addsuffix $(IMAGE_SUFFIX), gsc-$*-python3) /graphene/Examples/scripts/fibonacci.py >out 2>&1
+	grep -q "fib2              55" out
+	$(RM) out
+
+.PHONY: test-4-%
+test-4-%: gsc-%-python3
+	docker run $(DEVICES_VOLUMES) $(addsuffix $(IMAGE_SUFFIX), gsc-$*-python3) -c 'import os;os.system("ls")' >out 2>&1
+	grep -q "ls.manifest.sgx" out
+	$(RM) out
+
+.PHONY: test-5-%
+test-5-%: gsc-%-python3
+	docker run $(DEVICES_VOLUMES) -d -p 8005:8005 $(addsuffix $(IMAGE_SUFFIX), gsc-$*-python3) /graphene/Examples/scripts/dummy-web-server.py 8005 >c.id 2>/dev/null
+	sleep 30
+	wget -q http://localhost:8005/ -O output
+	grep -q "hi!" output
+	cat c.id | head -n 1 | xargs docker container rm -f >/dev/null 2>/dev/null
+	$(RM) c.id output
+
+.PHONY: test-6-%
+test-6-%: gsc-%-hello-world
+	docker run $(DEVICES_VOLUMES) $(addsuffix $(IMAGE_SUFFIX), gsc-$*-hello-world) > out 2>/dev/null
+	grep -q "Hello World!" out
+	$(RM) out
+
+.PHONY: test-7-%
+test-7-%: gsc-%-nodejs
+	docker run $(DEVICES_VOLUMES) $(addsuffix $(IMAGE_SUFFIX), gsc-$*-nodejs) -e 'console.log("HelloWorld");' >out 2>/dev/null
+	grep -q "HelloWorld" out
+	$(RM) out
+
+.PHONY: test-8-%
+test-8-%: gsc-%-nodejs
+	docker run $(DEVICES_VOLUMES) $(addsuffix $(IMAGE_SUFFIX), gsc-$*-nodejs) /graphene/Examples/helloworld.js >out 2>/dev/null
+	grep -q "Hello World" out
+	$(RM) out
+
+.PHONY: test-9-%
+test-9-%: gsc-%-numpy
+	docker run $(DEVICES_VOLUMES) $(addsuffix $(IMAGE_SUFFIX), gsc-$*-numpy) /graphene/Examples/scripts/test-numpy.py >out 2>/dev/null
+	grep -q "numpy version:" out
+	$(RM) out
+
+.PHONY: test-10-%
+test-10-%: gsc-%-bash
+	docker run $(DEVICES_VOLUMES) $(addsuffix $(IMAGE_SUFFIX), gsc-$*-bash) -c 'ls' >out 2>/dev/null
+	grep -q "ls.manifest.sgx" out
+	$(RM) out
+
+.PHONY: test-11-%
+test-11-%: gsc-%-pytorch
+	touch result.txt
+	docker run $(DEVICES_VOLUMES) -v$${PWD}/result.txt:/graphene/Examples/result.txt $(addsuffix $(IMAGE_SUFFIX), gsc-$*-pytorch) pytorchexample.py
+	grep -q "('Labrador retriever'" result.txt
+	$(RM) results.txt
+
+.PHONY: clean-image-%
+clean-image-%:
+	docker image rm -f $*
+
+.PHONY: clean-base
+clean-base: $(addsuffix $(IMAGE_SUFFIX), $(addprefix clean-image-, $(TESTS)))
+
+.PHONY: clean-gsc
+clean-gsc: $(addsuffix $(IMAGE_SUFFIX), $(addprefix clean-image-gsc-, $(TESTS))) $(addsuffix $(IMAGE_SUFFIX)-unsigned, $(addprefix clean-image-gsc-, $(TESTS)))
+
+# Create a space to be used in subst
+space :=
+space +=
+
+.PHONY: clean-containers
+clean-containers:
+	docker container ls -a | grep -e '$(subst $(space),\|,$(addsuffix $(IMAGE_SUFFIX), $(TESTS)))\|$(subst $(space),\|,$(addsuffix $(IMAGE_SUFFIX), $(addprefix gsc-, $(TESTS))))' | cut -d ' ' -f 1 | grep -v CONTAINER | xargs -r docker container rm -f
+
+.PHONY: clean-files
+clean-files:
+	for d in $(DISTRIBUTIONS); do \
+		for t in $(TESTCASES); do \
+			$(RM) -r ../gsc-$${d}-$${t}$(IMAGE_SUFFIX) || exit 1; \
+			$(RM) gsc-$${d}-$${t}$(IMAGE_SUFFIX) $${d}-$${t}$(IMAGE_SUFFIX); \
+		done \
+	done
+
+.PHONY: clean
+clean: clean-containers clean-base clean-gsc clean-files

--- a/Tools/gsc/test/README.rst
+++ b/Tools/gsc/test/README.rst
@@ -1,0 +1,112 @@
+Examples and Tests for GSC
+==========================
+
+This folder includes sample images and test cases for GSC:
+
+-  Hello-World (print "Hello World!" using echo)
+-  Python3 (run python3 command line) which is tested with a
+   ``-c 'print("Hello World!")'`` and the three
+   `Graphene Examples <https://github.com/oscarlab/graphene/tree/master/Examples>`__
+   from python-simple
+-  NodeJS (print "Hello World")
+-  Pytorch script, from
+    `Graphene Examples <https://github.com/oscarlab/graphene/tree/master/Examples>`__
+
+Each sample consists of two files ``<distro>-<image-name>.dockerfile`` and
+``<distro>-<image-name>.manifest`` where ``<distro>`` specifies the underlying
+Linux distribution and ``<image-name>`` specifies the test case. The manifest
+file may not exist, since the standard arguments for manifest files often
+suffice.
+
+*\*.dockerfile* describes the basic image and its application. It builds the
+Docker image by installing required software packages, configuring the
+application and changing the Docker entrypoint to start the application.
+
+*\*.manifest* describes the specific Graphene manifest changes required to run
+this application reliably. For instance, this includes the memory size and the
+number of threads. In some cases this file might be empty, but its existence is
+required for the makefile structure.
+
+Building sample images
+----------------------
+
+Run::
+
+    make
+
+To build base Docker images named ``<image-name>``::
+
+    make <image-name>
+
+To build a graphenized Docker image of ``<image-name>``::
+
+    make gsc-<image-name>
+
+To build a graphenized image of ``<image-name>`` with additional `gsc build`
+arguments (e.g., ``-d``, ``--no-cache``, or ``--rm``)::
+
+    make BUILD_FLAGS=-d gsc-<image-name>
+
+To build the base Docker image named ``<image-name>`` with additional
+Docker `build` arguments (e.g., ``--no-cache``, or ``--rm``)::
+
+    make DOCKER_BUILD_FLAGS=--no-cache <image-name>
+
+To sign the graphenized image of ``<image-name>`` with a custom signing key
+<your_signing_key.pem>, specify ``KEY_FILE`` (default: ``../enclave_key.pem``)::
+
+    make KEY_FILE=<your_signing_key.pem>
+
+To make a specific distribution, specify ``DISTRIBUTION`` (default:
+``ubuntu18.04``)::
+
+    make DISTRIBUTION=ubuntu18.04
+
+To make a specific test case (here ``python3``), specify ``TESTCASES`` (default:
+``python3 hello-world nodejs bash numpy pytorch``)
+
+    make TESTCASES=python3
+
+Run sample images with test arguments
+-------------------------------------
+
+::
+
+    make test
+
+``make test`` may also be restricted with the ``DISTRIBUTION`` and ``TESTCASES``
+arguments.
+
+To run the first ``n`` tests, specify ``MAXTESTNUM``.
+
+::
+
+    make test MAXTESTNUM=<n>
+
+To run a specific test case, specify the test number and distribution.
+
+::
+
+    make test-<test number>-<distribution>
+
+Remove images & containers from Docker daemon
+---------------------------------------------
+
+All clean targets can be combined with ``DISTRIBUTION`` and ``TESTCASES`` to
+restrict the images to clean.
+
+Remove GSC built sample images::
+
+    make clean-gsc
+
+Remove base sample images::
+
+    make clean-base
+
+Remove containers::
+
+    make clean-containers
+
+Remove all containers built by this test folder (images are kept)::
+
+    make clean

--- a/Tools/gsc/test/bash.manifest
+++ b/Tools/gsc/test/bash.manifest
@@ -1,0 +1,1 @@
+sgx.enclave_size = 4G

--- a/Tools/gsc/test/ls.manifest
+++ b/Tools/gsc/test/ls.manifest
@@ -1,0 +1,1 @@
+sgx.enclave_size = 4G

--- a/Tools/gsc/test/sh.manifest
+++ b/Tools/gsc/test/sh.manifest
@@ -1,0 +1,1 @@
+sgx.enclave_size = 4G

--- a/Tools/gsc/test/ubuntu18.04-bash.dockerfile
+++ b/Tools/gsc/test/ubuntu18.04-bash.dockerfile
@@ -1,0 +1,5 @@
+From ubuntu:18.04
+
+RUN apt-get update
+
+CMD ["bash"]

--- a/Tools/gsc/test/ubuntu18.04-hello-world.dockerfile
+++ b/Tools/gsc/test/ubuntu18.04-hello-world.dockerfile
@@ -1,0 +1,5 @@
+From ubuntu:18.04
+
+RUN apt-get update
+
+CMD ["echo", "\"Hello World!\""]

--- a/Tools/gsc/test/ubuntu18.04-nodejs.dockerfile
+++ b/Tools/gsc/test/ubuntu18.04-nodejs.dockerfile
@@ -1,0 +1,14 @@
+From ubuntu:18.04
+
+WORKDIR /app
+
+RUN apt-get update
+
+RUN apt-get -y install nodejs \
+    && mkdir -p /graphene/Examples
+
+# The build environment of this Dockerfile should point to the root of Graphene's Examples
+# directory.
+COPY nodejs/ /graphene/Examples
+
+CMD ["node"]

--- a/Tools/gsc/test/ubuntu18.04-nodejs.manifest
+++ b/Tools/gsc/test/ubuntu18.04-nodejs.manifest
@@ -1,0 +1,3 @@
+sgx.allow_file_creation = 1
+sgx.enclave_size = 2G
+sgx.thread_num = 16

--- a/Tools/gsc/test/ubuntu18.04-numpy.dockerfile
+++ b/Tools/gsc/test/ubuntu18.04-numpy.dockerfile
@@ -1,0 +1,13 @@
+From ubuntu:18.04
+
+RUN apt-get update
+
+RUN apt-get install -y python3 python3-pip git \
+    && pip3 install numpy \
+    && mkdir -p /graphene/Examples
+
+# The build environment of this Dockerfile should point to the root of Graphene's Examples
+# directory.
+COPY python-scipy-insecure/ /graphene/Examples
+
+CMD ["python3"]

--- a/Tools/gsc/test/ubuntu18.04-numpy.manifest
+++ b/Tools/gsc/test/ubuntu18.04-numpy.manifest
@@ -1,0 +1,4 @@
+sgx.allow_file_creation = 1
+sgx.enclave_size = 2G
+sgx.thread_num = 32
+sys.stack.size = 2M

--- a/Tools/gsc/test/ubuntu18.04-python3.dockerfile
+++ b/Tools/gsc/test/ubuntu18.04-python3.dockerfile
@@ -1,0 +1,12 @@
+From ubuntu:18.04
+
+RUN apt-get update
+
+RUN apt-get install -y python3 \
+    && mkdir -p /graphene/Examples
+
+# The build environment of this Dockerfile should point to the root of Graphene's Examples
+# directory.
+COPY python-simple/ /graphene/Examples
+
+CMD ["python3"]

--- a/Tools/gsc/test/ubuntu18.04-python3.manifest
+++ b/Tools/gsc/test/ubuntu18.04-python3.manifest
@@ -1,0 +1,3 @@
+sgx.allow_file_creation = 1
+sgx.enclave_size = 4G
+sgx.thread_num = 8

--- a/Tools/gsc/test/ubuntu18.04-pytorch.dockerfile
+++ b/Tools/gsc/test/ubuntu18.04-pytorch.dockerfile
@@ -1,0 +1,17 @@
+From ubuntu:18.04
+
+RUN apt-get update
+
+RUN apt-get install -y python3 python3-pip \
+    && pip3 install torch torchvision \
+    && mkdir -p /graphene/Examples
+
+# The build environment of this Dockerfile should point to the root of Graphene's Examples
+# directory.
+COPY pytorch/ /graphene/Examples
+
+WORKDIR /graphene/Examples
+
+RUN python3 download-pretrained-model.py
+
+CMD ["python3"]

--- a/Tools/gsc/test/ubuntu18.04-pytorch.manifest
+++ b/Tools/gsc/test/ubuntu18.04-pytorch.manifest
@@ -1,0 +1,4 @@
+sgx.allow_file_creation = 1
+sgx.enclave_size = 4G
+sgx.thread_num = 32
+sys.stack.size = 2M

--- a/Tools/gsc/test/uname.manifest
+++ b/Tools/gsc/test/uname.manifest
@@ -1,0 +1,1 @@
+sgx.enclave_size = 4G


### PR DESCRIPTION
## Description of the changes 

Recreation of PR #1345.

Tooling to automatically translate docker images to graphenized docker image using Linux-SGX Pal.

Implemented in the folder Tools/gsc in a python script called gsc.py. Tools/gsc/README.md describes the implementation of the tool gsc.py (or gsc). Its usage is described in the Documentation in Documentation/manpages/gsc.rst. The gsc command line tool follows the common docker approach to first build an image and subsequently run a container of an image. 

GSC build: gsc prepares the a two stage dockerfile, manifest files, and an application loader. The Docker file is split into two stages. The first stage compiles Graphene based on the provided configuration (see config.json) which includes the Ubuntu version, the Intel SGX driver, and Graphene repository. The second stage copies the important Graphene artifacts (e.g., the runtime and signer tool) from the first stage. It then finalizes the manifest files by adding image specific variables such as the executable path and the library path, and scanning the entire image to generate a list of trusted files (we overestimate the application's file accesses to the entire docker image). Based on these manifest files, we use Graphene's signer tool to generate a signature and the Intel SGX manifest files. Afterwards we remove any previously created files. In a last step the entrypoint is changed to one which launches the application using the pal-Linux-SGX loader from Graphene. 

Running GSC images: Graphenized Docker images run inside containers via the regular Docker run command . It requires to add isgx and gsgx as devices and mount the AESMD socket file as a volume.

## How to test this PR?

This PR introduces a new pipeline to Jenkins (Jenkins/Linux-SGX-gsc. 

Generally, GSC may be tested via the provided test folder on Tools/gsc/test. Please follow the installation directions in Documentation/manpages/gsc.rst and install the required SGX driver, SDK, Graphene and docker packages.

```
cd Tools/gsc/test
make
make test
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1430)
<!-- Reviewable:end -->
