### PR TITLE
Use proper integer types in socket-related syscalls and ocalls

### DIFF
--- a/LibOS/shim/include/shim_table.h
+++ b/LibOS/shim/include/shim_table.h
@@ -364,12 +364,12 @@ pid_t shim_do_getpid(void);
 ssize_t shim_do_sendfile(int out_fd, int in_fd, off_t* offset, size_t count);
 int shim_do_socket(int family, int type, int protocol);
 int shim_do_connect(int sockfd, struct sockaddr* addr, int addrlen);
-int shim_do_accept(int fd, struct sockaddr* addr, socklen_t* addrlen);
+int shim_do_accept(int fd, struct sockaddr* addr, int* addrlen);
 ssize_t shim_do_sendto(int fd, const void* buf, size_t len, int flags,
-                       const struct sockaddr* dest_addr, socklen_t addrlen);
+                       const struct sockaddr* dest_addr, int addrlen);
 ssize_t shim_do_recvfrom(int fd, void* buf, size_t len, int flags, struct sockaddr* addr,
-                         socklen_t* addrlen);
-int shim_do_bind(int sockfd, struct sockaddr* addr, socklen_t addrlen);
+                         int* addrlen);
+int shim_do_bind(int sockfd, struct sockaddr* addr, int addrlen);
 int shim_do_listen(int sockfd, int backlog);
 ssize_t shim_do_sendmsg(int fd, struct msghdr* msg, int flags);
 ssize_t shim_do_recvmsg(int fd, struct msghdr* msg, int flags);
@@ -484,17 +484,17 @@ int shim_do_set_robust_list(struct robust_list_head* head, size_t len);
 int shim_do_get_robust_list(pid_t pid, struct robust_list_head** head, size_t* len);
 int shim_do_epoll_pwait(int epfd, struct __kernel_epoll_event* events, int maxevents,
                         int timeout_ms, const __sigset_t* sigmask, size_t sigsetsize);
-int shim_do_accept4(int sockfd, struct sockaddr* addr, socklen_t* addrlen, int flags);
+int shim_do_accept4(int sockfd, struct sockaddr* addr, int* addrlen, int flags);
 int shim_do_dup3(unsigned int oldfd, unsigned int newfd, int flags);
 int shim_do_epoll_create1(int flags);
 int shim_do_pipe2(int* fildes, int flags);
 int shim_do_mknod(const char *pathname, mode_t mode, dev_t dev);
 int shim_do_mknodat(int dirfd, const char *pathname, mode_t mode, dev_t dev);
-ssize_t shim_do_recvmmsg(int sockfd, struct mmsghdr* msg, size_t vlen, int flags,
+ssize_t shim_do_recvmmsg(int sockfd, struct mmsghdr* msg, unsigned int vlen, int flags,
                          struct __kernel_timespec* timeout);
 int shim_do_prlimit64(pid_t pid, int resource, const struct __kernel_rlimit64* new_rlim,
                       struct __kernel_rlimit64* old_rlim);
-ssize_t shim_do_sendmmsg(int sockfd, struct mmsghdr* msg, size_t vlen, int flags);
+ssize_t shim_do_sendmmsg(int sockfd, struct mmsghdr* msg, unsigned int vlen, int flags);
 int shim_do_eventfd2(unsigned int count, int flags);
 int shim_do_eventfd(unsigned int count);
 
@@ -552,12 +552,12 @@ pid_t shim_getpid(void);
 ssize_t shim_sendfile(int out_fd, int in_fd, off_t* offset, size_t count);
 int shim_socket(int family, int type, int protocol);
 int shim_connect(int sockfd, struct sockaddr* addr, int addrlen);
-int shim_accept(int fd, struct sockaddr* addr, socklen_t* addrlen);
+int shim_accept(int fd, struct sockaddr* addr, int* addrlen);
 ssize_t shim_sendto(int fd, const void* buf, size_t len, int flags,
-                    const struct sockaddr* dest_addr, socklen_t addrlen);
+                    const struct sockaddr* dest_addr, int addrlen);
 ssize_t shim_recvfrom(int fd, void* buf, size_t len, int flags, struct sockaddr* addr,
-                      socklen_t* addrlen);
-int shim_bind(int sockfd, struct sockaddr* addr, socklen_t addrlen);
+                      int* addrlen);
+int shim_bind(int sockfd, struct sockaddr* addr, int addrlen);
 int shim_listen(int sockfd, int backlog);
 ssize_t shim_sendmsg(int fd, struct msghdr* msg, int flags);
 ssize_t shim_recvmsg(int fd, struct msghdr* msg, int flags);
@@ -802,7 +802,7 @@ int shim_fallocate(int fd, int mode, loff_t offset, loff_t len);
 int shim_timerfd_settime(int ufd, int flags, const struct __kernel_itimerspec* utmr,
                          struct __kernel_itimerspec* otmr);
 int shim_timerfd_gettime(int ufd, struct __kernel_itimerspec* otmr);
-int shim_accept4(int sockfd, struct sockaddr* addr, socklen_t* addrlen, int flags);
+int shim_accept4(int sockfd, struct sockaddr* addr, int* addrlen, int flags);
 int shim_signalfd4(int ufd, __sigset_t* user_mask, size_t sizemask, int flags);
 int shim_eventfd2(unsigned int count, int flags);
 int shim_epoll_create1(int flags);
