### PR TITLE
[LibOS] Add dummy implementation of getcpu

### DIFF
--- a/LibOS/shim/include/shim_table.h
+++ b/LibOS/shim/include/shim_table.h
@@ -505,6 +505,7 @@ int shim_do_prlimit64(pid_t pid, int resource, const struct __kernel_rlimit64* n
 ssize_t shim_do_sendmmsg(int sockfd, struct mmsghdr* msg, unsigned int vlen, int flags);
 int shim_do_eventfd2(unsigned int count, int flags);
 int shim_do_eventfd(unsigned int count);
+int shim_do_getcpu(unsigned* cpu, unsigned* node, struct getcpu_cache* unused);
 
 /* libos call implementation */
 int shim_do_msgpersist(int msqid, int cmd);
@@ -833,6 +834,7 @@ ssize_t shim_recvmmsg(int sockfd, struct mmsghdr* msg, unsigned int vlen, int fl
 int shim_prlimit64(pid_t pid, int resource, const struct __kernel_rlimit64* new_rlim,
                    struct __kernel_rlimit64* old_rlim);
 ssize_t shim_sendmmsg(int sockfd, struct mmsghdr* msg, unsigned int vlen, int flags);
+int shim_getcpu(unsigned* cpu, unsigned* node, struct getcpu_cache* unused);
 
 /* libos call wrappers */
 int shim_msgpersist(int msqid, int cmd);

--- a/LibOS/shim/src/shim_parser.c
+++ b/LibOS/shim/src/shim_parser.c
@@ -390,6 +390,7 @@ struct parser_table {
         [__NR_rt_tgsigqueueinfo] = {.slow = 0, .parser = {NULL}},
         [__NR_perf_event_open]   = {.slow = 0, .parser = {NULL}},
         [__NR_recvmmsg]          = {.slow = 0, .parser = {NULL}},
+        [__NR_getcpu]        = {.slow = 0, .parser = {NULL}},
 
         [LIBOS_SYSCALL_BASE] = {.slow = 0, .parser = {NULL}},
 

--- a/LibOS/shim/src/shim_syscalls.c
+++ b/LibOS/shim/src/shim_syscalls.c
@@ -1040,8 +1040,8 @@ DEFINE_SHIM_SYSCALL(sendmmsg, 4, shim_do_sendmmsg, ssize_t, int, fd, struct mmsg
 
 SHIM_SYSCALL_RETURN_ENOSYS(setns, 2, int, int, fd, int, nstype)
 
-SHIM_SYSCALL_RETURN_ENOSYS(getcpu, 3, int, unsigned*, cpu, unsigned*, node, struct getcpu_cache*,
-                           cache)
+DEFINE_SHIM_SYSCALL(getcpu, 3, shim_do_getcpu, int, unsigned*, cpu, unsigned*, node,
+                    struct getcpu_cache*, cache)
 
 /* libos calls */
 

--- a/LibOS/shim/src/sys/shim_sched.c
+++ b/LibOS/shim/src/sys/shim_sched.c
@@ -20,7 +20,7 @@
  * Implementation of system calls "sched_yield", "setpriority", "getpriority",
  * "sched_setparam", "sched_getparam", "sched_setscheduler", "sched_getscheduler",
  * "sched_get_priority_max", "sched_get_priority_min", "sched_rr_get_interval",
- * "sched_setaffinity", "sched_getaffinity".
+ * "sched_setaffinity", "sched_getaffinity", "getcpu".
  */
 
 #include <api.h>
@@ -196,4 +196,25 @@ int shim_do_sched_getaffinity(pid_t pid, size_t len, __kernel_cpu_set_t* user_ma
     /* imitate the Linux kernel implementation
      * See SYSCALL_DEFINE3(sched_getaffinity) */
     return bitmask_size_in_bytes;
+}
+
+/* dummy implementation: always return cpu0  */
+int shim_do_getcpu(unsigned* cpu, unsigned* node, struct getcpu_cache* unused) {
+    __UNUSED(unused);
+
+    if (cpu) {
+        if (test_user_memory(cpu, sizeof(*cpu), /*write=*/true)) {
+            return -EFAULT;
+        }
+        *cpu = 0;
+    }
+
+    if (node) {
+        if (test_user_memory(node, sizeof(*node), /*write=*/true)) {
+            return -EFAULT;
+        }
+        *node = 0;
+    }
+
+    return 0;
 }


### PR DESCRIPTION
This commit adds dummy implementation for getcpu, which is needed at the
beginning of OpenJDK 11 runtime.

Fixes #1552.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1554)
<!-- Reviewable:end -->
