### PR TITLE
[LibOS] Fixes for two bugs revealed on Erlang workload

### DIFF
--- a/LibOS/shim/include/shim_internal.h
+++ b/LibOS/shim/include/shim_internal.h
@@ -613,9 +613,6 @@ static inline void wait_event (AEVENTTYPE * e)
         char byte;
         int n = 0;
         do {
-            if (!DkSynchronizationObjectWait(e->event, NO_TIMEOUT))
-                continue;
-
             n = DkStreamRead(e->event, 0, 1, &byte, NULL, 0);
         } while (!n);
     }

--- a/LibOS/shim/src/shim_parser.c
+++ b/LibOS/shim/src/shim_parser.c
@@ -100,7 +100,7 @@ struct parser_table {
          .parser = {NULL, &parse_access_mode}},
         {.slow   = 0, /* pipe */
          .parser = {&parse_pipe_fds}},
-        {.slow = 0, .parser = {NULL}},                           /* select */
+        {.slow = 1, .parser = {NULL}},                           /* select */
         {.slow = 0, .parser = {NULL}},                           /* sched_yield */
         {.slow = 0, .parser = {NULL}},                           /* mremap */
         {.slow = 0, .parser = {NULL}},                           /* msync */
@@ -353,7 +353,7 @@ struct parser_table {
         {.slow = 0, .parser = {&parse_at_fdcwd}}, /* readlinkat */
         {.slow = 0, .parser = {&parse_at_fdcwd}}, /* fchmodat */
         {.slow = 0, .parser = {&parse_at_fdcwd}}, /* faccessat */
-        {.slow = 0, .parser = {NULL}}, /* pselect6 */
+        {.slow = 1, .parser = {NULL}}, /* pselect6 */
         {.slow = 1, .parser = {NULL}}, /* ppoll */
         {.slow = 0, .parser = {NULL}}, /* unshare */
         {.slow = 0, .parser = {NULL}}, /* set_robust_list */

--- a/LibOS/shim/src/sys/shim_poll.c
+++ b/LibOS/shim/src/sys/shim_poll.c
@@ -215,7 +215,7 @@ int shim_do_select(int nfds, fd_set* readfds, fd_set* writefds, fd_set* errorfds
 
     if (!nfds) {
         if (!tsv)
-            return -EINVAL;
+            return shim_do_pause();
 
         /* special case of select(0, ..., tsv) used for sleep */
         struct __kernel_timespec tsp;


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Running Erlang workload (helloworld) revealed two bugs in Graphene:

- [LibOS] Force `select(0, NULL, NULL, NULL, NULL)` to sleep indefinitely. Previously, Graphene returned -EINVAL for select() with all zeroes. This behavior was chosen due to man page of select: "Some code calls select() with all three sets empty, nfds zero, and a non-NULL timeout" (notice "non-NULL timeout"). In reality, Linux allows to specify timeout as NULL, which leads to indefinite sleep, same as pause(). This commit forces select() with all zeroes to perform shim_do_pause() to comply with Linux behavior.

- [LibOS] Remove DkSynchronizationObjectWait() from wait_event(). LibOS events create_event() / set_event() / wait_event() are emulated as reads/writes on a private pipe. On the other hand, PAL API
 DkSynchronizationObjectWait() works only on event/mutex objects, not on pipes. So wait_event(), which previously used this API, failed on assert because it provided a pipe object. This bug manifests only in rare circumstances (I found it with Erlang workload) because wait_event() is called very rarely, on data-race path of epoll wait. This commit simply removes DkSynchronizationObjectWait() call, so  that the event is awaited via reading from the pipe.

## How to test this PR? <!-- (if applicable) -->

I found these bugs on an Erlang workload: https://github.com/emilhem/graphene-erlang. No new tests are provided (first bug is trivial, second bug is hard to catch).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1483)
<!-- Reviewable:end -->
