### PR TITLE
[LibOS] Rename SHIM_SYSCALL_PASSTHROUGH to SHIM_SYSCALL_RETURN_ENOSYS

### DIFF
--- a/Documentation/devel/new-syscall.rst
+++ b/Documentation/devel/new-syscall.rst
@@ -8,8 +8,8 @@ For example, assume we are implementing :manpage:`sched_setaffinity(2)`. You
 must find the definition of ``sched_setaffinity`` in
 :file:`shim_syscalls.c`, which will be the following code::
 
-   SHIM_SYSCALL_PASSTHROUGH(sched_setaffinity, 3, int, pid_t, pid, size_t, len,
-                           __kernel_cpu_set_t*, user_mask_ptr)
+   SHIM_SYSCALL_RETURN_ENOSYS(sched_setaffinity, 3, int, pid_t, pid, size_t,
+                              len, __kernel_cpu_set_t*, user_mask_ptr)
 
 Change this line to ``DEFINE_SHIM_SYSCALL(...)`` to name the function that
 implements this system call: ``shim_do_sched_setaffinity`` (this is the naming

--- a/LibOS/shim/include/shim_internal.h
+++ b/LibOS/shim/include/shim_internal.h
@@ -354,55 +354,34 @@ void parse_syscall_after (int sysno, const char * name, int nr, ...);
         __UNUSED(__arg1);                       \
     } while (0)
 #define SHIM_UNUSED_ARGS_2() do {               \
-        __UNUSED(__arg1);                       \
+        SHIM_UNUSED_ARGS_1();                   \
         __UNUSED(__arg2);                       \
     } while (0)
 #define SHIM_UNUSED_ARGS_3() do {               \
-        __UNUSED(__arg1);                       \
-        __UNUSED(__arg2);                       \
+        SHIM_UNUSED_ARGS_2();                   \
         __UNUSED(__arg3);                       \
     } while (0)
 #define SHIM_UNUSED_ARGS_4() do {               \
-        __UNUSED(__arg1);                       \
-        __UNUSED(__arg2);                       \
-        __UNUSED(__arg3);                       \
+        SHIM_UNUSED_ARGS_3();                   \
         __UNUSED(__arg4);                       \
     } while (0)
 
 #define SHIM_UNUSED_ARGS_5() do {               \
-        __UNUSED(__arg1);                       \
-        __UNUSED(__arg2);                       \
-        __UNUSED(__arg3);                       \
-        __UNUSED(__arg4);                       \
+        SHIM_UNUSED_ARGS_4();                   \
         __UNUSED(__arg5);                       \
     } while (0)
 
 #define SHIM_UNUSED_ARGS_6() do {               \
-        __UNUSED(__arg1);                       \
-        __UNUSED(__arg2);                       \
-        __UNUSED(__arg3);                       \
-        __UNUSED(__arg4);                       \
-        __UNUSED(__arg5);                       \
+        SHIM_UNUSED_ARGS_5();                   \
         __UNUSED(__arg6);                       \
     } while (0)
 
