### PR TITLE
[LibOS] Do not inherit signal handlers on execve()

### DIFF
--- a/LibOS/shim/include/shim_signal.h
+++ b/LibOS/shim/include/shim_signal.h
@@ -6,6 +6,7 @@
 #include <ucontext.h>
 
 void sigaction_make_defaults(struct __kernel_sigaction* sig_action);
+void thread_sigaction_reset_on_execve(struct shim_thread* thread);
 
 # define BITS_PER_WORD (8 * sizeof(unsigned long))
 /* The standard def of this macro is dumb */

--- a/LibOS/shim/src/bookkeep/shim_signal.c
+++ b/LibOS/shim/src/bookkeep/shim_signal.c
@@ -50,6 +50,24 @@ void sigaction_make_defaults(struct __kernel_sigaction* sig_action) {
     __sigemptyset(&sig_action->sa_mask);
 }
 
+void thread_sigaction_reset_on_execve(struct shim_thread* thread) {
+    lock(&thread->signal_handles->lock);
+    for (size_t i = 0; i < ARRAY_SIZE(thread->signal_handles->actions); i++) {
+        struct __kernel_sigaction* sig_action = &thread->signal_handles->actions[i];
+
+        __sighandler_t handler = sig_action->k_sa_handler;
+        if (handler == (void*)SIG_DFL || handler == (void*)SIG_IGN) {
+            /* POSIX.1: dispositions of any signals that are ignored or set to the default are left
+             * unchanged. On Linux, this rule applies to SIGCHLD as well. */
+            continue;
+        }
+
+        /* app installed its own signal handler, reset it to default */
+        sigaction_make_defaults(sig_action);
+    }
+    unlock(&thread->signal_handles->lock);
+}
+
 static __rt_sighandler_t default_sighandler[NUM_SIGS];
 
 #define MAX_SIGNAL_LOG 32

--- a/LibOS/shim/src/bookkeep/shim_thread.c
+++ b/LibOS/shim/src/bookkeep/shim_thread.c
@@ -801,6 +801,9 @@ BEGIN_RS_FUNC(running_thread)
              * shim_tcb = NULL
              * in_vm = false
              */
+            if (thread->signal_handles)
+                thread_sigaction_reset_on_execve(thread);
+
             set_cur_thread(thread);
             debug_setbuf(thread->shim_tcb, false);
         }

--- a/LibOS/shim/src/sys/shim_exec.c
+++ b/LibOS/shim/src/sys/shim_exec.c
@@ -91,6 +91,8 @@ noreturn static void __shim_do_execve_rtld(struct execve_rtld_arg* __arg) {
     update_fs_base(fs_base);
     debug("set fs_base to 0x%lx\n", fs_base);
 
+    thread_sigaction_reset_on_execve(cur_thread);
+
     remove_loaded_libraries();
     clean_link_map_list();
 

--- a/LibOS/shim/test/regression/.gitignore
+++ b/LibOS/shim/test/regression/.gitignore
@@ -17,6 +17,7 @@
 /epoll_wait_timeout
 /eventfd
 /exec
+/exec_fork
 /exec_invalid_args
 /exec_same
 /exec_victim

--- a/LibOS/shim/test/regression/Makefile
+++ b/LibOS/shim/test/regression/Makefile
@@ -10,6 +10,7 @@ c_executables = \
 	epoll_wait_timeout \
 	eventfd \
 	exec \
+	exec_fork \
 	exec_invalid_args \
 	exec_same \
 	exec_victim \

--- a/LibOS/shim/test/regression/exec_fork.c
+++ b/LibOS/shim/test/regression/exec_fork.c
@@ -1,0 +1,62 @@
+#define _XOPEN_SOURCE 700
+#include <errno.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+static void child_handler(int sig) {
+    (void)sig;
+    /* should never be printed because child doesn't inherit this handler */
+    printf("Handled SIGCHLD\n");
+    fflush(stdout);
+}
+
+int main(int argc, const char** argv, const char** envp) {
+    if (argc > 1) {
+        /* execv'ed child: do dummy fork, wait, and exit */
+        pid_t child_pid = fork();
+        if (child_pid == 0) {
+            /* child just exits */
+            return 0;
+        } else if (child_pid > 0) {
+            /* parent waits for child termination */
+            int status;
+            pid_t pid = wait(&status);
+            if (pid != child_pid) {
+                perror("wait failed");
+                return 1;
+            }
+            if (WIFEXITED(status))
+                printf("child exited with status: %d\n", WEXITSTATUS(status));
+        } else {
+            /* error */
+            perror("fork failed");
+            return 1;
+        }
+
+        puts("test completed successfully");
+        return 0;
+    }
+
+    /* set signal handler for SIGCHLD signal */
+    struct sigaction sa = {0};
+    sa.sa_handler = child_handler;
+    int ret = sigaction(SIGCHLD, &sa, NULL);
+    if (ret < 0) {
+        perror("sigaction error");
+        return 1;
+    }
+
+    printf("Set up handler for SIGCHLD\n");
+    fflush(stdout);
+
+    /* SIGCHLD signal handler must *not* be inherited by execv'ed child */
+    char* const new_argv[] = {(char*)argv[0], "dummy", NULL};
+    execv(new_argv[0], new_argv);
+
+    perror("execv failed");
+    return 1;
+}

--- a/LibOS/shim/test/regression/test_libos.py
+++ b/LibOS/shim/test/regression/test_libos.py
@@ -105,6 +105,13 @@ class TC_01_Bootstrap(RegressionTestCase):
         stdout, _ = self.run_binary(['system'], timeout=60)
         self.assertIn('hello from system', stdout)
 
+    def test_205_exec_fork(self):
+        stdout, _ = self.run_binary(['exec_fork'], timeout=60)
+        self.assertNotIn('Handled SIGCHLD', stdout)
+        self.assertIn('Set up handler for SIGCHLD', stdout)
+        self.assertIn('child exited with status: 0', stdout)
+        self.assertIn('test completed successfully', stdout)
+
     def test_210_exec_invalid_args(self):
         stdout, _ = self.run_binary(['exec_invalid_args'])
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Previously, Graphene forgot to reset signal handlers to defaults. This led to segfaults when parent process installed a signal handler (e.g., SIGCHLD), spawned a child via execve(), and the child spawned a grand-child via e.g. fork(). When the grand-child terminated, the child noticed that it had some SIGCHLD handler installed and tried to call it, but the memory region where the handler was in parent didn't exist any more, so Graphene crashed with segfault.

This PR resets signal handlers on execve() to fix this bug.

Kudos to Manoj Gopalakrishnan for reporting this bug.

## How to test this PR? <!-- (if applicable) -->

New LibOS test `exec_fork` is added. Without this PR, this test crashed Graphene.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1551)
<!-- Reviewable:end -->
