### PR TITLE
[Examples] Makefiles now use SGX_SIGNER_KEY

### DIFF
--- a/Examples/bash/Makefile
+++ b/Examples/bash/Makefile
@@ -12,7 +12,7 @@ PROGRAMS = ls cat rm cp date
 
 # Relative path to Graphene root and key for enclave signing
 GRAPHENEDIR ?= ../..
-GRAPHENEKEY ?= $(GRAPHENEDIR)/Pal/src/host/Linux-SGX/signer/enclave-key.pem
+SGX_SIGNER_KEY ?= $(GRAPHENEDIR)/Pal/src/host/Linux-SGX/signer/enclave-key.pem
 
 ifeq ($(DEBUG),1)
 GRAPHENEDEBUG = inline
@@ -91,7 +91,7 @@ $(addsuffix .manifest,$(PROGRAMS)): %.manifest: manifest.template %.trusted-libs
 bash.manifest.sgx: bash.manifest $(addsuffix .manifest.sgx,$(PROGRAMS))
 	$(GRAPHENEDIR)/Pal/src/host/Linux-SGX/signer/pal-sgx-sign \
 		-libpal $(GRAPHENEDIR)/Runtime/libpal-Linux-SGX.so \
-		-key $(GRAPHENEKEY) \
+		-key $(SGX_SIGNER_KEY) \
 		-manifest $< -output $@
 
 bash.sig: bash.manifest.sgx
@@ -103,7 +103,7 @@ bash.token: bash.sig
 $(addsuffix .manifest.sgx,$(PROGRAMS)): %.manifest.sgx: %.manifest
 	$(GRAPHENEDIR)/Pal/src/host/Linux-SGX/signer/pal-sgx-sign \
 		-libpal $(GRAPHENEDIR)/Runtime/libpal-Linux-SGX.so \
-		-key $(GRAPHENEKEY) \
+		-key $(SGX_SIGNER_KEY) \
 		-manifest $< -output $@
 
 $(addsuffix .sig,$(PROGRAMS)): %.sig: %.manifest.sgx

--- a/Examples/capnproto/Makefile
+++ b/Examples/capnproto/Makefile
@@ -13,7 +13,7 @@
 
 # Relative path to Graphene root and key for enclave signing
 GRAPHENEDIR ?= ../..
-GRAPHENEKEY ?= $(GRAPHENEDIR)/Pal/src/host/Linux-SGX/signer/enclave-key.pem
+SGX_SIGNER_KEY ?= $(GRAPHENEDIR)/Pal/src/host/Linux-SGX/signer/enclave-key.pem
 
 SRCDIR = src
 CAPNPROTO_SRC_URL ?= https://raw.githubusercontent.com/capnproto/capnproto/v0.7.0
@@ -86,7 +86,7 @@ addressbook.manifest: addressbook.manifest.template addressbook-trusted-libs
 addressbook.manifest.sgx: addressbook.manifest $(SRCDIR)/addressbook
 	$(GRAPHENEDIR)/Pal/src/host/Linux-SGX/signer/pal-sgx-sign \
 		-libpal $(GRAPHENEDIR)/Runtime/libpal-Linux-SGX.so \
-		-key $(GRAPHENEKEY) \
+		-key $(SGX_SIGNER_KEY) \
 		-manifest $< -output $@ \
 		-exec $(SRCDIR)/addressbook
 

--- a/Examples/curl/Makefile
+++ b/Examples/curl/Makefile
@@ -12,7 +12,7 @@ CURL_DIR ?= /usr/bin/
 
 # Relative path to Graphene root and key for enclave signing
 GRAPHENEDIR ?= ../..
-GRAPHENEKEY ?= $(GRAPHENEDIR)/Pal/src/host/Linux-SGX/signer/enclave-key.pem
+SGX_SIGNER_KEY ?= $(GRAPHENEDIR)/Pal/src/host/Linux-SGX/signer/enclave-key.pem
 
 ifeq ($(DEBUG),1)
 GRAPHENEDEBUG = inline
@@ -64,7 +64,7 @@ curl.manifest: curl.manifest.template curl-trusted-libs
 curl.manifest.sgx: curl.manifest
 	$(GRAPHENEDIR)/Pal/src/host/Linux-SGX/signer/pal-sgx-sign \
 		-libpal $(GRAPHENEDIR)/Runtime/libpal-Linux-SGX.so \
