### PR TITLE
[LibOS] Wrap shim_context and shim_regs accesses in functions

### DIFF
--- a/LibOS/shim/include/arch/x86_64/shim_tcb-arch.h
+++ b/LibOS/shim/include/arch/x86_64/shim_tcb-arch.h
@@ -32,4 +32,12 @@ static inline void shim_regs_set_sp(struct shim_regs* sr, uint64_t sp) {
     sr->rsp = sp;
 }
 
+static inline uint64_t shim_regs_get_syscallnr(struct shim_regs* sr) {
+    return sr->orig_rax;
+}
+
+static inline void shim_regs_set_syscallnr(struct shim_regs* sr, uint64_t sc_num) {
+    sr->orig_rax = sc_num;
+}
+
 #endif /* _SHIM_TCB_ARCH_H_ */

--- a/LibOS/shim/include/arch/x86_64/shim_tcb-arch.h
+++ b/LibOS/shim/include/arch/x86_64/shim_tcb-arch.h
@@ -24,4 +24,12 @@ struct shim_regs {
     uint64_t    rip;
 };
 
+static inline uint64_t shim_regs_get_sp(struct shim_regs* sr) {
+    return sr->rsp;
+}
+
+static inline void shim_regs_set_sp(struct shim_regs* sr, uint64_t sp) {
+    sr->rsp = sp;
+}
+
 #endif /* _SHIM_TCB_ARCH_H_ */

--- a/LibOS/shim/include/arch/x86_64/shim_types-arch.h
+++ b/LibOS/shim/include/arch/x86_64/shim_types-arch.h
@@ -3,6 +3,8 @@
 
 #include <stdint.h>
 
+#include "shim_tcb-arch.h"
+
 /* asm/signal.h */
 #define NUM_SIGS            64
 #define NUM_KNOWN_SIGS      32
@@ -117,6 +119,32 @@ typedef struct ucontext {
     __sigset_t uc_sigmask;
     struct _libc_fpstate __fpregs_mem;
 } ucontext_t;
+
+static inline void shim_regs_to_ucontext(ucontext_t* context, struct shim_regs* regs) {
+    context->uc_mcontext.gregs[REG_R8]  = regs->r8;
+    context->uc_mcontext.gregs[REG_R9]  = regs->r9;
+    context->uc_mcontext.gregs[REG_R10] = regs->r10;
+    context->uc_mcontext.gregs[REG_R11] = regs->r11;
+    context->uc_mcontext.gregs[REG_R12] = regs->r12;
+    context->uc_mcontext.gregs[REG_R13] = regs->r13;
+    context->uc_mcontext.gregs[REG_R14] = regs->r14;
+    context->uc_mcontext.gregs[REG_R15] = regs->r15;
+    context->uc_mcontext.gregs[REG_RDI] = regs->rdi;
+    context->uc_mcontext.gregs[REG_RSI] = regs->rsi;
+    context->uc_mcontext.gregs[REG_RBP] = regs->rbp;
+    context->uc_mcontext.gregs[REG_RBX] = regs->rbx;
+    context->uc_mcontext.gregs[REG_RDX] = regs->rdx;
+    context->uc_mcontext.gregs[REG_RAX] = regs->orig_rax;
+    context->uc_mcontext.gregs[REG_RCX] = regs->rcx;
+    context->uc_mcontext.gregs[REG_RSP] = regs->rsp;
+    context->uc_mcontext.gregs[REG_RIP] = regs->rip;
+    context->uc_mcontext.gregs[REG_EFL] = regs->rflags;
+    context->uc_mcontext.gregs[REG_CSGSFS] = 0;
+    context->uc_mcontext.gregs[REG_ERR] = 0;
+    context->uc_mcontext.gregs[REG_TRAPNO] = 0;
+    context->uc_mcontext.gregs[REG_OLDMASK] = 0;
+    context->uc_mcontext.gregs[REG_CR2]  = 0;
+}
 
 #define RED_ZONE_SIZE   128
 

--- a/LibOS/shim/include/shim_tcb.h
+++ b/LibOS/shim/include/shim_tcb.h
@@ -12,7 +12,6 @@
 struct shim_context {
     struct shim_regs *      regs;
     uint64_t                fs_base;
-    struct shim_context *   next;
     struct atomic_int       preempt;
 };
 

--- a/LibOS/shim/include/shim_tcb.h
+++ b/LibOS/shim/include/shim_tcb.h
@@ -16,6 +16,14 @@ struct shim_context {
     struct atomic_int       preempt;
 };
 
+static inline unsigned long shim_context_get_sp(struct shim_context* sc) {
+    return shim_regs_get_sp(sc->regs);
+}
+
+static inline void shim_context_set_sp(struct shim_context* sc, unsigned long sp) {
+    shim_regs_set_sp(sc->regs, sp);
+}
+
 struct debug_buf;
 
 typedef struct shim_tcb shim_tcb_t;

