### PR TITLE
[DO NOT MERGE] Make sched_yield() no-op for performance testing

### DIFF
--- a/LibOS/shim/src/sys/shim_sched.c
+++ b/LibOS/shim/src/sys/shim_sched.c
@@ -32,7 +32,11 @@
 #include <shim_table.h>
 
 int shim_do_sched_yield(void) {
+#if 0
+    /* ONLY FOR PERFORMANCE TESTING: sched_yield() is a no-op to test SGX performance on
+     * multi-threaded synchronization-heavy workloads like OpenVINO. */
     DkThreadYieldExecution();
+#endif
     return 0;
 }
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

**DO NOT MERGE**.

This PR is to test the performance of Graphene-SGX on multi-threaded and synchronization-heavy workloads like OpenVINO. We'll also report the results here.

This PR simply stubs `sched_yield()` to be a no-op. (Previously, Graphene-SGX would perform an OCALL to do a host-level `sched_yield()`.)