### PR TITLE
[LibOS] Fix goto target in __map_elf_object

### DIFF
--- a/LibOS/shim/src/elf/shim_rtld.c
+++ b/LibOS/shim/src/elf/shim_rtld.c
@@ -556,7 +556,7 @@ static struct link_map* __map_elf_object(struct shim_handle* file, const void* f
             }
         }
 
-        goto postmap;
+        goto do_remap;
     }
 
     /* Remember which part of the address space this object uses.  */
@@ -586,7 +586,6 @@ do_remap:
                            file, c->mapoff, NULL);
         }
 
-    postmap:
         if (l->l_phdr == 0 && (ElfW(Off))c->mapoff <= header->e_phoff &&
             ((size_t)(c->mapend - c->mapstart + c->mapoff) >=
              header->e_phoff + header->e_phnum * sizeof(ElfW(Phdr))))


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://graphene.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->
`__map_elf_object` skipped bookkeeping of first elf segment.

## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1439)
<!-- Reviewable:end -->