@@ -816,11 +816,11 @@ int shim_pwritev(unsigned long fd, const struct iovec* vec, unsigned long vlen, 
 int shim_rt_tgsigqueueinfo(pid_t tgid, pid_t pid, int sig, siginfo_t* uinfo);
 int shim_perf_event_open(struct perf_event_attr* attr_uptr, pid_t pid, int cpu, int group_fd,
                          int flags);
-ssize_t shim_recvmmsg(int sockfd, struct mmsghdr* msg, size_t vlen, int flags,
+ssize_t shim_recvmmsg(int sockfd, struct mmsghdr* msg, unsigned int vlen, int flags,
                       struct __kernel_timespec* timeout);
 int shim_prlimit64(pid_t pid, int resource, const struct __kernel_rlimit64* new_rlim,
                    struct __kernel_rlimit64* old_rlim);
-ssize_t shim_sendmmsg(int sockfd, struct mmsghdr* msg, size_t vlen, int flags);
+ssize_t shim_sendmmsg(int sockfd, struct mmsghdr* msg, unsigned int vlen, int flags);
 
 /* libos call wrappers */
 int shim_msgpersist(int msqid, int cmd);

--- a/LibOS/shim/include/shim_types.h
+++ b/LibOS/shim/include/shim_types.h
@@ -34,7 +34,6 @@ typedef unsigned int        __u32;
 typedef unsigned long int   nfds_t;
 typedef unsigned long int   nlink_t;
 
-typedef uint32_t            socklen_t;
 typedef __kernel_uid_t      uid_t;
 typedef __kernel_gid_t      gid_t;
 typedef __kernel_pid_t      pid_t;
@@ -342,18 +341,15 @@ enum
 
 struct msghdr {
     void *msg_name;         /* Address to send to/receive from.  */
-    socklen_t msg_namelen;  /* Length of address data.  */
+    int msg_namelen;        /* Length of address data.  */
 
     struct iovec *msg_iov;  /* Vector of data to send/receive into.  */
     size_t msg_iovlen;      /* Number of elements in the vector.  */
 
     void *msg_control;      /* Ancillary data (eg BSD filedesc passing). */
-    size_t msg_controllen;  /* Ancillary data buffer length.
-                               !! The type should be socklen_t but the
-                               definition of the kernel is incompatible
-                               with this.  */
+    size_t msg_controllen;  /* Ancillary data buffer length. */
 
-    int msg_flags;          /* Flags on received message.  */
+    unsigned int msg_flags; /* Flags on received message.  */
 };
 
 /* For `recvmmsg'.  */
@@ -457,18 +453,6 @@ struct linux_file_handle {
     unsigned int handle_bytes;
     int handle_type;
     unsigned char f_handle[0];
-};
-
-struct __kernel_addrinfo
-{
-  int ai_flags;                 /* Input flags.  */
-  int ai_family;                /* Protocol family for socket.  */
-  int ai_socktype;              /* Socket type.  */
-  int ai_protocol;              /* Protocol for socket.  */
-  socklen_t ai_addrlen;         /* Length of socket address.  */
-  struct sockaddr *ai_addr;     /* Socket address for socket.  */
-  char *ai_canonname;           /* Canonical name for service location.  */
-  struct addrinfo *ai_next;     /* Pointer to next in list.  */
 };
 
 #include "elf.h"

--- a/LibOS/shim/src/shim_syscalls.c
+++ b/LibOS/shim/src/shim_syscalls.c
@@ -259,20 +259,18 @@ DEFINE_SHIM_SYSCALL(connect, 3, shim_do_connect, int, int, sockfd, struct sockad
                     addrlen)
 
 /* accept: sys/shim_socket.c */
-DEFINE_SHIM_SYSCALL(accept, 3, shim_do_accept, int, int, fd, struct sockaddr*, addr, socklen_t*,
-                    addrlen)
+DEFINE_SHIM_SYSCALL(accept, 3, shim_do_accept, int, int, fd, struct sockaddr*, addr, int*, addrlen)
 
 /* sendto: sys/shim_socket.c */
 DEFINE_SHIM_SYSCALL(sendto, 6, shim_do_sendto, ssize_t, int, fd, const void*, buf, size_t, len, int,
-                    flags, const struct sockaddr*, dest_addr, socklen_t, addrlen)
+                    flags, const struct sockaddr*, dest_addr, int, addrlen)
 
 /* recvfrom : sys/shim_socket.c */
 DEFINE_SHIM_SYSCALL(recvfrom, 6, shim_do_recvfrom, ssize_t, int, fd, void*, buf, size_t, len, int,
-                    flags, struct sockaddr*, addr, socklen_t*, addrlen)
+                    flags, struct sockaddr*, addr, int*, addrlen)
 
 /* bind: sys/shim_socket.c */
-DEFINE_SHIM_SYSCALL(bind, 3, shim_do_bind, int, int, sockfd, struct sockaddr*, addr, socklen_t,
-                    addrlen)
+DEFINE_SHIM_SYSCALL(bind, 3, shim_do_bind, int, int, sockfd, struct sockaddr*, addr, int, addrlen)
 
 /* listen: sys/shim_socket.c */
 DEFINE_SHIM_SYSCALL(listen, 2, shim_do_listen, int, int, sockfd, int, backlog)
@@ -977,7 +975,7 @@ SHIM_SYSCALL_RETURN_ENOSYS(timerfd_gettime, 2, int, int, ufd, struct __kernel_it
 
 /* accept4: sys/shim_socket.c */
 DEFINE_SHIM_SYSCALL(accept4, 4, shim_do_accept4, int, int, sockfd, struct sockaddr*, addr,
-                    socklen_t*, addrlen, int, flags)
+                    int*, addrlen, int, flags)
 
 SHIM_SYSCALL_RETURN_ENOSYS(signalfd4, 4, int, int, ufd, __sigset_t*, user_mask, size_t, sizemask,
                            int, flags)
