### PR TITLE
[PAL] Define a macro for copying to and from PAL_CONTEXT

### DIFF
--- a/Pal/src/host/Linux/db_exception.c
+++ b/Pal/src/host/Linux/db_exception.c
@@ -186,12 +186,12 @@ static void _DkGenericEventTrigger(PAL_EVENT_HANDLER upcall,
     }
 
     PAL_CONTEXT context;
-    memcpy(&context, uc->uc_mcontext.gregs, sizeof(uc->uc_mcontext.gregs));
-    context.fpregs = (PAL_XREGS_STATE*)uc->uc_mcontext.fpregs;
+    ucontext_to_pal_context(&context, uc);
+
     (*upcall)(NULL, arg, &context);
+
     /* copy the context back to ucontext */
-    memcpy(uc->uc_mcontext.gregs, &context, sizeof(uc->uc_mcontext.gregs));
-    uc->uc_mcontext.fpregs = (struct _libc_fpstate*)context.fpregs;
+    pal_context_to_ucontext(uc, &context);
 }
 
 static bool _DkGenericSignalHandle (int event_num, siginfo_t * info,


### PR DESCRIPTION
Define a macro for copying CPU context between PAL_CONTEXT and
ucontext_t. Add an assert to make sure that the number of registers
in both contexts is the same.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1505)
<!-- Reviewable:end -->
