### PR TITLE
Fix a bunch of crashes found by socket-related LTP tests

### DIFF
--- a/LibOS/shim/include/shim_fs.h
+++ b/LibOS/shim/include/shim_fs.h
@@ -341,7 +341,7 @@ int lookup_dentry(struct shim_dentry* parent, const char* name, int namelen,
  * Assumes dcache_lock is held; main difference from path_lookupat is that dcache_lock is not
  * released on return.
  *
- * The refcount is dropped by one on the returned dentry.
+ * The refcount is raised by one on the returned dentry.
  *
  * The make_ancestor flag creates pseudo-dentries for any parent paths that are not in cache and do
  * not exist on the underlying file system. This is intended for use only in setting up the

--- a/LibOS/shim/src/sys/shim_msgget.c
+++ b/LibOS/shim/src/sys/shim_msgget.c
@@ -382,6 +382,8 @@ int shim_do_msgsnd(int msqid, const void* msgp, size_t msgsz, int msgflg) {
     if ((ret = connect_msg_handle(msqid, &msgq)) < 0)
         return ret;
 
+    // FIXME: This call crashes Graphene, causing NULL dereference in add_sysv_msg. Everything in
+    // this file seems to be broken, so probably better to just rewrite it?
     ret = add_sysv_msg(msgq, msgbuf->mtype, msgsz, msgbuf->mtext, NULL);
     put_msg_handle(msgq);
     return ret;
@@ -572,7 +574,8 @@ static struct sysv_balance_policy msg_policy = {
 int add_sysv_msg(struct shim_msg_handle* msgq, long type, size_t size, const void* data,
                  struct sysv_client* src) {
     struct shim_handle* hdl = MSG_TO_HANDLE(msgq);
-    int ret                 = 0;
+    int ret = 0;
+
     lock(&hdl->lock);
 
     if (msgq->deleted) {
@@ -582,6 +585,7 @@ int add_sysv_msg(struct shim_msg_handle* msgq, long type, size_t size, const voi
 
     if (!msgq->owned) {
         unlock(&hdl->lock);
+        assert(src);
         ret = ipc_sysv_msgsnd_send(src->port, src->vmid, msgq->msqid, type, data, size, src->seq);
         goto out;
     }

--- a/LibOS/shim/src/sys/shim_socket.c
+++ b/LibOS/shim/src/sys/shim_socket.c
@@ -107,10 +107,10 @@ int shim_do_socket(int family, int type, int protocol) {
         return -ENOMEM;
 
     struct shim_sock_handle* sock = &hdl->info.sock;
-    hdl->type                     = TYPE_SOCK;
+    hdl->type     = TYPE_SOCK;
     set_handle_fs(hdl, &socket_builtin_fs);
-    hdl->flags      = type & SOCK_NONBLOCK ? O_NONBLOCK : 0;
-    hdl->acc_mode   = 0;
+    hdl->flags    = type & SOCK_NONBLOCK ? O_NONBLOCK : 0;
+    hdl->acc_mode = 0;
     sock->domain    = family;
     sock->sock_type = type & ~(SOCK_NONBLOCK | SOCK_CLOEXEC);
     sock->protocol  = protocol;
@@ -141,7 +141,7 @@ int shim_do_socket(int family, int type, int protocol) {
     }
 
     sock->sock_state = SOCK_CREATED;
-    ret              = set_new_fd_handle(hdl, type & SOCK_CLOEXEC ? FD_CLOEXEC : 0, NULL);
+    ret = set_new_fd_handle(hdl, type & SOCK_CLOEXEC ? FD_CLOEXEC : 0, NULL);
 err:
     put_handle(hdl);
     return ret;
@@ -680,7 +680,7 @@ int shim_do_listen(int sockfd, int backlog) {
     lock(&hdl->lock);
 
     enum shim_sock_state state = sock->sock_state;
-    int ret                    = -EINVAL;
+    int ret = -EINVAL;
 
     if (state != SOCK_BOUND && state != SOCK_LISTENED) {
         debug("shim_listen: listen on unbound socket\n");
@@ -769,6 +769,7 @@ int shim_do_connect(int sockfd, struct sockaddr* addr, int addrlen) {
         if (dent->state & DENTRY_VALID && !(dent->state & DENTRY_NEGATIVE) &&
                 dent->fs != &socket_builtin_fs) {
             ret = -ECONNREFUSED;
+            put_dentry(dent);
             goto out;
         }
 
@@ -776,11 +777,12 @@ int shim_do_connect(int sockfd, struct sockaddr* addr, int addrlen) {
          * (deterministic so that independent parent and child connect to the same socket) */
         ret = hash_to_hex_string(dent->rel_path.hash, sock->addr.un.name,
                                  sizeof(sock->addr.un.name));
-        if (ret < 0)
+        if (ret < 0) {
+            put_dentry(dent);
             goto out;
+        }
 
         sock->addr.un.dentry = dent;
-        get_dentry(dent);
     }
 
     if (state == SOCK_BOUND) {
@@ -873,13 +875,13 @@ int __do_accept(struct shim_handle* hdl, int flags, struct sockaddr* addr, sockl
     }
 
     if (addr) {
-        if (!addrlen || test_user_memory(addrlen, sizeof(*addrlen), false))
+        if (!addrlen || test_user_memory(addrlen, sizeof(*addrlen), /*write=*/true))
             return -EINVAL;
 
         if (*addrlen < minimal_addrlen(sock->domain))
             return -EINVAL;
 
-        if (test_user_memory(addr, *addrlen, true))
+        if (test_user_memory(addr, *addrlen, /*write=*/true))
             return -EINVAL;
     }
 
@@ -1147,8 +1149,10 @@ ssize_t shim_do_sendmsg(int sockfd, struct msghdr* msg, int flags) {
 }
 
 ssize_t shim_do_sendmmsg(int sockfd, struct mmsghdr* msg, size_t vlen, int flags) {
-    ssize_t total = 0;
+    if (test_user_memory(msg, vlen, /*write=*/true))
+        return -EFAULT;
 
+    ssize_t total = 0;
     for (size_t i = 0; i * sizeof(struct mmsghdr) < vlen; i++) {
         struct msghdr* m = &msg[i].msg_hdr;
 
@@ -1164,45 +1168,55 @@ ssize_t shim_do_sendmmsg(int sockfd, struct mmsghdr* msg, size_t vlen, int flags
     return total;
 }
 
-static ssize_t do_recvmsg(int fd, struct iovec* bufs, int nbufs, int flags, struct sockaddr* addr,
-                          socklen_t* addrlen) {
-    if (flags & ~MSG_PEEK) {
-        debug("recvmsg()/recvmmsg()/recvfrom(): unknown flag (only MSG_PEEK is supported).\n");
-        return -EOPNOTSUPP;
-    }
-
+static ssize_t do_recvmsg(int fd, struct iovec* bufs, size_t nbufs, int flags,
+                          struct sockaddr* addr, socklen_t* addrlen) {
     struct shim_handle* hdl = get_fd_handle(fd, NULL, NULL);
     if (!hdl)
         return -EBADF;
 
-    struct shim_peek_buffer* peek_buffer = NULL;
-    int ret = -ENOTSOCK;
-    if (hdl->type != TYPE_SOCK)
+    int ret;
+    if (hdl->type != TYPE_SOCK) {
+        ret = -ENOTSOCK;
         goto out;
+    }
 
+    struct shim_peek_buffer* peek_buffer = NULL;
     struct shim_sock_handle* sock = &hdl->info.sock;
 
     if (addr) {
         ret = -EINVAL;
-        if (!addrlen || test_user_memory(addrlen, sizeof(*addrlen), false))
+        if (!addrlen || test_user_memory(addrlen, sizeof(*addrlen), /*write=*/true))
             goto out;
 
         if (*addrlen < minimal_addrlen(sock->domain))
             goto out;
 
-        if (test_user_memory(addr, *addrlen, true))
+        if (test_user_memory(addr, *addrlen, /*write=*/true))
             goto out;
     }
 
+    size_t bufs_size;
+    if (__builtin_mul_overflow(sizeof(*bufs), nbufs, &bufs_size)) {
+        ret = -EMSGSIZE;
+        goto out;
+    }
+
     ret = -EFAULT;
-    if (!bufs || test_user_memory(bufs, sizeof(*bufs) * nbufs, false))
+    if (!bufs || test_user_memory(bufs, bufs_size, /*write=*/false))
         goto out;
 
     size_t expected_size = 0;
-    for (int i = 0; i < nbufs; i++) {
-        if (!bufs[i].iov_base || test_user_memory(bufs[i].iov_base, bufs[i].iov_len, true))
+    for (size_t i = 0; i < nbufs; i++) {
+        if (!bufs[i].iov_base || test_user_memory(bufs[i].iov_base, bufs[i].iov_len,
+                                                  /*write=*/true))
             goto out;
         expected_size += bufs[i].iov_len;
+    }
+
+    if (flags & ~MSG_PEEK) {
+        debug("recvmsg()/recvmmsg()/recvfrom(): unknown flag (only MSG_PEEK is supported).\n");
+        ret = -EOPNOTSUPP;
+        goto out;
     }
 
     lock(&hdl->lock);
@@ -1287,7 +1301,7 @@ static ssize_t do_recvmsg(int fd, struct iovec* bufs, int nbufs, int flags, stru
     bool address_received = false;
     size_t total_bytes    = 0;
 
-    for (int i = 0; i < nbufs; i++) {
+    for (size_t i = 0; i < nbufs; i++) {
         size_t iov_bytes = 0;
         if (peek_buffer) {
             /* some data left to read from peek buffer */
@@ -1402,8 +1416,10 @@ ssize_t shim_do_recvmsg(int sockfd, struct msghdr* msg, int flags) {
 
 ssize_t shim_do_recvmmsg(int sockfd, struct mmsghdr* msg, size_t vlen, int flags,
                          struct __kernel_timespec* timeout) {
-    ssize_t total = 0;
+    if (test_user_memory(msg, vlen, /*write=*/true))
+        return -EFAULT;
 
+    ssize_t total = 0;
     // Issue # 753 - https://github.com/oscarlab/graphene/issues/753
     /* TODO(donporter): timeout properly. For now, explicitly return an error. */
     if (timeout) {
@@ -1435,7 +1451,7 @@ int shim_do_shutdown(int sockfd, int how) {
     if (!hdl)
         return -EBADF;
 
-    int ret                       = 0;
+    int ret = 0;
     struct shim_sock_handle* sock = &hdl->info.sock;
 
     if (hdl->type != TYPE_SOCK) {
@@ -1479,23 +1495,28 @@ out:
 }
 
 int shim_do_getsockname(int sockfd, struct sockaddr* addr, int* addrlen) {
-    if (!addr || !addrlen)
-        return -EFAULT;
-
-    if (*addrlen <= 0)
-        return -EINVAL;
-
-    if (test_user_memory(addr, *addrlen, true))
-        return -EFAULT;
-
     struct shim_handle* hdl = get_fd_handle(sockfd, NULL, NULL);
     if (!hdl)
         return -EBADF;
 
-    int ret = -EINVAL;
-
+    int ret = 0;
     if (hdl->type != TYPE_SOCK) {
         ret = -ENOTSOCK;
+        goto out;
+    }
+
+    if (!addr || !addrlen || test_user_memory(addrlen, sizeof(*addrlen), /*write=*/true)) {
+        ret = -EFAULT;
+        goto out;
+    }
+
+    if (*addrlen <= 0) {
+        ret = -EINVAL;
+        goto out;
+    }
+
+    if (test_user_memory(addr, *addrlen, /*write=*/true)) {
+        ret = -EFAULT;
         goto out;
     }
 
@@ -1504,7 +1525,6 @@ int shim_do_getsockname(int sockfd, struct sockaddr* addr, int* addrlen) {
 
     *addrlen = inet_copy_addr(sock->domain, addr, *addrlen, &sock->addr.in.bind);
 
-    ret      = 0;
     unlock(&hdl->lock);
 out:
     put_handle(hdl);
@@ -1512,23 +1532,28 @@ out:
 }
 
 int shim_do_getpeername(int sockfd, struct sockaddr* addr, int* addrlen) {
-    if (!addr || !addrlen)
-        return -EFAULT;
-
-    if (*addrlen <= 0)
-        return -EINVAL;
-
-    if (test_user_memory(addr, *addrlen, true))
-        return -EFAULT;
-
     struct shim_handle* hdl = get_fd_handle(sockfd, NULL, NULL);
     if (!hdl)
         return -EBADF;
 
-    int ret = -EINVAL;
-
+    int ret = 0;
     if (hdl->type != TYPE_SOCK) {
         ret = -ENOTSOCK;
+        goto out;
+    }
+
+    if (!addr || !addrlen || test_user_memory(addrlen, sizeof(*addrlen), /*write=*/true)) {
+        ret = -EFAULT;
+        goto out;
+    }
+
+    if (*addrlen <= 0) {
+        ret = -EINVAL;
+        goto out;
+    }
+
+    if (test_user_memory(addr, *addrlen, /*write=*/true)) {
+        ret = -EFAULT;
         goto out;
     }
 
@@ -1549,7 +1574,6 @@ int shim_do_getpeername(int sockfd, struct sockaddr* addr, int* addrlen) {
     }
 
     *addrlen = inet_copy_addr(sock->domain, addr, *addrlen, &sock->addr.in.conn);
-    ret      = 0;
 out_locked:
     unlock(&hdl->lock);
 out:
@@ -1778,20 +1802,19 @@ out:
 }
 
 int shim_do_getsockopt(int fd, int level, int optname, char* optval, int* optlen) {
-    if (!optlen || test_user_memory(optlen, sizeof(*optlen), /*write=*/true))
-        return -EFAULT;
-
-    if (!optval || test_user_memory(optval, *optlen, /*write=*/true))
-        return -EFAULT;
-
     struct shim_handle* hdl = get_fd_handle(fd, NULL, NULL);
     if (!hdl)
         return -EBADF;
 
     int ret = 0;
-
     if (hdl->type != TYPE_SOCK) {
         ret = -ENOTSOCK;
+        goto out;
+    }
+
+    if (!optlen || test_user_memory(optlen, sizeof(*optlen), /*write=*/true)
+        || !optval || test_user_memory(optval, *optlen, /*write=*/true)) {
+        ret = -EFAULT;
         goto out;
     }
 
@@ -1800,8 +1823,8 @@ int shim_do_getsockopt(int fd, int level, int optname, char* optval, int* optlen
 
     int* intval = (int*)optval;
 
-    if (level != SOL_SOCKET && level != SOL_TCP && level != IPPROTO_IPV6)
-        goto unknown;
+    if (level != SOL_SOCKET && level != SOL_TCP && level != IPPROTO_IPV6 && level != IPPROTO_IP)
+        goto unknown_level;
 
     if (level == SOL_SOCKET) {
         switch (optname) {
@@ -1823,7 +1846,7 @@ int shim_do_getsockopt(int fd, int level, int optname, char* optval, int* optlen
                         *intval = IPPROTO_UDP;
                         break;
                     default:
-                        goto unknown;
+                        goto unknown_opt;
                 }
                 goto out;
             case SO_TYPE:
@@ -1838,7 +1861,7 @@ int shim_do_getsockopt(int fd, int level, int optname, char* optval, int* optlen
             case SO_REUSEADDR:
                 break;
             default:
-                goto unknown;
+                goto unknown_opt;
         }
     }
 
@@ -1848,8 +1871,12 @@ int shim_do_getsockopt(int fd, int level, int optname, char* optval, int* optlen
             case TCP_NODELAY:
                 break;
             default:
-                goto unknown;
+                goto unknown_opt;
         }
+    }
+
+    if (level == IPPROTO_IP) {
+        goto unknown_opt;
     }
 
     if (level == IPPROTO_IPV6) {
@@ -1857,7 +1884,7 @@ int shim_do_getsockopt(int fd, int level, int optname, char* optval, int* optlen
             case IPV6_V6ONLY:
                 break;
             default:
-                goto unknown;
+                goto unknown_opt;
         }
     }
 
@@ -1937,7 +1964,11 @@ out:
     put_handle(hdl);
     return ret;
 
-unknown:
+unknown_level:
+    ret = -EOPNOTSUPP;  /* Kernel seems to return this value despite `man` saying that it can
+                         * return only ENOPROTOOPT. */
+    goto out;
+unknown_opt:
     ret = -ENOPROTOOPT;
     goto out;
 }

--- a/LibOS/shim/test/ltp/README.rst
+++ b/LibOS/shim/test/ltp/README.rst
@@ -47,49 +47,5 @@ Another config file path can be specified using ``--config`` argument to
 ``./runltp_xml.py``. Options can be overridden as parameters to ``-o`` argument.
 See ``--help``.
 
-
-Flaky tests
------------
-
-::
-
-   clone02 - Invokes clone with CLONE_VM but without either of CLONE_THREAD or CLONE_VFORK, i.e., a
-   process sharing its parents address space. Graphene doesn't support this exotic model. Bug exposed by #1034.
-
-   waitpid03,1 and 2 - fails about 20% of the time
-   preadv01 - fails intermittently in CI - perhaps an unrelated bug?
-   preadv01,2
-   preadv01,3
-   preadv01,4
-
-   waitpid02 - Gets a segfault in debug build fairly often
-   waitpid02,1
-   waitpid02,2
-   waitpid02,3
-
-   clock_nanosleep01,11 - Pretty prone to hanging, don't think it is a timeout
-
-   sendfile05,1 - pretty prone to a segfault, perhaps an unrelated issue
-   Internal memory fault at 0x8 (IP = +0x34f1a, VMID = 3902099696, TID = 1)
-
-   Prone to hanging - I think a memory corruption issue that may have a pending fix
-   recvfrom01,1
-   recvfrom01,2
-
-   futex_wait03,1 (see https://github.com/oscarlab/graphene/pull/180#issuecomment-368970338)
-
-   Intermittent seg fault
-   kill03,1
-
-   Intermittent hang
-   send01,1
-   send01,2
-   sendto01,1
-   sendto01,2
-   sendto01,3
-   recv01,1
-   recv01,2
-
-   Intermittent failure on Linux debug host
-   recvmsg01,1
-   recvmsg01,2
+A lot of LTP tests cause problems in Graphene. The ones we've already analyzed
+should have an appropriate comment in the ``ltp.cfg`` file.

--- a/LibOS/shim/test/ltp/ltp.cfg
+++ b/LibOS/shim/test/ltp/ltp.cfg
@@ -1592,9 +1592,9 @@ timeout = 40
 [msgsnd02]
 skip = yes
 
+# Crashes Graphene due to shim_do_msgsnd calling add_sysv_msg with src=NULL, causing NULL deref.
 [msgsnd05]
-must-pass =
-    1
+skip = yes
 
 [msgsnd06]
 skip = yes

--- a/LibOS/shim/test/ltp/ltp.cfg
+++ b/LibOS/shim/test/ltp/ltp.cfg
@@ -191,6 +191,9 @@ skip = yes
 [clock_settime02]
 skip = yes
 
+# Invokes clone() with CLONE_VM but without either of CLONE_THREAD or CLONE_VFORK, i.e., a process
+# sharing its parents address space. Graphene doesn't support this exotic model. Bug exposed by
+# https://github.com/oscarlab/graphene/pull/1034.
 [clone02]
 skip = yes
 
@@ -761,6 +764,7 @@ skip = yes
 [futex_wait02]
 skip = yes
 
+# See https://github.com/oscarlab/graphene/pull/180#issuecomment-368970338.
 [futex_wait03]
 skip = yes
 
@@ -850,15 +854,6 @@ skip = yes
 [getitimer03]
 skip = yes
 
-[getpeername01]
-must-pass =
-    1
-    2
-    3
-    4
-    5
-    6
-
 [getpgid01]
 must-pass =
     1
@@ -945,20 +940,7 @@ skip = yes
 [getsid02]
 skip = yes
 
-[getsockname01]
-must-pass =
-    3
-    4
-
-[getsockopt01]
-must-pass =
-    1
-    2
-    3
-    4
-    8
-    9
-
+# Requires support for getsockopt(level=SOL_SOCKET, optname=SO_PEERCRED, ...)
 [getsockopt02]
 skip = yes
 
@@ -1816,6 +1798,7 @@ skip = yes
 [pread03_64]
 skip = yes
 
+# Fails intermittently in CI.
 [preadv01]
 skip = yes
 timeout = 80
@@ -2001,24 +1984,42 @@ skip = yes
 [reboot02]
 skip = yes
 
+# Subtests 4 and 5 require handling MSG_OOB and MSG_ERRQUEUE flags in recv.
 [recv01]
 must-pass =
     1
     2
+    3
 
+# subtest 3: recvfrom(addr=-1) should return 0 (this is weird, couldn't trace this path in Linux).
+# subtest 6: Requires MSG_OOB support.
+# subtest 7: Requires MSG_ERRQUEUE support.
 [recvfrom01]
 must-pass =
     1
     2
+    4
+    5
 
+# subtest 3: recvmsg01(addr=-1) should return 0 (this is weird, couldn't trace this path in Linux).
+# subtest 4: Requires MSG_ERRQUEUE support.
+# subtest 8: Crashes Graphene in a child process, because socket migration is totally broken. A unix
+#            socket is bound in the parent and then used in the child, but because migration is
+#            broken, the child uses a dangling pointer (hdl->info.sock.addr.un.dentry; actually
+#            pointing to the parent's address space) and crashes in __do_accept which tries to do
+#            get_dentry(sock->addr.un.dentry).
 [recvmsg01]
 must-pass =
     1
     2
+    5
+    6
+    7
 
 [recvmsg02]
 skip = yes
 
+# Requires AF_RDS support in socket().
 [recvmsg03]
 skip = yes
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

I debugged a few cases LTP cases where Graphene was crashing.
Unfortunately, currently AF_UNIX sockets migration is broken and would require much more work to fix, so a bunch of currently disabled socket-related tests are crashing and can't be easily enabled.

## How to test this PR? <!-- (if applicable) -->

Run newly enabled LTP tests in Jenkins.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1457)
<!-- Reviewable:end -->
