### PR TITLE
[LibOS] Add support for FIFOs (named pipes)

### DIFF
--- a/LibOS/shim/include/shim_fs.h
+++ b/LibOS/shim/include/shim_fs.h
@@ -525,6 +525,7 @@ extern struct shim_d_ops str_d_ops;
 
 extern struct shim_mount chroot_builtin_fs;
 extern struct shim_mount pipe_builtin_fs;
+extern struct shim_mount fifo_builtin_fs;
 extern struct shim_mount socket_builtin_fs;
 extern struct shim_mount epoll_builtin_fs;
 extern struct shim_mount eventfd_builtin_fs;

--- a/LibOS/shim/include/shim_handle.h
+++ b/LibOS/shim/include/shim_handle.h
@@ -127,6 +127,7 @@ struct shim_dev_handle {
 };
 
 struct shim_pipe_handle {
+    bool ready_for_ops; /* true for pipes, false for FIFOs that were mknod'ed but not open'ed */
     char name[PIPE_URI_SIZE];
 };
 

--- a/LibOS/shim/include/shim_table.h
+++ b/LibOS/shim/include/shim_table.h
@@ -488,6 +488,8 @@ int shim_do_accept4(int sockfd, struct sockaddr* addr, socklen_t* addrlen, int f
 int shim_do_dup3(unsigned int oldfd, unsigned int newfd, int flags);
 int shim_do_epoll_create1(int flags);
 int shim_do_pipe2(int* fildes, int flags);
+int shim_do_mknod(const char *pathname, mode_t mode, dev_t dev);
+int shim_do_mknodat(int dirfd, const char *pathname, mode_t mode, dev_t dev);
 ssize_t shim_do_recvmmsg(int sockfd, struct mmsghdr* msg, size_t vlen, int flags,
                          struct __kernel_timespec* timeout);
 int shim_do_prlimit64(pid_t pid, int resource, const struct __kernel_rlimit64* new_rlim,

--- a/LibOS/shim/src/bookkeep/shim_handle.c
+++ b/LibOS/shim/src/bookkeep/shim_handle.c
@@ -755,7 +755,7 @@ BEGIN_CP_FUNC(handle) {
         DO_CP_IN_MEMBER(qstr, new_hdl, path);
         DO_CP_IN_MEMBER(qstr, new_hdl, uri);
 
-        if (fs && hdl->dentry) {
+        if (fs && fs != &fifo_builtin_fs && hdl->dentry) {
             DO_CP_MEMBER(mount, hdl, new_hdl, fs);
         } else {
             new_hdl->fs = NULL;

--- a/LibOS/shim/src/fs/pipe/fs.c
+++ b/LibOS/shim/src/fs/pipe/fs.c
@@ -39,6 +39,9 @@
 #include <shim_thread.h>
 
 static ssize_t pipe_read(struct shim_handle* hdl, void* buf, size_t count) {
+    if (!hdl->info.pipe.ready_for_ops)
+        return -EACCES;
+
     PAL_NUM bytes = DkStreamRead(hdl->pal_handle, 0, count, buf, NULL, 0);
 
     if (bytes == PAL_STREAM_ERROR)
@@ -48,6 +51,9 @@ static ssize_t pipe_read(struct shim_handle* hdl, void* buf, size_t count) {
 }
 
 static ssize_t pipe_write(struct shim_handle* hdl, const void* buf, size_t count) {
+    if (!hdl->info.pipe.ready_for_ops)
+        return -EACCES;
+
     PAL_NUM bytes = DkStreamWrite(hdl->pal_handle, 0, count, (void*)buf, NULL);
 
     if (bytes == PAL_STREAM_ERROR)
@@ -91,6 +97,9 @@ static int pipe_checkout(struct shim_handle* hdl) {
 
 static off_t pipe_poll(struct shim_handle* hdl, int poll_type) {
     off_t ret = 0;
+
+    if (!hdl->info.pipe.ready_for_ops)
+        return -EACCES;
 
     lock(&hdl->lock);
 
@@ -150,7 +159,79 @@ static int pipe_setflags(struct shim_handle* hdl, int flags) {
     return 0;
 }
 
-struct shim_fs_ops pipe_fs_ops = {
+static int fifo_open(struct shim_handle* hdl, struct shim_dentry* dent, int flags) {
+    assert(hdl);
+    assert(dent && dent->data && dent->fs);
+    static_assert(sizeof(dent->data) >= sizeof(uint64_t),
+                  "dentry's data must be at least 8B in size");
+
+    /* FIXME: man 7 fifo says "[with non-blocking flag], opening for write-only fails with ENXIO
+     *        unless the other end has already been opened". We cannot enforce this failure since
+     *        Graphene doesn't know whether the other process already opened this FIFO. */
+
+    if (flags & O_RDWR) {
+        /* POSIX disallows FIFOs opened for read-write, but Linux allows it. We must choose only
+         * one end (read or write) in our emulation, so we treat such FIFOs as read-only. This
+         * covers most apps seen in the wild (in particular, LTP apps). */
+        debug("FIFO (named pipe) '%s' cannot be opened in read-write mode in Graphene. "
+              "Treating it as read-only.", qstrgetstr(&dent->fs->path));
+        flags = O_RDONLY;
+    }
+
+    int fd = -1;
+    if (flags & O_WRONLY) {
+        /* write end of FIFO is stashed in upper bits of dentry's data; invalidate afterwards */
+        fd = (uint32_t)((uint64_t)dent->data >> 32);
+        dent->data = (void*)((uint64_t)dent->data | 0xFFFFFFFF00000000ULL);
+    } else {
+        /* read end of FIFO is stashed in lower bits of dentry's data; invalidate afterwards */
+        fd = (uint32_t)((uint64_t)dent->data);
+        dent->data = (void*)((uint64_t)dent->data | 0x00000000FFFFFFFFULL);
+    }
+
+    if (fd == -1) {
+        /* fd is invalid, happens if app tries to open the same FIFO end twice; this is ok in
+         * normal Linux but Graphene uses TLS-encrypted pipes which are inherently point-to-point;
+         * if this changes, should remove this error case (see GitHub issue #1417) */
+        return -EOPNOTSUPP;
+    }
+
+    struct shim_handle* fifo_hdl = get_fd_handle(fd, /*fd_flags=*/NULL, /*map=*/NULL);
+    if (!fifo_hdl) {
+        return -ENOENT;
+    }
+
+    if (flags & O_NONBLOCK) {
+        /* FIFOs were created in blocking mode (see shim_do_mknodat), change their attributes */
+        int ret = pipe_setflags(fifo_hdl, flags);
+        if (ret < 0) {
+            put_handle(fifo_hdl);
+            return ret;
+        }
+    }
+
+    /* rewire new hdl to contents of intermediate FIFO hdl */
+    hdl->type       = fifo_hdl->type;
+    hdl->acc_mode   = fifo_hdl->acc_mode;
+    hdl->owner      = fifo_hdl->owner;
+    hdl->info       = fifo_hdl->info;
+    hdl->pal_handle = fifo_hdl->pal_handle;
+    qstrcopy(&hdl->uri, &fifo_hdl->uri);
+
+    hdl->info.pipe.ready_for_ops = true;
+
+    fifo_hdl->pal_handle = NULL; /* ownership of PAL handle is transferred to hdl */
+
+    /* can remove intermediate FIFO hdl and its fd now */
+    struct shim_handle* tmp = detach_fd_handle(fd, NULL, NULL);
+    assert(tmp == fifo_hdl);
+    put_handle(tmp);      /* matches detach_fd_handle() */
+    put_handle(fifo_hdl); /* matches get_fd_handle() */
+
+    return 0;
+}
+
+static struct shim_fs_ops pipe_fs_ops = {
     .read     = &pipe_read,
     .write    = &pipe_write,
     .hstat    = &pipe_hstat,
@@ -159,7 +240,24 @@ struct shim_fs_ops pipe_fs_ops = {
     .setflags = &pipe_setflags,
 };
 
+static struct shim_fs_ops fifo_fs_ops = {
+    .read     = &pipe_read,
+    .write    = &pipe_write,
+    .poll     = &pipe_poll,
+    .setflags = &pipe_setflags,
+};
+
+static struct shim_d_ops fifo_d_ops = {
+    .open = &fifo_open,
+};
+
 struct shim_mount pipe_builtin_fs = {
     .type   = URI_TYPE_PIPE,
     .fs_ops = &pipe_fs_ops,
+};
+
+struct shim_mount fifo_builtin_fs = {
+    .type   = "fifo",
+    .fs_ops = &fifo_fs_ops,
+    .d_ops  = &fifo_d_ops,
 };

--- a/LibOS/shim/src/fs/shim_fs.c
+++ b/LibOS/shim/src/fs/shim_fs.c
@@ -37,9 +37,7 @@ struct shim_fs {
     struct shim_d_ops* d_ops;
 };
 
-#define NUM_MOUNTABLE_FS 3
-
-struct shim_fs mountable_fs[NUM_MOUNTABLE_FS] = {
+struct shim_fs mountable_fs[] = {
     {
         .name   = "chroot",
         .fs_ops = &chroot_fs_ops,
@@ -57,11 +55,10 @@ struct shim_fs mountable_fs[NUM_MOUNTABLE_FS] = {
     },
 };
 
-#define NUM_BUILTIN_FS 5
-
-struct shim_mount* builtin_fs[NUM_BUILTIN_FS] = {
+struct shim_mount* builtin_fs[] = {
     &chroot_builtin_fs,
     &pipe_builtin_fs,
+    &fifo_builtin_fs,
     &socket_builtin_fs,
     &epoll_builtin_fs,
     &eventfd_builtin_fs,
@@ -259,7 +256,7 @@ static inline struct shim_fs* find_fs(const char* type) {
     struct shim_fs* fs = NULL;
     size_t len = strlen(type);
 
-    for (int i = 0; i < NUM_MOUNTABLE_FS; i++)
+    for (size_t i = 0; i < ARRAY_SIZE(mountable_fs); i++)
         if (!memcmp(type, mountable_fs[i].name, len + 1)) {
             fs = &mountable_fs[i];
             break;
@@ -271,7 +268,7 @@ static inline struct shim_fs* find_fs(const char* type) {
 int search_builtin_fs(const char* type, struct shim_mount** fs) {
     size_t len = strlen(type);
 
-    for (int i = 0; i < NUM_BUILTIN_FS; i++)
+    for (size_t i = 0; i < ARRAY_SIZE(builtin_fs); i++)
         if (!memcmp(type, builtin_fs[i]->type, len + 1)) {
             *fs = builtin_fs[i];
             return 0;

--- a/LibOS/shim/src/shim_parser.c
+++ b/LibOS/shim/src/shim_parser.c
@@ -215,7 +215,7 @@ struct parser_table {
         {.slow = 1, .parser = {NULL}},                      /* rt_sigsuspend */
         {.slow = 0, .parser = {NULL}},                      /* sigaltstack */
         {.slow = 0, .parser = {NULL}},                      /* utime */
-        {.slow = 0, .parser = {NULL}},                      /* mknod */
+        {.slow = 1, .parser = {NULL, &parse_open_mode}},    /* mknod */
         {.slow = 0, .parser = {NULL}},                      /* uselib */
         {.slow = 0, .parser = {NULL}},                      /* personality */
         {.slow = 0, .parser = {NULL}},                      /* ustat */
@@ -342,7 +342,7 @@ struct parser_table {
         {.slow   = 0,
          .parser = {&parse_at_fdcwd, NULL, &parse_open_flags, &parse_open_mode}}, /* openat */
         {.slow = 0, .parser = {&parse_at_fdcwd}}, /* mkdirat */
-        {.slow = 0, .parser = {&parse_at_fdcwd}}, /* mknodat */
+        {.slow = 0, .parser = {&parse_at_fdcwd, NULL, &parse_open_mode}},    /* mknodat */
         {.slow = 0, .parser = {&parse_at_fdcwd}}, /* fchownat */
         {.slow = 0, .parser = {&parse_at_fdcwd}}, /* futimesat */
         {.slow = 0, .parser = {&parse_at_fdcwd}}, /* newfstatat */

--- a/LibOS/shim/src/shim_syscalls.c
+++ b/LibOS/shim/src/shim_syscalls.c
@@ -520,7 +520,7 @@ DEFINE_SHIM_SYSCALL(sigaltstack, 2, shim_do_sigaltstack, int, const stack_t*, ss
 
 SHIM_SYSCALL_RETURN_ENOSYS(utime, 2, int, char*, filename, struct utimbuf*, times)
 
-SHIM_SYSCALL_RETURN_ENOSYS(mknod, 3, int, const char*, filename, int, mode, unsigned, dev)
+DEFINE_SHIM_SYSCALL(mknod, 3, shim_do_mknod, int, const char*, filename, int, mode, unsigned, dev)
 
 SHIM_SYSCALL_RETURN_ENOSYS(uselib, 1, int, const char*, library)
 
@@ -887,8 +887,8 @@ DEFINE_SHIM_SYSCALL(openat, 4, shim_do_openat, int, int, dfd, const char*, filen
 /* mkdirat: sys/shim_fs.c */
 DEFINE_SHIM_SYSCALL(mkdirat, 3, shim_do_mkdirat, int, int, dfd, const char*, pathname, int, mode)
 
-SHIM_SYSCALL_RETURN_ENOSYS(mknodat, 4, int, int, dfd, const char*, filename, int, mode, unsigned,
-                           dev)
+DEFINE_SHIM_SYSCALL(mknodat, 4, shim_do_mknodat, int, int, dfd, const char*, filename, int, mode,
+                    unsigned, dev)
 
 DEFINE_SHIM_SYSCALL(fchownat, 5, shim_do_fchownat, int, int, dfd, const char*, filename, uid_t,
                     user, gid_t, group, int, flag)

--- a/LibOS/shim/test/ltp/ltp-sgx.cfg
+++ b/LibOS/shim/test/ltp/ltp-sgx.cfg
@@ -2656,10 +2656,6 @@ skip = yes
 must-pass =
     1
 
-# TBROK: uses mknodat() syscall not implemented in Graphene
-[select03]
-skip = yes
-
 [semctl01]
 skip = yes
 

--- a/LibOS/shim/test/ltp/ltp.cfg
+++ b/LibOS/shim/test/ltp/ltp.cfg
@@ -1328,37 +1328,38 @@ skip = yes
 [mkdirat02]
 skip = yes
 
+# first two tests use supported regular files and FIFOs, other tests use unsupported char/block
+# devices
 [mknod01]
-skip = yes
+must-pass =
+    1
+    2
 
+# requires root and uses unsupported S_ISGID
 [mknod02]
 skip = yes
 
+# requires root and uses unsupported S_ISGID
 [mknod03]
 skip = yes
 
+# requires root and uses unsupported S_ISGID
 [mknod04]
 skip = yes
 
+# requires root and uses unsupported S_ISGID
 [mknod05]
 skip = yes
 
-[mknod06]
-skip = yes
-
+# requires root and wants to mount FS, also tests unsupported char, socket, and block devices
 [mknod07]
-timeout = 60
 skip = yes
 
+# requires root and uses unsupported S_ISGID
 [mknod08]
 skip = yes
 
-[mknod09]
-skip = yes
-
-[mknodat01]
-skip = yes
-
+# requires root and wants to mount FS
 [mknodat02]
 skip = yes
 
@@ -1660,7 +1661,7 @@ skip = yes
 [open05]
 skip = yes
 
-# Requires mknod() support
+# Requires support of ENXIO (fail to open for write if other side didn't open) in mknod()
 [open06]
 skip = yes
 
@@ -2213,10 +2214,6 @@ skip = yes
 skip = yes
 
 [sched_setscheduler03]
-skip = yes
-
-# TBROK: uses mknodat() syscall not implemented in Graphene
-[select03]
 skip = yes
 
 [semctl01]

--- a/LibOS/shim/test/regression/.gitignore
+++ b/LibOS/shim/test/regression/.gitignore
@@ -40,6 +40,7 @@
 /init_fail
 /large_dir_read
 /large_mmap
+/mkfifo
 /mmap_file
 /mprotect_file_fork
 /multi_pthread

--- a/LibOS/shim/test/regression/Makefile
+++ b/LibOS/shim/test/regression/Makefile
@@ -32,6 +32,7 @@ c_executables = \
 	init_fail \
 	large_mmap \
 	large_dir_read \
+	mkfifo \
 	mmap_file \
 	mprotect_file_fork \
 	multi_pthread \

--- a/LibOS/shim/test/regression/mkfifo.c
+++ b/LibOS/shim/test/regression/mkfifo.c
@@ -1,0 +1,99 @@
+#include <errno.h>
+#include <fcntl.h>
+#include <sched.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#define FIFO_PATH "fifo123"
+
+int main(int argc, char** argv) {
+    int fd;
+    char buffer[1024];
+
+    if (mkfifo(FIFO_PATH, S_IRWXU) < 0) {
+        perror("mkfifo error");
+        return 1;
+    }
+
+    pid_t pid = fork();
+
+    if (pid < 0) {
+        perror("fork error");
+        return 1;
+    } else if (pid == 0) {
+        /* client */
+        fd = open(FIFO_PATH, O_NONBLOCK | O_RDONLY);
+        if (fd < 0) {
+            perror("[child] open error");
+            return 1;
+        }
+
+        /* note that Linux guarantees either no read message or the complete message on FIFO since
+         * message size is less than PIPE_BUF; see man pipe(7) */
+        ssize_t bytes = 0;
+        while (bytes <= 0) {
+            errno = 0;
+            bytes = read(fd, &buffer, sizeof(buffer));
+            if (bytes < 0 && errno != EAGAIN && errno != EWOULDBLOCK) {
+                perror("[child] read error");
+                return 1;
+            }
+            sched_yield();
+        }
+
+        buffer[sizeof(buffer) - 1] = '\0';
+        if (bytes < sizeof(buffer))
+            buffer[bytes] = '\0';
+
+        if (close(fd) < 0) {
+            perror("[child] close error");
+            return 1;
+        }
+
+        printf("read on FIFO: %s\n", buffer);
+    } else {
+        /* server */
+        fd = -1;
+        while (fd < 0) {
+            /* wait until client is ready for read */
+            errno = 0;
+            fd = open(FIFO_PATH, O_NONBLOCK | O_WRONLY);
+            if (fd < 0 && errno != ENXIO) {
+                perror("[parent] open error");
+                return 1;
+            }
+            sched_yield();
+        }
+
+        /* note that Linux guarantees sending the complete message on FIFO since message size is
+         * less than PIPE_BUF and there are no signals possible in this test; see man pipe(7) */
+        snprintf(buffer, sizeof(buffer), "Hello from write end of FIFO!");
+        if (write(fd, &buffer, strlen(buffer) + 1) < 0) {
+            perror("[parent] write error");
+            return 1;
+        }
+
+        if (close(fd) < 0) {
+            perror("[parent] close error");
+            return 1;
+        }
+
+        pid = wait(NULL); /* wait for child termination, just for sanity */
+        if (pid < 0) {
+            perror("[parent] wait error");
+            return 1;
+        }
+
+        if (unlink(FIFO_PATH) < 0) {
+            perror("[parent] unlink error");
+            return 1;
+        }
+    }
+
+    return 0;
+}

--- a/LibOS/shim/test/regression/test_libos.py
+++ b/LibOS/shim/test/regression/test_libos.py
@@ -500,6 +500,10 @@ class TC_80_Socket(RegressionTestCase):
         stdout, _ = self.run_binary(['pipe'], timeout=60)
         self.assertIn('read on pipe: Hello from write end of pipe!', stdout)
 
+    def test_095_mkfifo(self):
+        stdout, _ = self.run_binary(['mkfifo'], timeout=60)
+        self.assertIn('read on FIFO: Hello from write end of FIFO!', stdout)
+
     def test_100_socket_unix(self):
         stdout, _ = self.run_binary(['unix'])
         self.assertIn('Data: This is packet 0', stdout)

--- a/Pal/lib/crypto/adapters/mbedtls_adapter.c
+++ b/Pal/lib/crypto/adapters/mbedtls_adapter.c
@@ -105,6 +105,12 @@ int mbedtls_to_pal_error(int error)
         case MBEDTLS_ERR_RSA_RNG_FAILED:
             return -PAL_ERROR_CRYPTO_RNG_FAILED;
 
+        case MBEDTLS_ERR_SSL_WANT_READ:
+        case MBEDTLS_ERR_SSL_WANT_WRITE:
+        case MBEDTLS_ERR_SSL_ASYNC_IN_PROGRESS:
+        case MBEDTLS_ERR_SSL_CRYPTO_IN_PROGRESS:
+            return -PAL_ERROR_TRYAGAIN;
+
         default:
             return -PAL_ERROR_DENIED;
     }
@@ -456,15 +462,15 @@ int lib_SSLHandshake(LIB_SSL_CONTEXT* ssl_ctx) {
 
 int lib_SSLRead(LIB_SSL_CONTEXT* ssl_ctx, uint8_t* buf, size_t len) {
     int ret = mbedtls_ssl_read(&ssl_ctx->ssl, buf, len);
-    if (ret <= 0)
-       return -PAL_ERROR_DENIED;
+    if (ret < 0)
+       return mbedtls_to_pal_error(ret);
     return ret;
 }
 
 int lib_SSLWrite(LIB_SSL_CONTEXT* ssl_ctx, const uint8_t* buf, size_t len) {
     int ret = mbedtls_ssl_write(&ssl_ctx->ssl, buf, len);
-    if (ret <= 0)
-       return -PAL_ERROR_DENIED;
+    if (ret < 0)
+       return mbedtls_to_pal_error(ret);
     return ret;
 }
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

This PR adds support for FIFOs and the corresponding syscalls `mknod()` and `mknodat()`. Internally, FIFOs are emulated as pseudo-files in chroot mount points (not visible in host FS). FIFOs' read/write operations are emulated via pipes at PAL level (this means that they are transparently encrypted under SGX PAL). Generally, emulation of FIFOs is similar to emulation of named UNIX domain sockets, i.e., they are "ephemeral" and only allow communication between two related processes. FIFOs cannot be O_RDWR (opening fails with EINVAL).

FIFOs can be blocking and non-blocking. The only caveat with non-blocking FIFOs is that `open(O_WRONLY)` doesn't fail with ENXIO if the other end is not opened yet (but this is a rare corner-case probably not used by real-world apps).

## How to test this PR? <!-- (if applicable) -->

New LibOS test is added: multi-process `mkfifo`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1454)
<!-- Reviewable:end -->
