### PR TITLE
[Pal] Force PIE executable to be located at address 0x555555554000

### DIFF
--- a/Pal/src/pal_internal.h
+++ b/Pal/src/pal_internal.h
@@ -316,8 +316,8 @@ int _DkAttestationQuote(PAL_PTR user_report_data, PAL_NUM user_report_data_size,
         _DkProcessExit(exitcode);                                                       \
     } while (0)
 
-/* function and definition for loading binaries */
-#define DEFAULT_OBJECT_EXEC_ADDR ((void*)0x00400000)
+/* Loading ELF binaries */
+#define DEFAULT_OBJECT_EXEC_ADDR ((void*)0x555555554000) /* Linux base location for PIE binaries */
 enum object_type { OBJECT_RTLD, OBJECT_EXEC, OBJECT_PRELOAD, OBJECT_EXTERNAL };
 
 bool has_elf_magic(const void* header, size_t len);


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Previously, we forced PIE executables to be located at address `0x00400000` (4MB). However, there is a bug in the ELF relocation code in LibOS that leads to double-relocation. To circumvent this bug,
relocation code checks if the offset was already relocated. But if the offset itself exceeds the base address of PIE executable (i.e., exceeds 4MB), then the offset is not relocated and segfaults follow.

This PR changes base address from `0x00400000` to `0x555555554000`, similar to what Linux does.

## How to test this PR? <!-- (if applicable) -->

Run NodeJS example manually. It will work now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1443)
<!-- Reviewable:end -->
