### PR TITLE
[Pal] Copy precise number of bytes into PAL_CONTEXT

### DIFF
--- a/Pal/src/host/Linux/db_exception.c
+++ b/Pal/src/host/Linux/db_exception.c
@@ -185,11 +185,11 @@ static void _DkGenericEventTrigger(PAL_EVENT_HANDLER upcall,
     }
 
     PAL_CONTEXT context;
-    memcpy(&context, uc->uc_mcontext.gregs, sizeof(context));
+    memcpy(&context, uc->uc_mcontext.gregs, sizeof(uc->uc_mcontext.gregs));
     context.fpregs = (PAL_XREGS_STATE*)uc->uc_mcontext.fpregs;
     (*upcall)(NULL, arg, &context);
     /* copy the context back to ucontext */
-    memcpy(uc->uc_mcontext.gregs, &context, sizeof(context));
+    memcpy(uc->uc_mcontext.gregs, &context, sizeof(uc->uc_mcontext.gregs));
     uc->uc_mcontext.fpregs = (struct _libc_fpstate*)context.fpregs;
 }
 


### PR DESCRIPTION
The PAL_CONTEXT is larger than uc_mcontext.gregs, so be careful in
copying the precise number of bytes out of uc_mcontext.gregs and
back into them to avoid reading from or writing into unrelated memory.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1502)
<!-- Reviewable:end -->
