### PR TITLE
[LibOS] Split off x86_64 specifics from common header files

### DIFF
--- a/LibOS/shim/include/arch/x86_64/shim_tcb-arch.h
+++ b/LibOS/shim/include/arch/x86_64/shim_tcb-arch.h
@@ -1,0 +1,27 @@
+#ifndef _SHIM_TCB_ARCH_H_
+#define _SHIM_TCB_ARCH_H_
+
+#include <stdint.h>
+
+struct shim_regs {
+    uint64_t    orig_rax;
+    uint64_t    rsp;
+    uint64_t    r15;
+    uint64_t    r14;
+    uint64_t    r13;
+    uint64_t    r12;
+    uint64_t    r11;
+    uint64_t    r10;
+    uint64_t    r9;
+    uint64_t    r8;
+    uint64_t    rcx;
+    uint64_t    rdx;
+    uint64_t    rsi;
+    uint64_t    rdi;
+    uint64_t    rbx;
+    uint64_t    rbp;
+    uint64_t    rflags;
+    uint64_t    rip;
+};
+
+#endif /* _SHIM_TCB_ARCH_H_ */

--- a/LibOS/shim/include/arch/x86_64/shim_types-arch.h
+++ b/LibOS/shim/include/arch/x86_64/shim_types-arch.h
@@ -1,0 +1,123 @@
+#ifndef _SHIM_TYPES_ARCH_H_
+#define _SHIM_TYPES_ARCH_H_
+
+#include <stdint.h>
+
+/* asm/signal.h */
+#define NUM_SIGS            64
+#define NUM_KNOWN_SIGS      32
+
+typedef struct {
+    unsigned long __val[NUM_SIGS / (8 * sizeof(unsigned long))];
+} __sigset_t;
+
+/* sys/ucontext.h */
+/* Type for general register.  */
+typedef long int greg_t;
+
+/* Number of general registers.  */
+#define NGREG    23
+
+/* Container for all general registers.  */
+typedef greg_t gregset_t[NGREG];
+
+/* Number of each register in the `gregset_t' array.  */
+enum
+{
+    REG_R8 = 0,
+# define REG_R8     REG_R8
+    REG_R9,
+# define REG_R9     REG_R9
+    REG_R10,
+# define REG_R10    REG_R10
+    REG_R11,
+# define REG_R11    REG_R11
+    REG_R12,
+# define REG_R12    REG_R12
+    REG_R13,
+# define REG_R13    REG_R13
+    REG_R14,
+# define REG_R14    REG_R14
+    REG_R15,
+# define REG_R15    REG_R15
+    REG_RDI,
+# define REG_RDI    REG_RDI
+    REG_RSI,
+# define REG_RSI    REG_RSI
+    REG_RBP,
+# define REG_RBP    REG_RBP
+    REG_RBX,
+# define REG_RBX    REG_RBX
+    REG_RDX,
+# define REG_RDX    REG_RDX
+    REG_RAX,
+# define REG_RAX    REG_RAX
+    REG_RCX,
+# define REG_RCX    REG_RCX
+    REG_RSP,
+# define REG_RSP    REG_RSP
+    REG_RIP,
+# define REG_RIP    REG_RIP
+    REG_EFL,
+# define REG_EFL    REG_EFL
+    REG_CSGSFS,        /* Actually short cs, gs, fs, __pad0.  */
+# define REG_CSGSFS REG_CSGSFS
+    REG_ERR,
+# define REG_ERR    REG_ERR
+    REG_TRAPNO,
+# define REG_TRAPNO REG_TRAPNO
+    REG_OLDMASK,
+# define REG_OLDMASK REG_OLDMASK
+    REG_CR2
+# define REG_CR2    REG_CR2
+};
+
+struct _libc_fpxreg {
+    unsigned short int significand[4];
+    unsigned short int exponent;
+    unsigned short int padding[3];
+};
+
+struct _libc_xmmreg {
+    __uint32_t    element[4];
+};
+
+struct _libc_fpstate {
+    /* 64-bit FXSAVE format.  */
+    __uint16_t          cwd;
+    __uint16_t          swd;
+    __uint16_t          ftw;
+    __uint16_t          fop;
+    __uint64_t          rip;
+    __uint64_t          rdp;
+    __uint32_t          mxcsr;
+    __uint32_t          mxcr_mask;
+    struct _libc_fpxreg st[8];
+    struct _libc_xmmreg _xmm[16];
+    __uint32_t          padding[24];
+};
+
+/* Structure to describe FPU registers.  */
+typedef struct _libc_fpstate *fpregset_t;
+
+/* Context to describe whole processor state.  */
+typedef struct {
+    gregset_t gregs;
+    /* Note that fpregs is a pointer.  */
+    fpregset_t fpregs;
+    unsigned long __reserved1 [8];
+} mcontext_t;
+
+/* Userlevel context.  */
+typedef struct ucontext {
+    unsigned long int uc_flags;
+    struct ucontext* uc_link;
+    stack_t uc_stack;
+    mcontext_t uc_mcontext;
+    __sigset_t uc_sigmask;
+    struct _libc_fpstate __fpregs_mem;
+} ucontext_t;
+
+#define RED_ZONE_SIZE   128
+
+#endif /* _SHIM_TYPES_ARCH_H_ */

