### PR TITLE
[LibOS] Use unsigned int for ioctl ops in shim_parser

### DIFF
--- a/LibOS/shim/src/shim_parser.c
+++ b/LibOS/shim/src/shim_parser.c
@@ -1142,7 +1142,7 @@ static void parse_fcntlop(va_list* ap) {
 }
 
 static void parse_ioctlop(va_list* ap) {
-    int op = va_arg(*ap, int);
+    unsigned int op = va_arg(*ap, unsigned int);
 
     if (op >= TCGETS && op <= TIOCVHANGUP) {
         const char* opnames[] = {


### PR DESCRIPTION
This patch fixes this ppc64 compiler warning and also works on x86_64.

shim_parser.c: In function \u2018parse_ioctlop\u2019:
shim_parser.c:1184:12: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
     if (op >= TCGETS && op <= TIOCVHANGUP) {
            ^~
shim_parser.c:1219:12: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
     if (op >= FIONCLEX && op <= TIOCSERSETMULTI) {
            ^~


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1559)
<!-- Reviewable:end -->
