### PR TITLE
[LibOS/test] Fix incorrect options arg for waitpid() in udp.c and tcp.c

### DIFF
--- a/LibOS/shim/test/native/tcp.c
+++ b/LibOS/shim/test/native/tcp.c
@@ -196,7 +196,7 @@ int main(int argc, char** argv) {
             client();
         else {
             server();
-            waitpid(pid, NULL, -1);
+            waitpid(pid, NULL, 0);
         }
     }
 

--- a/LibOS/shim/test/regression/udp.c
+++ b/LibOS/shim/test/regression/udp.c
@@ -155,7 +155,7 @@ int main(int argc, char** argv) {
         return client();
     } else {
         int ret = server();
-        if (waitpid(pid, NULL, -1) == -1) {
+        if (waitpid(pid, NULL, 0) == -1) {
             perror("waitpid error");
             ret = 1;
         }


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

`udp` LibOS regression test failed with exit code `1` on normal Linux (without Graphene). This happened because of the `waitpid(..., -1)` code -- this `-1` is an impossible value for the `options` argument. Graphene's emulation of waitpid ignored that, but normal Linux failed. Interestingly, since our testing Python framework never tests native apps, it required a manual invocation to spot this bug.

Similar in `tcp` LibOS deprecated test. Fixed it just in case.

Kudos to @boryspoplawski for finding this.
 
## How to test this PR? <!-- (if applicable) -->

All tests must run.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1433)
<!-- Reviewable:end -->
