### PR TITLE
[LibOS,Pal/Linux-SGX] Allow DkAttestationQuote() to get SGX DCAP quote

### DIFF
--- a/Documentation/manifest-syntax.rst
+++ b/Documentation/manifest-syntax.rst
@@ -316,6 +316,25 @@ trusted and allowed are allowed for access, and Graphene-SGX emits a warning
 message for every such file. This is a convenient way to determine the set of
 files that the ported application uses.
 
+Attestation and Quotes
+^^^^^^^^^^^^^^^^^^^^^^
+
+::
+
+    sgx.remote_attestation=[1|0]
+    (Default: 0)
+    sgx.ra_client_linkable=[1|0]
+    (Default: 0)
+    sgx.ra_client_spid=[HEX]
+
+This syntax specifies the parameters for remote attestation. To enable it,
+``remote_attestation`` must be set to ``1``.
+
+For ECDSA/DCAP based attestation, no additional parameters are required. For
+EPID based attestation, ``ra_client_linkable`` and ``ra_client_spid`` must
+be additionally specified (linkable/unlinkable mode and SPID of the client
+respectively).
+
 Printing per-thread and process-wide SGX stats
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/LibOS/shim/src/fs/dev/attestation.c
+++ b/LibOS/shim/src/fs/dev/attestation.c
@@ -32,10 +32,10 @@
 
 /* user_report_data, target_info and quote are opaque blobs of predefined maximum sizes. Currently
  * these sizes are overapproximations of SGX requirements (report_data is 64B, target_info is
- * 512B, quote is about 1024B). */
+ * 512B, EPID quote is about 1KB, DCAP quote is about 4KB). */
 #define USER_REPORT_DATA_MAX_SIZE 256
 #define TARGET_INFO_MAX_SIZE 1024
-#define QUOTE_MAX_SIZE 2048
+#define QUOTE_MAX_SIZE 8192
 
 static char g_user_report_data[USER_REPORT_DATA_MAX_SIZE] = {0};
 static size_t g_user_report_data_size = 0;

--- a/LibOS/shim/src/fs/dev/attestation.c
+++ b/LibOS/shim/src/fs/dev/attestation.c
@@ -52,10 +52,10 @@ static int init_attestation_struct_sizes(void) {
         return 0;
     }
 
