### PR TITLE
[Pal] Move x86_64 syscall arch_prctl into pal_set_tcb

### DIFF
--- a/LibOS/shim/src/Makefile
+++ b/LibOS/shim/src/Makefile
@@ -8,9 +8,9 @@ CFLAGS += -fPIC -Winline -Wwrite-strings \
 	  $(cc-option, -Wnull-dereference) \
 	  -fno-stack-protector -fno-builtin -Wno-inline \
 	  -I../include -I../include/arch/$(ARCH) \
-	  -I../../../Pal/include/lib -I../../../Pal/include/pal \
+	  -I../../../Pal/include -I../../../Pal/include/lib -I../../../Pal/include/pal \
 	  -I../../../Pal/include/elf -I../../../Pal/include/lib/$(ARCH) \
-	  -I../../../Pal/include/arch/$(ARCH)
+	  -I../../../Pal/include/arch/$(ARCH) -I../../../Pal/include/arch/$(ARCH)/$(PAL_HOST)
 
 CFLAGS += -Wextra
 

--- a/LibOS/shim/test/inline/Makefile
+++ b/LibOS/shim/test/inline/Makefile
@@ -19,8 +19,10 @@ include ../../../../Scripts/Makefile.manifest
 include ../../../../Scripts/Makefile.Test
 
 CFLAGS += \
+	-I ../../include/arch/$(ARCH) \
+	-I $(PALDIR)/../include \
 	-I $(PALDIR)/../include/arch/$(ARCH) \
-	-I ../../include/arch/$(ARCH)
+	-I $(PALDIR)/../include/arch/$(ARCH)/$(PAL_HOST)
 
 .PHONY: crt_init-recurse
 crt_init-recurse:

--- a/Pal/include/arch/x86_64/Linux-SGX/pal_host-arch.h
+++ b/Pal/include/arch/x86_64/Linux-SGX/pal_host-arch.h
@@ -1,0 +1,26 @@
+/*
+   This file is part of Graphene Library OS.
+
+   Graphene Library OS is free software: you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public License
+   as published by the Free Software Foundation, either version 3 of the
+   License, or (at your option) any later version.
+
+   Graphene Library OS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
+
+/*
+ * pal_host-arch.h
+ *
+ * This file contains Linux-SGX-specific functions related to the PAL.
+ */
+
+#ifndef __LINUX_SGX_X86_64_PAL_HOST_ARCH_H__
+#define __LINUX_SGX_X86_64_PAL_HOST_ARCH_H__
+
+#endif /* __LINUX_SGX_X86_64_PAL_HOST_ARCH_H__ */

--- a/Pal/include/arch/x86_64/Linux/pal_host-arch.h
+++ b/Pal/include/arch/x86_64/Linux/pal_host-arch.h
@@ -1,0 +1,42 @@
+/*
+   This file is part of Graphene Library OS.
+
+   Graphene Library OS is free software: you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public License
+   as published by the Free Software Foundation, either version 3 of the
+   License, or (at your option) any later version.
+
+   Graphene Library OS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
+
+/*
+ * pal_host-arch.h
+ *
+ * This file contains Linux on x86_64 specific functions related to the PAL.
+ */
+
+#ifndef __LINUX_X86_64_PAL_HOST_ARCH_H__
+#define __LINUX_X86_64_PAL_HOST_ARCH_H__
+
+#ifdef IN_PAL
+
+#if defined(__i386__)
+#include <asm/ldt.h>
+#else
+#include <asm/prctl.h>
+#endif
+
+#include "sysdep-arch.h"
+
+static inline int pal_set_tcb(PAL_TCB* tcb) {
+    return INLINE_SYSCALL(arch_prctl, 2, ARCH_SET_GS, tcb);
+}
+
+#endif /* IN_PAL */
+
+#endif /* __LINUX_X86_64_PAL_HOST_ARCH_H__ */

--- a/Pal/include/arch/x86_64/Linux/sysdep-arch.h
+++ b/Pal/include/arch/x86_64/Linux/sysdep-arch.h
@@ -19,6 +19,7 @@
 #ifndef _LINUX_X86_64_SYSDEP_ARCH_H
 #define _LINUX_X86_64_SYSDEP_ARCH_H 1
 
+#include <syscall.h>
 #include <sysdeps/generic/sysdep.h>
 
 /* For Linux we can use the system call table in the header file

--- a/Pal/include/arch/x86_64/Skeleton/pal_host-arch.h
+++ b/Pal/include/arch/x86_64/Skeleton/pal_host-arch.h
@@ -1,0 +1,22 @@
+/*
+   This file is part of Graphene Library OS.
+
+   Graphene Library OS is free software: you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public License
+   as published by the Free Software Foundation, either version 3 of the
+   License, or (at your option) any later version.
+
+   Graphene Library OS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
+
+/*
+ * pal_host-arch.h
+ *
+ * This file contains Skeleton-specific functions related to the PAL.
+ */
+

--- a/Pal/include/arch/x86_64/pal-arch.h
+++ b/Pal/include/arch/x86_64/pal-arch.h
@@ -39,6 +39,8 @@ typedef struct pal_tcb {
     /* data private to PAL implementation follows this struct. */
 } PAL_TCB;
 
