### PR TITLE
Add a missing prerequisite (libcurl4-openssl-dev) to build and quick start documentation

### DIFF
--- a/Documentation/building.rst
+++ b/Documentation/building.rst
@@ -32,7 +32,8 @@ Run the following command on Ubuntu to install dependencies for Graphene::
 
 For building Graphene for SGX, run the following command in addition::
 
-    sudo apt-get install -y libprotobuf-c-dev protobuf-c-compiler
+    sudo apt-get install -y libprotobuf-c-dev protobuf-c-compiler \
+       libcurl4-openssl-dev
 
     # For Ubuntu 18.04
     sudo apt-get install -y python3-protobuf

--- a/Documentation/quickstart.rst
+++ b/Documentation/quickstart.rst
@@ -76,7 +76,7 @@ second command should list the process status of :command:`aesm_service`.
 #. Build Graphene-SGX::
 
       sudo apt-get install -y \
-         build-essential autoconf gawk bison \
+         build-essential autoconf gawk bison libcurl4-openssl-dev \
          python3-protobuf libprotobuf-c-dev protobuf-c-compiler
       cd $GRAPHENE_DIR
       make SGX=1


### PR DESCRIPTION
## Description of the changes 

Building Graphene-SGX using the commands in the documentation (Documentation/quickstart.rst or Documentation/building.rst) fails during `make SGX=1`:
```
gcc -Wall -std=c11 -O2 -I../.. -I../../../../../include/lib -I../../../../../lib/crypto/mbedtls/install/include -I../../../../../lib/crypto/mbedtls/crypto/include -DCRYPTO_USE_MBEDTLS -D_POSIX_C_SOURCE=200809L -fPIC   -c -o ias.o ias.c
ias.c:17:23: fatal error: curl/curl.h: No such file or directory
```

The culprit is the description of required software packages which misses `libcurl4-openssl-dev`.

This PR adds the library to the description in quickstart.rst and building.rst.

## How to test this PR? 

Test the document generation. No changes to the Graphene sources where made.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1456)
<!-- Reviewable:end -->
