### PR TITLE
[Examples] Patch lmbench for distros without rpc/rpc.h and llseek

### DIFF
--- a/Examples/lmbench/Makefile
+++ b/Examples/lmbench/Makefile
@@ -45,6 +45,10 @@ endif
 
 include ../../Scripts/Makefile.configs
 
+ifneq (,$(wildcard $(ARCH_LIBDIR)/libtirpc.so))
+TIRPC_TRUSTED_LIBS=sgx.trusted_files.libtirpc = file:$(ARCH_LIBDIR)/libtirpc.so
+endif
+
 # Building LMBench binaries
 
 $(INSTALLDIR)/lmbench: $(LMBENCHDIR)/src/Makefile
@@ -54,6 +58,8 @@ $(INSTALLDIR)/lmbench: $(LMBENCHDIR)/src/Makefile
 $(LMBENCHDIR)/src/Makefile: $(LMBENCHDIR).tgz
 	tar -xzf $<
 	touch $@
+	cd $(LMBENCHDIR) && patch -p1 < ../patches/tirpc.patch
+	cd $(LMBENCHDIR) && patch -p1 < ../patches/llseek.patch
 
 $(LMBENCHDIR).tgz:
 	$(GRAPHENEDIR)/Scripts/download --output $@ --sha256 $(LMBENCHHASH) $(foreach url,$(LMBENCHURLS),--url $(url))
@@ -68,6 +74,8 @@ $(MANIFESTS): $(INSTALLDIR)/%: %.template $(INSTALLDIR)/lmbench
 	sed -e 's|$$(GRAPHENEDIR)|'"$(GRAPHENEDIR_FROM_INSTALLDIR)"'|g' \
 		-e 's|$$(GRAPHENEDEBUG)|'"$(GRAPHENEDEBUG)"'|g' \
 		-e 's|$$(ARCH_LONG)|'"$(ARCH_LONG)"'|g' \
+		-e 's|$$(ARCH_LIBDIR)|'"$(ARCH_LIBDIR)"'|g' \
+		-e 's|$$(TIRPC_TRUSTED_LIBS)|'"$(TIRPC_TRUSTED_LIBS)"'|g' \
 		$< > $@
 
 # Generating the manifests for SGX

--- a/Examples/lmbench/manifest.template
+++ b/Examples/lmbench/manifest.template
@@ -14,7 +14,7 @@ loader.preload = file:$(GRAPHENEDIR)/Runtime/libsysdb.so
 loader.debug_type = $(GRAPHENEDEBUG)
 
 # Environment variables for LMBench
-loader.env.LD_LIBRARY_PATH = /lib
+loader.env.LD_LIBRARY_PATH = /lib:$(ARCH_LIBDIR)
 
 # Mounted FSes. The following "chroot" FSes mount a part of the host FS into the
 # guest. Other parts of the host FS will not be available in the guest.
@@ -23,6 +23,11 @@ loader.env.LD_LIBRARY_PATH = /lib
 fs.mount.lib.type = chroot
 fs.mount.lib.path = /lib
 fs.mount.lib.uri = file:$(GRAPHENEDIR)/Runtime
+
+# Host-level libraries (e.g., /lib64) required by tests
+fs.mount.lib2.type = chroot
+fs.mount.lib2.path = $(ARCH_LIBDIR)
+fs.mount.lib2.uri = file:$(ARCH_LIBDIR)
 
 # Mount /bin (mainly needed for running /bin/sh)
 fs.mount.bin.type = chroot
@@ -39,10 +44,10 @@ fs.mount.var_tmp.type = chroot
 fs.mount.var_tmp.path = /var/tmp
 fs.mount.var_tmp.uri = file:/var/tmp
 
-# Mount /usr/include/x84_64-linux-gnu/ (used by LMBench for file tests)
+# Mount /usr/include/ (used by LMBench for file tests)
 fs.mount.inc.type = chroot
-fs.mount.inc.path = /usr/include/$(ARCH_LONG)
-fs.mount.inc.uri = file:/usr/include/$(ARCH_LONG)
+fs.mount.inc.path = /usr/include/
+fs.mount.inc.uri = file:/usr/include/
 
 # Network related rules. These rules are used only for sandboxing, which is
 # currently an EXPERIMENTAL feature.
@@ -73,6 +78,9 @@ sgx.trusted_files.libc = file:$(GRAPHENEDIR)/Runtime/libc.so.6
 sgx.trusted_files.libm = file:$(GRAPHENEDIR)/Runtime/libm.so.6
 sgx.trusted_files.libdl = file:$(GRAPHENEDIR)/Runtime/libdl.so.2
 sgx.trusted_files.libpthread = file:$(GRAPHENEDIR)/Runtime/libpthread.so.0
+
+# tirpc libraries
+$(TIRPC_TRUSTED_LIBS)
 
 # SGX untrusted (allowed) files/directories
 sgx.allowed_files.tmp = file:/tmp

