### PR TITLE
[Pal/Linux-SGX] Sanitize return values of ocalls

### DIFF
--- a/Pal/include/lib/api.h
+++ b/Pal/include/lib/api.h
@@ -172,6 +172,25 @@ void *calloc(size_t nmemb, size_t size);
         memcpy(*_d, *_s, sizeof(*_d));                                          \
     } while (0)
 
+#ifdef __x86_64__
+#define COMPILER_BARRIER() ({ __asm__ __volatile__ ("" ::: "memory"); })
+#endif // __x86_64__
+
+/* Idea taken from: https://elixir.bootlin.com/linux/v5.6/source/include/linux/compiler.h */
+#define READ_ONCE(x) ({                     \
+    __typeof__(x) _y;                       \
+    COMPILER_BARRIER();                     \
+    __builtin_memcpy(&_y, &(x), sizeof(x)); \
+    COMPILER_BARRIER();                     \
+    _y; })
+
+#define WRITE_ONCE(x, y) ({                 \
+    __typeof__(x) _y = (__typeof__(x))(y);  \
+    COMPILER_BARRIER();                     \
+    __builtin_memcpy(&(x), &_y, sizeof(x)); \
+    COMPILER_BARRIER();                     \
+    _y; })
+
 /* Libc printf functions. stdio.h/stdarg.h. */
 void fprintfmt (int (*_fputch)(void *, int, void *), void * f, void * putdat,
                 const char * fmt, ...) __attribute__((format(printf, 4, 5)));

--- a/Pal/include/lib/atomic.h
+++ b/Pal/include/lib/atomic.h
@@ -43,8 +43,6 @@ Copyright (C) 2005-2014 Rich Felker, et al.
 
 #include <stdint.h>
 
-/* Optimization barrier */
-#define COMPILER_BARRIER() __asm__ __volatile__("": : :"memory")
 #define CPU_RELAX() __asm__ __volatile__("rep; nop" ::: "memory")
 
 #ifdef __i386__

--- a/Pal/src/host/Linux-SGX/enclave_ocalls.c
+++ b/Pal/src/host/Linux-SGX/enclave_ocalls.c
@@ -7,6 +7,7 @@
 #include <linux/futex.h>
 #include <stdalign.h>
 #include <stdbool.h>
+#include <stdint.h>
 
 #include "ecall_types.h"
 #include "enclave_ocalls.h"
