### PR TITLE
[Pal] Factor out TCB part from pal.h

### DIFF
--- a/Pal/include/arch/x86_64/pal-arch.h
+++ b/Pal/include/arch/x86_64/pal-arch.h
@@ -30,6 +30,15 @@
 
 typedef struct pal_tcb PAL_TCB;
 
+#define PAL_LIBOS_TCB_SIZE 256
+
+typedef struct pal_tcb {
+    struct pal_tcb* self;
+    /* uint64_t for alignment */
+    uint64_t libos_tcb[(PAL_LIBOS_TCB_SIZE + sizeof(uint64_t) - 1) / sizeof(uint64_t)];
+    /* data private to PAL implementation follows this struct. */
+} PAL_TCB;
+
 static inline PAL_TCB * pal_get_tcb (void)
 {
     PAL_TCB * tcb;

--- a/Pal/include/pal/pal.h
+++ b/Pal/include/pal/pal.h
@@ -97,15 +97,6 @@ typedef union pal_handle
 
 #endif /* !IN_PAL */
 
-#define PAL_LIBOS_TCB_SIZE  256
-
-typedef struct pal_tcb {
-    struct pal_tcb * self;
-    /* uint64_t for alignment */
-    uint64_t libos_tcb[(PAL_LIBOS_TCB_SIZE + sizeof(uint64_t) - 1) / sizeof(uint64_t)];
-    /* data private to PAL implementation follows this struct. */
-} PAL_TCB;
-
 #include "pal-arch.h"
 
 /********** PAL TYPE DEFINITIONS **********/


### PR DESCRIPTION
Factor out the TCB part from pal.h into pal_tcb_common.h. Have applications
now include the processor specific pal_tcb.h, which was previously called
pal-arch.h.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1486)
<!-- Reviewable:end -->
