### PR TITLE
[Pal/Linux-SGX] Improve printing of MRENCLAVE and MRSIGNER

### DIFF
--- a/Pal/src/host/Linux-SGX/sgx_framework.c
+++ b/Pal/src/host/Linux-SGX/sgx_framework.c
@@ -52,7 +52,10 @@ int read_enclave_token(int token_file, sgx_arch_token_t * token)
     if (IS_ERR(bytes))
         return -ERRNO(bytes);
 
-    SGX_DBG(DBG_I, "read token:\n");
+#ifdef SGX_DCAP
+    SGX_DBG(DBG_I, "Read dummy DCAP token\n");
+#else
+    SGX_DBG(DBG_I, "Read token:\n");
     SGX_DBG(DBG_I, "    valid:                 0x%08x\n",   token->body.valid);
     SGX_DBG(DBG_I, "    attr.flags:            0x%016lx\n", token->body.attributes.flags);
     SGX_DBG(DBG_I, "    attr.xfrm:             0x%016lx\n", token->body.attributes.xfrm);
@@ -64,6 +67,7 @@ int read_enclave_token(int token_file, sgx_arch_token_t * token)
     SGX_DBG(DBG_I, "    LE masked_misc_select: 0x%08x\n",   token->masked_misc_select_le);
     SGX_DBG(DBG_I, "    LE attr.flags:         0x%016lx\n", token->attributes_le.flags);
     SGX_DBG(DBG_I, "    LE attr.xfrm:          0x%016lx\n", token->attributes_le.xfrm);
+#endif
 
     return 0;
 }
@@ -343,10 +347,7 @@ int init_enclave(sgx_arch_secs_t * secs,
 
     SGX_DBG(DBG_I, "enclave initializing:\n");
     SGX_DBG(DBG_I, "    enclave id:   0x%016lx\n", enclave_valid_addr);
-    SGX_DBG(DBG_I, "    enclave hash:");
-    for (size_t i = 0 ; i < sizeof(sgx_measurement_t) ; i++)
-        SGX_DBG(DBG_I, " %02x", sigstruct->body.enclave_hash.m[i]);
-    SGX_DBG(DBG_I, "\n");
+    SGX_DBG(DBG_I, "    mr_enclave:   %s\n", ALLOCA_BYTES2HEXSTR(sigstruct->body.enclave_hash.m));
 
     struct sgx_enclave_init param = {
 #ifndef SGX_DCAP_16_OR_LATER

--- a/Pal/src/host/Linux-SGX/signer/pal-sgx-get-token
+++ b/Pal/src/host/Linux-SGX/signer/pal-sgx-get-token
@@ -3,6 +3,7 @@
 
 import argparse
 import array
+import hashlib
 import os
 import socket
 import struct
@@ -163,7 +164,7 @@ argparser.add_argument('--sig', '-sig', metavar='SIGNATURE',
                        type=argparse.FileType('rb'), required=True,
                        help='Input .sig file (contains SIGSTRUCT)')
 argparser.add_argument('--output', '-output', metavar='OUTPUT',
-                       type=argparse.FileType('wb'), required=True,
+                       type=argparse.FileType('wb'), required=False,
                        help='Output .token file (contains EINITTOKEN)')
 
 
@@ -174,8 +175,13 @@ def main(args=None):
     attr = read_sigstruct(args.sig.read())
     set_optional_sgx_features(attr)
 
+    # calculate MRSIGNER as sha256 hash over RSA public key's modulus
+    mrsigner = hashlib.sha256()
+    mrsigner.update(attr['modulus'])
+
     print("Attributes:")
     print("    mr_enclave:  %s" % attr['enclave_hash'].hex())
+    print("    mr_signer:   %s" % mrsigner.digest().hex())
     print("    isv_prod_id: %d" % attr['isv_prod_id'])
     print("    isv_svn:     %d" % attr['isv_svn'])
     print("    attr.flags:  %016x" % int.from_bytes(attr['flags'], byteorder='big'))
@@ -192,7 +198,8 @@ def main(args=None):
     else:
         token = connect_aesmd(attr)
 
-    args.output.write(token)
+    if args.output:
+        args.output.write(token)
     return 0
 
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Standardize prints of MRENCLAVE. Also print MRSIGNER in output of the `pal-sgx-get-token` script, so it can be used to retrieve SGX measurements from the SIGSTRUCT (.sig) file for manual inspection.

## How to test this PR? <!-- (if applicable) -->

All tests must pass.

To see MRENCLAVE, MRSIGNER, ... of a particular app, use its SIGSTRUCT file:
```
graphene/LibOS/shim/test/regression$ make SGX=1
...

graphene/LibOS/shim/test/regression$ ~/graphene/Pal/src/host/Linux-SGX/signer/pal-sgx-get-token --sig multi_pthread.sig
Attributes:
    mr_enclave:  0d34e21e9a3796b503760d454c7bf33aa186ba7daf2c62d8e96bcf1b4da05890
    mr_signer:   2521f4b9d2f0338db3bf3f913444e5b8fca76e93948613483f3ccf9ac55c742d
    isv_prod_id: 0
    isv_svn:     0
    ...
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1560)
<!-- Reviewable:end -->