@@ -373,6 +374,10 @@ ssize_t ocall_read(int fd, void* buf, size_t count) {
     retval = sgx_exitless_ocall(OCALL_READ, ms);
 
     if (retval > 0) {
+        if ((size_t)retval > count) {
+            retval = -EPERM;
+            goto out;
+        }
         if (!sgx_copy_to_enclave(buf, count, READ_ONCE(ms->ms_buf), retval)) {
             retval = -EPERM;
             goto out;
@@ -433,6 +438,11 @@ ssize_t ocall_write(int fd, const void* buf, size_t count) {
 
     retval = sgx_exitless_ocall(OCALL_WRITE, ms);
 
+    if (retval > 0 && (size_t)retval > count) {
+        retval = -EPERM;
+        goto out;
+    }
+
 out:
     sgx_reset_ustack(old_ustack);
     if (obuf)
@@ -476,6 +486,10 @@ ssize_t ocall_pread(int fd, void* buf, size_t count, off_t offset) {
 
     retval = sgx_exitless_ocall(OCALL_PREAD, ms);
     if (retval > 0) {
+        if ((size_t)retval > count) {
+            retval = -EPERM;
+            goto out;
+        }
         if (!sgx_copy_to_enclave(buf, count, READ_ONCE(ms->ms_buf), retval)) {
             retval = -EPERM;
         }
@@ -535,6 +549,10 @@ ssize_t ocall_pwrite(int fd, const void* buf, size_t count, off_t offset) {
     WRITE_ONCE(ms->ms_buf, ms_buf);
 
     retval = sgx_exitless_ocall(OCALL_PWRITE, ms);
+    if (retval > 0 && (size_t)retval > count) {
+        retval = -EPERM;
+        goto out;
+    }
 
 out:
     sgx_reset_ustack(old_ustack);
@@ -560,7 +578,6 @@ int ocall_fstat (int fd, struct stat * buf)
     retval = sgx_exitless_ocall(OCALL_FSTAT, ms);
 
     if (!retval) {
-        /* TODO: does any of `struct stat` fields need sanitization? */
         memcpy(buf, &ms->ms_stat, sizeof(struct stat));
     }
 
@@ -698,7 +715,7 @@ int ocall_mkdir (const char * pathname, unsigned short mode)
     return retval;
 }
 
-int ocall_getdents (int fd, struct linux_dirent64 * dirp, unsigned int size)
+int ocall_getdents (int fd, struct linux_dirent64 * dirp, unsigned int dirp_size)
 {
     int retval = 0;
     ms_ocall_getdents_t * ms;
@@ -706,29 +723,50 @@ int ocall_getdents (int fd, struct linux_dirent64 * dirp, unsigned int size)
     void* old_ustack = sgx_prepare_ustack();
     ms = sgx_alloc_on_ustack_aligned(sizeof(*ms), alignof(*ms));
     if (!ms) {
-        sgx_reset_ustack(old_ustack);
-        return -EPERM;
+        retval = -EPERM;
+        goto out;
     }
 
     WRITE_ONCE(ms->ms_fd, fd);
-    WRITE_ONCE(ms->ms_size, size);
-    void* untrusted_dirp = sgx_alloc_on_ustack_aligned(size, alignof(*dirp));
+    WRITE_ONCE(ms->ms_size, dirp_size);
+    void* untrusted_dirp = sgx_alloc_on_ustack_aligned(dirp_size, alignof(*dirp));
     if (!untrusted_dirp) {
-        sgx_reset_ustack(old_ustack);
-        return -EPERM;
+        retval = -EPERM;
+        goto out;
     }
     WRITE_ONCE(ms->ms_dirp, untrusted_dirp);
 
     retval = sgx_exitless_ocall(OCALL_GETDENTS, ms);
 
     if (retval > 0) {
-        /* TODO: some fields of `dirp` need sanitization. */
-        if (!sgx_copy_to_enclave(dirp, size, READ_ONCE(ms->ms_dirp), retval)) {
-            sgx_reset_ustack(old_ustack);
-            return -EPERM;
+        unsigned int size = (unsigned int)retval;
+        if (size > dirp_size) {
+            retval = -EPERM;
+            goto out;
+        }
+        if (!sgx_copy_to_enclave(dirp, dirp_size, READ_ONCE(ms->ms_dirp), size)) {
+            retval = -EPERM;
+            goto out;
+        }
+
+        unsigned int size_left = size;
+        while (size_left > offsetof(struct linux_dirent64, d_name)) {
+            /* `drip->d_off` is understandable only by the fs driver in kernel, we have no way of
+             * validating it. */
+            if (dirp->d_reclen > size_left) {
+                retval = -EPERM;
+                goto out;
+            }
+            size_left -= dirp->d_reclen;
+            dirp = (struct linux_dirent64*)((char*)dirp + dirp->d_reclen);
+        }
+        if (size_left != 0) {
+            retval = -EPERM;
+            goto out;
         }
     }
 
+out:
     sgx_reset_ustack(old_ustack);
     return retval;
 }
@@ -1041,6 +1079,10 @@ ssize_t ocall_recv(int sockfd, void* buf, size_t count,
     retval = sgx_exitless_ocall(OCALL_RECV, ms);
 
     if (retval >= 0) {
+        if ((size_t)retval > count) {
+            retval = -EPERM;
+            goto out;
+        }
         if (addr && addrlen) {
             copied = sgx_copy_to_enclave(addr, addrlen,
                                          READ_ONCE(ms->ms_addr), READ_ONCE(ms->ms_addrlen));
@@ -1131,6 +1173,10 @@ ssize_t ocall_send (int sockfd, const void* buf, size_t count,
     WRITE_ONCE(ms->ms_controllen, controllen);
 
     retval = sgx_exitless_ocall(OCALL_SEND, ms);
+    if (retval > 0 && (size_t)retval > count) {
+        retval = -EPERM;
+        goto out;
+    }
 
 out:
     sgx_reset_ustack(old_ustack);
@@ -1225,8 +1271,8 @@ int ocall_sleep (unsigned long * microsec)
     void* old_ustack = sgx_prepare_ustack();
     ms = sgx_alloc_on_ustack_aligned(sizeof(*ms), alignof(*ms));
     if (!ms) {
-        sgx_reset_ustack(old_ustack);
-        return -EPERM;
+        retval = -EPERM;
+        goto out;
     }
 
     WRITE_ONCE(ms->ms_microsec, microsec ? *microsec : 0);
@@ -1234,46 +1280,57 @@ int ocall_sleep (unsigned long * microsec)
     /* NOTE: no reason to use exitless for sleep() */
     retval = sgx_ocall(OCALL_SLEEP, ms);
     if (microsec) {
-        if (!retval)
+        if (!retval) {
             *microsec = 0;
-        else if (retval == -EINTR)
-            *microsec = READ_ONCE(ms->ms_microsec);
+        } else if (retval == -EINTR) {
+            unsigned long untrusted_microsec = READ_ONCE(ms->ms_microsec);
+            if (*microsec < untrusted_microsec) {
+                retval = -EPERM;
+                goto out;
+            }
+            *microsec = untrusted_microsec;
+        }
     }
 
+out:
     sgx_reset_ustack(old_ustack);
     return retval;
 }
 
-int ocall_poll(struct pollfd* fds, int nfds, int64_t timeout_us) {
+int ocall_poll(struct pollfd* fds, size_t nfds, int64_t timeout_us) {
     int retval = 0;
-    unsigned int nfds_bytes = nfds * sizeof(struct pollfd);
-    ms_ocall_poll_t * ms;
+    size_t nfds_bytes = nfds * sizeof(struct pollfd);
+    ms_ocall_poll_t* ms;
 
     void* old_ustack = sgx_prepare_ustack();
     ms = sgx_alloc_on_ustack_aligned(sizeof(*ms), alignof(*ms));
     if (!ms) {
-        sgx_reset_ustack(old_ustack);
-        return -EPERM;
+        retval = -EPERM;
+        goto out;
     }
 
     WRITE_ONCE(ms->ms_nfds, nfds);
     WRITE_ONCE(ms->ms_timeout_us, timeout_us);
     void* untrusted_fds = sgx_copy_to_ustack(fds, nfds_bytes);
     if (!untrusted_fds) {
-        sgx_reset_ustack(old_ustack);
-        return -EPERM;
+        retval = -EPERM;
+        goto out;
     }
     WRITE_ONCE(ms->ms_fds, untrusted_fds);
 
     retval = sgx_exitless_ocall(OCALL_POLL, ms);
-
     if (retval >= 0) {
+        if ((size_t)retval > nfds) {
+            retval = -EPERM;
+            goto out;
+        }
         if (!sgx_copy_to_enclave(fds, nfds_bytes, READ_ONCE(ms->ms_fds), nfds_bytes)) {
-            sgx_reset_ustack(old_ustack);
-            return -EPERM;
+            retval = -EPERM;
+            goto out;
         }
     }
 
+out:
     sgx_reset_ustack(old_ustack);
     return retval;
 }

--- a/Pal/src/host/Linux-SGX/enclave_ocalls.h
+++ b/Pal/src/host/Linux-SGX/enclave_ocalls.h
@@ -86,7 +86,7 @@ int ocall_sleep (unsigned long * microsec);
 
 int ocall_socketpair (int domain, int type, int protocol, int sockfds[2]);
 
-int ocall_poll(struct pollfd* fds, int nfds, int64_t timeout_us);
+int ocall_poll(struct pollfd* fds, size_t nfds, int64_t timeout_us);
 
 int ocall_rename (const char * oldpath, const char * newpath);
 

--- a/Pal/src/host/Linux-SGX/linux_types.h
+++ b/Pal/src/host/Linux-SGX/linux_types.h
@@ -18,8 +18,8 @@ typedef __kernel_size_t size_t;
 #endif
 
 struct linux_dirent64 {
-    unsigned long d_ino;
-    unsigned long d_off;
+    uint64_t d_ino;
+    int64_t d_off;
     unsigned short d_reclen;
     unsigned char d_type;
     char d_name[];

--- a/Pal/src/host/Linux-SGX/ocall_types.h
+++ b/Pal/src/host/Linux-SGX/ocall_types.h
@@ -252,7 +252,7 @@ typedef struct {
 
 typedef struct {
     struct pollfd* ms_fds;
-    int ms_nfds;
+    size_t ms_nfds;
     int64_t ms_timeout_us;
 } ms_ocall_poll_t;
 


### PR DESCRIPTION
When doing an ocall, untrusted part could return an invalid value for
example `write` could return size bigger than passed to it. This commit
adds checks for such invalid values.

<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://graphene.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1466)
<!-- Reviewable:end -->
