### PR TITLE
[Pal & LibOS] Deliver SIGPIPE to an application or terminate it if no handler installed

### DIFF
--- a/LibOS/shim/src/bookkeep/shim_signal.c
+++ b/LibOS/shim/src/bookkeep/shim_signal.c
@@ -644,6 +644,14 @@ static void resume_upcall (PAL_PTR event, PAL_NUM arg, PAL_CONTEXT * context)
     DkExceptionReturn(event);
 }
 
+static void pipe_upcall(PAL_PTR event, PAL_NUM arg, PAL_CONTEXT* context) {
+    if (!is_internal_tid(get_cur_tid()))
+        deliver_signal(ALLOC_SIGINFO(SIGPIPE, 0, si_pid, 0), /*context=*/NULL);
+    else
+        internal_fault("Internal SIGPIPE fault", arg, context);
+    DkExceptionReturn(event);
+}
+
 int init_signal (void)
 {
     DkSetExceptionHandler(&arithmetic_error_upcall,     PAL_EVENT_ARITHMETIC_ERROR);
@@ -652,6 +660,7 @@ int init_signal (void)
     DkSetExceptionHandler(&quit_upcall,        PAL_EVENT_QUIT);
     DkSetExceptionHandler(&suspend_upcall,     PAL_EVENT_SUSPEND);
     DkSetExceptionHandler(&resume_upcall,      PAL_EVENT_RESUME);
+    DkSetExceptionHandler(&pipe_upcall,        PAL_EVENT_PIPE);
     return 0;
 }
 

--- a/LibOS/shim/test/ltp/ltp.cfg
+++ b/LibOS/shim/test/ltp/ltp.cfg
@@ -3243,12 +3243,6 @@ timeout = 40
 [write04]
 skip = yes
 
-[write05]
-timeout = 40
-must-pass =
-    1
-    2
-
 [writev02]
 skip = yes
 

--- a/LibOS/shim/test/regression/.gitignore
+++ b/LibOS/shim/test/regression/.gitignore
@@ -60,6 +60,7 @@
 /sigaction_per_process
 /sigaltstack
 /sighandler_reset
+/sighandler_sigpipe
 /sigprocmask
 /spinlock
 /stat_invalid_args

--- a/LibOS/shim/test/regression/Makefile
+++ b/LibOS/shim/test/regression/Makefile
@@ -52,6 +52,7 @@ c_executables = \
 	sigaction_per_process \
 	sigaltstack \
 	sighandler_reset \
+	sighandler_sigpipe \
 	sigprocmask \
 	spinlock \
 	stat_invalid_args \

--- a/LibOS/shim/test/regression/sighandler_sigpipe.c
+++ b/LibOS/shim/test/regression/sighandler_sigpipe.c
@@ -1,0 +1,63 @@
+#define _XOPEN_SOURCE 700
+#include <errno.h>
+#include <stdatomic.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/signal.h>
+#include <unistd.h>
+
+static atomic_int sigpipe_ctr = 0;
+
+static void sigpipe_handler(int signum, siginfo_t* si, void* uc) {
+    printf("Got signal %d\n", signum);
+    if (signum == SIGPIPE)
+        sigpipe_ctr++;
+}
+
+int main(void) {
+    int fds[2];
+    int n;
+    ssize_t written;
+    const struct sigaction act = {
+        .sa_sigaction = sigpipe_handler,
+    };
+    struct sigaction oldact;
+
+    n = sigaction(SIGPIPE, &act, &oldact);
+    if (n < 0) {
+        fprintf(stderr, "sigaction failed: %s\n", strerror(errno));
+        exit(EXIT_FAILURE);
+    }
+
+    n = pipe(fds);
+    if (n < 0) {
+        fprintf(stderr, "Could not create pipe: %s\n", strerror(errno));
+        exit(EXIT_FAILURE);
+    }
+
+    /* close read end */
+    close(fds[0]);
+
+    written = write(fds[1], "!", 1);
+    /* we expect a failure */
+    if (written < 0) {
+        fprintf(stderr, "Could not write to pipe: %s\n", strerror(errno));
+    }
+
+    printf("Got %d SIGPIPE signal(s)\n", sigpipe_ctr);
+    fflush(stderr);
+    fflush(stdout);
+
+    n = sigaction(SIGPIPE, &oldact, NULL);
+    if (n < 0) {
+        fprintf(stderr, "sigaction failed: %s\n", strerror(errno));
+        exit(EXIT_FAILURE);
+    }
+
+    /* this write has to terminate us */
+    written = write(fds[1], "!", 1);
+    /* we must never get here */
+
+    exit(EXIT_SUCCESS);
+}

