### PR TITLE
[Pal/Linux-SGX] Add support for the DCAP SGX driver versions 1.6+

### DIFF
--- a/Documentation/quickstart.rst
+++ b/Documentation/quickstart.rst
@@ -37,7 +37,7 @@ SGX Quick Start
 Before you run any applications in Graphene-SGX, please make sure that Intel SGX
 SDK and the SGX driver are installed on your system. We recommend using Intel
 SGX SDK and the SGX driver no older than version 1.9 (or the DCAP SGX SDK and
-the driver version 1.4/1.5).
+the driver version 1.4/1.5/1.6).
 
 If Intel SGX SDK and the SGX driver are not installed, please follow the READMEs
 in https://github.com/01org/linux-sgx and

--- a/Jenkinsfiles/Linux-SGX
+++ b/Jenkinsfiles/Linux-SGX
@@ -31,7 +31,7 @@ pipeline {
                         '''
                         sh '''
                             cd Pal/src/host/Linux-SGX/sgx-driver
-                            ISGX_DRIVER_PATH=/opt/intel/linux-sgx-driver ISGX_DRIVER_VERSION=1.9 make
+                            ISGX_DRIVER_PATH=/opt/intel/linux-sgx-driver make
                         '''
                         sh '''
                             make -j 8 SGX=1 WERROR=1 GLIBC_VERSION=2.27

--- a/Jenkinsfiles/Linux-SGX-18.04
+++ b/Jenkinsfiles/Linux-SGX-18.04
@@ -39,18 +39,18 @@ pipeline {
                            # no need to build, we only need the SGX header file (sgx.h)
                         '''
                         sh '''
-                            # test the build with the DCAP driver and clean up afterwards
+                            # test the build with the DCAP driver v1.5 and clean up afterwards
                             cd Pal/src/host/Linux-SGX/sgx-driver
                             ISGX_DRIVER_PATH=/opt/intel/SGXDataCenterAttestationPrimitives/driver/linux make
                             cd ../../../../../
-                            CFLAGS="-DSGX_DCAP" make -j 8 SGX=1 WERROR=1
-                            CFLAGS="-DSGX_DCAP" make -j 8 SGX=1 clean
+                            make -j 8 SGX=1 WERROR=1
+                            make -j 8 SGX=1 clean
                             cd Pal/src/host/Linux-SGX/sgx-driver
                             make distclean
                         '''
                         sh '''
                             cd Pal/src/host/Linux-SGX/sgx-driver
-                            ISGX_DRIVER_PATH=/opt/intel/linux-sgx-driver ISGX_DRIVER_VERSION=1.9 make
+                            ISGX_DRIVER_PATH=/opt/intel/linux-sgx-driver make
                         '''
                         sh '''
                             make -j 8 SGX=1 WERROR=1

--- a/Jenkinsfiles/Linux-SGX-18.04-apps
+++ b/Jenkinsfiles/Linux-SGX-18.04-apps
@@ -31,10 +31,26 @@ pipeline {
                            cd linux-sgx-driver
                            git checkout sgx_driver_1.9
                            make
+
+                           cd /opt/intel
+                           git clone https://github.com/intel/SGXDataCenterAttestationPrimitives.git
+                           cd SGXDataCenterAttestationPrimitives
+                           git checkout DCAP_1.6
+                           # no need to build, we only need the SGX header file (sgx_oot.h)
+                        '''
+                        sh '''
+                            # test the build with the DCAP driver v1.6 and clean up afterwards
+                            cd Pal/src/host/Linux-SGX/sgx-driver
+                            ISGX_DRIVER_PATH=/opt/intel/SGXDataCenterAttestationPrimitives/driver/linux make
+                            cd ../../../../../
+                            make -j 8 SGX=1 WERROR=1
+                            make -j 8 SGX=1 clean
+                            cd Pal/src/host/Linux-SGX/sgx-driver
+                            make distclean
                         '''
                         sh '''
                             cd Pal/src/host/Linux-SGX/sgx-driver
-                            ISGX_DRIVER_PATH=/opt/intel/linux-sgx-driver ISGX_DRIVER_VERSION=1.9 make
+                            ISGX_DRIVER_PATH=/opt/intel/linux-sgx-driver make
                         '''
                         sh '''
                             make -j 8 SGX=1 WERROR=1

--- a/Jenkinsfiles/Linux-SGX-apps
+++ b/Jenkinsfiles/Linux-SGX-apps
@@ -31,7 +31,7 @@ pipeline {
                         '''
                         sh '''
                             cd Pal/src/host/Linux-SGX/sgx-driver
-                            ISGX_DRIVER_PATH=/opt/intel/linux-sgx-driver ISGX_DRIVER_VERSION=1.9 make
+                            ISGX_DRIVER_PATH=/opt/intel/linux-sgx-driver make
                         '''
                         sh '''
                             make -j 8 SGX=1 WERROR=1 GLIBC_VERSION=2.27

--- a/Pal/src/host/Linux-SGX/generated-offsets.c
+++ b/Pal/src/host/Linux-SGX/generated-offsets.c
@@ -181,4 +181,7 @@ void dummy(void)
 #ifdef SGX_DCAP
     DEFINE(SGX_DCAP, SGX_DCAP);
 #endif
+#ifdef SGX_DCAP_16_OR_LATER
+    DEFINE(SGX_DCAP_16_OR_LATER, SGX_DCAP_16_OR_LATER);
+#endif
 }


### PR DESCRIPTION
The DCAP SGX driver v1.6+ closely follows the in-kernel SGX driver v28+. This version changes the driver path to `/dev/sgx/enclave` and changes argument struct of the `SGX_IOC_ENCLAVE_ADD_PAGE` ioctl.

The corresponding PR is https://github.com/oscarlab/graphene-sgx-driver/pull/16.

<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://graphene.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1467)
<!-- Reviewable:end -->