--- a/Examples/lmbench/patches/llseek.patch
+++ b/Examples/lmbench/patches/llseek.patch
@@ -1,0 +1,27 @@
+---
+ src/disk.c |    5 ++---
+ 1 file changed, 2 insertions(+), 3 deletions(-)
+
+Index: lmbench-2.5/src/disk.c
+===================================================================
+--- lmbench-2.5.orig/src/disk.c
++++ lmbench-2.5/src/disk.c
+@@ -7,6 +7,7 @@
+  * Bits of this are derived from work by Ethan Solomita.
+  */
+ 
++#define _LARGEFILE64_SOURCE
+ #include	<stdio.h>
+ #include	<sys/types.h>
+ #include	<unistd.h>
+@@ -291,9 +292,7 @@ int
+ seekto(int fd, uint64 off)
+ {
+ #ifdef	__linux__
+-	extern	loff_t llseek(int, loff_t, int);
+-
+-	if (llseek(fd, (loff_t)off, SEEK_SET) == (loff_t)-1) {
++	if (lseek64(fd, (loff_t)off, SEEK_SET) == (loff_t)-1) {
+ 		return(-1);
+ 	}
+ 	return (0);

--- a/Examples/lmbench/patches/tirpc.patch
+++ b/Examples/lmbench/patches/tirpc.patch
@@ -1,0 +1,77 @@
+---
+ src/Makefile |   21 ++++++++++++---------
+ 1 file changed, 12 insertions(+), 9 deletions(-)
+
+Index: lmbench-2.5/src/Makefile
+===================================================================
+--- lmbench-2.5.orig/src/Makefile
++++ lmbench-2.5/src/Makefile
+@@ -48,7 +48,10 @@ SAMPLES=lmbench/Results/aix/rs6000 lmben
+ 	lmbench/Results/irix/indigo2 lmbench/Results/linux/pentium \
+ 	lmbench/Results/osf1/alpha lmbench/Results/solaris/ss20*
+ 
+-COMPILE=$(CC) $(CFLAGS) $(CPPFLAGS) $(LDFLAGS)
++TIRPC_CFLAGS=$(shell pkg-config --cflags libtirpc 2>/dev/null)
++TIRPC_LIBS=$(shell pkg-config --libs libtirpc 2>/dev/null)
++
++COMPILE=$(CC) $(TIRPC_CFLAGS) $(CFLAGS) $(CPPFLAGS) $(LDFLAGS)
+ 
+ INCS =	bench.h lib_tcp.h lib_udp.h stats.h timing.h
+ 
+@@ -199,10 +202,10 @@ $O/lat_ctx: lat_ctx.c timing.h stats.h b
+ 	$(COMPILE) -o $O/lat_ctx lat_ctx.c $O/lmbench.a $(LDLIBS)
+ 
+ $O/lmhttp:  lmhttp.c timing.h stats.h bench.h $O/lmbench.a
+-	$(COMPILE) -o $O/lmhttp lmhttp.c $O/lmbench.a $(LDLIBS)
++	$(COMPILE) -o $O/lmhttp lmhttp.c $O/lmbench.a $(LDLIBS) $(TIRPC_LIBS)
+ 
+ $O/lat_http:  lat_http.c timing.h stats.h bench.h $O/lmbench.a
+-	$(COMPILE) -o $O/lat_http lat_http.c $O/lmbench.a $(LDLIBS)
++	$(COMPILE) -o $O/lat_http lat_http.c $O/lmbench.a $(LDLIBS) $(TIRPC_LIBS)
+ 
+ $O/bw_file_rd:  bw_file_rd.c timing.h stats.h bench.h $O/lmbench.a
+ 	$(COMPILE) -o $O/bw_file_rd bw_file_rd.c $O/lmbench.a $(LDLIBS)
+@@ -217,7 +220,7 @@ $O/bw_pipe:  bw_pipe.c timing.h stats.h
+ 	$(COMPILE) -o $O/bw_pipe bw_pipe.c $O/lmbench.a $(LDLIBS)
+ 
+ $O/bw_tcp:  bw_tcp.c bench.h timing.h stats.h lib_tcp.h $O/lmbench.a
+-	$(COMPILE) -o $O/bw_tcp bw_tcp.c $O/lmbench.a $(LDLIBS)
++	$(COMPILE) -o $O/bw_tcp bw_tcp.c $O/lmbench.a $(LDLIBS) $(TIRPC_LIBS)
+ 
+ $O/bw_unix:  bw_unix.c timing.h stats.h bench.h $O/lmbench.a
+ 	$(COMPILE) -o $O/bw_unix bw_unix.c $O/lmbench.a $(LDLIBS)
+@@ -235,7 +238,7 @@ $O/lat_alarm:  lat_alarm.c timing.h stat
+ 	$(COMPILE) -o $O/lat_alarm lat_alarm.c $O/lmbench.a $(LDLIBS)
+ 
+ $O/lat_connect:  lat_connect.c lib_tcp.c bench.h lib_tcp.h timing.h stats.h $O/lmbench.a
+-	$(COMPILE) -o $O/lat_connect lat_connect.c $O/lmbench.a $(LDLIBS)
++	$(COMPILE) -o $O/lat_connect lat_connect.c $O/lmbench.a $(LDLIBS) $(TIRPC_LIBS)
+ 
+ $O/lat_unix_connect:  lat_unix_connect.c lib_tcp.c bench.h lib_tcp.h timing.h stats.h $O/lmbench.a
+ 	$(COMPILE) -o $O/lat_unix_connect lat_unix_connect.c $O/lmbench.a $(LDLIBS)
+@@ -277,7 +280,7 @@ $O/lat_proc:  lat_proc.c timing.h stats.
+ 	$(COMPILE) -o $O/lat_proc lat_proc.c $O/lmbench.a $(LDLIBS)
+ 
+ $O/lat_rpc:  lat_rpc.c timing.h stats.h bench.h $O/lmbench.a
+-	$(COMPILE) -o $O/lat_rpc lat_rpc.c $O/lmbench.a $(LDLIBS)
++	$(COMPILE) -o $O/lat_rpc lat_rpc.c $O/lmbench.a $(LDLIBS) $(TIRPC_LIBS)
+ 
+ $O/lat_sig:  lat_sig.c timing.h stats.h bench.h $O/lmbench.a
+ 	$(COMPILE) -o $O/lat_sig lat_sig.c $O/lmbench.a $(LDLIBS)
+@@ -286,13 +289,13 @@ $O/lat_syscall:  lat_syscall.c timing.h
+ 	$(COMPILE) -o $O/lat_syscall lat_syscall.c $O/lmbench.a $(LDLIBS)
+ 
+ $O/lat_select:  lat_select.c timing.h stats.h bench.h $O/lmbench.a
+-	$(COMPILE) -o $O/lat_select lat_select.c $O/lmbench.a $(LDLIBS)
++	$(COMPILE) -o $O/lat_select lat_select.c $O/lmbench.a $(LDLIBS) $(TIRPC_LIBS)
+ 
+ $O/lat_tcp:  lat_tcp.c timing.h stats.h bench.h lib_tcp.h $O/lmbench.a
+-	$(COMPILE) -o $O/lat_tcp lat_tcp.c $O/lmbench.a $(LDLIBS)
++	$(COMPILE) -o $O/lat_tcp lat_tcp.c $O/lmbench.a $(LDLIBS) $(TIRPC_LIBS)
+ 
+ $O/lat_udp:  lat_udp.c timing.h stats.h bench.h lib_udp.h $O/lmbench.a
+-	$(COMPILE) -o $O/lat_udp lat_udp.c $O/lmbench.a $(LDLIBS)
++	$(COMPILE) -o $O/lat_udp lat_udp.c $O/lmbench.a $(LDLIBS) $(TIRPC_LIBS)
+ 
+ $O/lat_unix:  lat_unix.c timing.h stats.h bench.h $O/lmbench.a
+ 	$(COMPILE) -o $O/lat_unix lat_unix.c $O/lmbench.a $(LDLIBS)

--- a/Examples/lmbench/sh.manifest.template
+++ b/Examples/lmbench/sh.manifest.template
@@ -11,7 +11,7 @@ loader.preload = file:$(GRAPHENEDIR)/Runtime/libsysdb.so
 loader.debug_type = $(GRAPHENEDEBUG)
 
 # Environment variables
-loader.env.LD_LIBRARY_PATH = /lib
+loader.env.LD_LIBRARY_PATH = /lib:$(ARCH_LIBDIR)
 
 # Mounted FSes. The following "chroot" FSes mount a part of the host FS into the
 # guest. Other parts of the host FS will not be available in the guest.
@@ -20,6 +20,11 @@ loader.env.LD_LIBRARY_PATH = /lib
 fs.mount.lib.type = chroot
 fs.mount.lib.path = /lib
 fs.mount.lib.uri = file:$(GRAPHENEDIR)/Runtime
+
+# Host-level libraries (e.g., /lib64) required by sh
+fs.mount.lib2.type = chroot
+fs.mount.lib2.path = $(ARCH_LIBDIR)
+fs.mount.lib2.uri = file:$(ARCH_LIBDIR)
 
 # SGX general options
 


### PR DESCRIPTION
Patch lmbench for distros where the is no rpc/rpc.h from glibc but
needs tirpc. Also patch llseek to use lseek64. This is now working
on Fedora and Ubuntu-18.04 and it works also when libtircp is not
installed, so we can patch unconditionally.

Add the new library to the sgx trusted libraries in the manifest.

<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://graphene.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1476)
<!-- Reviewable:end -->
