### PR TITLE
[Examples] Remove Ubuntu check from pytorch example

### DIFF
--- a/Examples/pytorch/Makefile
+++ b/Examples/pytorch/Makefile
@@ -20,8 +20,10 @@ endif
 DISTRIB_ID ?= $(shell lsb_release --short --id)
 DISTRIB_RELEASE ?= $(shell lsb_release --short --release)
 
+ifeq ($(SGX), 1)
 ifneq ($(DISTRIB_ID),Ubuntu)
-$(error This example requires Ubuntu.)
+$(error This example requires Ubuntu when building for SGX.)
+endif
 endif
 
 UBUNTU_VERSION = $(DISTRIB_ID)$(DISTRIB_RELEASE)


### PR DESCRIPTION
The pytorch example can also run on Fedora, so remove the Ubuntu check.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1460)
<!-- Reviewable:end -->
