### PR TITLE
[LibOS] Do not show "illegal instruction" message on syscall instruction

### DIFF
--- a/LibOS/shim/src/bookkeep/shim_signal.c
+++ b/LibOS/shim/src/bookkeep/shim_signal.c
@@ -555,7 +555,6 @@ static void illegal_upcall (PAL_PTR event, PAL_NUM arg, PAL_CONTEXT * context)
         !(vma_info.flags & VMA_INTERNAL)) {
 
         assert(context);
-        debug("illegal instruction at 0x%08lx\n", context->IP);
 
         uint8_t * rip = (uint8_t*)context->IP;
         /*
@@ -594,11 +593,13 @@ static void illegal_upcall (PAL_PTR event, PAL_NUM arg, PAL_CONTEXT * context)
             context->r11 = context->efl;
             context->rip = (long)&syscall_wrapper;
         } else {
+            debug("Illegal instruction during app execution at 0x%08lx; delivering to app\n",
+                  context->IP);
             deliver_signal(ALLOC_SIGINFO(SIGILL, ILL_ILLOPC,
                                          si_addr, (void *) arg), context);
         }
     } else {
-        internal_fault("Internal illegal fault", arg, context);
+        internal_fault("Illegal instruction during Graphene internal execution", arg, context);
     }
 
     if (vma_info.file) {


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Previously, Graphene showed debug message "illegal instruction at" on every trapped instruction, including syscall inst (trapped in SGX PAL). This message is confusing, do not show it on emulated
instructions and rephrase.

## How to test this PR? <!-- (if applicable) -->

N/A.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1516)
<!-- Reviewable:end -->
