### PR TITLE
[Pal] Move page size definitions to new pal_user.h

### DIFF
--- a/Pal/include/arch/x86_64/pal-arch.h
+++ b/Pal/include/arch/x86_64/pal-arch.h
@@ -25,6 +25,8 @@
 
 #include <stdint.h>
 
+#define PRESET_PAGESIZE (1 << 12)
+
 typedef struct pal_tcb PAL_TCB;
 
 static inline PAL_TCB * pal_get_tcb (void)

--- a/Pal/include/arch/x86_64/pal-arch.h
+++ b/Pal/include/arch/x86_64/pal-arch.h
@@ -25,7 +25,8 @@
 
 #include <stdint.h>
 
-#define PRESET_PAGESIZE (1 << 12)
+#define PAGE_SIZE       (1 << 12)
+#define PRESET_PAGESIZE PAGE_SIZE
 
 typedef struct pal_tcb PAL_TCB;
 

--- a/Pal/regression/File.c
+++ b/Pal/regression/File.c
@@ -58,7 +58,7 @@ int main(int argc, char** argv, char** envp) {
 
         /* test file map */
 
-        void* mem1 = (void*)DkStreamMap(file1, NULL, PAL_PROT_READ | PAL_PROT_WRITECOPY, 0, 4096);
+        void* mem1 = (void*)DkStreamMap(file1, NULL, PAL_PROT_READ | PAL_PROT_WRITECOPY, 0, PAGE_SIZE);
         if (mem1) {
             memcpy(buffer1, mem1, 40);
             print_hex("Map Test 1 (0th - 40th): %s\n", buffer1, 40);
@@ -66,14 +66,14 @@ int main(int argc, char** argv, char** envp) {
             memcpy(buffer2, mem1 + 200, 40);
             print_hex("Map Test 2 (200th - 240th): %s\n", buffer2, 40);
 
-            DkStreamUnmap(mem1, 4096);
+            DkStreamUnmap(mem1, PAGE_SIZE);
         } else {
             pal_printf("Map Test 1 & 2: Failed to map buffer\n");
         }
 
         /* DEP 11/24/17: For SGX writecopy exercises a different path in the PAL */
         void* mem2 =
-            (void*)DkStreamMap(file1, NULL, PAL_PROT_READ | PAL_PROT_WRITECOPY, 4096, 4096);
+            (void*)DkStreamMap(file1, NULL, PAL_PROT_READ | PAL_PROT_WRITECOPY, 4096, PAGE_SIZE);
         if (mem2) {
             memcpy(buffer3, mem2, 40);
             print_hex("Map Test 3 (4096th - 4136th): %s\n", buffer3, 40);
@@ -81,7 +81,7 @@ int main(int argc, char** argv, char** envp) {
             memcpy(buffer3, mem2 + 200, 40);
             print_hex("Map Test 4 (4296th - 4336th): %s\n", buffer3, 40);
 
-            DkStreamUnmap(mem2, 4096);
+            DkStreamUnmap(mem2, PAGE_SIZE);
         }
 
         DkObjectClose(file1);

--- a/Pal/src/host/Linux-SGX/pal_linux.h
+++ b/Pal/src/host/Linux-SGX/pal_linux.h
@@ -62,8 +62,6 @@ extern struct pal_linux_state {
 
 #include <asm/mman.h>
 
-#define PRESET_PAGESIZE (1 << 12)
-
 #define DEFAULT_BACKLOG 2048
 
 #define ACCESS_R    4

--- a/Pal/src/host/Linux/pal_linux.h
+++ b/Pal/src/host/Linux/pal_linux.h
@@ -118,8 +118,6 @@ extern struct pal_linux_state {
     (INLINE_SYSCALL(clone, 4, CLONE_VM|CLONE_VFORK, 0, NULL, NULL))
 #endif
 
-#define PRESET_PAGESIZE (1 << 12)
-
 #define DEFAULT_BACKLOG 2048
 
 int clone (int (*__fn) (void * __arg), void * __child_stack,


### PR DESCRIPTION
Move page size definitions to a new pal_user.h , which would be similar to sys/user.h where this definition would typically be found.

Define PAGE_SIZE and use it in a regression test that maps memory of a page.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1491)
<!-- Reviewable:end -->
