### PR TITLE
[LibOS,Pal] Add MSG_DONTWAIT and SCM_RIGHTS for recvmsg/sendmsg

### DIFF
--- a/LibOS/shim/include/shim_table.h
+++ b/LibOS/shim/include/shim_table.h
@@ -490,11 +490,11 @@ int shim_do_epoll_create1(int flags);
 int shim_do_pipe2(int* fildes, int flags);
 int shim_do_mknod(const char *pathname, mode_t mode, dev_t dev);
 int shim_do_mknodat(int dirfd, const char *pathname, mode_t mode, dev_t dev);
-ssize_t shim_do_recvmmsg(int sockfd, struct mmsghdr* msg, unsigned int vlen, int flags,
-                         struct __kernel_timespec* timeout);
+int shim_do_recvmmsg(int sockfd, struct mmsghdr* msg, unsigned int vlen, int flags,
+                     struct __kernel_timespec* timeout);
 int shim_do_prlimit64(pid_t pid, int resource, const struct __kernel_rlimit64* new_rlim,
                       struct __kernel_rlimit64* old_rlim);
-ssize_t shim_do_sendmmsg(int sockfd, struct mmsghdr* msg, unsigned int vlen, int flags);
+int shim_do_sendmmsg(int sockfd, struct mmsghdr* msg, unsigned int vlen, int flags);
 int shim_do_eventfd2(unsigned int count, int flags);
 int shim_do_eventfd(unsigned int count);
 