-		-key $(GRAPHENEKEY) \
+		-key $(SGX_SIGNER_KEY) \
 		-manifest $< -output $@
 
 curl.sig: curl.manifest.sgx

--- a/Examples/nodejs-express-server/Makefile
+++ b/Examples/nodejs-express-server/Makefile
@@ -12,7 +12,7 @@ NODEJS_DIR ?= /usr/bin/
 
 # Relative path to Graphene root and key for enclave signing
 GRAPHENEDIR ?= ../..
-GRAPHENEKEY ?= $(GRAPHENEDIR)/Pal/src/host/Linux-SGX/signer/enclave-key.pem
+SGX_SIGNER_KEY ?= $(GRAPHENEDIR)/Pal/src/host/Linux-SGX/signer/enclave-key.pem
 
 ifeq ($(DEBUG),1)
 GRAPHENEDEBUG = inline
@@ -64,7 +64,7 @@ nodejs.manifest: nodejs.manifest.template nodejs-trusted-libs
 nodejs.manifest.sgx: nodejs.manifest
 	$(GRAPHENEDIR)/Pal/src/host/Linux-SGX/signer/pal-sgx-sign \
 		-libpal $(GRAPHENEDIR)/Runtime/libpal-Linux-SGX.so \
-		-key $(GRAPHENEKEY) \
+		-key $(SGX_SIGNER_KEY) \
 		-manifest $< -output $@
 
 nodejs.sig: nodejs.manifest.sgx

--- a/Examples/nodejs/Makefile
+++ b/Examples/nodejs/Makefile
@@ -12,7 +12,7 @@ NODEJS_DIR ?= /usr/bin/
 
 # Relative path to Graphene root and key for enclave signing
 GRAPHENEDIR ?= ../..
-GRAPHENEKEY ?= $(GRAPHENEDIR)/Pal/src/host/Linux-SGX/signer/enclave-key.pem
+SGX_SIGNER_KEY ?= $(GRAPHENEDIR)/Pal/src/host/Linux-SGX/signer/enclave-key.pem
 
 ifeq ($(DEBUG),1)
 GRAPHENEDEBUG = inline
@@ -64,7 +64,7 @@ nodejs.manifest: nodejs.manifest.template nodejs-trusted-libs
 nodejs.manifest.sgx: nodejs.manifest
 	$(GRAPHENEDIR)/Pal/src/host/Linux-SGX/signer/pal-sgx-sign \
 		-libpal $(GRAPHENEDIR)/Runtime/libpal-Linux-SGX.so \
-		-key $(GRAPHENEKEY) \
+		-key $(SGX_SIGNER_KEY) \
 		-manifest $< -output $@
 
 nodejs.sig: nodejs.manifest.sgx

--- a/Examples/openvino/Makefile
+++ b/Examples/openvino/Makefile
@@ -20,7 +20,7 @@ OPENVINO_COMMIT ?= ba6e22b1b5ee4cbefcc30e8d9493cddb0bb3dfdf  # corresponds to ta
 
 # Relative path to Graphene root and key for enclave signing
 GRAPHENE_DIR ?= ../..
-GRAPHENE_KEY ?= $(GRAPHENE_DIR)/Pal/src/host/Linux-SGX/signer/enclave-key.pem
+SGX_SIGNER_KEY ?= $(GRAPHENE_DIR)/Pal/src/host/Linux-SGX/signer/enclave-key.pem
 
 ifeq ($(DEBUG),1)
 GRAPHENE_DEBUG = inline
@@ -79,7 +79,7 @@ openvino.manifest: openvino.manifest.template
 openvino.manifest.sgx: openvino.manifest
 	$(GRAPHENE_DIR)/Pal/src/host/Linux-SGX/signer/pal-sgx-sign \
 		-libpal $(GRAPHENE_DIR)/Runtime/libpal-Linux-SGX.so \
-		-key $(GRAPHENE_KEY) \
+		-key $(SGX_SIGNER_KEY) \
 		-manifest $< -output $@
 
 openvino.sig: openvino.manifest.sgx


### PR DESCRIPTION
The documentation [1] currently specifies SGX_SIGNER_KEY
as the parameter to enable Graphene to find your keys.

Some examples doesn't use this environment parameter,
this pull request fixes that.

[1] https://graphene.readthedocs.io/en/latest/building.html#id2

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1468)
<!-- Reviewable:end -->
