### PR TITLE
[LibOS,Pal] Make Graphene build on Clear Linux and GCC 9.3

### DIFF
--- a/LibOS/Makefile
+++ b/LibOS/Makefile
@@ -26,7 +26,7 @@ GLIBC_LIBS = \
 GLIBC_TARGET = $(addprefix $(BUILD_DIR)/, $(GLIBC_LIBS))
 GLIBC_RUNTIME = $(addprefix $(RUNTIME_DIR)/, $(notdir $(GLIBC_TARGET)))
 
-GLIBC_CFLAGS = -O2 -U_FORTIFY_SOURCE -fno-stack-protector -Wno-unused-value
+GLIBC_CFLAGS = -O2 -Wp,-U_FORTIFY_SOURCE -fno-stack-protector -Wno-unused-value
 ifeq ($(DEBUG),1)
 	GLIBC_CFLAGS += -g
 endif

--- a/LibOS/shim/include/shim_flags_conv.h
+++ b/LibOS/shim/include/shim_flags_conv.h
@@ -22,7 +22,7 @@
 #define SHIM_FLAGS_CONV_H
 
 #include <asm/fcntl.h>
-#include <asm/mman.h>
+#include <linux/mman.h>
 #include <linux/fcntl.h>
 
 #include "assert.h"

