### PR TITLE
[Pal/Linux-SGX] sgx-gdb: Fix single-stepping by jumping to ERESUME

### DIFF
--- a/Pal/src/host/Linux-SGX/debugger/sgx_gdb.h
+++ b/Pal/src/host/Linux-SGX/debugger/sgx_gdb.h
@@ -1,3 +1,5 @@
+#include <stdint.h>
+
 #define MAX_DBG_THREADS 1024
 
 /* This address is shared between our GDB and Graphene-SGX and must
@@ -8,13 +10,15 @@
 #define DBGINFO_ADDR 0x100000000000
 
 /* This struct is read using PTRACE_PEEKDATA in 8B increments
- * therefore it is aligned as long. */
-struct __attribute__((aligned(__alignof__(long)))) enclave_dbginfo {
+ * therefore it is aligned as uint64_t. */
+struct __attribute__((aligned(__alignof__(uint64_t)))) enclave_dbginfo {
     int pid;
-    unsigned long base, size;
-    unsigned long ssaframesize;
+    uint64_t base;
+    uint64_t size;
+    uint64_t ssaframesize;
     void* aep;
+    void* eresume;
     int thread_tids[MAX_DBG_THREADS];
     void* tcs_addrs[MAX_DBG_THREADS];
-    unsigned long long thread_stepping;
+    uint64_t thread_stepping[MAX_DBG_THREADS/64]; /* bit vector */
 };

--- a/Pal/src/host/Linux-SGX/sgx_entry.S
+++ b/Pal/src/host/Linux-SGX/sgx_entry.S
@@ -51,6 +51,12 @@ sgx_ecall:
 async_exit_pointer:
 	# increment per-thread AEX counter for stats
 	lock incq %gs:PAL_TCB_URTS_AEX_CNT
+	# fall-through to ERESUME
+
+	.global eresume_pointer
+	.type eresume_pointer, @function
+
+eresume_pointer:
 	ENCLU   # perform ERESUME
 
 	.global sgx_raise

--- a/Pal/src/host/Linux-SGX/sgx_internal.h
+++ b/Pal/src/host/Linux-SGX/sgx_internal.h
@@ -133,7 +133,8 @@ void exit_process (int status, uint64_t start_exiting);
 int sgx_ecall (long ecall_no, void * ms);
 int sgx_raise (int event);
 
-void async_exit_pointer (void);
+void async_exit_pointer(void);
+void eresume_pointer(void);
 
 int interrupt_thread (void * tcs);
 int clone_thread (void);

--- a/Pal/src/host/Linux-SGX/sgx_main.c
+++ b/Pal/src/host/Linux-SGX/sgx_main.c
@@ -624,8 +624,9 @@ int initialize_enclave (struct pal_enclave * enclave)
         dbg->pid = INLINE_SYSCALL(getpid, 0);
         dbg->base = enclave->baseaddr;
         dbg->size = enclave->size;
-        dbg->ssaframesize = enclave->ssaframesize;
-        dbg->aep  = async_exit_pointer;
+        dbg->ssaframesize   = enclave->ssaframesize;
+        dbg->aep            = async_exit_pointer;
+        dbg->eresume        = eresume_pointer;
         dbg->thread_tids[0] = dbg->pid;
         for (int i = 0 ; i < MAX_DBG_THREADS ; i++)
             dbg->tcs_addrs[i] = tcs_addrs[i];


### PR DESCRIPTION

## Description of the changes <!-- (reasons and measures) -->

Commit 3178e26 "Add sgx.print_stats manifest option to display SGX stats" broke the SGX-GDB ptrace wrapper by adding a new instruction to the Asynchronous Exit Pointer assembly. This new instruction confused the GDB wrapper when it tried to single-step using ptrace's SINGLESTEP command: it assumed that the only instruction in AEP is ERESUME. This commit adds new function entry to the AEP assembly so that the GDB wrapper moves RIP to ERESUME and continues single-
stepping from the correct position. This commit also fixes small bug with thread_stepping by converting it to a proper bit vector.

## How to test this PR? <!-- (if applicable) -->

Run GDB and try to single-step through the enclave.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1548)
<!-- Reviewable:end -->
