### PR TITLE
[LibOS] Remove unnecessary includes

### DIFF
--- a/LibOS/shim/src/elf/shim_rtld.c
+++ b/LibOS/shim/src/elf/shim_rtld.c
@@ -23,22 +23,12 @@
  * Most of the source codes are imported from GNU C library.
  */
 
-#include <asm/mman.h>
-#include <asm/prctl.h>
-#include <errno.h>
-
-#include "elf.h"
 #include "ldsodefs.h"
 #include "shim_checkpoint.h"
 #include "shim_flags_conv.h"
 #include "shim_fs.h"
-#include "shim_handle.h"
-#include "shim_internal.h"
 #include "shim_table.h"
-#include "shim_thread.h"
-#include "shim_utils.h"
 #include "shim_vdso.h"
-#include "shim_vma.h"
 
 #ifndef DT_THISPROCNUM
 #define DT_THISPROCNUM 0

--- a/LibOS/shim/src/fs/chroot/fs.c
+++ b/LibOS/shim/src/fs/chroot/fs.c
@@ -20,24 +20,8 @@
  * This file contains codes for implementation of 'chroot' filesystem.
  */
 
-// FIXME: Sorting these includes causes a bunch of "error: ‘S_IFREG’ undeclared" errors.
 #include "shim_flags_conv.h"
-#include "shim_internal.h"
-#include "shim_thread.h"
-#include "shim_handle.h"
-#include "shim_vma.h"
 #include "shim_fs.h"
-#include "shim_utils.h"
-#include "pal.h"
-#include "pal_error.h"
-
-#include <asm/fcntl.h>
-#include <asm/mman.h>
-#include <asm/prctl.h>
-#include <asm/unistd.h>
-#include <errno.h>
-#include <linux/fcntl.h>
-#include <linux/stat.h>
 
 #define URI_MAX_SIZE    STR_SIZE
 

--- a/LibOS/shim/src/fs/eventfd/fs.c
+++ b/LibOS/shim/src/fs/eventfd/fs.c
@@ -20,16 +20,7 @@
  * This file contains codes for implementation of 'eventfd' filesystem.
  */
 
-#include <asm/fcntl.h>
-#include <asm/unistd.h>
-#include <errno.h>
-#include <linux/fcntl.h>
-#include <linux/stat.h>
-
-#include <pal.h>
 #include <shim_fs.h>
