### PR TITLE
[PAL+LibOS] Fix SIGPIPE emulation

### DIFF
--- a/LibOS/shim/include/shim_signal.h
+++ b/LibOS/shim/include/shim_signal.h
@@ -126,6 +126,8 @@ const char * signal_name (int sig)
 
 struct shim_thread;
 
+void do_epipe_upcall(void);
+
 int init_signal (void);
 
 void __store_context (shim_tcb_t * tcb, PAL_CONTEXT * pal_context,

--- a/LibOS/shim/src/bookkeep/shim_signal.c
+++ b/LibOS/shim/src/bookkeep/shim_signal.c
@@ -628,12 +628,8 @@ static void resume_upcall (PAL_PTR event, PAL_NUM arg, PAL_CONTEXT * context)
     DkExceptionReturn(event);
 }
 
-static void pipe_upcall(PAL_PTR event, PAL_NUM arg, PAL_CONTEXT* context) {
-    if (!is_internal_tid(get_cur_tid()))
-        deliver_signal(ALLOC_SIGINFO(SIGPIPE, 0, si_pid, 0), /*context=*/NULL);
-    else
-        internal_fault("Internal SIGPIPE fault", arg, context);
-    DkExceptionReturn(event);
+void do_epipe_upcall(void) {
+    deliver_signal(ALLOC_SIGINFO(SIGPIPE, 0, si_pid, 0), /*context=*/NULL);
 }
 
 int init_signal (void)
@@ -644,7 +640,6 @@ int init_signal (void)
     DkSetExceptionHandler(&quit_upcall,        PAL_EVENT_QUIT);
     DkSetExceptionHandler(&suspend_upcall,     PAL_EVENT_SUSPEND);
     DkSetExceptionHandler(&resume_upcall,      PAL_EVENT_RESUME);
-    DkSetExceptionHandler(&pipe_upcall,        PAL_EVENT_PIPE);
     return 0;
 }
 

--- a/LibOS/shim/src/sys/shim_open.c
+++ b/LibOS/shim/src/sys/shim_open.c
@@ -89,7 +89,11 @@ int do_handle_write (struct shim_handle * hdl, const void * buf, int count)
     if (hdl->type == TYPE_DIR)
         return -EISDIR;
 
-    return fs->fs_ops->write(hdl, buf, count);
+    int ret = fs->fs_ops->write(hdl, buf, count);
+    if (ret == -EPIPE)
+        do_epipe_upcall();
+
+    return ret;
 }
 
 size_t shim_do_write (int fd, const void * buf, size_t count)

--- a/LibOS/shim/src/sys/shim_wrappers.c
+++ b/LibOS/shim/src/sys/shim_wrappers.c
@@ -26,6 +26,7 @@
 #include <shim_fs.h>
 #include <shim_handle.h>
 #include <shim_internal.h>
+#include <shim_signal.h>
 #include <shim_table.h>
 #include <shim_utils.h>
 
@@ -125,6 +126,8 @@ ssize_t shim_do_writev(int fd, const struct iovec* vec, int vlen) {
 
         b_vec = hdl->fs->fs_ops->write(hdl, vec[i].iov_base, vec[i].iov_len);
         if (b_vec < 0) {
+            if (b_vec == -EPIPE)
+                do_epipe_upcall();
             ret = bytes ?: b_vec;
             goto out;
         }

--- a/Pal/include/pal/pal.h
+++ b/Pal/include/pal/pal.h
@@ -580,10 +580,8 @@ enum PAL_EVENT {
     PAL_EVENT_RESUME           = 6,
     /*! failure within PAL calls */
     PAL_EVENT_FAILURE          = 7,
-    /*! pipe event */
-    PAL_EVENT_PIPE             = 8,
 
-    PAL_EVENT_NUM_BOUND        = 9,
+    PAL_EVENT_NUM_BOUND        = 8,
 };
 
 typedef void (*PAL_EVENT_HANDLER) (PAL_PTR event, PAL_NUM arg, PAL_CONTEXT*);

--- a/Pal/src/db_exception.c
+++ b/Pal/src/db_exception.c
@@ -47,7 +47,6 @@ struct pal_event_handler handlers[] = {
     [PAL_EVENT_SUSPEND]          = INIT_EVENT_HANDLER,
     [PAL_EVENT_RESUME]           = INIT_EVENT_HANDLER,
     [PAL_EVENT_FAILURE]          = INIT_EVENT_HANDLER,
-    [PAL_EVENT_PIPE]             = INIT_EVENT_HANDLER,
 };
 
 PAL_EVENT_HANDLER _DkGetExceptionHandler(PAL_NUM event) {


### PR DESCRIPTION
This PR addresses issue #1534.

We must not install a signal handler for SIGPIPE on the PAL layer that
simply forwards all SIGPIPE signals to the LibOS layer since we have
internal file descriptors that also may also receive a SIGPIPE and we
must not forward the SIGPIPE received on those to the application but
handle their EPIPE after the write operation.

The solution is to ignore the SIGPIPE on the PAL layer and intercept
EPIPEs on the LibOS layer after write/writev operations and then do
the signal emulation.

<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://graphene.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1543)
<!-- Reviewable:end -->
