### PR TITLE
[Pal/Linux-SGX] Add sgx.print_stats manifest option to display SGX stats

### DIFF
--- a/Documentation/manifest-syntax.rst
+++ b/Documentation/manifest-syntax.rst
@@ -315,3 +315,17 @@ access. If the file check policy is ``allow_all_but_log``, all files other than
 trusted and allowed are allowed for access, and Graphene-SGX emits a warning
 message for every such file. This is a convenient way to determine the set of
 files that the ported application uses.
+
+Printing per-thread and process-wide SGX stats
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+::
+
+    sgx.print_stats=[1|0]
+    (Default: 0)
+
+This syntax specifies whether to print SGX enclave-specific statistics. The
+currently supported stats are: number of EENTERs (corresponds to ECALLs plus
+returns from OCALLs), number of EEXITs (corresponds to OCALLs plus returns from
+ECALLs) and number of AEXs (corresponds to interrupts/exceptions/signals during
+enclave execution). Set it to ``1`` to print per-thread and per-process stats.

--- a/LibOS/shim/test/regression/multi_pthread.manifest.template
+++ b/LibOS/shim/test/regression/multi_pthread.manifest.template
@@ -15,3 +15,4 @@ sgx.trusted_files.libpthread = file:../../../../Runtime/libpthread.so.0
 sgx.thread_num = 8
 
 sgx.static_address = 1
+sgx.print_stats = 1

--- a/LibOS/shim/test/regression/multi_pthread_exitless.manifest.template
+++ b/LibOS/shim/test/regression/multi_pthread_exitless.manifest.template
@@ -19,3 +19,4 @@ sgx.thread_num = 8
 sgx.rpc_thread_num = 8
 
 sgx.static_address = 1
+sgx.print_stats = 1

--- a/Pal/regression/Thread2.manifest.template
+++ b/Pal/regression/Thread2.manifest.template
@@ -1,1 +1,2 @@
 sgx.thread_num = 2
+sgx.print_stats = 1

--- a/Pal/regression/Thread2_exitless.manifest.template
+++ b/Pal/regression/Thread2_exitless.manifest.template
@@ -3,3 +3,4 @@ loader.execname = Thread2
 
 sgx.thread_num = 2
 sgx.rpc_thread_num = 2
+sgx.print_stats = 1

--- a/Pal/src/host/Linux-SGX/generated-offsets.c
+++ b/Pal/src/host/Linux-SGX/generated-offsets.c
@@ -108,6 +108,9 @@ void dummy(void)
 
     /* struct pal_tcb_urts aka PAL_TCB_URTS */
     OFFSET(PAL_TCB_URTS_TCS, pal_tcb_urts, tcs);
+    OFFSET(PAL_TCB_URTS_EENTER_CNT, pal_tcb_urts, eenter_cnt);
+    OFFSET(PAL_TCB_URTS_EEXIT_CNT, pal_tcb_urts, eexit_cnt);
+    OFFSET(PAL_TCB_URTS_AEX_CNT, pal_tcb_urts, aex_cnt);
 
     /* sgx_arch_tcs_t */
     OFFSET_T(TCS_FLAGS, sgx_arch_tcs_t, flags);

--- a/Pal/src/host/Linux-SGX/sgx_entry.S
+++ b/Pal/src/host/Linux-SGX/sgx_entry.S
@@ -23,6 +23,9 @@ sgx_ecall:
 	pushq %r15
 
 .Ldo_ecall:
+	# increment per-thread EENTER counter for stats
+	lock incq %gs:PAL_TCB_URTS_EENTER_CNT
+
 	# RBX has to be the TCS of the thread
 	movq %gs:PAL_TCB_URTS_TCS, %rbx
 
@@ -46,7 +49,9 @@ sgx_ecall:
 	.type async_exit_pointer, @function
 
 async_exit_pointer:
-	ENCLU
+	# increment per-thread AEX counter for stats
+	lock incq %gs:PAL_TCB_URTS_AEX_CNT
+	ENCLU   # perform ERESUME
 
 	.global sgx_raise
 	.type sgx_raise, @function
@@ -57,8 +62,11 @@ sgx_raise:
 
 .Lsgx_entry:
 	# arguments: RDI - code, RSI - ms
-
 	.cfi_startproc
+
+	# increment per-thread EEXIT counter for stats
+	lock incq %gs:PAL_TCB_URTS_EEXIT_CNT
+
 	leaq ocall_table(%rip), %rbx
 	movq (%rbx,%rdi,8), %rbx
 	movq %rsi, %rdi

--- a/Pal/src/host/Linux-SGX/sgx_main.c
+++ b/Pal/src/host/Linux-SGX/sgx_main.c
@@ -324,6 +324,11 @@ int initialize_enclave (struct pal_enclave * enclave)
         heap_min = 0;
     }
 
+    if (get_config(enclave->config, "sgx.print_stats", cfgbuf, sizeof(cfgbuf)) > 0 &&
+            cfgbuf[0] == '1') {
+        g_sgx_print_stats = true;
+    }
+
     ret = read_enclave_token(enclave->token, &enclave_token);
     if (ret < 0) {
         SGX_DBG(DBG_E, "Reading enclave token failed: %d\n", -ret);

--- a/Pal/src/host/Linux-SGX/signer/pal_sgx_sign.py
+++ b/Pal/src/host/Linux-SGX/signer/pal_sgx_sign.py
@@ -875,6 +875,9 @@ def main_sign(args):
     if manifest.get('sgx.allow_file_creation', None) is None:
         manifest['sgx.allow_file_creation'] = '0'
 
+    if manifest.get('sgx.print_stats', None) is None:
+        manifest['sgx.print_stats'] = '0'
+
     output_manifest(args['output'], manifest, manifest_layout)
 
     memory_areas = [


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

New manifest option `sgx.print_stats=[1|0]` specifies whether to print SGX enclave-specific statistics, both per-thread and per-process.

The currently supported stats are:
- number of EENTERs (corresponds to ECALLs plus returns from OCALLs),
- number of EEXITs (corresponds to OCALLs plus returns from ECALLs),
- number of AEXs (corresponds to interrupts/exceptions/signals during enclave execution).

## How to test this PR? <!-- (if applicable) -->

A couple multi-threaded tests among Pal and LibOS regression tests are built with `sgx.print_stats = 1`. Check it out manually via e.g. `SGX=1 ./pal_loader multi_pthread_exitless.manifest.sgx`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1519)
<!-- Reviewable:end -->
