### PR TITLE
[LibOS] Add a missing check for stack guard page when removing VMAs

### DIFF
--- a/LibOS/shim/src/sys/shim_exec.c
+++ b/LibOS/shim/src/sys/shim_exec.c
@@ -147,7 +147,7 @@ retry_dump_vmas:
     count = ret;
     for (struct shim_vma_val* vma = vmas; vma < vmas + count; vma++) {
         /* Don't free the current stack */
-        if (vma->addr == cur_thread->stack)
+        if (vma->addr == cur_thread->stack || vma->addr == cur_thread->stack_red)
             continue;
 
         /* Free all the mapped VMAs */

--- a/LibOS/shim/test/regression/exec_same.c
+++ b/LibOS/shim/test/regression/exec_same.c
@@ -1,15 +1,18 @@
-#include <errno.h>
 #include <stdio.h>
-#include <stdlib.h>
 #include <unistd.h>
 
-int main(int argc, char** argv, char** envp) {
-    if (argc > 1) {
-        puts(argv[1]);
+int main(int argc, char** argv) {
+    if (argc <= 0) {
+        return 1;
+    } else if (argc == 1) {
         return 0;
     }
-    char* const new_argv[] = {argv[0], "hello from execv process", NULL};
-    execv(new_argv[0], new_argv);
+
+    puts(argv[1]);
+    fflush(stdout);
+
+    argv[1] = argv[0];
+    execv(argv[0], &argv[1]);
 
     /* must never reach this */
     return 1;

--- a/LibOS/shim/test/regression/test_libos.py
+++ b/LibOS/shim/test/regression/test_libos.py
@@ -83,8 +83,9 @@ class TC_01_Bootstrap(RegressionTestCase):
             stdout)
 
     def test_201_exec_same(self):
-        stdout, _ = self.run_binary(['exec_same'])
-        self.assertIn('hello from execv process', stdout)
+        args = [str(i) for i in range(50)]
+        stdout, _ = self.run_binary(['exec_same'] + args, timeout=40)
+        self.assertIn('\n'.join(args), stdout)
 
     def test_202_fork_and_exec(self):
         stdout, _ = self.run_binary(['fork_and_exec'], timeout=60)


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://graphene.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->
While executing a new binary in the same process, graphene removed all user VMAs except for the stack, but it didn't account stack guard page. This could occasionally lead to crashes (guard page unmapped, new stack lands there, on the next exec it's unmapped while being used).

## How to test this PR? <!-- (if applicable) -->
Remove the fix in `shim_exec.c` and run `exec_same` (with modifications from this PR) form LibOS regression tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1453)
<!-- Reviewable:end -->
