### PR TITLE
[PAL+LibOS] Add -Wmissing-prototypes to CFLAGS and deal with the fallouts

### DIFF
--- a/LibOS/shim/include/shim_fork.h
+++ b/LibOS/shim/include/shim_fork.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2014 Stony Brook University
+/*
    This file is part of Graphene Library OS.
 
    Graphene Library OS is free software: you can redistribute it and/or
@@ -14,27 +14,14 @@
    You should have received a copy of the GNU Lesser General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
 
-/*
- * db_rtld.c
- *
- * This file contains utilities to load ELF binaries into the memory
- * and link them against each other.
- * The source code in this file is imported and modified from the GNU C
- * Library.
- */
+#ifndef _SHIM_FORK_H_
+#define _SHIM_FORK_H_
 
-#include <api.h>
-#include <pal_internal.h>
+#include <stdarg.h>
 
-#include "sgx_internal.h"
+#include "shim_checkpoint.h"
 
-__asm__(".pushsection \".debug_gdb_scripts\", \"MS\",@progbits,1\r\n"
-        ".byte 1\r\n"
-        ".asciz \"" PAL_FILE("host/Linux-SGX/debugger/pal-gdb.py") "\"\r\n"
-        ".popsection\r\n");
+int migrate_fork(struct shim_cp_store* store, struct shim_thread* thread,
+                 struct shim_process* process, va_list ap);
 
-/* This function is hooked by our gdb integration script and should be
- * left as is. */
-void load_gdb_command(const char* command) {
-    __UNUSED(command);
-}
+#endif /* _SHIM_FORK_H_ */

--- a/LibOS/shim/include/shim_internal.h
+++ b/LibOS/shim/include/shim_internal.h
@@ -41,6 +41,8 @@
 #include <shim_tcb.h>
 #include <shim_types.h>
 
+void* shim_init(int argc, void* args);
+
 noreturn void shim_clean_and_exit(int exit_code);
 
 /* important macros and static inline functions */
@@ -376,7 +378,29 @@ void parse_syscall_after (int sysno, const char * name, int nr, ...);
         __UNUSED(__arg6);                       \
     } while (0)
 
+#define SHIM_SYSCALL_PROTO_0(NAME, RTYPE) \
+    RTYPE shim_##NAME(void)
+
+#define SHIM_SYSCALL_PROTO_1(NAME, RTYPE, T1, P1) \
+    RTYPE shim_##NAME(T1 P1)
+
+#define SHIM_SYSCALL_PROTO_2(NAME, RTYPE, T1, P1, T2, P2) \
+    RTYPE shim_##NAME(T1 P1, T2 P2)
+
+#define SHIM_SYSCALL_PROTO_3(NAME, RTYPE, T1, P1, T2, P2, T3, P3) \
+    RTYPE shim_##NAME(T1 P1, T2 P2, T3 P3)
+
+#define SHIM_SYSCALL_PROTO_4(NAME, RTYPE, T1, P1, T2, P2, T3, P3, T4, P4) \
+    RTYPE shim_##NAME(T1 P1, T2 P2, T3 P3, T4 P4)
+
+#define SHIM_SYSCALL_PROTO_5(NAME, RTYPE, T1, P1, T2, P2, T3, P3, T4, P4, T5, P5) \
+    RTYPE shim_##NAME(T1 P1, T2 P2, T3 P3, T4 P4, T5 P5)
+
+#define SHIM_SYSCALL_PROTO_6(NAME, RTYPE, T1, P1, T2, P2, T3, P3, T4, P4, T5, P5, T6, P6) \
+    RTYPE shim_##NAME(T1 P1, T2 P2, T3 P3, T4 P4, T5 P5, T6 P6)
+
 #define SHIM_SYSCALL_RETURN_ENOSYS(name, n, ...)                                   \
