### PR TITLE
[PAL] Handle SIGTERM in application

### DIFF
--- a/Pal/src/host/Linux/db_exception.c
+++ b/Pal/src/host/Linux/db_exception.c
@@ -176,7 +176,7 @@ static void handle_async_signal(int signum, siginfo_t* info, struct ucontext* uc
 
     uintptr_t rip = uc->uc_mcontext.gregs[REG_RIP];
 
-    if (!ADDR_IN_PAL(rip)) {
+    if (signum == SIGTERM || !ADDR_IN_PAL(rip)) {
         /* signal arrived while in application or LibOS code, normal benign case */
         perform_signal_handling(event, info, uc);
         return;


### PR DESCRIPTION
The dummy server in python-simple does not terminate upon SIGTERM
anymore. This patch fixes this by having the application handle the
signal.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1576)
<!-- Reviewable:end -->
