### PR TITLE
[Pal] Relax addrlen check to require buffer to be 'large enough'

### DIFF
--- a/Pal/src/host/Linux-SGX/db_sockets.c
+++ b/Pal/src/host/Linux-SGX/db_sockets.c
@@ -153,7 +153,7 @@ static int inet_create_uri(char* uri, int count, struct sockaddr* addr, size_t a
     int len = 0;
 
     if (addr->sa_family == AF_INET) {
-        if (addrlen != sizeof(struct sockaddr_in))
+        if (addrlen < sizeof(struct sockaddr_in))
             return -PAL_ERROR_INVAL;
 
         struct sockaddr_in* addr_in = (struct sockaddr_in*)addr;
@@ -163,7 +163,7 @@ static int inet_create_uri(char* uri, int count, struct sockaddr* addr, size_t a
         len = snprintf(uri, count, "%u.%u.%u.%u:%u", (unsigned char)addr[0], (unsigned char)addr[1],
                        (unsigned char)addr[2], (unsigned char)addr[3], __ntohs(addr_in->sin_port));
     } else if (addr->sa_family == AF_INET6) {
-        if (addrlen != sizeof(struct sockaddr_in6))
+        if (addrlen < sizeof(struct sockaddr_in6))
             return -PAL_ERROR_INVAL;
 
         struct sockaddr_in6* addr_in6 = (struct sockaddr_in6*)addr;

--- a/Pal/src/host/Linux/db_sockets.c
+++ b/Pal/src/host/Linux/db_sockets.c
@@ -155,7 +155,7 @@ static int inet_create_uri(char* uri, size_t count, struct sockaddr* addr, size_
     size_t len = 0;
 
     if (addr->sa_family == AF_INET) {
-        if (addrlen != sizeof(struct sockaddr_in))
+        if (addrlen < sizeof(struct sockaddr_in))
             return -PAL_ERROR_INVAL;
 
         struct sockaddr_in* addr_in = (struct sockaddr_in*)addr;
@@ -165,7 +165,7 @@ static int inet_create_uri(char* uri, size_t count, struct sockaddr* addr, size_
         len = snprintf(uri, count, "%u.%u.%u.%u:%u", (unsigned char)addr[0], (unsigned char)addr[1],
                        (unsigned char)addr[2], (unsigned char)addr[3], __ntohs(addr_in->sin_port));
     } else if (addr->sa_family == AF_INET6) {
-        if (addrlen != sizeof(struct sockaddr_in6))
+        if (addrlen < sizeof(struct sockaddr_in6))
             return -PAL_ERROR_INVAL;
 
         struct sockaddr_in6* addr_in6 = (struct sockaddr_in6*)addr;


### PR DESCRIPTION
Relax the addrlen check in inet_create_uri to only ensure that the passed buffer is large enough but doesn't need to be precise the needed size. This addresses the caller from udp_receivebyaddr that calls us like this:

```C
struct sockaddr_storage conn_addr;
socklen_t conn_addrlen = sizeof(conn_addr);

struct msghdr hdr;
struct iovec iov;
iov.iov_base       = buf;
iov.iov_len        = len;
hdr.msg_name       = &conn_addr;
hdr.msg_namelen    = conn_addrlen;
[...]

int ret = inet_create_uri(addr_uri, addr + addrlen - addr_uri,
                          (struct sockaddr*)&conn_addr, hdr.msg_namelen);
```

hdr.msg_namelen indicates a buffer that is bigger than needed, so we should be able to accept it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1503)
<!-- Reviewable:end -->
