### PR TITLE
[LibOS] Conditionally compile MAP_32BIT code and reset address if MAP_FIXED is not set

### DIFF
--- a/LibOS/shim/src/bookkeep/shim_vma.c
+++ b/LibOS/shim/src/bookkeep/shim_vma.c
@@ -940,6 +940,7 @@ int bkeep_mmap_any_in_range(void* _bottom_addr, void* _top_addr, size_t length, 
     int ret = 0;
     uintptr_t ret_val = 0;
 
+#ifdef MAP_32BIT /* x86_64-specific */
     if (flags & MAP_32BIT) {
         /* Only consider first 2 gigabytes. */
         top_addr = MIN(top_addr, 1ul << 31);
@@ -947,6 +948,7 @@ int bkeep_mmap_any_in_range(void* _bottom_addr, void* _top_addr, size_t length, 
             return -ENOMEM;
         }
     }
+#endif
 
     struct shim_vma* new_vma = alloc_vma();
     if (!new_vma) {

--- a/LibOS/shim/src/sys/shim_mmap.c
+++ b/LibOS/shim/src/sys/shim_mmap.c
@@ -62,6 +62,9 @@ void* shim_do_mmap(void* addr, size_t length, int prot, int flags, int fd, off_t
     struct shim_handle* hdl = NULL;
     long ret                = 0;
 
+    if (!(flags & MAP_FIXED) && addr)
+        addr = ALLOC_ALIGN_DOWN_PTR(addr);
+
     /*
      * According to the manpage, both addr and offset have to be page-aligned,
      * but not the length. mmap() will automatically round up the length.


### PR DESCRIPTION
This PR solves the following issues related to mmap operations
- MAP_32BIT is only useful on x86_64 platforms, anywhere else it cannot be used
- if MAP_FIXED is not set we set address to NULL so it's ignored in alignment checks

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1521)
<!-- Reviewable:end -->