--- a/LibOS/shim/src/ipc/shim_ipc_pid.c
+++ b/LibOS/shim/src/ipc/shim_ipc_pid.c
@@ -536,7 +536,7 @@ int ipc_pid_retmeta_callback(IPC_CALLBACK_ARGS) {
 }
 
 int get_pid_port(IDTYPE pid, IDTYPE* dest, struct shim_ipc_port** port) {
-    IDTYPE owner;
+    IDTYPE owner = 0;
     int ret;
 
     if ((ret = connect_owner(pid, port, &owner)) < 0)

--- a/Pal/regression/Directory.c
+++ b/Pal/regression/Directory.c
@@ -2,6 +2,8 @@
 #include "pal.h"
 #include "pal_debug.h"
 
+char buffer[80];
+
 int main(int argc, char** argv, char** envp) {
     /* test regular directory opening */
 
@@ -13,7 +15,6 @@ int main(int argc, char** argv, char** envp) {
         if (DkStreamAttributesQueryByHandle(dir1, &attr1))
             pal_printf("Query by Handle: type = %d\n", attr1.handle_type);
 
-        char buffer[80];
         int bytes = DkStreamRead(dir1, 0, 80, buffer, NULL, 0);
         if (bytes) {
             for (char* c = buffer; c < buffer + bytes; c += strlen(c) + 1)

--- a/Pal/regression/File.c
+++ b/Pal/regression/File.c
@@ -3,20 +3,24 @@
 #include "pal_debug.h"
 
 #define NUM_TO_HEX(num) ((num) >= 10 ? 'a' + ((num) - 10) : '0' + (num))
+#define BUF_SIZE 40
 
-static __attribute__((noinline)) void print_hex(char* fmt, const void* data, int len) {
-    char* buf    = __alloca(len * 2 + 1);
-    buf[len * 2] = '\0';
+char buffer1[BUF_SIZE];
+char buffer2[BUF_SIZE];
+char buffer3[BUF_SIZE];
+char hex_buf[BUF_SIZE * 2 + 1];
+
+static void print_hex(char* fmt, const void* data, int len) {
+    hex_buf[len * 2] = '\0';
     for (int i = 0; i < len; i++) {
         unsigned char b = ((unsigned char*)data)[i];
-        buf[i * 2]      = NUM_TO_HEX(b >> 4);
-        buf[i * 2 + 1]  = NUM_TO_HEX(b & 0xf);
+        hex_buf[i * 2]      = NUM_TO_HEX(b >> 4);
+        hex_buf[i * 2 + 1]  = NUM_TO_HEX(b & 0xf);
     }
-    pal_printf(fmt, buf);
+    pal_printf(fmt, hex_buf);
 }
 
 int main(int argc, char** argv, char** envp) {
-    char buffer1[40], buffer2[40], buffer3[40];
     int ret;
 
     /* test regular file opening */

--- a/Pal/regression/Hex.c
+++ b/Pal/regression/Hex.c
@@ -6,15 +6,19 @@
 #include "api.h"
 #include "pal.h"
 
+char x[] = {0xde, 0xad, 0xbe, 0xef};
+char y[] = {0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd};
+
+static_assert(sizeof(x) <= sizeof(y), "array x is longer than array y");
+char hex_buf[sizeof(y) * 2 + 1];
+
 noreturn void __abort(void) {
     // ENOTRECOVERABLE = 131
     DkProcessExit(-131);
 }
 
 int main(void) {
-    char x[] = {0xde, 0xad, 0xbe, 0xef};
-    char y[] = {0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd};
-    pal_printf("Hex test 1 is %s\n", ALLOCA_BYTES2HEXSTR(x));
-    pal_printf("Hex test 2 is %s\n", ALLOCA_BYTES2HEXSTR(y));
+    pal_printf("Hex test 1 is %s\n", BYTES2HEXSTR(x, hex_buf, sizeof(hex_buf)));
+    pal_printf("Hex test 2 is %s\n", BYTES2HEXSTR(y, hex_buf, sizeof(hex_buf)));
     return 0;
 }

--- a/Pal/regression/Makefile
+++ b/Pal/regression/Makefile
@@ -1,7 +1,7 @@
 include ../../Scripts/Makefile.configs
 include ../../Scripts/Makefile.rules
 
-CFLAGS	+= -fno-builtin -nostdlib \
+CFLAGS	+= -Wp,-U_FORTIFY_SOURCE -fno-builtin -nostdlib \
 	  -I../include/pal -I../include/lib -I../src
 
 preloads = \

--- a/Pal/regression/Tcp.c
+++ b/Pal/regression/Tcp.c
@@ -5,15 +5,17 @@
 #define PORT   8000
 #define NTRIES 10
 
+char addr[40];
+char time_arg[24];
+char buffer[12];
+
 int main(int argc, char** argv) {
-    char addr[40];
     int i;
 
     if (argc == 1) {
         unsigned long time = DkSystemTimeQuery();
         pal_printf("start time = %lu\n", time);
 
-        char time_arg[24];
         snprintf(time_arg, 24, "%ld", time);
 
         const char* newargs[4] = {"Tcp", time_arg, NULL};
@@ -67,7 +69,6 @@ int main(int argc, char** argv) {
             DkStreamGetName(cli, addr, 40);
             pal_printf("client connected on %s\n", addr);
 
-            char buffer[12];
             int bytes = DkStreamRead(cli, 0, 12, buffer, NULL, 0);
 
             if (!bytes) {

--- a/Pal/regression/Udp.c
+++ b/Pal/regression/Udp.c
@@ -4,8 +4,10 @@
 
 #define NTRIES 10
 
+char addr[40];
+char buffer[20];
+
 int main(int argc, char** argv) {
-    char addr[40];
     int i;
 
     if (argc == 1) {
@@ -26,7 +28,6 @@ int main(int argc, char** argv) {
         PAL_HANDLE proc = DkProcessCreate("file:Udp", newargs);
 
         for (i = 0; i < NTRIES; i++) {
-            char buffer[20];
             int bytes = DkStreamRead(srv, 0, 20, buffer, addr, 40);
 
             if (!bytes) {

--- a/Pal/regression/normalize_path.c
+++ b/Pal/regression/normalize_path.c
@@ -49,9 +49,9 @@ static size_t cases_len;
 static int (*func_to_test)(const char*, char*, size_t*);
 static const char* func_name;
 
-static int run_test(void) {
-    char buf[URI_MAX] = {0};
+char buf[URI_MAX] = {0};
 
+static int run_test(void) {
     for (size_t i = 0; i < cases_len; i++) {
         size_t size = sizeof(buf);
         int ret     = func_to_test(cases[i][0], buf, &size);

--- a/Pal/src/db_rtld.c
+++ b/Pal/src/db_rtld.c
@@ -480,7 +480,13 @@ int load_elf_object (const char * uri, enum object_type type)
 
 int add_elf_object(void * addr, PAL_HANDLE handle, int type)
 {
+    if (!addr)
+        return -PAL_ERROR_INVAL;
+
     struct link_map * map = new_elf_object(_DkStreamRealpath(handle), type);
+    if (!map)
+        return -PAL_ERROR_NOMEM;
+
     const ElfW(Ehdr) * header = (void *) addr;
     const ElfW(Phdr) * ph, * phdr =
             (ElfW(Phdr) *) ((char *) addr + header->e_phoff);
@@ -944,11 +950,13 @@ void DkDebugAttachBinary (PAL_STR uri, PAL_PTR start_addr)
     __UNUSED(uri);
     __UNUSED(start_addr);
 #else
-    if (!strstartswith_static(uri, URI_PREFIX_FILE))
+    if (!strstartswith_static(uri, URI_PREFIX_FILE) || !start_addr)
         return;
 
     const char * realname = uri + URI_PREFIX_FILE_LEN;
     struct link_map * l = new_elf_object(realname, OBJECT_EXTERNAL);
+    if (!l)
+        return;
 
     /* This is the ELF header.  We read it in `open_verify'.  */
     const ElfW(Ehdr) * header = (ElfW(Ehdr) *) start_addr;

--- a/Pal/src/host/Linux-SGX/Makefile.am
+++ b/Pal/src/host/Linux-SGX/Makefile.am
@@ -1,6 +1,6 @@
 # Add host-specific compilation rules here
 
-CFLAGS += -fPIC -maes -U_FORTIFY_SOURCE \
+CFLAGS += -fPIC -maes -Wp,-U_FORTIFY_SOURCE \
 	  -fno-stack-protector -fno-builtin -Wtrampolines
 
 CFLAGS += -Wextra $(call cc-option,-Wnull-dereference)

--- a/Pal/src/host/Linux/Makefile.am
+++ b/Pal/src/host/Linux/Makefile.am
@@ -1,7 +1,7 @@
 # Add host-specific compilation rules here
 SEC_DIR = security/$(PAL_HOST)
 
-CFLAGS += -fPIC -U_FORTIFY_SOURCE \
+CFLAGS += -fPIC -Wp,-U_FORTIFY_SOURCE \
 	  -fno-stack-protector -fno-builtin -Wtrampolines
 
 CFLAGS += -Wextra $(call cc-option,-Wnull-dereference)

--- a/Pal/src/host/Linux/db_sockets.c
+++ b/Pal/src/host/Linux/db_sockets.c
@@ -329,7 +329,9 @@ static int tcp_listen(PAL_HANDLE* handle, char* uri, int create, int options) {
     if ((ret = socket_parse_uri(uri, &bind_addr, &bind_addrlen, NULL, NULL)) < 0)
         return ret;
 
-    assert(bind_addr);
+    if (!bind_addr)
+        return -PAL_ERROR_DENIED;
+
     assert(bind_addrlen == addr_size(bind_addr));
 
 #if ALLOW_BIND_ANY == 0
@@ -624,7 +626,9 @@ static int udp_bind(PAL_HANDLE* handle, char* uri, int create, int options) {
     if ((ret = socket_parse_uri(uri, &bind_addr, &bind_addrlen, NULL, NULL)) < 0)
         return ret;
 
-    assert(bind_addr);
+    if (!bind_addr)
+        return -PAL_ERROR_DENIED;
+
     assert(bind_addrlen == addr_size(bind_addr));
 
 #if ALLOW_BIND_ANY == 0

--- a/Pal/src/host/Skeleton/Makefile.am
+++ b/Pal/src/host/Skeleton/Makefile.am
@@ -1,6 +1,6 @@
 # Add host-specific compilation rules here
 
-CFLAGS += -fPIC -U_FORTIFY_SOURCE \
+CFLAGS += -fPIC -Wp,-U_FORTIFY_SOURCE \
          -fno-stack-protector -fno-builtin
 
 CFLAGS += -Wextra -Wno-unused-parameter -Wno-sign-compare $(call cc-option,-Wnull-dereference)


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

This PR makes Graphene to correctly build and run (most) tests on Clear Linux with GCC 9.3. In particular:

- [Makefiles] Make Graphene build on Clear Linux. Clear Linux ships with Glibc built with `-Wp,-DFORTIFY_SOURCE=2`. This overwrites Graphene's `-UFORTIFY_SOURCE` because of the quirk in how GCC applies arguments (first without Wp, then with Wp). This commit updates Makefiles to use `-Wp,-UFORTIFY_SOURCE`.

- [LibOS,Pal] Make Graphene build with GCC 9.3. GCC 9.3 adds more static checks on C headers and sources. This commit fixes all detected issues (mainly possible NULL pointer dereferences).

**NOTE:** Some tests (especially LibOS tests) require changes in manifests to correctly run on Clear Linux. In particular, some paths in mount points are different, as well as some library names. This PR does *not* attempt to change the manifests.

Fixes #1442.

## How to test this PR? <!-- (if applicable) -->

Normal Ubuntu build and all tests must pass. You can manually test this PR on Clear Linux.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1455)
<!-- Reviewable:end -->