+#include "pal_host-arch.h"
+
 static inline PAL_TCB * pal_get_tcb (void)
 {
     PAL_TCB * tcb;

--- a/Pal/lib/Makefile
+++ b/Pal/lib/Makefile
@@ -3,7 +3,7 @@ include ../../Scripts/Makefile.rules
 include ../src/host/$(PAL_HOST)/Makefile.am
 
 CFLAGS += -I../include/lib -I../include -I../include/pal -I../include/arch/$(ARCH) \
-          -I../include/host/$(PAL_HOST) \
+          -I../include/arch/$(ARCH)/$(PAL_HOST) -I../include/host/$(PAL_HOST) \
           -I../src/host/$(PAL_HOST) -Icrypto/mbedtls/include -Icrypto/mbedtls/crypto/include
 
 CRYPTO_PROVIDER ?= mbedtls

--- a/Pal/regression/Makefile
+++ b/Pal/regression/Makefile
@@ -2,8 +2,13 @@ include ../../Scripts/Makefile.configs
 include ../../Scripts/Makefile.rules
 
 CFLAGS	+= -Wp,-U_FORTIFY_SOURCE -fno-builtin -nostdlib \
-	  -I../include/pal -I../include/lib -I../src -I../include/lib/$(ARCH) \
-	  -I../include/arch/$(ARCH)
+	  -I../src \
+	  -I../include \
+	  -I../include/pal \
+	  -I../include/lib \
+	  -I../include/lib/$(ARCH) \
+	  -I../include/arch/$(ARCH) \
+	  -I../include/arch/$(ARCH)/$(PAL_HOST)
 
 preloads = \
 	Preload1.so \

--- a/Pal/src/Makefile
+++ b/Pal/src/Makefile
@@ -21,7 +21,8 @@ OBJ_DIR = $(HOST_DIR)/.obj
 include host/$(PAL_HOST)/Makefile.am
 
 CFLAGS += -I. -I../include -I../include/pal -I../include/$(HOST_DIR) \
-    -I$(HOST_DIR) -I../include/lib -I../include/arch/$(ARCH) -I../include/lib/$(ARCH)
+    -I$(HOST_DIR) -I../include/lib -I../include/arch/$(ARCH) -I../include/arch/$(ARCH)/$(PAL_HOST) \
+    -I../include/lib/$(ARCH)
 
 PAL_HOST_MACRO = $(shell echo $(PAL_HOST) | tr '[:lower:]' '[:upper:]' | tr '-' '_')
 

--- a/Pal/src/host/Linux/db_threading.c
+++ b/Pal/src/host/Linux/db_threading.c
@@ -36,12 +36,6 @@
 #include <linux/types.h>
 #include <linux/wait.h>
 
-#if defined(__i386__)
-#include <asm/ldt.h>
-#else
-#include <asm/prctl.h>
-#endif
-
 /* Linux PAL cannot use mmap/unmap to manage thread stacks because this may overlap with
  * pal_control.user_address. Linux PAL also cannot just use malloc/free because DkThreadExit
  * needs to use raw system calls and inline asm. Thus, we resort to recycling thread stacks
@@ -100,12 +94,11 @@ out:
  * of the thread. The rest of the TCB is used as the alternative stack for signal
  * handling.
  */
-int pal_thread_init (void * tcbptr)
-{
-    PAL_TCB_LINUX * tcb = tcbptr;
+int pal_thread_init(void* tcbptr) {
+    PAL_TCB_LINUX* tcb = tcbptr;
     int ret;
 
-    ret = INLINE_SYSCALL(arch_prctl, 2, ARCH_SET_GS, tcb);
+    ret = pal_set_tcb(&tcb->common);
     if (IS_ERR(ret))
         return -ERRNO(ret);
 
@@ -246,7 +239,7 @@ noreturn void _DkThreadExit(int* clear_child_tid) {
         ss.ss_size  = 0;
 
         // Take precautions to unset the TCB and alternative stack first.
-        INLINE_SYSCALL(arch_prctl, 2, ARCH_SET_GS, 0);
+        pal_set_tcb(NULL);
         INLINE_SYSCALL(sigaltstack, 2, &ss, NULL);
     }
 

--- a/Pal/src/host/Skeleton/Makefile
+++ b/Pal/src/host/Skeleton/Makefile
@@ -1,9 +1,16 @@
 include ../../../../Scripts/Makefile.configs
 include Makefile.am
 
-CFLAGS  += -I. -I../.. -I../../../include  -I../../../include/pal \
+CFLAGS  += \
+	-I. \
+	-I../.. \
+	-I../../../include  \
 	-I../../../include/arch/$(ARCH) \
-	-I../../../include/host/Skeleton -I../../../include/lib -I../../../include/lib/$(ARCH)
+	-I../../../include/arch/$(ARCH)/$(PAL_HOST) \
+	-I../../../include/host/Skeleton \
+	-I../../../include/lib \
+	-I../../../include/lib/$(ARCH) \
+	-I../../../include/pal
 ASFLAGS += -I. -I../.. -I../../../include
 
 host_files = libpal-Skeleton.a pal.map


### PR DESCRIPTION
Move the x86_64 specific syscall arch_prctrl into a new inline function
pal_set_tcb located in include/arch/x86_64/Linux/pal_host-arch.h

The SGX build also needs a pal_host-arch.h, which can be empty at this
point.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1504)
<!-- Reviewable:end -->