--- a/LibOS/shim/include/shim_tcb.h
+++ b/LibOS/shim/include/shim_tcb.h
@@ -5,28 +5,9 @@
 #include <atomic.h>
 #include <pal.h>
 
-#define SHIM_TCB_CANARY 0xdeadbeef
+#include "shim_tcb-arch.h"
 
-struct shim_regs {
-    uint64_t    orig_rax;
-    uint64_t    rsp;
-    uint64_t    r15;
-    uint64_t    r14;
-    uint64_t    r13;
-    uint64_t    r12;
-    uint64_t    r11;
-    uint64_t    r10;
-    uint64_t    r9;
-    uint64_t    r8;
-    uint64_t    rcx;
-    uint64_t    rdx;
-    uint64_t    rsi;
-    uint64_t    rdi;
-    uint64_t    rbx;
-    uint64_t    rbp;
-    uint64_t    rflags;
-    uint64_t    rip;
-};
+#define SHIM_TCB_CANARY 0xdeadbeef
 
 struct shim_context {
     struct shim_regs *      regs;

--- a/LibOS/shim/include/shim_types.h
+++ b/LibOS/shim/include/shim_types.h
@@ -29,6 +29,8 @@
 #include <asm/siginfo.h>
 #include <asm/poll.h>
 
+#include "shim_types-arch.h"
+
 typedef unsigned int        __u32;
 
 typedef unsigned long int   nfds_t;
@@ -160,14 +162,6 @@ struct __kernel_sigaction {
 /* linux/aio_abi.h (for io_setup which has no glibc wrapper) */
 typedef unsigned long aio_context_t;
 
-/* asm/signal.h */
-#define NUM_SIGS            64
-#define NUM_KNOWN_SIGS      32
-
-typedef struct {
-    unsigned long __val[NUM_SIGS / (8 * sizeof(unsigned long))];
-} __sigset_t;
-
 /* linux/rlimit.h */
 struct __kernel_rusage {
     struct __kernel_timeval ru_utime;    /* user time used */
@@ -211,115 +205,6 @@ __attribute__((packed));
 #else
 ;
 #endif
-
-/* sys/ucontext.h */
-/* Type for general register.  */
-typedef long int greg_t;
-
-/* Number of general registers.  */
-#define NGREG    23
-
-/* Container for all general registers.  */
-typedef greg_t gregset_t[NGREG];
-
-/* Number of each register in the `gregset_t' array.  */
-enum
-{
-    REG_R8 = 0,
-# define REG_R8     REG_R8
-    REG_R9,
-# define REG_R9     REG_R9
-    REG_R10,
-# define REG_R10    REG_R10
-    REG_R11,
-# define REG_R11    REG_R11
-    REG_R12,
-# define REG_R12    REG_R12
-    REG_R13,
-# define REG_R13    REG_R13
-    REG_R14,
-# define REG_R14    REG_R14
-    REG_R15,
-# define REG_R15    REG_R15
-    REG_RDI,
-# define REG_RDI    REG_RDI
-    REG_RSI,
-# define REG_RSI    REG_RSI
-    REG_RBP,
-# define REG_RBP    REG_RBP
-    REG_RBX,
-# define REG_RBX    REG_RBX
-    REG_RDX,
-# define REG_RDX    REG_RDX
-    REG_RAX,
-# define REG_RAX    REG_RAX
-    REG_RCX,
-# define REG_RCX    REG_RCX
-    REG_RSP,
-# define REG_RSP    REG_RSP
-    REG_RIP,
-# define REG_RIP    REG_RIP
-    REG_EFL,
-# define REG_EFL    REG_EFL
-    REG_CSGSFS,        /* Actually short cs, gs, fs, __pad0.  */
-# define REG_CSGSFS REG_CSGSFS
-    REG_ERR,
-# define REG_ERR    REG_ERR
-    REG_TRAPNO,
-# define REG_TRAPNO REG_TRAPNO
-    REG_OLDMASK,
-# define REG_OLDMASK REG_OLDMASK
-    REG_CR2
-# define REG_CR2    REG_CR2
-};
-
-struct _libc_fpxreg {
-    unsigned short int significand[4];
-    unsigned short int exponent;
-    unsigned short int padding[3];
-};
-
-struct _libc_xmmreg {
-    __uint32_t    element[4];
-};
-
-struct _libc_fpstate {
-    /* 64-bit FXSAVE format.  */
-    __uint16_t          cwd;
-    __uint16_t          swd;
-    __uint16_t          ftw;
-    __uint16_t          fop;
-    __uint64_t          rip;
-    __uint64_t          rdp;
-    __uint32_t          mxcsr;
-    __uint32_t          mxcr_mask;
-    struct _libc_fpxreg st[8];
-    struct _libc_xmmreg _xmm[16];
-    __uint32_t          padding[24];
-};
-
-/* Structure to describe FPU registers.  */
-typedef struct _libc_fpstate *fpregset_t;
-
-/* Context to describe whole processor state.  */
-typedef struct {
-    gregset_t gregs;
-    /* Note that fpregs is a pointer.  */
-    fpregset_t fpregs;
-    unsigned long __reserved1 [8];
-} mcontext_t;
-
-/* Userlevel context.  */
-typedef struct ucontext {
-    unsigned long int uc_flags;
-    struct ucontext *uc_link;
-    stack_t uc_stack;
-    mcontext_t uc_mcontext;
-    __sigset_t uc_sigmask;
-    struct _libc_fpstate __fpregs_mem;
-} ucontext_t;
-
-#define RED_ZONE_SIZE   128
 
 /* bits/ustat.h */
 struct __kernel_ustat

--- a/LibOS/shim/test/inline/Makefile
+++ b/LibOS/shim/test/inline/Makefile
@@ -18,7 +18,9 @@ include ../../../../Scripts/Makefile.configs
 include ../../../../Scripts/Makefile.manifest
 include ../../../../Scripts/Makefile.Test
 
-CFLAGS += -I $(PALDIR)/../include/arch/$(ARCH)
+CFLAGS += \
+	-I $(PALDIR)/../include/arch/$(ARCH) \
+	-I ../../include/arch/$(ARCH)
 
 .PHONY: crt_init-recurse
 crt_init-recurse:


### PR DESCRIPTION
Split off x86_64 specific data structures and move them into x86_64 specific header files.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1499)
<!-- Reviewable:end -->