@@ -1010,8 +1008,8 @@ SHIM_SYSCALL_RETURN_ENOSYS(rt_tgsigqueueinfo, 4, int, pid_t, tgid, pid_t, pid, i
 SHIM_SYSCALL_RETURN_ENOSYS(perf_event_open, 5, int, struct perf_event_attr*, attr_uptr, pid_t, pid,
                            int, cpu, int, group_fd, int, flags)
 
-DEFINE_SHIM_SYSCALL(recvmmsg, 5, shim_do_recvmmsg, ssize_t, int, fd, struct mmsghdr*, msg, size_t,
-                    vlen, int, flags, struct __kernel_timespec*, timeout)
+DEFINE_SHIM_SYSCALL(recvmmsg, 5, shim_do_recvmmsg, ssize_t, int, fd, struct mmsghdr*, msg,
+                    unsigned int, vlen, int, flags, struct __kernel_timespec*, timeout)
 
 SHIM_SYSCALL_RETURN_ENOSYS(fanotify_init, 2, int, int, flags, int, event_f_flags)
 
@@ -1031,8 +1029,8 @@ SHIM_SYSCALL_RETURN_ENOSYS(clock_adjtime, 2, int, clockid_t, which_clock, struct
 
 SHIM_SYSCALL_RETURN_ENOSYS(syncfs, 1, int, int, fd)
 
-DEFINE_SHIM_SYSCALL(sendmmsg, 4, shim_do_sendmmsg, ssize_t, int, fd, struct mmsghdr*, msg, size_t,
-                    vlen, int, flags)
+DEFINE_SHIM_SYSCALL(sendmmsg, 4, shim_do_sendmmsg, ssize_t, int, fd, struct mmsghdr*, msg,
+                    unsigned int, vlen, int, flags)
 
 SHIM_SYSCALL_RETURN_ENOSYS(setns, 2, int, int, fd, int, nstype)
 

--- a/LibOS/shim/src/sys/shim_socket.c
+++ b/LibOS/shim/src/sys/shim_socket.c
@@ -312,7 +312,7 @@ static inline void unix_copy_addr(struct sockaddr* saddr, struct shim_dentry* de
     memcpy(un->sun_path, path, size + 1);
 }
 
-static int inet_check_addr(int domain, struct sockaddr* addr, socklen_t addrlen) {
+static int inet_check_addr(int domain, struct sockaddr* addr, size_t addrlen) {
     if (domain == AF_INET) {
         if (addr->sa_family != AF_INET)
             return -EAFNOSUPPORT;
@@ -332,12 +332,12 @@ static int inet_check_addr(int domain, struct sockaddr* addr, socklen_t addrlen)
     return -EINVAL;
 }
 
-static socklen_t inet_copy_addr(int domain, struct sockaddr* saddr, socklen_t saddr_len,
-                                const struct addr_inet* addr) {
+static size_t inet_copy_addr(int domain, struct sockaddr* saddr, size_t saddr_len,
+                             const struct addr_inet* addr) {
     struct sockaddr_storage ss;
     struct sockaddr_in* in;
     struct sockaddr_in6* in6;
-    socklen_t len = 0;
+    size_t len = 0;
 
     switch (domain) {
       case AF_INET:
@@ -463,7 +463,10 @@ static int hash_to_hex_string(HASHTYPE hash, char* buf, size_t size) {
 }
 
 
-int shim_do_bind(int sockfd, struct sockaddr* addr, socklen_t addrlen) {
+int shim_do_bind(int sockfd, struct sockaddr* addr, int _addrlen) {
+    if (_addrlen < 0)
+        return -EINVAL;
+    size_t addrlen = _addrlen;
     if (!addr || test_user_memory(addr, addrlen, false))
         return -EFAULT;
 
@@ -708,7 +711,11 @@ out:
  * connect again for that socket for one of two reasons: 1. To
  * specify a new IP address and port 2. To unconnect the socket.
  */
-int shim_do_connect(int sockfd, struct sockaddr* addr, int addrlen) {
+int shim_do_connect(int sockfd, struct sockaddr* addr, int _addrlen) {
+    if (_addrlen < 0)
+        return -EINVAL;
+    size_t addrlen = _addrlen;
+
     if (!addr || test_user_memory(addr, addrlen, false))
         return -EFAULT;
 
@@ -861,7 +868,7 @@ out:
     return ret;
 }
 
-int __do_accept(struct shim_handle* hdl, int flags, struct sockaddr* addr, socklen_t* addrlen) {
+int __do_accept(struct shim_handle* hdl, int flags, struct sockaddr* addr, int* addrlen) {
     if (hdl->type != TYPE_SOCK)
         return -ENOTSOCK;
 
@@ -878,7 +885,7 @@ int __do_accept(struct shim_handle* hdl, int flags, struct sockaddr* addr, sockl
         if (!addrlen || test_user_memory(addrlen, sizeof(*addrlen), /*write=*/true))
             return -EINVAL;
 
-        if (*addrlen < minimal_addrlen(sock->domain))
+        if (*addrlen < 0 || (size_t)*addrlen < minimal_addrlen(sock->domain))
             return -EINVAL;
 
         if (test_user_memory(addr, *addrlen, /*write=*/true))
@@ -985,7 +992,7 @@ out:
     return ret;
 }
 
-int shim_do_accept(int fd, struct sockaddr* addr, socklen_t* addrlen) {
+int shim_do_accept(int fd, struct sockaddr* addr, int* addrlen) {
     int flags;
     struct shim_handle* hdl = get_fd_handle(fd, &flags, NULL);
     if (!hdl)
@@ -996,7 +1003,7 @@ int shim_do_accept(int fd, struct sockaddr* addr, socklen_t* addrlen) {
     return ret;
 }
 
-int shim_do_accept4(int fd, struct sockaddr* addr, socklen_t* addrlen, int flags) {
+int shim_do_accept4(int fd, struct sockaddr* addr, int* addrlen, int flags) {
     struct shim_handle* hdl = get_fd_handle(fd, NULL, NULL);
     if (!hdl)
         return -EBADF;
@@ -1009,7 +1016,7 @@ int shim_do_accept4(int fd, struct sockaddr* addr, socklen_t* addrlen, int flags
 }
 
 static ssize_t do_sendmsg(int fd, struct iovec* bufs, int nbufs, int flags,
-                          const struct sockaddr* addr, socklen_t addrlen) {
+                          const struct sockaddr* addr, int addrlen) {
     // Issue #752 - https://github.com/oscarlab/graphene/issues/752
     __UNUSED(flags);
 
@@ -1135,7 +1142,7 @@ out:
 }
 
 ssize_t shim_do_sendto(int sockfd, const void* buf, size_t len, int flags,
-                       const struct sockaddr* addr, socklen_t addrlen) {
+                       const struct sockaddr* addr, int addrlen) {
     struct iovec iovbuf;
     iovbuf.iov_base = (void*)buf;
     iovbuf.iov_len  = len;
@@ -1148,7 +1155,7 @@ ssize_t shim_do_sendmsg(int sockfd, struct msghdr* msg, int flags) {
                       msg->msg_namelen);
 }
 
-ssize_t shim_do_sendmmsg(int sockfd, struct mmsghdr* msg, size_t vlen, int flags) {
+ssize_t shim_do_sendmmsg(int sockfd, struct mmsghdr* msg, unsigned int vlen, int flags) {
     if (test_user_memory(msg, vlen, /*write=*/true))
         return -EFAULT;
 
@@ -1169,7 +1176,7 @@ ssize_t shim_do_sendmmsg(int sockfd, struct mmsghdr* msg, size_t vlen, int flags
 }
 
 static ssize_t do_recvmsg(int fd, struct iovec* bufs, size_t nbufs, int flags,
-                          struct sockaddr* addr, socklen_t* addrlen) {
+                          struct sockaddr* addr, int* addrlen) {
     struct shim_handle* hdl = get_fd_handle(fd, NULL, NULL);
     if (!hdl)
         return -EBADF;
@@ -1188,7 +1195,7 @@ static ssize_t do_recvmsg(int fd, struct iovec* bufs, size_t nbufs, int flags,
         if (!addrlen || test_user_memory(addrlen, sizeof(*addrlen), /*write=*/true))
             goto out;
 
-        if (*addrlen < minimal_addrlen(sock->domain))
+        if (*addrlen < 0 || (size_t)*addrlen < minimal_addrlen(sock->domain))
             goto out;
 
         if (test_user_memory(addr, *addrlen, /*write=*/true))
@@ -1401,7 +1408,7 @@ out:
 }
 
 ssize_t shim_do_recvfrom(int sockfd, void* buf, size_t len, int flags, struct sockaddr* addr,
-                         socklen_t* addrlen) {
+                         int* addrlen) {
     struct iovec iovbuf;
     iovbuf.iov_base = (void*)buf;
     iovbuf.iov_len  = len;
@@ -1414,7 +1421,7 @@ ssize_t shim_do_recvmsg(int sockfd, struct msghdr* msg, int flags) {
                       &msg->msg_namelen);
 }
 
-ssize_t shim_do_recvmmsg(int sockfd, struct mmsghdr* msg, size_t vlen, int flags,
+ssize_t shim_do_recvmmsg(int sockfd, struct mmsghdr* msg, unsigned int vlen, int flags,
                          struct __kernel_timespec* timeout) {
     if (test_user_memory(msg, vlen, /*write=*/true))
         return -EFAULT;

--- a/Pal/src/host/Linux-SGX/db_pipes.c
+++ b/Pal/src/host/Linux-SGX/db_pipes.c
@@ -122,7 +122,7 @@ static int pipe_listen(PAL_HANDLE* handle, const char* name, int options) {
         return -PAL_ERROR_DENIED;
 
     struct sockopt sock_options;
-    unsigned int addrlen = sizeof(struct sockaddr_un);
+    size_t addrlen = sizeof(struct sockaddr_un);
     int nonblock = options & PAL_OPTION_NONBLOCK ? SOCK_NONBLOCK : 0;
 
     ret = ocall_listen(AF_UNIX, SOCK_STREAM | nonblock, 0, /*ipv6_v6only=*/0,

--- a/Pal/src/host/Linux-SGX/enclave_ocalls.c
+++ b/Pal/src/host/Linux-SGX/enclave_ocalls.c
@@ -881,10 +881,10 @@ int ocall_socketpair (int domain, int type, int protocol,
 }
 
 int ocall_listen(int domain, int type, int protocol, int ipv6_v6only,
-                 struct sockaddr* addr, unsigned int* addrlen, struct sockopt* sockopt) {
+                 struct sockaddr* addr, size_t* addrlen, struct sockopt* sockopt) {
     int retval = 0;
-    unsigned int copied;
-    unsigned int len = addrlen ? *addrlen : 0;
+    size_t copied;
+    size_t len = addrlen ? *addrlen : 0;
     ms_ocall_listen_t* ms;
 
     void* old_ustack = sgx_prepare_ustack();
@@ -928,13 +928,11 @@ int ocall_listen(int domain, int type, int protocol, int ipv6_v6only,
     return retval;
 }
 
-int ocall_accept (int sockfd, struct sockaddr * addr,
-                  unsigned int * addrlen, struct sockopt * sockopt)
-{
+int ocall_accept(int sockfd, struct sockaddr* addr, size_t* addrlen, struct sockopt* sockopt) {
     int retval = 0;
-    unsigned int copied;
-    unsigned int len = addrlen ? *addrlen : 0;
-    ms_ocall_accept_t * ms;
+    size_t copied;
+    size_t len = addrlen ? *addrlen : 0;
+    ms_ocall_accept_t* ms;
 
     void* old_ustack = sgx_prepare_ustack();
     ms = sgx_alloc_on_ustack_aligned(sizeof(*ms), alignof(*ms));
@@ -956,8 +954,8 @@ int ocall_accept (int sockfd, struct sockaddr * addr,
 
     if (retval >= 0) {
         if (addr && len) {
-            copied = sgx_copy_to_enclave(addr, len,
-                                         READ_ONCE(ms->ms_addr), READ_ONCE(ms->ms_addrlen));
+            copied = sgx_copy_to_enclave(addr, len, READ_ONCE(ms->ms_addr),
+                                         READ_ONCE(ms->ms_addrlen));
             if (!copied) {
                 sgx_reset_ustack(old_ustack);
                 return -EPERM;
@@ -974,13 +972,12 @@ int ocall_accept (int sockfd, struct sockaddr * addr,
     return retval;
 }
 
-int ocall_connect(int domain, int type, int protocol, int ipv6_v6only,
-                  const struct sockaddr* addr, unsigned int addrlen,
-                  struct sockaddr* bind_addr, unsigned int* bind_addrlen,
+int ocall_connect(int domain, int type, int protocol, int ipv6_v6only, const struct sockaddr* addr,
+                  size_t addrlen, struct sockaddr* bind_addr, size_t* bind_addrlen,
                   struct sockopt* sockopt) {
     int retval = 0;
-    unsigned int copied;
-    unsigned int bind_len = bind_addrlen ? *bind_addrlen : 0;
+    size_t copied;
+    size_t bind_len = bind_addrlen ? *bind_addrlen : 0;
     ms_ocall_connect_t* ms;
 
     void* old_ustack = sgx_prepare_ustack();
@@ -1027,17 +1024,15 @@ int ocall_connect(int domain, int type, int protocol, int ipv6_v6only,
     return retval;
 }
 
-ssize_t ocall_recv(int sockfd, void* buf, size_t count,
-                   struct sockaddr* addr, unsigned int* addrlenptr,
-                   void* control, uint64_t* controllenptr)
-{
+ssize_t ocall_recv(int sockfd, void* buf, size_t count, struct sockaddr* addr, size_t* addrlenptr,
+                   void* control, size_t* controllenptr) {
     ssize_t retval = 0;
-    void * obuf = NULL;
+    void* obuf = NULL;
     bool is_obuf_mapped = false;
-    unsigned int copied;
-    unsigned int addrlen = addrlenptr ? *addrlenptr : 0;
-    uint64_t controllen  = controllenptr ? *controllenptr : 0;
-    ms_ocall_recv_t * ms;
+    size_t copied;
+    size_t addrlen = addrlenptr ? *addrlenptr : 0;
+    size_t controllen  = controllenptr ? *controllenptr : 0;
+    ms_ocall_recv_t* ms;
     bool need_munmap = false;
 
     void* old_ustack = sgx_prepare_ustack();
@@ -1116,14 +1111,12 @@ out:
     return retval;
 }
 
-ssize_t ocall_send (int sockfd, const void* buf, size_t count,
-                    const struct sockaddr* addr, unsigned int addrlen,
-                    void* control, uint64_t controllen)
-{
+ssize_t ocall_send(int sockfd, const void* buf, size_t count, const struct sockaddr* addr,
+                   size_t addrlen, void* control, size_t controllen) {
     ssize_t retval = 0;
-    void * obuf = NULL;
+    void* obuf = NULL;
     bool is_obuf_mapped = false;
-    ms_ocall_send_t * ms;
+    ms_ocall_send_t* ms;
     bool need_munmap;
 
     void* old_ustack = sgx_prepare_ustack();
@@ -1185,11 +1178,9 @@ out:
     return retval;
 }
 
-int ocall_setsockopt (int sockfd, int level, int optname,
-                      const void * optval, unsigned int optlen)
-{
+int ocall_setsockopt(int sockfd, int level, int optname, const void* optval, size_t optlen) {
     int retval = 0;
-    ms_ocall_setsockopt_t * ms;
+    ms_ocall_setsockopt_t* ms;
 
     void* old_ustack = sgx_prepare_ustack();
     ms = sgx_alloc_on_ustack_aligned(sizeof(*ms), alignof(*ms));

--- a/Pal/src/host/Linux-SGX/enclave_ocalls.h
+++ b/Pal/src/host/Linux-SGX/enclave_ocalls.h
@@ -48,27 +48,22 @@ int ocall_mkdir (const char *pathname, unsigned short mode);
 
 int ocall_getdents (int fd, struct linux_dirent64 *dirp, unsigned int size);
 
-int ocall_listen(int domain, int type, int protocol, int ipv6_v6only,
-                 struct sockaddr* addr, unsigned int* addrlen, struct sockopt* sockopt);
+int ocall_listen(int domain, int type, int protocol, int ipv6_v6only, struct sockaddr* addr,
+                 size_t* addrlen, struct sockopt* sockopt);
 
-int ocall_accept (int sockfd, struct sockaddr * addr,
-                  unsigned int * addrlen, struct sockopt * opt);
+int ocall_accept(int sockfd, struct sockaddr* addr, size_t* addrlen, struct sockopt* opt);
 
-int ocall_connect(int domain, int type, int protocol, int ipv6_v6only,
-                  const struct sockaddr* addr, unsigned int addrlen,
-                  struct sockaddr* bind_addr, unsigned int* bind_addrlen,
+int ocall_connect(int domain, int type, int protocol, int ipv6_v6only, const struct sockaddr* addr,
+                  size_t addrlen, struct sockaddr* bind_addr, size_t* bind_addrlen,
                   struct sockopt* sockopt);
 
-ssize_t ocall_recv(int sockfd, void* buf, size_t count,
-                   struct sockaddr* addr, unsigned int* addrlenptr,
-                   void* control, uint64_t* controllenptr);
+ssize_t ocall_recv(int sockfd, void* buf, size_t count, struct sockaddr* addr, size_t* addrlenptr,
+                   void* control, size_t* controllenptr);
 
-ssize_t ocall_send(int sockfd, const void* buf, size_t count,
-                   const struct sockaddr* addr, unsigned int addrlen,
-                   void* control, uint64_t controllen);
+ssize_t ocall_send(int sockfd, const void* buf, size_t count, const struct sockaddr* addr,
+                   size_t addrlen, void* control, size_t controllen);
 
-int ocall_setsockopt (int sockfd, int level, int optname,
-                      const void * optval, unsigned int optlen);
+int ocall_setsockopt(int sockfd, int level, int optname, const void* optval, size_t optlen);
 
 int ocall_shutdown (int sockfd, int how);
 

--- a/Pal/src/host/Linux-SGX/linux_types.h
+++ b/Pal/src/host/Linux-SGX/linux_types.h
@@ -86,11 +86,9 @@ struct sockaddr {
 #define SHUT_RDWR 2
 #endif
 
-typedef unsigned int socklen_t;
-
 struct msghdr {
     void* msg_name;
-    socklen_t msg_namelen;
+    int msg_namelen;
     struct iovec* msg_iov;
     size_t msg_iovlen;
     void* msg_control;

--- a/Pal/src/host/Linux-SGX/ocall_types.h
+++ b/Pal/src/host/Linux-SGX/ocall_types.h
@@ -186,14 +186,14 @@ typedef struct {
     int ms_protocol;
     int ms_ipv6_v6only;
     const struct sockaddr* ms_addr;
-    unsigned int ms_addrlen;
+    size_t ms_addrlen;
     struct sockopt ms_sockopt;
 } ms_ocall_listen_t;
 
 typedef struct {
     int ms_sockfd;
-    struct sockaddr * ms_addr;
-    unsigned int ms_addrlen;
+    struct sockaddr* ms_addr;
+    size_t ms_addrlen;
     struct sockopt ms_sockopt;
 } ms_ocall_accept_t;
 
@@ -203,38 +203,38 @@ typedef struct {
     int ms_protocol;
     int ms_ipv6_v6only;
     const struct sockaddr* ms_addr;
-    unsigned int ms_addrlen;
+    size_t ms_addrlen;
     struct sockaddr* ms_bind_addr;
-    unsigned int ms_bind_addrlen;
+    size_t ms_bind_addrlen;
     struct sockopt ms_sockopt;
 } ms_ocall_connect_t;
 
 typedef struct {
     PAL_IDX ms_sockfd;
-    void * ms_buf;
-    unsigned int ms_count;
-    struct sockaddr * ms_addr;
-    unsigned int ms_addrlen;
-    void * ms_control;
-    uint64_t ms_controllen;
+    void* ms_buf;
+    size_t ms_count;
+    struct sockaddr* ms_addr;
+    size_t ms_addrlen;
+    void* ms_control;
+    size_t ms_controllen;
 } ms_ocall_recv_t;
 
 typedef struct {
     PAL_IDX ms_sockfd;
-    const void * ms_buf;
-    unsigned int ms_count;
-    const struct sockaddr * ms_addr;
-    unsigned int ms_addrlen;
-    void * ms_control;
-    uint64_t ms_controllen;
+    const void* ms_buf;
+    size_t ms_count;
+    const struct sockaddr* ms_addr;
+    size_t ms_addrlen;
+    void* ms_control;
+    size_t ms_controllen;
 } ms_ocall_send_t;
 
 typedef struct {
     int ms_sockfd;
     int ms_level;
     int ms_optname;
-    const void * ms_optval;
-    unsigned int ms_optlen;
+    const void* ms_optval;
+    size_t ms_optlen;
 } ms_ocall_setsockopt_t;
 
 typedef struct {

--- a/Pal/src/host/Linux-SGX/sgx_enclave.c
+++ b/Pal/src/host/Linux-SGX/sgx_enclave.c
@@ -315,16 +315,18 @@ static long sock_getopt(int fd, struct sockopt * opt)
     return 0;
 }
 
-static long sgx_ocall_listen(void * pms)
-{
-    ms_ocall_listen_t * ms = (ms_ocall_listen_t *) pms;
+static long sgx_ocall_listen(void* pms) {
+    ms_ocall_listen_t* ms = (ms_ocall_listen_t*)pms;
     long ret;
     int fd;
     ODEBUG(OCALL_LISTEN, ms);
 
-    ret = INLINE_SYSCALL(socket, 3, ms->ms_domain,
-                         ms->ms_type|SOCK_CLOEXEC,
-                         ms->ms_protocol);
+    if (ms->ms_addrlen > INT_MAX) {
+        ret = -EINVAL;
+        goto err;
+    }
+
+    ret = INLINE_SYSCALL(socket, 3, ms->ms_domain, ms->ms_type | SOCK_CLOEXEC, ms->ms_protocol);
     if (IS_ERR(ret))
         goto err;
 
@@ -344,12 +346,12 @@ static long sgx_ocall_listen(void * pms)
             goto err_fd;
     }
 
-    ret = INLINE_SYSCALL(bind, 3, fd, ms->ms_addr, ms->ms_addrlen);
+    ret = INLINE_SYSCALL(bind, 3, fd, ms->ms_addr, (int)ms->ms_addrlen);
     if (IS_ERR(ret))
         goto err_fd;
 
     if (ms->ms_addr) {
-        socklen_t addrlen = ms->ms_addrlen;
+        int addrlen = ms->ms_addrlen;
         ret = INLINE_SYSCALL(getsockname, 3, fd, ms->ms_addr, &addrlen);
         if (IS_ERR(ret))
             goto err_fd;
@@ -374,16 +376,19 @@ err:
     return ret;
 }
 
-static long sgx_ocall_accept(void * pms)
-{
-    ms_ocall_accept_t * ms = (ms_ocall_accept_t *) pms;
+static long sgx_ocall_accept(void* pms) {
+    ms_ocall_accept_t* ms = (ms_ocall_accept_t*)pms;
     long ret;
     int fd;
     ODEBUG(OCALL_ACCEPT, ms);
-    socklen_t addrlen = ms->ms_addrlen;
 
-    ret = INLINE_SYSCALL(accept4, 4, ms->ms_sockfd, ms->ms_addr,
-                         &addrlen, O_CLOEXEC);
+    if (ms->ms_addrlen > INT_MAX) {
+        ret = -EINVAL;
+        goto err;
+    }
+    int addrlen = ms->ms_addrlen;
+
+    ret = INLINE_SYSCALL(accept4, 4, ms->ms_sockfd, ms->ms_addr, &addrlen, O_CLOEXEC);
     if (IS_ERR(ret))
         goto err;
 
@@ -401,16 +406,18 @@ err:
     return ret;
 }
 
-static long sgx_ocall_connect(void * pms)
-{
-    ms_ocall_connect_t * ms = (ms_ocall_connect_t *) pms;
+static long sgx_ocall_connect(void* pms) {
+    ms_ocall_connect_t* ms = (ms_ocall_connect_t*)pms;
     long ret;
     int fd;
     ODEBUG(OCALL_CONNECT, ms);
 
-    ret = INLINE_SYSCALL(socket, 3, ms->ms_domain,
-                         ms->ms_type|SOCK_CLOEXEC,
-                         ms->ms_protocol);
+    if (ms->ms_addrlen > INT_MAX || ms->ms_bind_addrlen > INT_MAX) {
+        ret = -EINVAL;
+        goto err;
+    }
+
+    ret = INLINE_SYSCALL(socket, 3, ms->ms_domain, ms->ms_type | SOCK_CLOEXEC, ms->ms_protocol);
     if (IS_ERR(ret))
         goto err;
 
@@ -425,8 +432,7 @@ static long sgx_ocall_connect(void * pms)
                 goto err_fd;
         }
 
-        ret = INLINE_SYSCALL(bind, 3, fd, ms->ms_bind_addr,
-                             ms->ms_bind_addrlen);
+        ret = INLINE_SYSCALL(bind, 3, fd, ms->ms_bind_addr, ms->ms_bind_addrlen);
         if (IS_ERR(ret))
             goto err_fd;
     }
@@ -438,8 +444,7 @@ static long sgx_ocall_connect(void * pms)
             do {
                 struct pollfd pfd = { .fd = fd, .events = POLLOUT, .revents = 0, };
                 ret = INLINE_SYSCALL(ppoll, 4, &pfd, 1, NULL, NULL);
-            } while (IS_ERR(ret) &&
-                    ERRNO(ret) == -EWOULDBLOCK);
+            } while (IS_ERR(ret) && ERRNO(ret) == -EWOULDBLOCK);
         }
 
         if (IS_ERR(ret))
@@ -447,9 +452,8 @@ static long sgx_ocall_connect(void * pms)
     }
 
     if (ms->ms_bind_addr && !ms->ms_bind_addr->sa_family) {
-        socklen_t addrlen = ms->ms_bind_addrlen;
-        ret = INLINE_SYSCALL(getsockname, 3, fd, ms->ms_bind_addr,
-                             &addrlen);
+        int addrlen = ms->ms_bind_addrlen;
+        ret = INLINE_SYSCALL(getsockname, 3, fd, ms->ms_bind_addr, &addrlen);
         if (IS_ERR(ret))
             goto err_fd;
         ms->ms_bind_addrlen = addrlen;
@@ -467,13 +471,16 @@ err:
     return ret;
 }
 
-static long sgx_ocall_recv(void * pms)
-{
-    ms_ocall_recv_t * ms = (ms_ocall_recv_t *) pms;
+static long sgx_ocall_recv(void* pms) {
+    ms_ocall_recv_t* ms = (ms_ocall_recv_t*)pms;
     long ret;
     ODEBUG(OCALL_RECV, ms);
-    struct sockaddr * addr = ms->ms_addr;
-    socklen_t addrlen = ms->ms_addr ? ms->ms_addrlen : 0;
+    struct sockaddr* addr = ms->ms_addr;
+
+    if (ms->ms_addr && ms->ms_addrlen > INT_MAX) {
+        return -EINVAL;
+    }
+    int addrlen = ms->ms_addr ? ms->ms_addrlen : 0;
 
     struct msghdr hdr;
     struct iovec iov[1];
@@ -503,13 +510,16 @@ static long sgx_ocall_recv(void * pms)
     return ret;
 }
 
-static long sgx_ocall_send(void * pms)
-{
-    ms_ocall_send_t * ms = (ms_ocall_send_t *) pms;
+static long sgx_ocall_send(void* pms) {
+    ms_ocall_send_t* ms = (ms_ocall_send_t*)pms;
     long ret;
     ODEBUG(OCALL_SEND, ms);
-    const struct sockaddr * addr = ms->ms_addr;
-    socklen_t addrlen = ms->ms_addr ? ms->ms_addrlen : 0;
+    const struct sockaddr* addr = ms->ms_addr;
+
+    if (ms->ms_addr && ms->ms_addrlen > INT_MAX) {
+        return -EINVAL;
+    }
+    int addrlen = ms->ms_addr ? ms->ms_addrlen : 0;
 
     struct msghdr hdr;
     struct iovec iov[1];
@@ -528,14 +538,15 @@ static long sgx_ocall_send(void * pms)
     return ret;
 }
 
-static long sgx_ocall_setsockopt(void * pms)
-{
-    ms_ocall_setsockopt_t * ms = (ms_ocall_setsockopt_t *) pms;
+static long sgx_ocall_setsockopt(void* pms) {
+    ms_ocall_setsockopt_t* ms = (ms_ocall_setsockopt_t*)pms;
     long ret;
     ODEBUG(OCALL_SETSOCKOPT, ms);
-    ret = INLINE_SYSCALL(setsockopt, 5,
-                         ms->ms_sockfd, ms->ms_level, ms->ms_optname,
-                         ms->ms_optval, ms->ms_optlen);
+    if (ms->ms_optlen > INT_MAX) {
+        return -EINVAL;
+    }
+    ret = INLINE_SYSCALL(setsockopt, 5, ms->ms_sockfd, ms->ms_level, ms->ms_optname, ms->ms_optval,
+                         (int)ms->ms_optlen);
     return ret;
 }
 

--- a/Pal/src/host/Linux/db_sockets.c
+++ b/Pal/src/host/Linux/db_sockets.c
@@ -266,12 +266,12 @@ static inline PAL_HANDLE socket_create_handle(int type, int fd, int options,
         hdl->sock.sendbuf    = 0;
     } else {
         int ret, val;
-        socklen_t len = sizeof(int);
+        int len = sizeof(int);
 
-        ret                  = INLINE_SYSCALL(getsockopt, 5, fd, SOL_SOCKET, SO_RCVBUF, &val, &len);
+        ret = INLINE_SYSCALL(getsockopt, 5, fd, SOL_SOCKET, SO_RCVBUF, &val, &len);
         hdl->sock.receivebuf = IS_ERR(ret) ? 0 : val;
 
-        ret               = INLINE_SYSCALL(getsockopt, 5, fd, SOL_SOCKET, SO_SNDBUF, &val, &len);
+        ret = INLINE_SYSCALL(getsockopt, 5, fd, SOL_SOCKET, SO_SNDBUF, &val, &len);
         hdl->sock.sendbuf = IS_ERR(ret) ? 0 : val;
     }
 
@@ -419,7 +419,7 @@ static int tcp_accept(PAL_HANDLE handle, PAL_HANDLE* client) {
     struct sockaddr* bind_addr = (struct sockaddr*)handle->sock.bind;
     size_t bind_addrlen        = addr_size(bind_addr);
     struct sockaddr_storage buffer;
-    socklen_t addrlen = sizeof(buffer);
+    int addrlen = sizeof(buffer);
     int ret           = 0;
 
     int newfd = INLINE_SYSCALL(accept4, 4, handle->sock.fd, &buffer, &addrlen, SOCK_CLOEXEC);
@@ -435,7 +435,7 @@ static int tcp_accept(PAL_HANDLE handle, PAL_HANDLE* client) {
         }
 
     struct sockaddr* dest_addr = (struct sockaddr*)&buffer;
-    size_t dest_addrlen        = addrlen;
+    size_t dest_addrlen = addrlen;
 
     *client = socket_create_handle(pal_type_tcp, newfd, 0, bind_addr, bind_addrlen, dest_addr,
                                    dest_addrlen);
@@ -828,14 +828,13 @@ static int64_t udp_receivebyaddr(PAL_HANDLE handle, uint64_t offset, size_t len,
         return -PAL_ERROR_BADHANDLE;
 
     struct sockaddr_storage conn_addr;
-    socklen_t conn_addrlen = sizeof(conn_addr);
 
     struct msghdr hdr;
     struct iovec iov;
     iov.iov_base       = buf;
     iov.iov_len        = len;
     hdr.msg_name       = &conn_addr;
-    hdr.msg_namelen    = conn_addrlen;
+    hdr.msg_namelen    = sizeof(conn_addr);
     hdr.msg_iov        = &iov;
     hdr.msg_iovlen     = 1;
     hdr.msg_control    = NULL;


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

This contains two socket-related changes, which would be hard to factor out into two commits: (because of compilation warnings)

- Making ocalls use `size_t` in their interface. It's not the same as Linux syscall interface anyway, so why not make it sane?
- Fixing sycalls arguments types to match the ones use by kernel. Note: there's no such type as `socklen_t` in the kernel, so it got removed.

This is an SGX follow-up to #1487. It's also a small step towards resolving #152.

## How to test this PR? <!-- (if applicable) -->

Just Jenkins, I guess.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1501)
<!-- Reviewable:end -->
