### PR TITLE
[Pal] Fix more IPv6 related stack buffer overflows

### DIFF
--- a/Pal/src/host/Linux-SGX/db_sockets.c
+++ b/Pal/src/host/Linux-SGX/db_sockets.c
@@ -78,7 +78,7 @@ static int inet_parse_uri(char** uri, struct sockaddr* addr, unsigned int* addrl
     void* addr_buf;
     int addr_len;
     __be16* port_buf;
-    unsigned int slen;
+    size_t slen;
 
     assert(addrlen);
 
@@ -323,8 +323,8 @@ static inline int sock_type(int type, int options) {
 
 /* listen on a tcp socket */
 static int tcp_listen(PAL_HANDLE* handle, char* uri, int create, int options) {
-    struct sockaddr buffer;
-    struct sockaddr* bind_addr = &buffer;
+    struct sockaddr_storage buffer;
+    struct sockaddr* bind_addr = (struct sockaddr*)&buffer;
     unsigned int bind_addrlen = sizeof(buffer);
     int ret;
 
@@ -368,8 +368,8 @@ static int tcp_accept(PAL_HANDLE handle, PAL_HANDLE* client) {
         return -PAL_ERROR_BADHANDLE;
 
     struct sockaddr* bind_addr = (struct sockaddr*)handle->sock.bind;
-    unsigned int bind_addrlen  = addr_size(bind_addr);
-    struct sockaddr dest_addr;
+    size_t bind_addrlen = addr_size(bind_addr);
+    struct sockaddr_storage dest_addr;
     unsigned int dest_addrlen = sizeof(dest_addr);
     int ret                   = 0;
 
@@ -378,12 +378,13 @@ static int tcp_accept(PAL_HANDLE handle, PAL_HANDLE* client) {
     memset(&sock_options, 0, sizeof(sock_options));
     sock_options.reuseaddr = 1; /* sockets are always set as reusable in Graphene */
 
-    ret = ocall_accept(handle->sock.fd, &dest_addr, &dest_addrlen, &sock_options);
+    ret = ocall_accept(handle->sock.fd, (struct sockaddr*)&dest_addr, &dest_addrlen,
+                       &sock_options);
     if (IS_ERR(ret))
         return unix_to_pal_error(ERRNO(ret));
 
-    *client = socket_create_handle(pal_type_tcp, ret, 0, bind_addr, bind_addrlen, &dest_addr,
-                                   dest_addrlen, &sock_options);
+    *client = socket_create_handle(pal_type_tcp, ret, 0, bind_addr, bind_addrlen,
+                                   (struct sockaddr*)&dest_addr, dest_addrlen, &sock_options);
 
     if (!(*client)) {
         ocall_close(ret);
@@ -395,10 +396,10 @@ static int tcp_accept(PAL_HANDLE handle, PAL_HANDLE* client) {
 
 /* connect on a tcp socket */
 static int tcp_connect(PAL_HANDLE* handle, char* uri, int options) {
-    struct sockaddr buffer[2];
-    struct sockaddr* bind_addr = &buffer[0];
+    struct sockaddr_storage buffer[2];
+    struct sockaddr* bind_addr = (struct sockaddr*)&buffer[0];
     unsigned int bind_addrlen = sizeof(buffer[0]);
-    struct sockaddr* dest_addr = &buffer[1];
+    struct sockaddr* dest_addr = (struct sockaddr*)&buffer[1];
     unsigned int dest_addrlen = sizeof(buffer[1]);
     int ret;
 
@@ -517,8 +518,8 @@ static int64_t tcp_write(PAL_HANDLE handle, uint64_t offset, uint64_t len, const
 
 /* used by 'open' operation of tcp stream for bound socket */
 static int udp_bind(PAL_HANDLE* handle, char* uri, int create, int options) {
-    struct sockaddr buffer;
-    struct sockaddr* bind_addr = &buffer;
+    struct sockaddr_storage buffer;
+    struct sockaddr* bind_addr = (struct sockaddr*)&buffer;
     unsigned int bind_addrlen = sizeof(buffer);
     int ret = 0;
 
@@ -559,10 +560,10 @@ static int udp_bind(PAL_HANDLE* handle, char* uri, int create, int options) {
 
 /* used by 'open' operation of tcp stream for connected socket */
 static int udp_connect(PAL_HANDLE* handle, char* uri, int create, int options) {
-    struct sockaddr buffer[2];
-    struct sockaddr* bind_addr = &buffer[0];
+    struct sockaddr_storage buffer[2];
+    struct sockaddr* bind_addr = (struct sockaddr*)&buffer[0];
     unsigned int bind_addrlen = sizeof(buffer[0]);
-    struct sockaddr* dest_addr = &buffer[1];
+    struct sockaddr* dest_addr = (struct sockaddr*)&buffer[1];
     unsigned int dest_addrlen = sizeof(buffer[1]);
     int ret;
 
@@ -658,10 +659,11 @@ static int64_t udp_receivebyaddr(PAL_HANDLE handle, uint64_t offset, uint64_t le
     if (len != (uint32_t)len)
         return -PAL_ERROR_INVAL;
 
-    struct sockaddr conn_addr;
+    struct sockaddr_storage conn_addr;
     socklen_t conn_addrlen = sizeof(conn_addr);
 
-    ssize_t bytes = ocall_recv(handle->sock.fd, buf, len, &conn_addr, &conn_addrlen, NULL, NULL);
+    ssize_t bytes = ocall_recv(handle->sock.fd, buf, len,
+                               (struct sockaddr*)&conn_addr, &conn_addrlen, NULL, NULL);
 
     if (IS_ERR(bytes))
         return unix_to_pal_error(ERRNO(bytes));
@@ -670,7 +672,8 @@ static int64_t udp_receivebyaddr(PAL_HANDLE handle, uint64_t offset, uint64_t le
     if (!addr_uri)
         return -PAL_ERROR_OVERFLOW;
 
-    int ret = inet_create_uri(addr_uri, addr + addrlen - addr_uri, &conn_addr, conn_addrlen);
+    int ret = inet_create_uri(addr_uri, addr + addrlen - addr_uri,
+                              (struct sockaddr*)&conn_addr, conn_addrlen);
     if (ret < 0)
         return ret;
 
@@ -720,14 +723,15 @@ static int64_t udp_sendbyaddr(PAL_HANDLE handle, uint64_t offset, uint64_t len, 
     char* addrbuf = __alloca(addrlen);
     memcpy(addrbuf, addr, addrlen);
 
-    struct sockaddr conn_addr;
+    struct sockaddr_storage conn_addr;
     unsigned int conn_addrlen = sizeof(conn_addr);
 
-    int ret = inet_parse_uri(&addrbuf, &conn_addr, &conn_addrlen);
+    int ret = inet_parse_uri(&addrbuf, (struct sockaddr*)&conn_addr, &conn_addrlen);
     if (ret < 0)
         return ret;
 
-    ssize_t bytes = ocall_send(handle->sock.fd, buf, len, &conn_addr, conn_addrlen, NULL, 0);
+    ssize_t bytes = ocall_send(handle->sock.fd, buf, len,
+                               (struct sockaddr*)&conn_addr, conn_addrlen, NULL, 0);
     if (IS_ERR(bytes))
         return unix_to_pal_error(ERRNO(bytes));
 

--- a/Pal/src/host/Linux-SGX/linux_types.h
+++ b/Pal/src/host/Linux-SGX/linux_types.h
@@ -130,4 +130,22 @@ struct sockopt {
     int tcp_nodelay : 1;
 };
 
+/* POSIX.1g specifies this type name for the `sa_family' member.  */
+typedef unsigned short int sa_family_t;
+
+/* This macro is used to declare the initial common members
+   of the data types used for socket addresses, `struct sockaddr',
+   `struct sockaddr_in', `struct sockaddr_un', etc.  */
+
+#define __SOCKADDR_COMMON(sa_prefix) \
+  sa_family_t sa_prefix##family
+
+/* From bits/socket.h */
+/* Structure large enough to hold any socket address (with the historical
+   exception of AF_UNIX).  */
+struct sockaddr_storage {
+    __SOCKADDR_COMMON(ss_);    /* Address family, etc.  */
+    char __ss_padding[128 - sizeof(sa_family_t)];
+};
+
 #endif

--- a/Pal/src/host/Linux/db_sockets.c
+++ b/Pal/src/host/Linux/db_sockets.c
@@ -82,12 +82,17 @@ static int inet_parse_uri(char** uri, struct sockaddr* addr, size_t* addrlen) {
     __be16* port_buf;
     size_t slen;
 
+    assert(addrlen);
+
     if (tmp[0] == '[') {
         /* for IPv6, the address will be in the form of
            "[xxxx:xxxx:xxxx:xxxx:xxxx:xxxx:xxxx:xxxx]:port". */
         struct sockaddr_in6* addr_in6 = (struct sockaddr_in6*)addr;
 
-        slen = sizeof(struct sockaddr_in6);
+        slen = sizeof(*addr_in6);
+        if (*addrlen < slen)
+            goto inval;
+
         memset(addr, 0, slen);
 
         end = strchr(tmp + 1, ']');
@@ -106,7 +111,10 @@ static int inet_parse_uri(char** uri, struct sockaddr* addr, size_t* addrlen) {
         /* for IP, the address will be in the form of "x.x.x.x:port". */
         struct sockaddr_in* addr_in = (struct sockaddr_in*)addr;
 
-        slen = sizeof(struct sockaddr_in);
+        slen = sizeof(*addr_in);
+        if (*addrlen < slen)
+            goto inval;
+
         memset(addr, 0, slen);
 
         end = strchr(tmp, ':');
@@ -134,8 +142,7 @@ static int inet_parse_uri(char** uri, struct sockaddr* addr, size_t* addrlen) {
     *port_buf = __htons(atoi(port_str));
     *uri      = *end ? end + 1 : NULL;
 
-    if (addrlen)
-        *addrlen = slen;
+    *addrlen = slen;
 
     return 0;
 
@@ -323,7 +330,7 @@ static bool check_any_addr(struct sockaddr* addr) {
 static int tcp_listen(PAL_HANDLE* handle, char* uri, int create, int options) {
     struct sockaddr buffer;
     struct sockaddr* bind_addr = &buffer;
-    size_t bind_addrlen;
+    size_t bind_addrlen = sizeof(buffer);
     int ret, fd = -1;
 
     if ((ret = socket_parse_uri(uri, &bind_addr, &bind_addrlen, NULL, NULL)) < 0)
@@ -448,9 +455,10 @@ failed:
 /* connect on a tcp socket */
 static int tcp_connect(PAL_HANDLE* handle, char* uri, int options) {
     struct sockaddr buffer[3];
-    struct sockaddr* bind_addr = buffer;
-    struct sockaddr* dest_addr = buffer + 1;
-    size_t bind_addrlen, dest_addrlen;
+    struct sockaddr* bind_addr = &buffer[0];
+    size_t bind_addrlen = sizeof(buffer[0]);
+    struct sockaddr* dest_addr = &buffer[1];
+    size_t dest_addrlen = sizeof(buffer[1]);
     int ret, fd = -1;
 
     /* accepting two kind of different uri:
@@ -501,8 +509,8 @@ static int tcp_connect(PAL_HANDLE* handle, char* uri, int options) {
 
     if (!bind_addr) {
         /* save some space to get socket address */
-        bind_addr    = buffer + 2;
-        bind_addrlen = sizeof(struct sockaddr);
+        bind_addr    = &buffer[2];
+        bind_addrlen = sizeof(buffer[2]);
 
         /* call getsockname to get socket address */
         if ((ret = INLINE_SYSCALL(getsockname, 3, fd, bind_addr, &bind_addrlen)) < 0)
@@ -620,7 +628,7 @@ static int64_t tcp_write(PAL_HANDLE handle, uint64_t offset, size_t len, const v
 static int udp_bind(PAL_HANDLE* handle, char* uri, int create, int options) {
     struct sockaddr buffer;
     struct sockaddr* bind_addr = &buffer;
-    size_t bind_addrlen;
+    size_t bind_addrlen = sizeof(buffer);
     int ret = 0, fd = -1;
 
     if ((ret = socket_parse_uri(uri, &bind_addr, &bind_addrlen, NULL, NULL)) < 0)
@@ -686,9 +694,10 @@ failed:
 /* used by 'open' operation of tcp stream for connected socket */
 static int udp_connect(PAL_HANDLE* handle, char* uri, int create, int options) {
     struct sockaddr buffer[2];
-    struct sockaddr* bind_addr = buffer;
-    struct sockaddr* dest_addr = buffer + 1;
-    size_t bind_addrlen, dest_addrlen;
+    struct sockaddr* bind_addr = &buffer[0];
+    size_t bind_addrlen = sizeof(buffer[0]);
+    struct sockaddr* dest_addr = &buffer[1];
+    size_t dest_addrlen = sizeof(buffer[1]);
     int ret, fd = -1;
 
     if ((ret = socket_parse_uri(uri, &bind_addr, &bind_addrlen, &dest_addr, &dest_addrlen)) < 0)
@@ -899,7 +908,7 @@ static int64_t udp_sendbyaddr(PAL_HANDLE handle, uint64_t offset, size_t len, co
     memcpy(addrbuf, addr, addrlen);
 
     struct sockaddr conn_addr;
-    size_t conn_addrlen;
+    size_t conn_addrlen = sizeof(conn_addr);
 
     int ret = inet_parse_uri(&addrbuf, &conn_addr, &conn_addrlen);
     if (ret < 0)


### PR DESCRIPTION
This series of patches fixes more IPv6 related stack buffer overflows . We first add checks to the size of the passed buffers, which requires each caller to pass in the size of the buffer. If the buffers are too small for what they are used for, we fail the function before touching the buffer. Adapt all callers and extend their buffers by using sockaddr_storage, which also fits a sockaddr_in6.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1487)
<!-- Reviewable:end -->