--- a/Pal/include/pal/pal.h
+++ b/Pal/include/pal/pal.h
@@ -580,8 +580,10 @@ enum PAL_EVENT {
     PAL_EVENT_RESUME           = 6,
     /*! failure within PAL calls */
     PAL_EVENT_FAILURE          = 7,
+    /*! pipe event */
+    PAL_EVENT_PIPE             = 8,
 
-    PAL_EVENT_NUM_BOUND        = 8,
+    PAL_EVENT_NUM_BOUND        = 9,
 };
 
 typedef void (*PAL_EVENT_HANDLER) (PAL_PTR event, PAL_NUM arg, PAL_CONTEXT*);

--- a/Pal/src/db_exception.c
+++ b/Pal/src/db_exception.c
@@ -47,6 +47,7 @@ struct pal_event_handler handlers[] = {
     [PAL_EVENT_SUSPEND]          = INIT_EVENT_HANDLER,
     [PAL_EVENT_RESUME]           = INIT_EVENT_HANDLER,
     [PAL_EVENT_FAILURE]          = INIT_EVENT_HANDLER,
+    [PAL_EVENT_PIPE]             = INIT_EVENT_HANDLER,
 };
 
 PAL_EVENT_HANDLER _DkGetExceptionHandler(PAL_NUM event) {

--- a/Pal/src/host/Linux/db_exception.c
+++ b/Pal/src/host/Linux/db_exception.c
@@ -173,6 +173,7 @@ static int get_event_num (int signum)
         case SIGTERM:               return PAL_EVENT_QUIT;
         case SIGINT:                return PAL_EVENT_SUSPEND;
         case SIGCONT:               return PAL_EVENT_RESUME;
+        case SIGPIPE:               return PAL_EVENT_PIPE;
         default: return -1;
     }
 }
@@ -295,14 +296,15 @@ static void _DkTerminateSighandler (int signum, siginfo_t * info,
 static void _DkPipeSighandler (int signum, siginfo_t * info,
                                struct ucontext * uc)
 {
-    __UNUSED(signum);
     __UNUSED(info);
+
     assert(signum == SIGPIPE);
 
-    uintptr_t rip = uc->uc_mcontext.gregs[REG_RIP];
-    __UNUSED(rip);
-    assert(ADDR_IN_PAL(rip)); // This signal can only happens inside PAL
-    return;
+    int event_num = get_event_num(signum);
+    assert(event_num == PAL_EVENT_PIPE);
+
+    if (!_DkGenericSignalHandle(event_num, NULL, uc))
+        _DkThreadExit(/*clear_child_tid=*/NULL);
 }
 
 /*
@@ -355,6 +357,8 @@ struct signal_ops on_signals[] = {
                                          .handler = _DkTerminateSighandler },
         [PAL_EVENT_RESUME]           = { .signum = { SIGCONT, 0 },
                                          .handler = _DkTerminateSighandler },
+        [PAL_EVENT_PIPE]             = { .signum = { SIGPIPE, 0 },
+                                         .handler = _DkPipeSighandler },
     };
 
 static int _DkPersistentSighandlerSetup (int event_num)
@@ -378,10 +382,6 @@ void signal_setup (void)
 #endif
         set_sighandler(&sig, 1, NULL);
 
-    sig = SIGPIPE;
-    if ((ret = set_sighandler(&sig, 1, &_DkPipeSighandler)) < 0)
-        goto err;
-
     int events[] = {
         PAL_EVENT_ARITHMETIC_ERROR,
         PAL_EVENT_MEMFAULT,
@@ -389,6 +389,7 @@ void signal_setup (void)
         PAL_EVENT_QUIT,
         PAL_EVENT_SUSPEND,
         PAL_EVENT_RESUME,
+        PAL_EVENT_PIPE,
     };
 
     for (size_t e = 0; e < ARRAY_SIZE(events); e++)


### PR DESCRIPTION
This PR extends the Pal and LibOS to deliver SIGPIPE to an application if it has a signal handler installed or it terminates the applications with the expected termination code (141) if no signal handler has been installed. A test case is provided. One more test case of LTP now passes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1495)
<!-- Reviewable:end -->
