### PR TITLE
[Pal] Enforce that executable is always located at a predefined address

### DIFF
--- a/Pal/src/pal_internal.h
+++ b/Pal/src/pal_internal.h
@@ -318,6 +318,7 @@ int _DkAttestationQuote(PAL_PTR user_report_data, PAL_NUM user_report_data_size,
     } while (0)
 
 /* function and definition for loading binaries */
+#define DEFAULT_OBJECT_EXEC_ADDR ((void*)0x00400000)
 enum object_type { OBJECT_RTLD, OBJECT_EXEC, OBJECT_PRELOAD, OBJECT_EXTERNAL };
 
 int check_elf_magic (const void* header, size_t len);


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Previously, the PAL layer would put an executable at a first unoccupied address range if the executable was position-independent (PIE). This could lead to the same executable being located at different addresses across forks (Graphene correctly checkpoints shared libraries but has separate handling for the executable). This is a rare scenario since the PAL initialization code is typically deterministic across forks. However, rarely there would be small difference in allocations which would lead to different base addresses for executable segments in parent and child processes, and segfaults and data corruptions
happened (this was the case for Nginx on Ubuntu 18.04 with change in the manifest file processing). 

This PR simply forces executables to always be loaded at a predefined address (currently `0x00400000`).

**Note** that this only happens in the Linux PAL. The Linux-SGX PAL explicitly specifies the base address at which the executable must be always loaded (this is due to the enclave measurement which requires to always put the executable at the same address).

## How to test this PR? <!-- (if applicable) -->

This PR fixes a bug in Nginx on Ubuntu 18.04 in https://github.com/oscarlab/graphene/pull/1428. Since this is largely non-deterministic (and was triggered under a difference of `file:./install/sbin/nginx` vs `file:install/sbin/nginx` in parent and child processes), I don't know how to create a stable test case.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1434)
<!-- Reviewable:end -->
