### PR TITLE
[LibOS] Replace and move inline assembly

### DIFF
--- a/LibOS/shim/include/arch/x86_64/shim_internal-arch.h
+++ b/LibOS/shim/include/arch/x86_64/shim_internal-arch.h
@@ -26,4 +26,14 @@ static_always_inline void* current_stack(void) {
     return _rsp;
 }
 
+#define CALL_ELF_ENTRY(ENTRY, ARGCP)     \
+    __asm__ volatile(                    \
+        "pushq $0\r\n"                   \
+        "popfq\r\n"                      \
+        "movq %%rbx, %%rsp\r\n"          \
+        "jmp *%%rax\r\n"                 \
+        :                                \
+        : "a"(ENTRY), "b"(ARGCP), "d"(0) \
+        : "memory", "cc")
+
 #endif /* _SHIM_INTERNAL_ARCH_H_ */

--- a/LibOS/shim/src/elf/shim_rtld.c
+++ b/LibOS/shim/src/elf/shim_rtld.c
@@ -1592,18 +1592,8 @@ noreturn void execute_elf_object(struct shim_handle* exec, int* argcp, const cha
     shim_tcb_t* tcb = shim_get_tcb();
     __enable_preempt(tcb);
 
-#if defined(__x86_64__)
-    __asm__ volatile(
-        "pushq $0\r\n"
-        "popfq\r\n"
-        "movq %%rbx, %%rsp\r\n"
-        "jmp *%%rax\r\n"
-        :
-        : "a"(entry), "b"(argcp), "d"(0)
-        : "memory", "cc");
-#else
-#error "architecture not supported"
-#endif
+    CALL_ELF_ENTRY(entry, argcp);
+
     while (true)
         /* nothing */;
 }

--- a/LibOS/shim/src/shim_init.c
+++ b/LibOS/shim/src/shim_init.c
@@ -874,8 +874,7 @@ void check_stack_hook (void)
 {
     struct shim_thread * cur_thread = get_cur_thread();
 
-    void * rsp;
-    __asm__ volatile ("movq %%rsp, %0" : "=r"(rsp) :: "memory");
+    void* rsp = current_stack();
 
     if (rsp <= cur_thread->stack_top && rsp > cur_thread->stack) {
         if ((uintptr_t)rsp - (uintptr_t)cur_thread->stack < PAL_CB(alloc_align))


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

This PR makes use of current_stack() to get rid of inline assembly and moves some other inline assembly into a header file (as macro).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1577)
<!-- Reviewable:end -->