-#define DO_SYSCALL(...) DO_SYSCALL2(__VA_ARGS__)
-#define DO_SYSCALL2(n, ...) -ENOSYS
-
-#define DO_SYSCALL_0(sysno) -ENOSYS
-#define DO_SYSCALL_1(sysno, ...) DO_SYSCALL(1, sysno, SHIM_PASS_ARGS_1)
-#define DO_SYSCALL_2(sysno, ...) DO_SYSCALL(2, sysno, SHIM_PASS_ARGS_2)
-#define DO_SYSCALL_3(sysno, ...) DO_SYSCALL(3, sysno, SHIM_PASS_ARGS_3)
-#define DO_SYSCALL_4(sysno, ...) DO_SYSCALL(4, sysno, SHIM_PASS_ARGS_4)
-#define DO_SYSCALL_5(sysno, ...) DO_SYSCALL(5, sysno, SHIM_PASS_ARGS_5)
-#define DO_SYSCALL_6(sysno, ...) DO_SYSCALL(6, sysno, SHIM_PASS_ARGS_6)
-
-#define SHIM_SYSCALL_PASSTHROUGH(name, n, ...)                      \
-    BEGIN_SHIM(name, SHIM_PROTO_ARGS_##n)                           \
-        debug("WARNING: shim_" #name " not implemented\n");         \
-        SHIM_UNUSED_ARGS_##n();                                     \
-        ret = DO_SYSCALL_##n(__NR_##name);                          \
-    END_SHIM(name)                                                  \
+#define SHIM_SYSCALL_RETURN_ENOSYS(name, n, ...)                                   \
+    BEGIN_SHIM(name, SHIM_PROTO_ARGS_##n)                                          \
+        debug("WARNING: syscall " #name " not implemented. Returning -ENOSYS.\n"); \
+        SHIM_UNUSED_ARGS_##n();                                                    \
+        ret = -ENOSYS;                                                             \
+    END_SHIM(name)                                                                 \
     EXPORT_SHIM_SYSCALL(name, n, __VA_ARGS__)
 
 #define CONCAT2(t1, t2) __CONCAT2(t1, t2)

--- a/LibOS/shim/src/shim_syscalls.c
+++ b/LibOS/shim/src/shim_syscalls.c
@@ -203,22 +203,22 @@ DEFINE_SHIM_SYSCALL(select, 5, shim_do_select, int, int, nfds, fd_set*, readfds,
 /* sched_yield: sys/shim_sched.c */
 DEFINE_SHIM_SYSCALL(sched_yield, 0, shim_do_sched_yield, int)
 
-SHIM_SYSCALL_PASSTHROUGH(mremap, 5, void*, void*, addr, size_t, old_len, size_t, new_len, int,
-                         flags, void*, new_addr)
+SHIM_SYSCALL_RETURN_ENOSYS(mremap, 5, void*, void*, addr, size_t, old_len, size_t, new_len, int,
+                           flags, void*, new_addr)
 
-SHIM_SYSCALL_PASSTHROUGH(msync, 3, int, void*, start, size_t, len, int, flags)
+SHIM_SYSCALL_RETURN_ENOSYS(msync, 3, int, void*, start, size_t, len, int, flags)
 
 /* mincore: sys/shim_mmap.c */
 DEFINE_SHIM_SYSCALL(mincore, 3, shim_do_mincore, int, void*, start, size_t, len, unsigned char*,
                     vec)
 
-SHIM_SYSCALL_PASSTHROUGH(madvise, 3, int, void*, start, size_t, len, int, behavior)
+SHIM_SYSCALL_RETURN_ENOSYS(madvise, 3, int, void*, start, size_t, len, int, behavior)
 
-SHIM_SYSCALL_PASSTHROUGH(shmget, 3, int, key_t, key, size_t, size, int, shmflg)
+SHIM_SYSCALL_RETURN_ENOSYS(shmget, 3, int, key_t, key, size_t, size, int, shmflg)
 
-SHIM_SYSCALL_PASSTHROUGH(shmat, 3, void*, int, shmid, const void*, shmaddr, int, shmflg)
+SHIM_SYSCALL_RETURN_ENOSYS(shmat, 3, void*, int, shmid, const void*, shmaddr, int, shmflg)
 
-SHIM_SYSCALL_PASSTHROUGH(shmctl, 3, int, int, shmid, int, cmd, struct shmid_ds*, buf)
+SHIM_SYSCALL_RETURN_ENOSYS(shmctl, 3, int, int, shmid, int, cmd, struct shmid_ds*, buf)
 
 /* dup: sys/shim_dup.c */
 DEFINE_SHIM_SYSCALL(dup, 1, shim_do_dup, int, unsigned int, fd)
@@ -344,7 +344,7 @@ DEFINE_SHIM_SYSCALL(semop, 3, shim_do_semop, int, int, semid, struct sembuf*, so
 DEFINE_SHIM_SYSCALL(semctl, 4, shim_do_semctl, int, int, semid, int, semnum, int, cmd,
                     unsigned long, arg)
 
-SHIM_SYSCALL_PASSTHROUGH(shmdt, 1, int, const void*, shmaddr)
+SHIM_SYSCALL_RETURN_ENOSYS(shmdt, 1, int, const void*, shmaddr)
 
 /* msgget: sys/shim_msgget.c */
 DEFINE_SHIM_SYSCALL(msgget, 2, shim_do_msgget, int, key_t, key, int, msgflg)
@@ -363,7 +363,7 @@ DEFINE_SHIM_SYSCALL(msgctl, 3, shim_do_msgctl, int, int, msqid, int, cmd, struct
 /* fcntl: sys/shim_fcntl.c */
 DEFINE_SHIM_SYSCALL(fcntl, 3, shim_do_fcntl, int, int, fd, int, cmd, unsigned long, arg)
 
-SHIM_SYSCALL_PASSTHROUGH(flock, 2, int, int, fd, int, cmd)
+SHIM_SYSCALL_RETURN_ENOSYS(flock, 2, int, int, fd, int, cmd)
 
 /* fsync: sys/shim_open.c */
 DEFINE_SHIM_SYSCALL(fsync, 1, shim_do_fsync, int, int, fd)
@@ -401,12 +401,12 @@ DEFINE_SHIM_SYSCALL(rmdir, 1, shim_do_rmdir, int, const char*, pathname)
 
 DEFINE_SHIM_SYSCALL(creat, 2, shim_do_creat, int, const char*, path, mode_t, mode)
 
-SHIM_SYSCALL_PASSTHROUGH(link, 2, int, const char*, oldname, const char*, newname)
+SHIM_SYSCALL_RETURN_ENOSYS(link, 2, int, const char*, oldname, const char*, newname)
 
 /* unlink: sys/shim_fs.c */
 DEFINE_SHIM_SYSCALL(unlink, 1, shim_do_unlink, int, const char*, file)
 
-SHIM_SYSCALL_PASSTHROUGH(symlink, 2, int, const char*, old, const char*, new)
+SHIM_SYSCALL_RETURN_ENOSYS(symlink, 2, int, const char*, old, const char*, new)
 
 /* readlink: sys/shim_stat.c */
 DEFINE_SHIM_SYSCALL(readlink, 3, shim_do_readlink, int, const char*, path, char*, buf, size_t,
@@ -420,7 +420,7 @@ DEFINE_SHIM_SYSCALL(chown, 3, shim_do_chown, int, const char*, filename, uid_t, 
 
 DEFINE_SHIM_SYSCALL(fchown, 3, shim_do_fchown, int, int, fd, uid_t, user, gid_t, group)
 
-SHIM_SYSCALL_PASSTHROUGH(lchown, 3, int, const char*, filename, uid_t, user, gid_t, group)
+SHIM_SYSCALL_RETURN_ENOSYS(lchown, 3, int, const char*, filename, uid_t, user, gid_t, group)
 
 DEFINE_SHIM_SYSCALL(umask, 1, shim_do_umask, mode_t, mode_t, mask)
 
@@ -439,16 +439,16 @@ int shim_do_getrusage(int who, struct __kernel_rusage* ru) {
 
 DEFINE_SHIM_SYSCALL(getrusage, 2, shim_do_getrusage, int, int, who, struct __kernel_rusage*, ru)
 
-SHIM_SYSCALL_PASSTHROUGH(sysinfo, 1, int, struct sysinfo*, info)
+SHIM_SYSCALL_RETURN_ENOSYS(sysinfo, 1, int, struct sysinfo*, info)
 
-SHIM_SYSCALL_PASSTHROUGH(times, 1, int, struct tms*, tbuf)
+SHIM_SYSCALL_RETURN_ENOSYS(times, 1, int, struct tms*, tbuf)
 
-SHIM_SYSCALL_PASSTHROUGH(ptrace, 4, int, long, request, pid_t, pid, void*, addr, void*, data)
+SHIM_SYSCALL_RETURN_ENOSYS(ptrace, 4, int, long, request, pid_t, pid, void*, addr, void*, data)
 
 /* getuid: sys/shim_getpid.c */
 DEFINE_SHIM_SYSCALL(getuid, 0, shim_do_getuid, uid_t)
 
-SHIM_SYSCALL_PASSTHROUGH(syslog, 3, int, int, type, char*, buf, int, len)
+SHIM_SYSCALL_RETURN_ENOSYS(syslog, 3, int, int, type, char*, buf, int, len)
 
 /* getgid: sys/shim_getgid.c */
 DEFINE_SHIM_SYSCALL(getgid, 0, shim_do_getgid, gid_t)
@@ -483,56 +483,56 @@ DEFINE_SHIM_SYSCALL(getpgrp, 0, shim_do_getpgrp, pid_t)
 /* setsid: sys/shim_getpid.c */
 DEFINE_SHIM_SYSCALL(setsid, 0, shim_do_setsid, int)
 
-SHIM_SYSCALL_PASSTHROUGH(setreuid, 2, int, uid_t, ruid, uid_t, euid)
+SHIM_SYSCALL_RETURN_ENOSYS(setreuid, 2, int, uid_t, ruid, uid_t, euid)
 
-SHIM_SYSCALL_PASSTHROUGH(setregid, 2, int, gid_t, rgid, gid_t, egid)
+SHIM_SYSCALL_RETURN_ENOSYS(setregid, 2, int, gid_t, rgid, gid_t, egid)
 
-SHIM_SYSCALL_PASSTHROUGH(setresuid, 3, int, uid_t, ruid, uid_t, euid, uid_t, suid)
+SHIM_SYSCALL_RETURN_ENOSYS(setresuid, 3, int, uid_t, ruid, uid_t, euid, uid_t, suid)
 
-SHIM_SYSCALL_PASSTHROUGH(getresuid, 3, int, uid_t*, ruid, uid_t*, euid, uid_t*, suid)
+SHIM_SYSCALL_RETURN_ENOSYS(getresuid, 3, int, uid_t*, ruid, uid_t*, euid, uid_t*, suid)
 
-SHIM_SYSCALL_PASSTHROUGH(setresgid, 3, int, gid_t, rgid, gid_t, egid, gid_t, sgid)
+SHIM_SYSCALL_RETURN_ENOSYS(setresgid, 3, int, gid_t, rgid, gid_t, egid, gid_t, sgid)
 
-SHIM_SYSCALL_PASSTHROUGH(getresgid, 3, int, gid_t*, rgid, gid_t*, egid, gid_t*, sgid)
+SHIM_SYSCALL_RETURN_ENOSYS(getresgid, 3, int, gid_t*, rgid, gid_t*, egid, gid_t*, sgid)
 
 DEFINE_SHIM_SYSCALL(getpgid, 1, shim_do_getpgid, int, pid_t, pid)
 
-SHIM_SYSCALL_PASSTHROUGH(setfsuid, 1, int, uid_t, uid)
+SHIM_SYSCALL_RETURN_ENOSYS(setfsuid, 1, int, uid_t, uid)
 
-SHIM_SYSCALL_PASSTHROUGH(setfsgid, 1, int, gid_t, gid)
+SHIM_SYSCALL_RETURN_ENOSYS(setfsgid, 1, int, gid_t, gid)
 
 DEFINE_SHIM_SYSCALL(getsid, 1, shim_do_getsid, int, pid_t, pid)
 
-SHIM_SYSCALL_PASSTHROUGH(capget, 2, int, cap_user_header_t, header, cap_user_data_t, dataptr)
+SHIM_SYSCALL_RETURN_ENOSYS(capget, 2, int, cap_user_header_t, header, cap_user_data_t, dataptr)
 
-SHIM_SYSCALL_PASSTHROUGH(capset, 2, int, cap_user_header_t, header, const cap_user_data_t, data)
+SHIM_SYSCALL_RETURN_ENOSYS(capset, 2, int, cap_user_header_t, header, const cap_user_data_t, data)
 
 DEFINE_SHIM_SYSCALL(rt_sigpending, 2, shim_do_sigpending, int, __sigset_t*, set, size_t, sigsetsize)
 
-SHIM_SYSCALL_PASSTHROUGH(rt_sigtimedwait, 4, int, const __sigset_t*, uthese, siginfo_t*, uinfo,
-                         const struct timespec*, uts, size_t, sigsetsize)
+SHIM_SYSCALL_RETURN_ENOSYS(rt_sigtimedwait, 4, int, const __sigset_t*, uthese, siginfo_t*, uinfo,
+                           const struct timespec*, uts, size_t, sigsetsize)
 
-SHIM_SYSCALL_PASSTHROUGH(rt_sigqueueinfo, 3, int, int, pid, int, sig, siginfo_t*, uinfo)
+SHIM_SYSCALL_RETURN_ENOSYS(rt_sigqueueinfo, 3, int, int, pid, int, sig, siginfo_t*, uinfo)
 
 DEFINE_SHIM_SYSCALL(rt_sigsuspend, 1, shim_do_sigsuspend, int, const __sigset_t*, mask)
 
 DEFINE_SHIM_SYSCALL(sigaltstack, 2, shim_do_sigaltstack, int, const stack_t*, ss, stack_t*, oss)
 
-SHIM_SYSCALL_PASSTHROUGH(utime, 2, int, char*, filename, struct utimbuf*, times)
+SHIM_SYSCALL_RETURN_ENOSYS(utime, 2, int, char*, filename, struct utimbuf*, times)
 
-SHIM_SYSCALL_PASSTHROUGH(mknod, 3, int, const char*, filename, int, mode, unsigned, dev)
+SHIM_SYSCALL_RETURN_ENOSYS(mknod, 3, int, const char*, filename, int, mode, unsigned, dev)
 
-SHIM_SYSCALL_PASSTHROUGH(uselib, 1, int, const char*, library)
+SHIM_SYSCALL_RETURN_ENOSYS(uselib, 1, int, const char*, library)
 
-SHIM_SYSCALL_PASSTHROUGH(personality, 1, int, unsigned int, personality)
+SHIM_SYSCALL_RETURN_ENOSYS(personality, 1, int, unsigned int, personality)
 
-SHIM_SYSCALL_PASSTHROUGH(ustat, 2, int, unsigned, dev, struct __kernel_ustat*, ubuf)
+SHIM_SYSCALL_RETURN_ENOSYS(ustat, 2, int, unsigned, dev, struct __kernel_ustat*, ubuf)
 
-SHIM_SYSCALL_PASSTHROUGH(statfs, 2, int, const char*, path, struct statfs*, buf)
+SHIM_SYSCALL_RETURN_ENOSYS(statfs, 2, int, const char*, path, struct statfs*, buf)
 
-SHIM_SYSCALL_PASSTHROUGH(fstatfs, 2, int, int, fd, struct statfs*, buf)
+SHIM_SYSCALL_RETURN_ENOSYS(fstatfs, 2, int, int, fd, struct statfs*, buf)
 
-SHIM_SYSCALL_PASSTHROUGH(sysfs, 3, int, int, option, unsigned long, arg1, unsigned long, arg2)
+SHIM_SYSCALL_RETURN_ENOSYS(sysfs, 3, int, int, option, unsigned long, arg1, unsigned long, arg2)
 
 DEFINE_SHIM_SYSCALL(setpriority, 3, shim_do_setpriority, int, int, which, int, who, int, niceval)
 
@@ -556,24 +556,24 @@ DEFINE_SHIM_SYSCALL(sched_get_priority_min, 1, shim_do_sched_get_priority_min, i
 DEFINE_SHIM_SYSCALL(sched_rr_get_interval, 2, shim_do_sched_rr_get_interval, int, pid_t, pid,
                     struct timespec*, interval)
 
-SHIM_SYSCALL_PASSTHROUGH(mlock, 2, int, void*, start, size_t, len)
+SHIM_SYSCALL_RETURN_ENOSYS(mlock, 2, int, void*, start, size_t, len)
 
-SHIM_SYSCALL_PASSTHROUGH(munlock, 2, int, void*, start, size_t, len)
+SHIM_SYSCALL_RETURN_ENOSYS(munlock, 2, int, void*, start, size_t, len)
 
-SHIM_SYSCALL_PASSTHROUGH(mlockall, 1, int, int, flags)
+SHIM_SYSCALL_RETURN_ENOSYS(mlockall, 1, int, int, flags)
 
-SHIM_SYSCALL_PASSTHROUGH(munlockall, 0, int)
+SHIM_SYSCALL_RETURN_ENOSYS(munlockall, 0, int)
 
-SHIM_SYSCALL_PASSTHROUGH(vhangup, 0, int)
+SHIM_SYSCALL_RETURN_ENOSYS(vhangup, 0, int)
 
-SHIM_SYSCALL_PASSTHROUGH(modify_ldt, 3, int, int, func, void*, ptr, unsigned long, bytecount)
+SHIM_SYSCALL_RETURN_ENOSYS(modify_ldt, 3, int, int, func, void*, ptr, unsigned long, bytecount)
 
-SHIM_SYSCALL_PASSTHROUGH(pivot_root, 2, int, const char*, new_root, const char*, put_old)
+SHIM_SYSCALL_RETURN_ENOSYS(pivot_root, 2, int, const char*, new_root, const char*, put_old)
 
-SHIM_SYSCALL_PASSTHROUGH(_sysctl, 1, int, struct __kernel_sysctl_args*, args)
+SHIM_SYSCALL_RETURN_ENOSYS(_sysctl, 1, int, struct __kernel_sysctl_args*, args)
 
-SHIM_SYSCALL_PASSTHROUGH(prctl, 5, int, int, option, unsigned long, arg2, unsigned long, arg3,
-                         unsigned long, arg4, unsigned long, arg5)
+SHIM_SYSCALL_RETURN_ENOSYS(prctl, 5, int, int, option, unsigned long, arg2, unsigned long, arg3,
+                           unsigned long, arg4, unsigned long, arg5)
 
 DEFINE_SHIM_SYSCALL(arch_prctl, 2, shim_do_arch_prctl, void*, int, code, void*, addr)
 
@@ -599,7 +599,7 @@ void* shim_do_arch_prctl(int code, void* addr) {
     return (void*)-ENOSYS;
 }
 
-SHIM_SYSCALL_PASSTHROUGH(adjtimex, 1, int, struct ____kernel_timex*, txc_p)
+SHIM_SYSCALL_RETURN_ENOSYS(adjtimex, 1, int, struct ____kernel_timex*, txc_p)
 
 /* setrlimit: sys/shim_getrlimit.c */
 DEFINE_SHIM_SYSCALL(setrlimit, 2, shim_do_setrlimit, int, int, resource, struct __kernel_rlimit*,
@@ -608,104 +608,104 @@ DEFINE_SHIM_SYSCALL(setrlimit, 2, shim_do_setrlimit, int, int, resource, struct 
 /* chroot: sys/shim_isolate.c */
 DEFINE_SHIM_SYSCALL(chroot, 1, shim_do_chroot, int, const char*, filename)
 
-SHIM_SYSCALL_PASSTHROUGH(sync, 0, int)
+SHIM_SYSCALL_RETURN_ENOSYS(sync, 0, int)
 
-SHIM_SYSCALL_PASSTHROUGH(acct, 1, int, const char*, name)
+SHIM_SYSCALL_RETURN_ENOSYS(acct, 1, int, const char*, name)
 
-SHIM_SYSCALL_PASSTHROUGH(settimeofday, 2, int, struct timeval*, tv, struct __kernel_timezone*, tz)
+SHIM_SYSCALL_RETURN_ENOSYS(settimeofday, 2, int, struct timeval*, tv, struct __kernel_timezone*, tz)
 
-SHIM_SYSCALL_PASSTHROUGH(mount, 5, int, char*, dev_name, char*, dir_name, char*, type,
-                         unsigned long, flags, void*, data)
+SHIM_SYSCALL_RETURN_ENOSYS(mount, 5, int, char*, dev_name, char*, dir_name, char*, type,
+                           unsigned long, flags, void*, data)
 
-SHIM_SYSCALL_PASSTHROUGH(umount2, 2, int, const char*, target, int, flags)
+SHIM_SYSCALL_RETURN_ENOSYS(umount2, 2, int, const char*, target, int, flags)
 
-SHIM_SYSCALL_PASSTHROUGH(swapon, 2, int, const char*, specialfile, int, swap_flags)
+SHIM_SYSCALL_RETURN_ENOSYS(swapon, 2, int, const char*, specialfile, int, swap_flags)
 
-SHIM_SYSCALL_PASSTHROUGH(swapoff, 1, int, const char*, specialfile)
+SHIM_SYSCALL_RETURN_ENOSYS(swapoff, 1, int, const char*, specialfile)
 
-SHIM_SYSCALL_PASSTHROUGH(reboot, 4, int, int, magic1, int, magic2, int, cmd, void*, arg)
+SHIM_SYSCALL_RETURN_ENOSYS(reboot, 4, int, int, magic1, int, magic2, int, cmd, void*, arg)
 
-SHIM_SYSCALL_PASSTHROUGH(sethostname, 2, int, char*, name, int, len)
+SHIM_SYSCALL_RETURN_ENOSYS(sethostname, 2, int, char*, name, int, len)
 
-SHIM_SYSCALL_PASSTHROUGH(setdomainname, 2, int, char*, name, int, len)
+SHIM_SYSCALL_RETURN_ENOSYS(setdomainname, 2, int, char*, name, int, len)
 
-SHIM_SYSCALL_PASSTHROUGH(iopl, 1, int, int, level)
+SHIM_SYSCALL_RETURN_ENOSYS(iopl, 1, int, int, level)
 
-SHIM_SYSCALL_PASSTHROUGH(ioperm, 3, int, unsigned long, from, unsigned long, num, int, on)
+SHIM_SYSCALL_RETURN_ENOSYS(ioperm, 3, int, unsigned long, from, unsigned long, num, int, on)
 
-SHIM_SYSCALL_PASSTHROUGH(create_module, 2, int, const char*, name, size_t, size)
+SHIM_SYSCALL_RETURN_ENOSYS(create_module, 2, int, const char*, name, size_t, size)
 
-SHIM_SYSCALL_PASSTHROUGH(init_module, 3, int, void*, umod, unsigned long, len, const char*, uargs)
+SHIM_SYSCALL_RETURN_ENOSYS(init_module, 3, int, void*, umod, unsigned long, len, const char*, uargs)
 
-SHIM_SYSCALL_PASSTHROUGH(delete_module, 2, int, const char*, name_user, unsigned int, flags)
+SHIM_SYSCALL_RETURN_ENOSYS(delete_module, 2, int, const char*, name_user, unsigned int, flags)
 
 /*
-SHIM_SYSCALL_PASSTHROUGH (get_kernel_syms, 1, int, struct kernel_sym *, table)
+SHIM_SYSCALL_RETURN_ENOSYS(get_kernel_syms, 1, int, struct kernel_sym*, table)
 */
 
-SHIM_SYSCALL_PASSTHROUGH(query_module, 5, int, const char*, name, int, which, void*, buf, size_t,
-                         bufsize, size_t*, retsize)
+SHIM_SYSCALL_RETURN_ENOSYS(query_module, 5, int, const char*, name, int, which, void*, buf, size_t,
+                           bufsize, size_t*, retsize)
 
-SHIM_SYSCALL_PASSTHROUGH(quotactl, 4, int, int, cmd, const char*, special, qid_t, id, void*, addr)
+SHIM_SYSCALL_RETURN_ENOSYS(quotactl, 4, int, int, cmd, const char*, special, qid_t, id, void*, addr)
 
 /*
-SHIM_SYSCALL_PASSTHROUGH (nfsservctl, 3, int, int, cmd, struct nfsctl_arg *,
-                          arg, void *, res)
+SHIM_SYSCALL_RETURN_ENOSYS(nfsservctl, 3, int, int, cmd, struct nfsctl_arg*, arg, void*, res)
 */
 
 /* shim_getpmsg MISSING
-   TODO: getpmsg syscall is not implemented (kernel always returns -ENOSYS),
-   how should we handle this?*/
+   TODO: getpmsg syscall is not implemented (kernel always returns -ENOSYS), how should we handle
+   this? */
 
 /* shim_putpmsg MISSING
-   TODO: putpmsg syscall is not implemented (kernel always returns -ENOSYS),
-   how should we handle this?*/
+   TODO: putpmsg syscall is not implemented (kernel always returns -ENOSYS), how should we handle
+   this? */
 
 /* shim_afs_syscall MISSING
-   TODO: afs_syscall is not implemented (kernel always returns -ENOSYS),
-   how should we handle this?*/
+   TODO: afs_syscall is not implemented (kernel always returns -ENOSYS), how should we handle 
+   this? */
 
 /* shim_tuxcall MISSING
-   TODO: tuxcall syscall is not implemented (kernel always returns -ENOSYS),
-   how should we handle this?*/
+   TODO: tuxcall syscall is not implemented (kernel always returns -ENOSYS), how should we handle 
+   this? */
 
 /* shim_security MISSING
-   TODO: security syscall is not implemented (kernel always returns -ENOSYS),
-   how should we handle this?*/
+   TODO: security syscall is not implemented (kernel always returns -ENOSYS), how should we handle 
+   this? */
 
 /* gettid: sys/shim_getpid.c */
 DEFINE_SHIM_SYSCALL(gettid, 0, shim_do_gettid, pid_t)
 
-SHIM_SYSCALL_PASSTHROUGH(readahead, 3, int, int, fd, loff_t, offset, size_t, count)
+SHIM_SYSCALL_RETURN_ENOSYS(readahead, 3, int, int, fd, loff_t, offset, size_t, count)
 
-SHIM_SYSCALL_PASSTHROUGH(setxattr, 5, int, const char*, path, const char*, name, const void*, value,
-                         size_t, size, int, flags)
+SHIM_SYSCALL_RETURN_ENOSYS(setxattr, 5, int, const char*, path, const char*, name, const void*,
+                           value, size_t, size, int, flags)
 
-SHIM_SYSCALL_PASSTHROUGH(lsetxattr, 5, int, const char*, path, const char*, name, const void*,
-                         value, size_t, size, int, flags)
+SHIM_SYSCALL_RETURN_ENOSYS(lsetxattr, 5, int, const char*, path, const char*, name, const void*,
+                           value, size_t, size, int, flags)
 
-SHIM_SYSCALL_PASSTHROUGH(fsetxattr, 5, int, int, fd, const char*, name, const void*, value, size_t,
-                         size, int, flags)
+SHIM_SYSCALL_RETURN_ENOSYS(fsetxattr, 5, int, int, fd, const char*, name, const void*, value,
+                           size_t, size, int, flags)
 
-SHIM_SYSCALL_PASSTHROUGH(getxattr, 4, int, const char*, path, const char*, name, void*, value,
-                         size_t, size)
+SHIM_SYSCALL_RETURN_ENOSYS(getxattr, 4, int, const char*, path, const char*, name, void*, value,
+                           size_t, size)
 
-SHIM_SYSCALL_PASSTHROUGH(lgetxattr, 4, int, const char*, path, const char*, name, void*, value,
-                         size_t, size)
+SHIM_SYSCALL_RETURN_ENOSYS(lgetxattr, 4, int, const char*, path, const char*, name, void*, value,
+                           size_t, size)
 
-SHIM_SYSCALL_PASSTHROUGH(fgetxattr, 4, int, int, fd, const char*, name, void*, value, size_t, size)
+SHIM_SYSCALL_RETURN_ENOSYS(fgetxattr, 4, int, int, fd, const char*, name, void*, value, size_t,
+                           size)
 
-SHIM_SYSCALL_PASSTHROUGH(listxattr, 3, int, const char*, path, char*, list, size_t, size)
+SHIM_SYSCALL_RETURN_ENOSYS(listxattr, 3, int, const char*, path, char*, list, size_t, size)
 
-SHIM_SYSCALL_PASSTHROUGH(llistxattr, 3, int, const char*, path, char*, list, size_t, size)
+SHIM_SYSCALL_RETURN_ENOSYS(llistxattr, 3, int, const char*, path, char*, list, size_t, size)
 
-SHIM_SYSCALL_PASSTHROUGH(flistxattr, 3, int, int, fd, char*, list, size_t, size)
+SHIM_SYSCALL_RETURN_ENOSYS(flistxattr, 3, int, int, fd, char*, list, size_t, size)
 
-SHIM_SYSCALL_PASSTHROUGH(removexattr, 2, int, const char*, path, const char*, name)
+SHIM_SYSCALL_RETURN_ENOSYS(removexattr, 2, int, const char*, path, const char*, name)
 
-SHIM_SYSCALL_PASSTHROUGH(lremovexattr, 2, int, const char*, path, const char*, name)
+SHIM_SYSCALL_RETURN_ENOSYS(lremovexattr, 2, int, const char*, path, const char*, name)
 
-SHIM_SYSCALL_PASSTHROUGH(fremovexattr, 2, int, int, fd, const char*, name)
+SHIM_SYSCALL_RETURN_ENOSYS(fremovexattr, 2, int, int, fd, const char*, name)
 
 DEFINE_SHIM_SYSCALL(tkill, 2, shim_do_tkill, int, pid_t, pid, int, sig)
 
@@ -721,25 +721,26 @@ DEFINE_SHIM_SYSCALL(sched_setaffinity, 3, shim_do_sched_setaffinity, int, pid_t,
 DEFINE_SHIM_SYSCALL(sched_getaffinity, 3, shim_do_sched_getaffinity, int, pid_t, pid, size_t, len,
                     __kernel_cpu_set_t*, user_mask_ptr)
 
-SHIM_SYSCALL_PASSTHROUGH(set_thread_area, 1, int, struct user_desc*, u_info)
+SHIM_SYSCALL_RETURN_ENOSYS(set_thread_area, 1, int, struct user_desc*, u_info)
 
 /* no glibc wrapper */
 
-SHIM_SYSCALL_PASSTHROUGH(io_setup, 2, int, unsigned, nr_reqs, aio_context_t*, ctx)
+SHIM_SYSCALL_RETURN_ENOSYS(io_setup, 2, int, unsigned, nr_reqs, aio_context_t*, ctx)
 
-SHIM_SYSCALL_PASSTHROUGH(io_destroy, 1, int, aio_context_t, ctx)
+SHIM_SYSCALL_RETURN_ENOSYS(io_destroy, 1, int, aio_context_t, ctx)
 
-SHIM_SYSCALL_PASSTHROUGH(io_getevents, 5, int, aio_context_t, ctx_id, long, min_nr, long, nr,
-                         struct io_event*, events, struct timespec*, timeout)
+SHIM_SYSCALL_RETURN_ENOSYS(io_getevents, 5, int, aio_context_t, ctx_id, long, min_nr, long, nr,
+                           struct io_event*, events, struct timespec*, timeout)
 
-SHIM_SYSCALL_PASSTHROUGH(io_submit, 3, int, aio_context_t, ctx_id, long, nr, struct iocb**, iocbpp)
+SHIM_SYSCALL_RETURN_ENOSYS(io_submit, 3, int, aio_context_t, ctx_id, long, nr, struct iocb**,
+                           iocbpp)
 
-SHIM_SYSCALL_PASSTHROUGH(io_cancel, 3, int, aio_context_t, ctx_id, struct iocb*, iocb,
-                         struct io_event*, result)
+SHIM_SYSCALL_RETURN_ENOSYS(io_cancel, 3, int, aio_context_t, ctx_id, struct iocb*, iocb,
+                           struct io_event*, result)
 
-SHIM_SYSCALL_PASSTHROUGH(get_thread_area, 1, int, struct user_desc*, u_info)
+SHIM_SYSCALL_RETURN_ENOSYS(get_thread_area, 1, int, struct user_desc*, u_info)
 
-SHIM_SYSCALL_PASSTHROUGH(lookup_dcookie, 3, int, unsigned long, cookie64, char*, buf, size_t, len)
+SHIM_SYSCALL_RETURN_ENOSYS(lookup_dcookie, 3, int, unsigned long, cookie64, char*, buf, size_t, len)
 
 DEFINE_SHIM_SYSCALL(epoll_create, 1, shim_do_epoll_create, int, int, size)
 
@@ -751,8 +752,8 @@ DEFINE_SHIM_SYSCALL(epoll_create, 1, shim_do_epoll_create, int, int, size)
    TODO: epoll_wait_old syscall is not implemented (kernel always returns -ENOSYS),
    how should we handle this?*/
 
-SHIM_SYSCALL_PASSTHROUGH(remap_file_pages, 5, int, void*, start, size_t, size, int, prot, ssize_t,
-                         pgoff, int, flags)
+SHIM_SYSCALL_RETURN_ENOSYS(remap_file_pages, 5, int, void*, start, size_t, size, int, prot, ssize_t,
+                           pgoff, int, flags)
 
 /* getdents64: sys/shim_open.c */
 DEFINE_SHIM_SYSCALL(getdents64, 3, shim_do_getdents64, size_t, int, fd, struct linux_dirent64*, buf,
@@ -761,29 +762,30 @@ DEFINE_SHIM_SYSCALL(getdents64, 3, shim_do_getdents64, size_t, int, fd, struct l
 /* set_tid_address: sys/shim_getpid.c */
 DEFINE_SHIM_SYSCALL(set_tid_address, 1, shim_do_set_tid_address, int, int*, tidptr)
 
-SHIM_SYSCALL_PASSTHROUGH(restart_syscall, 0, int)
+SHIM_SYSCALL_RETURN_ENOSYS(restart_syscall, 0, int)
 
 /* semtimedop: sys/shim_semget.c */
 DEFINE_SHIM_SYSCALL(semtimedop, 4, shim_do_semtimedop, int, int, semid, struct sembuf*, sops,
                     unsigned int, nsops, const struct timespec*, timeout)
 
-SHIM_SYSCALL_PASSTHROUGH(fadvise64, 4, int, int, fd, loff_t, offset, size_t, len, int, advice)
+SHIM_SYSCALL_RETURN_ENOSYS(fadvise64, 4, int, int, fd, loff_t, offset, size_t, len, int, advice)
 
-SHIM_SYSCALL_PASSTHROUGH(timer_create, 3, int, clockid_t, which_clock, struct sigevent*,
-                         timer_event_spec, timer_t*, created_timer_id)
+SHIM_SYSCALL_RETURN_ENOSYS(timer_create, 3, int, clockid_t, which_clock, struct sigevent*,
+                           timer_event_spec, timer_t*, created_timer_id)
 
-SHIM_SYSCALL_PASSTHROUGH(timer_settime, 4, int, timer_t, timer_id, int, flags,
-                         const struct __kernel_itimerspec*, new_setting,
-                         struct __kernel_itimerspec*, old_setting)
+SHIM_SYSCALL_RETURN_ENOSYS(timer_settime, 4, int, timer_t, timer_id, int, flags,
+                           const struct __kernel_itimerspec*, new_setting,
+                           struct __kernel_itimerspec*, old_setting)
 
-SHIM_SYSCALL_PASSTHROUGH(timer_gettime, 2, int, timer_t, timer_id, struct __kernel_itimerspec*,
-                         setting)
+SHIM_SYSCALL_RETURN_ENOSYS(timer_gettime, 2, int, timer_t, timer_id, struct __kernel_itimerspec*,
+                           setting)
 
-SHIM_SYSCALL_PASSTHROUGH(timer_getoverrun, 1, int, timer_t, timer_id)
+SHIM_SYSCALL_RETURN_ENOSYS(timer_getoverrun, 1, int, timer_t, timer_id)
 
-SHIM_SYSCALL_PASSTHROUGH(timer_delete, 1, int, timer_t, timer_id)
+SHIM_SYSCALL_RETURN_ENOSYS(timer_delete, 1, int, timer_t, timer_id)
 
-SHIM_SYSCALL_PASSTHROUGH(clock_settime, 2, int, clockid_t, which_clock, const struct timespec*, tp)
+SHIM_SYSCALL_RETURN_ENOSYS(clock_settime, 2, int, clockid_t, which_clock, const struct timespec*,
+                           tp)
 
 /* clock_gettime: sys/shim_time.c */
 DEFINE_SHIM_SYSCALL(clock_gettime, 2, shim_do_clock_gettime, int, clockid_t, which_clock,
@@ -807,7 +809,7 @@ DEFINE_SHIM_SYSCALL(epoll_ctl, 4, shim_do_epoll_ctl, int, int, epfd, int, op, in
 
 DEFINE_SHIM_SYSCALL(tgkill, 3, shim_do_tgkill, int, pid_t, tgid, pid_t, pid, int, sig)
 
-SHIM_SYSCALL_PASSTHROUGH(utimes, 2, int, char*, filename, struct timeval*, utimes)
+SHIM_SYSCALL_RETURN_ENOSYS(utimes, 2, int, char*, filename, struct timeval*, utimes)
 
 /* shim_vserver MISSING
    TODO: vserver syscall is not implemented (kernel always returns -ENOSYS),
@@ -816,68 +818,67 @@ SHIM_SYSCALL_PASSTHROUGH(utimes, 2, int, char*, filename, struct timeval*, utime
 DEFINE_SHIM_SYSCALL(mbind, 6, shim_do_mbind, int, void*, start, unsigned long, len, int, mode,
                     unsigned long*, nmask, unsigned long, maxnode, int, flags)
 
-SHIM_SYSCALL_PASSTHROUGH(set_mempolicy, 3, int, int, mode, unsigned long*, nmask, unsigned long,
-                         maxnode)
+SHIM_SYSCALL_RETURN_ENOSYS(set_mempolicy, 3, int, int, mode, unsigned long*, nmask, unsigned long,
+                           maxnode)
 
-SHIM_SYSCALL_PASSTHROUGH(get_mempolicy, 5, int, int*, policy, unsigned long*, nmask, unsigned long,
-                         maxnode, unsigned long, addr, unsigned long, flags)
+SHIM_SYSCALL_RETURN_ENOSYS(get_mempolicy, 5, int, int*, policy, unsigned long*, nmask, unsigned long,
+                           maxnode, unsigned long, addr, unsigned long, flags)
 
-SHIM_SYSCALL_PASSTHROUGH(mq_open, 4, int, const char*, name, int, oflag, mode_t, mode,
-                         struct __kernel_mq_attr*, attr)
+SHIM_SYSCALL_RETURN_ENOSYS(mq_open, 4, int, const char*, name, int, oflag, mode_t, mode,
+                           struct __kernel_mq_attr*, attr)
 
-SHIM_SYSCALL_PASSTHROUGH(mq_unlink, 1, int, const char*, name)
+SHIM_SYSCALL_RETURN_ENOSYS(mq_unlink, 1, int, const char*, name)
 
-SHIM_SYSCALL_PASSTHROUGH(mq_timedsend, 5, int, __kernel_mqd_t, mqdes, const char*, msg_ptr, size_t,
-                         msg_len, unsigned int, msg_prio, const struct timespec*, abs_timeout)
+SHIM_SYSCALL_RETURN_ENOSYS(mq_timedsend, 5, int, __kernel_mqd_t, mqdes, const char*, msg_ptr,
+                           size_t, msg_len, unsigned int, msg_prio, const struct timespec*,
+                           abs_timeout)
 
-SHIM_SYSCALL_PASSTHROUGH(mq_timedreceive, 5, int, __kernel_mqd_t, mqdes, char*, msg_ptr, size_t,
-                         msg_len, unsigned int*, msg_prio, const struct timespec*, abs_timeout)
+SHIM_SYSCALL_RETURN_ENOSYS(mq_timedreceive, 5, int, __kernel_mqd_t, mqdes, char*, msg_ptr, size_t,
+                           msg_len, unsigned int*, msg_prio, const struct timespec*, abs_timeout)
 
-SHIM_SYSCALL_PASSTHROUGH(mq_notify, 2, int, __kernel_mqd_t, mqdes, const struct sigevent*,
-                         notification)
+SHIM_SYSCALL_RETURN_ENOSYS(mq_notify, 2, int, __kernel_mqd_t, mqdes, const struct sigevent*,
+                           notification)
 
-SHIM_SYSCALL_PASSTHROUGH(mq_getsetattr, 3, int, __kernel_mqd_t, mqdes,
-                         const struct __kernel_mq_attr*, mqstat, struct __kernel_mq_attr*, omqstat)
+SHIM_SYSCALL_RETURN_ENOSYS(mq_getsetattr, 3, int, __kernel_mqd_t, mqdes,
+                           const struct __kernel_mq_attr*, mqstat, struct __kernel_mq_attr*,
+                           omqstat)
 
 /*
-SHIM_SYSCALL_PASSTHROUGH (kexec_load, 4, int, unsigned long, entry,
-                          unsigned long, nr_segments, struct kexec_segment *,
-                          segments, unsigned long, flags)
+SHIM_SYSCALL_RETURN_ENOSYS(kexec_load, 4, int, unsigned long, entry, unsigned long, nr_segments,
+                           struct kexec_segment*, segments, unsigned long, flags)
 */
 
-SHIM_SYSCALL_PASSTHROUGH(waitid, 5, int, int, which, pid_t, pid, siginfo_t*, infop, int, options,
-                         struct __kernel_rusage*, ru)
+SHIM_SYSCALL_RETURN_ENOSYS(waitid, 5, int, int, which, pid_t, pid, siginfo_t*, infop, int, options,
+                           struct __kernel_rusage*, ru)
 
 /*
-SHIM_SYSCALL_PASSTHROUGH (add_key, 5, int, const char *, type, const char *,
-                          description, const void *, payload, size_t, plen,
-                          key_serial_t, destringid)
-*/
-
-/*
-SHIM_SYSCALL_PASSTHROUGH (request_key, 4, int, const char *, type,
-                          const char *, description, const char *, callout_info,
-                          key_serial_t, destringid)
+SHIM_SYSCALL_RETURN_ENOSYS(add_key, 5, int, const char*, type, const char*, description,
+                           const void*, payload, size_t, plen, key_serial_t, destringid)
 */
 
 /*
-SHIM_SYSCALL_PASSTHROUGH (keyctl, 5, int, int, cmd, unsigned long, arg2,
-                          unsigned long, arg3, unsigned long, arg4,
-                          unsigned long, arg5)
+SHIM_SYSCALL_RETURN_ENOSYS(request_key, 4, int, const char*, type, const char*, description,
+                           const char *, callout_info, key_serial_t, destringid)
 */
 
-SHIM_SYSCALL_PASSTHROUGH(ioprio_set, 3, int, int, which, int, who, int, ioprio)
+/*
+SHIM_SYSCALL_RETURN_ENOSYS(keyctl, 5, int, int, cmd, unsigned long, arg2, unsigned long, arg3,
+                           unsigned long, arg4, unsigned long, arg5)
+*/
 
-SHIM_SYSCALL_PASSTHROUGH(ioprio_get, 2, int, int, which, int, who)
+SHIM_SYSCALL_RETURN_ENOSYS(ioprio_set, 3, int, int, which, int, who, int, ioprio)
 
-SHIM_SYSCALL_PASSTHROUGH(inotify_init, 0, int)
+SHIM_SYSCALL_RETURN_ENOSYS(ioprio_get, 2, int, int, which, int, who)
 
-SHIM_SYSCALL_PASSTHROUGH(inotify_add_watch, 3, int, int, fd, const char*, path, unsigned int, mask)
+SHIM_SYSCALL_RETURN_ENOSYS(inotify_init, 0, int)
 
-SHIM_SYSCALL_PASSTHROUGH(inotify_rm_watch, 2, int, int, fd, unsigned int, wd)
+SHIM_SYSCALL_RETURN_ENOSYS(inotify_add_watch, 3, int, int, fd, const char*, path, unsigned int,
+                           mask)
 
-SHIM_SYSCALL_PASSTHROUGH(migrate_pages, 4, int, pid_t, pid, unsigned long, maxnode,
-                         const unsigned long*, from, const unsigned long*, to)
+SHIM_SYSCALL_RETURN_ENOSYS(inotify_rm_watch, 2, int, int, fd, unsigned int, wd)
+
+SHIM_SYSCALL_RETURN_ENOSYS(migrate_pages, 4, int, pid_t, pid, unsigned long, maxnode,
+                           const unsigned long*, from, const unsigned long*, to)
 
 /* openat: sys/shim_open.c */
 DEFINE_SHIM_SYSCALL(openat, 4, shim_do_openat, int, int, dfd, const char*, filename, int, flags,
@@ -886,13 +887,14 @@ DEFINE_SHIM_SYSCALL(openat, 4, shim_do_openat, int, int, dfd, const char*, filen
 /* mkdirat: sys/shim_fs.c */
 DEFINE_SHIM_SYSCALL(mkdirat, 3, shim_do_mkdirat, int, int, dfd, const char*, pathname, int, mode)
 
-SHIM_SYSCALL_PASSTHROUGH(mknodat, 4, int, int, dfd, const char*, filename, int, mode, unsigned, dev)
+SHIM_SYSCALL_RETURN_ENOSYS(mknodat, 4, int, int, dfd, const char*, filename, int, mode, unsigned,
+                           dev)
 
 DEFINE_SHIM_SYSCALL(fchownat, 5, shim_do_fchownat, int, int, dfd, const char*, filename, uid_t,
                     user, gid_t, group, int, flag)
 
-SHIM_SYSCALL_PASSTHROUGH(futimesat, 3, int, int, dfd, const char*, filename, struct timeval*,
-                         utimes)
+SHIM_SYSCALL_RETURN_ENOSYS(futimesat, 3, int, int, dfd, const char*, filename, struct timeval*,
+                           utimes)
 
 /* fstatat: sys/shim_stat.c */
 DEFINE_SHIM_SYSCALL(newfstatat, 4, shim_do_newfstatat, int, int, dfd, const char*, filename,
@@ -905,12 +907,13 @@ DEFINE_SHIM_SYSCALL(unlinkat, 3, shim_do_unlinkat, int, int, dfd, const char*, p
 DEFINE_SHIM_SYSCALL(renameat, 4, shim_do_renameat, int, int, olddfd, const char*, oldname, int,
                     newdfd, const char*, newname)
 
-SHIM_SYSCALL_PASSTHROUGH(linkat, 5, int, int, olddfd, const char*, oldname, int, newdfd,
-                         const char*, newname, int, flags)
+SHIM_SYSCALL_RETURN_ENOSYS(linkat, 5, int, int, olddfd, const char*, oldname, int, newdfd,
+                           const char*, newname, int, flags)
 
-SHIM_SYSCALL_PASSTHROUGH(symlinkat, 3, int, const char*, oldname, int, newdfd, const char*, newname)
+SHIM_SYSCALL_RETURN_ENOSYS(symlinkat, 3, int, const char*, oldname, int, newdfd, const char*,
+                           newname)
 
-SHIM_SYSCALL_PASSTHROUGH(readlinkat, 4, int, int, dfd, const char*, path, char*, buf, int, bufsiz)
+SHIM_SYSCALL_RETURN_ENOSYS(readlinkat, 4, int, int, dfd, const char*, path, char*, buf, int, bufsiz)
 
 /* fchmodat: sys/shim_fs.c */
 DEFINE_SHIM_SYSCALL(fchmodat, 3, shim_do_fchmodat, int, int, dfd, const char*, filename, mode_t,
@@ -929,7 +932,7 @@ DEFINE_SHIM_SYSCALL(pselect6, 6, shim_do_pselect6, int, int, nfds, fd_set*, read
 DEFINE_SHIM_SYSCALL(ppoll, 5, shim_do_ppoll, int, struct pollfd*, fds, int, nfds, struct timespec*,
                     tsp, const __sigset_t*, sigmask, size_t, sigsetsize)
 
-SHIM_SYSCALL_PASSTHROUGH(unshare, 1, int, int, unshare_flags)
+SHIM_SYSCALL_RETURN_ENOSYS(unshare, 1, int, int, unshare_flags)
 
 /* set_robust_list: sys/shim_futex.c */
 DEFINE_SHIM_SYSCALL(set_robust_list, 2, shim_do_set_robust_list, int, struct robust_list_head*,
@@ -939,44 +942,45 @@ DEFINE_SHIM_SYSCALL(set_robust_list, 2, shim_do_set_robust_list, int, struct rob
 DEFINE_SHIM_SYSCALL(get_robust_list, 3, shim_do_get_robust_list, int, pid_t, pid,
                     struct robust_list_head**, head, size_t*, len)
 
-SHIM_SYSCALL_PASSTHROUGH(splice, 6, int, int, fd_in, loff_t*, off_in, int, fd_out, loff_t*, off_out,
-                         size_t, len, int, flags)
+SHIM_SYSCALL_RETURN_ENOSYS(splice, 6, int, int, fd_in, loff_t*, off_in, int, fd_out, loff_t*,
+                           off_out, size_t, len, int, flags)
 
-SHIM_SYSCALL_PASSTHROUGH(tee, 4, int, int, fdin, int, fdout, size_t, len, unsigned int, flags)
+SHIM_SYSCALL_RETURN_ENOSYS(tee, 4, int, int, fdin, int, fdout, size_t, len, unsigned int, flags)
 
-SHIM_SYSCALL_PASSTHROUGH(sync_file_range, 4, int, int, fd, loff_t, offset, loff_t, nbytes, int,
-                         flags)
+SHIM_SYSCALL_RETURN_ENOSYS(sync_file_range, 4, int, int, fd, loff_t, offset, loff_t, nbytes, int,
+                           flags)
 
-SHIM_SYSCALL_PASSTHROUGH(vmsplice, 4, int, int, fd, const struct iovec*, iov, unsigned long,
-                         nr_segs, int, flags)
+SHIM_SYSCALL_RETURN_ENOSYS(vmsplice, 4, int, int, fd, const struct iovec*, iov, unsigned long,
+                           nr_segs, int, flags)
 
-SHIM_SYSCALL_PASSTHROUGH(move_pages, 6, int, pid_t, pid, unsigned long, nr_pages, void**, pages,
-                         const int*, nodes, int*, status, int, flags)
+SHIM_SYSCALL_RETURN_ENOSYS(move_pages, 6, int, pid_t, pid, unsigned long, nr_pages, void**, pages,
+                           const int*, nodes, int*, status, int, flags)
 
-SHIM_SYSCALL_PASSTHROUGH(utimensat, 4, int, int, dfd, const char*, filename, struct timespec*,
-                         utimes, int, flags)
+SHIM_SYSCALL_RETURN_ENOSYS(utimensat, 4, int, int, dfd, const char*, filename, struct timespec*,
+                           utimes, int, flags)
 
 DEFINE_SHIM_SYSCALL(epoll_pwait, 6, shim_do_epoll_pwait, int, int, epfd,
                     struct __kernel_epoll_event*, events, int, maxevents, int, timeout_ms,
                     const __sigset_t*, sigmask, size_t, sigsetsize)
 
-SHIM_SYSCALL_PASSTHROUGH(signalfd, 3, int, int, ufd, __sigset_t*, user_mask, size_t, sizemask)
+SHIM_SYSCALL_RETURN_ENOSYS(signalfd, 3, int, int, ufd, __sigset_t*, user_mask, size_t, sizemask)
 
-SHIM_SYSCALL_PASSTHROUGH(timerfd_create, 2, int, int, clockid, int, flags)
+SHIM_SYSCALL_RETURN_ENOSYS(timerfd_create, 2, int, int, clockid, int, flags)
 
-SHIM_SYSCALL_PASSTHROUGH(fallocate, 4, int, int, fd, int, mode, loff_t, offset, loff_t, len)
+SHIM_SYSCALL_RETURN_ENOSYS(fallocate, 4, int, int, fd, int, mode, loff_t, offset, loff_t, len)
 
-SHIM_SYSCALL_PASSTHROUGH(timerfd_settime, 4, int, int, ufd, int, flags,
-                         const struct __kernel_itimerspec*, utmr, struct __kernel_itimerspec*, otmr)
+SHIM_SYSCALL_RETURN_ENOSYS(timerfd_settime, 4, int, int, ufd, int, flags,
+                           const struct __kernel_itimerspec*, utmr, struct __kernel_itimerspec*,
+                           otmr)
 
-SHIM_SYSCALL_PASSTHROUGH(timerfd_gettime, 2, int, int, ufd, struct __kernel_itimerspec*, otmr)
+SHIM_SYSCALL_RETURN_ENOSYS(timerfd_gettime, 2, int, int, ufd, struct __kernel_itimerspec*, otmr)
 
 /* accept4: sys/shim_socket.c */
 DEFINE_SHIM_SYSCALL(accept4, 4, shim_do_accept4, int, int, sockfd, struct sockaddr*, addr,
                     socklen_t*, addrlen, int, flags)
 
-SHIM_SYSCALL_PASSTHROUGH(signalfd4, 4, int, int, ufd, __sigset_t*, user_mask, size_t, sizemask, int,
-                         flags)
+SHIM_SYSCALL_RETURN_ENOSYS(signalfd4, 4, int, int, ufd, __sigset_t*, user_mask, size_t, sizemask,
+                           int, flags)
 
 DEFINE_SHIM_SYSCALL(eventfd, 1, shim_do_eventfd, int, unsigned int, count)
 
@@ -992,48 +996,48 @@ DEFINE_SHIM_SYSCALL(dup3, 3, shim_do_dup3, int, unsigned int, oldfd, unsigned in
 /* pipe2: sys/shim_pipe.c */
 DEFINE_SHIM_SYSCALL(pipe2, 2, shim_do_pipe2, int, int*, fildes, int, flags)
 
-SHIM_SYSCALL_PASSTHROUGH(inotify_init1, 1, int, int, flags)
+SHIM_SYSCALL_RETURN_ENOSYS(inotify_init1, 1, int, int, flags)
 
-SHIM_SYSCALL_PASSTHROUGH(preadv, 5, int, unsigned long, fd, const struct iovec*, vec, unsigned long,
-                         vlen, unsigned long, pos_l, unsigned long, pos_h)
+SHIM_SYSCALL_RETURN_ENOSYS(preadv, 5, int, unsigned long, fd, const struct iovec*, vec,
+                           unsigned long, vlen, unsigned long, pos_l, unsigned long, pos_h)
 
-SHIM_SYSCALL_PASSTHROUGH(pwritev, 5, int, unsigned long, fd, const struct iovec*, vec,
-                         unsigned long, vlen, unsigned long, pos_l, unsigned long, pos_h)
+SHIM_SYSCALL_RETURN_ENOSYS(pwritev, 5, int, unsigned long, fd, const struct iovec*, vec,
+                           unsigned long, vlen, unsigned long, pos_l, unsigned long, pos_h)
 
-SHIM_SYSCALL_PASSTHROUGH(rt_tgsigqueueinfo, 4, int, pid_t, tgid, pid_t, pid, int, sig, siginfo_t*,
-                         uinfo)
+SHIM_SYSCALL_RETURN_ENOSYS(rt_tgsigqueueinfo, 4, int, pid_t, tgid, pid_t, pid, int, sig, siginfo_t*,
+                           uinfo)
 
-SHIM_SYSCALL_PASSTHROUGH(perf_event_open, 5, int, struct perf_event_attr*, attr_uptr, pid_t, pid,
-                         int, cpu, int, group_fd, int, flags)
+SHIM_SYSCALL_RETURN_ENOSYS(perf_event_open, 5, int, struct perf_event_attr*, attr_uptr, pid_t, pid,
+                           int, cpu, int, group_fd, int, flags)
 
 DEFINE_SHIM_SYSCALL(recvmmsg, 5, shim_do_recvmmsg, ssize_t, int, fd, struct mmsghdr*, msg, size_t,
                     vlen, int, flags, struct __kernel_timespec*, timeout)
 
-SHIM_SYSCALL_PASSTHROUGH(fanotify_init, 2, int, int, flags, int, event_f_flags)
+SHIM_SYSCALL_RETURN_ENOSYS(fanotify_init, 2, int, int, flags, int, event_f_flags)
 
-SHIM_SYSCALL_PASSTHROUGH(fanotify_mark, 5, int, int, fanotify_fd, int, flags, unsigned long, mask,
-                         int, fd, const char*, pathname)
+SHIM_SYSCALL_RETURN_ENOSYS(fanotify_mark, 5, int, int, fanotify_fd, int, flags, unsigned long, mask,
+                           int, fd, const char*, pathname)
 
 DEFINE_SHIM_SYSCALL(prlimit64, 4, shim_do_prlimit64, int, pid_t, pid, int, resource,
                     const struct __kernel_rlimit64*, new_rlim, struct __kernel_rlimit64*, old_rlim)
 
-SHIM_SYSCALL_PASSTHROUGH(name_to_handle_at, 5, int, int, dfd, const char*, name,
-                         struct linux_file_handle*, handle, int*, mnt_id, int, flag)
+SHIM_SYSCALL_RETURN_ENOSYS(name_to_handle_at, 5, int, int, dfd, const char*, name,
+                           struct linux_file_handle*, handle, int*, mnt_id, int, flag)
 
-SHIM_SYSCALL_PASSTHROUGH(open_by_handle_at, 3, int, int, mountdirfd, struct linux_file_handle*,
-                         handle, int, flags)
+SHIM_SYSCALL_RETURN_ENOSYS(open_by_handle_at, 3, int, int, mountdirfd, struct linux_file_handle*,
+                           handle, int, flags)
 
-SHIM_SYSCALL_PASSTHROUGH(clock_adjtime, 2, int, clockid_t, which_clock, struct timex*, tx)
+SHIM_SYSCALL_RETURN_ENOSYS(clock_adjtime, 2, int, clockid_t, which_clock, struct timex*, tx)
 
-SHIM_SYSCALL_PASSTHROUGH(syncfs, 1, int, int, fd)
+SHIM_SYSCALL_RETURN_ENOSYS(syncfs, 1, int, int, fd)
 
 DEFINE_SHIM_SYSCALL(sendmmsg, 4, shim_do_sendmmsg, ssize_t, int, fd, struct mmsghdr*, msg, size_t,
                     vlen, int, flags)
 
-SHIM_SYSCALL_PASSTHROUGH(setns, 2, int, int, fd, int, nstype)
+SHIM_SYSCALL_RETURN_ENOSYS(setns, 2, int, int, fd, int, nstype)
 
-SHIM_SYSCALL_PASSTHROUGH(getcpu, 3, int, unsigned*, cpu, unsigned*, node, struct getcpu_cache*,
-                         cache)
+SHIM_SYSCALL_RETURN_ENOSYS(getcpu, 3, int, unsigned*, cpu, unsigned*, node, struct getcpu_cache*,
+                           cache)
 
 /* libos calls */
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

The old name was very misleading, there wasn't any "passthrough" happening.

## How to test this PR? <!-- (if applicable) -->

Jenkins.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1458)
<!-- Reviewable:end -->
