### PR TITLE
Protected argv

### DIFF
--- a/Documentation/manifest-syntax.rst
+++ b/Documentation/manifest-syntax.rst
@@ -60,6 +60,28 @@ is run via the manifest (e.g. ``./app.manifest arg1 arg2 ...``). If the string
 is not specified in the manifest, the PAL will use the path to the manifest
 itself (standard UNIX convention).
 
+Command-Line Arguments
+^^^^^^^^^^^^^^^^^^^^^^
+
+::
+
+   loader.insecure__use_cmdline_argv = 1
+
+or
+
+::
+
+   loader.argv_src_file = file:file_with_serialized_argv
+
+If you want your application to use commandline arguments you need to either set
+``loader.insecure__use_cmdline_argv`` (insecure in almost all cases) or point
+``loader.argv_src_file`` to a file containing output of :file:`Tools/argv_serializer`.
+
+``loader.argv_src_file`` is intended to point to either a trusted file or a
+protected file. The former allows to securely hardcode arguments (current
+manifest syntax doesn't allow to include them inline), the latter allows the
+arguments to be provided at runtime from an external (trusted) source.
+
 Environment Variables
 ^^^^^^^^^^^^^^^^^^^^^
 
@@ -68,10 +90,10 @@ Environment Variables
    loader.env.[ENVIRON]=[VALUE]
 
 By default, the environment variables on the host will be passed to the library
-OS. Specifying an environment variable using this syntax adds/overwrites it and
-passes to the library OS. This syntax can be used multiple times to specify more
-than one environment variable. An environment variable can be deleted by giving
-it an empty value.
+OS (this is insecure and will be fixed in the future). Specifying an environment
+variable using this syntax adds/overwrites it and passes to the library OS. This
+syntax can be used multiple times to specify more than one environment variable.
+An environment variable can be deleted by giving it an empty value.
 
 Debug Type
 ^^^^^^^^^^

--- a/Documentation/manifest-syntax.rst
+++ b/Documentation/manifest-syntax.rst
@@ -155,7 +155,7 @@ Allowing eventfd
 
 ::
 
-    sys.allow_insecure_eventfd=[1|0]
+    sys.insecure__allow_eventfd=[1|0]
     (Default: 0)
 
 This specifies whether to allow system calls `eventfd()` and `eventfd2()`. Since

--- a/Examples/apache/httpd.manifest.template
+++ b/Examples/apache/httpd.manifest.template
@@ -10,6 +10,9 @@
 loader.exec = file:$(INSTALL_DIR)/bin/httpd
 loader.execname = httpd
 
+# Read application arguments directly from the command line. Don't use this on production!
+loader.insecure__use_cmdline_argv = 1
+
 # Graphene environment, including the path to the library OS and the debug
 # option (inline/none).
 loader.preload = file:$(GRAPHENEDIR)/Runtime/libsysdb.so

--- a/Examples/bash/manifest.template
+++ b/Examples/bash/manifest.template
@@ -8,6 +8,9 @@
 loader.exec = file:$(EXECPATH)
 loader.execname = $(EXECNAME)
 
+# Read application arguments directly from the command line. Don't use this on production!
+loader.insecure__use_cmdline_argv = 1
+
 # Graphene environment, including the path of the library OS and the debug
 # option (inline/none).
 loader.preload = file:$(GRAPHENEDIR)/Runtime/libsysdb.so

--- a/Examples/bash/manifest.template
+++ b/Examples/bash/manifest.template
@@ -6,7 +6,7 @@
 # The executable to load in Graphene. We replace EXECPATH and EXECNAME for
 # each program that a manifest is generated for.
 loader.exec = file:$(EXECPATH)
-loader.execname = file:$(EXECNAME)
+loader.execname = $(EXECNAME)
 
 # Graphene environment, including the path of the library OS and the debug
 # option (inline/none).

--- a/Examples/blender/blender.manifest.template
+++ b/Examples/blender/blender.manifest.template
@@ -14,6 +14,9 @@ sgx.allowed_files.blender_output = file:$(DATA_DIR)/images/
 loader.exec = file:$(BLENDER_DIR)/blender
 loader.execname = blender
 
+# Read application arguments directly from the command line. Don't use this on production!
+loader.insecure__use_cmdline_argv = 1
+
 loader.preload = file:$(GRAPHENE_DIR)/Runtime/libsysdb.so
 loader.debug_type = $(GRAPHENE_DEBUG)
 

--- a/Examples/busybox/busybox.manifest.template
+++ b/Examples/busybox/busybox.manifest.template
@@ -11,6 +11,9 @@ loader.exec = file:busybox
 # file (`./pal_loader busybox.manifest`).
 loader.execname = busybox
 
+# Read application arguments directly from the command line. Don't use this on production!
+loader.insecure__use_cmdline_argv = 1
+
 # LibOS layer library of Graphene. There is currently only one implementation,
 # so it is always set to libsysdb.so. Note that GRAPHENEDIR macro is expanded
 # to relative path to Graphene repository in the Makefile as part of the

--- a/Examples/capnproto/addressbook.manifest.template
+++ b/Examples/capnproto/addressbook.manifest.template
@@ -16,6 +16,9 @@ loader.preload = file:$(GRAPHENEDIR)/Runtime/libsysdb.so
 # Show/hide debug log of Graphene ('inline' or 'none' respectively)
 loader.debug_type = $(GRAPHENEDEBUG)
 
+# Read application arguments directly from the command line. Don't use this on production!
+loader.insecure__use_cmdline_argv = 1
+
 # Specify paths to search for libraries (usual LD_LIBRARY_PATH syntax)
 loader.env.LD_LIBRARY_PATH = /lib:$(ARCH_LIBDIR):/usr/$(ARCH_LIBDIR)
 

--- a/Examples/curl/curl.manifest.template
+++ b/Examples/curl/curl.manifest.template
@@ -4,7 +4,7 @@
 
 # Executable to load into Graphene and run.
 loader.exec = file:$(CURL_DIR)curl
-loader.execname = file:curl
+loader.execname = curl
 
 # LibOS layer library of Graphene. There is currently only one implementation,
 # so it is always set to libsysdb.so. 

--- a/Examples/curl/curl.manifest.template
+++ b/Examples/curl/curl.manifest.template
@@ -13,6 +13,9 @@ loader.preload = file:$(GRAPHENEDIR)/Runtime/libsysdb.so
 # Show/hide debug log of Graphene ('inline' or 'none' respectively).
 loader.debug_type = $(GRAPHENEDEBUG)
 
+# Read application arguments directly from the command line. Don't use this on production!
+loader.insecure__use_cmdline_argv = 1
+
 # Specify paths to search for libraries. The usual LD_LIBRARY_PATH syntax
 # applies. Paths must be in-Graphene visible paths, not host-OS paths (i.e.,
 # paths must be taken from fs.mount.xxx.path, not fs.mount.xxx.uri).

--- a/Examples/gcc/as.manifest.template
+++ b/Examples/gcc/as.manifest.template
@@ -5,6 +5,9 @@ loader.env.LD_LIBRARY_PATH = /lib:$(ARCH_LIBDIR):/usr/lib:/usr/$(ARCH_LIBDIR)
 loader.env.PATH = /bin:/usr/bin
 loader.debug_type = $(GRAPHENEDEBUG)
 
+# Read application arguments directly from the command line. Don't use this on production!
+loader.insecure__use_cmdline_argv = 1
+
 fs.mount.lib1.type = chroot
 fs.mount.lib1.path = /lib
 fs.mount.lib1.uri = file:$(GRAPHENEDIR)/Runtime

--- a/Examples/gcc/cc1.manifest.template
+++ b/Examples/gcc/cc1.manifest.template
@@ -5,6 +5,9 @@ loader.env.LD_LIBRARY_PATH = /lib:$(ARCH_LIBDIR):/usr/lib:/usr/$(ARCH_LIBDIR)
 loader.env.PATH = /bin:/usr/bin
 loader.debug_type = $(GRAPHENEDEBUG)
 
+# Read application arguments directly from the command line. Don't use this on production!
+loader.insecure__use_cmdline_argv = 1
+
 fs.mount.lib1.type = chroot
 fs.mount.lib1.path = /lib
 fs.mount.lib1.uri = file:$(GRAPHENEDIR)/Runtime

--- a/Examples/gcc/collect2.manifest.template
+++ b/Examples/gcc/collect2.manifest.template
@@ -5,6 +5,9 @@ loader.env.LD_LIBRARY_PATH = /lib:$(ARCH_LIBDIR):/usr/lib:/usr/$(ARCH_LIBDIR)
 loader.env.PATH = /bin:/usr/bin
 loader.debug_type = $(GRAPHENEDEBUG)
 
+# Read application arguments directly from the command line. Don't use this on production!
+loader.insecure__use_cmdline_argv = 1
+
 fs.mount.lib1.type = chroot
 fs.mount.lib1.path = /lib
 fs.mount.lib1.uri = file:$(GRAPHENEDIR)/Runtime

--- a/Examples/gcc/gcc.manifest.template
+++ b/Examples/gcc/gcc.manifest.template
@@ -5,6 +5,9 @@ loader.env.LD_LIBRARY_PATH = /lib:$(ARCH_LIBDIR):/usr/lib:/usr/$(ARCH_LIBDIR)
 loader.env.PATH = /bin:/usr/bin
 loader.debug_type = $(GRAPHENEDEBUG)
 
+# Read application arguments directly from the command line. Don't use this on production!
+loader.insecure__use_cmdline_argv = 1
+
 fs.mount.lib1.type = chroot
 fs.mount.lib1.path = /lib
 fs.mount.lib1.uri = file:$(GRAPHENEDIR)/Runtime

--- a/Examples/gcc/ld.manifest.template
+++ b/Examples/gcc/ld.manifest.template
@@ -5,6 +5,9 @@ loader.env.LD_LIBRARY_PATH = /lib:$(ARCH_LIBDIR):/usr/lib:/usr/$(ARCH_LIBDIR)
 loader.env.PATH = /bin:/usr/bin
 loader.debug_type = $(GRAPHENEDEBUG)
 
+# Read application arguments directly from the command line. Don't use this on production!
+loader.insecure__use_cmdline_argv = 1
+
 fs.mount.lib1.type = chroot
 fs.mount.lib1.path = /lib
 fs.mount.lib1.uri = file:$(GRAPHENEDIR)/Runtime

--- a/Examples/lighttpd/lighttpd.manifest.template
+++ b/Examples/lighttpd/lighttpd.manifest.template
@@ -15,6 +15,9 @@ loader.execname = lighttpd
 loader.preload = file:$(GRAPHENEDIR)/Runtime/libsysdb.so
 loader.debug_type = $(GRAPHENEDEBUG)
 
+# Read application arguments directly from the command line. Don't use this on production!
+loader.insecure__use_cmdline_argv = 1
+
 # Environment variables for lighttpd
 loader.env.LD_LIBRARY_PATH = /lib:$(ARCH_LIBDIR):$(INSTALL_DIR)/lib
 

--- a/Examples/lmbench/hello.manifest.template
+++ b/Examples/lmbench/hello.manifest.template
@@ -10,6 +10,9 @@ loader.exec = file:hello
 loader.preload = file:$(GRAPHENEDIR)/Runtime/libsysdb.so
 loader.debug_type = $(GRAPHENEDEBUG)
 
+# Read application arguments directly from the command line. Don't use this on production!
+loader.insecure__use_cmdline_argv = 1
+
 # Environment variables
 loader.env.LD_LIBRARY_PATH = /lib
 

--- a/Examples/lmbench/manifest.template
+++ b/Examples/lmbench/manifest.template
@@ -13,6 +13,9 @@
 loader.preload = file:$(GRAPHENEDIR)/Runtime/libsysdb.so
 loader.debug_type = $(GRAPHENEDEBUG)
 
+# Read application arguments directly from the command line. Don't use this on production!
+loader.insecure__use_cmdline_argv = 1
+
 # Environment variables for LMBench
 loader.env.LD_LIBRARY_PATH = /lib:$(ARCH_LIBDIR)
 

--- a/Examples/lmbench/sh.manifest.template
+++ b/Examples/lmbench/sh.manifest.template
@@ -10,6 +10,9 @@ loader.exec = file:/bin/sh
 loader.preload = file:$(GRAPHENEDIR)/Runtime/libsysdb.so
 loader.debug_type = $(GRAPHENEDEBUG)
 
+# Read application arguments directly from the command line. Don't use this on production!
+loader.insecure__use_cmdline_argv = 1
+
 # Environment variables
 loader.env.LD_LIBRARY_PATH = /lib:$(ARCH_LIBDIR)
 

--- a/Examples/memcached/memcached.manifest.template
+++ b/Examples/memcached/memcached.manifest.template
@@ -34,7 +34,12 @@ loader.preload = file:$(GRAPHENEDIR)/Runtime/libsysdb.so
 # build process.
 loader.debug_type = $(GRAPHENEDEBUG)
 
-################################# ENV VARS  ###################################
+################################# ARGUMENTS ###################################
+
+# Read application arguments directly from the command line. Don't use this on production!
+loader.insecure__use_cmdline_argv = 1
+
+################################# ENV VARS ####################################
 
 # Specify paths to search for libraries. The usual LD_LIBRARY_PATH syntax
 # applies. Paths must be in-Graphene visible paths, not host-OS paths (i.e.,

--- a/Examples/nginx/nginx.manifest.template
+++ b/Examples/nginx/nginx.manifest.template
@@ -15,6 +15,9 @@ loader.execname = nginx
 loader.preload = file:$(GRAPHENEDIR)/Runtime/libsysdb.so
 loader.debug_type = $(GRAPHENEDEBUG)
 
+# Read application arguments directly from the command line. Don't use this on production!
+loader.insecure__use_cmdline_argv = 1
+
 # Environment variables
 loader.env.LD_LIBRARY_PATH = /lib:$(ARCH_LIBDIR)
 

--- a/Examples/nodejs-express-server/nodejs.manifest.template
+++ b/Examples/nodejs-express-server/nodejs.manifest.template
@@ -13,6 +13,9 @@ loader.preload = file:$(GRAPHENEDIR)/Runtime/libsysdb.so
 # Show/hide debug log of Graphene ('inline' or 'none' respectively).
 loader.debug_type = $(GRAPHENEDEBUG)
 
+# Read application arguments directly from the command line. Don't use this on production!
+loader.insecure__use_cmdline_argv = 1
+
 # Specify paths to search for libraries. The usual LD_LIBRARY_PATH syntax
 # applies. Paths must be in-Graphene visible paths, not host-OS paths (i.e.,
 # paths must be taken from fs.mount.xxx.path, not fs.mount.xxx.uri).

--- a/Examples/nodejs-express-server/nodejs.manifest.template
+++ b/Examples/nodejs-express-server/nodejs.manifest.template
@@ -4,7 +4,7 @@
 
 # Executable to load into Graphene and run.
 loader.exec = file:$(NODEJS_DIR)nodejs
-loader.execname = file:nodejs
+loader.execname = nodejs
 
 # LibOS layer library of Graphene. There is currently only one implementation,
 # so it is always set to libsysdb.so.

--- a/Examples/nodejs/nodejs.manifest.template
+++ b/Examples/nodejs/nodejs.manifest.template
@@ -13,6 +13,9 @@ loader.preload = file:$(GRAPHENEDIR)/Runtime/libsysdb.so
 # Show/hide debug log of Graphene ('inline' or 'none' respectively).
 loader.debug_type = $(GRAPHENEDEBUG)
 
+# Read application arguments directly from the command line. Don't use this on production!
+loader.insecure__use_cmdline_argv = 1
+
 # Specify paths to search for libraries. The usual LD_LIBRARY_PATH syntax
 # applies. Paths must be in-Graphene visible paths, not host-OS paths (i.e.,
 # paths must be taken from fs.mount.xxx.path, not fs.mount.xxx.uri).

--- a/Examples/nodejs/nodejs.manifest.template
+++ b/Examples/nodejs/nodejs.manifest.template
@@ -4,7 +4,7 @@
 
 # Executable to load into Graphene and run.
 loader.exec = file:$(NODEJS_DIR)nodejs
-loader.execname = file:nodejs
+loader.execname = nodejs
 
 # LibOS layer library of Graphene. There is currently only one implementation,
 # so it is always set to libsysdb.so.

--- a/Examples/openvino/openvino.manifest.template
+++ b/Examples/openvino/openvino.manifest.template
@@ -15,6 +15,9 @@ loader.execname = object_detection_sample_ssd
 loader.preload = file:$(GRAPHENE_DIR)/Runtime/libsysdb.so
 loader.debug_type = $(GRAPHENE_DEBUG)
 
+# Read application arguments directly from the command line. Don't use this on production!
+loader.insecure__use_cmdline_argv = 1
+
 # Environment variables
 loader.env.LD_LIBRARY_PATH = /lib:$(ARCH_LIBDIR):/usr/$(ARCH_LIBDIR)
 

--- a/Examples/python-scipy-insecure/python.manifest.template
+++ b/Examples/python-scipy-insecure/python.manifest.template
@@ -16,6 +16,9 @@ loader.exec = file:$(PYTHONEXEC)
 loader.preload = file:$(GRAPHENEDIR)/Runtime/libsysdb.so
 loader.debug_type = $(GRAPHENEDEBUG)
 
+# Read application arguments directly from the command line. Don't use this on production!
+loader.insecure__use_cmdline_argv = 1
+
 # Environment variables for Python
 loader.env.LD_LIBRARY_PATH = $(PYTHONHOME)/lib:/lib:$(ARCH_LIBDIR):/usr/lib:/usr/$(ARCH_LIBDIR)
 loader.env.PATH = $(PYTHONHOME)/bin:/usr/bin:/bin

--- a/Examples/python-simple/python.manifest.template
+++ b/Examples/python-simple/python.manifest.template
@@ -17,6 +17,9 @@ loader.exec = file:$(PYTHONEXEC)
 loader.preload = file:$(GRAPHENEDIR)/Runtime/libsysdb.so
 loader.debug_type = $(GRAPHENEDEBUG)
 
+# Read application arguments directly from the command line. Don't use this on production!
+loader.insecure__use_cmdline_argv = 1
+
 # Environment variables for Python
 loader.env.LD_LIBRARY_PATH = $(PYTHONHOME)/lib:/lib:$(ARCH_LIBDIR):/usr/lib:/usr/$(ARCH_LIBDIR)
 loader.env.PATH = $(PYTHONHOME)/bin:/usr/bin:/bin

--- a/Examples/pytorch/pytorch.manifest.template
+++ b/Examples/pytorch/pytorch.manifest.template
@@ -15,6 +15,9 @@ loader.execname = python3
 loader.preload = file:$(GRAPHENEDIR)/Runtime/libsysdb.so
 loader.debug_type = $(GRAPHENEDEBUG)
 
+# Read application arguments directly from the command line. Don't use this on production!
+loader.insecure__use_cmdline_argv = 1
+
 # Environment variables
 loader.env.LD_LIBRARY_PATH = /lib:/usr/lib:$(ARCH_LIBDIR):/usr/$(ARCH_LIBDIR)
 

--- a/Examples/r/R.manifest.template
+++ b/Examples/r/R.manifest.template
@@ -16,6 +16,9 @@ loader.exec = file:$(R_EXEC)
 loader.preload = file:$(GRAPHENEDIR)/Runtime/libsysdb.so
 loader.debug_type = $(GRAPHENEDEBUG)
 
+# Read application arguments directly from the command line. Don't use this on production!
+loader.insecure__use_cmdline_argv = 1
+
 # Environment variables for R
 loader.env.LD_LIBRARY_PATH = $(R_HOME)/lib:/lib:$(ARCH_LIBDIR):/usr/lib:/usr/$(ARCH_LIBDIR)
 loader.env.PATH = $(R_HOME)/bin:/usr/bin:/bin

--- a/Examples/r/sh.manifest.template
+++ b/Examples/r/sh.manifest.template
@@ -10,6 +10,9 @@ loader.exec = file:/bin/sh
 loader.preload = file:$(GRAPHENEDIR)/Runtime/libsysdb.so
 loader.debug_type = $(GRAPHENEDEBUG)
 
+# Read application arguments directly from the command line. Don't use this on production!
+loader.insecure__use_cmdline_argv = 1
+
 # Environment variables
 loader.env.LD_LIBRARY_PATH = /lib
 

--- a/Examples/ra-tls-mbedtls/server.manifest.template
+++ b/Examples/ra-tls-mbedtls/server.manifest.template
@@ -3,6 +3,7 @@
 # This manifest was prepared and tested on Ubuntu 18.04.
 
 loader.exec = file:server
+loader.execname = server
 loader.preload = file:$(GRAPHENEDIR)/Runtime/libsysdb.so
 loader.debug_type = $(GRAPHENEDEBUG)
 
@@ -10,6 +11,9 @@ loader.env.LD_LIBRARY_PATH = /lib:/lib/x86_64-linux-gnu
 
 # RA-TLS library is preloaded (without it, server uses normal X.509 PKI flows)
 loader.env.LD_PRELOAD = libra_tls_attest.so
+
+# Read application arguments directly from the command line. Don't use this on production!
+loader.insecure__use_cmdline_argv = 1
 
 # Request remote attestation functionality from Graphene
 sgx.remote_attestation = 1

--- a/Examples/redis/redis-server.manifest.template
+++ b/Examples/redis/redis-server.manifest.template
@@ -23,7 +23,12 @@ loader.preload = file:$(GRAPHENEDIR)/Runtime/libsysdb.so
 # build process.
 loader.debug_type = $(GRAPHENEDEBUG)
 
-################################# ENV VARS  ###################################
+################################# ARGUMENTS ###################################
+
+# Read application arguments directly from the command line. Don't use this on production!
+loader.insecure__use_cmdline_argv = 1
+
+################################# ENV VARS ####################################
 
 # Specify paths to search for libraries. The usual LD_LIBRARY_PATH syntax
 # applies. Paths must be in-Graphene visible paths, not host-OS paths (i.e.,

--- a/Examples/tensorflow/label_image.manifest.template
+++ b/Examples/tensorflow/label_image.manifest.template
@@ -6,6 +6,9 @@ loader.env.LD_LIBRARY_PATH = /lib:.
 loader.env.PATH = /bin:/usr/bin
 loader.debug_type = none
 
+# Read application arguments directly from the command line. Don't use this on production!
+loader.insecure__use_cmdline_argv = 1
+
 fs.mount.lib1.type = chroot
 fs.mount.lib1.path = /lib
 fs.mount.lib1.uri = file:$(GRAPHENEDIR)/Runtime

--- a/LibOS/shim/src/sys/shim_eventfd.c
+++ b/LibOS/shim/src/sys/shim_eventfd.c
@@ -6,7 +6,7 @@
  *
  * Implementation of system calls "eventfd" and "eventfd2". Since eventfd emulation currently relies
  * on the host, these system calls are disallowed by default due to security concerns. To use them,
- * they must be explicitly allowed through the "sys.allow_insecure_eventfd" manifest key.
+ * they must be explicitly allowed through the "sys.insecure__allow_eventfd" manifest key.
  */
 
 #include <asm/fcntl.h>
@@ -28,7 +28,7 @@ static int create_eventfd(PAL_HANDLE* efd, unsigned count, int flags) {
 
     char eventfd_cfg[2];
     ssize_t len =
-        get_config(root_config, "sys.allow_insecure_eventfd", eventfd_cfg, sizeof(eventfd_cfg));
+        get_config(root_config, "sys.insecure__allow_eventfd", eventfd_cfg, sizeof(eventfd_cfg));
     if (len != 1 || eventfd_cfg[0] != '1') {
         /* eventfd is not explicitly allowed in manifest */
         return -ENOSYS;

--- a/LibOS/shim/test/fs/manifest.template
+++ b/LibOS/shim/test/fs/manifest.template
@@ -2,6 +2,7 @@ loader.preload = file:../../src/libsysdb.so
 loader.env.LD_LIBRARY_PATH = /lib:$(ARCH_LIBDIR):/usr/$(ARCH_LIBDIR)
 loader.debug_type = none
 loader.syscall_symbol = syscalldb
+loader.insecure__use_cmdline_argv = 1
 
 fs.mount.graphene_lib.type = chroot
 fs.mount.graphene_lib.path = /lib

--- a/LibOS/shim/test/ltp/manifest.template
+++ b/LibOS/shim/test/ltp/manifest.template
@@ -4,6 +4,7 @@ loader.env.PATH = /bin:/usr/bin:.
 loader.env.LD_PRELOAD = /usr/$(ARCH_LIBDIR)/coreutils/libstdbuf.so
 loader.env._STDBUF_O = L
 loader.debug_type = none
+loader.insecure__use_cmdline_argv = 1
 
 fs.mount.shm.type = chroot
 fs.mount.shm.path = /dev/shm

--- a/LibOS/shim/test/regression/.gitignore
+++ b/LibOS/shim/test/regression/.gitignore
@@ -7,6 +7,7 @@
 /.cache
 /abort
 /abort_multithread
+/argv_test_input
 /attestation
 /bootstrap
 /bootstrap_c++

--- a/LibOS/shim/test/regression/Makefile
+++ b/LibOS/shim/test/regression/Makefile
@@ -71,6 +71,7 @@ cxx_executables = bootstrap_c++
 
 manifests = \
 	manifest \
+	argv_from_file.manifest \
 	attestation.manifest \
 	echo.manifest \
 	eventfd.manifest \
@@ -96,6 +97,7 @@ manifests = \
 exec_target = \
 	$(c_executables) \
 	$(cxx_executables) \
+	argv_from_file.manifest \
 	echo.manifest \
 	file_check_policy_allow_all_but_log.manifest \
 	file_check_policy_strict.manifest \

--- a/LibOS/shim/test/regression/argv_from_file.manifest.template
+++ b/LibOS/shim/test/regression/argv_from_file.manifest.template
@@ -1,25 +1,19 @@
+loader.exec = file:bootstrap
+loader.execname = bootstrap
+
 loader.preload = file:../../src/libsysdb.so
 loader.env.LD_LIBRARY_PATH = /lib
 loader.debug_type = none
 loader.syscall_symbol = syscalldb
-loader.execname = mmap_file
+loader.argv_src_file = file:argv_test_input
 
 fs.mount.lib.type = chroot
 fs.mount.lib.path = /lib
 fs.mount.lib.uri = file:../../../../Runtime
 
-fs.mount.bin.type = chroot
-fs.mount.bin.path = /bin
-fs.mount.bin.uri = file:/bin
-
-# allow to bind on port 8000
-net.rules.1 = 127.0.0.1:8000:0.0.0.0:0-65535
-# allow to connect to port 8000
-net.rules.2 = 0.0.0.0:0-65535:127.0.0.1:8000
+sgx.allowed_files.argv = file:argv_test_input
 
 sgx.trusted_files.ld = file:../../../../Runtime/ld-linux-x86-64.so.2
 sgx.trusted_files.libc = file:../../../../Runtime/libc.so.6
-
-sgx.allowed_files.testfile = file:testfile
 
 sgx.static_address = 1

--- a/LibOS/shim/test/regression/attestation.manifest.template
+++ b/LibOS/shim/test/regression/attestation.manifest.template
@@ -2,6 +2,8 @@ loader.preload = file:$(SHIMPATH)
 loader.env.LD_LIBRARY_PATH = /lib
 loader.debug_type = none
 loader.syscall_symbol = syscalldb
+loader.execname = attestation
+loader.insecure__use_cmdline_argv = 1
 
 fs.mount.lib.type = chroot
 fs.mount.lib.path = /lib

--- a/LibOS/shim/test/regression/echo.manifest.template
+++ b/LibOS/shim/test/regression/echo.manifest.template
@@ -1,5 +1,5 @@
 loader.exec = file:/bin/echo
-loader.execname = file:echo
+loader.execname = echo
 
 loader.preload = file:../../src/libsysdb.so
 loader.env.LD_LIBRARY_PATH = /lib:$(ARCH_LIBDIR):/usr/$(ARCH_LIBDIR)

--- a/LibOS/shim/test/regression/echo.manifest.template
+++ b/LibOS/shim/test/regression/echo.manifest.template
@@ -1,5 +1,8 @@
+# This file is used by test_204_system test
+
 loader.exec = file:/bin/echo
 loader.execname = echo
+loader.insecure__use_cmdline_argv = 1
 
 loader.preload = file:../../src/libsysdb.so
 loader.env.LD_LIBRARY_PATH = /lib:$(ARCH_LIBDIR):/usr/$(ARCH_LIBDIR)

--- a/LibOS/shim/test/regression/eventfd.manifest.template
+++ b/LibOS/shim/test/regression/eventfd.manifest.template
@@ -4,7 +4,7 @@ loader.debug_type = none
 loader.syscall_symbol = syscalldb
 loader.execname = eventfd
 
-sys.allow_insecure_eventfd = 1
+sys.insecure__allow_eventfd = 1
 
 fs.mount.graphene_lib.type = chroot
 fs.mount.graphene_lib.path = /lib

--- a/LibOS/shim/test/regression/eventfd.manifest.template
+++ b/LibOS/shim/test/regression/eventfd.manifest.template
@@ -2,6 +2,7 @@ loader.preload = file:../../src/libsysdb.so
 loader.env.LD_LIBRARY_PATH = /lib
 loader.debug_type = none
 loader.syscall_symbol = syscalldb
+loader.execname = eventfd
 
 sys.allow_insecure_eventfd = 1
 

--- a/LibOS/shim/test/regression/exec_victim.manifest.template
+++ b/LibOS/shim/test/regression/exec_victim.manifest.template
@@ -2,6 +2,8 @@ loader.preload = file:$(SHIMPATH)
 loader.env.LD_LIBRARY_PATH = /lib
 loader.debug_type = none
 loader.syscall_symbol = syscalldb
+loader.execname = exec_victim
+loader.insecure__use_cmdline_argv = 1
 
 fs.mount.lib.type = chroot
 fs.mount.lib.path = /lib

--- a/LibOS/shim/test/regression/exit_group.manifest.template
+++ b/LibOS/shim/test/regression/exit_group.manifest.template
@@ -2,6 +2,7 @@ loader.preload = file:../../src/libsysdb.so
 loader.env.LD_LIBRARY_PATH = /lib
 loader.debug_type = none
 loader.syscall_symbol = syscalldb
+loader.execname = exit_group
 
 fs.mount.lib.type = chroot
 fs.mount.lib.path = /lib

--- a/LibOS/shim/test/regression/file_check_policy_allow_all_but_log.manifest.template
+++ b/LibOS/shim/test/regression/file_check_policy_allow_all_but_log.manifest.template
@@ -1,9 +1,11 @@
 #!$(PAL)
 
 loader.exec = file:file_check_policy
+loader.execname = file_check_policy
 loader.preload = file:$(SHIMPATH)
 loader.env.LD_LIBRARY_PATH = /lib
 loader.debug_type = none
+loader.insecure__use_cmdline_argv = 1
 
 fs.mount.lib.type = chroot
 fs.mount.lib.path = /lib

--- a/LibOS/shim/test/regression/file_check_policy_strict.manifest.template
+++ b/LibOS/shim/test/regression/file_check_policy_strict.manifest.template
@@ -1,9 +1,11 @@
 #!$(PAL)
 
 loader.exec = file:file_check_policy
+loader.execname = file_check_policy
 loader.preload = file:$(SHIMPATH)
 loader.env.LD_LIBRARY_PATH = /lib
 loader.debug_type = none
+loader.insecure__use_cmdline_argv = 1
 
 fs.mount.lib.type = chroot
 fs.mount.lib.path = /lib

--- a/LibOS/shim/test/regression/futex_bitset.manifest.template
+++ b/LibOS/shim/test/regression/futex_bitset.manifest.template
@@ -2,6 +2,7 @@ loader.preload = file:../../src/libsysdb.so
 loader.env.LD_LIBRARY_PATH = /lib
 loader.debug_type = none
 loader.syscall_symbol = syscalldb
+loader.execname = futex_bitset
 
 fs.mount.lib.type = chroot
 fs.mount.lib.path = /lib

--- a/LibOS/shim/test/regression/futex_requeue.manifest.template
+++ b/LibOS/shim/test/regression/futex_requeue.manifest.template
@@ -2,6 +2,7 @@ loader.preload = file:../../src/libsysdb.so
 loader.env.LD_LIBRARY_PATH = /lib
 loader.debug_type = none
 loader.syscall_symbol = syscalldb
+loader.execname = futex_requeue
 
 fs.mount.lib.type = chroot
 fs.mount.lib.path = /lib

--- a/LibOS/shim/test/regression/futex_wake_op.manifest.template
+++ b/LibOS/shim/test/regression/futex_wake_op.manifest.template
@@ -2,6 +2,7 @@ loader.preload = file:../../src/libsysdb.so
 loader.env.LD_LIBRARY_PATH = /lib
 loader.debug_type = none
 loader.syscall_symbol = syscalldb
+loader.execname = futex_wake_op
 
 fs.mount.lib.type = chroot
 fs.mount.lib.path = /lib

--- a/LibOS/shim/test/regression/getdents.manifest.template
+++ b/LibOS/shim/test/regression/getdents.manifest.template
@@ -1,6 +1,7 @@
 loader.preload = file:$(SHIMPATH)
 loader.env.LD_LIBRARY_PATH = /lib
 loader.debug_type = inline
+loader.execname = getdents
 
 fs.mount.lib.type = chroot
 fs.mount.lib.path = /lib

--- a/LibOS/shim/test/regression/host_root_fs.manifest.template
+++ b/LibOS/shim/test/regression/host_root_fs.manifest.template
@@ -2,6 +2,7 @@ loader.preload = file:../../src/libsysdb.so
 loader.env.LD_LIBRARY_PATH = /lib
 loader.debug_type = none
 loader.syscall_symbol = syscalldb
+loader.execname = host_root_fs
 
 fs.root.type = chroot
 fs.root.path = /

--- a/LibOS/shim/test/regression/init_fail.manifest.template
+++ b/LibOS/shim/test/regression/init_fail.manifest.template
@@ -1,6 +1,7 @@
 loader.preload = file:$(SHIMPATH)
 loader.env.LD_LIBRARY_PATH = /lib
 loader.debug_type = none
+loader.execname = init_fail
 
 fs.mount.lib.type = chroot
 fs.mount.lib.path = /lib

--- a/LibOS/shim/test/regression/large_mmap.manifest.template
+++ b/LibOS/shim/test/regression/large_mmap.manifest.template
@@ -2,6 +2,7 @@ loader.preload = file:../../src/libsysdb.so
 loader.env.LD_LIBRARY_PATH = /lib
 loader.debug_type = none
 loader.syscall_symbol = syscalldb
+loader.execname = large_mmap
 
 # application allocates 2GB and 4GB memory regions which may occasionally fail
 # in an SGX enclave restricted to 8GB of virtual space if ASLR is enabled

--- a/LibOS/shim/test/regression/manifest.template
+++ b/LibOS/shim/test/regression/manifest.template
@@ -2,6 +2,7 @@ loader.preload = file:../../src/libsysdb.so
 loader.env.LD_LIBRARY_PATH = /lib:$(ARCH_LIBDIR):/usr/$(ARCH_LIBDIR)
 loader.debug_type = none
 loader.syscall_symbol = syscalldb
+loader.insecure__use_cmdline_argv = 1
 
 fs.mount.graphene_lib.type = chroot
 fs.mount.graphene_lib.path = /lib

--- a/LibOS/shim/test/regression/multi_pthread.manifest.template
+++ b/LibOS/shim/test/regression/multi_pthread.manifest.template
@@ -2,6 +2,7 @@ loader.preload = file:../../src/libsysdb.so
 loader.env.LD_LIBRARY_PATH = /lib
 loader.debug_type = none
 loader.syscall_symbol = syscalldb
+loader.execname = multi_pthread
 
 fs.mount.lib.type = chroot
 fs.mount.lib.path = /lib

--- a/LibOS/shim/test/regression/openmp.manifest.template
+++ b/LibOS/shim/test/regression/openmp.manifest.template
@@ -2,6 +2,7 @@ loader.preload = file:../../src/libsysdb.so
 loader.env.LD_LIBRARY_PATH = /lib:/usrlib
 loader.debug_type = none
 loader.syscall_symbol = syscalldb
+loader.execname = openmp
 
 fs.mount.lib.type = chroot
 fs.mount.lib.path = /lib

--- a/LibOS/shim/test/regression/proc_path.manifest.template
+++ b/LibOS/shim/test/regression/proc_path.manifest.template
@@ -2,6 +2,7 @@ loader.preload = file:../../src/libsysdb.so
 loader.env.LD_LIBRARY_PATH = /lib
 loader.debug_type = none
 loader.syscall_symbol = syscalldb
+loader.execname = proc_path
 
 fs.mount.lib.type = chroot
 fs.mount.lib.path = /lib

--- a/LibOS/shim/test/regression/sh.manifest.template
+++ b/LibOS/shim/test/regression/sh.manifest.template
@@ -1,5 +1,5 @@
 loader.exec = file:/bin/sh
-loader.execname = file:sh
+loader.execname = sh
 
 loader.preload = file:../../src/libsysdb.so
 loader.env.LD_LIBRARY_PATH = /lib:$(ARCH_LIBDIR):/usr/$(ARCH_LIBDIR)

--- a/LibOS/shim/test/regression/sh.manifest.template
+++ b/LibOS/shim/test/regression/sh.manifest.template
@@ -1,5 +1,8 @@
+# This file is used by test_204_system test
+
 loader.exec = file:/bin/sh
 loader.execname = sh
+loader.insecure__use_cmdline_argv = 1
 
 loader.preload = file:../../src/libsysdb.so
 loader.env.LD_LIBRARY_PATH = /lib:$(ARCH_LIBDIR):/usr/$(ARCH_LIBDIR)

--- a/LibOS/shim/test/regression/shared_object.manifest.template
+++ b/LibOS/shim/test/regression/shared_object.manifest.template
@@ -1,6 +1,7 @@
 loader.preload = file:$(SHIMPATH)
 loader.env.LD_LIBRARY_PATH = /lib
 loader.debug_type = none
+loader.execname = shared_object
 
 fs.mount.lib.type = chroot
 fs.mount.lib.path = /lib

--- a/LibOS/shim/test/regression/test_libos.py
+++ b/LibOS/shim/test/regression/test_libos.py
@@ -37,16 +37,31 @@ class TC_01_Bootstrap(RegressionTestCase):
         self.assertIn('argv[3] = c', stdout)
         self.assertIn('argv[4] = d', stdout)
 
+    def test_102_argv_from_file(self):
+        args = ['bootstrap', 'THIS', 'SHOULD GO', 'TO', '\nTHE\n', 'APP']
+        result = subprocess.run(['../../../../Tools/argv_serializer'] + args,
+                                stdout=subprocess.PIPE, check=True)
+        with open('argv_test_input', 'wb') as f:
+            f.write(result.stdout)
+        try:
+            manifest = self.get_manifest('argv_from_file')
+            stdout, _ = self.run_binary([manifest, 'WRONG', 'ARGUMENTS'])
+            self.assertIn('# of Arguments: %d' % len(args), stdout)
+            for i, arg in enumerate(args):
+                self.assertIn('argv[%d] = %s' % (i, arg), stdout)
+        finally:
+            os.remove('argv_test_input')
+
     @unittest.skipUnless(HAS_SGX,
         'This test is only meaningful on SGX PAL because only SGX catches raw '
         'syscalls and redirects to Graphene\'s LibOS. If we will add seccomp to '
         'Linux PAL, then we should allow this test on Linux PAL as well.')
-    def test_102_basic_bootstrapping_static(self):
+    def test_103_basic_bootstrapping_static(self):
         # bootstrap_static
         stdout, _ = self.run_binary(['bootstrap_static'])
         self.assertIn('Hello world (bootstrap_static)!', stdout)
 
-    def test_103_basic_bootstrapping_pie(self):
+    def test_104_basic_bootstrapping_pie(self):
         # bootstrap_pie
         stdout, _ = self.run_binary(['bootstrap_pie'])
         self.assertIn('User program started', stdout)

--- a/Makefile
+++ b/Makefile
@@ -14,3 +14,4 @@ $(targets):
 	$(MAKE) -C Pal $@
 	$(MAKE) -C LibOS $@
 	$(MAKE) -C Runtime $@
+	$(MAKE) -C Tools $@

--- a/Pal/regression/AvxDisable.manifest.template
+++ b/Pal/regression/AvxDisable.manifest.template
@@ -1,3 +1,5 @@
+loader.execname = AvxDisable
+
 sgx.require_avx = 0
 sgx.require_avx512 = 0
 sgx.allowed_files.res = file:avxRes

--- a/Pal/regression/Bootstrap2.manifest.template
+++ b/Pal/regression/Bootstrap2.manifest.template
@@ -1,1 +1,2 @@
 loader.debug_type = inline
+loader.execname = Bootstrap2

--- a/Pal/regression/Bootstrap3.manifest.template
+++ b/Pal/regression/Bootstrap3.manifest.template
@@ -1,2 +1,3 @@
 loader.debug_type = inline
 loader.preload = file:Preload1.so,file:Preload2.so
+loader.execname = Bootstrap3

--- a/Pal/regression/Bootstrap5.manifest.template
+++ b/Pal/regression/Bootstrap5.manifest.template
@@ -1,2 +1,4 @@
 loader.debug_type = inline
 loader.preload = file:Preload1.so,file:Preload2.so
+# This example doesn't use any binary, this line is only to stop argv protection from complaining.
+loader.execname = Bootstrap

--- a/Pal/regression/Bootstrap6.manifest.template
+++ b/Pal/regression/Bootstrap6.manifest.template
@@ -1,6 +1,7 @@
 loader.exec = file:./Bootstrap
 loader.debug_type = inline
 loader.preload = file:Preload1.so,file:Preload2.so
+loader.execname = Bootstrap
 
 fs.mount.root.uri = file:
 

--- a/Pal/regression/File.manifest.template
+++ b/Pal/regression/File.manifest.template
@@ -1,17 +1,9 @@
-# the executable to run
-# loader.exec = file:./HelloWorld
-
-# debug type: inline|file
+loader.execname = File
 loader.debug_type = inline
-
-# debug as file
-# loader.debug_file = <path>
 
 fs.mount.root.uri = file:
 
-# allow to bind on port 8000
 net.allow_bind.1 = 127.0.0.1:8000
-# allow to connect to port 8000
 net.allow_peer.1 = 127.0.0.1:8000
 
 sgx.allow_file_creation = 0

--- a/Pal/regression/Process.manifest.template
+++ b/Pal/regression/Process.manifest.template
@@ -1,15 +1,8 @@
-# the executable to run
-# loader.exec = file:./HelloWorld
-
-# debug type: inline|file
+loader.execname = Process
+loader.insecure__use_cmdline_argv = 1
 loader.debug_type = inline
-
-# debug as file
-# loader.debug_file = <path>
 
 fs.mount.root.uri = file:
 
-# allow to bind on port 8000
 net.allow_bind.1 = 127.0.0.1:8000
-# allow to connect to port 8000
 net.allow_peer.1 = 127.0.0.1:8000

--- a/Pal/regression/Process2.manifest.template
+++ b/Pal/regression/Process2.manifest.template
@@ -1,3 +1,4 @@
+loader.execname = Process2
 loader.debug_type = inline
 
 sgx.trusted_children.1 = file:Bootstrap.sig

--- a/Pal/regression/Process3.manifest.template
+++ b/Pal/regression/Process3.manifest.template
@@ -1,2 +1,3 @@
 loader.debug_type = inline
 loader.preload = file:Preload1.so,file:Preload2.so
+loader.insecure__use_cmdline_argv = 1

--- a/Pal/regression/SendHandle.manifest.template
+++ b/Pal/regression/SendHandle.manifest.template
@@ -1,8 +1,8 @@
 loader.debug_type = inline
+loader.execname = SendHandle
+loader.insecure__use_cmdline_argv = 1
 
-# allow to bind on port 8000
 net.allow_bind.1 = 127.0.0.1:8000
-# allow to connect to port 8000
 net.allow_peer.1 = 127.0.0.1:8000
 
 sgx.allowed_files.tmp = file:to_send.tmp

--- a/Pal/regression/Thread2.manifest.template
+++ b/Pal/regression/Thread2.manifest.template
@@ -1,2 +1,4 @@
+loader.execname = Thread2
+
 sgx.thread_num = 2
 sgx.print_stats = 1

--- a/Pal/regression/manifest.template
+++ b/Pal/regression/manifest.template
@@ -1,15 +1,7 @@
-# the executable to run
-# loader.exec = file:./HelloWorld
-
-# debug type: inline|file
 loader.debug_type = inline
-
-# debug as file
-# loader.debug_file = <path>
+loader.insecure__use_cmdline_argv = 1
 
 fs.mount.root.uri = file:
 
-# allow to bind on port 8000
 net.allow_bind.1 = 127.0.0.1:8000
-# allow to connect to port 8000
 net.allow_peer.1 = 127.0.0.1:8000

--- a/Pal/src/db_main.c
+++ b/Pal/src/db_main.c
@@ -8,6 +8,8 @@
  * processes environment, arguments and manifest.
  */
 
+#include <stdbool.h>
+
 #include "pal_defs.h"
 #include "pal.h"
 #include "pal_internal.h"
@@ -203,6 +205,7 @@ noreturn void pal_main(
         PAL_HANDLE first_thread,     /* first thread handle */
         PAL_STR*   arguments,        /* application arguments */
         PAL_STR*   environments      /* environment variables */) {
+    char cfgbuf[CONFIG_MAX];
     pal_state.instance_id = instance_id;
     pal_state.alloc_align = _DkGetAllocationAlignment();
     assert(IS_POWER_OF_2(pal_state.alloc_align));
@@ -357,14 +360,82 @@ noreturn void pal_main(
         disable_aslr = len == 1 && aslr_cfg[0] == '1';
     }
 
-    if (pal_state.root_config && *arguments
-        && (strendswith(*arguments, ".manifest") || strendswith(*arguments, ".manifest.sgx"))) {
-        /* Run as a manifest file,
-         * replace argv[0] with the contents of the manifest's loader.execname */
-        char cfgbuf[CONFIG_MAX];
+    /* Load argv */
+    /* TODO: Add an option to specify argv inline in the manifest. This requires an upgrade to the
+     * manifest syntax. See https://github.com/oscarlab/graphene/issues/870 (Use YAML or TOML syntax
+     * for manifests). 'loader.execname' won't be needed after implementing this feature and
+     * resolving https://github.com/oscarlab/graphene/issues/1053 (RFC: graphene invocation).
+     */
+    bool using_loader_execname = false;
+    if (pal_state.root_config) {
         ret = get_config(pal_state.root_config, "loader.execname", cfgbuf, sizeof(cfgbuf));
-        if (ret > 0)
-            *arguments = malloc_copy(cfgbuf, ret + 1);
+        if (ret > 0) {
+            /* loader.execname specified, override argv[0] */
+            using_loader_execname = true;
+            if (!arguments[0]) {
+                arguments = malloc(sizeof(const char*) * 2);
+                if (!arguments)
+                    INIT_FAIL(PAL_ERROR_NOMEM, "malloc() failed");
+                arguments[1] = NULL;
+            }
+            arguments[0] = malloc_copy(cfgbuf, ret + 1);
+            if (!arguments[0])
+                INIT_FAIL(PAL_ERROR_NOMEM, "malloc() failed");
+        }
+    }
+
+    if (get_config(pal_state.root_config, "loader.insecure__use_cmdline_argv",
+                   cfgbuf, CONFIG_MAX) > 0) {
+        printf("WARNING: Using insecure argv source. Don't use this configuration in production!\n");
+    } else if (get_config(pal_state.root_config, "loader.argv_src_file", cfgbuf, CONFIG_MAX) > 0) {
+        /* Load argv from a file and discard cmdline argv. We trust the file contents (this can be
+         * achieved using protected or trusted files). */
+        if (arguments[0] && arguments[1])
+            printf("Discarding cmdline arguments (%s %s [...]) because loader.argv_src_file was "
+                   "specified in the manifest.\n", arguments[0], arguments[1]);
+
+        PAL_HANDLE argv_handle;
+        PAL_STREAM_ATTR attr;
+        ret = _DkStreamOpen(&argv_handle, cfgbuf, PAL_ACCESS_RDONLY, 0, 0, 0);
+        if (ret < 0)
+            INIT_FAIL(-ret, "can't open loader.argv_src_file");
+        ret = _DkStreamAttributesQueryByHandle(argv_handle, &attr);
+        if (ret < 0)
+            INIT_FAIL(-ret, "can't read attributes of loader.argv_src_file");
+        size_t argv_file_size = attr.pending_size;
+        char* buf = malloc(argv_file_size);
+        if (!buf)
+            INIT_FAIL(PAL_ERROR_NOMEM, "malloc failed");
+        ret = _DkStreamRead(argv_handle, 0, argv_file_size, buf, NULL, 0);
+        if (ret < 0)
+            INIT_FAIL(-ret, "can't read loader.argv_src_file");
+        if (argv_file_size == 0 || buf[argv_file_size - 1] != '\0')
+            INIT_FAIL(PAL_ERROR_INVAL, "loader.argv_src_file should contain a "
+                                       "list of C-strings");
+        ret = _DkObjectClose(argv_handle);
+        if (ret < 0)
+            INIT_FAIL(-ret, "closing loader.argv_src_file failed");
+
+        /* Create argv array from the file contents. */
+        size_t argc = 0;
+        for (size_t i = 0; i < argv_file_size; i++)
+            if (buf[i] == '\0')
+                argc++;
+        const char** argv = malloc(sizeof(const char*) * (argc + 1));
+        if (!argv)
+            INIT_FAIL(PAL_ERROR_NOMEM, "malloc() failed");
+        assert(argc > 0);
+        argv[argc] = NULL;
+        const char** argv_it = argv;
+        *(argv_it++) = buf;
+        assert(argv_file_size > 0);
+        for (size_t i = 0; i < argv_file_size - 1; i++)
+            if (buf[i] == '\0')
+                *(argv_it++) = buf + i + 1;
+        arguments = argv;
+    } else if (!using_loader_execname || (arguments[0] && arguments[1])) {
+        INIT_FAIL(PAL_ERROR_INVAL, "argv handling wasn't configured in the manifest, but cmdline "
+                  "arguments were specified.");
     }
 
     read_environments(&environments);

--- a/Tools/.gitignore
+++ b/Tools/.gitignore
@@ -1,0 +1,1 @@
+/argv_serializer

--- a/Tools/Makefile
+++ b/Tools/Makefile
@@ -1,0 +1,22 @@
+include ../Scripts/Makefile.configs
+include ../Scripts/Makefile.rules
+
+.PHONY: all
+all: argv_serializer
+
+.PHONY: test sgx-tokens
+test sgx-tokens:
+
+.PHONY: format
+format:
+	clang-format -i $(shell find . \( -name '*.h' -o -name '*.c' \) -print)
+
+%: %.c
+	$(call cmd,csingle)
+
+.PHONY: clean
+clean:
+	$(RM) argv_serializer *.d
+
+.PHONY: distclean
+distclean: clean

--- a/Tools/argv_serializer.c
+++ b/Tools/argv_serializer.c
@@ -1,0 +1,18 @@
+/* SPDX-License-Identifier: LGPL-3.0-or-later */
+/* Copyright (C) 2020 Invisible Things Lab
+ *                    Michał Kowalczyk <mkow@invisiblethingslab.com>
+ */
+
+/* Helper tool for protected argv ("loader.argv_src_file" manifest option). See Graphene
+ * documentation for usage.
+ */
+
+#include <stdio.h>
+#include <string.h>
+
+int main(int argc, char* argv[]) {
+    for (int i = 1; i < argc; i++)
+        if (fwrite(argv[i], strlen(argv[i]) + 1, 1, stdout) != 1)
+            return 1;
+    return 0;
+}


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

_This is an RFC PR. After we converge on the final version I'll implement a similar PR for envs._

This PR implements a way to pass runtime arguments from a file, with intention to use it in conjunction with either trusted or protected files.

Unfortunately, argv passing is quite ugly because of `loader.exename` and very limited manifest syntax. After fixing #870 and #1053 the implementation and usage could be simplified.

One known issue with the current code is that argv of children goes through the untrusted host under Linux-SGX PAL (through `execve` arguments, see #1561).

This PR is a breaking change and there's (AFAIK) no better way to implement it - the old manifest syntax was insecure-by-default (allowing unstrusted args). Users will need to use `loader.insecure__use_cmdline_argv` if they don't want to use the file arguments.
For apps which are intended to run without any special arguments, the recommended way is to set `loader.execname` and don't pass any additional arguments. This will get a bit more intuitive after allowing inline argv in the manifest (see a comment in the code).

This resolves a half of #508.

## How to test this PR? <!-- (if applicable) -->

New LibOS test included. Also, verify if this doesn't break any examples you use but aren't tested in Jenkins (or aren't committed to the repo).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1562)
<!-- Reviewable:end -->