-    int ret = DkAttestationReport(/*user_report_data=*/NULL, &g_user_report_data_size,
+    bool ok = DkAttestationReport(/*user_report_data=*/NULL, &g_user_report_data_size,
                                   /*target_info=*/NULL, &g_target_info_size,
                                   /*report=*/NULL, &g_report_size);
-    if (ret < 0)
+    if (!ok)
         return -EACCES;
 
     assert(g_user_report_data_size && g_user_report_data_size <= sizeof(g_user_report_data));
@@ -245,10 +245,10 @@ static int dev_attestation_my_target_info_open(struct shim_handle* hdl, const ch
 
     /* below invocation returns this enclave's target info because we zeroed out (via calloc)
      * target_info: it's a hint to function to update target_info with this enclave's info */
-    ret = DkAttestationReport(user_report_data, &user_report_data_size,
-                              target_info, &target_info_size,
-                              /*report=*/NULL, &report_size);
-    if (ret < 0) {
+    bool ok = DkAttestationReport(user_report_data, &user_report_data_size,
+                                  target_info, &target_info_size,
+                                  /*report=*/NULL, &report_size);
+    if (!ok) {
         ret = -EACCES;
         goto out;
     }
@@ -319,10 +319,10 @@ static int dev_attestation_report_open(struct shim_handle* hdl, const char* name
         goto out;
     }
 
-    ret = DkAttestationReport(&g_user_report_data, &g_user_report_data_size,
-                              &g_target_info, &g_target_info_size,
-                              report, &g_report_size);
-    if (ret < 0) {
+    bool ok = DkAttestationReport(&g_user_report_data, &g_user_report_data_size,
+                                  &g_target_info, &g_target_info_size,
+                                  report, &g_report_size);
+    if (!ok) {
         ret = -EACCES;
         goto out;
     }
@@ -400,9 +400,9 @@ static int dev_attestation_quote_open(struct shim_handle* hdl, const char* name,
         goto out;
     }
 
-    ret = DkAttestationQuote(&g_user_report_data, g_user_report_data_size,
-                             quote, &quote_size);
-    if (ret < 0) {
+    bool ok = DkAttestationQuote(&g_user_report_data, g_user_report_data_size,
+                                 quote, &quote_size);
+    if (!ok) {
         ret = -EACCES;
         goto out;
     }

--- a/LibOS/shim/test/regression/attestation.manifest.template
+++ b/LibOS/shim/test/regression/attestation.manifest.template
@@ -17,5 +17,6 @@ sgx.trusted_files.libc = file:$(LIBCDIR)/libc.so.6
 sgx.trusted_files.libdl = file:$(LIBCDIR)/libdl.so.2
 sgx.trusted_files.libm = file:$(LIBCDIR)/libm.so.6
 
+sgx.remote_attestation = 1
 sgx.ra_client_spid = $(RA_CLIENT_SPID)
 sgx.ra_client_linkable = $(RA_CLIENT_LINKABLE)

--- a/Pal/src/host/Linux-SGX/db_misc.c
+++ b/Pal/src/host/Linux-SGX/db_misc.c
@@ -24,6 +24,7 @@
 #include <linux/time.h>
 
 #include "api.h"
+#include "gsgx.h"
 #include "pal.h"
 #include "pal_debug.h"
 #include "pal_defs.h"
@@ -359,6 +360,11 @@ int _DkAttestationQuote(const PAL_PTR user_report_data, PAL_NUM user_report_data
     if (user_report_data_size != sizeof(sgx_report_data_t))
         return -PAL_ERROR_INVAL;
 
+#ifdef SGX_DCAP
+    /* for DCAP attestation, spid and linkable arguments are ignored */
+    sgx_spid_t spid = {0};
+    bool linkable = false;
+#else
     char spid_hex[sizeof(sgx_spid_t) * 2 + 1];
     ssize_t len = get_config(pal_state.root_config, "sgx.ra_client_spid", spid_hex,
                              sizeof(spid_hex));
@@ -386,6 +392,7 @@ int _DkAttestationQuote(const PAL_PTR user_report_data, PAL_NUM user_report_data
     char buf[2];
     len = get_config(pal_state.root_config, "sgx.ra_client_linkable", buf, sizeof(buf));
     bool linkable = (len == 1 && buf[0] == '1');
+#endif
 
     sgx_quote_nonce_t nonce;
     int ret = _DkRandomBitsRead(&nonce, sizeof(nonce));

--- a/Pal/src/host/Linux-SGX/quote/aesm.proto
+++ b/Pal/src/host/Linux-SGX/quote/aesm.proto
@@ -16,8 +16,25 @@ message Request {
         optional   uint32      timeout         = 9;
     }
 
-    optional   InitQuoteRequest    initQuoteReq                = 1;
-    optional   GetQuoteRequest     getQuoteReq                 = 2;
+    message InitQuoteExRequest {
+        optional    bytes  att_key_id              = 1;
+        required    bool   b_pub_key_id            = 3;
+        optional    uint64 buf_size                = 4;
+        optional    uint32 timeout                 = 9;
+    }
+
+    message GetQuoteExRequest {
+        required    bytes   report          = 1;
+        optional    bytes   att_key_id      = 2;
+        optional    bytes   qe_report_info  = 3;
+        required    uint32  buf_size        = 4;
+        optional    uint32  timeout         = 9;
+    }
+
+    optional   InitQuoteRequest    initQuoteReq               = 1;
+    optional   GetQuoteRequest     getQuoteReq                = 2;
+    optional   InitQuoteExRequest  initQuoteExReq             = 15;
+    optional   GetQuoteExRequest   getQuoteExReq              = 17;
 }
 
 message Response {
@@ -33,6 +50,21 @@ message Response {
         optional   bytes       qe_report       = 3;
     }
 
-    optional   InitQuoteResponse   initQuoteRes                = 1;
-    optional   GetQuoteResponse    getQuoteRes                 = 2;
+    message InitQuoteExResponse {
+        required    uint32 errorCode       = 1 [default = 1];
+        optional    bytes  target_info     = 2;
+        optional    uint64 pub_key_id_size = 3;
+        optional    bytes  pub_key_id      = 4;
+    }
+
+    message GetQuoteExResponse {
+        required    uint32 errorCode      = 1 [default = 1];
+        optional    bytes  quote          = 2;
+        optional    bytes  qe_report_info = 3;
+    }
+
+    optional   InitQuoteResponse   initQuoteRes             = 1;
+    optional   GetQuoteResponse    getQuoteRes              = 2;
+    optional   InitQuoteExResponse initQuoteExRes           = 15;
+    optional   GetQuoteExResponse  getQuoteExRes            = 17;
 }

--- a/Pal/src/host/Linux-SGX/sgx_attest.h
+++ b/Pal/src/host/Linux-SGX/sgx_attest.h
@@ -25,6 +25,33 @@
 
 #pragma pack(push, 1)
 
+/* different attestation key algorithms */
+typedef enum {
+    SGX_QL_ALG_EPID       = 0, /* EPID 2.0 - Anonymous */
+    SGX_QL_ALG_RESERVED_1 = 1, /* reserved */
+    SGX_QL_ALG_ECDSA_P256 = 2, /* ECDSA-256-with-P-256 curve, non-anonymous */
+    SGX_QL_ALG_ECDSA_P384 = 3, /* ECDSA-384-with-P-384 curve, non-anonymous */
+    SGX_QL_ALG_CNT        = 4,
+} sgx_ql_attestation_algorithm_id_t;
+
+/* generic attestation key format */
+typedef struct _att_key_id_t {
+    uint8_t     att_key_id[256];
+} sgx_att_key_id_t;
+
+/* single DCAP attestation key, contains both QE identity and the attestation algorithm ID */
+typedef struct _sgx_ql_att_key_id_t {
+    uint16_t    id;                   /* structure ID */
+    uint16_t    version;              /* structure version */
+    uint16_t    mrsigner_length;      /* number of valid bytes in MRSIGNER */
+    uint8_t     mrsigner[48];         /* SHA256 or SHA384 hash of public key that signed QE */
+    uint32_t    prod_id;              /* legacy Product ID of QE */
+    uint8_t     extended_prod_id[16]; /* extended Product ID of QE (all 0's for legacy) */
+    uint8_t     config_id[64];        /* Config ID of QE */
+    uint8_t     family_id[16];        /* Family ID of QE */
+    uint32_t    algorithm_id;         /* Identity of the attestation key algorithm */
+} sgx_ql_att_key_id_t;
+
 typedef uint8_t sgx_epid_group_id_t[4];
 
 typedef struct _sgx_basename_t {
@@ -54,8 +81,8 @@ enum {
     SGX_LINKABLE_SIGNATURE
 };
 
-/* typical SGX quotes are around 1K in size, overapproximate to 2K */
-#define SGX_QUOTE_MAX_SIZE 2048
+/* EPID SGX quotes are ~1K in size, DCAP SGX quotes ~4K, overapproximate to 8K */
+#define SGX_QUOTE_MAX_SIZE 8192
 
 /*!
  * \brief Obtain SGX Quote from the Quoting Enclave (communicate via AESM).

--- a/Pal/src/host/Linux-SGX/sgx_main.c
+++ b/Pal/src/host/Linux-SGX/sgx_main.c
@@ -902,8 +902,17 @@ static int load_enclave (struct pal_enclave * enclave,
     if (ret < 0)
         return ret;
 
-    if (get_config(enclave->config, "sgx.ra_client_spid", cfgbuf, sizeof(cfgbuf)) > 0) {
-        /* initialize communication with Quoting Enclave only if app requests Quote retrieval */
+    if (get_config(enclave->config, "sgx.remote_attestation", cfgbuf, sizeof(cfgbuf)) < 0 &&
+            (get_config(enclave->config, "sgx.ra_client_spid", cfgbuf, sizeof(cfgbuf)) > 0 ||
+             get_config(enclave->config, "sgx.ra_client_linkable", cfgbuf, sizeof(cfgbuf)) > 0)) {
+        SGX_DBG(DBG_E, "Detected EPID remote attestation parameters \'ra_client_spid\' and/or "
+                "\'ra_client_linkable\' in the manifest but no \'remote_attestation\' parameter. "
+                "Please add \'sgx.remote_attestation = 1\' to the manifest.\n");
+        return -EINVAL;
+    }
+
+    if (get_config(enclave->config, "sgx.remote_attestation", cfgbuf, sizeof(cfgbuf)) > 0) {
+        /* initialize communication with Quoting Enclave only if app requests attestation */
         ret = init_quoting_enclave_targetinfo(&pal_sec->qe_targetinfo);
         if (ret < 0)
             return ret;

--- a/Pal/src/host/Linux-SGX/signer/pal_sgx_sign.py
+++ b/Pal/src/host/Linux-SGX/signer/pal_sgx_sign.py
@@ -834,19 +834,6 @@ def main_sign(args):
     print("    misc_select: %08x" % int.from_bytes(attr['misc_select'], byteorder='big'))
     print("    date:        %d-%02d-%02d" % (attr['year'], attr['month'], attr['day']))
 
-    # Check client info for SGX quote retrieval (if sgx.ra_client.spid is provided)
-    print("SGX Quote Retrieval:")
-    if 'sgx.ra_client_spid' in manifest and manifest['sgx.ra_client_spid']:
-        print("    spid:     " + manifest['sgx.ra_client_spid'])
-        if 'sgx.ra_client_linkable' in manifest:
-            print("    linkable: " + manifest['sgx.ra_client_linkable'])
-        else:
-            print("    linkable: 0")
-    else:
-        print("    *** Client info is not specified. Graphene will not be able to perform SGX"
-              " quote retrieval (required for remote attestation). Please provide"
-              " sgx.ra_client_spid in the manifest. ***")
-
     # Get trusted checksums and measurements
     print("Trusted files:")
     for key, val in get_trusted_files(manifest, args).items():


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Previously, `DkAttestationQuote()` was able to retrieve only EPID based SGX quotes (with explicit messages to talk to AESM via Google Protobuf). This PR allows `DkAttestationQuote()` to retrieve ECDSA/DCAP based SGX quotes (so called version 3). This is implemented via new Protobuf
messages to talk to AESM (with "_ex" suffix).

Since DCAP based attestation doesn't require SPID and linkable, we introduce a new manifest syntax `sgx.attestation`. To enable DCAP attestation, it is enough to set `sgx.attestation = 1`.

## How to test this PR? <!-- (if applicable) -->

The `attestation` LibOS test works both with EPID and DCAP based attestations, and retrieves quotes v2 (EPID) and v3 (ECDSA/DCAP). (But you need an FLC/ECDSA/DCAP enabled machine with SGX SDK 2.9.1 and SGX DCAP 1.6 installed.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1471)
<!-- Reviewable:end -->
