### PR TITLE
[LibOS] Remove unnecessary include of asm/prctl.h where possible

### DIFF
--- a/LibOS/shim/src/elf/shim_rtld.c
+++ b/LibOS/shim/src/elf/shim_rtld.c
@@ -24,7 +24,6 @@
  */
 
 #include <asm/mman.h>
-#include <asm/prctl.h>
 #include <errno.h>
 
 #include "elf.h"

--- a/LibOS/shim/src/fs/chroot/fs.c
+++ b/LibOS/shim/src/fs/chroot/fs.c
@@ -33,7 +33,6 @@
 
 #include <asm/fcntl.h>
 #include <asm/mman.h>
-#include <asm/prctl.h>
 #include <asm/unistd.h>
 #include <errno.h>
 #include <linux/fcntl.h>

--- a/LibOS/shim/src/fs/pipe/fs.c
+++ b/LibOS/shim/src/fs/pipe/fs.c
@@ -24,7 +24,6 @@
 
 #include <asm/fcntl.h>
 #include <asm/mman.h>
-#include <asm/prctl.h>
 #include <asm/unistd.h>
 #include <errno.h>
 #include <linux/fcntl.h>

--- a/LibOS/shim/src/fs/proc/ipc-thread.c
+++ b/LibOS/shim/src/fs/proc/ipc-thread.c
@@ -2,7 +2,6 @@
 
 #include <asm/fcntl.h>
 #include <asm/mman.h>
-#include <asm/prctl.h>
 #include <asm/unistd.h>
 #include <errno.h>
 #include <linux/fcntl.h>

--- a/LibOS/shim/src/fs/proc/thread.c
+++ b/LibOS/shim/src/fs/proc/thread.c
@@ -2,7 +2,6 @@
 
 #include <asm/fcntl.h>
 #include <asm/mman.h>
-#include <asm/prctl.h>
 #include <asm/unistd.h>
 #include <errno.h>
 #include <linux/fcntl.h>

--- a/LibOS/shim/src/fs/socket/fs.c
+++ b/LibOS/shim/src/fs/socket/fs.c
@@ -24,7 +24,6 @@
 
 #include <asm/fcntl.h>
 #include <asm/mman.h>
-#include <asm/prctl.h>
 #include <asm/unistd.h>
 #include <errno.h>
 #include <linux/fcntl.h>

--- a/LibOS/shim/src/fs/str/fs.c
+++ b/LibOS/shim/src/fs/str/fs.c
@@ -22,7 +22,6 @@
 
 #include <asm/fcntl.h>
 #include <asm/mman.h>
-#include <asm/prctl.h>
 #include <asm/unistd.h>
 #include <errno.h>
 #include <linux/fcntl.h>

--- a/LibOS/shim/src/shim_parser.c
+++ b/LibOS/shim/src/shim_parser.c
@@ -23,7 +23,6 @@
 #include <asm/fcntl.h>
 #include <asm/ioctls.h>
 #include <asm/mman.h>
-#include <asm/prctl.h>
 #include <asm/unistd.h>
 #include <errno.h>
 #include <linux/fcntl.h>

--- a/LibOS/shim/src/sys/shim_clone.c
+++ b/LibOS/shim/src/sys/shim_clone.c
@@ -35,7 +35,6 @@
 #include <sys/syscall.h>
 #include <sys/mman.h>
 #include <linux/sched.h>
-#include <asm/prctl.h>
 
 void __attribute__((weak)) syscall_wrapper_after_syscalldb(void)
 {

--- a/LibOS/shim/src/sys/shim_exec.c
+++ b/LibOS/shim/src/sys/shim_exec.c
@@ -20,7 +20,6 @@
  * Implementation of system call "execve".
  */
 
-#include <asm/prctl.h>
 #include <errno.h>
 #include <linux/futex.h>
 #include <sys/mman.h>

--- a/LibOS/shim/src/sys/shim_exit.c
+++ b/LibOS/shim/src/sys/shim_exit.c
@@ -35,7 +35,6 @@
 #include <errno.h>
 #include <sys/syscall.h>
 #include <sys/mman.h>
-#include <asm/prctl.h>
 #include <linux/futex.h>
 
 void release_robust_list (struct robust_list_head * head);

--- a/LibOS/shim/src/sys/shim_fork.c
+++ b/LibOS/shim/src/sys/shim_fork.c
@@ -20,7 +20,6 @@
  * Implementation of system call "fork".
  */
 
-#include <asm/prctl.h>
 #include <errno.h>
 #include <linux/futex.h>
 #include <sys/mman.h>

--- a/LibOS/shim/src/sys/shim_getpid.c
+++ b/LibOS/shim/src/sys/shim_getpid.c
@@ -23,7 +23,6 @@
  * "setsid" and "getsid".
  */
 
-#include <asm/prctl.h>
 #include <errno.h>
 #include <pal.h>
 #include <pal_error.h>

--- a/LibOS/shim/src/sys/shim_vfork.c
+++ b/LibOS/shim/src/sys/shim_vfork.c
@@ -20,7 +20,6 @@
  * Implementation of system call "vfork".
  */
 
-#include <asm/prctl.h>
 #include <errno.h>
 #include <linux/futex.h>
 #include <pal.h>

--- a/LibOS/shim/src/sys/shim_wait.c
+++ b/LibOS/shim/src/sys/shim_wait.c
@@ -20,7 +20,6 @@
  * Implementation of system call "wait4".
  */
 
-#include <asm/prctl.h>
 #include <errno.h>
 #include <linux/wait.h>
 #include <pal.h>


### PR DESCRIPTION
This is a toned-down PR for removing only the prctl.h include in all c files. It's really not needed anywhere in those files in the shim and no shim header file includes it, either, so that it would be indirectly included now. shim_syscall.c is the only file where it is actually needed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1482)
<!-- Reviewable:end -->
