### PR TITLE
[LibOS] Fix typo "hdl1" to "hdl2" in socketpair()

### DIFF
--- a/LibOS/shim/src/sys/shim_pipe.c
+++ b/LibOS/shim/src/sys/shim_pipe.c
@@ -196,7 +196,7 @@ int shim_do_socketpair(int domain, int type, int protocol, int* sv) {
 
     hdl2->type = TYPE_SOCK;
     set_handle_fs(hdl2, &socket_builtin_fs);
-    hdl1->flags       = O_WRONLY;
+    hdl2->flags       = O_WRONLY;
     hdl2->acc_mode    = MAY_READ | MAY_WRITE;
     sock2->domain     = domain;
     sock2->sock_type  = type & ~(SOCK_NONBLOCK | SOCK_CLOEXEC);


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

This PR fixes a blooper in `socketpair()`. Graphene worked correctly despite this blooper because (apparently) `flags` are not really checked/enforced on UNIX domain sockets.

## How to test this PR? <!-- (if applicable) -->

All tests must run.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1506)
<!-- Reviewable:end -->
