### PR TITLE
pal_loader: Disable the annoying GDB banner

### DIFF
--- a/Runtime/pal_loader
+++ b/Runtime/pal_loader
@@ -53,7 +53,7 @@ if [ "$GDB" == "1" ]; then
 fi
 
 if [ "$GDB" != "" ] && [ "$GDB" != "0" ]; then
-	PREFIX=("$GDB")
+	PREFIX=("$GDB" -q)
 	if [ -n "$INSIDE_EMACS" ]; then
 		PREFIX+=("-i=mi")
 	fi


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

GDB is so awesome that it has to print 14 lines of useless information about itself on each run. This isn't actually configurable in `.gdbinit` (or at least I couldn't find any way to do this), so we need to fix it via the commandline.

## How to test this PR? <!-- (if applicable) -->

Just try `GDB=1 ./pal_loader <binary>` now and enjoy slightly better experience.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1447)
<!-- Reviewable:end -->