--- a/LibOS/shim/include/shim_tcb.h
+++ b/LibOS/shim/include/shim_tcb.h
@@ -24,6 +24,14 @@ static inline void shim_context_set_sp(struct shim_context* sc, unsigned long sp
     shim_regs_set_sp(sc->regs, sp);
 }
 
+static inline unsigned long shim_context_get_syscallnr(struct shim_context* sc) {
+    return shim_regs_get_syscallnr(sc->regs);
+}
+
+static inline void shim_context_set_syscallnr(struct shim_context* sc, unsigned long sc_num) {
+    shim_regs_set_syscallnr(sc->regs, sc_num);
+}
+
 struct debug_buf;
 
 typedef struct shim_tcb shim_tcb_t;

--- a/LibOS/shim/src/bookkeep/shim_signal.c
+++ b/LibOS/shim/src/bookkeep/shim_signal.c
@@ -175,7 +175,7 @@ void __store_context (shim_tcb_t * tcb, PAL_CONTEXT * pal_context,
 {
     ucontext_t * context = &signal->context;
 
-    if (tcb && tcb->context.regs && tcb->context.regs->orig_rax) {
+    if (tcb && tcb->context.regs && shim_context_get_syscallnr(&tcb->context)) {
         struct shim_context * ct = &tcb->context;
 
         if (ct->regs) {
@@ -741,10 +741,10 @@ __handle_one_signal(shim_tcb_t* tcb, int sig, struct shim_signal* signal) {
 
     struct shim_context * context = NULL;
 
-    if (tcb->context.regs && tcb->context.regs->orig_rax) {
+    if (tcb->context.regs && shim_context_get_syscallnr(&tcb->context)) {
         context = __alloca(sizeof(struct shim_context));
         memcpy(context, &tcb->context, sizeof(struct shim_context));
-        tcb->context.regs->orig_rax = 0;
+        shim_context_set_syscallnr(&tcb->context, 0);
         tcb->context.next = context;
     }
 

--- a/LibOS/shim/src/bookkeep/shim_signal.c
+++ b/LibOS/shim/src/bookkeep/shim_signal.c
@@ -727,7 +727,6 @@ __handle_one_signal(shim_tcb_t* tcb, int sig, struct shim_signal* signal) {
         context = __alloca(sizeof(struct shim_context));
         *context = tcb->context;
         shim_context_set_syscallnr(&tcb->context, 0);
-        tcb->context.next = context;
     }
 
     debug("run signal handler %p (%d, %p, %p)\n", handler, sig, &signal->info,

--- a/LibOS/shim/src/bookkeep/shim_signal.c
+++ b/LibOS/shim/src/bookkeep/shim_signal.c
@@ -173,31 +173,13 @@ static void __store_info (siginfo_t * info, struct shim_signal * signal)
 void __store_context (shim_tcb_t * tcb, PAL_CONTEXT * pal_context,
                       struct shim_signal * signal)
 {
-    ucontext_t * context = &signal->context;
+    ucontext_t* context = &signal->context;
 
     if (tcb && tcb->context.regs && shim_context_get_syscallnr(&tcb->context)) {
-        struct shim_context * ct = &tcb->context;
+        struct shim_context* ct = &tcb->context;
 
-        if (ct->regs) {
-            struct shim_regs * regs = ct->regs;
-            context->uc_mcontext.gregs[REG_RIP] = regs->rip;
-            context->uc_mcontext.gregs[REG_EFL] = regs->rflags;
-            context->uc_mcontext.gregs[REG_R15] = regs->r15;
-            context->uc_mcontext.gregs[REG_R14] = regs->r14;
-            context->uc_mcontext.gregs[REG_R13] = regs->r13;
-            context->uc_mcontext.gregs[REG_R12] = regs->r12;
-            context->uc_mcontext.gregs[REG_R11] = regs->r11;
-            context->uc_mcontext.gregs[REG_R10] = regs->r10;
-            context->uc_mcontext.gregs[REG_R9]  = regs->r9;
-            context->uc_mcontext.gregs[REG_R8]  = regs->r8;
-            context->uc_mcontext.gregs[REG_RCX] = regs->rcx;
-            context->uc_mcontext.gregs[REG_RDX] = regs->rdx;
-            context->uc_mcontext.gregs[REG_RSI] = regs->rsi;
-            context->uc_mcontext.gregs[REG_RDI] = regs->rdi;
-            context->uc_mcontext.gregs[REG_RBX] = regs->rbx;
-            context->uc_mcontext.gregs[REG_RBP] = regs->rbp;
-            context->uc_mcontext.gregs[REG_RSP] = regs->rsp;
-        }
+        if (ct->regs)
+            shim_regs_to_ucontext(context, ct->regs);
 
         signal->context_stored = true;
         return;

--- a/LibOS/shim/src/bookkeep/shim_signal.c
+++ b/LibOS/shim/src/bookkeep/shim_signal.c
@@ -261,28 +261,28 @@ void deliver_signal (siginfo_t * info, PAL_CONTEXT * context)
         _info;                                              \
     })
 
-#ifdef __x86_64__
-#define IP rip
-#else
-#define IP eip
-#endif
-
 static inline bool context_is_internal(PAL_CONTEXT * context)
 {
-    return context &&
-        (void *) context->IP >= (void *) &__code_address &&
-        (void *) context->IP < (void *) &__code_address_end;
+    if (!context)
+        return false;
+
+    void* ip = (void*)pal_context_get_ip(context);
+
+    return ip >= (void*)&__code_address &&
+           ip  < (void*)&__code_address_end;
 }
 
 static noreturn void internal_fault(const char* errstr, PAL_NUM addr, PAL_CONTEXT* context) {
     IDTYPE tid = get_cur_tid();
+    PAL_NUM ip = pal_context_get_ip(context);
+
     if (context_is_internal(context))
         SYS_PRINTF("%s at 0x%08lx (IP = +0x%lx, VMID = %u, TID = %u)\n", errstr,
-                   addr, (void*)context->IP - (void*)&__load_address,
+                   addr, (void*)ip - (void*)&__load_address,
                    cur_process.vmid, is_internal_tid(tid) ? 0 : tid);
     else
         SYS_PRINTF("%s at 0x%08lx (IP = 0x%08lx, VMID = %u, TID = %u)\n", errstr,
-                   addr, context ? context->IP : 0,
+                   addr, context ? ip : 0,
                    cur_process.vmid, is_internal_tid(tid) ? 0 : tid);
 
     DEBUG_BREAK_ON_FAILURE();
@@ -295,7 +295,7 @@ static void arithmetic_error_upcall (PAL_PTR event, PAL_NUM arg, PAL_CONTEXT * c
         internal_fault("Internal arithmetic fault", arg, context);
     } else {
         if (context)
-            debug("arithmetic fault at 0x%08lx\n", context->IP);
+            debug("arithmetic fault at 0x%08lx\n", pal_context_get_ip(context));
 
         deliver_signal(ALLOC_SIGINFO(SIGFPE, FPE_INTDIV,
                                      si_addr, (void *) arg), context);
@@ -313,7 +313,7 @@ static void memfault_upcall (PAL_PTR event, PAL_NUM arg, PAL_CONTEXT * context)
         && (void *) arg <= tcb->test_range.end) {
         assert(context);
         tcb->test_range.has_fault = true;
-        context->rip = (PAL_NUM) tcb->test_range.cont_addr;
+        pal_context_set_ip(context, (PAL_NUM)tcb->test_range.cont_addr);
         goto ret_exception;
     }
 
@@ -322,7 +322,7 @@ static void memfault_upcall (PAL_PTR event, PAL_NUM arg, PAL_CONTEXT * context)
     }
 
     if (context)
-        debug("memory fault at 0x%08lx (IP = 0x%08lx)\n", arg, context->IP);
+        debug("memory fault at 0x%08lx (IP = 0x%08lx)\n", arg, pal_context_get_ip(context));
 
     struct shim_vma_info vma_info;
     int signo = SIGSEGV;
@@ -556,7 +556,7 @@ static void illegal_upcall (PAL_PTR event, PAL_NUM arg, PAL_CONTEXT * context)
 
         assert(context);
 
-        uint8_t * rip = (uint8_t*)context->IP;
+        uint8_t* rip = (uint8_t*)pal_context_get_ip(context);
         /*
          * Emulate syscall instruction (opcode 0x0f 0x05);
          * syscall instruction is prohibited in
@@ -594,7 +594,7 @@ static void illegal_upcall (PAL_PTR event, PAL_NUM arg, PAL_CONTEXT * context)
             context->rip = (long)&syscall_wrapper;
         } else {
             debug("Illegal instruction during app execution at 0x%08lx; delivering to app\n",
-                  context->IP);
+                  (unsigned long)rip);
             deliver_signal(ALLOC_SIGINFO(SIGILL, ILL_ILLOPC,
                                          si_addr, (void *) arg), context);
         }

--- a/LibOS/shim/src/bookkeep/shim_signal.c
+++ b/LibOS/shim/src/bookkeep/shim_signal.c
@@ -721,11 +721,11 @@ __handle_one_signal(shim_tcb_t* tcb, int sig, struct shim_signal* signal) {
     if (!signal->context_stored)
         __store_context(tcb, NULL, signal);
 
-    struct shim_context * context = NULL;
+    struct shim_context* context = NULL;
 
     if (tcb->context.regs && shim_context_get_syscallnr(&tcb->context)) {
         context = __alloca(sizeof(struct shim_context));
-        memcpy(context, &tcb->context, sizeof(struct shim_context));
+        *context = tcb->context;
         shim_context_set_syscallnr(&tcb->context, 0);
         tcb->context.next = context;
     }
@@ -736,7 +736,7 @@ __handle_one_signal(shim_tcb_t* tcb, int sig, struct shim_signal* signal) {
     (*handler) (sig, &signal->info, &signal->context);
 
     if (context)
-        memcpy(&tcb->context, context, sizeof(struct shim_context));
+        tcb->context = *context;
 
     if (signal->pal_context)
         memcpy(signal->pal_context, signal->context.uc_mcontext.gregs, sizeof(PAL_CONTEXT));

--- a/LibOS/shim/src/bookkeep/shim_thread.c
+++ b/LibOS/shim/src/bookkeep/shim_thread.c
@@ -714,7 +714,6 @@ BEGIN_CP_FUNC(running_thread)
         /* don't export stale pointers */
         new_tcb->self = NULL;
         new_tcb->tp = NULL;
-        new_tcb->context.next = NULL;
         new_tcb->debug_buf = NULL;
     }
 }

--- a/LibOS/shim/src/bookkeep/shim_thread.c
+++ b/LibOS/shim/src/bookkeep/shim_thread.c
@@ -729,7 +729,7 @@ static int resume_wrapper (void * param)
        based on saved thread->shim_tcb */
     shim_tcb_init();
     shim_tcb_t* saved_tcb = thread->shim_tcb;
-    assert(saved_tcb->context.regs && saved_tcb->context.regs->rsp);
+    assert(saved_tcb->context.regs && shim_context_get_sp(&saved_tcb->context));
     set_cur_thread(thread);
     unsigned long fs_base = saved_tcb->context.fs_base;
     assert(fs_base);
@@ -786,7 +786,7 @@ BEGIN_RS_FUNC(running_thread)
             __shim_tcb_init(tcb);
             set_cur_thread(thread);
 
-            assert(tcb->context.regs && tcb->context.regs->rsp);
+            assert(tcb->context.regs && shim_context_get_sp(&tcb->context));
             update_fs_base(tcb->context.fs_base);
             /* Temporarily disable preemption until the thread resumes. */
             __disable_preempt(tcb);

--- a/LibOS/shim/src/shim_init.c
+++ b/LibOS/shim/src/shim_init.c
@@ -624,7 +624,7 @@ noreturn void* shim_init(int argc, void* args)
     shim_tcb_t * cur_tcb = shim_get_tcb();
     struct shim_thread * cur_thread = (struct shim_thread *) cur_tcb->tp;
 
-    if (cur_tcb->context.regs && cur_tcb->context.regs->rsp) {
+    if (cur_tcb->context.regs && shim_context_get_sp(&cur_tcb->context)) {
         vdso_map_migrate();
         restore_context(&cur_tcb->context);
     }

--- a/LibOS/shim/src/sys/shim_sigaction.c
+++ b/LibOS/shim/src/sys/shim_sigaction.c
@@ -141,7 +141,7 @@ int shim_do_sigaltstack(const stack_t* ss, stack_t* oss) {
     if (oss)
         *oss = *cur_ss;
 
-    void* sp = (void*)shim_get_tcb()->context.regs->rsp;
+    void* sp = (void*)shim_context_get_sp(&(shim_get_tcb()->context));
     /* check if thread is currently executing on an active altstack */
     if (!(cur_ss->ss_flags & SS_DISABLE) && sp && cur_ss->ss_sp <= sp &&
             sp < cur_ss->ss_sp + cur_ss->ss_size) {

--- a/Pal/include/arch/x86_64/pal-arch.h
+++ b/Pal/include/arch/x86_64/pal-arch.h
@@ -183,4 +183,12 @@ typedef struct PAL_CONTEXT_ PAL_CONTEXT;
 
 #define DEFAULT_OBJECT_EXEC_ADDR ((void*)0x555555554000) /* Linux base location for PIE binaries */
 
+static inline void pal_context_set_ip(PAL_CONTEXT* context, PAL_NUM insnptr) {
+    context->rip = insnptr;
+}
+
+static inline PAL_NUM pal_context_get_ip(PAL_CONTEXT *context) {
+    return context->rip;
+}
+
 #endif /* PAL_ARCH_H */


### PR DESCRIPTION
To factor out x86_64 specific names of fields in data structure accesses, implement inline functions that allow us to set and get the stack pointer, orig_rax, and the instruction pointer.
Implement a function to copy shim_regs to ucontext_t, similar to what we have in the PAL when copying between ucontext_t and PAL_CONTEXT.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1514)
<!-- Reviewable:end -->
