### PR TITLE
[LibOS] Completely rework LibOS VMA bookkeeping

### DIFF
--- a/Documentation/manifest-syntax.rst
+++ b/Documentation/manifest-syntax.rst
@@ -108,12 +108,13 @@ Program Break (Heap) Size
 
 ::
 
-    sys.brk.size=[# of bytes (with K/M/G)]
+    sys.brk.max_size=[# of bytes (with K/M/G)]
 
-This specifies the program break (brk) size in each Graphene process. The
-default value of the program break size is determined by the library OS. Units
-like ``K`` (KiB), ``M`` (MiB), and ``G`` (GiB) can be appended to the values for
-convenience. For example, ``sys.brk.size=1M`` indicates a 1 |~| MiB brk size.
+This specifies the maximal program break (brk) size in each Graphene process.
+The default value of the program break size is determined by the library OS.
+Units like ``K`` (KiB), ``M`` (MiB), and ``G`` (GiB) can be appended to the
+values for convenience. For example, ``sys.brk.max_size=1M`` indicates
+a 1 |~| MiB brk size.
 
 Allowing eventfd
 ^^^^^^^^^^^^^^^^

--- a/LibOS/shim/include/shim_internal.h
+++ b/LibOS/shim/include/shim_internal.h
@@ -700,13 +700,10 @@ unsigned long parse_int (const char * str);
 extern void * initial_stack;
 extern const char ** initial_envp;
 
-void get_brk_region (void ** start, void ** end, void ** current);
-
-int reset_brk (void);
 struct shim_handle;
 int init_brk_from_executable (struct shim_handle * exec);
 int init_brk_region(void* brk_region, size_t data_segment_size);
-int init_heap (void);
+void reset_brk(void);
 int init_internal_map (void);
 int init_loader (void);
 int init_manifest (PAL_HANDLE manifest_handle);

--- a/LibOS/shim/include/shim_tcb.h
+++ b/LibOS/shim/include/shim_tcb.h
@@ -39,13 +39,14 @@ struct debug_buf;
 
 typedef struct shim_tcb shim_tcb_t;
 struct shim_tcb {
-    uint64_t                canary;
-    shim_tcb_t *            self;
-    struct shim_thread *    tp;
-    struct shim_context     context;
-    unsigned int            tid;
-    int                     pal_errno;
-    struct debug_buf *      debug_buf;
+    uint64_t            canary;
+    shim_tcb_t*         self;
+    struct shim_thread* tp;
+    struct shim_context context;
+    unsigned int        tid;
+    int                 pal_errno;
+    struct debug_buf*   debug_buf;
+    void*               vma_cache;
 
     /* This record is for testing the memory of user inputs.
      * If a segfault occurs with the range [start, end],
@@ -140,6 +141,7 @@ struct shim_tcb {
 static inline void __shim_tcb_init(shim_tcb_t* shim_tcb) {
     shim_tcb->canary = SHIM_TCB_CANARY;
     shim_tcb->self = shim_tcb;
+    shim_tcb->vma_cache = NULL;
 }
 
 /* Call this function at the beginning of thread execution. */

--- a/LibOS/shim/include/shim_vma.h
+++ b/LibOS/shim/include/shim_vma.h
@@ -1,4 +1,5 @@
 /* Copyright (C) 2014 Stony Brook University
+   Copyright (C) 2020 Invisible Things Lab
    This file is part of Graphene Library OS.
 
    Graphene Library OS is free software: you can redistribute it and/or
@@ -23,110 +24,110 @@
 #ifndef _SHIM_VMA_H_
 #define _SHIM_VMA_H_
 
-#include <api.h>
 #include <linux/mman.h>
-#include <list.h>
-#include <pal.h>
-#include <shim_defs.h>
-#include <shim_handle.h>
-#include <shim_types.h>
 
-struct shim_handle;
+#include "api.h"
+#include "pal.h"
+#include "shim_defs.h"
+#include "shim_handle.h"
+#include "shim_types.h"
 
 #define VMA_COMMENT_LEN 16
 
-/*
- * struct shim_vma_val is the published version of struct shim_vma
- * (struct shim_vma is defined in bookkeep/shim_vma.c).
- */
-struct shim_vma_val {
+struct shim_vma_info {
     void* addr;
     size_t length;
-    int prot;
-    int flags;
-    off_t offset;
+    int prot; // memory protection flags: PROT_*
+    int flags; // MAP_* and VMA_*
     struct shim_handle* file;
+    off_t file_offset;
     char comment[VMA_COMMENT_LEN];
 };
 
-static inline void free_vma_val_array(struct shim_vma_val* vmas, size_t count) {
-    for (size_t i = 0; i < count; i++) {
-        /* need to release the file handle */
-        if (vmas[i].file)
-            put_handle(vmas[i].file);
-    }
+/* MAP_FIXED_NOREPLACE and MAP_SHARED_VALIDATE are fairly new and might not be defined. */
+#ifndef MAP_FIXED_NOREPLACE
+#define MAP_FIXED_NOREPLACE 0x100000
+#endif // MAP_FIXED_NOREPLACE
+#ifndef MAP_SHARED_VALIDATE
+#define MAP_SHARED_VALIDATE 0x03
+#endif // MAP_SHARED_VALIDATE
 
-    free(vmas);
-}
 
-/* an additional flag */
-#define VMA_UNMAPPED 0x10000000 /* vma is kept for bookkeeping, but the memory is not actually
-                                   allocated */
-#define VMA_INTERNAL 0x20000000 /* vma is used internally */
-
-#define VMA_TAINTED 0x40000000 /* vma has been protected as writable, so it has to be checkpointed
-                                  during migration */
-
-#define VMA_CP 0x80000000 /* vma is used for dumping checkpoint data */
-
-#define VMA_TYPE(flags) ((flags) & (VMA_INTERNAL | VMA_CP))
-
-/*
- * We distinguish checkpoint VMAs from user VMAs and other internal VMAs,
- * to prevent corrupting internal data when creating processes.
- */
-#define CP_VMA_FLAGS (MAP_PRIVATE | MAP_ANONYMOUS | VMA_INTERNAL | VMA_CP)
-
-#define NEED_MIGRATE_MEMORY(vma) \
-    (((vma)->flags & VMA_TAINTED || !(vma)->file) && !((vma)->flags & VMA_UNMAPPED))
+/* vma is kept for bookkeeping, but the memory is not actually allocated */
+#define VMA_UNMAPPED 0x10000000
+/* vma is used internally */
+#define VMA_INTERNAL 0x20000000
+/* vma is backed by a file and has been protected as writable, so it has to be checkpointed during
+ * migration */
+#define VMA_TAINTED 0x40000000
 
 int init_vma(void);
 
-/* Bookkeeping mmap() system call */
-int bkeep_mmap(void* addr, size_t length, int prot, int flags, struct shim_handle* file,
-               off_t offset, const char* comment);
+/*
+ * Bookkeeping a removal of mapped memory. On success returns a temporary VMA pointer in
+ * `tmp_vma_ptr`, which must be subsequently freed by calling `bkeep_remove_tmp_vma` - but this
+ * should be done only *AFTER* the memory deallocation itself. For example:
+ *
+ * void* tmp_vma = NULL;
+ * if (bkeep_munmap(ptr, len, is_internal, &tmp_vma) < 0) {
+ *     handle_errors();
+ * }
+ * DkVirtualMemoryFree(ptr, len);
+ * bkeep_remove_tmp_vma(tmp_vma);
+ *
+ * Such a way of freeing is needed, so that no other thread will map the same memory in the window
+ * between `bkeep_munmap` and `DkVirtualMemoryFree`.
+ */
+int bkeep_munmap(void* addr, size_t length, bool is_internal, void** tmp_vma_ptr);
+void bkeep_remove_tmp_vma(void* vma);
 
-/* Bookkeeping munmap() system call */
-int bkeep_munmap(void* addr, size_t length, int flags);
-
-/* Bookkeeping mprotect() system call */
-int bkeep_mprotect(void* addr, size_t length, int prot, int flags);
-
-/* Looking up VMA that contains [addr, length) */
-int lookup_vma(void* addr, struct shim_vma_val* vma);
-
-/* Looking up VMA that overlaps with [addr, length) */
-int lookup_overlap_vma(void* addr, size_t length, struct shim_vma_val* vma);
-
-/* True if [addr, addr+length) is found in one VMA (valid memory region) */
-bool is_in_adjacent_vmas(void* addr, size_t length);
+/* Bookkeeping a change to memory protections. */
+int bkeep_mprotect(void* addr, size_t length, int prot, bool is_internal);
 
 /*
- * Looking for an unmapped space and then adding the corresponding bookkeeping
- * (more info in bookkeep/shim_vma.c).
- *
- * Note: the first argument is "top_addr" because the search is top-down.
+ * Bookkeeping an allocation of memory at a fixed address. `flags` must contain either MAP_FIXED or
+ * MAP_FIXED_NOREPLACE - the former forces bookkeeping and removes any overlapping VMAs, the latter
+ * atomically checks for overlaps and fails if one is found.
  */
-void* bkeep_unmapped(void* top_addr, void* bottom_addr, size_t length, int prot, int flags,
+int bkeep_mmap_fixed(void* addr, size_t length, int prot, int flags, struct shim_handle* file,
                      off_t offset, const char* comment);
 
-static inline void* bkeep_unmapped_any(size_t length, int prot, int flags,
-                                       off_t offset, const char* comment) {
-    return bkeep_unmapped(PAL_CB(user_address.end), PAL_CB(user_address.start), length, prot, flags,
-                          offset, comment);
-}
+/*
+ * Bookkeeping an allocation of memory at any address in the range [`bottom_addr`, `top_addr`).
+ * The search is top-down, starting from `top_addr` - `length` and returning the first unoccupied
+ * area capable of fitting the requested size.
+ * Start of bookkept range is returned in `*ret_val_ptr`.
+ */
+int bkeep_mmap_any_in_range(void* bottom_addr, void* top_addr, size_t length, int prot, int flags,
+                            struct shim_handle* file, off_t offset, const char* comment,
+                            void** ret_val_ptr);
 
-void* bkeep_unmapped_heap(size_t length, int prot, int flags, struct shim_handle* file,
-                          off_t offset, const char* comment);
+/* Shorthand for `bkeep_mmap_any_in_range` with the range
+ * [`PAL_CB(user_address.start)`, `PAL_CB(user_address.end)`). */
+int bkeep_mmap_any(size_t length, int prot, int flags, struct shim_handle* file, off_t offset,
+                   const char* comment, void** ret_val_ptr);
+
+/* First tries to bookkeep in the range [`PAL_CB(user_address.start)`, `aslr_addr_top`) and if it
+ * fails calls `bkeep_mmap_any`. `aslr_addr_top` is a value randomized on each program run. */
+int bkeep_mmap_any_aslr(size_t length, int prot, int flags, struct shim_handle* file, off_t offset,
+                        const char* comment, void** ret_val_ptr);
+
+/* Looking up VMA that contains `addr`. If one is found, returns its description in `vma_info`.
+ * This function increases ref-count of `vma_info->file` by one (if it is not NULL). */
+int lookup_vma(void* addr, struct shim_vma_info* vma_info);
+
+/* Returns true if the whole range [`addr`, `addr` + `length`) is mapped as user memory. */
+bool is_in_adjacent_user_vmas(void* addr, size_t length);
 
 /*
- * Dumping all *non-internal* VMAs into a user-allocated buffer ("max_count" is
- * the maximal number of entries in the buffer). Return number of filled entries
- * if succeeded, or -EOVERFLOW if the buffer is too small.
+ * Dumps all non-internal and mapped VMAs.
+ * On success returns 0 and puts the pointer to result array into `*vma_infos` and its length into
+ * `*count`. On error returns negated error code.
+ * The returned array can be subsequently freed by `free_vma_info_array`.
  */
-int dump_all_vmas(struct shim_vma_val* vmas, size_t max_count);
+int dump_all_vmas(struct shim_vma_info** vma_infos, size_t* count);
+void free_vma_info_array(struct shim_vma_info* vma_infos, size_t count);
 
-/* Debugging */
-void debug_print_vma_list(void);
+void debug_print_all_vmas(void);
 
 #endif /* _SHIM_VMA_H_ */

--- a/LibOS/shim/include/shim_vma.h
+++ b/LibOS/shim/include/shim_vma.h
@@ -125,7 +125,7 @@ bool is_in_adjacent_user_vmas(void* addr, size_t length);
  * `*count`. On error returns negated error code.
  * The returned array can be subsequently freed by `free_vma_info_array`.
  */
-int dump_all_vmas(struct shim_vma_info** vma_infos, size_t* count);
+int dump_all_vmas(struct shim_vma_info** vma_infos, size_t* count, bool include_unmapped);
 void free_vma_info_array(struct shim_vma_info* vma_infos, size_t count);
 
 void debug_print_all_vmas(void);

--- a/LibOS/shim/src/bookkeep/shim_vma.c
+++ b/LibOS/shim/src/bookkeep/shim_vma.c
@@ -1,4 +1,5 @@
 /* Copyright (C) 2014 Stony Brook University
+   Copyright (C) 2020 Invisible Things Lab
    This file is part of Graphene Library OS.
 
    Graphene Library OS is free software: you can redistribute it and/or
@@ -14,1073 +15,1136 @@
    You should have received a copy of the GNU Lesser General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
 
-/*
- * shim_vma.c
- *
- * This file contains code to maintain bookkeeping of VMAs in library OS.
- */
-
-#include <asm/mman.h>
-#include <errno.h>
+#include <linux/fcntl.h>
+#include <linux/mman.h>
+#include <stdalign.h>
 #include <stdbool.h>
+#include <stdint.h>
 
-#include "list.h"
-#include "pal.h"
+#include "api.h"
+#include "assert.h"
+#include "avl_tree.h"
 #include "shim_checkpoint.h"
+#include "shim_defs.h"
 #include "shim_flags_conv.h"
+/* TODO: remove the include of "shim_fs.h" once the circular dependency of it and "shim_handle.h"
+ * is fixed. */
 #include "shim_fs.h"
 #include "shim_handle.h"
 #include "shim_internal.h"
-#include "shim_thread.h"
+#include "shim_tcb.h"
+#include "shim_utils.h"
 #include "shim_vma.h"
+#include "spinlock.h"
 
-/*
- * Internal bookkeeping for VMAs (virtual memory areas). This data
- * structure can only be accessed in this source file, with vma_list_lock
- * held. No reference counting needed in this data structure.
- */
-DEFINE_LIST(shim_vma);
-/* struct shim_vma tracks the area of [start, end) */
+/* Filter flags that will be saved in `struct shim_vma`. For example there is no need for saving
+ * MAP_FIXED or unsupported flags. */
+static int filter_saved_flags(int flags) {
+    return flags & (MAP_SHARED | MAP_SHARED_VALIDATE | MAP_PRIVATE | MAP_ANONYMOUS | MAP_FILE
+                    | MAP_GROWSDOWN | MAP_HUGETLB | MAP_HUGE_2MB | MAP_HUGE_1GB | MAP_STACK
+                    | VMA_UNMAPPED | VMA_INTERNAL | VMA_TAINTED);
+}
+
+/* TODO: split flags into internal (Graphene) and Linux; also to consider: completely remove Linux
+ * flags - we only need MAP_SHARED/MAP_PRIVATE and possibly MAP_STACK/MAP_GROWSDOWN */
 struct shim_vma {
-    LIST_TYPE(shim_vma)     list;
-    void *                  start;
-    void *                  end;
-    int                     prot;
-    int                     flags;
-    off_t                   offset;
-    struct shim_handle *    file;
-    char                    comment[VMA_COMMENT_LEN];
+    uintptr_t begin;
+    uintptr_t end;
+    int prot;
+    int flags;
+    struct shim_handle* file;
+    off_t offset; // offset inside `file`, where `begin` starts
+    union {
+        /* If this `vma` is used, it is included in `vma_tree` using this node. */
+        struct avl_tree_node tree_node;
+        /* Otherwise it might be cached in per thread vma cache, or might be on a temporary list
+         * of to-be-freed vmas (used by _vma_bkeep_remove). Such lists use the field below. */
+        struct shim_vma* next_free;
+    };
+    char comment[VMA_COMMENT_LEN];
 };
 
-#define VMA_MGR_ALLOC   DEFAULT_VMA_COUNT
-#define RESERVED_VMAS   6
+static void copy_comment(struct shim_vma* vma, const char* comment) {
+    size_t len = MIN(sizeof(vma->comment), strlen(comment) + 1);
+    memcpy(vma->comment, comment, len);
+    vma->comment[sizeof(vma->comment) - 1] = '\0';
+}
 
-static struct shim_vma * reserved_vmas[RESERVED_VMAS];
-static struct shim_vma early_vmas[RESERVED_VMAS];
+static void copy_vma(struct shim_vma* old_vma, struct shim_vma* new_vma) {
+    new_vma->begin = old_vma->begin;
+    new_vma->end = old_vma->end;
+    new_vma->prot = old_vma->prot;
+    new_vma->flags = old_vma->flags;
+    new_vma->file = old_vma->file;
+    if (new_vma->file) {
+        get_handle(new_vma->file);
+    }
+    new_vma->offset = old_vma->offset;
+    copy_comment(new_vma, old_vma->comment);
+}
 
-static void * __bkeep_unmapped (void * top_addr, void * bottom_addr,
-                                size_t length, int prot, int flags,
-                                struct shim_handle * file,
-                                off_t offset, const char * comment);
+static bool vma_tree_cmp(struct avl_tree_node* node_a, struct avl_tree_node* node_b) {
+    struct shim_vma* a = container_of(node_a, struct shim_vma, tree_node);
+    struct shim_vma* b = container_of(node_b, struct shim_vma, tree_node);
+
+    return a->end <= b->end;
+}
+
+static bool is_addr_in_vma(uintptr_t addr, struct shim_vma* vma) {
+    return vma->begin <= addr && addr < vma->end;
+}
+
+/* Returns whether `addr` is smaller or inside a vma (`node`). */
+static bool cmp_addr_to_vma(void* addr, struct avl_tree_node* node) {
+    struct shim_vma* vma = container_of(node, struct shim_vma, tree_node);
+
+    return (uintptr_t)addr < vma->end;
+}
 
 /*
- * Because the default system_malloc() must create VMA(s), we need
- * a new system_malloc() to avoid cicular dependency. This __malloc()
- * stores the VMA address and size in the current thread to delay the
- * bookkeeping until the allocator finishes extension.
+ * "vma_tree" holds all vmas with the assumption that no 2 overlap (though they could be adjacent).
+ * Currently we do not merge similar adjacent vmas - if we ever start doing it, this code needs
+ * to be revisited as there might be some optimizations that would break due to it.
  */
-static inline void * __malloc (size_t size)
-{
-    void * addr;
+static struct avl_tree vma_tree = { .cmp = vma_tree_cmp };
+static spinlock_t vma_tree_lock = INIT_SPINLOCK_UNLOCKED;
+
+static struct shim_vma* node2vma(struct avl_tree_node* node) {
+    if (!node) {
+        return NULL;
+    }
+    return container_of(node, struct shim_vma, tree_node);
+}
+
+static struct shim_vma* _get_next_vma(struct shim_vma* vma) {
+    assert(spinlock_is_locked(&vma_tree_lock));
+    return node2vma(avl_tree_next(&vma->tree_node));
+}
+
+static struct shim_vma* _get_prev_vma(struct shim_vma* vma) {
+    assert(spinlock_is_locked(&vma_tree_lock));
+    return node2vma(avl_tree_prev(&vma->tree_node));
+}
+
+static struct shim_vma* _get_last_vma(void) {
+    assert(spinlock_is_locked(&vma_tree_lock));
+    return node2vma(avl_tree_last(&vma_tree));
+}
+
+static struct shim_vma* _get_first_vma(void) {
+    assert(spinlock_is_locked(&vma_tree_lock));
+    return node2vma(avl_tree_first(&vma_tree));
+}
+
+/* Returns the vma that contains `addr`. If there is no such vma, returns the closest vma with
+ * higher address. */
+static struct shim_vma* _lookup_vma(uintptr_t addr) {
+    assert(spinlock_is_locked(&vma_tree_lock));
+
+    struct avl_tree_node* node = avl_tree_lower_bound_fn(&vma_tree, (void*)addr, cmp_addr_to_vma);
+    if (!node) {
+        return NULL;
+    }
+    return container_of(node, struct shim_vma, tree_node);
+}
+
+static void split_vma(struct shim_vma* old_vma, struct shim_vma* new_vma, uintptr_t addr) {
+    assert(old_vma->begin < addr && addr < old_vma->end);
+
+    copy_vma(old_vma, new_vma);
+    new_vma->begin = addr;
+    if (new_vma->file) {
+        new_vma->offset += new_vma->begin - old_vma->begin;
+    }
+
+    old_vma->end = addr;
+}
+
+/*
+ * This function might need a preallocated vma in `new_vma_ptr`, because it might need to split
+ * an existing vma into two parts. If the vma is provided and this function happens to use it,
+ * `*new_vma_ptr` will be set to NULL.
+ * It returns a list of vmas that need to be freed in `vmas_to_free`.
+ * Range [begin, end) can consist of multiple vmas even with holes in between, but they all must be
+ * either internal or non-internal.
+ */
+static int _vma_bkeep_remove(uintptr_t begin, uintptr_t end, bool is_internal,
+                             struct shim_vma** new_vma_ptr,
+                             struct shim_vma** vmas_to_free) {
+    assert(spinlock_is_locked(&vma_tree_lock));
+    assert(!new_vma_ptr || *new_vma_ptr);
+    assert(IS_ALLOC_ALIGNED_PTR(begin) && IS_ALLOC_ALIGNED_PTR(end));
+
+    struct shim_vma* vma = _lookup_vma(begin);
+    if (!vma) {
+        return 0;
+    }
+
+    struct shim_vma* first_vma = vma;
+
+    while (vma && vma->begin < end) {
+        if (!!(vma->flags & VMA_INTERNAL) != is_internal) {
+            if (is_internal) {
+                debug("Warning: LibOS tried to free a user vma!\n");
+            } else {
+                debug("Warning: user app tried to free an internal vma!\n");
+            }
+            return -EACCES;
+        }
+
+        vma = _get_next_vma(vma);
+    }
+
+
+    vma = first_vma;
+
+    if (vma->begin < begin) {
+        if (end < vma->end) {
+            if (!new_vma_ptr) {
+                debug("Warning: need an additional vma to free this range!\n");
+                return -ENOMEM;
+            }
+            struct shim_vma* new_vma = *new_vma_ptr;
+            *new_vma_ptr = NULL;
+
+            split_vma(vma, new_vma, end);
+            vma->end = begin;
+
+            avl_tree_insert(&vma_tree, &new_vma->tree_node);
+            return 0;
+        }
+
+        vma->end = begin;
+
+        vma = _get_next_vma(vma);
+        if (!vma) {
+            return 0;
+        }
+    }
+
+    while (vma->end <= end) {
+        /* We need to search for the next node before deletion. */
+        struct shim_vma* next = _get_next_vma(vma);
+
+        avl_tree_delete(&vma_tree, &vma->tree_node);
+
+        vma->next_free = NULL;
+        *vmas_to_free = vma;
+        vmas_to_free = &vma->next_free;
+
+        if (!next) {
+            return 0;
+        }
+        vma = next;
+    }
+
+    if (vma->begin < end) {
+        if (vma->file) {
+            vma->offset += end - vma->begin;
+        }
+        vma->begin = end;
+    }
+
+    return 0;
+}
+
+static void free_vmas_freelist(struct shim_vma* vma);
+
+/* This function uses at most 1 vma (in `bkeep_mmap_any`). `alloc_vma` depends on this behavior. */
+static void* _vma_malloc(size_t size) {
+    void* addr = NULL;
     size = ALLOC_ALIGN_UP(size);
 
-    /*
-     * Chia-Che 3/3/18: We must enforce the policy that all VMAs have to
-     * be created before issuing the PAL calls.
-     */
-    addr = __bkeep_unmapped(PAL_CB(user_address.end),
-                            PAL_CB(user_address.start), size,
-                            PROT_READ|PROT_WRITE,
-                            MAP_PRIVATE|MAP_ANONYMOUS|VMA_INTERNAL,
-                            NULL, 0, "vma");
+    if (bkeep_mmap_any(size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS | VMA_INTERNAL,
+                       NULL, 0, "vma", &addr) < 0) {
+        return NULL;
+    }
 
-    debug("allocate %p-%p for vmas\n", addr, addr + size);
+    if (DkVirtualMemoryAlloc(addr, size, 0, PAL_PROT_WRITE | PAL_PROT_READ) != addr) {
+        struct shim_vma* vmas_to_free = NULL;
 
-    return (void *) DkVirtualMemoryAlloc(addr, size, 0,
-                                         PAL_PROT_WRITE|PAL_PROT_READ);
+        spinlock_lock_signal_off(&vma_tree_lock);
+        /* Since we are freeing a range we just created, additional vma is not needed. */
+        int ret = _vma_bkeep_remove((uintptr_t)addr, (uintptr_t)addr + size, /*is_internal=*/true,
+                                    NULL, &vmas_to_free);
+        spinlock_unlock_signal_on(&vma_tree_lock);
+        if (ret < 0) {
+            debug("Removing a vma we just created failed with %d!\n", ret);
+            BUG();
+        }
+
+        free_vmas_freelist(vmas_to_free);
+        return NULL;
+    }
+
+    return addr;
+}
+
+/* We never free `vma_mgr`. */
+static void _vma_free(void* ptr, size_t size) {
+    __UNUSED(ptr);
+    __UNUSED(size);
+    BUG();
 }
 
 #undef system_malloc
-#define system_malloc __malloc
-
+#undef system_free
+#define system_malloc _vma_malloc
+#define system_free _vma_free
 #define OBJ_TYPE struct shim_vma
 #include <memmgr.h>
 
-/*
- * "vma_mgr" has no specific lock. "vma_list_lock" must be held when
- * allocating or freeing any VMAs.
- */
+static struct shim_lock vma_mgr_lock;
 static MEM_MGR vma_mgr = NULL;
 
 /*
- * "vma_list" contains a sorted list of non-overlapping VMAs.
- * "vma_list_lock" must be held when accessing either the vma_list or any
- * field of a VMA.
+ * We use a following per-thread caching mechanism of VMAs:
+ * Each thread has a singly linked list of free VMAs, with maximal length of 3.
+ * Allocation first checks if there is a cached VMA, deallocation adds it to cache, unless it is
+ * full (3 entries already present).
+ * Note that 3 is configurable number as long as it is a power of 2 minus 1 and `struct shim_vma`
+ * alignment is not less that it. This is needed for storing the list length in lower bits of
+ * the pointer (small optimization not to add more fields to TCB - can be removed if the max list
+ * size needs to be increased or any supported architecture does not allow for it).
  */
-DEFINE_LISTP(shim_vma);
-static LISTP_TYPE(shim_vma) vma_list = LISTP_INIT;
-static struct shim_lock vma_list_lock;
-
-/*
- * Return true if [s, e) is exactly the area represented by vma.
- */
-static inline bool test_vma_equal (struct shim_vma * vma,
-                                   void * s, void * e)
-{
-    assert(s < e);
-    return vma->start == s && vma->end == e;
-}
-
-/*
- * Return true if [s, e) is part of the area represented by vma.
- */
-static inline bool test_vma_contain (struct shim_vma * vma,
-                                     void * s, void * e)
-{
-    assert(s < e);
-    return vma->start <= s && vma->end >= e;
-}
-
-/*
- * Return true if [s, e) contains the starting address of vma.
- */
-static inline bool test_vma_startin (struct shim_vma * vma,
-                                     void * s, void * e)
-{
-    assert(s < e);
-    return vma->start >= s && vma->start < e;
-}
-
-/*
- * Return true if [s, e) contains the ending address of vma.
- */
-static inline bool test_vma_endin (struct shim_vma * vma,
-                                   void * s, void * e)
-{
-    assert(s < e);
-    return vma->end > s && vma->end <= e;
-}
-
-/*
- * Return true if [s, e) overlaps with the area represented by vma.
- */
-static inline bool test_vma_overlap (struct shim_vma * vma,
-                                     void * s, void * e)
-{
-    assert(s < e);
-    return test_vma_contain(vma, s, s + 1) ||
-           test_vma_contain(vma, e - 1, e) ||
-           test_vma_startin(vma, s, e);
-}
-
-static inline void __assert_vma_list (void)
-{
-    assert(locked(&vma_list_lock));
-
-    struct shim_vma * tmp;
-    struct shim_vma * prev __attribute__((unused)) = NULL;
-
-    LISTP_FOR_EACH_ENTRY(tmp, &vma_list, list) {
-        /* Assert we are really sorted */
-        assert(tmp->end > tmp->start);
-        assert(!prev || prev->end <= tmp->start);
-        prev = tmp;
-    }
-}
-
-// In a debug build only, assert that the VMA list is
-// sorted.  This should be called with the vma_list_lock held.
-static inline void assert_vma_list (void)
-{
-#ifdef DEBUG
-    __assert_vma_list();
+#ifndef __x86_64__
+/* If this optimization will work on the architecture you port Graphene to, add it to the check
+ * above. */
+#error "This optimization requires specific representation of pointers."
 #endif
+
+#define VMA_CACHE_SIZE 3ull
+static_assert((VMA_CACHE_SIZE & (VMA_CACHE_SIZE + 1)) == 0,
+              "VMA_CACHE_SIZE must be a power of 2 minus 1!");
+
+static struct shim_vma* cache2ptr(void* vma) {
+    static_assert(alignof(struct shim_vma) >= VMA_CACHE_SIZE + 1,
+                  "We need some lower bits of pointers to `struct shim_vma` for this optimization!"
+                  );
+    return (struct shim_vma*)((uintptr_t)vma & ~VMA_CACHE_SIZE);
 }
 
-/*
- * __lookup_vma() returns the VMA that contains the address; otherwise,
- * returns NULL. "pprev" returns the highest VMA below the address.
- * __lookup_vma() fills "pprev" even when the function cannot find a
- * matching vma for "addr".
- *
- * vma_list_lock must be held when calling this function.
- */
-static inline struct shim_vma *
-__lookup_vma (void * addr, struct shim_vma ** pprev)
-{
-    assert(locked(&vma_list_lock));
+static void* create_cache_ptr(struct shim_vma* vma, size_t size) {
+    assert(size <= VMA_CACHE_SIZE);
+    return (void*)((uintptr_t)vma | size);
+}
 
-    struct shim_vma * vma, * prev = NULL;
-    struct shim_vma * found = NULL;
+static size_t cache2size(void* vma) {
+    return (size_t)((uintptr_t)vma & VMA_CACHE_SIZE);
+}
 
-    LISTP_FOR_EACH_ENTRY(vma, &vma_list, list) {
-        if (addr < vma->start)
-            break;
-        if (test_vma_contain(vma, addr, addr + 1)) {
-            found = vma;
+static struct shim_vma* get_from_thread_vma_cache(void) {
+    struct shim_vma* vma = cache2ptr(SHIM_TCB_GET(vma_cache));
+    if (!vma) {
+        return NULL;
+    }
+    SHIM_TCB_SET(vma_cache, vma->next_free);
+    return vma;
+}
+
+static bool add_to_thread_vma_cache(struct shim_vma* vma) {
+    assert(cache2size(vma) == 0);
+    void* ptr = SHIM_TCB_GET(vma_cache);
+    size_t size = cache2size(ptr);
+
+    if (size >= VMA_CACHE_SIZE) {
+        return false;
+    }
+
+    vma->next_free = ptr;
+    SHIM_TCB_SET(vma_cache, create_cache_ptr(vma, size + 1));
+    return true;
+}
+
+static void remove_from_thread_vma_cache(struct shim_vma* to_remove) {
+    assert(to_remove);
+
+    struct shim_vma* first_vma = cache2ptr(SHIM_TCB_GET(vma_cache));
+
+    if (first_vma == to_remove) {
+        SHIM_TCB_SET(vma_cache, first_vma->next_free);
+        return;
+    }
+
+    struct shim_vma* vma = first_vma;
+    bool found = false;
+    while (vma) {
+        struct shim_vma* next = cache2ptr(vma->next_free);
+        if (next == to_remove) {
+            found = true;
             break;
         }
-
-        assert(vma->end > vma->start);
-        assert(!prev || prev->end <= vma->start);
-        prev = vma;
+        vma = next;
+    }
+    if (!found) {
+        return;
     }
 
-    if (pprev) *pprev = prev;
-    return found;
+    SHIM_TCB_SET(vma_cache, create_cache_ptr(first_vma, cache2size(first_vma) - 1));
+    vma = first_vma;
+    while (vma) {
+        struct shim_vma* next = cache2ptr(vma->next_free);
+        if (next == to_remove) {
+            vma->next_free = next->next_free;
+            return;
+        }
+        vma->next_free = create_cache_ptr(next, cache2size(vma->next_free) - 1);
+        vma = next;
+    }
 }
 
-/*
- * __insert_vma() places "vma" after "prev", or at the beginning of
- * vma_list if "prev" is NULL. vma_list_lock must be held when calling
- * this function.
- */
-static inline void
-__insert_vma (struct shim_vma * vma, struct shim_vma * prev)
-{
-    assert(locked(&vma_list_lock));
-    assert(!prev || prev->end <= vma->start);
-    assert(vma != prev);
+static struct shim_vma* alloc_vma(void) {
+    struct shim_vma* vma = get_from_thread_vma_cache();
+    if (vma) {
+        goto out;
+    }
 
-    /* check the next entry */
-    struct shim_vma * next = prev ?
-            LISTP_NEXT_ENTRY(prev, &vma_list, list) :
-            LISTP_FIRST_ENTRY(&vma_list, struct shim_vma, list);
+    lock(&vma_mgr_lock);
+    vma = get_mem_obj_from_mgr(vma_mgr);
+    if (!vma) {
+        /* `enlarge_mem_mgr` below will call _vma_malloc, which uses at most 1 vma - so we
+         * temporarily provide it. */
+        struct shim_vma tmp_vma = { 0 };
+        /* vma cache is empty, as we checked it before. */
+        if (!add_to_thread_vma_cache(&tmp_vma)) {
+            debug("Failed to add tmp vma to cache!\n");
+            BUG();
+        }
+        if (!enlarge_mem_mgr(vma_mgr, size_align_up(DEFAULT_VMA_COUNT))) {
+            remove_from_thread_vma_cache(&tmp_vma);
+            goto out_unlock;
+        }
 
-    __UNUSED(next);
-    assert(!next || vma->end <= next->start);
+        struct shim_vma* vma_migrate = get_mem_obj_from_mgr(vma_mgr);
+        if (!vma_migrate) {
+            debug("Failed to allocate a vma right after enlarge_mem_mgr!\n");
+            BUG();
+        }
 
-    if (prev)
-        LISTP_ADD_AFTER(vma, prev, &vma_list, list);
-    else
-        LISTP_ADD(vma, &vma_list, list);
+        spinlock_lock_signal_off(&vma_tree_lock);
+        /* Currently `tmp_vma` is always used (added to `vma_tree`), but this assumption could
+         * easily be changed (e.g. if we implement VMAs merging).*/
+        struct avl_tree_node* node = &tmp_vma.tree_node;
+        if (node->parent || vma_tree.root == node) {
+            /* `tmp_vma` is in `vma_tree`, we need to migrate it. */
+            copy_vma(&tmp_vma, vma_migrate);
+            avl_tree_swap_node(&vma_tree, node, &vma_migrate->tree_node);
+            vma_migrate = NULL;
+        }
+        spinlock_unlock_signal_on(&vma_tree_lock);
+
+        if (vma_migrate) {
+            free_mem_obj_to_mgr(vma_mgr, vma_migrate);
+        }
+        remove_from_thread_vma_cache(&tmp_vma);
+
+        vma = get_mem_obj_from_mgr(vma_mgr);
+    }
+
+out_unlock:
+    unlock(&vma_mgr_lock);
+out:
+    if (vma) {
+        memset(vma, 0, sizeof(*vma));
+    }
+    return vma;
 }
 
-/*
- * __remove_vma() removes "vma" after "prev", or at the beginnning of
- * vma_list if "prev" is NULL. vma_list_lock must be held when calling
- * this function.
- */
-static inline void
-__remove_vma (struct shim_vma * vma, struct shim_vma * prev)
-{
-    assert(locked(&vma_list_lock));
-    __UNUSED(prev);
-    assert(vma != prev);
-    LISTP_DEL(vma, &vma_list, list);
+static void free_vma(struct shim_vma* vma) {
+    if (vma->file) {
+        put_handle(vma->file);
+    }
+
+    if (add_to_thread_vma_cache(vma)) {
+        return;
+    }
+
+    lock(&vma_mgr_lock);
+    free_mem_obj_to_mgr(vma_mgr, vma);
+    unlock(&vma_mgr_lock);
 }
 
-/*
- * Storing a cursor pointing to the current heap top. With ASLR, the cursor
- * is randomized at initialization. The cursor is monotonically decremented
- * when allocating user VMAs. Updating this cursor needs holding vma_list_lock.
- */
-static void * current_heap_top;
+static void free_vmas_freelist(struct shim_vma* vma) {
+    while (vma) {
+        struct shim_vma* next = vma->next_free;
+        free_vma(vma);
+        vma = next;
+    }
+}
 
-static int __bkeep_mmap (struct shim_vma * prev,
-                         void * start, void * end, int prot, int flags,
-                         struct shim_handle * file, off_t offset,
-                         const char * comment);
+static int _bkeep_initial_vma(struct shim_vma* new_vma) {
+    assert(spinlock_is_locked(&vma_tree_lock));
 
-static int __bkeep_munmap (struct shim_vma ** prev,
-                           void * start, void * end, int flags);
-
-static int __bkeep_mprotect (struct shim_vma * prev,
-                             void * start, void * end, int prot, int flags);
-
-static int
-__bkeep_preloaded (void * start, void * end, int prot, int flags,
-                   const char * comment)
-{
-    assert(locked(&vma_list_lock));
-
-    if (!start || !end || start == end)
+    struct shim_vma* tmp_vma = _lookup_vma(new_vma->begin);
+    if (tmp_vma && tmp_vma->begin < new_vma->end) {
+        return -EEXIST;
+    } else {
+        avl_tree_insert(&vma_tree, &new_vma->tree_node);
         return 0;
-
-    struct shim_vma * prev = NULL;
-    __lookup_vma(start, &prev);
-    return __bkeep_mmap(prev, start, end, prot, flags, NULL, 0, comment);
+    }
 }
+
+#define ASLR_BITS 12
+/* This variable is written to only once, during initialization, so it does not need to
+ * be atomic. */
+static void* g_aslr_addr_top = NULL;
 
 int init_vma(void) {
-    int ret = 0;
+    struct shim_vma init_vmas[] = {
+        { .begin = 0 }, // vma for creation of memory manager
+        {
+            .begin = (uintptr_t)&__load_address,
+            .end = (uintptr_t)ALLOC_ALIGN_UP_PTR(&__load_address_end),
+            .prot = PROT_NONE,
+            .flags = MAP_PRIVATE | MAP_ANONYMOUS | VMA_INTERNAL,
+            .file = NULL,
+            .offset = 0,
+            .comment = "LibOS",
+        },
+        {
+            .begin = (uintptr_t)ALLOC_ALIGN_DOWN_PTR(PAL_CB(manifest_preload.start)),
+            .end = (uintptr_t)ALLOC_ALIGN_UP_PTR(PAL_CB(manifest_preload.end)),
+            .prot = PROT_NONE,
+            .flags = MAP_PRIVATE | MAP_ANONYMOUS | VMA_INTERNAL,
+            .file = NULL,
+            .offset = 0,
+            .comment = "manifest",
+        },
+        {
+            .begin = (uintptr_t)PAL_CB(executable_range.start),
+            .end = (uintptr_t)PAL_CB(executable_range.end),
+            .prot = PROT_NONE,
+            .flags = MAP_PRIVATE | MAP_ANONYMOUS | VMA_UNMAPPED,
+            .file = NULL,
+            .offset = 0,
+            .comment = "exec",
+        },
+        /* TODO: remove these 2 guard pages, they should not exist (but Linux-SGX Pal adds them). */
+        {
+            .begin = (uintptr_t)PAL_CB(executable_range.start) - PAL_CB(exec_memory_gap),
+            .end = (uintptr_t)PAL_CB(executable_range.start),
+            .prot = PROT_NONE,
+            .flags = MAP_PRIVATE | MAP_ANONYMOUS | VMA_UNMAPPED | VMA_INTERNAL,
+            .file = NULL,
+            .offset = 0,
+            .comment = "guard_page",
+        },
+        {
+            .begin = (uintptr_t)PAL_CB(executable_range.end),
+            .end = (uintptr_t)PAL_CB(executable_range.end) + PAL_CB(exec_memory_gap),
+            .prot = PROT_NONE,
+            .flags = MAP_PRIVATE | MAP_ANONYMOUS | VMA_UNMAPPED | VMA_INTERNAL,
+            .file = NULL,
+            .offset = 0,
+            .comment = "guard_page",
+        },
+    };
 
-    if (!create_lock(&vma_list_lock)) {
+    spinlock_lock_signal_off(&vma_tree_lock);
+    int ret = 0;
+    /* First of init_vmas is reserved for later usage. */
+    for (size_t i = 1; i < ARRAY_SIZE(init_vmas); i++) {
+        assert(init_vmas[i].begin <= init_vmas[i].end);
+        /* Skip empty areas. */
+        if (init_vmas[i].begin == init_vmas[i].end) {
+            debug("Skipping bookkeeping of empty region at 0x%lx (comment: \"%s\")\n",
+                  init_vmas[i].begin, init_vmas[i].comment);
+            continue;
+        }
+        if (!IS_ALLOC_ALIGNED(init_vmas[i].begin) || !IS_ALLOC_ALIGNED(init_vmas[i].end)) {
+            debug("Unaligned VMA region: 0x%lx-0x%lx (%s)\n", init_vmas[i].begin, init_vmas[i].end,
+                                                              init_vmas[i].comment);
+            ret = -EINVAL;
+            break;
+        }
+        ret = _bkeep_initial_vma(&init_vmas[i]);
+        if (ret < 0) {
+            debug("Failed to bookkeep initial VMA region 0x%lx-0x%lx (%s)\n", init_vmas[i].begin,
+                                                                              init_vmas[i].end,
+                                                                              init_vmas[i].comment);
+            break;
+        }
+        debug("Initial VMA region 0x%lx-0x%lx (%s) bookkeeped\n", init_vmas[i].begin,
+                                                                  init_vmas[i].end,
+                                                                  init_vmas[i].comment);
+    }
+    spinlock_unlock_signal_on(&vma_tree_lock);
+    /* From now on if we return with an error we might leave a structure local to this function in
+     * vma_tree. We do not bother with removing them - this is initialization of VMA subsystem, if
+     * it fails the whole application startup fails and we should never call any of functions in
+     * this file. */
+    if (ret < 0) {
+        return ret;
+    }
+
+    g_aslr_addr_top = PAL_CB(user_address.end);
+
+#if ENABLE_ASLR == 1
+    /* Inspired by: https://elixir.bootlin.com/linux/v5.6.3/source/arch/x86/mm/mmap.c#L80 */
+    size_t gap_max_size = (PAL_CB(user_address.end) - PAL_CB(user_address.start)) / 6 * 5;
+    /* We do address space randomization only if we have at least ASLR_BITS to randomize. */
+    if (gap_max_size / ALLOC_ALIGNMENT >= (1ul << ASLR_BITS)) {
+        size_t gap = 0;
+
+        int ret = DkRandomBitsRead(&gap, sizeof(gap));
+        if (ret < 0) {
+            return -convert_pal_errno(-ret);
+        }
+
+        /* Resulting distribution is not ideal, but it should not be an issue here. */
+        gap = ALLOC_ALIGN_DOWN(gap % gap_max_size);
+        g_aslr_addr_top = (char*)g_aslr_addr_top - gap;
+
+        debug("ASLR top address adjusted to %p\n", g_aslr_addr_top);
+    } else {
+        debug("Not enough space to make meaningful address space randomization.\n");
+    }
+#endif
+
+    /* We need 1 vma to create the memmgr. */
+    if (!add_to_thread_vma_cache(&init_vmas[0])) {
+        debug("Failed to add tmp vma to cache!\n");
+        BUG();
+    }
+    vma_mgr = create_mem_mgr(DEFAULT_VMA_COUNT);
+    if (!vma_mgr) {
+        debug("Failed to create VMA memory manager!\n");
         return -ENOMEM;
     }
 
-    lock(&vma_list_lock);
-
-    for (int i = 0 ; i < RESERVED_VMAS ; i++)
-        reserved_vmas[i] = &early_vmas[i];
-
-    /* Bookkeeping for preloaded areas */
-
-    if (PAL_CB(user_address_hole.end) - PAL_CB(user_address_hole.start) > 0) {
-        ret = __bkeep_preloaded(PAL_CB(user_address_hole.start),
-                                PAL_CB(user_address_hole.end),
-                                PROT_NONE, MAP_PRIVATE|MAP_ANONYMOUS|VMA_UNMAPPED,
-                                "reserved");
-        if (ret < 0)
-            goto out;
+    if (!create_lock(&vma_mgr_lock)) {
+        return -ENOMEM;
     }
 
-    ret = __bkeep_preloaded(PAL_CB(executable_range.start),
-                            PAL_CB(executable_range.end),
-                            PROT_NONE, MAP_PRIVATE|MAP_ANONYMOUS|VMA_UNMAPPED,
-                            "exec");
-    if (ret < 0)
-        goto out;
+    /* Now we need to migrate temporary initial vmas. */
+    struct shim_vma* vmas_to_migrate_to[ARRAY_SIZE(init_vmas)];
+    for (size_t i = 0; i < ARRAY_SIZE(vmas_to_migrate_to); i++) {
+        vmas_to_migrate_to[i] = alloc_vma();
+        if (!vmas_to_migrate_to[i]) {
+            return -ENOMEM;
+        }
+    }
 
-    ret = __bkeep_preloaded(PAL_CB(manifest_preload.start),
-                            PAL_CB(manifest_preload.end),
-                            PROT_READ, MAP_PRIVATE|MAP_ANONYMOUS|VMA_INTERNAL,
-                            "manifest");
-    if (ret < 0)
-        goto out;
+    spinlock_lock_signal_off(&vma_tree_lock);
+    for (size_t i = 0; i < ARRAY_SIZE(init_vmas); i++) {
+        /* Skip empty areas. */
+        if (init_vmas[i].begin == init_vmas[i].end) {
+            continue;
+        }
+        copy_vma(&init_vmas[i], vmas_to_migrate_to[i]);
+        avl_tree_swap_node(&vma_tree, &init_vmas[i].tree_node, &vmas_to_migrate_to[i]->tree_node);
+        vmas_to_migrate_to[i] = NULL;
+    }
+    spinlock_unlock_signal_on(&vma_tree_lock);
 
-    /* Keep track of LibOS code itself so nothing overwrites it */
-    ret = __bkeep_preloaded(&__load_address,
-                            ALLOC_ALIGN_UP_PTR(&__load_address_end),
-                            PROT_READ, MAP_PRIVATE|MAP_ANONYMOUS|VMA_INTERNAL,
-                            "LibOS");
-    if (ret < 0)
-        goto out;
+    for (size_t i = 0; i < ARRAY_SIZE(vmas_to_migrate_to); i++) {
+        if (vmas_to_migrate_to[i]) {
+            free_vma(vmas_to_migrate_to[i]);
+        }
+    }
 
-    /* Initialize the allocator */
+    return 0;
+}
 
-    if (!(vma_mgr = create_mem_mgr(init_align_up(VMA_MGR_ALLOC)))) {
-        debug("failed creating the VMA allocator\n");
+static void _add_unmapped_vma(uintptr_t begin, uintptr_t end, struct shim_vma* vma) {
+    assert(spinlock_is_locked(&vma_tree_lock));
+
+    vma->begin = begin;
+    vma->end = end;
+    vma->prot = 0;
+    vma->flags = VMA_INTERNAL | VMA_UNMAPPED;
+    vma->file = NULL;
+    vma->offset = 0;
+    copy_comment(vma, "");
+
+    avl_tree_insert(&vma_tree, &vma->tree_node);
+}
+
+// TODO change so that vma1 is provided by caller
+int bkeep_munmap(void* addr, size_t length, bool is_internal, void** tmp_vma_ptr) {
+    assert(tmp_vma_ptr);
+
+    if (!length || !IS_ALLOC_ALIGNED(length) || !IS_ALLOC_ALIGNED_PTR(addr)) {
+        return -EINVAL;
+    }
+
+    struct shim_vma* vma1 = alloc_vma();
+    if (!vma1) {
+        return -ENOMEM;
+    }
+    /* Unmapping may succeed even without this vma, so if this allocation fails we move on. */
+    struct shim_vma* vma2 = alloc_vma();
+
+    struct shim_vma* vmas_to_free = NULL;
+
+    spinlock_lock_signal_off(&vma_tree_lock);
+    int ret = _vma_bkeep_remove((uintptr_t)addr, (uintptr_t)addr + length, is_internal,
+                                vma2 ? &vma2 : NULL, &vmas_to_free);
+    if (ret >= 0) {
+        _add_unmapped_vma((uintptr_t)addr, (uintptr_t)addr + length, vma1);
+        *tmp_vma_ptr = (void*)vma1;
+        vma1 = NULL;
+    }
+    spinlock_unlock_signal_on(&vma_tree_lock);
+
+    free_vmas_freelist(vmas_to_free);
+    if (vma1) {
+        free_vma(vma1);
+    }
+    if (vma2) {
+        free_vma(vma2);
+    }
+
+    remove_r_debug(addr);
+    return ret;
+}
+
+void bkeep_remove_tmp_vma(void* _vma) {
+    struct shim_vma* vma = (struct shim_vma*)_vma;
+
+    assert(vma->flags == (VMA_INTERNAL | VMA_UNMAPPED));
+
+    spinlock_lock_signal_off(&vma_tree_lock);
+    avl_tree_delete(&vma_tree, &vma->tree_node);
+    spinlock_unlock_signal_on(&vma_tree_lock);
+
+    free_vma(vma);
+}
+
+static bool is_file_prot_matching(struct shim_handle* file_hdl, int prot) {
+    return !(prot & PROT_WRITE) || (file_hdl->flags & O_RDWR);
+}
+
+int bkeep_mmap_fixed(void* addr, size_t length, int prot, int flags,
+                     struct shim_handle* file, off_t offset, const char* comment) {
+    assert(flags & (MAP_FIXED | MAP_FIXED_NOREPLACE));
+
+    if (!length || !IS_ALLOC_ALIGNED(length) || !IS_ALLOC_ALIGNED_PTR(addr)) {
+        return -EINVAL;
+    }
+
+    struct shim_vma* new_vma = alloc_vma();
+    if (!new_vma) {
+        return -ENOMEM;
+    }
+    /* Unmapping may succeed even without this vma, so if this allocation fails we move on. */
+    struct shim_vma* vma1 = alloc_vma();
+
+    new_vma->begin = (uintptr_t)addr;
+    new_vma->end = new_vma->begin + length;
+    new_vma->prot = prot;
+    new_vma->flags = filter_saved_flags(flags) | ((file && (prot & PROT_WRITE)) ? VMA_TAINTED : 0);
+    new_vma->file = file;
+    if (new_vma->file) {
+        get_handle(new_vma->file);
+    }
+    new_vma->offset = file ? offset : 0;
+    copy_comment(new_vma, comment ?: "");
+
+    struct shim_vma* vmas_to_free = NULL;
+
+    spinlock_lock_signal_off(&vma_tree_lock);
+    int ret = 0;
+    if (flags & MAP_FIXED_NOREPLACE) {
+        struct shim_vma* tmp_vma = _lookup_vma(new_vma->begin);
+        if (tmp_vma && tmp_vma->begin < new_vma->end) {
+            ret = -EEXIST;
+        }
+    } else {
+        ret = _vma_bkeep_remove(new_vma->begin, new_vma->end, !!(flags & VMA_INTERNAL),
+                                vma1 ? &vma1 : NULL, &vmas_to_free);
+    }
+    if (ret >= 0) {
+        avl_tree_insert(&vma_tree, &new_vma->tree_node);
+    }
+    spinlock_unlock_signal_on(&vma_tree_lock);
+
+    free_vmas_freelist(vmas_to_free);
+    if (vma1) {
+        free_vma(vma1);
+    }
+
+    if (ret < 0) {
+        free_vma(new_vma);
+    }
+    return ret;
+}
+
+static void vma_update_prot(struct shim_vma* vma, int prot) {
+    vma->prot = prot;
+    if (vma->file && (prot & PROT_WRITE)) {
+        vma->flags |= VMA_TAINTED;
+    }
+}
+
+static int _vma_bkeep_change(uintptr_t begin, uintptr_t end, int prot, bool is_internal,
+                             struct shim_vma** new_vma_ptr1,
+                             struct shim_vma** new_vma_ptr2) {
+    assert(spinlock_is_locked(&vma_tree_lock));
+    assert(IS_ALLOC_ALIGNED_PTR(begin) && IS_ALLOC_ALIGNED_PTR(end));
+
+    struct shim_vma* vma = _lookup_vma(begin);
+    if (!vma) {
+        return -ENOMEM;
+    }
+
+    struct shim_vma* prev = NULL;
+    struct shim_vma* first_vma = vma;
+
+    if (begin < vma->begin) {
+        return -ENOMEM;
+    }
+
+    bool is_continuous = true;
+    bool is_ok = true;
+
+    while (1) {
+        is_ok &= !!(vma->flags & VMA_INTERNAL) == is_internal;
+        if (vma->file && (vma->flags & MAP_SHARED)) {
+            is_ok &= is_file_prot_matching(vma->file, prot);
+        }
+
+        if (end <= vma->end) {
+            break;
+        }
+
+        prev = vma;
+
+        vma = _get_next_vma(vma);
+        if (!vma) {
+            is_continuous = false;
+            break;
+        }
+
+        is_continuous &= prev->end == vma->begin;
+    }
+
+    if (!is_continuous) {
+        return -ENOMEM;
+    }
+    if (!is_ok) {
+        return -EACCES;
+    }
+
+    vma = first_vma;
+
+    if (vma->begin < begin) {
+        struct shim_vma* new_vma1 = *new_vma_ptr1;
+        *new_vma_ptr1 = NULL;
+
+        split_vma(vma, new_vma1, begin);
+        vma_update_prot(new_vma1, prot);
+
+        struct shim_vma* next = _get_next_vma(vma);
+
+        avl_tree_insert(&vma_tree, &new_vma1->tree_node);
+
+        if (end < new_vma1->end) {
+            struct shim_vma* new_vma2 = *new_vma_ptr2;
+            *new_vma_ptr2 = NULL;
+
+            split_vma(new_vma1, new_vma2, end);
+            vma_update_prot(new_vma2, vma->prot);
+
+            avl_tree_insert(&vma_tree, &new_vma2->tree_node);
+            return 0;
+        }
+
+        /* Error checking at the begining ensures we always have the next node. */
+        assert(next);
+        vma = next;
+    }
+
+    while (vma->end <= end) {
+        vma_update_prot(vma, prot);
+
+#ifdef DEBUG
+        struct shim_vma* prev = vma;
+#endif
+        vma = _get_next_vma(vma);
+        if (!vma) {
+            /* We've reached the very last vma. */
+            assert(prev->end == end);
+            return 0;
+        }
+    }
+
+    if (end <= vma->begin) {
+        return 0;
+    }
+
+    struct shim_vma* new_vma2 = *new_vma_ptr2;
+    *new_vma_ptr2 = NULL;
+
+    split_vma(vma, new_vma2, end);
+    vma_update_prot(vma, prot);
+
+    avl_tree_insert(&vma_tree, &new_vma2->tree_node);
+
+    return 0;
+}
+
+int bkeep_mprotect(void* addr, size_t length, int prot, bool is_internal) {
+    if (!length || !IS_ALLOC_ALIGNED(length) || !IS_ALLOC_ALIGNED_PTR(addr)) {
+        return -EINVAL;
+    }
+
+    struct shim_vma* vma1 = alloc_vma();
+    if (!vma1) {
+        return -ENOMEM;
+    }
+    struct shim_vma* vma2 = alloc_vma();
+    if (!vma2) {
+        free_vma(vma1);
+        return -ENOMEM;
+    }
+
+    spinlock_lock_signal_off(&vma_tree_lock);
+    int ret = _vma_bkeep_change((uintptr_t)addr, (uintptr_t)addr + length, prot, is_internal,
+                                &vma1, &vma2);
+    spinlock_unlock_signal_on(&vma_tree_lock);
+
+    if (vma1) {
+        free_vma(vma1);
+    }
+    if (vma2) {
+        free_vma(vma2);
+    }
+
+    return ret;
+}
+
+/* TODO consider:
+ * maybe it's worth to keep another tree, complementary to `vma_tree`, that would hold free areas.
+ * It would give O(logn) unmapped lookup, which now is O(n) in the worst case, but it would also
+ * double the memory usage of this subsystem and add some complexity.
+ * Another idea is to merge adjacent vmas, that are not backed by any file and have the same prot
+ * and flags (the question is whether that happens often). */
+/* This function allocates at most 1 vma. If in the future it uses more, `_vma_malloc` should be
+ * updated as well. */
+int bkeep_mmap_any_in_range(void* _bottom_addr, void* _top_addr, size_t length, int prot, int flags,
+                            struct shim_handle* file, off_t offset, const char* comment,
+                            void** ret_val_ptr) {
+    assert(_bottom_addr < _top_addr);
+
+    if (!length || !IS_ALLOC_ALIGNED(length)) {
+        return -EINVAL;
+    }
+    if (!IS_ALLOC_ALIGNED_PTR(_bottom_addr) || !IS_ALLOC_ALIGNED_PTR(_top_addr)) {
+        return -EINVAL;
+    }
+
+    uintptr_t top_addr = (uintptr_t)_top_addr;
+    uintptr_t bottom_addr = (uintptr_t)_bottom_addr;
+    int ret = 0;
+    uintptr_t ret_val = 0;
+
+    if (flags & MAP_32BIT) {
+        /* Only consider first 2 gigabytes. */
+        top_addr = MIN(top_addr, 1ul << 31);
+        if (bottom_addr >= top_addr) {
+            return -ENOMEM;
+        }
+    }
+
+    struct shim_vma* new_vma = alloc_vma();
+    if (!new_vma) {
+        return -ENOMEM;
+    }
+    new_vma->prot = prot;
+    new_vma->flags = filter_saved_flags(flags) | ((file && (prot & PROT_WRITE)) ? VMA_TAINTED : 0);
+    new_vma->file = file;
+    if (new_vma->file) {
+        get_handle(new_vma->file);
+    }
+    new_vma->offset = file ? offset : 0;
+    copy_comment(new_vma, comment ?: "");
+
+    spinlock_lock_signal_off(&vma_tree_lock);
+
+    struct shim_vma* vma = _lookup_vma(top_addr);
+    uintptr_t max_addr;
+    if (!vma) {
+        vma = _get_last_vma();
+        max_addr = top_addr;
+    } else {
+        max_addr = MIN(top_addr, vma->begin);
+        vma = _get_prev_vma(vma);
+    }
+    assert(!vma || vma->end <= max_addr);
+
+    while (vma && bottom_addr <= vma->end) {
+        assert(vma->end <= max_addr);
+        if (max_addr - vma->end >= length) {
+            goto out_found;
+        }
+
+        max_addr = vma->begin;
+        vma = _get_prev_vma(vma);
+    }
+
+    if (!(bottom_addr <= max_addr && max_addr - bottom_addr >= length)) {
         ret = -ENOMEM;
         goto out;
     }
 
-    for (int i = 0 ; i < RESERVED_VMAS ; i++) {
-        if (!reserved_vmas[i]) {
-            struct shim_vma * new = get_mem_obj_from_mgr(vma_mgr);
-            assert(new);
-            struct shim_vma * e = &early_vmas[i];
-            struct shim_vma * prev = LISTP_PREV_ENTRY(e, &vma_list, list);
-            debug("Converting early VMA [%p] %p-%p\n", e, e->start, e->end);
-            memcpy(new, e, sizeof(*e));
-            INIT_LIST_HEAD(new, list);
-            __remove_vma(e, prev);
-            __insert_vma(new, prev);
-        }
+out_found:
+    new_vma->end = max_addr;
+    new_vma->begin = new_vma->end - length;
 
-        /* replace all reserved VMAs */
-        reserved_vmas[i] = get_mem_obj_from_mgr(vma_mgr);
-        assert(reserved_vmas[i]);
-    }
+    avl_tree_insert(&vma_tree, &new_vma->tree_node);
 
-    current_heap_top = PAL_CB(user_address.end);
-
-#if ENABLE_ASLR == 1
-    /*
-     * Randomize the heap top in top 5/6 of the user address space.
-     * This is a simplified version of the mmap_base() logic in the Linux
-     * kernel: https://elixir.bootlin.com/linux/v4.8/ident/mmap_base
-     */
-    size_t addr_rand_size =
-        (PAL_CB(user_address.end) - PAL_CB(user_address.start)) * 5 / 6;
-    size_t rand;
-    ret = DkRandomBitsRead(&rand, sizeof(rand));
-    if (ret < 0) {
-        ret = -convert_pal_errno(-ret);
-        goto out;
-    }
-    current_heap_top -= ALLOC_ALIGN_DOWN(rand % addr_rand_size);
-#endif
-
-    debug("heap top adjusted to %p\n", current_heap_top);
+    ret_val = new_vma->begin;
+    new_vma = NULL;
 
 out:
-    unlock(&vma_list_lock);
+    spinlock_unlock_signal_on(&vma_tree_lock);
+    if (new_vma) {
+        free_vma(new_vma);
+    }
+    if (ret >= 0) {
+        *ret_val_ptr = (void*)ret_val;
+    }
     return ret;
 }
 
-static inline struct shim_vma * __get_new_vma (void)
-{
-    assert(locked(&vma_list_lock));
-
-    struct shim_vma * tmp = NULL;
-
-    if (vma_mgr)
-        tmp = get_mem_obj_from_mgr(vma_mgr);
-    if (tmp == NULL) {
-        for (int i = 0 ; i < RESERVED_VMAS ; i++)
-            if (reserved_vmas[i]) {
-                tmp = reserved_vmas[i];
-                reserved_vmas[i] = NULL;
-                break;
-            }
-    }
-
-    if (tmp == NULL) {
-        /* Should never reach here; if this happens, increase RESERVED_VMAS */
-        debug("failed to allocate new vma\n");
-        BUG();
-        return NULL;
-    }
-    memset(tmp, 0, sizeof(*tmp));
-    INIT_LIST_HEAD(tmp, list);
-    return tmp;
+int bkeep_mmap_any(size_t length, int prot, int flags, struct shim_handle* file, off_t offset,
+                   const char* comment, void** ret_val_ptr) {
+    return bkeep_mmap_any_in_range(PAL_CB(user_address.start), PAL_CB(user_address.end), length,
+                                   prot, flags, file, offset, comment, ret_val_ptr);
 }
 
-static inline void __restore_reserved_vmas (void)
-{
-    assert(locked(&vma_list_lock));
-
-    bool nothing_reserved;
-    do {
-        nothing_reserved = true;
-        for (int i = 0 ; i < RESERVED_VMAS ; i++)
-            if (!reserved_vmas[i]) {
-                struct shim_vma * new =
-                    get_mem_obj_from_mgr_enlarge(vma_mgr,
-                                                 size_align_up(VMA_MGR_ALLOC));
-
-                /* this allocation must succeed */
-                assert(new);
-                reserved_vmas[i] = new;
-                nothing_reserved = false;
-            }
-    } while (!nothing_reserved);
-}
-
-static inline void __drop_vma (struct shim_vma * vma)
-{
-    assert(locked(&vma_list_lock));
-
-    if (vma->file)
-        put_handle(vma->file);
-
-    for (int i = 0 ; i < RESERVED_VMAS ; i++)
-        if (!reserved_vmas[i]) {
-            reserved_vmas[i] = vma;
-            return;
-        }
-
-    free_mem_obj_to_mgr(vma_mgr, vma);
-}
-
-static inline void
-__assert_vma_flags (const struct shim_vma * vma, int flags)
-{
-    if (!(vma->flags & VMA_UNMAPPED)
-            && VMA_TYPE(vma->flags) != VMA_TYPE(flags)) {
-        debug("Check vma flag failure: vma flags %x, checked flags %x\n",
-              vma->flags, flags);
-        BUG();
-    }
-}
-
-static inline void
-__set_vma_comment (struct shim_vma * vma, const char * comment)
-{
-    if (!comment) {
-        vma->comment[0] = 0;
-        return;
-    }
-
-    size_t len = strlen(comment);
-
-    if (len > VMA_COMMENT_LEN - 1)
-        len = VMA_COMMENT_LEN - 1;
-
-    memcpy(vma->comment, comment, len);
-    vma->comment[len] = 0;
-}
-
-/*
- * Add bookkeeping for mmap(). "prev" must point to the the immediately
- * precedent vma of the address to map, or be NULL if no vma is lower than
- * the address. If the bookkeeping area overlaps with some existing vmas,
- * we must check whether the caller (from user, internal code, or checkpointing
- * procedure) is allowed to overwrite the existing vmas.
- *
- * Bookkeeping convention (must follow):
- * Create the bookkeeping BEFORE any allocation PAL calls
- * (DkVirtualMemoryAlloc() or DkStreamMap()).
- */
-static int __bkeep_mmap (struct shim_vma * prev,
-                         void * start, void * end, int prot, int flags,
-                         struct shim_handle * file, off_t offset,
-                         const char * comment)
-{
-    assert(locked(&vma_list_lock));
-
-    int ret = 0;
-    struct shim_vma * new = __get_new_vma();
-
-    /* First, remove any overlapping VMAs */
-    ret = __bkeep_munmap(&prev, start, end, flags);
-    if (ret < 0) {
-        __drop_vma(new);
+int bkeep_mmap_any_aslr(size_t length, int prot, int flags, struct shim_handle* file, off_t offset,
+                        const char* comment, void** ret_val_ptr) {
+    int ret;
+    ret = bkeep_mmap_any_in_range(PAL_CB(user_address.start), g_aslr_addr_top, length, prot, flags,
+                                  file, offset, comment, ret_val_ptr);
+    if (ret >= 0) {
         return ret;
     }
 
-    /* Inserting the new VMA */
-    new->start  = start;
-    new->end    = end;
-    new->prot   = prot;
-    new->flags  = flags|((file && (prot & PROT_WRITE)) ? VMA_TAINTED : 0);
-    new->file   = file;
-    if (new->file)
-        get_handle(new->file);
-    new->offset = offset;
-    __set_vma_comment(new, comment);
-    __insert_vma(new, prev);
-    return 0;
+    return bkeep_mmap_any(length, prot, flags, file, offset, comment, ret_val_ptr);
 }
 
-int bkeep_mmap (void * addr, size_t length, int prot, int flags,
-                struct shim_handle * file, off_t offset, const char * comment)
-{
-    if (!addr || !length)
-        return -EINVAL;
+static void dump_vma(struct shim_vma_info* vma_info, struct shim_vma* vma) {
+    vma_info->addr = (void*)vma->begin;
+    vma_info->length = vma->end - vma->begin;
+    vma_info->prot = vma->prot;
+    vma_info->flags = vma->flags;
+    vma_info->file_offset = vma->offset;
+    vma_info->file = vma->file;
+    if (vma_info->file) {
+        get_handle(vma_info->file);
+    }
+    static_assert(sizeof(vma_info->comment) == sizeof(vma->comment), "Comments sizes do not match");
+    memcpy(vma_info->comment, vma->comment, sizeof(vma_info->comment));
+}
 
-    if (comment && !comment[0])
-        comment = NULL;
+int lookup_vma(void* addr, struct shim_vma_info* vma_info) {
+    assert(vma_info);
+    int ret = 0;
 
-    debug("bkeep_mmap: %p-%p\n", addr, addr + length);
+    spinlock_lock_signal_off(&vma_tree_lock);
+    struct shim_vma* vma = _lookup_vma((uintptr_t)addr);
+    if (!vma || !is_addr_in_vma((uintptr_t)addr, vma)) {
+        ret = -ENOENT;
+        goto out;
+    }
 
-    lock(&vma_list_lock);
-    struct shim_vma * prev = NULL;
-    __lookup_vma(addr, &prev);
-    int ret = __bkeep_mmap(prev, addr, addr + length, prot, flags, file, offset,
-                           comment);
-    assert_vma_list();
-    __restore_reserved_vmas();
-    unlock(&vma_list_lock);
+    dump_vma(vma_info, vma);
+
+out:
+    spinlock_unlock_signal_on(&vma_tree_lock);
     return ret;
 }
 
-/*
- * __shrink_vma() removes the area in a VMA that overlaps with [start, end).
- * The function deals with three cases:
- * (1) [start, end) overlaps with the beginning of the VMA.
- * (2) [start, end) overlaps with the ending of the VMA.
- * (3) [start, end) overlaps with the middle of the VMA. In this case, the VMA
- *     is splitted into two. The new VMA is stored in 'tailptr'.
- * In either of these cases, "vma" is the only one changed among vma_list.
- */
-static inline void __shrink_vma (struct shim_vma * vma, void * start, void * end,
-                                 struct shim_vma ** tailptr)
-{
-    assert(locked(&vma_list_lock));
+bool is_in_adjacent_user_vmas(void* addr, size_t length) {
+    uintptr_t begin = (uintptr_t)addr;
+    uintptr_t end = begin + length;
+    bool ret = false;
 
-    if (test_vma_startin(vma, start, end)) {
-        /*
-         * Dealing with the head: if the starting address of "vma" is in
-         * [start, end), move the starting address.
-         */
-        if (end < vma->end) {
-            if (vma->file) /* must adjust offset */
-                vma->offset += end - vma->start;
-            vma->start = end;
-        } else {
-            if (vma->file) /* must adjust offset */
-                vma->offset += vma->end - vma->start;
-            vma->start = vma->end;
-        }
-    } else if (test_vma_endin(vma, start, end)) {
-        /*
-         * Dealing with the tail: if the ending address of "vma" is in
-         * [start, end), move the ending address.
-         */
-        if (start > vma->start) {
-            vma->end = start;
-        } else {
-            vma->end = vma->start;
-        }
-        /* offset is not affected */
-    } else if (test_vma_contain(vma, start, end)) {
-        /*
-         * If [start, end) is inside the range of "vma", divide up
-         * the VMA. A new VMA is created to represent the remaining tail.
-         */
-        void * old_end = vma->end;
-        vma->end = start;
-
-        /* Remaining space after [start, end), creating a new VMA */
-        if (old_end > end) {
-            struct shim_vma * tail = __get_new_vma();
-
-            tail->start = end;
-            tail->end   = old_end;
-            tail->prot  = vma->prot;
-            tail->flags = vma->flags;
-            tail->file  = vma->file;
-            if (tail->file) {
-                get_handle(tail->file);
-                tail->offset = vma->offset + (tail->start - vma->start);
-            } else {
-                tail->offset = 0;
-            }
-            memcpy(tail->comment, vma->comment, VMA_COMMENT_LEN);
-            *tailptr = tail;
-        }
-    } else {
-        /* Never reach here */
-        BUG();
+    spinlock_lock_signal_off(&vma_tree_lock);
+    struct shim_vma* vma = _lookup_vma(begin);
+    if (!vma || begin < vma->begin || (vma->flags & (VMA_INTERNAL | VMA_UNMAPPED))) {
+        goto out;
     }
 
-    assert(!test_vma_overlap(vma, start, end));
-    assert(vma->start < vma->end);
-}
-
-/*
- * Update bookkeeping for munmap(). "*pprev" must point to the immediately
- * precedent vma of the address to unmap, or be NULL if no vma is lower than
- * the address. If the bookkeeping area overlaps with some existing vmas,
- * we must check whether the caller (from user, internal code, or checkpointing
- * procedure) is allowed to overwrite the existing vmas. "pprev" can be
- * updated if a new vma lower than the unmapping address is added.
- *
- * Bookkeeping convention (must follow):
- * Make deallocation PAL calls (DkVirtualMemoryFree() or DkStreamUnmap())
- * BEFORE updating the bookkeeping.
- */
-static int __bkeep_munmap (struct shim_vma ** pprev,
-                           void * start, void * end, int flags)
-{
-    assert(locked(&vma_list_lock));
-
-    struct shim_vma * prev = *pprev;
-    struct shim_vma * cur, * next;
-
-    if (!prev) {
-        cur = LISTP_FIRST_ENTRY(&vma_list, struct shim_vma, list);
-        if (!cur)
-            return 0;
-    } else {
-        cur = LISTP_NEXT_ENTRY(prev, &vma_list, list);
-    }
-
-    next = cur ? LISTP_NEXT_ENTRY(cur, &vma_list, list) : NULL;
-
-    while (cur) {
-        struct shim_vma * tail = NULL;
-
-        /* Stop unmapping if "cur" no longer overlaps with [start, end) */
-        if (!test_vma_overlap(cur, start, end))
-            break;
-
-        if (VMA_TYPE(cur->flags) != VMA_TYPE(flags))
-            return -EACCES;
-
-        /* If [start, end) contains the VMA, just drop the VMA. */
-        if (start <= cur->start && cur->end <= end) {
-            __remove_vma(cur, prev);
-            __drop_vma(cur);
-        } else {
-            __shrink_vma(cur, start, end, &tail);
-
-            if (cur->end <= start) {
-                prev = cur;
-                if (tail) {
-                    __insert_vma(tail, cur); /* insert "tail" after "cur" */
-                    cur = tail; /* "tail" is the new "cur" */
-                    break;
-                }
-            } else if (cur->start >= end) {
-                /* __shrink_vma() only creates a new VMA when the beginning of the
-                 * original VMA is preserved. */
-                assert(!tail);
-                break;
-            } else {
-                /* __shrink_vma() should never allow this case. */
-                BUG();
-            }
+    while (vma->end < end) {
+        struct shim_vma* next = _get_next_vma(vma);
+        if (!next || vma->end != next->begin || (next->flags & (VMA_INTERNAL | VMA_UNMAPPED))) {
+            goto out;
         }
-
-        cur = next;
-        next = cur ? LISTP_NEXT_ENTRY(cur, &vma_list, list) : NULL;
+        vma = next;
     }
 
-    if (prev)
-        assert(cur == LISTP_NEXT_ENTRY(prev, &vma_list, list));
-    else
-        assert(cur == LISTP_FIRST_ENTRY(&vma_list, struct shim_vma, list));
-
-    assert(!prev || prev->end <= start);
-    assert(!cur || end <= cur->start);
-    *pprev = prev;
-    return 0;
-}
-
-int bkeep_munmap (void * addr, size_t length, int flags)
-{
-    if (!length)
-        return -EINVAL;
-
-    debug("bkeep_munmap: %p-%p\n", addr, addr + length);
-
-    lock(&vma_list_lock);
-    struct shim_vma * prev = NULL;
-    __lookup_vma(addr, &prev);
-    int ret = __bkeep_munmap(&prev, addr, addr + length, flags);
-    assert_vma_list();
-    __restore_reserved_vmas();
-    /* DEP 5/20/19: If this is a debugging region we are removing, take it out
-     * of the checkpoint.  Otherwise, it will be restored erroneously after a fork. */
-    remove_r_debug(addr);
-    unlock(&vma_list_lock);
+    ret = true;
+out:
+    spinlock_unlock_signal_on(&vma_tree_lock);
     return ret;
 }
 
-/*
- * Update bookkeeping for mprotect(). "prev" must point to the immediately
- * precedent vma of the address to protect, or be NULL if no vma is lower than
- * the address. If the bookkeeping area overlaps with some existing vmas,
- * we must check whether the caller (from user, internal code, or checkpointing
- * procedure) is allowed to overwrite the existing vmas.
- *
- * Bookkeeping convention (must follow):
- * Update the bookkeeping BEFORE calling DkVirtualMemoryProtect().
- */
-static int __bkeep_mprotect (struct shim_vma * prev,
-                             void * start, void * end, int prot, int flags)
-{
-    assert(locked(&vma_list_lock));
+static size_t dump_all_vmas_with_buf(struct shim_vma_info* infos, size_t max_count,
+                                     bool include_unmapped) {
+    size_t size = 0;
+    struct shim_vma_info* vma_info = infos;
 
-    struct shim_vma * cur, * next;
+    spinlock_lock_signal_off(&vma_tree_lock);
+    struct shim_vma* vma;
 
-    if (!prev) {
-        cur = LISTP_FIRST_ENTRY(&vma_list, struct shim_vma, list);
-        if (!cur)
-            return 0;
-    } else {
-        cur = LISTP_NEXT_ENTRY(prev, &vma_list, list);
-    }
-
-    next = cur ? LISTP_NEXT_ENTRY(cur, &vma_list, list) : NULL;
-
-    while (cur) {
-        struct shim_vma * new, * tail = NULL;
-
-        /* Stop protecting if "cur" no longer overlaps with [start, end) */
-        if (!test_vma_overlap(cur, start, end))
-            break;
-
-        if (VMA_TYPE(cur->flags) != VMA_TYPE(flags))
-            /* For now, just shout loudly. */
-            return -EACCES;
-
-        /* If protection doesn't change anything, move on to the next */
-        if (cur->prot != prot) {
-            /* If [start, end) contains the VMA, just update its protection. */
-            if (start <= cur->start && cur->end <= end) {
-                cur->prot = prot;
-                if (cur->file && (prot & PROT_WRITE)) {
-                    cur->flags |= VMA_TAINTED;
-                }
-            } else {
-                /* Create a new VMA for the protected area */
-                new = __get_new_vma();
-                new->start = cur->start > start ? cur->start : start;
-                new->end   = cur->end < end ? cur->end : end;
-                new->prot  = prot;
-                new->flags = cur->flags | ((cur->file && (prot & PROT_WRITE)) ? VMA_TAINTED : 0);
-                new->file  = cur->file;
-                if (new->file) {
-                    get_handle(new->file);
-                    new->offset = cur->offset + (new->start - cur->start);
-                } else {
-                    new->offset = 0;
-                }
-                memcpy(new->comment, cur->comment, VMA_COMMENT_LEN);
-
-                /* Like unmapping, shrink (and potentially split) the VMA first. */
-                __shrink_vma(cur, start, end, &tail);
-
-                if (cur->end <= start) {
-                    prev = cur;
-                    if (tail) {
-                        __insert_vma(tail, cur); /* insert "tail" after "cur" */
-                        cur = tail; /* "tail" is the new "cur" */
-                        /* "next" is the same */
-                    }
-                } else if (cur->start >= end) {
-                    /* __shrink_vma() only creates a new VMA when the beginning of the
-                     * original VMA is preserved. */
-                    assert(!tail);
-                } else {
-                    /* __shrink_vma() should never allow this case. */
-                    BUG();
-                }
-
-                /* Now insert the new protected vma between prev and cur */
-                __insert_vma(new, prev);
-                assert(!prev || prev->end <= new->end);
-                assert(new->start < new->end);
-            }
+    for (vma = _get_first_vma(); vma; vma = _get_next_vma(vma)) {
+        if (vma->flags & ((include_unmapped ? 0 : VMA_UNMAPPED) | VMA_INTERNAL)) {
+            continue;
         }
-
-        prev = cur;
-        cur = next;
-        next = cur ? LISTP_NEXT_ENTRY(cur, &vma_list, list) : NULL;
+        if (size < max_count) {
+            dump_vma(vma_info, vma);
+            vma_info++;
+        }
+        size++;
     }
 
-    return 0;
+    spinlock_unlock_signal_on(&vma_tree_lock);
+
+    return size;
 }
 
-int bkeep_mprotect (void * addr, size_t length, int prot, int flags)
-{
-    if (!addr || !length)
-        return -EINVAL;
-
-    debug("bkeep_mprotect: %p-%p\n", addr, addr + length);
-
-    lock(&vma_list_lock);
-    struct shim_vma * prev = NULL;
-    __lookup_vma(addr, &prev);
-    int ret = __bkeep_mprotect(prev, addr, addr + length, prot, flags);
-    assert_vma_list();
-    __restore_reserved_vmas();
-    unlock(&vma_list_lock);
-    return ret;
-}
-
-/*
- * Search for an unmapped area within [bottom, top) that is big enough
- * to allocate "length" bytes. The search approach is top-down.
- * If this function returns a non-NULL address, the corresponding VMA is
- * added to the VMA list.
- */
-static void * __bkeep_unmapped (void * top_addr, void * bottom_addr,
-                                size_t length, int prot, int flags,
-                                struct shim_handle * file,
-                                off_t offset, const char * comment)
-{
-    assert(locked(&vma_list_lock));
-    assert(top_addr > bottom_addr);
-
-    if (!length || length > (uintptr_t) top_addr - (uintptr_t) bottom_addr)
-        return NULL;
-
-    struct shim_vma * prev = NULL;
-    struct shim_vma * cur = __lookup_vma(top_addr, &prev);
+int dump_all_vmas(struct shim_vma_info** ret_infos, size_t* ret_count, bool include_unmapped) {
+    size_t count = DEFAULT_VMA_COUNT;
 
     while (true) {
-        /* Set the range for searching */
-        void * end = cur ? cur->start : top_addr;
-        void * start =
-            (prev && prev->end > bottom_addr) ? prev->end : bottom_addr;
-
-        assert(start <= end);
-
-        /* Check if there is enough space between prev and cur */
-        if (length <= (uintptr_t) end - (uintptr_t) start) {
-            /* create a new VMA at the top of the range */
-            __bkeep_mmap(prev, end - length, end, prot, flags,
-                         file, offset, comment);
-            assert_vma_list();
-
-            debug("bkeep_unmapped: %p-%p%s%s\n", end - length, end,
-                  comment ? " => " : "", comment ? : "");
-
-            return end - length;
+        struct shim_vma_info* vmas = calloc(count, sizeof(*vmas));
+        if (!vmas) {
+            return -ENOMEM;
         }
 
-        if (!prev || prev->start <= bottom_addr)
-            break;
-
-        cur = prev;
-        prev = LISTP_PREV_ENTRY(cur, &vma_list, list);
-    }
-
-    return NULL;
-}
-
-void * bkeep_unmapped (void * top_addr, void * bottom_addr, size_t length,
-                       int prot, int flags, off_t offset, const char * comment)
-{
-    lock(&vma_list_lock);
-    void * addr = __bkeep_unmapped(top_addr, bottom_addr, length, prot, flags,
-                                   NULL, offset, comment);
-    assert_vma_list();
-    __restore_reserved_vmas();
-    unlock(&vma_list_lock);
-    return addr;
-}
-
-void * bkeep_unmapped_heap (size_t length, int prot, int flags,
-                            struct shim_handle * file,
-                            off_t offset, const char * comment)
-{
-    lock(&vma_list_lock);
-
-    void * bottom_addr = PAL_CB(user_address.start);
-    void * top_addr = current_heap_top;
-    void * heap_max = PAL_CB(user_address.end);
-    void * addr = NULL;
-
-#ifdef MAP_32BIT
-    /*
-     * If MAP_32BIT is given in the flags, force the searching range to
-     * be lower than 1ULL << 32.
-     */
-#define ADDR_32BIT ((void*)(1ULL << 32))
-
-    if (flags & MAP_32BIT) {
-        /* Try the lower 4GB memory space */
-        if (heap_max > ADDR_32BIT)
-            heap_max = ADDR_32BIT;
-
-        if (top_addr > heap_max)
-            top_addr = heap_max;
-    }
-#endif
-
-    if (top_addr > bottom_addr) {
-        /* Try first time */
-        addr = __bkeep_unmapped(top_addr, bottom_addr,
-                                length, prot, flags,
-                                file, offset, comment);
-        assert_vma_list();
-    }
-    if (addr) {
-        /*
-         * we only update the current heap top when we get the
-         * address from [bottom_addr, current_heap_top).
-         */
-        if (top_addr == current_heap_top) {
-            debug("heap top adjusted to %p\n", addr);
-            current_heap_top = addr;
-        }
-    } else if (top_addr < heap_max) {
-        /* Try to allocate above the current heap top */
-        addr = __bkeep_unmapped(heap_max, bottom_addr,
-                                length, prot, flags,
-                                file, offset, comment);
-        assert_vma_list();
-    }
-
-    __restore_reserved_vmas();
-    unlock(&vma_list_lock);
-#ifdef MAP_32BIT
-    assert(!(flags & MAP_32BIT) || !addr || addr + length <= ADDR_32BIT);
-#endif
-    return addr;
-}
-
-static inline void
-__dump_vma (struct shim_vma_val * val, const struct shim_vma * vma)
-{
-    val->addr   = vma->start;
-    val->length = vma->end - vma->start;
-    val->prot   = vma->prot;
-    val->flags  = vma->flags;
-    val->file   = vma->file;
-    if (val->file)
-        get_handle(val->file);
-    val->offset = vma->offset;
-    memcpy(val->comment, vma->comment, VMA_COMMENT_LEN);
-}
-
-int lookup_vma (void * addr, struct shim_vma_val * res)
-{
-    lock(&vma_list_lock);
-
-    struct shim_vma * vma = __lookup_vma(addr, NULL);
-    if (!vma) {
-        unlock(&vma_list_lock);
-        return -ENOENT;
-    }
-
-    if (res)
-        __dump_vma(res, vma);
-
-    unlock(&vma_list_lock);
-    return 0;
-}
-
-int lookup_overlap_vma (void * addr, size_t length, struct shim_vma_val * res)
-{
-    struct shim_vma * tmp, * vma = NULL;
-
-    lock(&vma_list_lock);
-
-    LISTP_FOR_EACH_ENTRY(tmp, &vma_list, list)
-        if (test_vma_overlap (tmp, addr, addr + length)) {
-            vma = tmp;
-            break;
+        size_t needed_count = dump_all_vmas_with_buf(vmas, count, include_unmapped);
+        if (needed_count <= count) {
+            *ret_infos = vmas;
+            *ret_count = needed_count;
+            return 0;
         }
 
-
-    if (!vma) {
-        unlock(&vma_list_lock);
-        return -ENOENT;
+        free_vma_info_array(vmas, count);
+        count = needed_count;
     }
-
-    if (res)
-        __dump_vma(res, vma);
-
-    unlock(&vma_list_lock);
-    return 0;
 }
 
-bool is_in_adjacent_vmas (void * addr, size_t length)
-{
-    struct shim_vma* vma;
-    struct shim_vma* prev = NULL;
-    lock(&vma_list_lock);
-
-    /* we rely on the fact that VMAs are sorted (for adjacent VMAs) */
-    assert_vma_list();
-
-    LISTP_FOR_EACH_ENTRY(vma, &vma_list, list) {
-        if (addr >= vma->start && addr < vma->end) {
-            assert(prev == NULL);
-            prev = vma;
-        }
-        if (prev) {
-            if (prev != vma && prev->end != vma->start) {
-                /* prev and current VMAs are not adjacent */
-                break;
-            }
-            if ((addr + length) > vma->start && (addr + length) <= vma->end) {
-                unlock(&vma_list_lock);
-                return true;
-            }
-            prev = vma;
+void free_vma_info_array(struct shim_vma_info* vma_infos, size_t count) {
+    for (size_t i = 0; i < count; i++) {
+        if (vma_infos[i].file) {
+            put_handle(vma_infos[i].file);
         }
     }
 
-    unlock(&vma_list_lock);
-    return false;
-}
-
-int dump_all_vmas (struct shim_vma_val * vmas, size_t max_count)
-{
-    struct shim_vma_val * val = vmas;
-    struct shim_vma * vma;
-    size_t cnt = 0;
-    lock(&vma_list_lock);
-
-    LISTP_FOR_EACH_ENTRY(vma, &vma_list, list) {
-        if (VMA_TYPE(vma->flags))
-            continue;
-        if (vma->flags & VMA_UNMAPPED)
-            continue;
-
-        if (cnt == max_count) {
-            cnt = -EOVERFLOW;
-            for (size_t i = 0 ; i < max_count ; i++)
-                if (vmas[i].file)
-                    put_handle(vmas[i].file);
-            break;
-        }
-
-        __dump_vma(val, vma);
-        cnt++;
-        val++;
-    }
-
-    unlock(&vma_list_lock);
-    return cnt;
+    free(vma_infos);
 }
 
 BEGIN_CP_FUNC(vma)
 {
     __UNUSED(size);
-    assert(size == sizeof(struct shim_vma_val));
+    assert(size == sizeof(struct shim_vma_info));
 
-    struct shim_vma_val * vma = (struct shim_vma_val *) obj;
-    struct shim_vma_val * new_vma = NULL;
-    PAL_FLG pal_prot = LINUX_PROT_TO_PAL(vma->prot, /*map_flags=*/0);
+    struct shim_vma_info* vma = (struct shim_vma_info*) obj;
+    struct shim_vma_info* new_vma = NULL;
 
     ptr_t off = GET_FROM_CP_MAP(obj);
 
@@ -1088,7 +1152,7 @@ BEGIN_CP_FUNC(vma)
         off = ADD_CP_OFFSET(sizeof(*vma));
         ADD_TO_CP_MAP(obj, off);
 
-        new_vma = (struct shim_vma_val *) (base + off);
+        new_vma = (struct shim_vma_info*) (base + off);
         memcpy(new_vma, vma, sizeof(*vma));
 
         if (vma->file)
@@ -1096,7 +1160,8 @@ BEGIN_CP_FUNC(vma)
 
         void * need_mapped = vma->addr;
 
-        if (NEED_MIGRATE_MEMORY(vma)) {
+        /* Check whether we need to checkpoint memory this vma bookkeeps. */
+        if ((vma->flags & VMA_TAINTED || !vma->file) && !(vma->flags & VMA_UNMAPPED)) {
             void* send_addr  = vma->addr;
             size_t send_size = vma->length;
             if (vma->file) {
@@ -1117,16 +1182,16 @@ BEGIN_CP_FUNC(vma)
                  */
                 off_t file_len = get_file_size(vma->file);
                 if (file_len >= 0 &&
-                    (off_t)(vma->offset + vma->length) > file_len) {
-                    send_size = file_len > vma->offset ?
-                                file_len - vma->offset : 0;
+                    (off_t)(vma->file_offset + vma->length) > file_len) {
+                    send_size = file_len > vma->file_offset ?
+                                file_len - vma->file_offset : 0;
                     send_size = ALLOC_ALIGN_UP(send_size);
                 }
             }
             if (send_size > 0) {
                 struct shim_mem_entry * mem;
                 DO_CP_SIZE(memory, send_addr, send_size, &mem);
-                mem->prot = pal_prot;
+                mem->prot = LINUX_PROT_TO_PAL(vma->prot, /*map_flags=*/0);
 
                 need_mapped = vma->addr + vma->length;
             }
@@ -1134,7 +1199,7 @@ BEGIN_CP_FUNC(vma)
         ADD_CP_FUNC_ENTRY(off);
         ADD_CP_ENTRY(ADDR, need_mapped);
     } else {
-        new_vma = (struct shim_vma_val *) (base + off);
+        new_vma = (struct shim_vma_info*) (base + off);
     }
 
     if (objp)
@@ -1144,17 +1209,17 @@ END_CP_FUNC(vma)
 
 BEGIN_RS_FUNC(vma)
 {
-    struct shim_vma_val * vma = (void *) (base + GET_CP_FUNC_ENTRY());
+    struct shim_vma_info* vma = (void *) (base + GET_CP_FUNC_ENTRY());
     void * need_mapped = (void *) GET_CP_ENTRY(ADDR);
     CP_REBASE(vma->file);
 
-    int ret = bkeep_mmap(vma->addr, vma->length, vma->prot, vma->flags,
-                         vma->file, vma->offset, vma->comment);
+    DEBUG_RS("vma: %p-%p flags 0x%x prot 0x%08x comment \"%s\"\n",
+             vma->addr, vma->addr + vma->length, vma->flags, vma->prot, vma->comment);
+
+    int ret = bkeep_mmap_fixed(vma->addr, vma->length, vma->prot, vma->flags | MAP_FIXED,
+                               vma->file, vma->file_offset, vma->comment);
     if (ret < 0)
         return ret;
-
-    DEBUG_RS("vma: %p-%p flags %x prot 0x%08x\n",
-             vma->addr, vma->addr + vma->length, vma->flags, vma->prot);
 
     if (!(vma->flags & VMA_UNMAPPED)) {
         if (vma->file) {
@@ -1163,16 +1228,17 @@ BEGIN_RS_FUNC(vma)
 
             if (need_mapped < vma->addr + vma->length) {
                 /* first try, use hstat to force it resumes pal handle */
-                assert(vma->file->fs && vma->file->fs->fs_ops &&
-                       vma->file->fs->fs_ops->mmap);
+                if (!fs || !fs->fs_ops || !fs->fs_ops->mmap) {
+                    return -EINVAL;
+                }
 
                 void * addr = need_mapped;
                 int ret = fs->fs_ops->mmap(vma->file, &addr,
                                            vma->addr + vma->length -
                                            need_mapped,
                                            vma->prot,
-                                           vma->flags,
-                                           vma->offset +
+                                           vma->flags | MAP_FIXED,
+                                           vma->file_offset +
                                            (need_mapped - vma->addr));
 
                 if (ret < 0)
@@ -1205,86 +1271,56 @@ BEGIN_RS_FUNC(vma)
     if (vma->file)
         DEBUG_RS("%p-%p,size=%ld,prot=%08x,flags=%08x,off=%ld,path=%s,uri=%s",
                  vma->addr, vma->addr + vma->length, vma->length,
-                 vma->prot, vma->flags, vma->offset,
+                 vma->prot, vma->flags, vma->file_offset,
                  qstrgetstr(&vma->file->path), qstrgetstr(&vma->file->uri));
     else
         DEBUG_RS("%p-%p,size=%ld,prot=%08x,flags=%08x,off=%ld",
                  vma->addr, vma->addr + vma->length, vma->length,
-                 vma->prot, vma->flags, vma->offset);
+                 vma->prot, vma->flags, vma->file_offset);
 }
 END_RS_FUNC(vma)
 
 BEGIN_CP_FUNC(all_vmas)
 {
-    size_t count = DEFAULT_VMA_COUNT;
-    struct shim_vma_val * vmas = malloc(sizeof(*vmas) * count);
-    int ret;
     __UNUSED(obj);
     __UNUSED(size);
     __UNUSED(objp);
-
-    if (!vmas)
-        return -ENOMEM;
-
-    while (true) {
-        ret = dump_all_vmas(vmas, count);
-        if (ret != -EOVERFLOW)
-            break;
-
-        struct shim_vma_val * new_vmas
-            = malloc(sizeof(*new_vmas) * count * 2);
-        if (!new_vmas) {
-            free(vmas);
-            return -ENOMEM;
-        }
-        free(vmas);
-        vmas = new_vmas;
-        count *= 2;
+    size_t count;
+    struct shim_vma_info* vmas;
+    int ret = dump_all_vmas(&vmas, &count, /*include_unmapped=*/true);
+    if (ret < 0) {
+        return ret;
     }
 
-    if (ret < 0)
-        return ret;
-
-    count = ret;
-    for (struct shim_vma_val * vma = &vmas[count - 1] ; vma >= vmas ; vma--)
+    for (struct shim_vma_info* vma = &vmas[count - 1] ; vma >= vmas ; vma--)
         DO_CP(vma, vma, NULL);
 
-    free_vma_val_array(vmas, count);
+    free_vma_info_array(vmas, count);
 }
 END_CP_FUNC_NO_RS(all_vmas)
 
-void debug_print_vma (struct shim_vma *vma)
-{
-    const char * type = "", * name = "";
 
-    if (vma->file) {
-        if (!qstrempty(&vma->file->path)) {
-            type = " path=";
-            name = qstrgetstr(&vma->file->path);
-        } else if (!qstrempty(&vma->file->uri)) {
-            type = " uri=";
-            name = qstrgetstr(&vma->file->uri);
-        }
-    }
-
-    SYS_PRINTF("[%p-%p] prot=%08x flags=%08x%s%s offset=%ld%s%s%s%s\n",
-               vma->start, vma->end,
+static void debug_print_vma(struct shim_vma* vma) {
+    SYS_PRINTF("[0x%lx-0x%lx] prot=0x%x flags=0x%x%s%s file=%p (offset=%ld)%s%s\n",
+               vma->begin, vma->end,
                vma->prot,
-               vma->flags & ~(VMA_INTERNAL|VMA_UNMAPPED|VMA_TAINTED|VMA_CP),
-               type, name,
+               vma->flags & ~(VMA_INTERNAL | VMA_UNMAPPED),
+               vma->flags & VMA_INTERNAL ? "(INTERNAL " : "(",
+               vma->flags & VMA_UNMAPPED ? "UNMAPPED)" : ")",
+               vma->file,
                vma->offset,
-               vma->flags & VMA_INTERNAL ? " (internal)" : "",
-               vma->flags & VMA_UNMAPPED ? " (unmapped)" : "",
                vma->comment[0] ? " comment=" : "",
                vma->comment[0] ? vma->comment : "");
 }
 
-void debug_print_vma_list (void)
-{
-    SYS_PRINTF("vma bookkeeping:\n");
+void debug_print_all_vmas(void) {
+    spinlock_lock_signal_off(&vma_tree_lock);
 
-    struct shim_vma * vma;
-    LISTP_FOR_EACH_ENTRY(vma, &vma_list, list) {
+    struct shim_vma* vma = _get_first_vma();
+    while (vma) {
         debug_print_vma(vma);
+        vma = _get_next_vma(vma);
     }
+
+    spinlock_unlock_signal_on(&vma_tree_lock);
 }

--- a/LibOS/shim/src/fs/proc/thread.c
+++ b/LibOS/shim/src/fs/proc/thread.c
@@ -480,7 +480,7 @@ static int proc_thread_maps_open(struct shim_handle* hdl, const char* name, int 
 
     size_t count;
     struct shim_vma_info* vmas = NULL;
-    ret = dump_all_vmas(&vmas, &count);
+    ret = dump_all_vmas(&vmas, &count, /*include_unmapped=*/false);
     if (ret < 0) {
         goto err;
     }

--- a/LibOS/shim/src/sys/shim_brk.c
+++ b/LibOS/shim/src/sys/shim_brk.c
@@ -220,15 +220,5 @@ BEGIN_RS_FUNC(brk) {
     brk_region.brk_current       = brk_region.brk_start + GET_CP_ENTRY(SIZE);
     brk_region.brk_end           = brk_region.brk_start + GET_CP_ENTRY(SIZE);
     brk_region.data_segment_size = GET_CP_ENTRY(SIZE);
-
-    char* current = ALLOC_ALIGN_UP_PTR(brk_region.brk_current);
-    int ret = bkeep_mmap_fixed(current, brk_region.brk_end - current, PROT_NONE,
-                               MAP_FIXED_NOREPLACE | VMA_UNMAPPED, NULL, 0, "heap");
-    if (ret < 0) {
-        return ret;
-    }
-
-    debug("migrated reserved brk area: %p - %p\n", current, brk_region.brk_end);
-
 }
 END_RS_FUNC(brk)

--- a/LibOS/shim/src/sys/shim_brk.c
+++ b/LibOS/shim/src/sys/shim_brk.c
@@ -1,4 +1,5 @@
 /* Copyright (C) 2014 Stony Brook University
+   Copyright (C) 2020 Invisible Things Lab
    This file is part of Graphene Library OS.
 
    Graphene Library OS is free software: you can redistribute it and/or
@@ -22,224 +23,183 @@
 
 #include <sys/mman.h>
 
-#include <pal.h>
-#include <shim_checkpoint.h>
-#include <shim_internal.h>
-#include <shim_table.h>
-#include <shim_utils.h>
-#include <shim_vma.h>
+#include "pal.h"
+#include "shim_checkpoint.h"
+#include "shim_internal.h"
+#include "shim_table.h"
+#include "shim_utils.h"
+#include "shim_vma.h"
 
-#define BRK_SIZE 4096
-
-struct shim_brk_info {
+static struct {
     size_t data_segment_size;
-    void* brk_start;
-    void* brk_end;
-    void* brk_current;
-};
+    char* brk_start;
+    char* brk_current;
+    char* brk_end;
+} brk_region;
 
-static struct shim_brk_info region;
+static struct shim_lock brk_lock;
 
-void get_brk_region(void** start, void** end, void** current) {
-    MASTER_LOCK();
-    *start   = region.brk_start;
-    *end     = region.brk_end;
-    *current = region.brk_current;
-    MASTER_UNLOCK();
-}
-
-int init_brk_region(void* brk_region, size_t data_segment_size) {
-    if (region.brk_start)
-        return 0;
-
-    data_segment_size     = ALLOC_ALIGN_UP(data_segment_size);
-    uint64_t brk_max_size = DEFAULT_BRK_MAX_SIZE;
+int init_brk_region(void* brk_start, size_t data_segment_size) {
+    size_t brk_max_size = DEFAULT_BRK_MAX_SIZE;
+    data_segment_size = ALLOC_ALIGN_UP(data_segment_size);
 
     if (root_config) {
         char brk_cfg[CONFIG_MAX];
-        if (get_config(root_config, "sys.brk.size", brk_cfg, sizeof(brk_cfg)) > 0)
+        if (get_config(root_config, "sys.brk.max_size", brk_cfg, sizeof(brk_cfg)) > 0)
             brk_max_size = parse_int(brk_cfg);
     }
 
-    set_rlimit_cur(RLIMIT_DATA, brk_max_size + data_segment_size);
-
-    int flags        = MAP_PRIVATE | MAP_ANONYMOUS;
-    bool brk_on_heap = true;
-    const int TRIES  = 10;
-
-    /*
-     * Chia-Che 8/24/2017
-     * Adding an argument to specify the initial starting address of brk region. The general
-     * assumption of Linux is that the brk region should be within
-     * [exec-data-end, exec-data-end + 0x2000000).
-     */
-    if (brk_region) {
-        size_t max_brk = 0;
-        if (PAL_CB(user_address.end) >= PAL_CB(executable_range.end))
-            max_brk = PAL_CB(user_address.end) - PAL_CB(executable_range.end);
-
-        if (PAL_CB(user_address_hole.end) - PAL_CB(user_address_hole.start) > 0) {
-            /* XXX: This assumes that we always want brk to be after the hole. */
-            brk_region = MAX(brk_region, PAL_CB(user_address_hole.end));
-            max_brk =
-                MIN(max_brk, (size_t)(PAL_CB(user_address.end) - PAL_CB(user_address_hole.end)));
-        }
-
-        /* Check whether the brk region can potentially be located after exec at all. */
-        if (brk_max_size <= max_brk) {
-            int try;
-            for (try = TRIES; try > 0; try--) {
-                uint32_t rand = 0;
-#if ENABLE_ASLR == 1
-                int ret = DkRandomBitsRead(&rand, sizeof(rand));
-                if (ret < 0)
-                    return -convert_pal_errno(-ret);
-                rand %= MIN((size_t)0x2000000,
-                            (size_t)(PAL_CB(user_address.end) - brk_region - brk_max_size));
-                rand = ALLOC_ALIGN_DOWN(rand);
-
-                if (brk_region + rand + brk_max_size >= PAL_CB(user_address.end))
-                    continue;
-#else
-                /* Without randomization there is no point to retry here */
-                if (brk_region + rand + brk_max_size >= PAL_CB(user_address.end))
-                    break;
-#endif
-
-                struct shim_vma_val vma;
-                if (lookup_overlap_vma(brk_region + rand, brk_max_size, &vma) == -ENOENT) {
-                    /* Found a place for brk */
-                    brk_region += rand;
-                    brk_on_heap = false;
-                    break;
-                }
-#if !(ENABLE_ASLR == 1)
-                /* Without randomization, try memory directly after the overlapping block */
-                brk_region = vma.addr + vma.length;
-#endif
-            }
-        }
+    if (brk_start && !IS_ALLOC_ALIGNED_PTR(brk_start)) {
+        debug("Starting brk address is not aligned!\n");
+        return -EINVAL;
+    }
+    if (!IS_ALLOC_ALIGNED(brk_max_size)) {
+        debug("Max brk size is not aligned!\n");
+        return -EINVAL;
     }
 
-    if (brk_on_heap) {
-        brk_region = bkeep_unmapped_heap(brk_max_size, PROT_READ | PROT_WRITE, flags | VMA_UNMAPPED,
-                                         NULL, 0, "brk");
-        if (!brk_region) {
-            return -ENOMEM;
+    if (brk_start && brk_start <= PAL_CB(user_address.end)
+            && brk_max_size <= (uintptr_t)PAL_CB(user_address.end)
+            && (uintptr_t)brk_start < (uintptr_t)PAL_CB(user_address.end) - brk_max_size) {
+        size_t offset = 0;
+#if ENABLE_ASLR == 1
+        int ret = DkRandomBitsRead(&offset, sizeof(offset));
+        if (ret < 0) {
+            return -convert_pal_errno(-ret);
+        }
+        /* Linux randomizes brk at offset from 0 to 0x2000000 from main executable data section
+         * https://elixir.bootlin.com/linux/v5.6.3/source/arch/x86/kernel/process.c#L914 */
+        offset %= MIN((size_t)0x2000000,
+                      (size_t)((char*)PAL_CB(user_address.end) - brk_max_size - (char*)brk_start));
+        offset = ALLOC_ALIGN_DOWN(offset);
+#endif
+        brk_start = (char*)brk_start + offset;
+
+        ret = bkeep_mmap_fixed(brk_start, brk_max_size, PROT_NONE,
+                               MAP_FIXED_NOREPLACE | VMA_UNMAPPED, NULL, 0, "heap");
+        if (ret == -EEXIST) {
+            /* Let's try mapping brk anywhere. */
+            brk_start = NULL;
+            ret = 0;
+        }
+        if (ret < 0) {
+            return ret;
         }
     } else {
-        /*
-         * Create the bookkeeping before allocating the brk region. The bookkeeping should never
-         * fail because we've already confirmed the availability.
-         */
-        if (bkeep_mmap(brk_region, brk_max_size, PROT_READ | PROT_WRITE, flags | VMA_UNMAPPED, NULL,
-                       0, "brk") < 0)
-            BUG();
+        /* Let's try mapping brk anywhere. */
+        brk_start = NULL;
     }
 
-    void* end_brk_region = NULL;
+    if (!brk_start) {
+        int ret;
+#if ENABLE_ASLR == 1
+        ret = bkeep_mmap_any_aslr
+#else
+        ret = bkeep_mmap_any
+#endif
+                            (brk_max_size, PROT_NONE, VMA_UNMAPPED, NULL, 0, "heap", &brk_start);
+        if (ret < 0) {
+            return ret;
+        }
+    }
 
-    /* Allocate the whole brk region */
-    void* ret = (void*)DkVirtualMemoryAlloc(brk_region, brk_max_size, /*alloc_type=*/0,
-                                            PAL_PROT_READ | PAL_PROT_WRITE);
+    brk_region.brk_start = brk_start;
+    brk_region.brk_current = brk_region.brk_start;
+    brk_region.brk_end = (char*)brk_start + brk_max_size;
+    brk_region.data_segment_size = data_segment_size;
 
-    /* Checking if the PAL call succeeds. */
-    if (!ret) {
-        bkeep_munmap(brk_region, brk_max_size, flags);
+    set_rlimit_cur(RLIMIT_DATA, brk_max_size + data_segment_size);
+
+    if (!create_lock(&brk_lock)) {
+        debug("Creating brk_lock failed!\n");
         return -ENOMEM;
     }
 
-    end_brk_region = brk_region + BRK_SIZE;
+    return 0;
+}
 
-    region.data_segment_size = data_segment_size;
-    region.brk_start         = brk_region;
-    region.brk_end           = end_brk_region;
-    region.brk_current       = brk_region;
+void reset_brk(void) {
+    lock(&brk_lock);
 
-    debug("brk area: %p - %p\n", brk_region, end_brk_region);
-    debug("brk reserved area: %p - %p\n", end_brk_region, brk_region + brk_max_size);
-
-    /*
-     * Create another bookkeeping for the current brk region. The remaining space will be marked as
-     * unmapped so that the library OS can reuse the space for other purpose.
-     */
-    if (bkeep_mmap(brk_region, BRK_SIZE, PROT_READ | PROT_WRITE, flags, NULL, 0, "brk") < 0)
+    void* tmp_vma = NULL;
+    size_t allocated_size = ALLOC_ALIGN_UP_PTR(brk_region.brk_current) - brk_region.brk_start;
+    if (bkeep_munmap(brk_region.brk_start, brk_region.brk_end - brk_region.brk_start,
+                     /*is_internal=*/false, &tmp_vma) < 0) {
         BUG();
+    }
 
-    return 0;
+    DkVirtualMemoryFree(brk_region.brk_start, allocated_size);
+    bkeep_remove_tmp_vma(tmp_vma);
+
+    brk_region.brk_start = NULL;
+    brk_region.brk_current = NULL;
+    brk_region.brk_end = NULL;
+    brk_region.data_segment_size = 0;
+    unlock(&brk_lock);
+
+    destroy_lock(&brk_lock);
 }
 
-int reset_brk(void) {
-    MASTER_LOCK();
+void* shim_do_brk(void* _brk) {
+    char* brk = _brk;
+    size_t size = 0;
+    char* brk_aligned = ALLOC_ALIGN_UP_PTR(brk);
 
-    if (!region.brk_start) {
-        MASTER_UNLOCK();
-        return 0;
-    }
+    lock(&brk_lock);
 
-    int ret = shim_do_munmap(region.brk_start, region.brk_end - region.brk_start);
+    char* brk_current = ALLOC_ALIGN_UP_PTR(brk_region.brk_current);
 
-    if (ret < 0) {
-        MASTER_UNLOCK();
-        return ret;
-    }
-
-    region.brk_start = region.brk_end = region.brk_current = NULL;
-
-    MASTER_UNLOCK();
-    return 0;
-}
-
-void* shim_do_brk(void* brk) {
-    MASTER_LOCK();
-
-    if (init_brk_region(NULL, 0) < 0) {  // If brk is never initialized, assume no executable
-        debug("Failed to initialize brk!\n");
-        brk = NULL;
+    if (brk < brk_region.brk_start) {
         goto out;
-    }
+    } else if (brk <= brk_current) {
+        size = brk_current - brk_aligned;
 
-    if (!brk) {
-    unchanged:
-        brk = region.brk_current;
-        goto out;
-    }
+        if (size) {
+            if (bkeep_mmap_fixed(brk_aligned, brk_region.brk_end - brk_aligned, PROT_NONE,
+                                 MAP_FIXED | VMA_UNMAPPED, NULL, 0, "heap")) {
+                goto out;
+            }
 
-    if (brk < region.brk_start)
-        goto unchanged;
-
-    if (brk > region.brk_end) {
-        uint64_t rlim_data = get_rlimit_cur(RLIMIT_DATA);
-
-        // Check if there is enough space within the system limit
-        if (rlim_data < region.data_segment_size) {
-            brk = NULL;
-            goto out;
+            DkVirtualMemoryFree(brk_aligned, size);
         }
 
-        uint64_t brk_max_size = rlim_data - region.data_segment_size;
-
-        if (brk > region.brk_start + brk_max_size)
-            goto unchanged;
-
-        void* brk_end = region.brk_end;
-        while (brk_end < brk)
-            brk_end += BRK_SIZE;
-
-        debug("brk area: %p - %p\n", region.brk_start, brk_end);
-        debug("brk reserved area: %p - %p\n", brk_end, region.brk_start + brk_max_size);
-
-        bkeep_mmap(region.brk_start, brk_end - region.brk_start, PROT_READ | PROT_WRITE,
-                   MAP_ANONYMOUS | MAP_PRIVATE, NULL, 0, "brk");
-
-        region.brk_current = brk;
-        region.brk_end     = brk_end;
+        brk_region.brk_current = brk;
+        goto out;
+    } else if (brk > brk_region.brk_end) {
         goto out;
     }
-    region.brk_current = brk;
+
+    uint64_t rlim_data = get_rlimit_cur(RLIMIT_DATA);
+    size = brk_aligned - brk_region.brk_start;
+
+    if (rlim_data < brk_region.data_segment_size
+            || rlim_data - brk_region.data_segment_size < size) {
+        goto out;
+    }
+
+    size = brk_aligned - brk_current;
+    /* brk_aligned >= brk > brk_current */
+    assert(size);
+
+    if (bkeep_mmap_fixed(brk_current, size, PROT_READ | PROT_WRITE,
+                         MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED,
+                         NULL, 0, "heap") < 0) {
+        goto out;
+    }
+
+    if (!DkVirtualMemoryAlloc(brk_current, size, 0, PAL_PROT_READ | PAL_PROT_WRITE)) {
+        if (bkeep_mmap_fixed(brk_current, brk_region.brk_end - brk_current, PROT_NONE,
+                             MAP_FIXED | VMA_UNMAPPED, NULL, 0, "heap") < 0) {
+            BUG();
+        }
+        goto out;
+    }
+
+    brk_region.brk_current = brk;
 
 out:
-    MASTER_UNLOCK();
+    brk = brk_region.brk_current;
+    unlock(&brk_lock);
     return brk;
 }
 
@@ -247,52 +207,28 @@ BEGIN_CP_FUNC(brk) {
     __UNUSED(obj);
     __UNUSED(size);
     __UNUSED(objp);
-    if (region.brk_start) {
-        ADD_CP_FUNC_ENTRY((ptr_t)region.brk_start);
-        ADD_CP_ENTRY(ADDR, region.brk_current);
-        ADD_CP_ENTRY(SIZE, region.brk_end - region.brk_start);
-        ADD_CP_ENTRY(SIZE, region.data_segment_size);
-    }
+    ADD_CP_FUNC_ENTRY((ptr_t)brk_region.brk_start);
+    ADD_CP_ENTRY(SIZE, brk_region.brk_current - brk_region.brk_start);
+    ADD_CP_ENTRY(SIZE, brk_region.brk_end - brk_region.brk_start);
+    ADD_CP_ENTRY(SIZE, brk_region.data_segment_size);
 }
-END_CP_FUNC(bek)
+END_CP_FUNC(brk)
 
 BEGIN_RS_FUNC(brk) {
     __UNUSED(rebase);
-    region.brk_start         = (void*)GET_CP_FUNC_ENTRY();
-    region.brk_current       = (void*)GET_CP_ENTRY(ADDR);
-    region.brk_end           = region.brk_start + GET_CP_ENTRY(SIZE);
-    region.data_segment_size = GET_CP_ENTRY(SIZE);
+    brk_region.brk_start         = (char*)GET_CP_FUNC_ENTRY();
+    brk_region.brk_current       = brk_region.brk_start + GET_CP_ENTRY(SIZE);
+    brk_region.brk_end           = brk_region.brk_start + GET_CP_ENTRY(SIZE);
+    brk_region.data_segment_size = GET_CP_ENTRY(SIZE);
 
-    debug("brk area: %p - %p\n", region.brk_start, region.brk_end);
-
-    size_t brk_size    = region.brk_end - region.brk_start;
-    uint64_t rlim_data = get_rlimit_cur(RLIMIT_DATA);
-    assert(rlim_data > region.data_segment_size);
-    uint64_t brk_max_size = rlim_data - region.data_segment_size;
-
-    if (brk_size < brk_max_size) {
-        void* alloc_addr  = region.brk_end;
-        size_t alloc_size = brk_max_size - brk_size;
-        struct shim_vma_val vma;
-
-        if (!lookup_overlap_vma(alloc_addr, alloc_size, &vma)) {
-            /* if memory are already allocated here, adjust RLIMIT_DATA */
-            alloc_size = vma.addr - alloc_addr;
-            set_rlimit_cur(RLIMIT_DATA, (uint64_t)brk_size + alloc_size + region.data_segment_size);
-        }
-
-        int ret = bkeep_mmap(alloc_addr, alloc_size, PROT_READ | PROT_WRITE,
-                             MAP_ANONYMOUS | MAP_PRIVATE | VMA_UNMAPPED, NULL, 0, "brk");
-        if (ret < 0)
-            return ret;
-
-        void* ptr = DkVirtualMemoryAlloc(alloc_addr, alloc_size, /*alloc_type=*/0,
-                                         PAL_PROT_READ | PAL_PROT_WRITE);
-        __UNUSED(ptr);
-        assert(ptr == alloc_addr);
-        debug("brk reserved area: %p - %p\n", alloc_addr, alloc_addr + alloc_size);
+    char* current = ALLOC_ALIGN_UP_PTR(brk_region.brk_current);
+    int ret = bkeep_mmap_fixed(current, brk_region.brk_end - current, PROT_NONE,
+                               MAP_FIXED_NOREPLACE | VMA_UNMAPPED, NULL, 0, "heap");
+    if (ret < 0) {
+        return ret;
     }
 
-    DEBUG_RS("current=%p,region=%p-%p", region.brk_current, region.brk_start, region.brk_end);
+    debug("migrated reserved brk area: %p - %p\n", current, brk_region.brk_end);
+
 }
 END_RS_FUNC(brk)

--- a/LibOS/shim/src/sys/shim_exec.c
+++ b/LibOS/shim/src/sys/shim_exec.c
@@ -121,7 +121,7 @@ noreturn static void __shim_do_execve_rtld(struct execve_rtld_arg* __arg) {
 
     size_t count;
     struct shim_vma_info* vmas;
-    ret = dump_all_vmas(&vmas, &count);
+    ret = dump_all_vmas(&vmas, &count, /*include_unmapped=*/true);
     if (ret < 0) {
         goto error;
     }

--- a/LibOS/shim/src/sys/shim_exec.c
+++ b/LibOS/shim/src/sys/shim_exec.c
@@ -128,7 +128,7 @@ noreturn static void __shim_do_execve_rtld(struct execve_rtld_arg* __arg) {
 
     for (struct shim_vma_info* vma = vmas; vma < vmas + count; vma++) {
         /* Don't free the current stack */
-        if (vma->addr == cur_thread->stack)
+        if (vma->addr == cur_thread->stack || vma->addr == cur_thread->stack_red)
             continue;
 
         if (bkeep_munmap(vma->addr, vma->length, !!(vma->flags & VMA_INTERNAL), &tmp_vma) < 0) {

--- a/LibOS/shim/src/sys/shim_exec.c
+++ b/LibOS/shim/src/sys/shim_exec.c
@@ -73,9 +73,6 @@ static int close_cloexec_handle(struct shim_handle_map* map) {
 }
 
 struct execve_rtld_arg {
-    void* old_stack_top;
-    void* old_stack;
-    void* old_stack_red;
     const char** new_argp;
     int* new_argcp;
     elf_auxv_t* new_auxp;
@@ -84,9 +81,6 @@ struct execve_rtld_arg {
 noreturn static void __shim_do_execve_rtld(struct execve_rtld_arg* __arg) {
     struct execve_rtld_arg arg;
     memcpy(&arg, __arg, sizeof(arg));
-    void* old_stack_top   = arg.old_stack_top;
-    void* old_stack       = arg.old_stack;
-    void* old_stack_red   = arg.old_stack_red;
     const char** new_argp = arg.new_argp;
     int* new_argcp        = arg.new_argcp;
     elf_auxv_t* new_auxp  = arg.new_auxp;
@@ -97,22 +91,6 @@ noreturn static void __shim_do_execve_rtld(struct execve_rtld_arg* __arg) {
     unsigned long fs_base = 0;
     update_fs_base(fs_base);
     debug("set fs_base to 0x%lx\n", fs_base);
-
-    void* tmp_vma = NULL;
-    if (bkeep_munmap(old_stack, old_stack_top - old_stack, /*is_internal=*/false, &tmp_vma) < 0) {
-        BUG();
-    }
-    DkVirtualMemoryFree(old_stack, old_stack_top - old_stack);
-    bkeep_remove_tmp_vma(tmp_vma);
-
-    if (old_stack - old_stack_red > 0) {
-        if (bkeep_munmap(old_stack_red, old_stack - old_stack_red, /*is_internal=*/false,
-            &tmp_vma) < 0) {
-                BUG();
-        }
-        DkVirtualMemoryFree(old_stack_red, old_stack - old_stack_red);
-        bkeep_remove_tmp_vma(tmp_vma);
-    }
 
     remove_loaded_libraries();
     clean_link_map_list();
@@ -131,6 +109,7 @@ noreturn static void __shim_do_execve_rtld(struct execve_rtld_arg* __arg) {
         if (vma->addr == cur_thread->stack || vma->addr == cur_thread->stack_red)
             continue;
 
+        void* tmp_vma = NULL;
         if (bkeep_munmap(vma->addr, vma->length, !!(vma->flags & VMA_INTERNAL), &tmp_vma) < 0) {
             BUG();
         }
@@ -170,9 +149,6 @@ static int shim_do_execve_rtld(struct shim_handle* hdl, const char** argv, const
     get_handle(hdl);
     cur_thread->exec = hdl;
 
-    void* old_stack_top   = cur_thread->stack_top;
-    void* old_stack       = cur_thread->stack;
-    void* old_stack_red   = cur_thread->stack_red;
     cur_thread->stack_top = NULL;
     cur_thread->stack     = NULL;
     cur_thread->stack_red = NULL;
@@ -191,9 +167,6 @@ static int shim_do_execve_rtld(struct shim_handle* hdl, const char** argv, const
     __disable_preempt(shim_get_tcb());  // Temporarily disable preemption during execve().
 
     struct execve_rtld_arg arg = {
-        .old_stack_top = old_stack_top,
-        .old_stack     = old_stack,
-        .old_stack_red = old_stack_red,
         .new_argp      = new_argp,
         .new_argcp     = new_argcp,
         .new_auxp      = new_auxp

--- a/LibOS/shim/src/sys/shim_mmap.c
+++ b/LibOS/shim/src/sys/shim_mmap.c
@@ -1,4 +1,5 @@
 /* Copyright (C) 2014 Stony Brook University
+   Copyright (C) 2020 Invisible Things Lab
    This file is part of Graphene Library OS.
 
    Graphene Library OS is free software: you can redistribute it and/or
@@ -17,7 +18,7 @@
 /*
  * shim_mmap.c
  *
- * Implementation of system call "mmap", "munmap" and "mprotect".
+ * Implementation of system calls "mmap", "munmap" and "mprotect".
  */
 
 #include <errno.h>
@@ -32,6 +33,24 @@
 #include "shim_internal.h"
 #include "shim_table.h"
 #include "shim_vma.h"
+
+#define LEGACY_MAP_MASK (MAP_SHARED         \
+                       | MAP_PRIVATE        \
+                       | MAP_FIXED          \
+                       | MAP_ANONYMOUS      \
+                       | MAP_DENYWRITE      \
+                       | MAP_EXECUTABLE     \
+                       | MAP_UNINITIALIZED  \
+                       | MAP_GROWSDOWN      \
+                       | MAP_LOCKED         \
+                       | MAP_NORESERVE      \
+                       | MAP_POPULATE       \
+                       | MAP_NONBLOCK       \
+                       | MAP_STACK          \
+                       | MAP_HUGETLB        \
+                       | MAP_32BIT          \
+                       | MAP_HUGE_2MB       \
+                       | MAP_HUGE_1GB)
 
 void* shim_do_mmap(void* addr, size_t length, int prot, int flags, int fd, off_t offset) {
     struct shim_handle* hdl = NULL;
@@ -53,93 +72,128 @@ void* shim_do_mmap(void* addr, size_t length, int prot, int flags, int fd, off_t
     if (!length || !access_ok(addr, length))
         return (void*)-EINVAL;
 
+    /* This check is Graphene specific. */
+    if (flags & (VMA_UNMAPPED | VMA_TAINTED | VMA_INTERNAL)) {
+        return (void*)-EINVAL;
+    }
+
+    if (flags & MAP_ANONYMOUS) {
+        switch (flags & MAP_TYPE) {
+            case MAP_SHARED:
+            case MAP_PRIVATE:
+                break;
+            default:
+                return (void*)-EINVAL;
+        }
+    } else {
+        /* MAP_FILE is the opposite of MAP_ANONYMOUS and is implicit */
+        switch (flags & MAP_TYPE) {
+            case MAP_SHARED:
+                flags &= LEGACY_MAP_MASK;
+                /* fall through */
+            case MAP_SHARED_VALIDATE:
+                /* Currently we do not support additional flags like MAP_SYNC */
+                if (flags & ~LEGACY_MAP_MASK) {
+                    return (void*)-EOPNOTSUPP;
+                }
+                /* fall through */
+            case MAP_PRIVATE:
+                if (fd < 0) {
+                    return (void*)-EINVAL;
+                }
+
+                hdl = get_fd_handle(fd, NULL, NULL);
+                if (!hdl) {
+                    return (void*)-EBADF;
+                }
+
+                if (!hdl->fs || !hdl->fs->fs_ops || !hdl->fs->fs_ops->mmap) {
+                    ret = -ENODEV;
+                    goto out_handle;
+                }
+
+                if (hdl->flags & O_WRONLY) {
+                    ret = -EACCES;
+                    goto out_handle;
+                }
+
+                if ((flags & MAP_SHARED) && (prot & PROT_WRITE) && !(hdl->flags & O_RDWR)) {
+                    ret = -EACCES;
+                    goto out_handle;
+                }
+
+                break;
+            default:
+                return (void*)-EINVAL;
+        }
+    }
+
     /* ignore MAP_32BIT when MAP_FIXED is set */
     if ((flags & (MAP_32BIT | MAP_FIXED)) == (MAP_32BIT | MAP_FIXED))
         flags &= ~MAP_32BIT;
 
-    assert(!(flags & (VMA_UNMAPPED | VMA_TAINTED)));
-
-    int pal_alloc_type = 0;
-
-    if ((flags & MAP_FIXED) || addr) {
-        struct shim_vma_val tmp;
-
-        if (addr < PAL_CB(user_address.start) || PAL_CB(user_address.end) <= addr ||
-            (uintptr_t)PAL_CB(user_address.end) - (uintptr_t)addr < length) {
-            debug(
-                "mmap: user specified address %p with length %lu "
-                "not in allowed user space, ignoring this hint\n",
-                addr, length);
-            if (flags & MAP_FIXED)
-                return (void*)-EINVAL;
-            addr = NULL;
-        } else if (!lookup_overlap_vma(addr, length, &tmp)) {
-            if (flags & MAP_FIXED)
-                debug(
-                    "mmap: allowing overlapping MAP_FIXED allocation at %p with "
-                    "length %lu\n",
-                    addr, length);
-            else
-                addr = NULL;
+    if (flags & (MAP_FIXED | MAP_FIXED_NOREPLACE)) {
+        ret = bkeep_mmap_fixed(addr, length, prot, flags, hdl, offset, NULL);
+        if (ret < 0) {
+            goto out_handle;
         }
-    }
-
-    if ((flags & (MAP_ANONYMOUS | MAP_FILE)) == MAP_FILE) {
-        if (fd < 0)
-            return (void*)-EINVAL;
-
-        hdl = get_fd_handle(fd, NULL, NULL);
-        if (!hdl)
-            return (void*)-EBADF;
-
-        if (!hdl->fs || !hdl->fs->fs_ops || !hdl->fs->fs_ops->mmap) {
-            put_handle(hdl);
-            return (void*)-ENODEV;
-        }
-    }
-
-    if (addr) {
-        bkeep_mmap(addr, length, prot, flags, hdl, offset, NULL);
     } else {
-        addr = bkeep_unmapped_heap(length, prot, flags, hdl, offset, NULL);
-        /*
-         * Let the library OS manages the address space. If we can't find
-         * proper space to allocate the memory, simply return failure.
-         */
-        if (!addr)
-            return (void*)-ENOMEM;
+        /* We know that `addr + length` does not overflow (`access_ok` above). */
+        if (addr && ((uintptr_t)addr + length <= (uintptr_t)PAL_CB(user_address.end))) {
+            ret = bkeep_mmap_any_in_range(PAL_CB(user_address.start), (char*)addr + length, length,
+                                          prot, flags, hdl, offset, NULL, &addr);
+        } else {
+            /* Hacky way to mark we had no hit and need to search below. */
+            ret = -1;
+        }
+        if (ret < 0) {
+            /* We either had no hinted address or could not allocate memory at it. */
+            ret = bkeep_mmap_any_aslr(length, prot, flags, hdl, offset, NULL, &addr);
+        }
+        if (ret < 0) {
+            ret = -ENOMEM;
+            goto out_handle;
+        }
     }
 
-    // Approximate check only, to help root out bugs.
-    void* cur_stack = current_stack();
-    __UNUSED(cur_stack);
-    assert(cur_stack < addr || cur_stack > addr + length);
+    /* From now on `addr` contains the actual address we want to map (and already bookkeeped). */
 
-    /* addr needs to be kept for bkeep_munmap() below */
-    void* ret_addr = addr;
     if (!hdl) {
-        ret_addr = (void*)DkVirtualMemoryAlloc(ret_addr, length, pal_alloc_type,
-                                               LINUX_PROT_TO_PAL(prot, /*map_flags=*/0));
-
-        if (!ret_addr) {
-            if (PAL_NATIVE_ERRNO == PAL_ERROR_DENIED)
+        if (DkVirtualMemoryAlloc(addr, length, 0, LINUX_PROT_TO_PAL(prot, flags)) != addr) {
+            if (PAL_NATIVE_ERRNO == PAL_ERROR_DENIED) {
                 ret = -EPERM;
-            else
+            } else {
                 ret = -PAL_ERRNO;
+            }
         }
     } else {
+        void* ret_addr = addr;
         ret = hdl->fs->fs_ops->mmap(hdl, &ret_addr, length, prot, flags, offset);
+        if (ret_addr != addr) {
+            debug("Requested address (%p) differs from allocated (%p)!\n", addr, ret_addr);
+            BUG();
+        }
     }
-
-    if (hdl)
-        put_handle(hdl);
 
     if (ret < 0) {
-        bkeep_munmap(addr, length, flags);
-        return (void*)ret;
+        void* tmp_vma = NULL;
+        if (bkeep_munmap(addr, length, /*is_internal=*/false, &tmp_vma) < 0) {
+            debug("[mmap] Failed to remove bookkeeped memory that was not allocated at %p-%p!\n",
+                  addr, (char*)addr + length);
+            BUG();
+        }
+        bkeep_remove_tmp_vma(tmp_vma);
     }
 
-    return ret_addr;
+out_handle:
+    if (hdl) {
+        put_handle(hdl);
+    }
+
+    if (ret < 0) {
+        return (void*)ret;
+    }
+    return addr;
 }
 
 int shim_do_mprotect(void* addr, size_t length, int prot) {
@@ -153,8 +207,10 @@ int shim_do_mprotect(void* addr, size_t length, int prot) {
     if (!IS_ALLOC_ALIGNED(length))
         length = ALLOC_ALIGN_UP(length);
 
-    if (bkeep_mprotect(addr, length, prot, 0) < 0)
-        return -EPERM;
+    int ret = bkeep_mprotect(addr, length, prot, /*is_internal=*/false);
+    if (ret < 0) {
+        return ret;
+    }
 
     if (!DkVirtualMemoryProtect(addr, length, LINUX_PROT_TO_PAL(prot, /*map_flags=*/0)))
         return -PAL_ERRNO;
@@ -176,28 +232,15 @@ int shim_do_munmap(void* addr, size_t length) {
     if (!IS_ALLOC_ALIGNED(length))
         length = ALLOC_ALIGN_UP(length);
 
-    struct shim_vma_val vma;
-
-    if (lookup_overlap_vma(addr, length, &vma) < 0) {
-        debug("can't find addr %p - %p in map, quit unmapping\n", addr, addr + length);
-
-        /* Really not an error */
-        return -EFAULT;
+    void* tmp_vma = NULL;
+    int ret = bkeep_munmap(addr, length, /*is_internal=*/false, &tmp_vma);
+    if (ret < 0) {
+        return ret;
     }
-
-    /* lookup_overlap_vma() calls __dump_vma() which adds a reference to file */
-    if (vma.file)
-        put_handle(vma.file);
-
-    /* Protect first to make sure no overlapping with internal
-     * mappings */
-    if (bkeep_mprotect(addr, length, PROT_NONE, 0) < 0)
-        return -EPERM;
 
     DkVirtualMemoryFree(addr, length);
 
-    if (bkeep_munmap(addr, length, 0) < 0)
-        BUG();
+    bkeep_remove_tmp_vma(tmp_vma);
 
     return 0;
 }
@@ -217,19 +260,8 @@ int shim_do_mincore(void* addr, size_t len, unsigned char* vec) {
     if (test_user_memory(vec, pages, true))
         return -EFAULT;
 
-    for (unsigned long i = 0; i < pages; i++) {
-        struct shim_vma_val vma;
-        if (lookup_overlap_vma(addr + i * g_pal_alloc_align, 1, &vma) < 0)
-            return -ENOMEM;
-        /*
-         * lookup_overlap_vma() calls __dump_vma() which adds a reference to
-         * file, remove the reference to file immediately since we don't use
-         * it anyway
-         */
-        if (vma.file)
-            put_handle(vma.file);
-        if (vma.flags & VMA_UNMAPPED)
-            return -ENOMEM;
+    if (!is_in_adjacent_user_vmas(addr, len)) {
+        return -ENOMEM;
     }
 
     static atomic_bool warned = false;

--- a/LibOS/shim/test/ltp/ltp.cfg
+++ b/LibOS/shim/test/ltp/ltp.cfg
@@ -68,9 +68,6 @@ must-pass =
 [bind02]
 skip = yes
 
-[brk01]
-timeout = 40
-
 [cacheflush01]
 skip = yes
 
@@ -1421,12 +1418,6 @@ skip = yes
 
 # uses siglongjmp() from exception handler back into normal execution; not supported by Graphene
 [mmap05]
-skip = yes
-
-[mmap06]
-skip = yes
-
-[mmap07]
 skip = yes
 
 [mmap12]

--- a/LibOS/shim/test/ltp/manifest.template
+++ b/LibOS/shim/test/ltp/manifest.template
@@ -27,7 +27,7 @@ fs.mount.tmp.uri = file:/tmp
 
 # The line below may be causing problems on SGX, see
 # https://github.com/oscarlab/graphene/issues/1408.
-sys.brk.size = 32M
+sys.brk.max_size = 32M
 sys.stack.size = 4M
 
 sgx.trusted_files.ld = file:$(LIBCDIR)/ld-linux-x86-64.so.2

--- a/LibOS/shim/test/native/exec_fork.manifest.template
+++ b/LibOS/shim/test/native/exec_fork.manifest.template
@@ -11,7 +11,7 @@ fs.mount.bin.type = chroot
 fs.mount.bin.path = /bin
 fs.mount.bin.uri = file:/bin
 
-sys.brk.size = 32M
+sys.brk.max_size = 32M
 sys.stack.size = 4M
 
 sgx.trusted_files.ld = file:$(LIBCDIR)/ld-linux-x86-64.so.2

--- a/LibOS/shim/test/native/manifest.template
+++ b/LibOS/shim/test/native/manifest.template
@@ -11,7 +11,7 @@ fs.mount.bin.type = chroot
 fs.mount.bin.path = /bin
 fs.mount.bin.uri = file:/bin
 
-sys.brk.size = 32M
+sys.brk.max_size = 32M
 sys.stack.size = 4M
 
 # allow to bind on port 8000

--- a/LibOS/shim/test/native/script.manifest.template
+++ b/LibOS/shim/test/native/script.manifest.template
@@ -11,7 +11,7 @@ fs.mount.bin.type = chroot
 fs.mount.bin.path = /bin
 fs.mount.bin.uri = file:/bin
 
-sys.brk.size = 32M
+sys.brk.max_size = 32M
 sys.stack.size = 4M
 
 sgx.trusted_files.ld = file:$(LIBCDIR)/ld-linux-x86-64.so.2

--- a/LibOS/shim/test/regression/exec_same.c
+++ b/LibOS/shim/test/regression/exec_same.c
@@ -1,15 +1,18 @@
-#include <errno.h>
 #include <stdio.h>
-#include <stdlib.h>
 #include <unistd.h>
 
-int main(int argc, char** argv, char** envp) {
-    if (argc > 1) {
-        puts(argv[1]);
+int main(int argc, char** argv) {
+    if (argc <= 0) {
+        return 1;
+    } else if (argc == 1) {
         return 0;
     }
-    char* const new_argv[] = {argv[0], "hello from execv process", NULL};
-    execv(new_argv[0], new_argv);
+
+    puts(argv[1]);
+    fflush(stdout);
+
+    argv[1] = argv[0];
+    execv(argv[0], &argv[1]);
 
     /* must never reach this */
     return 1;

--- a/LibOS/shim/test/regression/test_libos.py
+++ b/LibOS/shim/test/regression/test_libos.py
@@ -83,8 +83,9 @@ class TC_01_Bootstrap(RegressionTestCase):
             stdout)
 
     def test_201_exec_same(self):
-        stdout, _ = self.run_binary(['exec_same'])
-        self.assertIn('hello from execv process', stdout)
+        args = [str(i) for i in range(50)]
+        stdout, _ = self.run_binary(['exec_same'] + args, timeout=40)
+        self.assertIn('\n'.join(args), stdout)
 
     def test_202_fork_and_exec(self):
         stdout, _ = self.run_binary(['fork_and_exec'], timeout=60)

--- a/Pal/include/lib/memmgr.h
+++ b/Pal/include/lib/memmgr.h
@@ -122,13 +122,11 @@ static inline void __set_free_mem_area(MEM_AREA area, MEM_MGR mgr) {
     mgr->active_area = area;
 }
 
-static inline MEM_MGR create_mem_mgr(unsigned int size) {
-    void* mem = system_malloc(__MAX_MEM_SIZE(size));
+static inline MEM_MGR create_mem_mgr_in_place(void* mem, unsigned int size) {
     MEM_AREA area;
     MEM_MGR mgr;
 
-    if (!mem)
-        return NULL;
+    assert(IS_ALIGNED_PTR(mem, __alignof__(*mgr)));
 
     mgr        = (MEM_MGR)mem;
     mgr->size  = 0;
@@ -143,6 +141,14 @@ static inline MEM_MGR create_mem_mgr(unsigned int size) {
     __set_free_mem_area(area, mgr);
 
     return mgr;
+}
+
+static inline MEM_MGR create_mem_mgr(unsigned int size) {
+    void* mem = system_malloc(__MAX_MEM_SIZE(size));
+    if (!mem) {
+        return NULL;
+    }
+    return create_mem_mgr_in_place(mem, size);
 }
 
 static inline MEM_MGR enlarge_mem_mgr(MEM_MGR mgr, unsigned int size) {

--- a/Pal/include/pal/pal.h
+++ b/Pal/include/pal/pal.h
@@ -315,15 +315,8 @@ typedef struct PAL_CONTROL_ {
      */
     PAL_PTR_RANGE user_address; /*!< The range of user addresses */
 
-    /*!
-     * \brief Reserved memory range inside of user address.
-     *
-     * Used for example by SGX for exec area (including memory gap) in the
-     * middle of the heap. If unused set start == end.
-     */
-    PAL_PTR_RANGE user_address_hole;
-
     PAL_PTR_RANGE executable_range; /*!< address where executable is loaded */
+    PAL_NUM exec_memory_gap; /*!< Size of memory gap before and after executable */
     PAL_PTR_RANGE manifest_preload; /*!< manifest preloaded here */
 
     /*

--- a/Pal/src/db_main.c
+++ b/Pal/src/db_main.c
@@ -400,8 +400,7 @@ noreturn void pal_main(
 
     _DkGetAvailableUserAddressRange(&__pal_control.user_address.start,
                                     &__pal_control.user_address.end,
-                                    &__pal_control.user_address_hole.start,
-                                    &__pal_control.user_address_hole.end);
+                                    &__pal_control.exec_memory_gap);
 
     __pal_control.alloc_align        = pal_state.alloc_align;
 

--- a/Pal/src/db_rtld.c
+++ b/Pal/src/db_rtld.c
@@ -1050,8 +1050,8 @@ noreturn void start_execution(const char** arguments, const char** environs) {
     /* First we will try to run all the preloaded libraries which come with
        entry points */
     if (exec_map) {
-        __pal_control.executable_range.start = (PAL_PTR) exec_map->l_map_start;
-        __pal_control.executable_range.end   = (PAL_PTR) exec_map->l_map_end;
+        __pal_control.executable_range.start = (PAL_PTR)ALLOC_ALIGN_DOWN_PTR(exec_map->l_map_start);
+        __pal_control.executable_range.end   = (PAL_PTR)ALLOC_ALIGN_UP_PTR(exec_map->l_map_end);
     }
 
     int narguments = 0;

--- a/Pal/src/host/Linux-SGX/db_main.c
+++ b/Pal/src/host/Linux-SGX/db_main.c
@@ -55,9 +55,7 @@ unsigned long _DkGetAllocationAlignment (void)
     return g_page_size;
 }
 
-void _DkGetAvailableUserAddressRange (PAL_PTR * start, PAL_PTR * end,
-                                      PAL_PTR * hole_start, PAL_PTR * hole_end)
-{
+void _DkGetAvailableUserAddressRange(PAL_PTR* start, PAL_PTR* end, PAL_NUM* gap) {
     *start = (PAL_PTR)pal_sec.heap_min;
     *end   = (PAL_PTR)get_enclave_heap_top();
 
@@ -70,8 +68,7 @@ void _DkGetAvailableUserAddressRange (PAL_PTR * start, PAL_PTR * end,
         ocall_exit(1, /*is_exitgroup=*/true);
     }
 
-    *hole_start = SATURATED_P_SUB(pal_sec.exec_addr, MEMORY_GAP, *start);
-    *hole_end   = SATURATED_P_ADD(pal_sec.exec_addr + pal_sec.exec_size, MEMORY_GAP, *end);
+    *gap = MEMORY_GAP;
 }
 
 PAL_NUM _DkGetProcessId (void)

--- a/Pal/src/host/Linux/db_main.c
+++ b/Pal/src/host/Linux/db_main.c
@@ -130,9 +130,7 @@ unsigned long _DkGetAllocationAlignment (void)
     return g_page_size;
 }
 
-void _DkGetAvailableUserAddressRange (PAL_PTR * start, PAL_PTR * end,
-                                      PAL_PTR * hole_start, PAL_PTR * hole_end)
-{
+void _DkGetAvailableUserAddressRange(PAL_PTR* start, PAL_PTR* end, PAL_NUM* gap) {
     void* end_addr = (void*)ALLOC_ALIGN_DOWN_PTR(TEXT_START);
     void* start_addr = (void*)USER_ADDRESS_LOWEST;
 
@@ -159,9 +157,7 @@ void _DkGetAvailableUserAddressRange (PAL_PTR * start, PAL_PTR * end,
     *end   = (PAL_PTR) end_addr;
     *start = (PAL_PTR) start_addr;
 
-    // Not used, so set it to an empty range.
-    *hole_start = start_addr;
-    *hole_end = start_addr;
+    *gap = 0;
 }
 
 PAL_NUM _DkGetProcessId (void)

--- a/Pal/src/host/Skeleton/db_main.c
+++ b/Pal/src/host/Skeleton/db_main.c
@@ -40,9 +40,7 @@ unsigned long _DkGetAllocationAlignment (void)
     return 0;
 }
 
-void _DkGetAvailableUserAddressRange (PAL_PTR * start, PAL_PTR * end,
-                                      PAL_PTR * hole_start, PAL_PTR * hole_end)
-{
+void _DkGetAvailableUserAddressRange(PAL_PTR* start, PAL_PTR* end, PAL_NUM* gap) {
     /* needs to be implemented */
 }
 

--- a/Pal/src/pal_internal.h
+++ b/Pal/src/pal_internal.h
@@ -215,7 +215,7 @@ noreturn void pal_main(
 
 /* For initialization */
 unsigned long _DkGetAllocationAlignment (void);
-void _DkGetAvailableUserAddressRange (PAL_PTR * start, PAL_PTR * end, PAL_PTR * hole_start, PAL_PTR * hole_end);
+void _DkGetAvailableUserAddressRange(PAL_PTR* start, PAL_PTR* end, PAL_NUM* gap);
 bool _DkCheckMemoryMappable (const void * addr, size_t size);
 PAL_NUM _DkGetProcessId (void);
 PAL_NUM _DkGetHostId (void);


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->
This commit completely reworks VMA subsystem along with its usages.
New version should be: cleaner (easier to maintain), faster (simple
tests show ~25% on memory heavy workloads) and allow for bookkeeping
requests from Pal.
It also fixes some bugs and inconsistencies found in the process and
changes brk and mmap/munmap implementations (at least partially).

Closes #1028 closes #1331

## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1431)
<!-- Reviewable:end -->