@@ -816,11 +816,11 @@ int shim_pwritev(unsigned long fd, const struct iovec* vec, unsigned long vlen, 
 int shim_rt_tgsigqueueinfo(pid_t tgid, pid_t pid, int sig, siginfo_t* uinfo);
 int shim_perf_event_open(struct perf_event_attr* attr_uptr, pid_t pid, int cpu, int group_fd,
                          int flags);
-ssize_t shim_recvmmsg(int sockfd, struct mmsghdr* msg, unsigned int vlen, int flags,
-                      struct __kernel_timespec* timeout);
+int shim_recvmmsg(int sockfd, struct mmsghdr* msg, unsigned int vlen, int flags,
+                  struct __kernel_timespec* timeout);
 int shim_prlimit64(pid_t pid, int resource, const struct __kernel_rlimit64* new_rlim,
                    struct __kernel_rlimit64* old_rlim);
-ssize_t shim_sendmmsg(int sockfd, struct mmsghdr* msg, unsigned int vlen, int flags);
+int shim_sendmmsg(int sockfd, struct mmsghdr* msg, unsigned int vlen, int flags);
 
 /* libos call wrappers */
 int shim_msgpersist(int msqid, int cmd);

--- a/LibOS/shim/include/shim_types.h
+++ b/LibOS/shim/include/shim_types.h
@@ -333,10 +333,12 @@ struct __kernel_ustat
 /* bits/socket.h */
 enum
 {
-    MSG_OOB  = 0x01, /* Process out-of-band data. */
-    MSG_PEEK = 0x02, /* Peek at incoming messages. */
+    MSG_OOB      = 0x01, /* Process out-of-band data. */
+    MSG_PEEK     = 0x02, /* Peek at incoming messages. */
+    MSG_DONTWAIT = 0x40, /* Nonblocking IO.  */
 #define MSG_OOB MSG_OOB
 #define MSG_PEEK MSG_PEEK
+#define MSG_DONTWAIT MSG_DONTWAIT
 };
 
 struct msghdr {
@@ -357,6 +359,17 @@ struct mmsghdr {
     struct msghdr msg_hdr;  /* Actual message header.  */
     unsigned int msg_len;   /* Number of received bytes for the entry.  */
 };
+
+/* Structure used for storage of ancillary data object information. */
+struct cmsghdr {
+    size_t cmsg_len;
+    int cmsg_level;
+    int cmsg_type;
+};
+
+#ifndef SCM_RIGHTS
+#define SCM_RIGHTS 1
+#endif
 
 /* POSIX.1g specifies this type name for the `sa_family' member.  */
 typedef unsigned short int sa_family_t;

--- a/LibOS/shim/include/shim_utils.h
+++ b/LibOS/shim/include/shim_utils.h
@@ -211,6 +211,7 @@ int create_pipe(char* name, char* uri, size_t size, PAL_HANDLE* hdl, struct shim
 int create_dir(const char* prefix, char* path, size_t size, struct shim_handle** hdl);
 int create_file(const char* prefix, char* path, size_t size, struct shim_handle** hdl);
 int create_handle(const char* prefix, char* path, size_t size, PAL_HANDLE* hdl, unsigned int* id);
+int bind_dummy_socket_to_pal_handle(PAL_HANDLE pal_hdl, struct shim_handle** out_hdl);
 
 /* Asynchronous event support */
 int init_async(void);

--- a/LibOS/shim/src/shim_syscalls.c
+++ b/LibOS/shim/src/shim_syscalls.c
@@ -1008,7 +1008,7 @@ SHIM_SYSCALL_RETURN_ENOSYS(rt_tgsigqueueinfo, 4, int, pid_t, tgid, pid_t, pid, i
 SHIM_SYSCALL_RETURN_ENOSYS(perf_event_open, 5, int, struct perf_event_attr*, attr_uptr, pid_t, pid,
                            int, cpu, int, group_fd, int, flags)
 
-DEFINE_SHIM_SYSCALL(recvmmsg, 5, shim_do_recvmmsg, ssize_t, int, fd, struct mmsghdr*, msg,
+DEFINE_SHIM_SYSCALL(recvmmsg, 5, shim_do_recvmmsg, int, int, fd, struct mmsghdr*, msg,
                     unsigned int, vlen, int, flags, struct __kernel_timespec*, timeout)
 
 SHIM_SYSCALL_RETURN_ENOSYS(fanotify_init, 2, int, int, flags, int, event_f_flags)
@@ -1029,7 +1029,7 @@ SHIM_SYSCALL_RETURN_ENOSYS(clock_adjtime, 2, int, clockid_t, which_clock, struct
 
 SHIM_SYSCALL_RETURN_ENOSYS(syncfs, 1, int, int, fd)
 
-DEFINE_SHIM_SYSCALL(sendmmsg, 4, shim_do_sendmmsg, ssize_t, int, fd, struct mmsghdr*, msg,
+DEFINE_SHIM_SYSCALL(sendmmsg, 4, shim_do_sendmmsg, int, int, fd, struct mmsghdr*, msg,
                     unsigned int, vlen, int, flags)
 
 SHIM_SYSCALL_RETURN_ENOSYS(setns, 2, int, int, fd, int, nstype)

--- a/LibOS/shim/test/ltp/ltp.cfg
+++ b/LibOS/shim/test/ltp/ltp.cfg
@@ -2309,9 +2309,11 @@ skip = yes
 [sendfile09_64]
 skip = yes
 
+# requires root and tries to execute system() to bring up loop back device
 [sendmsg01]
 skip = yes
 
+# requires root and is a bug reproducer for obscure selinux_socket_unix_may_send()
 [sendmsg02]
 skip = yes
 

--- a/LibOS/shim/test/regression/.gitignore
+++ b/LibOS/shim/test/regression/.gitignore
@@ -55,6 +55,7 @@
 /pselect
 /readdir
 /sched
+/scm_rights
 /select
 /shared_object
 /sigaltstack

--- a/LibOS/shim/test/regression/Makefile
+++ b/LibOS/shim/test/regression/Makefile
@@ -47,6 +47,7 @@ c_executables = \
 	pselect \
 	readdir \
 	sched \
+	scm_rights \
 	select \
 	shared_object \
 	sigaltstack \

--- a/LibOS/shim/test/regression/scm_rights.c
+++ b/LibOS/shim/test/regression/scm_rights.c
@@ -1,0 +1,289 @@
+#define _GNU_SOURCE
+#include <errno.h>
+#include <fcntl.h>
+#include <sched.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/un.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#define UNIX_SOCKET_NAME "dummy_unix_socket"
+
+#define VLEN 5
+#define BUFSIZE 100
+
+#define STR_ONE   "one"
+#define STR_TWO   "two"
+#define STR_THREE "three"
+#define STR_HELLO "hello world"
+
+/* ancillary data buffer, wrapped in a union in order to ensure it is suitably aligned */
+union {
+    char buf[CMSG_SPACE(sizeof(int)) * 2];  /* want to send two cmsg */
+    struct cmsghdr align;
+} cmsghdr_union;
+
+/* pipe to be transmitted from parent process to child via SCM_RIGHTS */
+int pipefds[2] = {-1, -1};
+
+int server(void) {
+    int ret;
+
+    ret = pipe(pipefds);
+    if (ret < 0) {
+        perror("[parent] pipe error");
+        exit(1);
+    }
+
+    int listen_fd = socket(AF_UNIX, SOCK_STREAM, 0);
+    if (listen_fd < 0) {
+        perror("[parent] socket error");
+        exit(1);
+    }
+
+    struct sockaddr_un address;
+    address.sun_family = AF_UNIX;
+    strncpy(address.sun_path, UNIX_SOCKET_NAME, sizeof(address.sun_path));
+
+    ret = bind(listen_fd, (struct sockaddr*)&address, sizeof(address));
+    if (ret < 0) {
+        close(listen_fd);
+        perror("[parent] bind error");
+        exit(1);
+    }
+
+    ret = listen(listen_fd, 3);
+    if (ret < 0) {
+        close(listen_fd);
+        perror("[parent] listen error");
+        exit(1);
+    }
+
+    socklen_t addrlen = sizeof(address);
+
+    int fd = accept(listen_fd, (struct sockaddr*)&address, &addrlen);
+    if (fd < 0) {
+        close(listen_fd);
+        perror("[parent] accept error");
+        exit(1);
+    }
+
+    if (close(listen_fd) < 0) {
+        perror("[parent] close error");
+        exit(1);
+    }
+
+    puts("[parent] The client is connected...");
+
+    struct mmsghdr msg[2] = {0};
+    struct iovec msg1[2]  = {0};
+    struct iovec msg2     = {0};
+
+	msg1[0].iov_base = STR_ONE;
+	msg1[0].iov_len = strlen(STR_ONE);
+	msg1[1].iov_base = STR_TWO;
+	msg1[1].iov_len = strlen(STR_TWO);
+
+	msg2.iov_base = STR_THREE;
+	msg2.iov_len = strlen(STR_THREE);
+
+	msg[0].msg_hdr.msg_iov = msg1;
+	msg[0].msg_hdr.msg_iovlen = 2;
+
+	msg[1].msg_hdr.msg_iov = &msg2;
+	msg[1].msg_hdr.msg_iovlen = 1;
+
+    /* send two ends of the pipe as ancillary data in two cmsg's (just for fun) */
+    msg[0].msg_hdr.msg_control = cmsghdr_union.buf;
+    msg[0].msg_hdr.msg_controllen = sizeof(cmsghdr_union.buf);
+
+    struct cmsghdr* cmsg;
+	cmsg = CMSG_FIRSTHDR(&msg[0].msg_hdr);
+	cmsg->cmsg_level = SOL_SOCKET;
+	cmsg->cmsg_type  = SCM_RIGHTS;
+	cmsg->cmsg_len   = CMSG_LEN(sizeof(int));
+	memcpy(CMSG_DATA(cmsg), &pipefds[0], sizeof(int));
+
+    cmsg = CMSG_NXTHDR(&msg[0].msg_hdr, cmsg);
+	cmsg->cmsg_level = SOL_SOCKET;
+	cmsg->cmsg_type  = SCM_RIGHTS;
+	cmsg->cmsg_len   = CMSG_LEN(sizeof(int));
+	memcpy(CMSG_DATA(cmsg), &pipefds[1], sizeof(int));
+
+	ret = sendmmsg(fd, msg, 2, /*flags=*/0);
+	if (ret < 0) {
+        close(fd);
+        perror("[parent] sendmmsg error\n");
+        exit(1);
+    }
+
+    if (msg[0].msg_len != strlen(STR_ONE) + strlen(STR_TWO) ||
+            msg[1].msg_len != strlen(STR_THREE)) {
+        close(fd);
+        fprintf(stderr, "[parent] sendmmsg error: not all messages were sent\n");
+        exit(1);
+    }
+
+    printf("[parent] %d messages sent\n", ret);
+
+    if (close(fd) < 0) {
+        perror("[parent] close error");
+        exit(1);
+    }
+
+    return 0;
+}
+
+int client(void) {
+    int ret;
+
+    int fd = socket(AF_UNIX, SOCK_STREAM, 0);
+    if (fd < 0) {
+        perror("[child] socket error");
+        exit(1);
+    }
+
+    struct sockaddr_un address;
+    address.sun_family = AF_UNIX;
+    strncpy(address.sun_path, UNIX_SOCKET_NAME, sizeof(address.sun_path));
+
+    ret = -1;
+    while (ret < 0) {
+        /* wait until client is ready for read */
+        errno = 0;
+        ret = connect(fd, (struct sockaddr*)&address, sizeof(address));
+        if (ret < 0 && errno != ENOENT && errno != ECONNREFUSED) {
+            close(fd);
+            perror("[child] connect error\n");
+            exit(1);
+        }
+        sched_yield();
+    }
+
+    puts("[child] Connected to the server, receiving...");
+
+	struct mmsghdr msgs[VLEN] = {0};
+	struct iovec iovecs[VLEN] = {0};
+	char bufs[VLEN][BUFSIZE + 1] = {0};
+
+	for (int i = 0; i < VLEN; i++) {
+		iovecs[i].iov_base         = bufs[i];
+		iovecs[i].iov_len          = BUFSIZE;
+		msgs[i].msg_hdr.msg_iov    = &iovecs[i];
+		msgs[i].msg_hdr.msg_iovlen = 1;
+	}
+
+    /* receive two ends of the pipe as ancillary data in cmsg (must come in the first msg) */
+    msgs[0].msg_hdr.msg_control = cmsghdr_union.buf;
+    msgs[0].msg_hdr.msg_controllen = sizeof(cmsghdr_union.buf);
+
+    ret = -1;
+    while (ret < 0) {
+        errno = 0;
+        ret = recvmmsg(fd, msgs, VLEN, MSG_DONTWAIT, /*timeout=*/NULL);
+        if (ret < 0 && errno != EAGAIN && errno != EWOULDBLOCK) {
+            close(fd);
+            perror("[child] recvmmsg error");
+            exit(1);
+        }
+        sched_yield();
+    }
+
+	printf("[child] %d messages received\n", ret);
+	for (int i = 0; i < ret; i++) {
+        if (!msgs[i].msg_len)
+            continue;
+
+		bufs[i][msgs[i].msg_len] = 0;
+		printf("[child] message %d: %s\n", i + 1, bufs[i]);
+
+        if (!msgs[i].msg_hdr.msg_control || !msgs[i].msg_hdr.msg_controllen)
+            continue;
+
+        struct cmsghdr* cmsg;
+        for (cmsg = CMSG_FIRSTHDR(&msgs[i].msg_hdr); cmsg != NULL;
+                cmsg = CMSG_NXTHDR(&msgs[i].msg_hdr, cmsg)) {
+            if (cmsg->cmsg_level != SOL_SOCKET || cmsg->cmsg_type != SCM_RIGHTS) {
+                close(fd);
+                fprintf(stderr, "[child] recvmmsg error: unexpected ancillary data\n");
+                exit(1);
+            }
+            int* received_fds = (int*)CMSG_DATA(cmsg);
+            pipefds[0] = received_fds[0];
+            pipefds[1] = received_fds[1];
+            break;
+        }
+	}
+
+    if (pipefds[0] == -1 || pipefds[1] == -1) {
+        close(fd);
+        fprintf(stderr, "[child] recvmmsg error: received incorrect pipefds as ancillary data\n");
+        exit(1);
+    }
+
+    /* test received pipe */
+    ssize_t bytes;
+    bytes = write(pipefds[1], STR_HELLO, sizeof(STR_HELLO));
+    if (bytes < 0) {
+        close(fd);
+        perror("[child] write error\n");
+        exit(1);
+    }
+
+    char buffer[128];
+    bytes = 0;
+    while (bytes <= 0) {
+        errno = 0;
+        bytes = read(pipefds[0], &buffer, sizeof(buffer));
+        if (bytes < 0 && errno != EAGAIN && errno != EWOULDBLOCK) {
+            close(fd);
+            perror("[child] read error");
+            exit(1);
+        }
+        sched_yield();
+    }
+
+    buffer[sizeof(buffer) - 1] = '\0';
+    if (bytes < sizeof(buffer))
+        buffer[bytes] = '\0';
+
+    printf("[child] read on received pipe: %s\n", buffer);
+
+    if (close(fd) < 0) {
+        perror("[child] close error");
+        exit(1);
+    }
+
+    return 0;
+}
+
+int main(int argc, char** argv) {
+    int pid = fork();
+    if (pid < 0) {
+        perror("fork error");
+        return 1;
+    }
+
+    if (pid == 0)
+        return client();
+
+    server();
+
+    pid = wait(NULL); /* wait for child termination, just for sanity */
+    if (pid < 0) {
+        perror("[parent] wait error");
+        return 1;
+    }
+
+    if (unlink(UNIX_SOCKET_NAME) < 0) {
+        perror("[parent] unlink error");
+        return 1;
+    }
+
+    return 0;
+}

--- a/LibOS/shim/test/regression/test_libos.py
+++ b/LibOS/shim/test/regression/test_libos.py
@@ -505,7 +505,7 @@ class TC_80_Socket(RegressionTestCase):
         self.assertIn('read on FIFO: Hello from write end of FIFO!', stdout)
 
     def test_100_socket_unix(self):
-        stdout, _ = self.run_binary(['unix'])
+        stdout, _ = self.run_binary(['unix'], timeout=60)
         self.assertIn('Data: This is packet 0', stdout)
         self.assertIn('Data: This is packet 1', stdout)
         self.assertIn('Data: This is packet 2', stdout)
@@ -516,6 +516,13 @@ class TC_80_Socket(RegressionTestCase):
         self.assertIn('Data: This is packet 7', stdout)
         self.assertIn('Data: This is packet 8', stdout)
         self.assertIn('Data: This is packet 9', stdout)
+
+    def test_101_scm_rights(self):
+        stdout, _ = self.run_binary(['scm_rights'], timeout=60)
+        self.assertIn('one', stdout)
+        self.assertIn('two', stdout)
+        self.assertIn('three', stdout)
+        self.assertIn('read on received pipe: hello world', stdout)
 
     def test_200_socket_udp(self):
         stdout, _ = self.run_binary(['udp'], timeout=50)


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

This commit improves the emulation of recvfrom/sendfrom, recvmsg/sendmsg, and recvmmsg/sendmmsg system calls. In particular, MSG_DONTWAIT flag is allowed though not really emulated (benign in most cases). Also, it is possible now to send/receive FDs via SCM_RIGHTS on a UNIX domain socket (only send/recv of pipes and UNIX domain sockets is currently supported). 

## How to test this PR? <!-- (if applicable) -->

Corresponding LibOS test `scm_rights` is added.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1511)
<!-- Reviewable:end -->
