### PR TITLE
[LibOS] Use memset to clear sa_mask

### DIFF
--- a/LibOS/shim/include/shim_types.h
+++ b/LibOS/shim/include/shim_types.h
@@ -156,7 +156,7 @@ struct __kernel_sigaction {
     __sighandler_t k_sa_handler;
     unsigned long sa_flags;
     void (*sa_restorer) (void);
-    sigset_t sa_mask;
+    __sigset_t sa_mask;
 };
 
 /* linux/aio_abi.h (for io_setup which has no glibc wrapper) */

--- a/LibOS/shim/src/bookkeep/shim_signal.c
+++ b/LibOS/shim/src/bookkeep/shim_signal.c
@@ -46,7 +46,7 @@ void sigaction_make_defaults(struct __kernel_sigaction* sig_action) {
     sig_action->k_sa_handler = (void*)SIG_DFL;
     sig_action->sa_flags = 0;
     sig_action->sa_restorer = NULL;
-    sig_action->sa_mask = 0;
+    __sigemptyset(&sig_action->sa_mask);
 }
 
 static __rt_sighandler_t default_sighandler[NUM_SIGS];


### PR DESCRIPTION
On some architecture sa_mask may not be a simple field, so we have to use memset to clear it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1522)
<!-- Reviewable:end -->
