### PR TITLE
[LibOS/test/fs] Remove invalid mmap on file opened write-only

### DIFF
--- a/LibOS/shim/test/fs/Makefile
+++ b/LibOS/shim/test/fs/Makefile
@@ -1,7 +1,10 @@
-copy_execs = \
+copy_mmap_execs = \
 	copy_mmap_rev \
 	copy_mmap_seq \
-	copy_mmap_whole \
+	copy_mmap_whole
+
+copy_execs = \
+	$(copy_mmap_execs) \
 	copy_rev \
 	copy_seq \
 	copy_whole
@@ -38,6 +41,8 @@ ifeq ($(findstring x86_64,$(SYS))$(findstring linux,$(SYS)),x86_64linux)
 $(execs): common.o
 
 $(copy_execs): common_copy.o
+
+$(copy_mmap_execs): CFLAGS += -DCOPY_MMAP
 
 %.o: %.c
 	$(call cmd,cc_o_c)

--- a/LibOS/shim/test/fs/common_copy.c
+++ b/LibOS/shim/test/fs/common_copy.c
@@ -1,5 +1,11 @@
 #include "common.h"
 
+#ifdef COPY_MMAP
+#define RDWR_OUTPUT_OPEN true
+#else
+#define RDWR_OUTPUT_OPEN false
+#endif
+
 void copy_file(const char* input_path, const char* output_path, size_t size) {
     int fi = open_input_fd(input_path);
     printf("open(%zu) input OK\n", size);
@@ -11,7 +17,7 @@ void copy_file(const char* input_path, const char* output_path, size_t size) {
         fatal_error("Size mismatch: expected %zu, got %zu\n", size, st.st_size);
     printf("fstat(%zu) input OK\n", size);
 
-    int fo = open_output_fd(output_path, /*rdwr=*/false);
+    int fo = open_output_fd(output_path, /*rdwr=*/RDWR_OUTPUT_OPEN);
     printf("open(%zu) output OK\n", size);
 
     if (fstat(fo, &st) < 0)


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://graphene.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->
LibOS fs tests tried mapping a file opened with `O_WRONLY` which is disallowed.

## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1432)
<!-- Reviewable:end -->
