### PR TITLE
[PAL+LibOS] Use function for x86_64 pause

### DIFF
--- a/LibOS/shim/src/bookkeep/shim_thread.c
+++ b/LibOS/shim/src/bookkeep/shim_thread.c
@@ -29,8 +29,9 @@
 #include <shim_checkpoint.h>
 #include <shim_utils.h>
 
-#include <pal.h>
+#include <cpu.h>
 #include <list.h>
+#include <pal.h>
 
 #include <linux/signal.h>
 
@@ -489,9 +490,8 @@ void cleanup_thread(IDTYPE caller, void* arg) {
     int exit_code = thread->term_signal ? : thread->exit_code;
 
     /* wait on clear_child_tid_pal; this signals that PAL layer exited child thread */
-    while (__atomic_load_n(&thread->clear_child_tid_pal, __ATOMIC_RELAXED) != 0) {
-        __asm__ volatile ("pause");
-    }
+    while (__atomic_load_n(&thread->clear_child_tid_pal, __ATOMIC_RELAXED) != 0)
+        cpu_pause();
 
     /* notify parent if any */
     release_clear_child_tid(thread->clear_child_tid);

--- a/LibOS/shim/test/regression/Makefile
+++ b/LibOS/shim/test/regression/Makefile
@@ -127,7 +127,7 @@ CFLAGS-futex_bitset = -pthread
 CFLAGS-futex_requeue = -pthread
 CFLAGS-futex_wake_op = -pthread
 CFLAGS-proc_common = -pthread
-CFLAGS-spinlock += -I$(PALDIR)/../include/lib -pthread
+CFLAGS-spinlock += -I$(PALDIR)/../include/lib -I$(PALDIR)/../include/arch/$(ARCH) -pthread
 CFLAGS-sigaction_per_process += -pthread
 CFLAGS-sigprocmask += -pthread
 

--- a/LibOS/shim/test/regression/sigaction_per_process.c
+++ b/LibOS/shim/test/regression/sigaction_per_process.c
@@ -41,9 +41,8 @@ static void set(int x) {
 }
 
 static void wait_for(int x) {
-    while (__atomic_load_n(&sync_var, __ATOMIC_SEQ_CST) != x) {
-        __asm__ volatile("pause");
-    }
+    while (__atomic_load_n(&sync_var, __ATOMIC_SEQ_CST) != x)
+        ;
 }
 
 static void* f(void* x) {

--- a/Pal/include/arch/x86_64/cpu.h
+++ b/Pal/include/arch/x86_64/cpu.h
@@ -1,0 +1,24 @@
+/*
+   This file is part of Graphene Library OS.
+
+   Graphene Library OS is free software: you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public License
+   as published by the Free Software Foundation, either version 3 of the
+   License, or (at your option) any later version.
+
+   Graphene Library OS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
+
+#ifndef CPU_H
+#define CPU_H
+
+static inline void cpu_pause(void) {
+    __asm__ volatile("pause");
+}
+
+#endif /* CPU_H */

--- a/Pal/include/lib/spinlock.h
+++ b/Pal/include/lib/spinlock.h
@@ -8,6 +8,7 @@
 #define _SPINLOCK_H
 
 #include <api.h>
+#include <cpu.h>
 
 #ifdef DEBUG
 #define DEBUG_SPINLOCKS
@@ -102,9 +103,8 @@ static inline void spinlock_lock(spinlock_t* lock) {
 
     do {
         /* This check imposes no inter-thread ordering, thus does not slow other threads. */
-        while (__atomic_load_n(&lock->lock, __ATOMIC_RELAXED) != SPINLOCK_UNLOCKED) {
-            __asm__ volatile ("pause");
-        }
+        while (__atomic_load_n(&lock->lock, __ATOMIC_RELAXED) != SPINLOCK_UNLOCKED)
+            cpu_pause();
         /* Seen lock as free, check if it still is, this time with acquire semantics (but only
          * if we really take it). */
         val = SPINLOCK_UNLOCKED;
@@ -136,7 +136,7 @@ static inline int spinlock_lock_timeout(spinlock_t* lock, unsigned long iteratio
                 return 1;
             }
             iterations--;
-            __asm__ volatile ("pause");
+            cpu_pause();
         }
         /* Seen lock as free, check if it still is, this time with acquire semantics (but only
          * if we really take it). */

--- a/Pal/src/host/Linux-SGX/db_exception.c
+++ b/Pal/src/host/Linux-SGX/db_exception.c
@@ -21,6 +21,7 @@
  * host, and the methods to pass the exceptions to the upcalls.
  */
 
+#include "cpu.h"
 #include "pal_defs.h"
 #include "pal_linux_defs.h"
 #include "pal.h"
@@ -236,7 +237,7 @@ void _DkExceptionHandler(
 #ifdef DEBUG
         printf("pausing for debug\n");
         while (true)
-            __asm__ volatile("pause");
+            cpu_pause();
 #endif
         _DkThreadExit(/*clear_child_tid=*/NULL);
     }

--- a/Pal/src/host/Linux-SGX/db_pipes.c
+++ b/Pal/src/host/Linux-SGX/db_pipes.c
@@ -22,6 +22,7 @@
  */
 
 #include "api.h"
+#include "cpu.h"
 #include "pal.h"
 #include "pal_crypto.h"
 #include "pal_debug.h"
@@ -402,7 +403,7 @@ static int64_t pipe_read(PAL_HANDLE handle, uint64_t offset, uint64_t len, void*
     } else {
         /* normal pipe, use a secure session (should be already initialized) */
         while (!__atomic_load_n(&handle->pipe.handshake_done, __ATOMIC_ACQUIRE))
-            __asm__ volatile ("pause");
+            cpu_pause();
 
         if (!handle->pipe.ssl_ctx)
             return -PAL_ERROR_NOTCONNECTION;
@@ -442,7 +443,7 @@ static int64_t pipe_write(PAL_HANDLE handle, uint64_t offset, uint64_t len, cons
     } else {
         /* normal pipe, use a secure session (should be already initialized) */
         while (!__atomic_load_n(&handle->pipe.handshake_done, __ATOMIC_ACQUIRE))
-            __asm__ volatile ("pause");
+            cpu_pause();
 
         if (!handle->pipe.ssl_ctx)
             return -PAL_ERROR_NOTCONNECTION;
@@ -471,7 +472,7 @@ static int pipe_close(PAL_HANDLE handle) {
         }
     } else if (handle->pipe.fd != PAL_IDX_POISON) {
         while (!__atomic_load_n(&handle->pipe.handshake_done, __ATOMIC_ACQUIRE))
-            __asm__ volatile ("pause");
+            cpu_pause();
 
         if (handle->pipe.ssl_ctx) {
             _DkStreamSecureFree((LIB_SSL_CONTEXT*)handle->pipe.ssl_ctx);

--- a/Pal/src/host/Linux-SGX/sgx_enclave.c
+++ b/Pal/src/host/Linux-SGX/sgx_enclave.c
@@ -1,3 +1,4 @@
+#include "cpu.h"
 #include "ecall_types.h"
 #include "ocall_types.h"
 #include "pal_linux_error.h"
@@ -728,7 +729,7 @@ static int rpc_thread_loop(void* arg) {
     while (1) {
         rpc_request_t* req = rpc_dequeue(g_rpc_queue);
         if (!req) {
-            __asm__ volatile("pause");
+            cpu_pause();
             continue;
         }
 


### PR DESCRIPTION
This PR creates an inline function (in Pal/include/arch/x86_64/cpu.h) cpu_pause() for the asm instruction 'pause'.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1531)
<!-- Reviewable:end -->
