### PR TITLE
[Pal] Return correct errno and return value in Dk* APIs

### DIFF
--- a/Pal/src/db_object.c
+++ b/Pal/src/db_object.c
@@ -75,7 +75,7 @@ PAL_BOL DkSynchronizationObjectWait(PAL_HANDLE handle, PAL_NUM timeout_us) {
 
     if (!handle) {
         _DkRaiseFailure(PAL_ERROR_INVAL);
-        LEAVE_PAL_CALL_RETURN(NULL);
+        LEAVE_PAL_CALL_RETURN(PAL_FALSE);
     }
 
     int ret = _DkSynchronizationObjectWait(handle, timeout_us);

--- a/Pal/src/db_streams.c
+++ b/Pal/src/db_streams.c
@@ -296,8 +296,8 @@ DkStreamRead(PAL_HANDLE handle, PAL_NUM offset, PAL_NUM count, PAL_PTR buffer, P
     ENTER_PAL_CALL(DkStreamRead);
 
     if (!handle || !buffer) {
-        _DkRaiseFailure(-PAL_ERROR_INVAL);
-        LEAVE_PAL_CALL_RETURN(0);
+        _DkRaiseFailure(PAL_ERROR_INVAL);
+        LEAVE_PAL_CALL_RETURN(PAL_STREAM_ERROR);
     }
 
     int64_t ret = _DkStreamRead(handle, offset, count, (void*)buffer, size ? (char*)source : NULL,
@@ -346,7 +346,7 @@ DkStreamWrite(PAL_HANDLE handle, PAL_NUM offset, PAL_NUM count, PAL_PTR buffer, 
 
     if (!handle || !buffer) {
         _DkRaiseFailure(PAL_ERROR_INVAL);
-        LEAVE_PAL_CALL_RETURN(0);
+        LEAVE_PAL_CALL_RETURN(PAL_STREAM_ERROR);
     }
 
     int64_t ret =
@@ -380,8 +380,8 @@ int _DkStreamAttributesQuery(const char* uri, PAL_STREAM_ATTR* attr) {
 }
 
 /* PAL call DkStreamAttributeQuery: query attribute of a stream by its
-   URI, attr is memory given by user space. Return the pointer of attr
-   if succeeded, or NULL if failed. Error code is notified */
+   URI, attr is memory given by user space. Return TRUE if succeeded
+   or FALSE if failed. Error code is notified */
 PAL_BOL DkStreamAttributesQuery(PAL_STR uri, PAL_STREAM_ATTR* attr) {
     ENTER_PAL_CALL(DkStreamAttributesQuery);
 
@@ -418,8 +418,8 @@ int _DkStreamAttributesQueryByHandle(PAL_HANDLE hdl, PAL_STREAM_ATTR* attr) {
 }
 
 /* PAL call DkStreamAttributesQueryByHandle: Query attribute of a stream by
-   its handle, attr is memory given by user space. Return the pointer of attr
-   if succeeded, or NULL if failed. Error code is notified */
+   its handle, attr is memory given by user space. Return TRUE if succeeded
+   or FALSE if failed. Error code is notified */
 PAL_BOL DkStreamAttributesQueryByHandle(PAL_HANDLE handle, PAL_STREAM_ATTR* attr) {
     ENTER_PAL_CALL(DkStreamAttributesQueryByHandle);
 
@@ -439,8 +439,8 @@ PAL_BOL DkStreamAttributesQueryByHandle(PAL_HANDLE handle, PAL_STREAM_ATTR* attr
 }
 
 /* PAL call DkStreamAttributesSetByHandle: Set attribute of a stream by
-   its handle, attr is memory given by user space. Return the pointer of attr
-   if succeeded, or NULL if failed. Error code is notified */
+   its handle, attr is memory given by user space. Return TRUE if succeeded
+   or FALSE if failed. Error code is notified */
 PAL_BOL DkStreamAttributesSetByHandle(PAL_HANDLE handle, PAL_STREAM_ATTR* attr) {
     ENTER_PAL_CALL(DkStreamAttributesSetByHandle);
 
@@ -488,9 +488,8 @@ int _DkStreamGetName(PAL_HANDLE handle, char* buffer, int size) {
     return ret;
 }
 
-/* PAL call DkStreamAttributesSetByHandle: Set attribute of a stream by
-   its handle, attr is memory given by user space. Return the pointer of attr
-   if succeeded, or NULL if failed. Error code is notified */
+/* PAL call DkStreamGetName: Copy handle name into buffer. Return size of
+ * name if succeeded or 0 if failed. Error code is notified */
 PAL_NUM DkStreamGetName(PAL_HANDLE handle, PAL_PTR buffer, PAL_NUM size) {
     ENTER_PAL_CALL(DkStreamGetName);
 
@@ -606,28 +605,25 @@ int64_t _DkStreamSetLength(PAL_HANDLE handle, uint64_t length) {
 }
 
 /* PAL call DkStreamSetLength: Truncate the stream at certain length.
-   Return the length if succeeded or 0 if failed. Error code is notified. */
+   Return 0 if succeeded or positive error code if failed. Error code
+   is additionally notified. */
 PAL_NUM DkStreamSetLength(PAL_HANDLE handle, PAL_NUM length) {
-    PAL_NUM rv = 0;
     ENTER_PAL_CALL(DkStreamSetLength);
 
     if (!handle) {
         _DkRaiseFailure(PAL_ERROR_INVAL);
-        LEAVE_PAL_CALL_RETURN(0);
+        LEAVE_PAL_CALL_RETURN(PAL_ERROR_INVAL);
     }
 
     int64_t ret = _DkStreamSetLength(handle, length);
 
-    // Convert failure to a positive value
     if (ret < 0) {
         _DkRaiseFailure(-ret);
-        rv = -ret;
-    } else {
-        // At this point, ret should equal length
-        assert((uint64_t)ret == length);
+        LEAVE_PAL_CALL_RETURN(-ret);
     }
 
-    LEAVE_PAL_CALL_RETURN(rv);
+    assert((uint64_t)ret == length);
+    LEAVE_PAL_CALL_RETURN(0);
 }
 
 /* _DkStreamFlush for internal use. This function sync up the handle with
@@ -647,8 +643,8 @@ int _DkStreamFlush(PAL_HANDLE handle) {
     return ops->flush(handle);
 }
 
-/* PAL call DkStreamFlush: Sync up a stream of a given handle. No return
-   value. Error code is notified. */
+/* PAL call DkStreamFlush: Sync up a stream of a given handle. Return TRUE
+ * if succeeded or FALSE if failed. Error code is notified. */
 PAL_BOL DkStreamFlush(PAL_HANDLE handle) {
     ENTER_PAL_CALL(DkStreamFlush);
 
@@ -668,7 +664,7 @@ PAL_BOL DkStreamFlush(PAL_HANDLE handle) {
 }
 
 /* PAL call DkSendHandle: Write to a process handle.
-   Return 1 on success and 0 on failure */
+   Return TRUE on success and FALSE on failure */
 PAL_BOL DkSendHandle(PAL_HANDLE handle, PAL_HANDLE cargo) {
     ENTER_PAL_CALL(DkSendHandle);
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Fix several bugs in incorrectly set errno and return values without changing the logic. These bugs led to e.g. periodic hangs of LTP tests.

## How to test this PR? <!-- (if applicable) -->

Without this PR, `fork11` LTP test periodically hanged. With this PR (+ https://github.com/oscarlab/graphene/pull/1542), `fork11` doesn't hang or fail.

Tested like this: `i=0; while [[ $i == 0 ]]; do ./pal_loader ./fork11; i=$?; done`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1572)
<!-- Reviewable:end -->