-#include <shim_handle.h>
-#include <shim_internal.h>
 
 static ssize_t eventfd_read(struct shim_handle* hdl, void* buf, size_t count) {
     if (count < sizeof(uint64_t))

--- a/LibOS/shim/src/fs/pipe/fs.c
+++ b/LibOS/shim/src/fs/pipe/fs.c
@@ -22,20 +22,8 @@
 
 #define __KERNEL__
 
-#include <asm/fcntl.h>
-#include <asm/mman.h>
-#include <asm/prctl.h>
-#include <asm/unistd.h>
-#include <errno.h>
-#include <linux/fcntl.h>
-#include <linux/stat.h>
-
-#include <pal.h>
 #include <pal_debug.h>
-#include <pal_error.h>
 #include <shim_fs.h>
-#include <shim_handle.h>
-#include <shim_internal.h>
 #include <shim_thread.h>
 
 static ssize_t pipe_read(struct shim_handle* hdl, void* buf, size_t count) {

--- a/LibOS/shim/src/fs/proc/ipc-thread.c
+++ b/LibOS/shim/src/fs/proc/ipc-thread.c
@@ -1,22 +1,7 @@
 #define __KERNEL__
 
-#include <asm/fcntl.h>
-#include <asm/mman.h>
-#include <asm/prctl.h>
-#include <asm/unistd.h>
-#include <errno.h>
-#include <linux/fcntl.h>
-#include <linux/stat.h>
-
-#include <pal.h>
-#include <pal_error.h>
 #include <shim_fs.h>
-#include <shim_handle.h>
-#include <shim_internal.h>
 #include <shim_ipc.h>
-#include <shim_table.h>
-#include <shim_thread.h>
-#include <shim_utils.h>
 
 static int parse_ipc_thread_name(const char* name, IDTYPE* pidptr, const char** next,
                                  size_t* next_len, const char** nextnext) {

--- a/LibOS/shim/src/fs/proc/thread.c
+++ b/LibOS/shim/src/fs/proc/thread.c
@@ -1,21 +1,7 @@
 #define __KERNEL__
 
-#include <asm/fcntl.h>
-#include <asm/mman.h>
-#include <asm/prctl.h>
-#include <asm/unistd.h>
-#include <errno.h>
-#include <linux/fcntl.h>
-#include <linux/stat.h>
-
-#include <pal.h>
-#include <pal_error.h>
 #include <shim_fs.h>
-#include <shim_handle.h>
-#include <shim_internal.h>
-#include <shim_table.h>
 #include <shim_thread.h>
-#include <shim_utils.h>
 
 static int parse_thread_name(const char* name, IDTYPE* pidptr, const char** next, size_t* next_len,
                              const char** nextnext) {

--- a/LibOS/shim/src/fs/shim_dcache.c
+++ b/LibOS/shim/src/fs/shim_dcache.c
@@ -21,12 +21,9 @@
  * This file contains codes for maintaining directory cache in library OS.
  */
 
-#include <list.h>
 #include <shim_checkpoint.h>
 #include <shim_fs.h>
-#include <shim_handle.h>
 #include <shim_internal.h>
-#include <shim_types.h>
 
 static struct shim_lock dcache_mgr_lock;
 

--- a/LibOS/shim/src/fs/shim_fs.c
+++ b/LibOS/shim/src/fs/shim_fs.c
@@ -20,16 +20,8 @@
  * This file contains codes for creating filesystems in library OS.
  */
 
-#include <linux/fcntl.h>
-
-#include <list.h>
-#include <pal.h>
-#include <pal_debug.h>
-#include <pal_error.h>
 #include <shim_checkpoint.h>
 #include <shim_fs.h>
-#include <shim_internal.h>
-#include <shim_utils.h>
 
 struct shim_fs {
     char name[8];

--- a/LibOS/shim/src/fs/shim_namei.c
+++ b/LibOS/shim/src/fs/shim_namei.c
@@ -22,17 +22,10 @@
  * directory cache.
  */
 
-#include <asm/fcntl.h>
 #include <linux/fcntl.h>
-#include <linux/stat.h>
-#include <stdbool.h>
 
-#include <pal.h>
 #include <shim_fs.h>
-#include <shim_handle.h>
-#include <shim_internal.h>
 #include <shim_thread.h>
-#include <shim_utils.h>
 
 /* Advances a char pointer (string) past any repeated slashes and returns the result.
  * Must be a null-terminated string. */

--- a/LibOS/shim/src/fs/socket/fs.c
+++ b/LibOS/shim/src/fs/socket/fs.c
@@ -22,18 +22,7 @@
 
 #define __KERNEL__
 
-#include <asm/fcntl.h>
-#include <asm/mman.h>
-#include <asm/prctl.h>
-#include <asm/unistd.h>
-#include <errno.h>
-#include <linux/fcntl.h>
-#include <linux/stat.h>
-
-#include <pal.h>
-#include <pal_error.h>
 #include <shim_fs.h>
-#include <shim_internal.h>
 
 static int socket_close(struct shim_handle* hdl) {
     /* XXX: Shouldn't this do something? */

--- a/LibOS/shim/src/fs/str/fs.c
+++ b/LibOS/shim/src/fs/str/fs.c
@@ -20,17 +20,7 @@
  * This file contains codes for implementation of 'str' filesystem.
  */
 
-#include <asm/fcntl.h>
-#include <asm/mman.h>
-#include <asm/prctl.h>
-#include <asm/unistd.h>
-#include <errno.h>
-#include <linux/fcntl.h>
-#include <linux/stat.h>
-#include <pal.h>
-#include <pal_error.h>
 #include <shim_fs.h>
-#include <shim_internal.h>
 
 int str_open(struct shim_handle* hdl, struct shim_dentry* dent, int flags) {
     struct shim_str_data* data = dent->data;

--- a/LibOS/shim/src/shim_parser.c
+++ b/LibOS/shim/src/shim_parser.c
@@ -20,27 +20,12 @@
  * This file contains code for parsing system call arguments for debug purpose.
  */
 
-#include <asm/fcntl.h>
 #include <asm/ioctls.h>
-#include <asm/mman.h>
-#include <asm/prctl.h>
-#include <asm/unistd.h>
-#include <errno.h>
 #include <linux/fcntl.h>
-#include <linux/futex.h>
-#include <linux/in.h>
-#include <linux/in6.h>
 #include <linux/sched.h>
-#include <linux/stat.h>
-#include <linux/un.h>
 #include <linux/wait.h>
-#include <pal.h>
-#include <pal_error.h>
-#include <shim_internal.h>
 #include <shim_table.h>
 #include <shim_thread.h>
-#include <shim_tcb.h>
-#include <shim_utils.h>
 
 static void parse_open_flags(va_list);
 static void parse_open_mode(va_list);

--- a/LibOS/shim/src/shim_syscalls.c
+++ b/LibOS/shim/src/shim_syscalls.c
@@ -23,15 +23,8 @@
 
 #include <asm/prctl.h>
 #include <asm/unistd.h>
-#include <errno.h>
-#include <pal.h>
-#include <pal_error.h>
-#include <shim_internal.h>
 #include <shim_table.h>
 #include <shim_thread.h>
-#include <shim_tcb.h>
-#include <shim_unistd.h>
-#include <shim_utils.h>
 
 long int if_call_defined(long int sys_no) {
     return shim_table[sys_no] != 0;

--- a/LibOS/shim/src/sys/shim_access.c
+++ b/LibOS/shim/src/sys/shim_access.c
@@ -20,16 +20,7 @@
  * Implementation of system call "access" and "faccessat".
  */
 
-#include <errno.h>
-#include <linux/fcntl.h>
-
-#include <pal.h>
-#include <pal_error.h>
 #include <shim_fs.h>
-#include <shim_handle.h>
-#include <shim_internal.h>
-#include <shim_table.h>
-#include <shim_thread.h>
 
 int shim_do_access(const char* file, mode_t mode) {
     if (!file)

--- a/LibOS/shim/src/sys/shim_alarm.c
+++ b/LibOS/shim/src/sys/shim_alarm.c
@@ -21,10 +21,7 @@
  */
 
 #include <shim_internal.h>
-#include <shim_signal.h>
-#include <shim_table.h>
 #include <shim_thread.h>
-#include <shim_utils.h>
 
 static void signal_alarm(IDTYPE target, void* arg) {
     // Kept for API compatibility wtih signal_itimer

--- a/LibOS/shim/src/sys/shim_benchmark.c
+++ b/LibOS/shim/src/sys/shim_benchmark.c
@@ -21,11 +21,7 @@
  * (These system calls are added for benchmarking purpose.)
  */
 
-#include <errno.h>
-#include <shim_internal.h>
 #include <shim_ipc.h>
-#include <shim_table.h>
-#include <shim_unistd.h>
 
 int get_pid_port(IDTYPE pid, IDTYPE* dest, struct shim_ipc_port** port);
 

--- a/LibOS/shim/src/sys/shim_brk.c
+++ b/LibOS/shim/src/sys/shim_brk.c
@@ -21,14 +21,7 @@
  * Implementation of system call "brk".
  */
 
-#include <sys/mman.h>
-
-#include "pal.h"
 #include "shim_checkpoint.h"
-#include "shim_internal.h"
-#include "shim_table.h"
-#include "shim_utils.h"
-#include "shim_vma.h"
 
 static struct {
     size_t data_segment_size;

--- a/LibOS/shim/src/sys/shim_clone.c
+++ b/LibOS/shim/src/sys/shim_clone.c
@@ -21,21 +21,10 @@
  * implemented yet.)
  */
 
-#include <shim_types.h>
-#include <shim_internal.h>
 #include <shim_table.h>
-#include <shim_thread.h>
-#include <shim_utils.h>
 #include <shim_checkpoint.h>
 
-#include <pal.h>
-#include <pal_error.h>
-
-#include <errno.h>
-#include <sys/syscall.h>
-#include <sys/mman.h>
 #include <linux/sched.h>
-#include <asm/prctl.h>
 
 void __attribute__((weak)) syscall_wrapper_after_syscalldb(void)
 {

--- a/LibOS/shim/src/sys/shim_dup.c
+++ b/LibOS/shim/src/sys/shim_dup.c
@@ -20,15 +20,7 @@
  * Implementation of system call "dup", "dup2" and "dup3".
  */
 
-#include <errno.h>
-#include <pal.h>
-#include <pal_error.h>
-#include <shim_fs.h>
-#include <shim_handle.h>
-#include <shim_internal.h>
-#include <shim_table.h>
 #include <shim_thread.h>
-#include <shim_utils.h>
 
 int shim_do_dup(unsigned int fd) {
     struct shim_handle_map* handle_map = get_cur_handle_map(NULL);

--- a/LibOS/shim/src/sys/shim_epoll.c
+++ b/LibOS/shim/src/sys/shim_epoll.c
@@ -21,16 +21,9 @@
  * and "epoll_wait".
  */
 
-#include <errno.h>
 #include <linux/eventpoll.h>
-#include <pal.h>
-#include <pal_error.h>
 #include <shim_checkpoint.h>
 #include <shim_fs.h>
-#include <shim_handle.h>
-#include <shim_internal.h>
-#include <shim_table.h>
-#include <shim_thread.h>
 
 /* Avoid duplicated definitions */
 #ifndef EPOLLIN

--- a/LibOS/shim/src/sys/shim_eventfd.c
+++ b/LibOS/shim/src/sys/shim_eventfd.c
@@ -22,16 +22,9 @@
  * they must be explicitly allowed through the "sys.allow_insecure_eventfd" manifest key.
  */
 
-#include <asm/fcntl.h>
 #include <sys/eventfd.h>
 
-#include <pal.h>
-#include <pal_error.h>
 #include <shim_fs.h>
-#include <shim_handle.h>
-#include <shim_internal.h>
-#include <shim_table.h>
-#include <shim_utils.h>
 
 static int create_eventfd(PAL_HANDLE* efd, unsigned count, int flags) {
     if (!root_config) {

--- a/LibOS/shim/src/sys/shim_exec.c
+++ b/LibOS/shim/src/sys/shim_exec.c
@@ -20,18 +20,7 @@
  * Implementation of system call "execve".
  */
 
-#include <asm/prctl.h>
-#include <errno.h>
-#include <linux/futex.h>
-#include <sys/mman.h>
-#include <sys/syscall.h>
-
-#include <pal.h>
-#include <pal_error.h>
 #include <shim_fs.h>
-#include <shim_internal.h>
-#include <shim_ipc.h>
-#include <shim_table.h>
 #include <shim_thread.h>
 
 /* returns 0 if normalized URIs are the same; assumes file URIs */

--- a/LibOS/shim/src/sys/shim_exit.c
+++ b/LibOS/shim/src/sys/shim_exit.c
@@ -20,23 +20,7 @@
  * Implementation of system call "exit" and "exit_group".
  */
 
-#include <shim_internal.h>
-#include <shim_table.h>
-#include <shim_thread.h>
-#include <shim_fs.h>
-#include <shim_handle.h>
 #include <shim_ipc.h>
-#include <shim_utils.h>
-#include <shim_checkpoint.h>
-
-#include <pal.h>
-#include <pal_error.h>
-
-#include <errno.h>
-#include <sys/syscall.h>
-#include <sys/mman.h>
-#include <asm/prctl.h>
-#include <linux/futex.h>
 
 void release_robust_list (struct robust_list_head * head);
 

--- a/LibOS/shim/src/sys/shim_fcntl.c
+++ b/LibOS/shim/src/sys/shim_fcntl.c
@@ -20,16 +20,9 @@
  * Implementation of system call "fcntl".
  */
 
-#include <errno.h>
 #include <linux/fcntl.h>
-#include <pal.h>
-#include <pal_error.h>
 #include <shim_fs.h>
-#include <shim_handle.h>
-#include <shim_internal.h>
-#include <shim_table.h>
 #include <shim_thread.h>
-#include <shim_utils.h>
 
 int shim_do_fcntl(int fd, int cmd, unsigned long arg) {
     struct shim_handle_map* handle_map = get_cur_handle_map(NULL);

--- a/LibOS/shim/src/sys/shim_fork.c
+++ b/LibOS/shim/src/sys/shim_fork.c
@@ -20,19 +20,7 @@
  * Implementation of system call "fork".
  */
 
-#include <asm/prctl.h>
-#include <errno.h>
-#include <linux/futex.h>
-#include <sys/mman.h>
-#include <sys/syscall.h>
-
-#include <pal.h>
-#include <pal_error.h>
 #include <shim_checkpoint.h>
-#include <shim_internal.h>
-#include <shim_ipc.h>
-#include <shim_table.h>
-#include <shim_thread.h>
 
 static BEGIN_MIGRATION_DEF(fork, struct shim_thread* thread, struct shim_process* process) {
     DEFINE_MIGRATE(process, process, sizeof(struct shim_process));

--- a/LibOS/shim/src/sys/shim_fs.c
+++ b/LibOS/shim/src/sys/shim_fs.c
@@ -24,19 +24,12 @@
 
 #define __KERNEL__
 
-#include <asm/mman.h>
-#include <errno.h>
 #include <linux/fcntl.h>
-#include <linux/stat.h>
 
 #include <pal.h>
-#include <pal_error.h>
 #include <shim_fs.h>
-#include <shim_handle.h>
-#include <shim_internal.h>
 #include <shim_table.h>
 #include <shim_thread.h>
-#include <shim_utils.h>
 
 /* The kernel would look up the parent directory, and remove the child from the inode. But we are
  * working with the PAL, so we open the file, truncate and close it. */

--- a/LibOS/shim/src/sys/shim_futex.c
+++ b/LibOS/shim/src/sys/shim_futex.c
@@ -28,16 +28,9 @@
  */
 
 #include <linux/futex.h>
-#include <linux/time.h>
 #include <stdint.h>
 
-#include "api.h"
-#include "assert.h"
-#include "list.h"
-#include "pal.h"
-#include "shim_internal.h"
 #include "shim_thread.h"
-#include "shim_types.h"
 #include "spinlock.h"
 
 struct shim_futex;

--- a/LibOS/shim/src/sys/shim_getcwd.c
+++ b/LibOS/shim/src/sys/shim_getcwd.c
@@ -20,15 +20,8 @@
  * Implementation of system call "getcwd", "chdir" and "fchdir".
  */
 
-#include <errno.h>
-#include <pal.h>
-#include <pal_error.h>
 #include <shim_fs.h>
-#include <shim_handle.h>
-#include <shim_internal.h>
-#include <shim_table.h>
 #include <shim_thread.h>
-#include <shim_utils.h>
 
 #ifndef ERANGE
 #define ERANGE 34

--- a/LibOS/shim/src/sys/shim_getpid.c
+++ b/LibOS/shim/src/sys/shim_getpid.c
@@ -23,17 +23,7 @@
  * "setsid" and "getsid".
  */
 
-#include <asm/prctl.h>
-#include <errno.h>
-#include <pal.h>
-#include <pal_error.h>
 #include <shim_checkpoint.h>
-#include <shim_internal.h>
-#include <shim_ipc.h>
-#include <shim_table.h>
-#include <shim_thread.h>
-#include <sys/mman.h>
-#include <sys/syscall.h>
 
 pid_t shim_do_getpid(void) {
     struct shim_thread* cur = get_cur_thread();

--- a/LibOS/shim/src/sys/shim_getrlimit.c
+++ b/LibOS/shim/src/sys/shim_getrlimit.c
@@ -20,12 +20,7 @@
  * Implementation of system call "getrlimit" and "setrlimit".
  */
 
-#include <asm/resource.h>
 #include <shim_checkpoint.h>
-#include <shim_internal.h>
-#include <shim_table.h>
-#include <shim_utils.h>
-#include <shim_vma.h>
 
 /*
  * TODO: implement actual limitation on each resource.

--- a/LibOS/shim/src/sys/shim_ioctl.c
+++ b/LibOS/shim/src/sys/shim_ioctl.c
@@ -20,20 +20,11 @@
  * Implementation of system call "ioctl".
  */
 
-#include <asm/ioctl.h>
-#include <asm/ioctls.h>
-#include <asm/termbits.h>
 #include <asm/termios.h>
-#include <asm/unistd.h>
-#include <errno.h>
 #include <linux/fd.h>
 #include <linux/sockios.h>
-#include <pal.h>
-#include <pal_error.h>
+
 #include <shim_fs.h>
-#include <shim_handle.h>
-#include <shim_internal.h>
-#include <shim_table.h>
 #include <shim_thread.h>
 
 #define TERM_DEFAULT_IFLAG (ICRNL | IUTF8)

--- a/LibOS/shim/src/sys/shim_migrate.c
+++ b/LibOS/shim/src/sys/shim_migrate.c
@@ -20,19 +20,8 @@
  * Implementation of system call "checkpoint" and "restore".
  */
 
-#include <asm/mman.h>
-#include <errno.h>
-#include <linux/fcntl.h>
-#include <pal.h>
-#include <pal_error.h>
 #include <shim_checkpoint.h>
 #include <shim_fs.h>
-#include <shim_handle.h>
-#include <shim_internal.h>
-#include <shim_ipc.h>
-#include <shim_table.h>
-#include <shim_thread.h>
-#include <shim_vma.h>
 
 /* cp_session objects are on the cp_sessions list, by the list field */
 /* cp_threads are organized onto a list, handing off of the

--- a/LibOS/shim/src/sys/shim_mmap.c
+++ b/LibOS/shim/src/sys/shim_mmap.c
@@ -21,17 +21,10 @@
  * Implementation of system calls "mmap", "munmap" and "mprotect".
  */
 
-#include <errno.h>
 #include <stdatomic.h>
-#include <sys/mman.h>
 
-#include "pal.h"
-#include "pal_error.h"
 #include "shim_flags_conv.h"
 #include "shim_fs.h"
-#include "shim_handle.h"
-#include "shim_internal.h"
-#include "shim_table.h"
 #include "shim_vma.h"
 
 #define LEGACY_MAP_MASK (MAP_SHARED         \

--- a/LibOS/shim/src/sys/shim_msgget.c
+++ b/LibOS/shim/src/sys/shim_msgget.c
@@ -24,16 +24,8 @@
  * it someday.
  */
 
-#include <errno.h>
-#include <list.h>
-#include <pal.h>
-#include <pal_error.h>
-#include <shim_handle.h>
-#include <shim_internal.h>
 #include <shim_ipc.h>
-#include <shim_sysv.h>
 #include <shim_unistd.h>
-#include <shim_utils.h>
 
 #define MSGQ_HASH_LEN  8
 #define MSGQ_HASH_NUM  (1 << MSGQ_HASH_LEN)

--- a/LibOS/shim/src/sys/shim_open.c
+++ b/LibOS/shim/src/sys/shim_open.c
@@ -22,21 +22,8 @@
  * "fsync", "truncate" and "ftruncate".
  */
 
-#include <shim_internal.h>
-#include <shim_utils.h>
 #include <shim_table.h>
-#include <shim_thread.h>
-#include <shim_handle.h>
 #include <shim_fs.h>
-
-#include <pal.h>
-#include <pal_error.h>
-
-#include <errno.h>
-#include <dirent.h>
-
-#include <linux/stat.h>
-#include <linux/fcntl.h>
 
 int do_handle_read (struct shim_handle * hdl, void * buf, int count)
 {

--- a/LibOS/shim/src/sys/shim_pipe.c
+++ b/LibOS/shim/src/sys/shim_pipe.c
@@ -20,17 +20,8 @@
  * Implementation of system call "pipe", "pipe2" and "socketpair".
  */
 
-#include <asm/fcntl.h>
-#include <errno.h>
-
-#include "pal.h"
-#include "pal_error.h"
 #include "shim_flags_conv.h"
 #include "shim_fs.h"
-#include "shim_handle.h"
-#include "shim_internal.h"
-#include "shim_table.h"
-#include "shim_utils.h"
 
 static int create_pipes(PAL_HANDLE* srv, PAL_HANDLE* cli, int flags, char* name,
                         struct shim_qstr* qstr) {

--- a/LibOS/shim/src/sys/shim_poll.c
+++ b/LibOS/shim/src/sys/shim_poll.c
@@ -20,16 +20,9 @@
  * Implementation of system calls "poll", "ppoll", "select" and "pselect6".
  */
 
-#include <errno.h>
-#include <linux/fcntl.h>
-#include <pal.h>
-#include <pal_error.h>
 #include <shim_fs.h>
-#include <shim_handle.h>
-#include <shim_internal.h>
 #include <shim_table.h>
 #include <shim_thread.h>
-#include <shim_utils.h>
 
 typedef long int __fd_mask;
 

--- a/LibOS/shim/src/sys/shim_sched.c
+++ b/LibOS/shim/src/sys/shim_sched.c
@@ -23,13 +23,9 @@
  * "sched_setaffinity", "sched_getaffinity".
  */
 
-#include <api.h>
-#include <errno.h>
 #include <linux/resource.h>
 #include <linux/sched.h>
-#include <pal.h>
 #include <shim_internal.h>
-#include <shim_table.h>
 
 int shim_do_sched_yield(void) {
     DkThreadYieldExecution();

--- a/LibOS/shim/src/sys/shim_semget.c
+++ b/LibOS/shim/src/sys/shim_semget.c
@@ -20,16 +20,7 @@
  * Implementation of system call "semget", "semop", "semtimedop" and "semctl".
  */
 
-#include <errno.h>
-#include <list.h>
-#include <pal.h>
-#include <pal_error.h>
-#include <shim_handle.h>
-#include <shim_internal.h>
 #include <shim_ipc.h>
-#include <shim_sysv.h>
-#include <shim_table.h>
-#include <shim_utils.h>
 
 #define SEM_HASH_LEN  8
 #define SEM_HASH_NUM  (1 << SEM_HASH_LEN)

--- a/LibOS/shim/src/sys/shim_sigaction.c
+++ b/LibOS/shim/src/sys/shim_sigaction.c
@@ -21,19 +21,13 @@
  * "kill", "tkill" and "tgkill".
  */
 
-#include <errno.h>
 #include <stddef.h>  // FIXME(mkow): Without this we get:
                      //     asm/signal.h:126:2: error: unknown type name ‘size_t’
                      // It definitely shouldn't behave like this...
 #include <linux/signal.h>
 
-#include <pal.h>
-#include <pal_error.h>
-#include <shim_internal.h>
 #include <shim_ipc.h>
 #include <shim_table.h>
-#include <shim_thread.h>
-#include <shim_utils.h>
 
 int shim_do_sigaction(int signum, const struct __kernel_sigaction* act,
                       struct __kernel_sigaction* oldact, size_t sigsetsize) {

--- a/LibOS/shim/src/sys/shim_sleep.c
+++ b/LibOS/shim/src/sys/shim_sleep.c
@@ -20,16 +20,7 @@
  * Implementation of system call "pause" and "nanosleep".
  */
 
-#include <errno.h>
-
-#include <pal.h>
-#include <pal_error.h>
-#include <shim_handle.h>
-#include <shim_internal.h>
-#include <shim_table.h>
 #include <shim_thread.h>
-#include <shim_utils.h>
-#include <shim_vma.h>
 
 static bool signal_pending(void) {
     struct shim_thread* cur = get_cur_thread();

--- a/LibOS/shim/src/sys/shim_socket.c
+++ b/LibOS/shim/src/sys/shim_socket.c
@@ -23,21 +23,10 @@
  */
 
 #include <asm/socket.h>
-#include <errno.h>
-#include <linux/fcntl.h>
-#include <linux/in.h>
-#include <linux/in6.h>
 
 #include "hex.h"
-#include "pal.h"
-#include "pal_error.h"
 #include "shim_checkpoint.h"
-#include "shim_flags_conv.h"
 #include "shim_fs.h"
-#include "shim_handle.h"
-#include "shim_internal.h"
-#include "shim_table.h"
-#include "shim_utils.h"
 
 /*
  * User-settable options (used with setsockopt).

--- a/LibOS/shim/src/sys/shim_stat.c
+++ b/LibOS/shim/src/sys/shim_stat.c
@@ -20,15 +20,9 @@
  * Implementation of system call "stat", "lstat", "fstat" and "readlink".
  */
 
-#include <errno.h>
 #include <linux/fcntl.h>
 
-#include <pal.h>
-#include <pal_error.h>
 #include <shim_fs.h>
-#include <shim_handle.h>
-#include <shim_internal.h>
-#include <shim_table.h>
 #include <shim_thread.h>
 
 int shim_do_stat(const char* file, struct stat* stat) {

--- a/LibOS/shim/src/sys/shim_time.c
+++ b/LibOS/shim/src/sys/shim_time.c
@@ -20,13 +20,7 @@
  * Implementation of system call "gettimeofday", "time" and "clock_gettime".
  */
 
-#include <errno.h>
-#include <pal.h>
-#include <pal_error.h>
-#include <shim_fs.h>
-#include <shim_handle.h>
 #include <shim_internal.h>
-#include <shim_table.h>
 
 int shim_do_gettimeofday(struct __kernel_timeval* tv, struct __kernel_timezone* tz) {
     if (!tv)

--- a/LibOS/shim/src/sys/shim_uname.c
+++ b/LibOS/shim/src/sys/shim_uname.c
@@ -20,13 +20,7 @@
  * Implementation of system call "uname".
  */
 
-#include <errno.h>
-#include <shim_fs.h>
-#include <shim_handle.h>
-#include <shim_internal.h>
-#include <shim_table.h>
 #include <shim_utils.h>
-#include <sys/utsname.h>
 
 /* DP: Damned lies */
 static struct old_utsname graphene_uname = {.sysname  = "Linux",

--- a/LibOS/shim/src/sys/shim_vfork.c
+++ b/LibOS/shim/src/sys/shim_vfork.c
@@ -20,18 +20,8 @@
  * Implementation of system call "vfork".
  */
 
-#include <asm/prctl.h>
-#include <errno.h>
-#include <linux/futex.h>
-#include <pal.h>
-#include <pal_error.h>
-#include <shim_checkpoint.h>
-#include <shim_internal.h>
 #include <shim_table.h>
-#include <shim_thread.h>
 #include <shim_utils.h>
-#include <sys/mman.h>
-#include <sys/syscall.h>
 
 int shim_do_vfork(void) {
 #ifdef ALIAS_VFORK_AS_FORK

--- a/LibOS/shim/src/sys/shim_wait.c
+++ b/LibOS/shim/src/sys/shim_wait.c
@@ -20,17 +20,8 @@
  * Implementation of system call "wait4".
  */
 
-#include <asm/prctl.h>
-#include <errno.h>
 #include <linux/wait.h>
-#include <pal.h>
-#include <pal_error.h>
-#include <shim_internal.h>
-#include <shim_table.h>
 #include <shim_thread.h>
-#include <shim_utils.h>
-#include <sys/mman.h>
-#include <sys/syscall.h>
 
 pid_t shim_do_wait4(pid_t pid, int* status, int option, struct __kernel_rusage* ru) {
     struct shim_thread* cur    = get_cur_thread();

--- a/LibOS/shim/src/sys/shim_wrappers.c
+++ b/LibOS/shim/src/sys/shim_wrappers.c
@@ -20,14 +20,7 @@
  * Implementation of system call "readv" and "writev".
  */
 
-#include <errno.h>
-#include <pal.h>
-#include <pal_error.h>
 #include <shim_fs.h>
-#include <shim_handle.h>
-#include <shim_internal.h>
-#include <shim_table.h>
-#include <shim_utils.h>
 
 ssize_t shim_do_readv(int fd, const struct iovec* vec, int vlen) {
     if (!vec || test_user_memory((void*)vec, sizeof(*vec) * vlen, false))


### PR DESCRIPTION
There are lots of includes that are not needed. Remove them all.

Initially I wanted to just remove asm/prctl.h, because that I know is not needed. But then it became a lot more... I suppose we have a working dependency system so that we don't depend on all of these includes that our c files would be rebuilt correctly, right? So we should be able to cleanup. Am I missing something?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1478)
<!-- Reviewable:end -->
