### PR TITLE
[PAL] Use va_list *ap for 2nd level functions

### DIFF
--- a/LibOS/shim/include/shim_internal.h
+++ b/LibOS/shim/include/shim_internal.h
@@ -74,7 +74,7 @@ extern PAL_HANDLE debug_handle;
 void debug_printf (const char * fmt, ...) __attribute__((format (printf, 1, 2)));
 void debug_puts (const char * str);
 void debug_putch (int ch);
-void debug_vprintf (const char * fmt, va_list ap) __attribute__((format (printf, 1, 0)));
+void debug_vprintf (const char * fmt, va_list* ap) __attribute__((format (printf, 1, 0)));
 
 #define VMID_PREFIX     "[P%05u] "
 #define TID_PREFIX      "[%-6u] "

--- a/LibOS/shim/src/shim_parser.c
+++ b/LibOS/shim/src/shim_parser.c
@@ -41,33 +41,33 @@
 #include <shim_tcb.h>
 #include <shim_utils.h>
 
-static void parse_open_flags(va_list);
-static void parse_open_mode(va_list);
-static void parse_access_mode(va_list);
-static void parse_clone_flags(va_list);
-static void parse_mmap_prot(va_list);
-static void parse_mmap_flags(va_list);
-static void parse_exec_args(va_list);
-static void parse_exec_envp(va_list);
-static void parse_pipe_fds(va_list);
-static void parse_signum(va_list);
-static void parse_sigmask(va_list);
-static void parse_sigprocmask_how(va_list);
-static void parse_timespec(va_list);
-static void parse_sockaddr(va_list);
-static void parse_domain(va_list);
-static void parse_socktype(va_list);
-static void parse_futexop(va_list);
-static void parse_ioctlop(va_list);
-static void parse_fcntlop(va_list);
-static void parse_seek(va_list);
-static void parse_at_fdcwd(va_list);
-static void parse_wait_option(va_list);
+static void parse_open_flags(va_list*);
+static void parse_open_mode(va_list*);
+static void parse_access_mode(va_list*);
+static void parse_clone_flags(va_list*);
+static void parse_mmap_prot(va_list*);
+static void parse_mmap_flags(va_list*);
+static void parse_exec_args(va_list*);
+static void parse_exec_envp(va_list*);
+static void parse_pipe_fds(va_list*);
+static void parse_signum(va_list*);
+static void parse_sigmask(va_list*);
+static void parse_sigprocmask_how(va_list*);
+static void parse_timespec(va_list*);
+static void parse_sockaddr(va_list*);
+static void parse_domain(va_list*);
+static void parse_socktype(va_list*);
+static void parse_futexop(va_list*);
+static void parse_ioctlop(va_list*);
+static void parse_fcntlop(va_list*);
+static void parse_seek(va_list*);
+static void parse_at_fdcwd(va_list*);
+static void parse_wait_option(va_list*);
 
 struct parser_table {
     int slow;
     int stop;
-    void (*parser[6])(va_list);
+    void (*parser[6])(va_list*);
 } syscall_parser_table[LIBOS_SYSCALL_BOUND] =
     {
         {.slow = 1, .parser = {NULL}}, /* read */
@@ -415,9 +415,9 @@ static inline int is_pointer(const char* type) {
         debug_vprintf(fmt, ap); \
     } while (0)
 
-static inline void parse_string_arg(va_list ap) {
+static inline void parse_string_arg(va_list* ap) {
     va_list ap_test_arg;
-    va_copy(ap_test_arg, ap);
+    va_copy(ap_test_arg, *ap);
     const char* test_arg = va_arg(ap_test_arg, const char*);
     if (!test_user_string(test_arg)) {
         VPRINTF("\"%s\"", ap);
@@ -428,16 +428,16 @@ static inline void parse_string_arg(va_list ap) {
     va_end(ap_test_arg);
 }
 
-static inline void parse_pointer_arg(va_list ap) {
+static inline void parse_pointer_arg(va_list* ap) {
     VPRINTF("%p", ap);
 }
 
-static inline void parse_integer_arg(va_list ap) {
+static inline void parse_integer_arg(va_list* ap) {
     VPRINTF("%d", ap);
 }
 
-static inline void parse_syscall_args(va_list ap) {
-    const char* arg_type = va_arg(ap, const char*);
+static inline void parse_syscall_args(va_list* ap) {
+    const char* arg_type = va_arg(*ap, const char*);
 
     if (!strcmp_static(arg_type, "const char *") || !strcmp_static(arg_type, "const char*"))
         parse_string_arg(ap);
@@ -447,21 +447,21 @@ static inline void parse_syscall_args(va_list ap) {
         parse_integer_arg(ap);
 }
 
-static inline void skip_syscall_args(va_list ap) {
-    const char* arg_type = va_arg(ap, const char*);
+static inline void skip_syscall_args(va_list* ap) {
+    const char* arg_type = va_arg(*ap, const char*);
 
     if (!strcmp_static(arg_type, "const char *") || !strcmp_static(arg_type, "const char*"))
-        va_arg(ap, const char*);
+        va_arg(*ap, const char*);
     else if (is_pointer(arg_type))
-        va_arg(ap, void*);
+        va_arg(*ap, void*);
     else
-        va_arg(ap, int);
+        va_arg(*ap, int);
 }
 
 void sysparser_printf(const char* fmt, ...) {
     va_list ap;
     va_start(ap, fmt);
-    VPRINTF(fmt, ap);
+    VPRINTF(fmt, &ap);
     va_end(ap);
 }
 
@@ -489,9 +489,9 @@ void parse_syscall_before(int sysno, const char* name, int nr, ...) {
         if (parser->parser[i]) {
             const char* type = va_arg(ap, const char*);
             __UNUSED(type);  // type not needed on this path
-            (*parser->parser[i])(ap);
+            (*parser->parser[i])(&ap);
         } else {
-            parse_syscall_args(ap);
+            parse_syscall_args(&ap);
         }
     }
 
@@ -528,7 +528,7 @@ void parse_syscall_after(int sysno, const char* name, int nr, ...) {
     if (!parser->slow || parser->stop)
         for (int i = 0; i < nr; i++) {
             if (parser->stop && i < parser->stop) {
-                skip_syscall_args(ap);
+                skip_syscall_args(&ap);
                 continue;
             }
 
@@ -538,9 +538,9 @@ void parse_syscall_after(int sysno, const char* name, int nr, ...) {
             if (parser->parser[i]) {
                 const char* type = va_arg(ap, const char*);
                 __UNUSED(type);  // type not needed on this path
-                (*parser->parser[i])(ap);
+                (*parser->parser[i])(&ap);
             } else {
-                parse_syscall_args(ap);
+                parse_syscall_args(&ap);
             }
         }
 
@@ -556,8 +556,8 @@ void parse_syscall_after(int sysno, const char* name, int nr, ...) {
     va_end(ap);
 }
 
-static void parse_open_flags(va_list ap) {
-    int flags = va_arg(ap, int);
+static void parse_open_flags(va_list* ap) {
+    int flags = va_arg(*ap, int);
 
     if (flags & O_WRONLY) {
         PUTS("O_WRONLY");
@@ -590,12 +590,12 @@ static void parse_open_flags(va_list ap) {
         PRINTF("|%o", flags);
 }
 
-static void parse_open_mode(va_list ap) {
+static void parse_open_mode(va_list* ap) {
     VPRINTF("%04o", ap);
 }
 
-static void parse_access_mode(va_list ap) {
-    int mode = va_arg(ap, int);
+static void parse_access_mode(va_list* ap) {
+    int mode = va_arg(*ap, int);
 
     PUTS("F_OK");
 
@@ -609,8 +609,8 @@ static void parse_access_mode(va_list ap) {
     }
 }
 
-static void parse_clone_flags(va_list ap) {
-    int flags = va_arg(ap, int);
+static void parse_clone_flags(va_list* ap) {
+    int flags = va_arg(*ap, int);
 
 #define FLG(n) \
     { "CLONE_" #n, CLONE_##n, }
@@ -668,8 +668,8 @@ static void parse_clone_flags(va_list ap) {
         PRINTF("|0x%x", flags);
 }
 
-static void parse_mmap_prot(va_list ap) {
-    int prot   = va_arg(ap, int);
+static void parse_mmap_prot(va_list* ap) {
+    int prot   = va_arg(*ap, int);
     int nflags = 0;
 
     if (prot == PROT_NONE) {
@@ -697,8 +697,8 @@ static void parse_mmap_prot(va_list ap) {
     }
 }
 
-static void parse_mmap_flags(va_list ap) {
-    int flags = va_arg(ap, int);
+static void parse_mmap_flags(va_list* ap) {
+    int flags = va_arg(*ap, int);
 
     if (flags & MAP_SHARED) {
         PUTS("MAP_SHARED");
@@ -736,8 +736,8 @@ static void parse_mmap_flags(va_list ap) {
         PRINTF("|0x%x", flags);
 }
 
-static void parse_exec_args(va_list ap) {
-    const char** args = va_arg(ap, const char**);
+static void parse_exec_args(va_list* ap) {
+    const char** args = va_arg(*ap, const char**);
 
     PUTS("[");
 
@@ -759,8 +759,8 @@ static void parse_exec_args(va_list ap) {
     PUTS("]");
 }
 
-static void parse_exec_envp(va_list ap) {
-    const char** envp = va_arg(ap, const char**);
+static void parse_exec_envp(va_list* ap) {
+    const char** envp = va_arg(*ap, const char**);
 
     if (!envp) {
         PUTS("NULL");
@@ -791,8 +791,8 @@ static void parse_exec_envp(va_list ap) {
     PUTS("]");
 }
 
-static void parse_pipe_fds(va_list ap) {
-    int* fds = va_arg(ap, int*);
+static void parse_pipe_fds(va_list* ap) {
+    int* fds = va_arg(*ap, int*);
 
     if (test_user_memory(fds, 2 * sizeof(*fds), false)) {
         PRINTF("[invalid-addr %p]", fds);
@@ -811,8 +811,8 @@ const char* const siglist[NUM_KNOWN_SIGS + 1] = {
     S(SIGWINCH),  S(SIGIO),   S(SIGPWR),    S(SIGSYS),  S(SIGRTMIN),
 };
 
-static void parse_signum(va_list ap) {
-    int signum = va_arg(ap, int);
+static void parse_signum(va_list* ap) {
+    int signum = va_arg(*ap, int);
 
     if (signum >= 0 && signum <= NUM_KNOWN_SIGS)
         PUTS(signal_name(signum));
@@ -820,8 +820,8 @@ static void parse_signum(va_list ap) {
         PRINTF("[SIG %d]", signum);
 }
 
-static void parse_sigmask(va_list ap) {
-    __sigset_t* sigset = va_arg(ap, __sigset_t*);
+static void parse_sigmask(va_list* ap) {
+    __sigset_t* sigset = va_arg(*ap, __sigset_t*);
 
     if (!sigset) {
         PUTS("NULL");
@@ -844,8 +844,8 @@ static void parse_sigmask(va_list ap) {
     PUTS("]");
 }
 
-static void parse_sigprocmask_how(va_list ap) {
-    int how = va_arg(ap, int);
+static void parse_sigprocmask_how(va_list* ap) {
+    int how = va_arg(*ap, int);
 
     switch (how) {
         case SIG_BLOCK:
@@ -863,8 +863,8 @@ static void parse_sigprocmask_how(va_list ap) {
     }
 }
 
-static void parse_timespec(va_list ap) {
-    const struct timespec* tv = va_arg(ap, const struct timespec*);
+static void parse_timespec(va_list* ap) {
+    const struct timespec* tv = va_arg(*ap, const struct timespec*);
 
     if (!tv) {
         PUTS("NULL");
@@ -879,8 +879,8 @@ static void parse_timespec(va_list ap) {
     PRINTF("[%ld,%ld]", tv->tv_sec, tv->tv_nsec);
 }
 
-static void parse_sockaddr(va_list ap) {
-    const struct sockaddr* addr = va_arg(ap, const struct sockaddr*);
+static void parse_sockaddr(va_list* ap) {
+    const struct sockaddr* addr = va_arg(*ap, const struct sockaddr*);
 
     if (!addr) {
         PUTS("NULL");
@@ -924,8 +924,8 @@ static void parse_sockaddr(va_list ap) {
     }
 }
 
-static void parse_domain(va_list ap) {
-    int domain = va_arg(ap, int);
+static void parse_domain(va_list* ap) {
+    int domain = va_arg(*ap, int);
 
 #define PF_UNSPEC    0  /* Unspecified.  */
 #define PF_INET      2  /* IP protocol family.  */
@@ -978,8 +978,8 @@ static void parse_domain(va_list ap) {
     }
 }
 
-static void parse_socktype(va_list ap) {
-    int socktype = va_arg(ap, int);
+static void parse_socktype(va_list* ap) {
+    int socktype = va_arg(*ap, int);
 
     if (socktype & SOCK_NONBLOCK) {
         socktype &= ~SOCK_NONBLOCK;
@@ -1022,8 +1022,8 @@ static void parse_socktype(va_list ap) {
     }
 }
 
-static void parse_futexop(va_list ap) {
-    int op = va_arg(ap, int);
+static void parse_futexop(va_list* ap) {
+    int op = va_arg(*ap, int);
 
 #ifdef FUTEX_PRIVATE_FLAG
     if (op & FUTEX_PRIVATE_FLAG) {
@@ -1072,8 +1072,8 @@ static void parse_futexop(va_list ap) {
     }
 }
 
-static void parse_fcntlop(va_list ap) {
-    int op = va_arg(ap, int);
+static void parse_fcntlop(va_list* ap) {
+    int op = va_arg(*ap, int);
 
     switch (op) {
         case F_DUPFD:
@@ -1136,8 +1136,8 @@ static void parse_fcntlop(va_list ap) {
     }
 }
 
-static void parse_ioctlop(va_list ap) {
-    int op = va_arg(ap, int);
+static void parse_ioctlop(va_list* ap) {
+    int op = va_arg(*ap, int);
 
     if (op >= TCGETS && op <= TIOCVHANGUP) {
         const char* opnames[] = {
@@ -1193,8 +1193,8 @@ static void parse_ioctlop(va_list ap) {
     PRINTF("OP 0x%04x", op);
 }
 
-static void parse_seek(va_list ap) {
-    int seek = va_arg(ap, int);
+static void parse_seek(va_list* ap) {
+    int seek = va_arg(*ap, int);
 
     switch (seek) {
         case SEEK_CUR:
@@ -1212,8 +1212,8 @@ static void parse_seek(va_list ap) {
     }
 }
 
-static void parse_at_fdcwd(va_list ap) {
-    int fd = va_arg(ap, int);
+static void parse_at_fdcwd(va_list* ap) {
+    int fd = va_arg(*ap, int);
 
     switch (fd) {
         case AT_FDCWD:
@@ -1225,8 +1225,8 @@ static void parse_at_fdcwd(va_list ap) {
     }
 }
 
-static void parse_wait_option(va_list ap) {
-    int option = va_arg(ap, int);
+static void parse_wait_option(va_list* ap) {
+    int option = va_arg(*ap, int);
 
     if (option & WNOHANG)
         PUTS("WNOHANG");

--- a/LibOS/shim/src/utils/printf.c
+++ b/LibOS/shim/src/utils/printf.c
@@ -98,14 +98,14 @@ void debug_putch(int ch) {
     debug_fputch(NULL, ch, shim_get_tcb()->debug_buf);
 }
 
-void debug_vprintf(const char* fmt, va_list ap) {
-    vfprintfmt((void*)debug_fputch, NULL, shim_get_tcb()->debug_buf, fmt, (va_list*)&ap);
+void debug_vprintf(const char* fmt, va_list* ap) {
+    vfprintfmt((void*)debug_fputch, NULL, shim_get_tcb()->debug_buf, fmt, ap);
 }
 
 void debug_printf(const char* fmt, ...) {
     va_list ap;
     va_start(ap, fmt);
-    debug_vprintf(fmt, ap);
+    debug_vprintf(fmt, &ap);
     va_end(ap);
 }
 

--- a/LibOS/shim/src/utils/printf.c
+++ b/LibOS/shim/src/utils/printf.c
@@ -99,7 +99,7 @@ void debug_putch(int ch) {
 }
 
 void debug_vprintf(const char* fmt, va_list ap) {
-    vfprintfmt((void*)debug_fputch, NULL, shim_get_tcb()->debug_buf, fmt, ap);
+    vfprintfmt((void*)debug_fputch, NULL, shim_get_tcb()->debug_buf, fmt, (va_list*)&ap);
 }
 
 void debug_printf(const char* fmt, ...) {
@@ -153,7 +153,7 @@ static void sys_fputch(void* f, int ch, void* b) {
 }
 
 static void sys_vfprintf(PAL_HANDLE hdl, const char* fmt, va_list ap) {
-    vfprintfmt((void*)&sys_fputch, hdl, NULL, fmt, ap);
+    vfprintfmt((void*)&sys_fputch, hdl, NULL, fmt, (va_list *)&ap);
 }
 
 void handle_printf(PAL_HANDLE hdl, const char* fmt, ...) {

--- a/Pal/include/lib/api.h
+++ b/Pal/include/lib/api.h
@@ -196,7 +196,7 @@ void fprintfmt (int (*_fputch)(void *, int, void *), void * f, void * putdat,
                 const char * fmt, ...) __attribute__((format(printf, 4, 5)));
 
 void vfprintfmt (int (*_fputch)(void *, int, void *), void * f, void * putdat,
-                 const char * fmt, va_list ap) __attribute__((format(printf, 4, 0)));
+                 const char* fmt, va_list* ap) __attribute__((format(printf, 4, 0)));
 
 int vsnprintf(char* buf, size_t n, const char* fmt, va_list ap);
 int snprintf(char* buf, size_t n, const char* fmt, ...) __attribute__((format(printf, 3, 4)));

--- a/Pal/lib/stdlib/printfmt.c
+++ b/Pal/lib/stdlib/printfmt.c
@@ -40,42 +40,42 @@ static int printnum(int (*_fputch)(void*, int, void*), void* f, void* putdat, un
 // Get an unsigned int of various possible sizes from a varargs list,
 // depending on the lflag parameter.
 #if !defined(__i386__)
-static inline unsigned long long getuint(va_list ap, int lflag)
+static inline unsigned long long getuint(va_list* ap, int lflag)
 #else
-static inline unsigned long getuint(va_list ap, int lflag)
+static inline unsigned long getuint(va_list* ap, int lflag)
 #endif
 {
 #if !defined(__i386__)
     if (lflag >= 2)
-        return va_arg(ap, unsigned long long);
+        return va_arg(*ap, unsigned long long);
 #endif
     if (lflag)
-        return va_arg(ap, unsigned long);
-    return va_arg(ap, unsigned int);
+        return va_arg(*ap, unsigned long);
+    return va_arg(*ap, unsigned int);
 }
 
 // Same as getuint but signed - can't use getuint
 // because of sign extension
 #if !defined(__i386__)
-static inline long long getint(va_list ap, int lflag)
+static inline long long getint(va_list* ap, int lflag)
 #else
-static inline long getint(va_list ap, int lflag)
+static inline long getint(va_list* ap, int lflag)
 #endif
 {
 #if !defined(__i386__)
     if (lflag >= 2)
-        return va_arg(ap, long long);
+        return va_arg(*ap, long long);
 #endif
     if (lflag)
-        return va_arg(ap, long);
-    return va_arg(ap, int);
+        return va_arg(*ap, long);
+    return va_arg(*ap, int);
 }
 
 // Main function to format and print a string.
 void fprintfmt(int (*_fputch)(void*, int, void*), void* f, void* putdat, const char* fmt, ...);
 
 void vfprintfmt(int (*_fputch)(void*, int, void*), void* f, void* putdat, const char* fmt,
-                va_list ap) {
+                va_list* ap) {
     register const char* p;
     register int ch;
 #if !defined(__i386__)
@@ -131,7 +131,7 @@ void vfprintfmt(int (*_fputch)(void*, int, void*), void* f, void* putdat, const 
                 goto process_precision;
 
             case '*':
-                precision = va_arg(ap, int);
+                precision = va_arg(*ap, int);
                 goto process_precision;
 
             case '.':
@@ -155,13 +155,13 @@ void vfprintfmt(int (*_fputch)(void*, int, void*), void* f, void* putdat, const 
 
             // character
             case 'c':
-                if ((*_fputch)(f, va_arg(ap, int), putdat) == -1)
+                if ((*_fputch)(f, va_arg(*ap, int), putdat) == -1)
                     return;
                 break;
 
             // string
             case 's':
-                if ((p = va_arg(ap, char*)) == NULL)
+                if ((p = va_arg(*ap, char*)) == NULL)
                     p = "(null)";
                 if (width > 0 && padc != '-')
                     for (width -= strnlen(p, precision); width > 0; width--)
@@ -220,9 +220,9 @@ void vfprintfmt(int (*_fputch)(void*, int, void*), void* f, void* putdat, const 
                 if ((*_fputch)(f, 'x', putdat) == -1)
                     return;
 #if !defined(__i386__)
-                num = (unsigned long long)(uintptr_t)va_arg(ap, void*);
+                num = (unsigned long long)(uintptr_t)va_arg(*ap, void*);
 #else
-                num = (unsigned long)(uintptr_t)va_arg(ap, void*);
+                num = (unsigned long)(uintptr_t)va_arg(*ap, void*);
 #endif
                 base = 16;
                 goto number;
@@ -261,7 +261,7 @@ void fprintfmt(int (*_fputch)(void*, int, void*), void* f, void* putdat, const c
     va_list ap;
 
     va_start(ap, fmt);
-    vfprintfmt(_fputch, f, putdat, fmt, ap);
+    vfprintfmt(_fputch, f, putdat, fmt, &ap);
     va_end(ap);
 }
 
@@ -288,7 +288,7 @@ int vsnprintf(char* buf, size_t n, const char* fmt, va_list ap) {
         return 0;
 
     // print the string to the buffer
-    vfprintfmt((void*)sprintputch, (void*)0, &b, fmt, ap);
+    vfprintfmt((void*)sprintputch, (void*)0, &b, fmt, (va_list *)&ap);
 
     // null terminate the buffer
     if (b.cnt < n)

--- a/Pal/src/printf.c
+++ b/Pal/src/printf.c
@@ -54,7 +54,7 @@ vprintf(const char * fmt, va_list ap)
 
     b.idx = 0;
     b.cnt = 0;
-    vfprintfmt((void *) &fputch, NULL, &b, fmt, ap);
+    vfprintfmt((void *) &fputch, NULL, &b, fmt, (va_list *)&ap);
     _DkPrintConsole(b.buf, b.idx);
 
     return b.cnt;


### PR DESCRIPTION
On powerpc64 the function that is called with a 'va_list ap' parameter
must either process the 'ap' parameter itself or must pass it to other
functions as a pointer. So those 2nd level functions need to have a
parameter 'va_list *ap'. This patch now solves this problem using va_list *ap
wherever necessary assuming this solves the issue for all architectures.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1509)
<!-- Reviewable:end -->