+    SHIM_SYSCALL_PROTO_##n(name, __VA_ARGS__);                                     \
     BEGIN_SHIM(name, SHIM_PROTO_ARGS_##n)                                          \
         debug("WARNING: syscall " #name " not implemented. Returning -ENOSYS.\n"); \
         SHIM_UNUSED_ARGS_##n();                                                    \

--- a/LibOS/shim/include/shim_ipc_helper.h
+++ b/LibOS/shim/include/shim_ipc_helper.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2014 Stony Brook University
+/*
    This file is part of Graphene Library OS.
 
    Graphene Library OS is free software: you can redistribute it and/or
@@ -14,27 +14,9 @@
    You should have received a copy of the GNU Lesser General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
 
-/*
- * db_rtld.c
- *
- * This file contains utilities to load ELF binaries into the memory
- * and link them against each other.
- * The source code in this file is imported and modified from the GNU C
- * Library.
- */
+#ifndef _SHIM_IPC_HELPER_H_
+#define _SHIM_IPC_HELPER_H_
 
-#include <api.h>
-#include <pal_internal.h>
+int init_ipc_ports(void);
 
-#include "sgx_internal.h"
-
-__asm__(".pushsection \".debug_gdb_scripts\", \"MS\",@progbits,1\r\n"
-        ".byte 1\r\n"
-        ".asciz \"" PAL_FILE("host/Linux-SGX/debugger/pal-gdb.py") "\"\r\n"
-        ".popsection\r\n");
-
-/* This function is hooked by our gdb integration script and should be
- * left as is. */
-void load_gdb_command(const char* command) {
-    __UNUSED(command);
-}
+#endif /* _SHIM_IPC_HELPER_H_ */

--- a/LibOS/shim/include/shim_ipc_pid.h
+++ b/LibOS/shim/include/shim_ipc_pid.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2014 Stony Brook University
+/*
    This file is part of Graphene Library OS.
 
    Graphene Library OS is free software: you can redistribute it and/or
@@ -14,27 +14,19 @@
    You should have received a copy of the GNU Lesser General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
 
-/*
- * db_rtld.c
- *
- * This file contains utilities to load ELF binaries into the memory
- * and link them against each other.
- * The source code in this file is imported and modified from the GNU C
- * Library.
- */
+#ifndef _SHIM_IPC_PID_H_
+#define _SHIM_IPC_PID_H_
 
-#include <api.h>
-#include <pal_internal.h>
+#include <shim_ipc.h>
 
-#include "sgx_internal.h"
+int init_ipc_ports(void);
+int init_ns_pid(void);
+int init_ns_sysv(void);
 
-__asm__(".pushsection \".debug_gdb_scripts\", \"MS\",@progbits,1\r\n"
-        ".byte 1\r\n"
-        ".asciz \"" PAL_FILE("host/Linux-SGX/debugger/pal-gdb.py") "\"\r\n"
-        ".popsection\r\n");
+void debug_print_pid_ranges(void);
 
-/* This function is hooked by our gdb integration script and should be
- * left as is. */
-void load_gdb_command(const char* command) {
-    __UNUSED(command);
-}
+int get_pid_port(IDTYPE pid, IDTYPE* dest, struct shim_ipc_port** port);
+int get_rpc_msg(IDTYPE* sender, void* buf, int len);
+int get_all_pid_status(struct pid_status** status);
+
+#endif /* _SHIM_IPC_PID_H_ */

--- a/LibOS/shim/include/shim_ipc_sysv.h
+++ b/LibOS/shim/include/shim_ipc_sysv.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2014 Stony Brook University
+/*
    This file is part of Graphene Library OS.
 
    Graphene Library OS is free software: you can redistribute it and/or
@@ -14,27 +14,10 @@
    You should have received a copy of the GNU Lesser General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
 
-/*
- * db_rtld.c
- *
- * This file contains utilities to load ELF binaries into the memory
- * and link them against each other.
- * The source code in this file is imported and modified from the GNU C
- * Library.
- */
+#ifndef _SHIM_IPC_SYSV_H_
+#define _SHIM_IPC_SYSV_H_
 
-#include <api.h>
-#include <pal_internal.h>
+int init_ns_sysv(void);
+void debug_print_sysv_ranges(void);
 
-#include "sgx_internal.h"
-
-__asm__(".pushsection \".debug_gdb_scripts\", \"MS\",@progbits,1\r\n"
-        ".byte 1\r\n"
-        ".asciz \"" PAL_FILE("host/Linux-SGX/debugger/pal-gdb.py") "\"\r\n"
-        ".popsection\r\n");
-
-/* This function is hooked by our gdb integration script and should be
- * left as is. */
-void load_gdb_command(const char* command) {
-    __UNUSED(command);
-}
+#endif /* _SHIM_IPC_SYSV_H_ */

--- a/LibOS/shim/include/shim_table.h
+++ b/LibOS/shim/include/shim_table.h
@@ -10,6 +10,8 @@
 
 #ifdef IN_SHIM
 
+void debug_unsupp(int num);
+
 typedef void (*shim_fp)(void);
 
 extern shim_fp shim_table[];
@@ -332,6 +334,8 @@ int shim_do_close(int fd);
 int shim_do_stat(const char* file, struct stat* statbuf);
 int shim_do_fstat(int fd, struct stat* statbuf);
 int shim_do_lstat(const char* file, struct stat* stat);
+int shim_do_statfs(const char* path, struct statfs* buf);
+int shim_do_fstatfs(int fd, struct statfs* buf);
 int shim_do_poll(struct pollfd* fds, nfds_t nfds, int timeout);
 off_t shim_do_lseek(int fd, off_t offset, int origin);
 void* shim_do_mmap(void* addr, size_t length, int prot, int flags, int fd, off_t offset);
@@ -420,6 +424,7 @@ int shim_do_fchown(int fd, uid_t user, gid_t group);
 mode_t shim_do_umask(mode_t mask);
 int shim_do_gettimeofday(struct __kernel_timeval* tv, struct __kernel_timezone* tz);
 int shim_do_getrlimit(int resource, struct __kernel_rlimit* rlim);
+int shim_do_getrusage(int who, struct __kernel_rusage* ru);
 uid_t shim_do_getuid(void);
 gid_t shim_do_getgid(void);
 int shim_do_setuid(uid_t uid);

--- a/LibOS/shim/include/shim_thread.h
+++ b/LibOS/shim/include/shim_thread.h
@@ -285,6 +285,8 @@ int check_last_thread(struct shim_thread* self);
 int walk_thread_list (int (*callback) (struct shim_thread *, void *, bool *),
                       void * arg);
 
+void dump_threads(void);
+
 /* reference counting of handle maps */
 void get_handle_map (struct shim_handle_map * map);
 void put_handle_map (struct shim_handle_map * map);

--- a/LibOS/shim/src/bookkeep/shim_handle.c
+++ b/LibOS/shim/src/bookkeep/shim_handle.c
@@ -540,24 +540,6 @@ off_t get_file_size(struct shim_handle* hdl) {
     return 0;
 }
 
-void dup_fd_handle(struct shim_handle_map* map, const struct shim_fd_handle* old,
-                   struct shim_fd_handle* new) {
-    struct shim_handle* replaced = NULL;
-
-    lock(&map->lock);
-
-    if (old->vfd != FD_NULL) {
-        get_handle(old->handle);
-        replaced    = new->handle;
-        new->handle = old->handle;
-    }
-
-    unlock(&map->lock);
-
-    if (replaced)
-        put_handle(replaced);
-}
-
 static struct shim_handle_map* get_new_handle_map(FDTYPE size) {
     struct shim_handle_map* handle_map = calloc(1, sizeof(struct shim_handle_map));
 

--- a/LibOS/shim/src/bookkeep/shim_thread.c
+++ b/LibOS/shim/src/bookkeep/shim_thread.c
@@ -139,7 +139,7 @@ static IDTYPE get_internal_pid (void)
     return idx;
 }
 
-struct shim_thread * alloc_new_thread (void)
+static struct shim_thread * alloc_new_thread (void)
 {
     struct shim_thread * thread = calloc(1, sizeof(struct shim_thread));
     if (!thread)

--- a/LibOS/shim/src/fs/shim_fs.c
+++ b/LibOS/shim/src/fs/shim_fs.c
@@ -277,7 +277,7 @@ int search_builtin_fs(const char* type, struct shim_mount** fs) {
     return -ENOENT;
 }
 
-int __mount_fs(struct shim_mount* mount, struct shim_dentry* dent) {
+static int __mount_fs(struct shim_mount* mount, struct shim_dentry* dent) {
     assert(locked(&dcache_lock));
 
     int ret = 0;

--- a/LibOS/shim/src/fs/shim_fs_hash.c
+++ b/LibOS/shim/src/fs/shim_fs_hash.c
@@ -18,6 +18,7 @@
  * This file contains functions to generate hash values for FS paths.
  */
 
+#include <shim_fs.h>
 #include <shim_internal.h>
 
 static HASHTYPE __hash(const char* p, size_t len) {

--- a/LibOS/shim/src/generated-offsets.c
+++ b/LibOS/shim/src/generated-offsets.c
@@ -5,6 +5,9 @@
 #include <shim_internal.h>
 #include <shim_tcb.h>
 
+/* prototype needed due to -Wmissing-prototypes */
+void dummy(void);
+
 void dummy(void)
 {
     OFFSET_T(SHIM_TCB_OFFSET, PAL_TCB, libos_tcb);
@@ -17,4 +20,3 @@ void dummy(void)
     /* definitions */
     DEFINE(RED_ZONE_SIZE, RED_ZONE_SIZE);
 }
-

--- a/LibOS/shim/src/ipc/shim_ipc.c
+++ b/LibOS/shim/src/ipc/shim_ipc.c
@@ -29,6 +29,9 @@
 #include <shim_handle.h>
 #include <shim_internal.h>
 #include <shim_ipc.h>
+#include <shim_ipc_helper.h>
+#include <shim_ipc_pid.h>
+#include <shim_ipc_sysv.h>
 #include <shim_thread.h>
 #include <shim_unistd.h>
 #include <shim_utils.h>
@@ -54,10 +57,6 @@ struct shim_process cur_process;
 #define CLIENT_HASH(vmid)  ((vmid)&CLIENT_HASH_MASK)
 DEFINE_LISTP(shim_ipc_info);
 static LISTP_TYPE(shim_ipc_info) info_hlist[CLIENT_HASH_NUM];
-
-int init_ipc_ports(void);
-int init_ns_pid(void);
-int init_ns_sysv(void);
 
 int init_ipc(void) {
     int ret = 0;

--- a/LibOS/shim/src/ipc/shim_ipc_helper.c
+++ b/LibOS/shim/src/ipc/shim_ipc_helper.c
@@ -21,6 +21,8 @@
  * of IPC ports.
  */
 
+#include "shim_ipc_helper.h"
+
 #include <list.h>
 #include <pal.h>
 #include <pal_error.h>

--- a/LibOS/shim/src/ipc/shim_ipc_nsimpl.h
+++ b/LibOS/shim/src/ipc/shim_ipc_nsimpl.h
@@ -578,7 +578,7 @@ failed:
     return ret;
 }
 
-int CONCAT3(renew, NS, range)(IDTYPE idx, LEASETYPE* lease) {
+static int CONCAT3(renew, NS, range)(IDTYPE idx, LEASETYPE* lease) {
     IDTYPE off = (idx - 1) / RANGE_SIZE;
 
     lock(&range_map_lock);
@@ -596,7 +596,7 @@ int CONCAT3(renew, NS, range)(IDTYPE idx, LEASETYPE* lease) {
     return 0;
 }
 
-int CONCAT3(renew, NS, subrange)(IDTYPE idx, LEASETYPE* lease) {
+static int CONCAT3(renew, NS, subrange)(IDTYPE idx, LEASETYPE* lease) {
     IDTYPE off  = (idx - 1) / RANGE_SIZE;
     IDTYPE base = off * RANGE_SIZE + 1;
 

--- a/LibOS/shim/src/ipc/shim_ipc_pid.c
+++ b/LibOS/shim/src/ipc/shim_ipc_pid.c
@@ -20,6 +20,8 @@
  * This file contains functions and callbacks to handle IPC of PID namespace.
  */
 
+#include "shim_ipc_pid.h"
+
 #include <errno.h>
 
 #include <pal.h>
@@ -159,7 +161,7 @@ struct thread_status {
     struct pid_status* status;
 };
 
-int check_thread(struct shim_thread* thread, void* arg, bool* unlocked) {
+static int check_thread(struct shim_thread* thread, void* arg, bool* unlocked) {
     __UNUSED(unlocked);  // Kept for API compatibility
     struct thread_status* status = (struct thread_status*)arg;
 

--- a/LibOS/shim/src/ipc/shim_ipc_sysv.c
+++ b/LibOS/shim/src/ipc/shim_ipc_sysv.c
@@ -20,14 +20,17 @@
  * This file contains functions and callbacks to handle IPC of SYSV namespace.
  */
 
+#include "shim_ipc_sysv.h"
+
 #include <errno.h>
-#include <pal.h>
-#include <pal_error.h>
-#include <shim_checkpoint.h>
-#include <shim_internal.h>
-#include <shim_ipc.h>
-#include <shim_sysv.h>
-#include <shim_thread.h>
+
+#include "pal.h"
+#include "pal_error.h"
+#include "shim_checkpoint.h"
+#include "shim_internal.h"
+#include "shim_ipc.h"
+#include "shim_sysv.h"
+#include "shim_thread.h"
 
 #define SYSV_RANGE_SIZE 128
 #define SYSV_LEASE_TIME 1000

--- a/LibOS/shim/src/shim_checkpoint.c
+++ b/LibOS/shim/src/shim_checkpoint.c
@@ -486,8 +486,7 @@ next:
     return 0;
 }
 
-int send_handles_on_stream (PAL_HANDLE stream, struct shim_cp_store * store)
-{
+static int send_handles_on_stream (PAL_HANDLE stream, struct shim_cp_store* store) {
     int nentries = store->palhdl_nentries;
     if (!nentries)
         return 0;
@@ -517,9 +516,7 @@ int send_handles_on_stream (PAL_HANDLE stream, struct shim_cp_store * store)
     return 0;
 }
 
-int receive_handles_on_stream (struct palhdl_header * hdr, ptr_t base,
-                               long rebase)
-{
+static int receive_handles_on_stream(struct palhdl_header* hdr, ptr_t base, long rebase) {
     struct shim_palhdl_entry * palhdl_entries =
                             (void *) (base + hdr->entoffset);
     int nentries = hdr->nentries;

--- a/LibOS/shim/src/shim_init.c
+++ b/LibOS/shim/src/shim_init.c
@@ -77,11 +77,6 @@ void warn (const char *format, ...)
     va_end (args);
 }
 
-
-void __stack_chk_fail (void)
-{
-}
-
 static int pal_errno_to_unix_errno [PAL_ERROR_NATIVE_COUNT + 1] = {
         /* reserved                  */  0,
         /* PAL_ERROR_NOTIMPLEMENTED  */  ENOSYS,
@@ -358,8 +353,7 @@ int init_stack (const char ** argv, const char ** envp,
     return 0;
 }
 
-int read_environs (const char ** envp)
-{
+static int read_environs(const char** envp) {
     for (const char ** e = envp ; *e ; e++) {
         if (strstartswith_static(*e, "LD_LIBRARY_PATH=")) {
             /* populate library_paths with entries from LD_LIBRARY_PATH envvar */

--- a/LibOS/shim/src/shim_malloc.c
+++ b/LibOS/shim/src/shim_malloc.c
@@ -107,14 +107,6 @@ int init_slab(void) {
 
 EXTERN_ALIAS(init_slab);
 
-int reinit_slab(void) {
-    if (slab_mgr) {
-        destroy_slab_mgr(slab_mgr);
-        slab_mgr = NULL;
-    }
-    return 0;
-}
-
 #if defined(SLAB_DEBUG_PRINT) || defined(SLABD_DEBUG_TRACE)
 void* __malloc_debug(size_t size, const char* file, int line)
 #else

--- a/LibOS/shim/src/shim_syscalls.c
+++ b/LibOS/shim/src/shim_syscalls.c
@@ -35,10 +35,6 @@
 #include <shim_unistd.h>
 #include <shim_utils.h>
 
-long int if_call_defined(long int sys_no) {
-    return shim_table[sys_no] != 0;
-}
-
 //////////////////////////////////////////////////
 //  Mappings from system calls to shim calls
 ///////////////////////////////////////////////////

--- a/LibOS/shim/src/sys/shim_alarm.c
+++ b/LibOS/shim/src/sys/shim_alarm.c
@@ -61,7 +61,7 @@ static struct {
     unsigned long reset;
 } real_itimer;
 
-void signal_itimer(IDTYPE target, void* arg) {
+static void signal_itimer(IDTYPE target, void* arg) {
     // XXX: Can we simplify this code or streamline with the other callback?
     __UNUSED(target);
 

--- a/LibOS/shim/src/sys/shim_clone.c
+++ b/LibOS/shim/src/sys/shim_clone.c
@@ -21,15 +21,17 @@
  * implemented yet.)
  */
 
-#include <shim_types.h>
-#include <shim_internal.h>
-#include <shim_table.h>
-#include <shim_thread.h>
-#include <shim_utils.h>
-#include <shim_checkpoint.h>
 
-#include <pal.h>
-#include <pal_error.h>
+#include "shim_fork.h"
+#include "shim_types.h"
+#include "shim_internal.h"
+#include "shim_table.h"
+#include "shim_thread.h"
+#include "shim_utils.h"
+#include "shim_checkpoint.h"
+
+#include "pal.h"
+#include "pal_error.h"
 
 #include <errno.h>
 #include <sys/syscall.h>
@@ -173,10 +175,6 @@ static int clone_implementation_wrapper(struct shim_clone_args * arg)
     restore_context(&tcb->context);
     return 0;
 }
-
-int migrate_fork (struct shim_cp_store * cpstore,
-                  struct shim_thread * thread,
-                  struct shim_process * process, va_list ap);
 
 /*  long int __arg0 - flags
  *  long int __arg1 - 16 bytes ( 2 words ) offset into the child stack allocated

--- a/LibOS/shim/src/sys/shim_fork.c
+++ b/LibOS/shim/src/sys/shim_fork.c
@@ -20,18 +20,20 @@
  * Implementation of system calls "fork" and "vfork".
  */
 
+#include "shim_fork.h"
+
 #include <errno.h>
 #include <linux/futex.h>
 #include <sys/mman.h>
 #include <sys/syscall.h>
 
-#include <pal.h>
-#include <pal_error.h>
-#include <shim_checkpoint.h>
-#include <shim_internal.h>
-#include <shim_ipc.h>
-#include <shim_table.h>
-#include <shim_thread.h>
+#include "pal.h"
+#include "pal_error.h"
+#include "shim_checkpoint.h"
+#include "shim_internal.h"
+#include "shim_ipc.h"
+#include "shim_table.h"
+#include "shim_thread.h"
 
 static BEGIN_MIGRATION_DEF(fork, struct shim_thread* thread, struct shim_process* process) {
     DEFINE_MIGRATE(process, process, sizeof(struct shim_process));

--- a/LibOS/shim/src/sys/shim_futex.c
+++ b/LibOS/shim/src/sys/shim_futex.c
@@ -36,6 +36,7 @@
 #include "list.h"
 #include "pal.h"
 #include "shim_internal.h"
+#include "shim_table.h"
 #include "shim_thread.h"
 #include "shim_types.h"
 #include "spinlock.h"

--- a/LibOS/shim/src/sys/shim_ioctl.c
+++ b/LibOS/shim/src/sys/shim_ioctl.c
@@ -287,7 +287,7 @@ passthrough:
     return -EAGAIN;
 }
 
-void signal_io(IDTYPE target, void* arg) {
+static void signal_io(IDTYPE target, void* arg) {
     // Kept for compatibility with signal_itimer
     __UNUSED(arg);
 

--- a/LibOS/shim/src/sys/shim_msgget.c
+++ b/LibOS/shim/src/sys/shim_msgget.c
@@ -32,6 +32,7 @@
 #include <shim_internal.h>
 #include <shim_ipc.h>
 #include <shim_sysv.h>
+#include <shim_table.h>
 #include <shim_unistd.h>
 #include <shim_utils.h>
 

--- a/LibOS/shim/src/sys/shim_socket.c
+++ b/LibOS/shim/src/sys/shim_socket.c
@@ -868,7 +868,7 @@ out:
     return ret;
 }
 
-int __do_accept(struct shim_handle* hdl, int flags, struct sockaddr* addr, int* addrlen) {
+static int __do_accept(struct shim_handle* hdl, int flags, struct sockaddr* addr, int* addrlen) {
     if (hdl->type != TYPE_SOCK)
         return -ENOTSOCK;
 

--- a/LibOS/shim/src/vdso/vdso.c
+++ b/LibOS/shim/src/vdso/vdso.c
@@ -19,7 +19,7 @@
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <shim_types.h>
+#include "vdso.h"
 
 /*
  * The symbols below need to be exported for libsysdb to inject those values,

--- a/LibOS/shim/src/vdso/vdso.h
+++ b/LibOS/shim/src/vdso/vdso.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2014 Stony Brook University
+/*
    This file is part of Graphene Library OS.
 
    Graphene Library OS is free software: you can redistribute it and/or
@@ -14,27 +14,14 @@
    You should have received a copy of the GNU Lesser General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
 
-/*
- * db_rtld.c
- *
- * This file contains utilities to load ELF binaries into the memory
- * and link them against each other.
- * The source code in this file is imported and modified from the GNU C
- * Library.
- */
+#ifndef _SHIM_VDSO_H_
+#define _SHIM_VDSO_H_
 
-#include <api.h>
-#include <pal_internal.h>
+#include "shim_types.h"
 
-#include "sgx_internal.h"
+int __vdso_clock_gettime(clockid_t clock, struct timespec* t);
+int __vdso_gettimeofday(struct timeval* tv, struct timezone* tz);
+time_t __vdso_time(time_t* t);
+long __vdso_getcpu(unsigned* cpu, struct getcpu_cache* unused);
 
-__asm__(".pushsection \".debug_gdb_scripts\", \"MS\",@progbits,1\r\n"
-        ".byte 1\r\n"
-        ".asciz \"" PAL_FILE("host/Linux-SGX/debugger/pal-gdb.py") "\"\r\n"
-        ".popsection\r\n");
-
-/* This function is hooked by our gdb integration script and should be
- * left as is. */
-void load_gdb_command(const char* command) {
-    __UNUSED(command);
-}
+#endif /* _SHIM_VDSO_H_ */

--- a/LibOS/shim/test/benchmark/sig_latency.c
+++ b/LibOS/shim/test/benchmark/sig_latency.c
@@ -16,7 +16,7 @@ int pids[TEST_TIMES][2];
 int firstpid;
 int secondpid;
 
-void sighand1(int signum, siginfo_t* sinfo, void* ucontext) {
+static void sighand1(int signum, siginfo_t* sinfo, void* ucontext) {
     count++;
 #ifndef DO_BENCH
     if (count % 100 == 0)
@@ -28,7 +28,7 @@ void sighand1(int signum, siginfo_t* sinfo, void* ucontext) {
     kill(secondpid, SIGUSR1);
 }
 
-void sighand2(int signum, siginfo_t* sinfo, void* ucontext) {
+static void sighand2(int signum, siginfo_t* sinfo, void* ucontext) {
     count++;
 #ifndef DO_BENCH
     if (count % 100 == 0)
@@ -42,7 +42,7 @@ void sighand2(int signum, siginfo_t* sinfo, void* ucontext) {
 
 void (*sighand)(int signum, siginfo_t* sinfo, void* ucontext) = NULL;
 
-void sigact(int signum, siginfo_t* sinfo, void* ucontext) {
+static void sigact(int signum, siginfo_t* sinfo, void* ucontext) {
     if (sighand)
         sighand(signum, sinfo, ucontext);
 }

--- a/LibOS/shim/test/benchmark/test_start.c
+++ b/LibOS/shim/test/benchmark/test_start.c
@@ -19,7 +19,7 @@
 #define OVERHEAD_TIMES 30000
 #define TEST_TIMES     1000
 
-void get_time(char* time_arg, unsigned long overhead) {
+static void get_time(char* time_arg, unsigned long overhead) {
     struct timeval tv;
     gettimeofday(&tv, NULL);
     unsigned long long msec = tv.tv_sec * 1000000ULL + tv.tv_usec;

--- a/LibOS/shim/test/fs/common.h
+++ b/LibOS/shim/test/fs/common.h
@@ -21,7 +21,7 @@
 #include <sys/types.h>
 
 noreturn void fatal_error(const char* fmt, ...);
-void setup();
+void setup(void);
 int open_input_fd(const char* path);
 void read_fd(const char* path, int fd, void* buffer, size_t size);
 void seek_fd(const char* path, int fd, off_t offset, int mode);

--- a/LibOS/shim/test/fs/common_copy.c
+++ b/LibOS/shim/test/fs/common_copy.c
@@ -6,7 +6,7 @@
 #define RDWR_OUTPUT_OPEN false
 #endif
 
-void copy_file(const char* input_path, const char* output_path, size_t size) {
+static void copy_file(const char* input_path, const char* output_path, size_t size) {
     int fi = open_input_fd(input_path);
     printf("open(%zu) input OK\n", size);
 

--- a/LibOS/shim/test/fs/delete.c
+++ b/LibOS/shim/test/fs/delete.c
@@ -1,6 +1,6 @@
 #include "common.h"
 
-void file_delete(const char* file_path_1, const char* file_path_2, bool writable) {
+static void file_delete(const char* file_path_1, const char* file_path_2, bool writable) {
     const char* type = writable ? "output" : "input";
 
     int fd = writable ? open_output_fd(file_path_1, /*rdwr=*/false) : open_input_fd(file_path_1);

--- a/LibOS/shim/test/fs/open_close.c
+++ b/LibOS/shim/test/fs/open_close.c
@@ -2,7 +2,7 @@
 
 #include "common.h"
 
-void open_close_input_fd(const char* input_path) {
+static void open_close_input_fd(const char* input_path) {
     int fi = open_input_fd(input_path);
     printf("open(%s) input OK\n", input_path);
     close_fd(input_path, fi);
@@ -18,7 +18,7 @@ void open_close_input_fd(const char* input_path) {
     printf("close(%s) input 2 OK\n", input_path);
 }
 
-void open_close_input_stdio(const char* input_path) {
+static void open_close_input_stdio(const char* input_path) {
     FILE* fi = open_input_stdio(input_path);
     printf("fopen(%s) input OK\n", input_path);
     close_stdio(input_path, fi);
@@ -34,7 +34,7 @@ void open_close_input_stdio(const char* input_path) {
     printf("fclose(%s) input 2 OK\n", input_path);
 }
 
-void open_close_output_fd(const char* output_path) {
+static void open_close_output_fd(const char* output_path) {
     int fo = open_output_fd(output_path, /*rdwr=*/false);
     printf("open(%s) output OK\n", output_path);
     close_fd(output_path, fo);
@@ -50,7 +50,7 @@ void open_close_output_fd(const char* output_path) {
     printf("close(%s) output 2 OK\n", output_path);
 }
 
-void open_close_output_stdio(const char* output_path) {
+static void open_close_output_stdio(const char* output_path) {
     FILE* fo = open_output_stdio(output_path, /*rdwr=*/false);
     printf("fopen(%s) output OK\n", output_path);
     close_stdio(output_path, fo);

--- a/LibOS/shim/test/fs/open_flags.c
+++ b/LibOS/shim/test/fs/open_flags.c
@@ -3,7 +3,7 @@
 const int g_mode = 0664;
 const char g_data = 'x';
 
-size_t get_file_size(const char* path) {
+static size_t get_file_size(const char* path) {
     struct stat st;
     if (stat(path, &st) < 0)
         fatal_error("Failed to stat file '%s': %s\n", path, strerror(errno));
@@ -11,8 +11,8 @@ size_t get_file_size(const char* path) {
     return st.st_size;
 }
 
-void open_test__(const char* path, int flags, const char* flags_str, bool exists,
-                 bool expect_success, bool do_write) {
+static void open_test__(const char* path, int flags, const char* flags_str, bool exists,
+                        bool expect_success, bool do_write) {
     const char* exists_str = exists ? "exists" : "doesn't exist";
     int fd = open(path, flags, g_mode);
     if (fd < 0) {

--- a/LibOS/shim/test/fs/read_write.c
+++ b/LibOS/shim/test/fs/read_write.c
@@ -1,6 +1,6 @@
 #include "common.h"
 
-void read_write(const char* file_path) {
+static void read_write(const char* file_path) {
     const size_t size = 1024 * 1024;
     int fd = open_output_fd(file_path, /*rdwr=*/true);
     printf("open(%s) RW OK\n", file_path);

--- a/LibOS/shim/test/fs/seek_tell.c
+++ b/LibOS/shim/test/fs/seek_tell.c
@@ -2,7 +2,7 @@
 
 #define EXTEND_SIZE 4097
 
-void seek_input_fd(const char* path) {
+static void seek_input_fd(const char* path) {
     int f = open_input_fd(path);
     printf("open(%s) input OK\n", path);
     seek_fd(path, f, 0, SEEK_SET);
@@ -19,7 +19,7 @@ void seek_input_fd(const char* path) {
     printf("close(%s) input OK\n", path);
 }
 
-void seek_input_stdio(const char* path) {
+static void seek_input_stdio(const char* path) {
     FILE* f = open_input_stdio(path);
     printf("fopen(%s) input OK\n", path);
     seek_stdio(path, f, 0, SEEK_SET);
@@ -36,7 +36,7 @@ void seek_input_stdio(const char* path) {
     printf("fclose(%s) input OK\n", path);
 }
 
-void seek_output_fd(const char* path) {
+static void seek_output_fd(const char* path) {
     uint8_t buf[EXTEND_SIZE + 1] = {1};
     int f = open_output_fd(path, /*rdwr=*/true);
     printf("open(%s) output OK\n", path);
@@ -67,7 +67,7 @@ void seek_output_fd(const char* path) {
     printf("close(%s) output OK\n", path);
 }
 
-void seek_output_stdio(const char* path) {
+static void seek_output_stdio(const char* path) {
     uint8_t buf[EXTEND_SIZE + 1] = {1};
     FILE* f = open_output_stdio(path, /*rdwr=*/true);
     printf("fopen(%s) output OK\n", path);

--- a/LibOS/shim/test/fs/stat.c
+++ b/LibOS/shim/test/fs/stat.c
@@ -1,6 +1,6 @@
 #include "common.h"
 
-void file_stat(const char* file_path, bool writable) {
+static void file_stat(const char* file_path, bool writable) {
     struct stat st;
     const char* type = writable ? "output" : "input";
 

--- a/LibOS/shim/test/fs/truncate.c
+++ b/LibOS/shim/test/fs/truncate.c
@@ -1,6 +1,6 @@
 #include "common.h"
 
-void file_truncate(const char* file_path_1, const char* file_path_2, size_t size) {
+static void file_truncate(const char* file_path_1, const char* file_path_2, size_t size) {
     if (truncate(file_path_1, size) != 0)
         fatal_error("Failed to truncate file %s to %zu: %s\n", file_path_1, size, strerror(errno));
     printf("truncate(%s) to %zu OK\n", file_path_1, size);

--- a/LibOS/shim/test/native/alarm.c
+++ b/LibOS/shim/test/native/alarm.c
@@ -3,7 +3,7 @@
 #include <stdlib.h>
 #include <unistd.h>
 
-void handler(int signal) {
+static void handler(int signal) {
     printf("alarm goes off\n");
 }
 

--- a/LibOS/shim/test/native/clone.c
+++ b/LibOS/shim/test/native/clone.c
@@ -14,13 +14,13 @@
 
 __thread int mypid = 0;
 
-unsigned long gettls(void) {
+static unsigned long gettls(void) {
     unsigned long tls;
     syscall(__NR_arch_prctl, ARCH_GET_FS, &tls);
     return tls;
 }
 
-int thread_function(void* argument) {
+static int thread_function(void* argument) {
     mypid    = getpid();
     int* ptr = (int*)argument;
     printf("in the child: pid (%016lx) = %d\n", (unsigned long)&mypid, mypid);

--- a/LibOS/shim/test/native/condvar.c
+++ b/LibOS/shim/test/native/condvar.c
@@ -5,8 +5,8 @@
 pthread_mutex_t count_mutex = PTHREAD_MUTEX_INITIALIZER;
 pthread_cond_t condvar      = PTHREAD_COND_INITIALIZER;
 
-void* function1();
-void* function2();
+static void* function1(void*);
+static void* function2(void*);
 int count = 0;
 
 #define COUNT_DONE  10
@@ -26,7 +26,7 @@ int main(int argc, const char** argv) {
     return 0;
 }
 
-void* function1(void) {
+static void* function1(void* unused) {
     for (;;) {
         // Lock mutex and then wait for signal to relase mutex
         pthread_mutex_lock(&count_mutex);
@@ -44,7 +44,7 @@ void* function1(void) {
     }
 }
 
-void* function2(void) {
+static void* function2(void* unused) {
     for (;;) {
         pthread_mutex_lock(&count_mutex);
 

--- a/LibOS/shim/test/native/divzero.c
+++ b/LibOS/shim/test/native/divzero.c
@@ -2,7 +2,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-void handler(int signal) {
+static void handler(int signal) {
     printf("get signal: %d\n", signal);
     exit(0);
 }

--- a/LibOS/shim/test/native/fork_bomb.c
+++ b/LibOS/shim/test/native/fork_bomb.c
@@ -15,7 +15,7 @@ int secondpid;
 
 int count = 0;
 
-void sighand1(int signum) {
+static void sighand1(int signum) {
     count++;
 #ifndef DO_BENCH
     printf("%d receive a SIGUSR (count = %d)\n", getpid(), count);
@@ -23,7 +23,7 @@ void sighand1(int signum) {
     kill(secondpid, SIGUSR1);
 }
 
-void sighand2(int signum) {
+static void sighand2(int signum) {
     count++;
 #ifndef DO_BENCH
     printf("%d receive a SIGUSR (count = %d)\n", getpid(), count);

--- a/LibOS/shim/test/native/futextest.c
+++ b/LibOS/shim/test/native/futextest.c
@@ -2,7 +2,7 @@
 #include <stdio.h>
 #include <unistd.h>
 
-void* print1(void* arg) {
+static void* print1(void* arg) {
     printf("This is Function 1 - go to sleep\n");
     sleep(5);
     printf("Function1 out of sleep\n");
@@ -10,7 +10,7 @@ void* print1(void* arg) {
     return NULL;
 }
 
-void* print2(void* arg) {
+static void* print2(void* arg) {
     printf("This is Function 2 - go to sleep\n");
     sleep(5);
     printf("Function2 out of sleep\n");
@@ -18,7 +18,7 @@ void* print2(void* arg) {
     return NULL;
 }
 
-void* func(void* arg) {
+static void* func(void* arg) {
     int* ptr = (int*)arg;
     printf("Parent gave %d\n", *ptr);
     return NULL;

--- a/LibOS/shim/test/native/get_time.c
+++ b/LibOS/shim/test/native/get_time.c
@@ -19,7 +19,7 @@
 #define OVERHEAD_TIMES 30000
 #define TEST_TIMES     1000
 
-void get_time(char* time_arg, unsigned long overhead) {
+static void get_time(char* time_arg, unsigned long overhead) {
     struct timeval tv;
     gettimeofday(&tv, NULL);
     unsigned long long msec = tv.tv_sec * 1000000ULL + tv.tv_usec;

--- a/LibOS/shim/test/native/helloworld_pthread.c
+++ b/LibOS/shim/test/native/helloworld_pthread.c
@@ -5,7 +5,7 @@
 #include <stdlib.h>
 #include <unistd.h>
 
-void* print(void* arg) {
+static void* print(void* arg) {
     printf("child: pid %d\n", getpid());
     puts((char*)arg);
     return NULL;

--- a/LibOS/shim/test/native/msg_create.c
+++ b/LibOS/shim/test/native/msg_create.c
@@ -19,7 +19,7 @@ struct msg_buf {
 #define TEST_TIMES 1000
 #define DO_BENCH   1
 
-int create_q(int key) {
+static int create_q(int key) {
     int r = msgget(key, IPC_CREAT | 0600);
 
 #ifndef DO_BENCH
@@ -38,7 +38,7 @@ int create_q(int key) {
     return r;
 }
 
-int connect_q(int key) {
+static int connect_q(int key) {
     int r = msgget(key, 0);
 
 #ifndef DO_BENCH
@@ -62,7 +62,7 @@ int pipefds[4];
 int keys[TEST_TIMES];
 
 /* server always creates queues */
-void server(void) {
+static void server(void) {
     struct timeval tv1, tv2;
     int i;
 
@@ -100,7 +100,7 @@ void server(void) {
 }
 
 /* client always connects queues */
-void client(void) {
+static void client(void) {
     struct timeval tv1, tv2;
     int i;
     int ids[TEST_TIMES];

--- a/LibOS/shim/test/native/msg_create_libos.c
+++ b/LibOS/shim/test/native/msg_create_libos.c
@@ -20,7 +20,7 @@ struct msg_buf {
 #define TEST_TIMES 1000
 #define DO_BENCH   1
 
-int create_q(int key) {
+static int create_q(int key) {
     int r = msgget(key, IPC_CREAT | 0600);
 
 #ifndef DO_BENCH
@@ -39,30 +39,11 @@ int create_q(int key) {
     return r;
 }
 
-int connect_q(int key) {
-    int r = msgget(key, 0);
-
-#ifndef DO_BENCH
-    printf("The identifier used is %d\n", r);
-#endif
-
-    if (r < 0) {
-        perror("msgget");
-        exit(-1);
-    }
-#ifndef DO_BENCH
-    else
-        printf("Connected the message queue\n");
-#endif
-
-    return r;
-}
-
 int keys[TEST_TIMES];
 int ids[TEST_TIMES];
 
 /* server always creates queues */
-void server(void) {
+static void server(void) {
     struct timeval tv1, tv2;
     int i;
 
@@ -83,7 +64,7 @@ void server(void) {
 }
 
 /* client always connects queues */
-void client(void) {
+static void client(void) {
     struct timeval tv1, tv2;
     int i;
 

--- a/LibOS/shim/test/native/msg_send.c
+++ b/LibOS/shim/test/native/msg_send.c
@@ -20,7 +20,7 @@ enum { PARALLEL, SERIAL, IN_PROCESS } mode = PARALLEL;
 int pipefds[4], key;
 
 /* server always sends messages */
-void server(void) {
+static void server(void) {
     struct timeval tv1, tv2;
     int msqid;
     alignas(struct msgbuf) char _data[sizeof(struct msgbuf) + PAYLOAD_SIZE];
@@ -71,7 +71,7 @@ void server(void) {
 }
 
 /* client always sends messages */
-void client(void) {
+static void client(void) {
     struct timeval tv1, tv2;
     int msqid;
     alignas(struct msgbuf) char _data[sizeof(struct msgbuf) + PAYLOAD_SIZE];

--- a/LibOS/shim/test/native/msg_send_libos.c
+++ b/LibOS/shim/test/native/msg_send_libos.c
@@ -23,7 +23,7 @@ struct msgbuf {
 int msqid;
 
 /* server always sends messages */
-void server(void) {
+static void server(void) {
     struct timeval tv1, tv2;
     struct msgbuf buf;
     int i;
@@ -52,7 +52,7 @@ void server(void) {
 }
 
 /* client always sends messages */
-void client(void) {
+static void client(void) {
     struct timeval tv1, tv2;
     struct msgbuf buf;
     int ret;

--- a/LibOS/shim/test/native/multisleep.c
+++ b/LibOS/shim/test/native/multisleep.c
@@ -13,7 +13,7 @@
 
 int proc;
 
-int thread_function(void* arg) {
+static int thread_function(void* arg) {
     int thread = (int)((unsigned long)arg);
     printf("in process %d thread %d\n", proc, thread);
     for (int i = 0; i < SLEEP_TIME; i++) {

--- a/LibOS/shim/test/native/pause.c
+++ b/LibOS/shim/test/native/pause.c
@@ -5,7 +5,7 @@
 #include <stdlib.h>
 #include <unistd.h>
 
-void handler(int signal) {
+static void handler(int signal) {
     printf("hello world\n");
 }
 

--- a/LibOS/shim/test/native/pid_alloc.c
+++ b/LibOS/shim/test/native/pid_alloc.c
@@ -6,7 +6,7 @@
 #include <sys/time.h>
 #include <sys/wait.h>
 
-int func(void* arg) {
+static int func(void* arg) {
     return 0;
 }
 

--- a/LibOS/shim/test/native/pid_kill.c
+++ b/LibOS/shim/test/native/pid_kill.c
@@ -13,13 +13,13 @@ int secondpid;
 
 int count = 0;
 
-void sighand1(int signum, siginfo_t* sinfo, void* ucontext) {
+static void sighand1(int signum, siginfo_t* sinfo, void* ucontext) {
     count++;
     printf("firstpid receive a SIGUSR from %d (count = %d)\n", sinfo->si_pid, count);
     kill(secondpid, SIGUSR1);
 }
 
-void sighand2(int signum, siginfo_t* sinfo, void* ucontext) {
+static void sighand2(int signum, siginfo_t* sinfo, void* ucontext) {
     count++;
     printf("secondpid receive a SIGUSR from %d (count = %d)\n", sinfo->si_pid, count);
     kill(firstpid, SIGUSR1);

--- a/LibOS/shim/test/native/sem.c
+++ b/LibOS/shim/test/native/sem.c
@@ -16,7 +16,7 @@ enum { PARALLEL, SERIAL, IN_PROCESS } mode = PARALLEL;
 int pipefds[2], key;
 
 /* server always sends messages */
-void server(void) {
+static void server(void) {
     struct timeval tv1, tv2;
     int semid;
     struct sembuf buf;
@@ -71,7 +71,7 @@ void server(void) {
 }
 
 /* client always sends messages */
-void client(void) {
+static void client(void) {
     struct timeval tv1, tv2;
     int semid;
     struct sembuf buf;

--- a/LibOS/shim/test/native/start.c
+++ b/LibOS/shim/test/native/start.c
@@ -6,11 +6,11 @@
 
 #define OVERHEAD_TIMES 30000
 
-double my_sqrt(double num) {
+static double my_sqrt(double num) {
     return sqrt(num);
 }
 
-pthread_t my_pthread_self(void) {
+static pthread_t my_pthread_self(void) {
     return pthread_self();
 }
 

--- a/LibOS/shim/test/native/sync.c
+++ b/LibOS/shim/test/native/sync.c
@@ -8,7 +8,7 @@
 pthread_mutex_t mutex;
 double target;
 
-void* opponent(void* arg) {
+static void* opponent(void* arg) {
     int i;
     for (i = 0; i < ITERATIONS; ++i) {
         // Lock the mutex

--- a/LibOS/shim/test/native/tcp.c
+++ b/LibOS/shim/test/native/tcp.c
@@ -25,7 +25,7 @@ int do_fork                    = 0;
 
 int pipefds[2];
 
-int server(void) {
+static int server(void) {
     int conn, create_socket, new_socket, fd;
     socklen_t addrlen;
     int bufsize  = 1024;
@@ -104,7 +104,7 @@ int server(void) {
     return 0;
 }
 
-int client(void) {
+static int client(void) {
     int count, create_socket;
     int bufsize  = 1024;
     char* buffer = malloc(bufsize);

--- a/LibOS/shim/test/native/test_start_pthread_m.c
+++ b/LibOS/shim/test/native/test_start_pthread_m.c
@@ -19,7 +19,7 @@
 #define OVERHEAD_TIMES 30000
 #define TEST_TIMES     30
 
-void get_time(char* time_arg, unsigned long overhead) {
+static void get_time(char* time_arg, unsigned long overhead) {
     struct timeval tv;
     gettimeofday(&tv, NULL);
     unsigned long long msec = tv.tv_sec * 1000000ULL + tv.tv_usec;

--- a/LibOS/shim/test/regression/abort_multithread.c
+++ b/LibOS/shim/test/regression/abort_multithread.c
@@ -5,7 +5,7 @@
 /* Test if abort() in a child thread kills the whole process. This should report 134 (128 + 6 where
  * 6 is SIGABRT) as its return code. */
 
-void* thread_abort(void* arg) {
+static void* thread_abort(void* arg) {
     abort();
     return NULL;  /* not reached */
 }

--- a/LibOS/shim/test/regression/attestation.c
+++ b/LibOS/shim/test/regression/attestation.c
@@ -22,7 +22,7 @@ char user_report_data_str[] = "This is user-provided report data";
 
 enum { SUCCESS = 0, FAILURE = -1 };
 
-ssize_t rw_file(const char* path, char* buf, size_t bytes, bool do_write) {
+static ssize_t rw_file(const char* path, char* buf, size_t bytes, bool do_write) {
     ssize_t rv = 0;
     ssize_t ret = 0;
 

--- a/LibOS/shim/test/regression/eventfd.c
+++ b/LibOS/shim/test/regression/eventfd.c
@@ -32,7 +32,7 @@
 
 int efds[MAX_EFDS] = {0};
 
-void* write_eventfd_thread(void* arg) {
+static void* write_eventfd_thread(void* arg) {
     uint64_t count = 10;
 
     int* efds = (int*)arg;
@@ -62,7 +62,7 @@ void* write_eventfd_thread(void* arg) {
 
 /* This function used to test polling on a group of eventfd descriptors.
  * To support regression testing, positive value returned for error case. */
-int eventfd_using_poll(void) {
+static int eventfd_using_poll(void) {
     int ret = 0;
     struct pollfd pollfds[MAX_EFDS];
     pthread_t tid    = 0;
@@ -140,7 +140,7 @@ out:
 /* This function used to test various flags supported while creating eventfd
  * descriptors.
  * To support regression testing, positive value returned for error case. */
-int eventfd_using_various_flags(void) {
+static int eventfd_using_various_flags(void) {
     uint64_t count      = 0;
     int efd             = 0;
     ssize_t bytes       = 0;
@@ -216,7 +216,7 @@ int eventfd_using_various_flags(void) {
     return 0;
 }
 
-int eventfd_using_fork(void) {
+static int eventfd_using_fork(void) {
     int status     = 0;
     int efd        = 0;
     uint64_t count = 0;

--- a/LibOS/shim/test/regression/exit_group.c
+++ b/LibOS/shim/test/regression/exit_group.c
@@ -15,7 +15,7 @@ pthread_barrier_t barrier;
 /* Test the process exit logic in Graphene. Multiple threads race to execute exit()/exit_group().
  * Expected return code is 0 .. 4, depending on which thread wins. */
 
-void* inc(void* arg) {
+static void* inc(void* arg) {
     int a = counter++;
     pthread_barrier_wait(&barrier);
     exit(a);

--- a/LibOS/shim/test/regression/file_size.c
+++ b/LibOS/shim/test/regression/file_size.c
@@ -17,7 +17,7 @@
 #define TEST_DIR  "tmp"
 #define TEST_FILE "__testfile__"
 
-ssize_t rw_file(int fd, char* buf, size_t bytes, bool write_flag) {
+static ssize_t rw_file(int fd, char* buf, size_t bytes, bool write_flag) {
     ssize_t rv = 0;
     ssize_t ret;
 

--- a/LibOS/shim/test/regression/futex_bitset.c
+++ b/LibOS/shim/test/regression/futex_bitset.c
@@ -20,7 +20,7 @@ static int futex(int* uaddr, int futex_op, int val, const struct timespec* timeo
     return syscall(SYS_futex, uaddr, futex_op, val, timeout, uaddr2, val3);
 }
 
-void* thread_function(void* argument) {
+static void* thread_function(void* argument) {
     int* ptr = (int*)argument;
     long rv;
 

--- a/LibOS/shim/test/regression/mmap_file.c
+++ b/LibOS/shim/test/regression/mmap_file.c
@@ -9,7 +9,7 @@
 
 static const char* message;
 
-void SIGBUS_handler(int sig) {
+static void SIGBUS_handler(int sig) {
     puts(message);
     exit(0);
 }

--- a/LibOS/shim/test/regression/multi_pthread.c
+++ b/LibOS/shim/test/regression/multi_pthread.c
@@ -9,7 +9,7 @@
 
 atomic_int counter = 0;
 
-void* inc(void* arg) {
+static void* inc(void* arg) {
     counter++;
     return NULL;
 }

--- a/LibOS/shim/test/regression/proc_common.c
+++ b/LibOS/shim/test/regression/proc_common.c
@@ -9,7 +9,7 @@
 #include <sys/wait.h>
 #include <unistd.h>
 
-void* fn(void* arg) {
+static void* fn(void* arg) {
     /* not to consume CPU, each thread simply sleeps */
     sleep(10000);
     return NULL;

--- a/LibOS/shim/test/regression/readdir.c
+++ b/LibOS/shim/test/regression/readdir.c
@@ -12,7 +12,7 @@
 #define TEST_FILE "__testfile__"
 
 /* return true if file_name exists, otherwise false */
-bool find_file(char* dir_name, char* file_name) {
+static bool find_file(char* dir_name, char* file_name) {
     bool found = false;
     DIR* dir = opendir(dir_name);
     if (dir == NULL) {

--- a/LibOS/shim/test/regression/sigaltstack.c
+++ b/LibOS/shim/test/regression/sigaltstack.c
@@ -11,7 +11,7 @@ uint8_t* sig_stack;
 size_t sig_stack_size = SIGSTKSZ;
 _Atomic int count     = 0;
 
-void handler(int signal, siginfo_t* info, void* ucontext) {
+static void handler(int signal, siginfo_t* info, void* ucontext) {
     int ret;
     count++;
 

--- a/LibOS/shim/test/regression/sighandler_reset.c
+++ b/LibOS/shim/test/regression/sighandler_reset.c
@@ -9,7 +9,7 @@
 
 static int count = 0;
 
-void handler(int signum) {
+static void handler(int signum) {
     printf("Got signal %d\n", signum);
     fflush(stdout);
     count++;

--- a/LibOS/shim/test/regression/sigprocmask.c
+++ b/LibOS/shim/test/regression/sigprocmask.c
@@ -5,7 +5,7 @@
 #include <stdlib.h>
 #include <unistd.h>
 
-void* thread_func(void* arg) {
+static void* thread_func(void* arg) {
     exit(113);
     return NULL;
 }

--- a/LibOS/shim/test/regression/tcp_msg_peek.c
+++ b/LibOS/shim/test/regression/tcp_msg_peek.c
@@ -19,7 +19,7 @@
 enum { SINGLE, PARALLEL } mode = PARALLEL;
 int pipefds[2];
 
-void server(void) {
+static void server(void) {
     int listening_socket, client_socket;
     struct sockaddr_in address;
     socklen_t addrlen;
@@ -128,7 +128,7 @@ static ssize_t client_recv(int server_socket, char* buf, size_t len, int flags) 
     return read;
 }
 
-void client(void) {
+static void client(void) {
     int server_socket;
     struct sockaddr_in address;
     char buffer[BUFLEN];

--- a/LibOS/shim/test/regression/udp.c
+++ b/LibOS/shim/test/regression/udp.c
@@ -19,7 +19,7 @@ int do_fork                    = 0;
 
 int pipefds[2];
 
-int server(void) {
+static int server(void) {
     struct sockaddr_in si_me, si_other;
     int s, i;
     socklen_t slen = sizeof(si_other);
@@ -73,7 +73,7 @@ int server(void) {
     return 0;
 }
 
-int client(void) {
+static int client(void) {
     struct sockaddr_in si_other;
     int s, i;
     socklen_t slen   = sizeof(si_other);

--- a/LibOS/shim/test/regression/unix.c
+++ b/LibOS/shim/test/regression/unix.c
@@ -20,7 +20,7 @@ int do_fork                    = 0;
 
 int pipefds[2];
 
-int server_dummy_socket(void) {
+static int server_dummy_socket(void) {
     int create_socket;
     struct sockaddr_un address;
 
@@ -46,7 +46,7 @@ int server_dummy_socket(void) {
     return 0;
 }
 
-int server(void) {
+static int server(void) {
     int create_socket, new_socket;
     socklen_t addrlen;
     int bufsize  = 1024;
@@ -116,7 +116,7 @@ int server(void) {
     return 0;
 }
 
-int client(void) {
+static int client(void) {
     int count, create_socket;
     int bufsize  = 1024;
     char* buffer = malloc(bufsize);

--- a/Pal/include/pal/pal.h
+++ b/Pal/include/pal/pal.h
@@ -661,6 +661,11 @@ DkEventSet(PAL_HANDLE eventHandle);
 void
 DkEventClear(PAL_HANDLE eventHandle);
 
+/*!
+ * \brief Wait for an event.
+ */
+void DkEventWait(PAL_HANDLE handle);
+
 /*! block until the handle's event is triggered */
 #define NO_TIMEOUT ((PAL_NUM)-1)
 

--- a/Pal/lib/Makefile
+++ b/Pal/lib/Makefile
@@ -2,9 +2,16 @@ include ../../Scripts/Makefile.configs
 include ../../Scripts/Makefile.rules
 include ../src/host/$(PAL_HOST)/Makefile.am
 
-CFLAGS += -I../include/lib -I../include -I../include/pal -I../include/arch/$(ARCH) \
-          -I../include/arch/$(ARCH)/$(PAL_HOST) -I../include/host/$(PAL_HOST) \
-          -I../src/host/$(PAL_HOST) -Icrypto/mbedtls/include -Icrypto/mbedtls/crypto/include
+CFLAGS += \
+	-I../include \
+	-I../include/arch/$(ARCH) \
+	-I../include/arch/$(ARCH)/$(PAL_HOST) \
+	-I../include/host/$(PAL_HOST) \
+	-I../include/lib \
+	-I../include/pal \
+	-I../src/host/$(PAL_HOST) \
+	-Icrypto/mbedtls/include \
+	-Icrypto/mbedtls/crypto/include
 
 CRYPTO_PROVIDER ?= mbedtls
 

--- a/Pal/lib/crypto/adapters/mbedtls_adapter.c
+++ b/Pal/lib/crypto/adapters/mbedtls_adapter.c
@@ -29,6 +29,7 @@
 #include "assert.h"
 #include "mbedtls/aes.h"
 #include "mbedtls/cmac.h"
+#include "mbedtls/entropy_poll.h"
 #include "mbedtls/error.h"
 #include "mbedtls/net_sockets.h"
 #include "mbedtls/rsa.h"

--- a/Pal/lib/crypto/udivmodti4.c
+++ b/Pal/lib/crypto/udivmodti4.c
@@ -14,14 +14,7 @@
 
 #include <limits.h>
 
-typedef          long long di_int;
-typedef unsigned long long du_int;
-
-typedef          int si_int;
-typedef unsigned int su_int;
-
-typedef          int ti_int __attribute__((mode (TI)));
-typedef unsigned int tu_int __attribute__((mode (TI)));
+#include "udivmodti4.h"
 
 typedef union
 {
@@ -49,7 +42,7 @@ typedef union
 
 /* Translated from Figure 3-40 of The PowerPC Compiler Writer's Guide */
 
-tu_int
+static tu_int
 __udivmodti4(tu_int a, tu_int b, tu_int* rem)
 {
     const unsigned n_udword_bits = sizeof(du_int) * CHAR_BIT;

--- a/Pal/lib/crypto/udivmodti4.h
+++ b/Pal/lib/crypto/udivmodti4.h
@@ -1,0 +1,29 @@
+/* ===-- udivmodti4.c - Implement __udivmodti4 -----------------------------===
+ *
+ *                    The LLVM Compiler Infrastructure
+ *
+ * This file is dual licensed under the MIT and the University of Illinois Open
+ * Source Licenses. See LICENSE.TXT for details.
+ *
+ * ===----------------------------------------------------------------------===
+ *
+ * This file implements __udivmodti4 for the compiler_rt library.
+ *
+ * ===----------------------------------------------------------------------===
+ */
+
+#ifndef _UDIVMODTI4_
+#define _UDIVMODTI4_
+
+typedef          long long di_int;
+typedef unsigned long long du_int;
+
+typedef          int si_int;
+typedef unsigned int su_int;
+
+typedef          int ti_int __attribute__((mode (TI)));
+typedef unsigned int tu_int __attribute__((mode (TI)));
+
+tu_int __udivti3(tu_int a, tu_int b);
+
+#endif /* _UDIVMODTI4_ */

--- a/Pal/regression/Event.c
+++ b/Pal/regression/Event.c
@@ -7,7 +7,7 @@
 static PAL_HANDLE event1;
 atomic_int timeouts = 0;
 
-int thread2_run(void* args) {
+static int thread2_run(void* args) {
     pal_printf("Second thread started.\n");
     DkThreadDelayExecution(3000000);
 
@@ -19,7 +19,7 @@ int thread2_run(void* args) {
     return 0;
 }
 
-void pal_failure_handler(PAL_PTR event, PAL_NUM error, PAL_CONTEXT* context) {
+static void pal_failure_handler(PAL_PTR event, PAL_NUM error, PAL_CONTEXT* context) {
     pal_printf("pal_failure_handler called\n");
 
     if (error == PAL_ERROR_TRYAGAIN) {

--- a/Pal/regression/Event2.c
+++ b/Pal/regression/Event2.c
@@ -5,7 +5,7 @@ static PAL_HANDLE event1;
 
 int count = 0;
 
-int thread_func(void* args) {
+static int thread_func(void* args) {
     DkThreadDelayExecution(1000);
 
     pal_printf("In thread 1\n");

--- a/Pal/regression/Exception.c
+++ b/Pal/regression/Exception.c
@@ -12,7 +12,7 @@ static void* get_stack(void) {
     return stack;
 }
 
-void handler1 (PAL_PTR event, PAL_NUM arg, PAL_CONTEXT * context)
+static void handler1(PAL_PTR event, PAL_NUM arg, PAL_CONTEXT* context)
 {
     pal_printf("Arithmetic Exception Handler 1: 0x%08lx, rip = 0x%08lx\n",
                arg, context->rip);
@@ -25,7 +25,7 @@ void handler1 (PAL_PTR event, PAL_NUM arg, PAL_CONTEXT * context)
     DkExceptionReturn(event);
 }
 
-void handler2 (PAL_PTR event, PAL_NUM arg, PAL_CONTEXT * context)
+static void handler2(PAL_PTR event, PAL_NUM arg, PAL_CONTEXT* context)
 {
     pal_printf("Arithmetic Exception Handler 2: 0x%08lx, rip = 0x%08lx\n",
                arg, context->rip);
@@ -36,7 +36,7 @@ void handler2 (PAL_PTR event, PAL_NUM arg, PAL_CONTEXT * context)
     DkExceptionReturn(event);
 }
 
-void handler3 (PAL_PTR event, PAL_NUM arg, PAL_CONTEXT * context)
+static void handler3(PAL_PTR event, PAL_NUM arg, PAL_CONTEXT* context)
 {
     pal_printf("Memory Fault Exception Handler: 0x%08lx, rip = 0x%08lx\n",
                arg, context->rip);
@@ -49,7 +49,7 @@ void handler3 (PAL_PTR event, PAL_NUM arg, PAL_CONTEXT * context)
 
 atomic_bool handler4_called = false;
 
-void handler4(PAL_PTR event, PAL_NUM arg, PAL_CONTEXT * context)
+static void handler4(PAL_PTR event, PAL_NUM arg, PAL_CONTEXT* context)
 {
     pal_printf("Arithmetic Exception Handler 4: 0x%" PRIx64 ", rip = 0x%" PRIx64 "\n", arg, context->rip);
 
@@ -60,7 +60,6 @@ void handler4(PAL_PTR event, PAL_NUM arg, PAL_CONTEXT * context)
 
     DkExceptionReturn(event);
 }
-
 
 static void red_zone_test(void) {
     uint64_t res = 0;

--- a/Pal/regression/Exception2.c
+++ b/Pal/regression/Exception2.c
@@ -4,7 +4,7 @@
 int count = 0;
 int i     = 0;
 
-void handler(PAL_PTR event, PAL_NUM arg, PAL_CONTEXT* context) {
+static void handler(PAL_PTR event, PAL_NUM arg, PAL_CONTEXT* context) {
     pal_printf("failure in the handler: 0x%08lx\n", arg);
     count++;
 

--- a/Pal/regression/Failure.c
+++ b/Pal/regression/Failure.c
@@ -4,7 +4,7 @@
 
 int handled = 0;
 
-void FailureHandler(PAL_PTR event, PAL_NUM arg, PAL_CONTEXT* context) {
+static void FailureHandler(PAL_PTR event, PAL_NUM arg, PAL_CONTEXT* context) {
     pal_printf("Failure notified: %s\n", pal_strerror((unsigned long)arg));
 
     handled = 1;

--- a/Pal/regression/Memory.c
+++ b/Pal/regression/Memory.c
@@ -6,7 +6,7 @@
 
 static volatile int count = 0;
 
-void handler(PAL_PTR event, PAL_NUM arg, PAL_CONTEXT* context) {
+static void handler(PAL_PTR event, PAL_NUM arg, PAL_CONTEXT* context) {
     count++;
     pal_printf("Memory Fault %d\n", count);
 

--- a/Pal/regression/Preload1.c
+++ b/Pal/regression/Preload1.c
@@ -1,6 +1,9 @@
 #include "pal.h"
 #include "pal_debug.h"
 
+/* prototype required due to -Wmissing-prototypes */
+void preload_func1(void);
+
 void preload_func1(void) {
     pal_printf("Preloaded Function 1 Called\n");
 }

--- a/Pal/regression/Preload2.c
+++ b/Pal/regression/Preload2.c
@@ -1,6 +1,9 @@
 #include "pal.h"
 #include "pal_debug.h"
 
+/* prototype required due to -Wmissing-prototypes */
+void preload_func2(void);
+
 void preload_func2(void) {
     pal_printf("Preloaded Function 2 Called\n");
 }

--- a/Pal/regression/Select.c
+++ b/Pal/regression/Select.c
@@ -3,7 +3,7 @@
 
 PAL_HANDLE wakeup;
 
-int thread_func(void* args) {
+static int thread_func(void* args) {
     pal_printf("Enter thread\n");
 
     DkThreadDelayExecution(3000000);

--- a/Pal/regression/Semaphore.c
+++ b/Pal/regression/Semaphore.c
@@ -2,7 +2,7 @@
 #include "pal.h"
 #include "pal_debug.h"
 
-void helper_timeout(PAL_NUM timeout) {
+static void helper_timeout(PAL_NUM timeout) {
     /* Create a binary semaphore */
 
     PAL_HANDLE sem1 = DkMutexCreate(1);
@@ -22,7 +22,7 @@ void helper_timeout(PAL_NUM timeout) {
     DkObjectClose(sem1);
 }
 
-void helper_success(PAL_NUM timeout) {
+static void helper_success(PAL_NUM timeout) {
     /* Create a binary semaphore */
 
     PAL_HANDLE sem1 = DkMutexCreate(0);

--- a/Pal/regression/Thread.c
+++ b/Pal/regression/Thread.c
@@ -6,7 +6,7 @@ void* private2 = "Hello World 2";
 
 static volatile int count1 = 0;
 
-int callback1(void* args) {
+static int callback1(void* args) {
     pal_printf("Run in Child Thread: %s\n", (char*)args);
 
     while (count1 < 10) {

--- a/Pal/regression/Thread2.c
+++ b/Pal/regression/Thread2.c
@@ -10,7 +10,7 @@ static atomic_bool thread3_started = false;
 static atomic_bool thread3_exit_ok = true;
 static atomic_bool thread4_started = false;
 
-int thread2_run(void* args) {
+static int thread2_run(void* args) {
     pal_printf("Thread 2 started.\n");
 
     thread2_started = true;
@@ -19,7 +19,7 @@ int thread2_run(void* args) {
     return 0;
 }
 
-int thread3_run(void* args) {
+static int thread3_run(void* args) {
     pal_printf("Thread 3 started.\n");
 
     thread3_started = true;
@@ -37,7 +37,7 @@ int thread3_run(void* args) {
     return 0;
 }
 
-int thread4_run(void* args) {
+static int thread4_run(void* args) {
     pal_printf("Thread 4 started.\n");
 
     thread4_started = true;

--- a/Pal/regression/Wait.c
+++ b/Pal/regression/Wait.c
@@ -4,7 +4,7 @@
 PAL_HANDLE event1;
 PAL_HANDLE event2;
 
-int thread1_func(void* args) {
+static int thread1_func(void* args) {
     pal_printf("Enter thread 1\n");
 
     DkThreadDelayExecution(3000);
@@ -14,7 +14,7 @@ int thread1_func(void* args) {
     return 0;
 }
 
-int thread2_func(void* args) {
+static int thread2_func(void* args) {
     pal_printf("Enter thread 2\n");
 
     DkThreadDelayExecution(5000);

--- a/Pal/regression/Yield.c
+++ b/Pal/regression/Yield.c
@@ -3,7 +3,7 @@
 
 PAL_HANDLE parent_thread, child_thread;
 
-int child(void* args) {
+static int child(void* args) {
     int i;
     pal_printf("Enter Child Thread\n");
 

--- a/Pal/src/db_rtld.c
+++ b/Pal/src/db_rtld.c
@@ -140,7 +140,7 @@ void setup_elf_hash (struct link_map *map)
 
 /* Map in the shared object NAME, actually located in REALNAME, and already
    opened on FD */
-struct link_map *
+static struct link_map*
 map_elf_object_by_handle (PAL_HANDLE handle, enum object_type type,
                           void * fbp, size_t fbp_len,
                           bool do_copy_dyn)

--- a/Pal/src/db_streams.c
+++ b/Pal/src/db_streams.c
@@ -197,7 +197,7 @@ PAL_HANDLE DkStreamOpen(PAL_STR uri, PAL_FLG access, PAL_FLG share, PAL_FLG crea
     LEAVE_PAL_CALL_RETURN(handle);
 }
 
-int _DkStreamWaitForClient(PAL_HANDLE handle, PAL_HANDLE* client) {
+static int _DkStreamWaitForClient(PAL_HANDLE handle, PAL_HANDLE* client) {
     if (UNKNOWN_HANDLE(handle))
         return -PAL_ERROR_BADHANDLE;
 

--- a/Pal/src/host/Linux-SGX/db_files.c
+++ b/Pal/src/host/Linux-SGX/db_files.c
@@ -365,7 +365,7 @@ static int file_getname(PAL_HANDLE handle, char* buffer, size_t count) {
     return tmp + len - buffer;
 }
 
-const char* file_getrealpath(PAL_HANDLE handle) {
+static const char* file_getrealpath(PAL_HANDLE handle) {
     return handle->file.realpath;
 }
 

--- a/Pal/src/host/Linux-SGX/db_main.c
+++ b/Pal/src/host/Linux-SGX/db_main.c
@@ -85,14 +85,7 @@ PAL_NUM _DkGetHostId (void)
 #include "dynamic_link.h"
 #include <asm/errno.h>
 
-void setup_pal_map (struct link_map * map);
 static struct link_map pal_map;
-
-void init_untrusted_slab_mgr(void);
-int init_enclave(void);
-int init_enclave_key(void);
-int init_child_process(PAL_HANDLE* parent_handle);
-void init_cpuid(void);
 
 /*
  * Creates a dummy file handle with the given name.

--- a/Pal/src/host/Linux-SGX/db_misc.c
+++ b/Pal/src/host/Linux-SGX/db_misc.c
@@ -93,7 +93,7 @@ static struct pal_cpuid {
 static int pal_cpuid_cache_top      = 0;
 static unsigned int pal_cpuid_clock = 0;
 
-int get_cpuid_from_cache(unsigned int leaf, unsigned int subleaf, unsigned int values[4]) {
+static int get_cpuid_from_cache(unsigned int leaf, unsigned int subleaf, unsigned int values[4]) {
     _DkInternalLock(&cpuid_cache_lock);
 
     for (int i = 0; i < pal_cpuid_cache_top; i++)
@@ -111,7 +111,7 @@ int get_cpuid_from_cache(unsigned int leaf, unsigned int subleaf, unsigned int v
     return -PAL_ERROR_DENIED;
 }
 
-void add_cpuid_to_cache(unsigned int leaf, unsigned int subleaf, unsigned int values[4]) {
+static void add_cpuid_to_cache(unsigned int leaf, unsigned int subleaf, unsigned int values[4]) {
     struct pal_cpuid* chosen;
     _DkInternalLock(&cpuid_cache_lock);
 

--- a/Pal/src/host/Linux-SGX/db_pipes.c
+++ b/Pal/src/host/Linux-SGX/db_pipes.c
@@ -81,7 +81,7 @@ fail:
     return ret;
 }
 
-int thread_handshake_func(void* param) {
+static int thread_handshake_func(void* param) {
     PAL_HANDLE handle = (PAL_HANDLE)param;
 
     assert(handle);

--- a/Pal/src/host/Linux-SGX/db_rtld.c
+++ b/Pal/src/host/Linux-SGX/db_rtld.c
@@ -140,8 +140,6 @@ void _DkDebugDelMap (struct link_map * map)
     ocall_load_debug(buffer);
 }
 
-void setup_elf_hash (struct link_map *map);
-
 extern void * section_text, * section_rodata, * section_dynamic,
             * section_data, * section_bss;
 

--- a/Pal/src/host/Linux-SGX/enclave_ecalls.c
+++ b/Pal/src/host/Linux-SGX/enclave_ecalls.c
@@ -4,6 +4,7 @@
 #include <api.h>
 
 #include "ecall_types.h"
+#include "enclave_ecalls.h"
 #include "rpc_queue.h"
 
 #define SGX_CAST(type, item) ((type)(item))

--- a/Pal/src/host/Linux-SGX/enclave_ecalls.h
+++ b/Pal/src/host/Linux-SGX/enclave_ecalls.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2014 Stony Brook University
+/*
    This file is part of Graphene Library OS.
 
    Graphene Library OS is free software: you can redistribute it and/or
@@ -14,27 +14,9 @@
    You should have received a copy of the GNU Lesser General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
 
-/*
- * db_rtld.c
- *
- * This file contains utilities to load ELF binaries into the memory
- * and link them against each other.
- * The source code in this file is imported and modified from the GNU C
- * Library.
- */
+#ifndef _ENCLAVE_ECALLS_H_
+#define _ENCLAVE_ECALLS_H_
 
-#include <api.h>
-#include <pal_internal.h>
+void handle_ecall(long ecall_index, void* ecall_args, void* exit_target, void* enclave_base_addr);
 
-#include "sgx_internal.h"
-
-__asm__(".pushsection \".debug_gdb_scripts\", \"MS\",@progbits,1\r\n"
-        ".byte 1\r\n"
-        ".asciz \"" PAL_FILE("host/Linux-SGX/debugger/pal-gdb.py") "\"\r\n"
-        ".popsection\r\n");
-
-/* This function is hooked by our gdb integration script and should be
- * left as is. */
-void load_gdb_command(const char* command) {
-    __UNUSED(command);
-}
+#endif /* _ENCLAVE_ECALLS_H_ */

--- a/Pal/src/host/Linux-SGX/generated-offsets.c
+++ b/Pal/src/host/Linux-SGX/generated-offsets.c
@@ -19,6 +19,9 @@
 
 #include <generated-offsets-build.h>
 
+/* required due to -Wmissing-prototypes */
+void dummy(void);
+
 void dummy(void)
 {
     /* defines in sgx_arch.h */

--- a/Pal/src/host/Linux-SGX/pal_linux.h
+++ b/Pal/src/host/Linux-SGX/pal_linux.h
@@ -71,6 +71,8 @@ extern struct pal_linux_state {
 struct stat;
 bool stataccess (struct stat * stats, int acc);
 
+int init_child_process(PAL_HANDLE* parent);
+
 #ifdef IN_ENCLAVE
 
 struct pal_sec;
@@ -78,6 +80,9 @@ void pal_linux_main(char * uptr_args, size_t args_size,
                     char * uptr_env, size_t env_size,
                     struct pal_sec * uptr_sec_info);
 void pal_start_thread (void);
+
+struct link_map;
+void setup_pal_map(struct link_map* map);
 
 /* Locking and unlocking of Mutexes */
 int __DkMutexCreate (struct mutex_handle * mut);
@@ -110,7 +115,12 @@ void save_xregs(PAL_XREGS_STATE* xsave_area);
 void restore_xregs(const PAL_XREGS_STATE* xsave_area);
 noreturn void _restore_sgx_context(sgx_cpu_context_t* uc, PAL_XREGS_STATE* xsave_area);
 
+void _DkExceptionHandler(unsigned int exit_info, sgx_cpu_context_t* uc, PAL_XREGS_STATE* xregs_state);
+void _DkHandleExternalEvent(PAL_NUM event, sgx_cpu_context_t* uc, PAL_XREGS_STATE* xregs_state);
+
+
 int init_trusted_files (void);
+void init_cpuid(void);
 
 /* Function: load_trusted_file
  * checks if the file to be opened is trusted or allowed,
@@ -143,6 +153,11 @@ int copy_and_verify_trusted_file (const char * path, const void * umem,
 
 int init_trusted_children (void);
 int register_trusted_child (const char * uri, const char * mr_enclave_str);
+
+int init_enclave(void);
+int init_enclave_key(void);
+
+void init_untrusted_slab_mgr(void);
 
 /* exchange and establish a 256-bit session key */
 int _DkStreamKeyExchange(PAL_HANDLE stream, PAL_SESSION_KEY* key);

--- a/Pal/src/host/Linux-SGX/sgx_enclave.c
+++ b/Pal/src/host/Linux-SGX/sgx_enclave.c
@@ -649,8 +649,6 @@ static long sgx_ocall_eventfd (void * pms)
     return ret;
 }
 
-void load_gdb_command (const char * command);
-
 static long sgx_ocall_load_debug(void * pms)
 {
     const char * command = (const char *) pms;

--- a/Pal/src/host/Linux-SGX/sgx_exception.c
+++ b/Pal/src/host/Linux-SGX/sgx_exception.c
@@ -81,8 +81,7 @@ static const int async_signals[] =
 
 static const int nasync_signals = ARRAY_SIZE(async_signals);
 
-int set_sighandler (int * sigs, int nsig, void * handler)
-{
+static int set_sighandler(int* sigs, int nsig, void* handler) {
     struct sigaction action;
     action.sa_handler = (void (*)(int)) handler;
     action.sa_flags = SA_SIGINFO | SA_ONSTACK;

--- a/Pal/src/host/Linux-SGX/sgx_internal.h
+++ b/Pal/src/host/Linux-SGX/sgx_internal.h
@@ -154,4 +154,6 @@ int sgx_signal_setup (void);
 int block_signals (bool block, const int * sigs, int nsig);
 int block_async_signals (bool block);
 
+void load_gdb_command(const char* command);
+
 #endif

--- a/Pal/src/host/Linux-SGX/sgx_main.c
+++ b/Pal/src/host/Linux-SGX/sgx_main.c
@@ -233,8 +233,7 @@ int load_enclave_binary (sgx_arch_secs_t * secs, int fd,
     return 0;
 }
 
-int initialize_enclave (struct pal_enclave * enclave)
-{
+static int initialize_enclave(struct pal_enclave* enclave) {
     int ret = 0;
     int                    enclave_image = -1;
     char*                  enclave_uri = NULL;

--- a/Pal/src/host/Linux-SGX/tools/common/ias.c
+++ b/Pal/src/host/Linux-SGX/tools/common/ias.c
@@ -12,6 +12,8 @@
    You should have received a copy of the GNU Lesser General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
 
+#include "ias.h"
+
 #include <assert.h>
 #include <ctype.h>
 #include <curl/curl.h>
@@ -59,7 +61,7 @@ struct ias_request_resp {
  *  \param[in]  src NULL-terminated URL-encoded input.
  *  \param[out] dst Buffer to write decoded output to. Can be the same as \a src.
  */
-void urldecode(const char* src, char* dst) {
+static void urldecode(const char* src, char* dst) {
     char a, b;
     while (*src) {
         if (*src == '%' && (a = src[1]) && (b = src[2]) && isxdigit(a) && isxdigit(b)) {

--- a/Pal/src/host/Linux-SGX/tools/common/util.h
+++ b/Pal/src/host/Linux-SGX/tools/common/util.h
@@ -44,7 +44,7 @@ extern endianness_t g_endianness;
 void set_verbose(bool verbose);
 
 /*! Get verbosity level */
-bool get_verbose();
+bool get_verbose(void);
 
 /*! Set endianness for hex strings */
 void set_endianness(endianness_t endianness);
@@ -78,6 +78,9 @@ void hexdump_mem(const void* data, size_t size);
 
 /*! Parse hex string to buffer */
 int parse_hex(const char* hex, void* buffer, size_t buffer_size);
+
+/*! abort */
+void __abort(void);
 
 /* For PAL's assert compatibility */
 #ifndef warn

--- a/Pal/src/host/Linux-SGX/tools/ias-request/ias_request.c
+++ b/Pal/src/host/Linux-SGX/tools/ias-request/ias_request.c
@@ -49,7 +49,7 @@ struct option g_options[] = {
     { 0, 0, 0, 0 }
 };
 
-void usage(const char* exec) {
+static void usage(const char* exec) {
     INFO("Usage: %s <request> [options]\n", exec);
     INFO("Available requests:\n");
     INFO("  sigrl                     Retrieve signature revocation list for a given EPID group\n");
@@ -75,9 +75,9 @@ void usage(const char* exec) {
          "                            %s)\n", IAS_URL_REPORT);
 }
 
-int report(struct ias_context_t* ias, const char* quote_path, const char* nonce,
-           const char* report_path, const char* sig_path, const char* cert_path,
-           const char* advisory_path) {
+static int report(struct ias_context_t* ias, const char* quote_path, const char* nonce,
+                  const char* report_path, const char* sig_path, const char* cert_path,
+                  const char* advisory_path) {
     int ret = -1;
     void* quote_data = NULL;
 
@@ -118,7 +118,7 @@ out:
     return ret;
 }
 
-int sigrl(struct ias_context_t* ias, const char* gid_str, const char* sigrl_path) {
+static int sigrl(struct ias_context_t* ias, const char* gid_str, const char* sigrl_path) {
     uint8_t gid[4];
 
     if (parse_hex(gid_str, gid, sizeof(gid)) != 0) {

--- a/Pal/src/host/Linux-SGX/tools/quote-dump/quote_dump.c
+++ b/Pal/src/host/Linux-SGX/tools/quote-dump/quote_dump.c
@@ -24,7 +24,7 @@ struct option g_options[] = {
     { 0, 0, 0, 0 }
 };
 
-void usage(const char* exec) {
+static void usage(const char* exec) {
     INFO("Usage: %s [options] <quote path>\n", exec);
     INFO("Available options:\n");
     INFO("  --help, -h  Display this help\n");

--- a/Pal/src/host/Linux-SGX/tools/verify-ias-report/verify_ias_report.c
+++ b/Pal/src/host/Linux-SGX/tools/verify-ias-report/verify_ias_report.c
@@ -36,7 +36,7 @@ struct option g_options[] = {
     { 0, 0, 0, 0 }
 };
 
-void usage(const char* exec) {
+static void usage(const char* exec) {
     INFO("Usage: %s [options]\n", exec);
     INFO("Available options:\n");
     INFO("  --help, -h                Display this help\n");

--- a/Pal/src/host/Linux/db_exception.c
+++ b/Pal/src/host/Linux/db_exception.c
@@ -83,7 +83,7 @@ static const int async_signals[] =
 static const int nasync_signals = ARRAY_SIZE(async_signals);
 
 
-int set_sighandler (int * sigs, int nsig, void * handler)
+static int set_sighandler (int * sigs, int nsig, void * handler)
 {
     struct sigaction action;
 

--- a/Pal/src/host/Linux/db_files.c
+++ b/Pal/src/host/Linux/db_files.c
@@ -304,7 +304,7 @@ static int file_getname (PAL_HANDLE handle, char * buffer, size_t count)
     return tmp + len - buffer;
 }
 
-const char * file_getrealpath (PAL_HANDLE handle)
+static const char* file_getrealpath (PAL_HANDLE handle)
 {
     return handle->file.realpath;
 }

--- a/Pal/src/host/Linux/db_main.c
+++ b/Pal/src/host/Linux/db_main.c
@@ -162,8 +162,6 @@ PAL_NUM _DkGetHostId (void)
 
 #include "dynamic_link.h"
 
-void setup_pal_map (struct link_map * map);
-
 #if USE_VDSO_GETTIME == 1
 void setup_vdso_map (ElfW(Addr) addr);
 #endif
@@ -353,7 +351,7 @@ static char * cpu_flags[]
  * Returns the number of online CPUs read from /sys/devices/system/cpu/online, -errno on failure.
  * Understands complex formats like "1,3-5,6".
  */
-int get_cpu_count(void) {
+static int get_cpu_count(void) {
     int fd = INLINE_SYSCALL(open, 3, "/sys/devices/system/cpu/online", O_RDONLY|O_CLOEXEC, 0);
     if (fd < 0)
         return unix_to_pal_error(ERRNO(fd));

--- a/Pal/src/host/Linux/db_mutex.c
+++ b/Pal/src/host/Linux/db_mutex.c
@@ -187,7 +187,7 @@ void _DkMutexRelease(PAL_HANDLE handle) {
     return;
 }
 
-bool _DkMutexIsLocked(struct mutex_handle* m) {
+static bool _DkMutexIsLocked(struct mutex_handle* m) {
     if (!m->locked) {
         return false;
     }

--- a/Pal/src/host/Linux/db_rtld.c
+++ b/Pal/src/host/Linux/db_rtld.c
@@ -23,6 +23,8 @@
  * Library.
  */
 
+#include "db_rtld.h"
+
 #include "pal_defs.h"
 #include "pal_linux_defs.h"
 #include "pal.h"
@@ -34,8 +36,8 @@
 #include "pal_rtld.h"
 #include "api.h"
 
-#include <sysdeps/generic/ldsodefs.h>
-#include <elf/elf.h>
+#include "sysdeps/generic/ldsodefs.h"
+#include "elf/elf.h"
 
 #include "elf-arch.h"
 
@@ -149,8 +151,6 @@ void _DkDebugDelMap (struct link_map * map)
     __UNUSED(map);
 #endif
 }
-
-extern void setup_elf_hash (struct link_map *map);
 
 void setup_pal_map (struct link_map * pal_map)
 {

--- a/Pal/src/host/Linux/db_rtld.h
+++ b/Pal/src/host/Linux/db_rtld.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2014 Stony Brook University
+/*
    This file is part of Graphene Library OS.
 
    Graphene Library OS is free software: you can redistribute it and/or
@@ -14,27 +14,14 @@
    You should have received a copy of the GNU Lesser General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
 
-/*
- * db_rtld.c
- *
- * This file contains utilities to load ELF binaries into the memory
- * and link them against each other.
- * The source code in this file is imported and modified from the GNU C
- * Library.
- */
+#ifndef _DB_RTLD_H_
+#define _DB_RTLD_H_
 
-#include <api.h>
-#include <pal_internal.h>
+#include "pal_linux_defs.h"
+#include "sysdeps/generic/ldsodefs.h"
 
-#include "sgx_internal.h"
+#if USE_VDSO_GETTIME == 1
+void setup_vdso_map(ElfW(Addr) addr);
+#endif /* USE_VDSO_GETTIME */
 
-__asm__(".pushsection \".debug_gdb_scripts\", \"MS\",@progbits,1\r\n"
-        ".byte 1\r\n"
-        ".asciz \"" PAL_FILE("host/Linux-SGX/debugger/pal-gdb.py") "\"\r\n"
-        ".popsection\r\n");
-
-/* This function is hooked by our gdb integration script and should be
- * left as is. */
-void load_gdb_command(const char* command) {
-    __UNUSED(command);
-}
+#endif /* _DB_RTLD_H_ */

--- a/Pal/src/host/Linux/pal_linux.h
+++ b/Pal/src/host/Linux/pal_linux.h
@@ -123,6 +123,12 @@ extern struct pal_linux_state {
 int clone (int (*__fn) (void * __arg), void * __child_stack,
            int __flags, const void * __arg, ...);
 
+/* PAL main function */
+void pal_linux_main(void* initial_rsp, void* fini_callback);
+
+struct link_map;
+void setup_pal_map(struct link_map* map);
+
 /* set/unset CLOEXEC flags of all fds in a handle */
 int handle_set_cloexec (PAL_HANDLE handle, bool enable);
 

--- a/Pal/src/host/Skeleton/db_events.c
+++ b/Pal/src/host/Skeleton/db_events.c
@@ -30,10 +30,6 @@ int _DkEventCreate(PAL_HANDLE* event, bool initialState, bool isnotification) {
     return -PAL_ERROR_NOTIMPLEMENTED;
 }
 
-void _DkEventDestroy(PAL_HANDLE handle) {
-    /* needs to be implemented */
-}
-
 int _DkEventSet(PAL_HANDLE event, int wakeup) {
     return -PAL_ERROR_NOTIMPLEMENTED;
 }

--- a/Pal/src/host/Skeleton/db_files.c
+++ b/Pal/src/host/Skeleton/db_files.c
@@ -88,7 +88,7 @@ static int file_getname(PAL_HANDLE handle, char* buffer, size_t count) {
     return -PAL_ERROR_NOTIMPLEMENTED;
 }
 
-const char* file_getrealpath(PAL_HANDLE handle) {
+static const char* file_getrealpath(PAL_HANDLE handle) {
     return NULL;
 }
 
@@ -117,7 +117,7 @@ static int dir_open(PAL_HANDLE* handle, const char* type, const char* uri, int a
 }
 
 /* 'read' operation for directory stream. Directory stream will not need a 'write' operation. */
-int64_t dir_read(PAL_HANDLE handle, uint64_t offset, uint64_t count, void* buf) {
+static int64_t dir_read(PAL_HANDLE handle, uint64_t offset, uint64_t count, void* buf) {
     return -PAL_ERROR_NOTIMPLEMENTED;
 }
 

--- a/Pal/src/host/Skeleton/db_main.c
+++ b/Pal/src/host/Skeleton/db_main.c
@@ -28,10 +28,6 @@
 #include "pal_error.h"
 #include "api.h"
 
-void __stack_chk_fail(void)
-{
-}
-
 /* must implement "pal_start", and call "pal_main" inside */
 void pal_start (void);
 

--- a/Pal/src/host/Skeleton/pal_host.h
+++ b/Pal/src/host/Skeleton/pal_host.h
@@ -34,6 +34,11 @@ typedef struct mutex_handle {
 #define LOCK_INIT {}
 #define INIT_LOCK(lock) do {} while (0)
 
+/* Locking and unlocking of mutexes */
+int _DkMutexLock(struct mutex_handle* mut);
+int _DkMutexLockTimeout(struct mutex_handle* mut, int64_t timeout_us);
+int _DkMutexUnlock(struct mutex_handle* mut);
+
 typedef struct pal_handle {
     /* TSAI: Here we define the internal types of PAL_HANDLE in PAL design, user has not to access
      * the content inside the handle, also there is no need to allocate the internal handles, so we

--- a/Pal/src/pal_rtld.h
+++ b/Pal/src/pal_rtld.h
@@ -153,7 +153,8 @@ ELF_PREFERRED_ADDRESS_DATA;
 
 struct link_map *
 new_elf_object (const char * realname, enum object_type type);
-void free_elf_object (struct link_map * map);
+void free_elf_object(struct link_map* map);
+void setup_elf_hash(struct link_map* map);
 
 static inline uint_fast32_t elf_fast_hash (const char *s)
 {

--- a/Scripts/Makefile.configs
+++ b/Scripts/Makefile.configs
@@ -40,7 +40,7 @@ ARCH_LONG := $(SYS)
 DEBUG ?=
 export DEBUG
 
-CFLAGS += -Wall -std=c11
+CFLAGS += -Wall -std=c11 -Wmissing-prototypes
 CXXFLAGS += -Wall -std=c++14
 
 ifeq ($(DEBUG),1)


### PR DESCRIPTION
We are not properly checking the signature of functions we are calling in other files. So add -Wmissing-prototypes to the CFLAGS and deal with the fallouts.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1550)
<!-- Reviewable:end -->
