### PR TITLE
Fix test_pal.py::TC_20_SingleProcess::test_500_thread

### DIFF
--- a/LibOS/shim/src/elf/shim_rtld.c
+++ b/LibOS/shim/src/elf/shim_rtld.c
@@ -1582,6 +1582,7 @@ noreturn void execute_elf_object(struct shim_handle* exec, int* argcp, const cha
     if (ret < 0) {
         debug("execute_elf_object: DkRandomBitsRead failed.\n");
         DkThreadExit(/*clear_child_tid=*/NULL);
+        /* UNREACHABLE */
     }
     auxp[5].a_un.a_val = random;
 

--- a/LibOS/shim/src/ipc/shim_ipc_helper.c
+++ b/LibOS/shim/src/ipc/shim_ipc_helper.c
@@ -813,6 +813,7 @@ noreturn static void shim_ipc_helper(void* dummy) {
     debug("IPC helper thread terminated\n");
 
     DkThreadExit(/*clear_child_tid=*/NULL);
+    /* UNREACHABLE */
 
 out_err_unlock:
     unlock(&ipc_helper_lock);
@@ -842,7 +843,7 @@ static void shim_ipc_helper_prepare(void* arg) {
         free(stack);
         put_thread(self);
         DkThreadExit(/*clear_child_tid=*/NULL);
-        return;
+        /* UNREACHABLE */
     }
 
     debug("IPC helper thread started\n");

--- a/LibOS/shim/src/shim_async.c
+++ b/LibOS/shim/src/shim_async.c
@@ -152,7 +152,7 @@ static void shim_async_helper(void* arg) {
     if (notme) {
         put_thread(self);
         DkThreadExit(/*clear_child_tid=*/NULL);
-        return;
+        /* UNREACHABLE */
     }
 
     /* Assume async helper thread will not drain the stack that PAL provides,
@@ -345,7 +345,7 @@ static void shim_async_helper(void* arg) {
     free(pal_events);
 
     DkThreadExit(/*clear_child_tid=*/NULL);
-    return;
+    /* UNREACHABLE */
 
 out_err_unlock:
     unlock(&async_helper_lock);

--- a/LibOS/shim/src/sys/shim_exit.c
+++ b/LibOS/shim/src/sys/shim_exit.c
@@ -136,9 +136,11 @@ noreturn void thread_exit(int error_code, int term_signal) {
             debug("failed to set up async cleanup_thread (exiting without clear child tid),"
                   " return code: %ld\n", ret);
             DkThreadExit(NULL);
+            /* UNREACHABLE */
         }
 
         DkThreadExit(&cur_thread->clear_child_tid_pal);
+        /* UNREACHABLE */
     }
 
     /* At this point other threads might be still in the middle of an exit routine, but we don't

--- a/Pal/regression/Event.c
+++ b/Pal/regression/Event.c
@@ -15,8 +15,7 @@ static int thread2_run(void* args) {
     DkEventSet(event1);
     pal_printf("End of second thread.\n");
     DkThreadExit(/*clear_child_tid=*/NULL);
-
-    return 0;
+    /* UNREACHABLE */
 }
 
 static void pal_failure_handler(PAL_PTR event, PAL_NUM error, PAL_CONTEXT* context) {

--- a/Pal/regression/Event2.c
+++ b/Pal/regression/Event2.c
@@ -15,7 +15,7 @@ static int thread_func(void* args) {
 
     DkEventSet(event1);
     DkThreadExit(/*clear_child_tid=*/NULL);
-    return 0; /* NOTREACHED */
+    /* UNREACHABLE */
 }
 
 int main(int argc, char** argv) {

--- a/Pal/regression/Thread2.c
+++ b/Pal/regression/Thread2.c
@@ -29,6 +29,7 @@ static int thread3_run(void* args) {
     // Ensure that the compiler can't know that this should never return.
     if (dummy_true) {
         DkThreadExit(/*clear_child_tid=*/NULL);
+        /* UNREACHABLE */
     }
 
     thread3_exit_ok = false;

--- a/Pal/src/db_rtld.c
+++ b/Pal/src/db_rtld.c
@@ -1085,4 +1085,5 @@ noreturn void start_execution(const char** arguments, const char** environs) {
         CALL_ENTRY(exec_map, cookies);
 
     _DkThreadExit(/*clear_child_tid=*/NULL);
+    /* UNREACHABLE */
 }

--- a/Pal/src/db_threading.c
+++ b/Pal/src/db_threading.c
@@ -61,10 +61,7 @@ void DkThreadYieldExecution(void) {
 noreturn void DkThreadExit(PAL_PTR clear_child_tid) {
     ENTER_PAL_CALL(DkThreadExit);
     _DkThreadExit((int*)clear_child_tid);
-    _DkRaiseFailure(PAL_ERROR_NOTKILLABLE);
-    while (true)
-        /* nothing */;
-    LEAVE_PAL_CALL();
+    /* UNREACHABLE */
 }
 
 /* PAL call DkThreadResume: resume the execution of a thread

--- a/Pal/src/host/Linux-SGX/db_threading.c
+++ b/Pal/src/host/Linux-SGX/db_threading.c
@@ -79,6 +79,7 @@ void pal_start_thread (void)
     memset(&pal_tcb->libos_tcb, 0, sizeof(pal_tcb->libos_tcb));
     callback((void *) param);
     _DkThreadExit(/*clear_child_tid=*/NULL);
+    /* UNREACHABLE */
 }
 
 /* _DkThreadCreate for internal use. Create an internal thread


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Almost everything in this test was wrong:
- race on `count = 100` in the main thread and `count++` in the worker thread
- using volatile as atomic
- dead code after `DkThreadExit`, which is `noreturn`
- checking if noreturn function didn't actually return
- doing the above with 500 loop iterations...

Additionally, I added 'UNREACHABLE' annotations after DkThreadExit calls.

Fixes  #1573.

## How to test this PR? <!-- (if applicable) -->

In `Pal/regression`, run:
```fish
for i in (seq 400000)
   echo "[$i]"
   ../../Runtime/pal-Linux init Thread ^stderr.txt >stdout.txt; and grep -q 'Child Thread Exited' stderr.txt; or break
end
```

After this patch I ran this test 400000 times without errors (previously it was failing after ~10k run).

See #1573.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1575)
<!-- Reviewable:end -->
