### PR TITLE
[LibOS] Fix bug to set exec handle's dentry to executable file

### DIFF
--- a/LibOS/shim/src/fs/shim_fs.c
+++ b/LibOS/shim/src/fs/shim_fs.c
@@ -533,7 +533,7 @@ struct shim_mount* find_mount_from_uri(const char* uri) {
         if (qstrempty(&mount->uri))
             continue;
 
-        if (!memcmp(qstrgetstr(&mount->uri), uri, mount->uri.len) && uri[mount->uri.len] == '/') {
+        if (!memcmp(qstrgetstr(&mount->uri), uri, mount->uri.len)) {
             if (mount->path.len > longest_path) {
                 longest_path = mount->path.len;
                 found = mount;

--- a/LibOS/shim/test/regression/.gitignore
+++ b/LibOS/shim/test/regression/.gitignore
@@ -49,7 +49,7 @@
 /poll
 /poll_many_types
 /ppoll
-/proc
+/proc_common
 /proc_cpuinfo
 /proc_path
 /pselect

--- a/LibOS/shim/test/regression/Makefile
+++ b/LibOS/shim/test/regression/Makefile
@@ -41,9 +41,9 @@ c_executables = \
 	poll \
 	poll_many_types \
 	ppoll \
-	proc \
-	proc_path \
+	proc_common \
 	proc_cpuinfo \
+	proc_path \
 	pselect \
 	readdir \
 	sched \
@@ -126,7 +126,7 @@ CFLAGS-eventfd = -pthread
 CFLAGS-futex_bitset = -pthread
 CFLAGS-futex_requeue = -pthread
 CFLAGS-futex_wake_op = -pthread
-CFLAGS-proc = -pthread
+CFLAGS-proc_common = -pthread
 CFLAGS-spinlock += -I$(PALDIR)/../include/lib -pthread
 CFLAGS-sigaction_per_process += -pthread
 CFLAGS-sigprocmask += -pthread

--- a/LibOS/shim/test/regression/proc_common.c
+++ b/LibOS/shim/test/regression/proc_common.c
@@ -1,3 +1,4 @@
+#define _XOPEN_SOURCE 700
 #include <dirent.h>
 #include <errno.h>
 #include <fcntl.h>
@@ -130,6 +131,16 @@ int main(int argc, char** argv) {
         perror("closedir /proc");
         return 1;
     }
+
+    printf("===== Reading /proc/self/exe symlink\n");
+    ssize_t len = readlink("/proc/self/exe", buf, sizeof(buf) - 1);
+    if (len < 0) {
+        perror("readlink /proc/self/exe");
+        return 1;
+    }
+
+    buf[len] = '\0';
+    printf("symlink /proc/self/exec resolves to %s\n", buf);
 
     /* this outputs all files in this current dir: a good test of realloced getdents buffer */
     printf("===== Contents of /proc/2/cwd\n");

--- a/LibOS/shim/test/regression/test_libos.py
+++ b/LibOS/shim/test/regression/test_libos.py
@@ -421,7 +421,7 @@ class TC_31_SyscallSGX(RegressionTestCase):
 
 class TC_40_FileSystem(RegressionTestCase):
     def test_000_proc(self):
-        stdout, _ = self.run_binary(['proc'])
+        stdout, _ = self.run_binary(['proc_common'])
         self.assertIn('/proc/1/..', stdout)
         self.assertIn('/proc/1/cwd', stdout)
         self.assertIn('/proc/1/exe', stdout)
@@ -442,7 +442,8 @@ class TC_40_FileSystem(RegressionTestCase):
         self.assertIn('/proc/self', stdout)
         self.assertIn('/proc/meminfo', stdout)
         self.assertIn('/proc/cpuinfo', stdout)
-        self.assertIn('/proc/2/cwd/proc.c', stdout)
+        self.assertIn('symlink /proc/self/exec resolves to /proc_common', stdout)
+        self.assertIn('/proc/2/cwd/proc_common.c', stdout)
         self.assertIn('/lib/libpthread.so', stdout)
         self.assertIn('stack', stdout)
         self.assertIn('vendor_id', stdout)


### PR DESCRIPTION

## Description of the changes <!-- (reasons and measures) -->

Previously, `find_mount_from_uri()` assumed that the URI of executable is an absolute path. This is not true in general case, so this commit removes this assumption. This bug fix allows to correctly follow symlink `/proc/self/exe` (previously it returned -EINVAL). LibOS's `proc` test is updated to verify this.

## How to test this PR? <!-- (if applicable) -->

`proc` LibOS test is updated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1515)
<!-- Reviewable:end -->
