### PR TITLE
[Examples/lmbench] Add more lmbench download urls

### DIFF
--- a/Examples/lmbench/Makefile
+++ b/Examples/lmbench/Makefile
@@ -10,7 +10,9 @@
 
 # Constants
 
-LMBENCHURL = https://sourceforge.net/projects/lmbench/files/lmbench/2.5/lmbench-2.5.tgz/download
+LMBENCHURLS = https://sourceforge.net/projects/lmbench/files/lmbench/2.5/lmbench-2.5.tgz/download \
+	https://fossies.org/linux/privat/old/lmbench-2.5.tgz \
+	https://borysp.com/lmbench-2.5.tgz
 LMBENCHHASH = e7431530a4cf4c44b5068e23454f95765dc0b51e7d98bc2bd70451b17d505bd9
 LMBENCHDIR = lmbench-2.5
 INSTALLDIR = $(LMBENCHDIR)/bin/linux
@@ -54,7 +56,7 @@ $(LMBENCHDIR)/src/Makefile: $(LMBENCHDIR).tgz
 	touch $@
 
 $(LMBENCHDIR).tgz:
-	$(GRAPHENEDIR)/Scripts/download --output $@ --sha256 $(LMBENCHHASH) --url $(LMBENCHURL)
+	$(GRAPHENEDIR)/Scripts/download --output $@ --sha256 $(LMBENCHHASH) $(foreach url,$(LMBENCHURLS),--url $(url))
 
 $(INSTALLDIR)/lmbench-test-ci.sh:
 	cp lmbench-test-ci.sh $@


### PR DESCRIPTION
The one lmbench download source we have is very unstable and downloading
often fails. This commit adds more urls that will be iteratively
fetched.

<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://graphene.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1474)
<!-- Reviewable:end -->
