### PR TITLE
[Linux-SGX] Add sched_setaffinity/sched_getaffinity support

### DIFF
--- a/LibOS/shim/src/sys/shim_sched.c
+++ b/LibOS/shim/src/sys/shim_sched.c
@@ -160,17 +160,17 @@ int shim_do_sched_setaffinity(pid_t pid, size_t cpusetsize, __kernel_cpu_set_t* 
     PAL_HANDLE thread = NULL;
     int ncpus = PAL_CB(cpu_info.cpu_num);
 
-    struct shim_thread* cur_thread = get_cur_thread();
-    if (!cur_thread)
-        return -ESRCH;
-
-    thread = cur_thread->pal_handle;
-
     /* setting affinity of other threads requires host tid mapping in a secure way */
     if (pid != 0) {
         debug("Changing the affinity of thread id: %d is not supported, only tid == 0 works for now.\n", pid);
         return -ENOSYS;
     }
+
+    struct shim_thread* cur_thread = get_cur_thread();
+    if (!cur_thread)
+        return -ESRCH;
+
+    thread = cur_thread->pal_handle;
 
     int bitmask_size_in_bytes = check_affinity_params(ncpus, cpusetsize, user_mask_ptr);
     if (bitmask_size_in_bytes < 0)
@@ -186,17 +186,17 @@ int shim_do_sched_getaffinity(pid_t pid, size_t cpusetsize, __kernel_cpu_set_t* 
     PAL_HANDLE thread = NULL;
     int ncpus = PAL_CB(cpu_info.cpu_num);
 
+    /* getting affinity of other threads requires host tid mapping in a secure way */
+    if (pid != 0) {
+        debug("Getting the affinity of thread id: %d is not supported, only tid == 0 works for now.\n", pid);
+        return -ENOSYS;
+    }
+
     struct shim_thread* cur_thread = get_cur_thread();
     if (!cur_thread)
         return -ESRCH;
 
     thread = cur_thread->pal_handle;
-
-    /* setting affinity of other threads requires host tid mapping in a secure way */
-    if (pid != 0) {
-        debug("Getting the affinity of thread id: %d is not supported, only tid == 0 works for now.\n", pid);
-        return -ENOSYS;
-    }
 
     int bitmask_size_in_bytes = check_affinity_params(ncpus, cpusetsize, user_mask_ptr);
     if (bitmask_size_in_bytes < 0)

--- a/LibOS/shim/src/sys/shim_sched.c
+++ b/LibOS/shim/src/sys/shim_sched.c
@@ -207,6 +207,7 @@ int shim_do_sched_getaffinity(pid_t pid, size_t len, __kernel_cpu_set_t* user_ma
     if (!DkThreadGetCPUAffinity(thread, bitmask_size_in_bytes, user_mask_ptr)) {
         return -PAL_ERRNO();
     }
+    /* on success, imitate Linux kernel implementation: see SYSCALL_DEFINE3(sched_getaffinity) */
     return bitmask_size_in_bytes;
 }
 

--- a/LibOS/shim/src/sys/shim_sched.c
+++ b/LibOS/shim/src/sys/shim_sched.c
@@ -157,7 +157,6 @@ static int check_affinity_params(int ncpus, size_t len, __kernel_cpu_set_t* user
 }
 
 int shim_do_sched_setaffinity(pid_t pid, size_t len, __kernel_cpu_set_t* user_mask_ptr) {
-    int retval = 0;
     PAL_HANDLE thread = NULL;
     int ncpus = PAL_CB(cpu_info.cpu_num);
 
@@ -184,7 +183,6 @@ int shim_do_sched_setaffinity(pid_t pid, size_t len, __kernel_cpu_set_t* user_ma
 }
 
 int shim_do_sched_getaffinity(pid_t pid, size_t len, __kernel_cpu_set_t* user_mask_ptr) {
-    int retval = 0;
     PAL_HANDLE thread = NULL;
     int ncpus = PAL_CB(cpu_info.cpu_num);
 

--- a/LibOS/shim/src/sys/shim_sched.c
+++ b/LibOS/shim/src/sys/shim_sched.c
@@ -177,8 +177,10 @@ int shim_do_sched_setaffinity(pid_t pid, size_t len, __kernel_cpu_set_t* user_ma
     if (bitmask_size_in_bytes < 0)
         return bitmask_size_in_bytes;
 
-    retval = DkThreadSetCPUAffinity(thread, bitmask_size_in_bytes, user_mask_ptr);
-    return retval;
+    if (!DkThreadSetCPUAffinity(thread, bitmask_size_in_bytes, user_mask_ptr)) {
+        return -PAL_ERRNO();
+    }
+    return 0;
 }
 
 int shim_do_sched_getaffinity(pid_t pid, size_t len, __kernel_cpu_set_t* user_mask_ptr) {
@@ -202,8 +204,10 @@ int shim_do_sched_getaffinity(pid_t pid, size_t len, __kernel_cpu_set_t* user_ma
     if (bitmask_size_in_bytes < 0)
         return bitmask_size_in_bytes;
 
-    retval = DkThreadGetCPUAffinity(thread, bitmask_size_in_bytes, user_mask_ptr);
-    return retval;
+    if (!DkThreadGetCPUAffinity(thread, bitmask_size_in_bytes, user_mask_ptr)) {
+        return -PAL_ERRNO();
+    }
+    return bitmask_size_in_bytes;
 }
 
 /* dummy implementation: always return cpu0  */

--- a/LibOS/shim/src/sys/shim_sched.c
+++ b/LibOS/shim/src/sys/shim_sched.c
@@ -17,6 +17,7 @@
 #include <pal.h>
 #include <shim_internal.h>
 #include <shim_table.h>
+#include <shim_thread.h>
 
 int shim_do_sched_yield(void) {
     DkThreadYieldExecution();
@@ -159,6 +160,12 @@ int shim_do_sched_setaffinity(pid_t pid, size_t len, __kernel_cpu_set_t* user_ma
     int retval = 0;
     PAL_HANDLE thread = NULL;
     int ncpus = PAL_CB(cpu_info.cpu_num);
+
+    struct shim_thread* cur_thread = get_cur_thread();
+    if (!cur_thread)
+        return -ESRCH;
+
+    thread = cur_thread->pal_handle;
 
     /* to set other thread requires host tid mapping */
     if (pid != 0) {

--- a/LibOS/shim/src/sys/shim_sched.c
+++ b/LibOS/shim/src/sys/shim_sched.c
@@ -155,34 +155,41 @@ static int check_affinity_params(int ncpus, size_t len, __kernel_cpu_set_t* user
     return bitmask_size_in_bytes;
 }
 
-/* dummy implementation: ignore user-supplied mask and return success */
 int shim_do_sched_setaffinity(pid_t pid, size_t len, __kernel_cpu_set_t* user_mask_ptr) {
-    __UNUSED(pid);
+    int retval = 0;
+    PAL_HANDLE thread = NULL;
     int ncpus = PAL_CB(cpu_info.cpu_num);
+
+    /* to set other thread requires host tid mapping */
+    if (pid != 0) {
+        debug("The thread id: %d is not supported for now.\n", pid);
+        return -ENOSYS;
+    }
 
     int bitmask_size_in_bytes = check_affinity_params(ncpus, len, user_mask_ptr);
     if (bitmask_size_in_bytes < 0)
         return bitmask_size_in_bytes;
 
-    return 0;
+    retval = DkThreadSetCPUAffinity(thread, bitmask_size_in_bytes, user_mask_ptr);
+    return retval;
 }
 
-/* dummy implementation: always return all-ones (as many as there are host CPUs)  */
 int shim_do_sched_getaffinity(pid_t pid, size_t len, __kernel_cpu_set_t* user_mask_ptr) {
-    __UNUSED(pid);
+    int retval = 0;
+    PAL_HANDLE thread = NULL;
     int ncpus = PAL_CB(cpu_info.cpu_num);
+
+    if (pid != 0) {
+        debug("The thread id: %d is not supported for now.\n", pid);
+        return -ENOSYS;
+    }
 
     int bitmask_size_in_bytes = check_affinity_params(ncpus, len, user_mask_ptr);
     if (bitmask_size_in_bytes < 0)
         return bitmask_size_in_bytes;
 
-    memset(user_mask_ptr, 0, len);
-    for (int i = 0; i < ncpus; i++) {
-        ((uint8_t*)user_mask_ptr)[i / 8] |= 1 << (i % 8);
-    }
-    /* imitate the Linux kernel implementation
-     * See SYSCALL_DEFINE3(sched_getaffinity) */
-    return bitmask_size_in_bytes;
+    retval = DkThreadGetCPUAffinity(thread, bitmask_size_in_bytes, user_mask_ptr);
+    return retval;
 }
 
 /* dummy implementation: always return cpu0  */

--- a/LibOS/shim/src/sys/shim_sched.c
+++ b/LibOS/shim/src/sys/shim_sched.c
@@ -183,6 +183,7 @@ int shim_do_sched_setaffinity(pid_t pid, size_t cpusetsize, __kernel_cpu_set_t* 
 }
 
 int shim_do_sched_getaffinity(pid_t pid, size_t cpusetsize, __kernel_cpu_set_t* user_mask_ptr) {
+    int retval;
     PAL_HANDLE thread = NULL;
     int ncpus = PAL_CB(cpu_info.cpu_num);
 
@@ -202,11 +203,12 @@ int shim_do_sched_getaffinity(pid_t pid, size_t cpusetsize, __kernel_cpu_set_t* 
     if (bitmask_size_in_bytes < 0)
         return bitmask_size_in_bytes;
 
-    if (!DkThreadGetCpuAffinity(thread, bitmask_size_in_bytes, user_mask_ptr)) {
+    retval = (int)DkThreadGetCpuAffinity(thread, bitmask_size_in_bytes, user_mask_ptr);
+    if (retval < 0) {
         return -PAL_ERRNO();
     }
     /* on success, imitate Linux kernel implementation: see SYSCALL_DEFINE3(sched_getaffinity) */
-    return bitmask_size_in_bytes;
+    return retval;
 }
 
 /* dummy implementation: always return cpu0  */

--- a/LibOS/shim/src/sys/shim_sched.c
+++ b/LibOS/shim/src/sys/shim_sched.c
@@ -186,6 +186,13 @@ int shim_do_sched_getaffinity(pid_t pid, size_t len, __kernel_cpu_set_t* user_ma
     PAL_HANDLE thread = NULL;
     int ncpus = PAL_CB(cpu_info.cpu_num);
 
+    struct shim_thread* cur_thread = get_cur_thread();
+    if (!cur_thread)
+        return -ESRCH;
+
+    thread = cur_thread->pal_handle;
+
+    /* to set other thread requires host tid mapping */
     if (pid != 0) {
         debug("The thread id: %d is not supported for now.\n", pid);
         return -ENOSYS;

--- a/LibOS/shim/test/regression/Makefile
+++ b/LibOS/shim/test/regression/Makefile
@@ -49,6 +49,7 @@ c_executables = \
 	pselect \
 	readdir \
 	sched \
+	sched_set_get_cpuaffinity \
 	select \
 	shared_object \
 	sigaction_per_process \

--- a/LibOS/shim/test/regression/sched_set_get_cpuaffinity.c
+++ b/LibOS/shim/test/regression/sched_set_get_cpuaffinity.c
@@ -1,18 +1,12 @@
-/* Copyright (C) 2020 Intel Corp.
-   This file is part of Graphene Library OS.
+/* SPDX-License-Identifier: LGPL-3.0-or-later */
+/* Copyright (C) 2014 Stony Brook University */
 
-   Graphene Library OS is free software: you can redistribute it and/or
-   modify it under the terms of the GNU Lesser General Public License
-   as published by the Free Software Foundation, either version 3 of the
-   License, or (at your option) any later version.
-
-   Graphene Library OS is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-   GNU Lesser General Public License for more details.
-
-   You should have received a copy of the GNU Lesser General Public License
-   along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
+/*
+ * sched_set_get_cpuaffinity.c
+ *
+ * Implementation of the regression test cases for setting/getting cpu affinity
+ * on single core or multiple cores.
+ */
 
 #define _GNU_SOURCE
 #include <assert.h>

--- a/LibOS/shim/test/regression/sched_set_get_cpuaffinity.c
+++ b/LibOS/shim/test/regression/sched_set_get_cpuaffinity.c
@@ -5,7 +5,7 @@
  * sched_set_get_cpuaffinity.c
  *
  * Implementation of the regression test cases for setting/getting cpu affinity
- * on single core or multiple cores.
+ * on a single core or multiple cores.
  */
 
 #define _GNU_SOURCE
@@ -25,6 +25,10 @@ int main(int argc, const char** argv) {
     long ret;
     cpu_set_t set_cs, get_cs;
     size_t cpucnt = sysconf(_SC_NPROCESSORS_ONLN);
+    if (cpucnt < 0) {
+        printf(" Failed to retrieve the number of cpu cores");
+        return 1;
+    }
 
     for (size_t i = 0; i < cpucnt; i++) {
         printf("Testing processor id: %ld\n", i);
@@ -33,38 +37,42 @@ int main(int argc, const char** argv) {
         CPU_SET(i, &set_cs);
         ret = sched_setaffinity(0, sizeof(set_cs), &set_cs);
         if (ret < 0) {
-            printf(" Failed to set affinity for current thread, id: %ld\n", i);
+            printf(" Failed to set affinity for current thread, core id: %ld\n", i);
             return 1;
         }
         ret = sched_getaffinity(0, sizeof(get_cs), &get_cs);
         if (ret < 0) {
-            printf(" Failed to get affinity for current thread, id: %ld\n", i);
+            printf(" Failed to get affinity for current thread, core id: %ld\n", i);
             return 1;
         }
         if (!CPU_EQUAL_S(sizeof(set_cs), &set_cs, &get_cs)) {
-            printf(" The get cpu set is not equal to set on id: %ld\n", i);
+            printf(" The get cpu set is not equal to set on core id: %ld\n", i);
             return 1;
         }
     }
 
-    /* test for multiple cpu affinity */
-    CPU_ZERO(&set_cs);
-    CPU_ZERO(&get_cs);
-    CPU_SET(0, &set_cs);
-    CPU_SET(1, &set_cs);
-    ret = sched_setaffinity(0, sizeof(set_cs), &set_cs);
-    if (ret < 0) {
-        printf(" Failed to set multiple affinity for current thread, id: 0 & 1\n");
-        return 1;
-    }
-    ret = sched_getaffinity(0, sizeof(get_cs), &get_cs);
-    if (ret < 0) {
-        printf(" Failed to get multiple affinity for current thread, id: 0 & 1\n");
-        return 1;
-    }
-    if (!CPU_EQUAL_S(sizeof(set_cs), &set_cs, &get_cs)) {
-        printf(" The get cpu set is not equal to set on id: 0 & 1\n");
-        return 1;
+    if (cpucnt >= 2) {
+        /* test for multiple cpu affinity */
+        CPU_ZERO(&set_cs);
+        CPU_ZERO(&get_cs);
+        CPU_SET(0, &set_cs);
+        CPU_SET(1, &set_cs);
+        ret = sched_setaffinity(0, sizeof(set_cs), &set_cs);
+        if (ret < 0) {
+            printf(" Failed to set multiple affinity for current thread, core id: 0 & 1\n");
+            return 1;
+        }
+        ret = sched_getaffinity(0, sizeof(get_cs), &get_cs);
+        if (ret < 0) {
+            printf(" Failed to get multiple affinity for current thread, core id: 0 & 1\n");
+            return 1;
+        }
+        if (!CPU_EQUAL_S(sizeof(set_cs), &set_cs, &get_cs)) {
+            printf(" The get cpu set is not equal to set on core id: 0 & 1\n");
+            return 1;
+        }
+    } else {
+        printf(" Multiple cpu affinity test skipped since only %ld identified \n", cpucnt);
     }
 
     printf("TEST OK: test completed successfully\n");

--- a/LibOS/shim/test/regression/sched_set_get_cpuaffinity.c
+++ b/LibOS/shim/test/regression/sched_set_get_cpuaffinity.c
@@ -1,0 +1,78 @@
+/* Copyright (C) 2020 Intel Corp.
+   This file is part of Graphene Library OS.
+
+   Graphene Library OS is free software: you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public License
+   as published by the Free Software Foundation, either version 3 of the
+   License, or (at your option) any later version.
+
+   Graphene Library OS is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
+
+#define _GNU_SOURCE
+#include <assert.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <sched.h>
+#include <stdlib.h>
+
+int main(int argc, const char** argv) {
+    long ret;
+    cpu_set_t set_cs, get_cs;
+    size_t cpucnt = sysconf(_SC_NPROCESSORS_ONLN);
+
+    for (size_t i = 0; i < cpucnt; i++) {
+        printf("Testing processor id: %d\n", i);
+        CPU_ZERO(&set_cs);
+        CPU_ZERO(&get_cs);
+        CPU_SET(i, &set_cs);
+        ret = sched_setaffinity(0, sizeof(set_cs), &set_cs);
+        if (ret < 0) {
+            printf(" Failed to set affinity for current thread, id: %d\n", i);
+            return 1;
+        }
+        ret = sched_getaffinity(0, sizeof(get_cs), &get_cs);
+        if (ret < 0) {
+            printf(" Failed to get affinity for current thread, id: %d\n", i);
+            return 1;
+        }
+        if (!CPU_EQUAL_S(sizeof(set_cs), &set_cs, &get_cs)) {
+            printf(" The get cpu set is not equal to set on id: %d\n", i);
+            return 1;
+        }
+    }
+
+    /* test for multiple cpu affinity */
+    CPU_ZERO(&set_cs);
+    CPU_ZERO(&get_cs);
+    CPU_SET(0, &set_cs);
+    CPU_SET(1, &set_cs);
+    ret = sched_setaffinity(0, sizeof(set_cs), &set_cs);
+    if (ret < 0) {
+        printf(" Failed to set multiple affinity for current thread, id: 0 & 1\n");
+        return 1;
+    }
+    ret = sched_getaffinity(0, sizeof(get_cs), &get_cs);
+    if (ret < 0) {
+        printf(" Failed to get multiple affinity for current thread, id: 0 & 1\n");
+        return 1;
+    }
+    if (!CPU_EQUAL_S(sizeof(set_cs), &set_cs, &get_cs)) {
+        printf(" The get cpu set is not equal to set on id: 0 & 1\n");
+        return 1;
+    }
+
+    printf("TEST OK: test completed successfully\n");
+    return 0;
+}

--- a/LibOS/shim/test/regression/sched_set_get_cpuaffinity.c
+++ b/LibOS/shim/test/regression/sched_set_get_cpuaffinity.c
@@ -18,14 +18,14 @@
 #include <assert.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <sched.h>
 #include <stdbool.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
-#include <sched.h>
-#include <stdlib.h>
 
 int main(int argc, const char** argv) {
     long ret;

--- a/LibOS/shim/test/regression/sched_set_get_cpuaffinity.c
+++ b/LibOS/shim/test/regression/sched_set_get_cpuaffinity.c
@@ -33,22 +33,22 @@ int main(int argc, const char** argv) {
     size_t cpucnt = sysconf(_SC_NPROCESSORS_ONLN);
 
     for (size_t i = 0; i < cpucnt; i++) {
-        printf("Testing processor id: %d\n", i);
+        printf("Testing processor id: %ld\n", i);
         CPU_ZERO(&set_cs);
         CPU_ZERO(&get_cs);
         CPU_SET(i, &set_cs);
         ret = sched_setaffinity(0, sizeof(set_cs), &set_cs);
         if (ret < 0) {
-            printf(" Failed to set affinity for current thread, id: %d\n", i);
+            printf(" Failed to set affinity for current thread, id: %ld\n", i);
             return 1;
         }
         ret = sched_getaffinity(0, sizeof(get_cs), &get_cs);
         if (ret < 0) {
-            printf(" Failed to get affinity for current thread, id: %d\n", i);
+            printf(" Failed to get affinity for current thread, id: %ld\n", i);
             return 1;
         }
         if (!CPU_EQUAL_S(sizeof(set_cs), &set_cs, &get_cs)) {
-            printf(" The get cpu set is not equal to set on id: %d\n", i);
+            printf(" The get cpu set is not equal to set on id: %ld\n", i);
             return 1;
         }
     }

--- a/LibOS/shim/test/regression/sched_set_get_cpuaffinity.c
+++ b/LibOS/shim/test/regression/sched_set_get_cpuaffinity.c
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: LGPL-3.0-or-later */
-/* Copyright (C) 2014 Stony Brook University */
+/* Copyright (C) 2020 Intel Corporation */
 
 /*
  * sched_set_get_cpuaffinity.c

--- a/LibOS/shim/test/regression/sched_set_get_cpuaffinity.c
+++ b/LibOS/shim/test/regression/sched_set_get_cpuaffinity.c
@@ -26,7 +26,7 @@ int main(int argc, const char** argv) {
     cpu_set_t set_cs, get_cs;
     size_t cpucnt = sysconf(_SC_NPROCESSORS_ONLN);
     if (cpucnt < 0) {
-        printf(" Failed to retrieve the number of cpu cores");
+        printf("Failed to retrieve the number of cpu cores\n");
         return 1;
     }
 
@@ -37,16 +37,16 @@ int main(int argc, const char** argv) {
         CPU_SET(i, &set_cs);
         ret = sched_setaffinity(0, sizeof(set_cs), &set_cs);
         if (ret < 0) {
-            printf(" Failed to set affinity for current thread, core id: %ld\n", i);
+            printf("Failed to set affinity for current thread, core id: %ld\n", i);
             return 1;
         }
         ret = sched_getaffinity(0, sizeof(get_cs), &get_cs);
         if (ret < 0) {
-            printf(" Failed to get affinity for current thread, core id: %ld\n", i);
+            printf("Failed to get affinity for current thread, core id: %ld\n", i);
             return 1;
         }
         if (!CPU_EQUAL_S(sizeof(set_cs), &set_cs, &get_cs)) {
-            printf(" The get cpu set is not equal to set on core id: %ld\n", i);
+            printf("The get cpu set is not equal to set on core id: %ld\n", i);
             return 1;
         }
     }
@@ -59,20 +59,20 @@ int main(int argc, const char** argv) {
         CPU_SET(1, &set_cs);
         ret = sched_setaffinity(0, sizeof(set_cs), &set_cs);
         if (ret < 0) {
-            printf(" Failed to set multiple affinity for current thread, core id: 0 & 1\n");
+            printf("Failed to set multiple affinity for current thread, core id: 0 & 1\n");
             return 1;
         }
         ret = sched_getaffinity(0, sizeof(get_cs), &get_cs);
         if (ret < 0) {
-            printf(" Failed to get multiple affinity for current thread, core id: 0 & 1\n");
+            printf("Failed to get multiple affinity for current thread, core id: 0 & 1\n");
             return 1;
         }
         if (!CPU_EQUAL_S(sizeof(set_cs), &set_cs, &get_cs)) {
-            printf(" The get cpu set is not equal to set on core id: 0 & 1\n");
+            printf("The get cpu set is not equal to set on core id: 0 & 1\n");
             return 1;
         }
     } else {
-        printf(" Multiple cpu affinity test skipped since only %ld identified \n", cpucnt);
+        printf("Multiple CPU affinity test skipped since only one core was identified\n");
     }
 
     printf("TEST OK: test completed successfully\n");

--- a/LibOS/shim/test/regression/test_libos.py
+++ b/LibOS/shim/test/regression/test_libos.py
@@ -440,6 +440,10 @@ class TC_30_Syscall(RegressionTestCase):
         stdout, _ = self.run_binary(['signal_multithread'])
         self.assertIn('TEST OK', stdout)
 
+    def test_094_sched_set_get_cpuaffinity(self):
+        stdout, _ = self.run_binary(['sched_set_get_cpuaffinity'])
+        self.assertIn('TEST OK', stdout)
+
 @unittest.skipUnless(HAS_SGX,
     'This test is only meaningful on SGX PAL because only SGX catches raw '
     'syscalls and redirects to Graphene\'s LibOS. If we will add seccomp to '

--- a/Pal/include/pal/pal.h
+++ b/Pal/include/pal/pal.h
@@ -543,10 +543,10 @@ PAL_BOL
 DkThreadResume(PAL_HANDLE thread);
 
 PAL_BOL
-DkThreadSetCPUAffinity(PAL_HANDLE thread, PAL_NUM cpu_num, PAL_PTR cpu_mask);
+DkThreadSetCPUAffinity(PAL_HANDLE thread, PAL_NUM cpu_len, PAL_PTR cpu_mask);
 
 PAL_BOL
-DkThreadGetCPUAffinity(PAL_HANDLE thread, PAL_NUM cpu_num, PAL_PTR cpu_mask);
+DkThreadGetCPUAffinity(PAL_HANDLE thread, PAL_NUM cpu_len, PAL_PTR cpu_mask);
 
 /*
  * Exception Handling

--- a/Pal/include/pal/pal.h
+++ b/Pal/include/pal/pal.h
@@ -544,7 +544,7 @@ DkThreadResume(PAL_HANDLE thread);
 
 PAL_BOL DkThreadSetCpuAffinity(PAL_HANDLE thread, PAL_NUM cpu_mask_size, PAL_PTR cpu_mask);
 
-PAL_BOL DkThreadGetCpuAffinity(PAL_HANDLE thread, PAL_NUM cpu_mask_size, PAL_PTR cpu_mask);
+PAL_NUM DkThreadGetCpuAffinity(PAL_HANDLE thread, PAL_NUM cpu_mask_size, PAL_PTR cpu_mask);
 
 /*
  * Exception Handling

--- a/Pal/include/pal/pal.h
+++ b/Pal/include/pal/pal.h
@@ -542,11 +542,9 @@ noreturn void DkThreadExit(PAL_PTR clear_child_tid);
 PAL_BOL
 DkThreadResume(PAL_HANDLE thread);
 
-PAL_BOL
-DkThreadSetCPUAffinity(PAL_HANDLE thread, PAL_NUM cpu_len, PAL_PTR cpu_mask);
+PAL_BOL DkThreadSetCpuAffinity(PAL_HANDLE thread, PAL_NUM cpu_mask_size, PAL_PTR cpu_mask);
 
-PAL_BOL
-DkThreadGetCPUAffinity(PAL_HANDLE thread, PAL_NUM cpu_len, PAL_PTR cpu_mask);
+PAL_BOL DkThreadGetCpuAffinity(PAL_HANDLE thread, PAL_NUM cpu_mask_size, PAL_PTR cpu_mask);
 
 /*
  * Exception Handling

--- a/Pal/include/pal/pal.h
+++ b/Pal/include/pal/pal.h
@@ -542,6 +542,12 @@ noreturn void DkThreadExit(PAL_PTR clear_child_tid);
 PAL_BOL
 DkThreadResume(PAL_HANDLE thread);
 
+PAL_BOL
+DkThreadSetCPUAffinity(PAL_HANDLE thread, PAL_NUM cpu_num, PAL_PTR cpu_mask);
+
+PAL_BOL
+DkThreadGetCPUAffinity(PAL_HANDLE thread, PAL_NUM cpu_num, PAL_PTR cpu_mask);
+
 /*
  * Exception Handling
  */

--- a/Pal/src/db_threading.c
+++ b/Pal/src/db_threading.c
@@ -83,3 +83,29 @@ PAL_BOL DkThreadResume(PAL_HANDLE threadHandle) {
 
     LEAVE_PAL_CALL_RETURN(PAL_TRUE);
 }
+
+PAL_BOL DkThreadSetCPUAffinity(PAL_HANDLE thread, PAL_NUM cpu_num, PAL_PTR cpu_mask) {
+    ENTER_PAL_CALL(DkThreadSetCPUAffinity);
+
+    int ret = _DkThreadSetCPUAffinity(thread, cpu_num, cpu_mask);
+
+    if (ret < 0) {
+        _DkRaiseFailure(-ret);
+        LEAVE_PAL_CALL_RETURN(PAL_FALSE);
+    }
+
+    LEAVE_PAL_CALL_RETURN(PAL_TRUE);
+}
+
+PAL_BOL DkThreadGetCPUAffinity(PAL_HANDLE thread, PAL_NUM cpu_num, PAL_PTR cpu_mask) {
+    ENTER_PAL_CALL(DkThreadGetCPUAffinity);
+
+    int ret = _DkThreadGetCPUAffinity(thread, cpu_num, cpu_mask);
+
+    if (ret < 0) {
+        _DkRaiseFailure(-ret);
+        LEAVE_PAL_CALL_RETURN(PAL_FALSE);
+    }
+
+    LEAVE_PAL_CALL_RETURN(PAL_TRUE);
+}

--- a/Pal/src/db_threading.c
+++ b/Pal/src/db_threading.c
@@ -84,10 +84,10 @@ PAL_BOL DkThreadResume(PAL_HANDLE threadHandle) {
     LEAVE_PAL_CALL_RETURN(PAL_TRUE);
 }
 
-PAL_BOL DkThreadSetCPUAffinity(PAL_HANDLE thread, PAL_NUM cpu_len, PAL_PTR cpu_mask) {
-    ENTER_PAL_CALL(DkThreadSetCPUAffinity);
+PAL_BOL DkThreadSetCpuAffinity(PAL_HANDLE thread, PAL_NUM cpu_mask_size, PAL_PTR cpu_mask) {
+    ENTER_PAL_CALL(DkThreadSetCpuAffinity);
 
-    int ret = _DkThreadSetCPUAffinity(thread, cpu_len, cpu_mask);
+    int ret = _DkThreadSetCpuAffinity(thread, cpu_mask_size, cpu_mask);
 
     if (ret < 0) {
         _DkRaiseFailure(-ret);
@@ -97,10 +97,10 @@ PAL_BOL DkThreadSetCPUAffinity(PAL_HANDLE thread, PAL_NUM cpu_len, PAL_PTR cpu_m
     LEAVE_PAL_CALL_RETURN(PAL_TRUE);
 }
 
-PAL_BOL DkThreadGetCPUAffinity(PAL_HANDLE thread, PAL_NUM cpu_len, PAL_PTR cpu_mask) {
-    ENTER_PAL_CALL(DkThreadGetCPUAffinity);
+PAL_BOL DkThreadGetCpuAffinity(PAL_HANDLE thread, PAL_NUM cpu_mask_size, PAL_PTR cpu_mask) {
+    ENTER_PAL_CALL(DkThreadGetCpuAffinity);
 
-    int ret = _DkThreadGetCPUAffinity(thread, cpu_len, cpu_mask);
+    int ret = _DkThreadGetCpuAffinity(thread, cpu_mask_size, cpu_mask);
 
     if (ret < 0) {
         _DkRaiseFailure(-ret);

--- a/Pal/src/db_threading.c
+++ b/Pal/src/db_threading.c
@@ -97,7 +97,7 @@ PAL_BOL DkThreadSetCpuAffinity(PAL_HANDLE thread, PAL_NUM cpu_mask_size, PAL_PTR
     LEAVE_PAL_CALL_RETURN(PAL_TRUE);
 }
 
-PAL_BOL DkThreadGetCpuAffinity(PAL_HANDLE thread, PAL_NUM cpu_mask_size, PAL_PTR cpu_mask) {
+PAL_NUM DkThreadGetCpuAffinity(PAL_HANDLE thread, PAL_NUM cpu_mask_size, PAL_PTR cpu_mask) {
     ENTER_PAL_CALL(DkThreadGetCpuAffinity);
 
     int ret = _DkThreadGetCpuAffinity(thread, cpu_mask_size, cpu_mask);
@@ -107,5 +107,5 @@ PAL_BOL DkThreadGetCpuAffinity(PAL_HANDLE thread, PAL_NUM cpu_mask_size, PAL_PTR
         LEAVE_PAL_CALL_RETURN(PAL_FALSE);
     }
 
-    LEAVE_PAL_CALL_RETURN(PAL_TRUE);
+    LEAVE_PAL_CALL_RETURN(ret);
 }

--- a/Pal/src/db_threading.c
+++ b/Pal/src/db_threading.c
@@ -104,7 +104,7 @@ PAL_NUM DkThreadGetCpuAffinity(PAL_HANDLE thread, PAL_NUM cpu_mask_size, PAL_PTR
 
     if (ret < 0) {
         _DkRaiseFailure(-ret);
-        LEAVE_PAL_CALL_RETURN(PAL_FALSE);
+        LEAVE_PAL_CALL_RETURN(ret);
     }
 
     LEAVE_PAL_CALL_RETURN(ret);

--- a/Pal/src/db_threading.c
+++ b/Pal/src/db_threading.c
@@ -84,10 +84,10 @@ PAL_BOL DkThreadResume(PAL_HANDLE threadHandle) {
     LEAVE_PAL_CALL_RETURN(PAL_TRUE);
 }
 
-PAL_BOL DkThreadSetCPUAffinity(PAL_HANDLE thread, PAL_NUM cpu_num, PAL_PTR cpu_mask) {
+PAL_BOL DkThreadSetCPUAffinity(PAL_HANDLE thread, PAL_NUM cpu_len, PAL_PTR cpu_mask) {
     ENTER_PAL_CALL(DkThreadSetCPUAffinity);
 
-    int ret = _DkThreadSetCPUAffinity(thread, cpu_num, cpu_mask);
+    int ret = _DkThreadSetCPUAffinity(thread, cpu_len, cpu_mask);
 
     if (ret < 0) {
         _DkRaiseFailure(-ret);
@@ -97,10 +97,10 @@ PAL_BOL DkThreadSetCPUAffinity(PAL_HANDLE thread, PAL_NUM cpu_num, PAL_PTR cpu_m
     LEAVE_PAL_CALL_RETURN(PAL_TRUE);
 }
 
-PAL_BOL DkThreadGetCPUAffinity(PAL_HANDLE thread, PAL_NUM cpu_num, PAL_PTR cpu_mask) {
+PAL_BOL DkThreadGetCPUAffinity(PAL_HANDLE thread, PAL_NUM cpu_len, PAL_PTR cpu_mask) {
     ENTER_PAL_CALL(DkThreadGetCPUAffinity);
 
-    int ret = _DkThreadGetCPUAffinity(thread, cpu_num, cpu_mask);
+    int ret = _DkThreadGetCPUAffinity(thread, cpu_len, cpu_mask);
 
     if (ret < 0) {
         _DkRaiseFailure(-ret);

--- a/Pal/src/host/Linux-SGX/db_misc.c
+++ b/Pal/src/host/Linux-SGX/db_misc.c
@@ -28,6 +28,8 @@
 #include "sgx_api.h"
 #include "sgx_attest.h"
 
+#define CPUID_0BH_LEAF 0xb
+
 unsigned long _DkSystemTimeQuery(void) {
     unsigned long microsec;
     int ret = ocall_gettime(&microsec);
@@ -253,7 +255,7 @@ int _DkCpuIdRetrieve(unsigned int leaf, unsigned int subleaf, unsigned int value
     int notcache = 0;
 
     /* the cpu topology info subjects to thread affinity */
-    if (leaf == 0xb) {
+    if (leaf == CPUID_0BH_LEAF) {
         notcache = 1;
     }
 

--- a/Pal/src/host/Linux-SGX/db_misc.c
+++ b/Pal/src/host/Linux-SGX/db_misc.c
@@ -253,15 +253,15 @@ static void sanity_check_cpuid(uint32_t leaf, uint32_t subleaf, uint32_t values[
 }
 
 int _DkCpuIdRetrieve(unsigned int leaf, unsigned int subleaf, unsigned int values[4]) {
-    bool skipcache = false;
+    bool skip_cache = false;
 
-    /* the cpu core info cannot be cached due to its data varies to the calling thread */
+    /* the cpu core info cannot be cached due to its data varying depending on the calling thread */
     if (leaf == CPUID_EXT_TOPOLOGY_ENUMERATION_LEAF ||
         leaf == CPUID_V2EXT_TOPOLOGY_ENUMERATION_LEAF) {
-        skipcache = true;
+        skip_cache = true;
     }
 
-    if (!skipcache && !get_cpuid_from_cache(leaf, subleaf, values))
+    if (!skip_cache && !get_cpuid_from_cache(leaf, subleaf, values))
         return 0;
 
     if (IS_ERR(ocall_cpuid(leaf, subleaf, values)))
@@ -269,7 +269,7 @@ int _DkCpuIdRetrieve(unsigned int leaf, unsigned int subleaf, unsigned int value
 
     sanity_check_cpuid(leaf, subleaf, values);
 
-    if (!skipcache)
+    if (!skip_cache)
         add_cpuid_to_cache(leaf, subleaf, values);
 
     return 0;

--- a/Pal/src/host/Linux-SGX/db_misc.c
+++ b/Pal/src/host/Linux-SGX/db_misc.c
@@ -250,7 +250,14 @@ static void sanity_check_cpuid(uint32_t leaf, uint32_t subleaf, uint32_t values[
 }
 
 int _DkCpuIdRetrieve(unsigned int leaf, unsigned int subleaf, unsigned int values[4]) {
-    if (!get_cpuid_from_cache(leaf, subleaf, values))
+    int notcache = 0;
+
+    /* the cpu topology info subjects to thread affinity */
+    if (leaf == 0xb) {
+        notcache = 1;
+    }
+
+    if (!notcache && !get_cpuid_from_cache(leaf, subleaf, values))
         return 0;
 
     if (IS_ERR(ocall_cpuid(leaf, subleaf, values)))
@@ -258,7 +265,9 @@ int _DkCpuIdRetrieve(unsigned int leaf, unsigned int subleaf, unsigned int value
 
     sanity_check_cpuid(leaf, subleaf, values);
 
-    add_cpuid_to_cache(leaf, subleaf, values);
+    if (!notcache)
+        add_cpuid_to_cache(leaf, subleaf, values);
+
     return 0;
 }
 

--- a/Pal/src/host/Linux-SGX/db_threading.c
+++ b/Pal/src/host/Linux-SGX/db_threading.c
@@ -155,18 +155,28 @@ int _DkThreadResume (PAL_HANDLE threadHandle)
 
 int _DkThreadSetCPUAffinity(PAL_HANDLE thread, PAL_NUM cpu_num, PAL_PTR cpu_mask)
 {
-    int ret = ocall_sched_setaffinity(thread->thread.tid, cpu_num, cpu_mask);
+    int tid;
+    if (thread != (PAL_HANDLE)GET_ENCLAVE_TLS(thread)) {
+        SGX_DBG(DBG_M, "[Warning] the host tid not supported in SGX mode, using tid:0 instead.");
+        tid = 0;
+    } else {
+        /* TODO: add actual host_tid to pal_thread handle and use it here */
+        tid = thread->thread.tid;
+    }
+
+    int ret = ocall_sched_setaffinity(tid, cpu_num, cpu_mask);
     return IS_ERR(ret) ? unix_to_pal_error(ERRNO(ret)) : ret;
 }
 
 int _DkThreadGetCPUAffinity(PAL_HANDLE thread, PAL_NUM cpu_num, PAL_PTR cpu_mask)
 {
-    uint64_t tid = 0;
-
-    if (thread != NULL ) {
-        SGX_DBG(DBG_E,
-                "Don't support to get cpu thread affinity other than current thread for now.\n");
-        return -PAL_ERROR_NOTIMPLEMENTED;
+    int tid;
+    if (thread != (PAL_HANDLE)GET_ENCLAVE_TLS(thread)) {
+        SGX_DBG(DBG_M, "[Warning] the host tid not supported in SGX mode, using tid:0 instead.");
+        tid = 0;
+    } else {
+        /* TODO: add actual host_tid to pal_thread handle and use it here */
+        tid = thread->thread.tid;
     }
 
     int ret = ocall_sched_getaffinity(tid, cpu_num, cpu_mask);

--- a/Pal/src/host/Linux-SGX/db_threading.c
+++ b/Pal/src/host/Linux-SGX/db_threading.c
@@ -153,6 +153,34 @@ int _DkThreadResume (PAL_HANDLE threadHandle)
     return IS_ERR(ret) ? unix_to_pal_error(ERRNO(ret)) : ret;
 }
 
+int _DkThreadSetCPUAffinity(PAL_HANDLE thread, PAL_NUM cpu_num, PAL_PTR cpu_mask)
+{
+    uint64_t tid = 0;
+
+    if (thread != NULL ) {
+        SGX_DBG(DBG_E,
+                "Don't support to set cpu thread affinity other than current thread for now.\n");
+        return -PAL_ERROR_NOTIMPLEMENTED;
+    }
+
+    int ret = ocall_sched_setaffinity(tid, cpu_num, cpu_mask);
+    return IS_ERR(ret) ? unix_to_pal_error(ERRNO(ret)) : ret;
+}
+
+int _DkThreadGetCPUAffinity(PAL_HANDLE thread, PAL_NUM cpu_num, PAL_PTR cpu_mask)
+{
+    uint64_t tid = 0;
+
+    if (thread != NULL ) {
+        SGX_DBG(DBG_E,
+                "Don't support to get cpu thread affinity other than current thread for now.\n");
+        return -PAL_ERROR_NOTIMPLEMENTED;
+    }
+
+    int ret = ocall_sched_getaffinity(tid, cpu_num, cpu_mask);
+    return IS_ERR(ret) ? unix_to_pal_error(ERRNO(ret)) : ret;
+}
+
 struct handle_ops thread_ops = {
     /* nothing */
 };

--- a/Pal/src/host/Linux-SGX/db_threading.c
+++ b/Pal/src/host/Linux-SGX/db_threading.c
@@ -157,11 +157,16 @@ int _DkThreadSetCpuAffinity(PAL_HANDLE thread, PAL_NUM cpu_mask_size, PAL_PTR cp
     int tid;
 
     SGX_DBG(DBG_M, "[Warning] Assuming the thread is changing its own affinity");
+    /* TODO: A secure tid should be initialized when starting thread
+     *       and retrievable through GET_ENCLAVE_TLS(thread)
+     */
     if (thread != (PAL_HANDLE)GET_ENCLAVE_TLS(thread)) {
-        /* TODO: get specific thread from enclave TLS */
+        /* TODO: Extract tid from thread argument for another thread */
         tid = 0;
     } else {
-        /* TODO: add actual host_tid to pal_thread handling and use it here */
+        /* TODO: Set affinity for current thread. it could be safer and more reliable
+         *       if using real secure tid instead of 0
+         */
         tid = 0;
     }
 
@@ -173,11 +178,16 @@ int _DkThreadGetCpuAffinity(PAL_HANDLE thread, PAL_NUM cpu_mask_size, PAL_PTR cp
     int tid;
 
     SGX_DBG(DBG_M, "[Warning] Assuming the thread is retrieving its own affinity");
+    /* TODO: A secure tid should be initialized when starting thread
+     *       and retrievable through GET_ENCLAVE_TLS(thread)
+     */
     if (thread != (PAL_HANDLE)GET_ENCLAVE_TLS(thread)) {
-        /* TODO: get specific thread from enclave TLS */
+        /* TODO: Extract tid from thread argument for another thread */
         tid = 0;
     } else {
-        /* TODO: add actual host_tid to pal_thread handling and use it */
+        /* TODO: Get affinity for current thread. it could be safer and more reliable
+         *       if using real secure tid instead of 0
+         */
         tid = 0;
     }
 

--- a/Pal/src/host/Linux-SGX/db_threading.c
+++ b/Pal/src/host/Linux-SGX/db_threading.c
@@ -153,7 +153,7 @@ int _DkThreadResume (PAL_HANDLE threadHandle)
     return IS_ERR(ret) ? unix_to_pal_error(ERRNO(ret)) : ret;
 }
 
-int _DkThreadSetCPUAffinity(PAL_HANDLE thread, PAL_NUM cpu_num, PAL_PTR cpu_mask)
+int _DkThreadSetCPUAffinity(PAL_HANDLE thread, PAL_NUM cpu_len, PAL_PTR cpu_mask)
 {
     int tid;
     if (thread != (PAL_HANDLE)GET_ENCLAVE_TLS(thread)) {
@@ -164,11 +164,11 @@ int _DkThreadSetCPUAffinity(PAL_HANDLE thread, PAL_NUM cpu_num, PAL_PTR cpu_mask
         tid = 0;
     }
 
-    int ret = ocall_sched_setaffinity(tid, cpu_num, cpu_mask);
+    int ret = ocall_sched_setaffinity(tid, cpu_len, cpu_mask);
     return IS_ERR(ret) ? unix_to_pal_error(ERRNO(ret)) : ret;
 }
 
-int _DkThreadGetCPUAffinity(PAL_HANDLE thread, PAL_NUM cpu_num, PAL_PTR cpu_mask)
+int _DkThreadGetCPUAffinity(PAL_HANDLE thread, PAL_NUM cpu_len, PAL_PTR cpu_mask)
 {
     int tid;
     if (thread != (PAL_HANDLE)GET_ENCLAVE_TLS(thread)) {
@@ -179,7 +179,7 @@ int _DkThreadGetCPUAffinity(PAL_HANDLE thread, PAL_NUM cpu_num, PAL_PTR cpu_mask
         tid = 0;
     }
 
-    int ret = ocall_sched_getaffinity(tid, cpu_num, cpu_mask);
+    int ret = ocall_sched_getaffinity(tid, cpu_len, cpu_mask);
     return IS_ERR(ret) ? unix_to_pal_error(ERRNO(ret)) : ret;
 }
 

--- a/Pal/src/host/Linux-SGX/db_threading.c
+++ b/Pal/src/host/Linux-SGX/db_threading.c
@@ -156,7 +156,7 @@ int _DkThreadResume (PAL_HANDLE threadHandle)
 int _DkThreadSetCpuAffinity(PAL_HANDLE thread, PAL_NUM cpu_mask_size, PAL_PTR cpu_mask) {
     int tid;
 
-    SGX_DBG(DBG_M, "[Warning] Assuming the thread is changing its own affinity here");
+    SGX_DBG(DBG_M, "[Warning] Assuming the thread is changing its own affinity");
     if (thread != (PAL_HANDLE)GET_ENCLAVE_TLS(thread)) {
         /* TODO: get specific thread from enclave TLS */
         tid = 0;
@@ -172,12 +172,12 @@ int _DkThreadSetCpuAffinity(PAL_HANDLE thread, PAL_NUM cpu_mask_size, PAL_PTR cp
 int _DkThreadGetCpuAffinity(PAL_HANDLE thread, PAL_NUM cpu_mask_size, PAL_PTR cpu_mask) {
     int tid;
 
-    SGX_DBG(DBG_M, "[Warning] Assuming the thread is retrieving its own affinity here");
+    SGX_DBG(DBG_M, "[Warning] Assuming the thread is retrieving its own affinity");
     if (thread != (PAL_HANDLE)GET_ENCLAVE_TLS(thread)) {
         /* TODO: get specific thread from enclave TLS */
         tid = 0;
     } else {
-        /* TODO: add actual host_tid to pal_thread handling and use it here */
+        /* TODO: add actual host_tid to pal_thread handling and use it */
         tid = 0;
     }
 

--- a/Pal/src/host/Linux-SGX/db_threading.c
+++ b/Pal/src/host/Linux-SGX/db_threading.c
@@ -155,15 +155,7 @@ int _DkThreadResume (PAL_HANDLE threadHandle)
 
 int _DkThreadSetCPUAffinity(PAL_HANDLE thread, PAL_NUM cpu_num, PAL_PTR cpu_mask)
 {
-    uint64_t tid = 0;
-
-    if (thread != NULL ) {
-        SGX_DBG(DBG_E,
-                "Don't support to set cpu thread affinity other than current thread for now.\n");
-        return -PAL_ERROR_NOTIMPLEMENTED;
-    }
-
-    int ret = ocall_sched_setaffinity(tid, cpu_num, cpu_mask);
+    int ret = ocall_sched_setaffinity(thread->thread.tid, cpu_num, cpu_mask);
     return IS_ERR(ret) ? unix_to_pal_error(ERRNO(ret)) : ret;
 }
 

--- a/Pal/src/host/Linux-SGX/db_threading.c
+++ b/Pal/src/host/Linux-SGX/db_threading.c
@@ -161,7 +161,7 @@ int _DkThreadSetCPUAffinity(PAL_HANDLE thread, PAL_NUM cpu_num, PAL_PTR cpu_mask
         tid = 0;
     } else {
         /* TODO: add actual host_tid to pal_thread handle and use it here */
-        tid = thread->thread.tid;
+        tid = 0;
     }
 
     int ret = ocall_sched_setaffinity(tid, cpu_num, cpu_mask);
@@ -176,7 +176,7 @@ int _DkThreadGetCPUAffinity(PAL_HANDLE thread, PAL_NUM cpu_num, PAL_PTR cpu_mask
         tid = 0;
     } else {
         /* TODO: add actual host_tid to pal_thread handle and use it here */
-        tid = thread->thread.tid;
+        tid = 0;
     }
 
     int ret = ocall_sched_getaffinity(tid, cpu_num, cpu_mask);

--- a/Pal/src/host/Linux-SGX/db_threading.c
+++ b/Pal/src/host/Linux-SGX/db_threading.c
@@ -153,33 +153,35 @@ int _DkThreadResume (PAL_HANDLE threadHandle)
     return IS_ERR(ret) ? unix_to_pal_error(ERRNO(ret)) : ret;
 }
 
-int _DkThreadSetCPUAffinity(PAL_HANDLE thread, PAL_NUM cpu_len, PAL_PTR cpu_mask)
-{
+int _DkThreadSetCpuAffinity(PAL_HANDLE thread, PAL_NUM cpu_mask_size, PAL_PTR cpu_mask) {
     int tid;
+
+    SGX_DBG(DBG_M, "[Warning] Assuming the thread is changing its own affinity here");
     if (thread != (PAL_HANDLE)GET_ENCLAVE_TLS(thread)) {
-        SGX_DBG(DBG_M, "[Warning] the host tid not supported in SGX mode, using tid:0 instead.");
+        /* TODO: get specific thread from enclave TLS */
         tid = 0;
     } else {
-        /* TODO: add actual host_tid to pal_thread handle and use it here */
+        /* TODO: add actual host_tid to pal_thread handling and use it here */
         tid = 0;
     }
 
-    int ret = ocall_sched_setaffinity(tid, cpu_len, cpu_mask);
+    int ret = ocall_sched_setaffinity(tid, cpu_mask_size, cpu_mask);
     return IS_ERR(ret) ? unix_to_pal_error(ERRNO(ret)) : ret;
 }
 
-int _DkThreadGetCPUAffinity(PAL_HANDLE thread, PAL_NUM cpu_len, PAL_PTR cpu_mask)
-{
+int _DkThreadGetCpuAffinity(PAL_HANDLE thread, PAL_NUM cpu_mask_size, PAL_PTR cpu_mask) {
     int tid;
+
+    SGX_DBG(DBG_M, "[Warning] Assuming the thread is retrieving its own affinity here");
     if (thread != (PAL_HANDLE)GET_ENCLAVE_TLS(thread)) {
-        SGX_DBG(DBG_M, "[Warning] the host tid not supported in SGX mode, using tid:0 instead.");
+        /* TODO: get specific thread from enclave TLS */
         tid = 0;
     } else {
-        /* TODO: add actual host_tid to pal_thread handle and use it here */
+        /* TODO: add actual host_tid to pal_thread handling and use it here */
         tid = 0;
     }
 
-    int ret = ocall_sched_getaffinity(tid, cpu_len, cpu_mask);
+    int ret = ocall_sched_getaffinity(tid, cpu_mask_size, cpu_mask);
     return IS_ERR(ret) ? unix_to_pal_error(ERRNO(ret)) : ret;
 }
 

--- a/Pal/src/host/Linux-SGX/enclave_ocalls.c
+++ b/Pal/src/host/Linux-SGX/enclave_ocalls.c
@@ -271,7 +271,7 @@ int ocall_cpuid (unsigned int leaf, unsigned int subleaf,
     bool bypass_rpc = false;
 
     /* the cpu topology info must be retrieved in the context of current thread
-     * rather than rpc thread in case of exitless feature enabled here.
+     * rather than rpc thread in case exitless feature is enabled.
      */
     if (leaf == CPUID_EXT_TOPOLOGY_ENUMERATION_LEAF ||
         leaf == CPUID_V2EXT_TOPOLOGY_ENUMERATION_LEAF) {
@@ -789,7 +789,7 @@ int ocall_resume_thread (void * tcs)
     return sgx_exitless_ocall(OCALL_RESUME_THREAD, tcs);
 }
 
-int ocall_sched_setaffinity (int tid, size_t cpu_mask_size, void* cpu_mask) {
+int ocall_sched_setaffinity(int tid, size_t cpu_mask_size, void* cpu_mask) {
     int retval = 0;
     ms_ocall_sched_setaffinity_t* ms;
 
@@ -813,10 +813,10 @@ int ocall_sched_setaffinity (int tid, size_t cpu_mask_size, void* cpu_mask) {
                         sgx_exitless_ocall(OCALL_SCHED_SETAFFINITY, ms);
 
     sgx_reset_ustack(old_ustack);
-    return retval;
+    return retval == 0 ? 0 : -PAL_ERROR_DENIED;
 }
 
-int ocall_sched_getaffinity (int tid, size_t cpu_mask_size, void* cpu_mask) {
+int ocall_sched_getaffinity(int tid, size_t cpu_mask_size, void* cpu_mask) {
     int retval = 0;
     ms_ocall_sched_getaffinity_t* ms;
 
@@ -845,7 +845,7 @@ int ocall_sched_getaffinity (int tid, size_t cpu_mask_size, void* cpu_mask) {
     }
 
     sgx_reset_ustack(old_ustack);
-    return retval;
+    return retval == (int)cpu_mask_size ? 0 : -PAL_ERROR_DENIED;
 }
 
 int ocall_clone_thread (void)

--- a/Pal/src/host/Linux-SGX/enclave_ocalls.c
+++ b/Pal/src/host/Linux-SGX/enclave_ocalls.c
@@ -270,7 +270,9 @@ int ocall_cpuid (unsigned int leaf, unsigned int subleaf,
     int retval = 0;
     bool bypass_rpc = false;
 
-    /* the cpu topology info retrieved in current thread rather than rpc thread */
+    /* the cpu topology info must be retrieved in the context of current thread
+     * rather than rpc thread in case of exitless feature enabled here.
+     */
     if (leaf == CPUID_EXT_TOPOLOGY_ENUMERATION_LEAF ||
         leaf == CPUID_V2EXT_TOPOLOGY_ENUMERATION_LEAF) {
         bypass_rpc = true;

--- a/Pal/src/host/Linux-SGX/enclave_ocalls.c
+++ b/Pal/src/host/Linux-SGX/enclave_ocalls.c
@@ -845,7 +845,7 @@ int ocall_sched_getaffinity(int tid, size_t cpu_mask_size, void* cpu_mask) {
     }
 
     sgx_reset_ustack(old_ustack);
-    return retval > 0 && retval <= (int)cpu_mask_size ? 0 : -EPERM;
+    return retval > 0 && retval <= (int)cpu_mask_size ? retval : -EPERM;
 }
 
 int ocall_clone_thread (void)

--- a/Pal/src/host/Linux-SGX/enclave_ocalls.c
+++ b/Pal/src/host/Linux-SGX/enclave_ocalls.c
@@ -806,7 +806,8 @@ int ocall_sched_setaffinity (uint64_t tid, uint64_t cpu_num, void * cpu_mask)
     }
     WRITE_ONCE(ms->ms_cpu_mask, untrusted_cpu_mask);
 
-    retval = sgx_exitless_ocall(OCALL_SCHED_SETAFFINITY, ms);
+    retval = tid == 0 ? sgx_ocall(OCALL_SCHED_GETAFFINITY, ms) :
+                        sgx_exitless_ocall(OCALL_SCHED_SETAFFINITY, ms);
 
     sgx_reset_ustack(old_ustack);
 
@@ -834,7 +835,8 @@ int ocall_sched_getaffinity (uint64_t tid, uint64_t cpu_num, void * cpu_mask)
     }
     WRITE_ONCE(ms->ms_cpu_mask, untrusted_cpu_mask);
 
-    retval = sgx_exitless_ocall(OCALL_SCHED_GETAFFINITY, ms);
+    retval = tid == 0 ? sgx_ocall(OCALL_SCHED_GETAFFINITY, ms) :
+                        sgx_exitless_ocall(OCALL_SCHED_GETAFFINITY, ms);
 
     if (retval > 0) {
         retval = sgx_copy_to_enclave(cpu_mask, cpu_num,

--- a/Pal/src/host/Linux-SGX/enclave_ocalls.c
+++ b/Pal/src/host/Linux-SGX/enclave_ocalls.c
@@ -813,7 +813,7 @@ int ocall_sched_setaffinity(int tid, size_t cpu_mask_size, void* cpu_mask) {
                         sgx_exitless_ocall(OCALL_SCHED_SETAFFINITY, ms);
 
     sgx_reset_ustack(old_ustack);
-    return retval == 0 ? 0 : -1;
+    return retval == 0 ? 0 : -EPERM;
 }
 
 int ocall_sched_getaffinity(int tid, size_t cpu_mask_size, void* cpu_mask) {
@@ -845,7 +845,7 @@ int ocall_sched_getaffinity(int tid, size_t cpu_mask_size, void* cpu_mask) {
     }
 
     sgx_reset_ustack(old_ustack);
-    return retval > 0 && retval <= (int)cpu_mask_size ? 0 : -1;
+    return retval > 0 && retval <= (int)cpu_mask_size ? 0 : -EPERM;
 }
 
 int ocall_clone_thread (void)

--- a/Pal/src/host/Linux-SGX/enclave_ocalls.c
+++ b/Pal/src/host/Linux-SGX/enclave_ocalls.c
@@ -27,6 +27,8 @@
  * size of 8MB. Thus, 512KB limit also works well for the main thread. */
 #define MAX_UNTRUSTED_STACK_BUF (THREAD_STACK_SIZE / 4)
 
+#define CPUID_0BH_LEAF 0xb
+
 /* global pointer to a single untrusted queue, all accesses must be protected by g_rpc_queue->lock */
 rpc_queue_t* g_rpc_queue;
 
@@ -267,8 +269,8 @@ int ocall_cpuid (unsigned int leaf, unsigned int subleaf,
     int retval = 0;
     int notrpc = 0;
 
-    /* the cpu topology info retrieved for  current thread rather than rpc thread */
-    if (leaf == 0xb) {
+    /* the cpu topology info retrieved in current thread rather than rpc thread */
+    if (leaf == CPUID_0BH_LEAF) {
         notrpc = 1;
     }
 
@@ -786,7 +788,7 @@ int ocall_resume_thread (void * tcs)
 int ocall_sched_setaffinity (uint64_t tid, uint64_t cpu_num, void * cpu_mask)
 {
     int retval = 0;
-    ms_ocall_sched_setaffinity_t * ms;
+    ms_ocall_sched_setaffinity_t* ms;
 
     void* old_ustack = sgx_prepare_ustack();
     ms = sgx_alloc_on_ustack_aligned(sizeof(*ms), alignof(*ms));
@@ -814,7 +816,7 @@ int ocall_sched_setaffinity (uint64_t tid, uint64_t cpu_num, void * cpu_mask)
 int ocall_sched_getaffinity (uint64_t tid, uint64_t cpu_num, void * cpu_mask)
 {
     int retval = 0;
-    ms_ocall_sched_getaffinity_t * ms;
+    ms_ocall_sched_getaffinity_t* ms;
 
     void* old_ustack = sgx_prepare_ustack();
     ms = sgx_alloc_on_ustack_aligned(sizeof(*ms), alignof(*ms));

--- a/Pal/src/host/Linux-SGX/enclave_ocalls.c
+++ b/Pal/src/host/Linux-SGX/enclave_ocalls.c
@@ -785,7 +785,7 @@ int ocall_resume_thread (void * tcs)
     return sgx_exitless_ocall(OCALL_RESUME_THREAD, tcs);
 }
 
-int ocall_sched_setaffinity (uint64_t tid, uint64_t cpu_len, void * cpu_mask)
+int ocall_sched_setaffinity (uint64_t tid, size_t cpu_len, void * cpu_mask)
 {
     int retval = 0;
     ms_ocall_sched_setaffinity_t* ms;
@@ -814,7 +814,7 @@ int ocall_sched_setaffinity (uint64_t tid, uint64_t cpu_len, void * cpu_mask)
     return retval;
 }
 
-int ocall_sched_getaffinity (uint64_t tid, uint64_t cpu_len, void * cpu_mask)
+int ocall_sched_getaffinity (uint64_t tid, size_t cpu_len, void * cpu_mask)
 {
     int retval = 0;
     ms_ocall_sched_getaffinity_t* ms;

--- a/Pal/src/host/Linux-SGX/enclave_ocalls.c
+++ b/Pal/src/host/Linux-SGX/enclave_ocalls.c
@@ -806,7 +806,7 @@ int ocall_sched_setaffinity (uint64_t tid, uint64_t cpu_num, void * cpu_mask)
     }
     WRITE_ONCE(ms->ms_cpu_mask, untrusted_cpu_mask);
 
-    retval = tid == 0 ? sgx_ocall(OCALL_SCHED_GETAFFINITY, ms) :
+    retval = tid == 0 ? sgx_ocall(OCALL_SCHED_SETAFFINITY, ms) :
                         sgx_exitless_ocall(OCALL_SCHED_SETAFFINITY, ms);
 
     sgx_reset_ustack(old_ustack);

--- a/Pal/src/host/Linux-SGX/enclave_ocalls.c
+++ b/Pal/src/host/Linux-SGX/enclave_ocalls.c
@@ -813,7 +813,7 @@ int ocall_sched_setaffinity(int tid, size_t cpu_mask_size, void* cpu_mask) {
                         sgx_exitless_ocall(OCALL_SCHED_SETAFFINITY, ms);
 
     sgx_reset_ustack(old_ustack);
-    return retval == 0 ? 0 : -PAL_ERROR_DENIED;
+    return retval == 0 ? 0 : -1;
 }
 
 int ocall_sched_getaffinity(int tid, size_t cpu_mask_size, void* cpu_mask) {
@@ -845,7 +845,7 @@ int ocall_sched_getaffinity(int tid, size_t cpu_mask_size, void* cpu_mask) {
     }
 
     sgx_reset_ustack(old_ustack);
-    return retval == (int)cpu_mask_size ? 0 : -PAL_ERROR_DENIED;
+    return retval > 0 && retval <= (int)cpu_mask_size ? 0 : -1;
 }
 
 int ocall_clone_thread (void)

--- a/Pal/src/host/Linux-SGX/enclave_ocalls.c
+++ b/Pal/src/host/Linux-SGX/enclave_ocalls.c
@@ -785,7 +785,7 @@ int ocall_resume_thread (void * tcs)
     return sgx_exitless_ocall(OCALL_RESUME_THREAD, tcs);
 }
 
-int ocall_sched_setaffinity (uint64_t tid, uint64_t cpu_num, void * cpu_mask)
+int ocall_sched_setaffinity (uint64_t tid, uint64_t cpu_len, void * cpu_mask)
 {
     int retval = 0;
     ms_ocall_sched_setaffinity_t* ms;
@@ -798,8 +798,8 @@ int ocall_sched_setaffinity (uint64_t tid, uint64_t cpu_num, void * cpu_mask)
     }
 
     WRITE_ONCE(ms->ms_tid, tid);
-    WRITE_ONCE(ms->ms_cpu_num, cpu_num);
-    void* untrusted_cpu_mask = sgx_copy_to_ustack(cpu_mask, cpu_num);
+    WRITE_ONCE(ms->ms_cpu_len, cpu_len);
+    void* untrusted_cpu_mask = sgx_copy_to_ustack(cpu_mask, cpu_len);
     if (!untrusted_cpu_mask) {
         sgx_reset_ustack(old_ustack);
         return -EPERM;
@@ -814,7 +814,7 @@ int ocall_sched_setaffinity (uint64_t tid, uint64_t cpu_num, void * cpu_mask)
     return retval;
 }
 
-int ocall_sched_getaffinity (uint64_t tid, uint64_t cpu_num, void * cpu_mask)
+int ocall_sched_getaffinity (uint64_t tid, uint64_t cpu_len, void * cpu_mask)
 {
     int retval = 0;
     ms_ocall_sched_getaffinity_t* ms;
@@ -827,8 +827,8 @@ int ocall_sched_getaffinity (uint64_t tid, uint64_t cpu_num, void * cpu_mask)
     }
 
     WRITE_ONCE(ms->ms_tid, tid);
-    WRITE_ONCE(ms->ms_cpu_num, cpu_num);
-    void* untrusted_cpu_mask = sgx_copy_to_ustack(cpu_mask, cpu_num);
+    WRITE_ONCE(ms->ms_cpu_len, cpu_len);
+    void* untrusted_cpu_mask = sgx_copy_to_ustack(cpu_mask, cpu_len);
     if (!untrusted_cpu_mask) {
         sgx_reset_ustack(old_ustack);
         return -EPERM;
@@ -839,7 +839,7 @@ int ocall_sched_getaffinity (uint64_t tid, uint64_t cpu_num, void * cpu_mask)
                         sgx_exitless_ocall(OCALL_SCHED_GETAFFINITY, ms);
 
     if (retval > 0) {
-        retval = sgx_copy_to_enclave(cpu_mask, cpu_num,
+        retval = sgx_copy_to_enclave(cpu_mask, cpu_len,
                                      READ_ONCE(ms->ms_cpu_mask), retval);
     }
 

--- a/Pal/src/host/Linux-SGX/enclave_ocalls.h
+++ b/Pal/src/host/Linux-SGX/enclave_ocalls.h
@@ -69,9 +69,9 @@ int ocall_shutdown (int sockfd, int how);
 
 int ocall_resume_thread (void * tcs);
 
-int ocall_sched_setaffinity(uint64_t tid, uint64_t cpu_num, void * cpu_mask);
+int ocall_sched_setaffinity(uint64_t tid, uint64_t cpu_num, void* cpu_mask);
 
-int ocall_sched_getaffinity(uint64_t tid, uint64_t cpu_num, void * cpu_mask);
+int ocall_sched_getaffinity(uint64_t tid, uint64_t cpu_num, void* cpu_mask);
 
 int ocall_clone_thread (void);
 

--- a/Pal/src/host/Linux-SGX/enclave_ocalls.h
+++ b/Pal/src/host/Linux-SGX/enclave_ocalls.h
@@ -69,9 +69,9 @@ int ocall_shutdown (int sockfd, int how);
 
 int ocall_resume_thread (void * tcs);
 
-int ocall_sched_setaffinity(uint64_t tid, uint64_t cpu_num, void* cpu_mask);
+int ocall_sched_setaffinity(uint64_t tid, uint64_t cpu_len, void* cpu_mask);
 
-int ocall_sched_getaffinity(uint64_t tid, uint64_t cpu_num, void* cpu_mask);
+int ocall_sched_getaffinity(uint64_t tid, uint64_t cpu_len, void* cpu_mask);
 
 int ocall_clone_thread (void);
 

--- a/Pal/src/host/Linux-SGX/enclave_ocalls.h
+++ b/Pal/src/host/Linux-SGX/enclave_ocalls.h
@@ -69,9 +69,9 @@ int ocall_shutdown (int sockfd, int how);
 
 int ocall_resume_thread (void * tcs);
 
-int ocall_sched_setaffinity(int tid, uint64_t cpu_mask_size, void* cpu_mask);
+int ocall_sched_setaffinity(int tid, size_t cpu_mask_size, void* cpu_mask);
 
-int ocall_sched_getaffinity(int tid, uint64_t cpu_mask_size, void* cpu_mask);
+int ocall_sched_getaffinity(int tid, size_t cpu_mask_size, void* cpu_mask);
 
 int ocall_clone_thread (void);
 

--- a/Pal/src/host/Linux-SGX/enclave_ocalls.h
+++ b/Pal/src/host/Linux-SGX/enclave_ocalls.h
@@ -69,9 +69,9 @@ int ocall_shutdown (int sockfd, int how);
 
 int ocall_resume_thread (void * tcs);
 
-int ocall_sched_setaffinity(uint64_t tid, uint64_t cpu_len, void* cpu_mask);
+int ocall_sched_setaffinity(int tid, uint64_t cpu_mask_size, void* cpu_mask);
 
-int ocall_sched_getaffinity(uint64_t tid, uint64_t cpu_len, void* cpu_mask);
+int ocall_sched_getaffinity(int tid, uint64_t cpu_mask_size, void* cpu_mask);
 
 int ocall_clone_thread (void);
 

--- a/Pal/src/host/Linux-SGX/enclave_ocalls.h
+++ b/Pal/src/host/Linux-SGX/enclave_ocalls.h
@@ -69,6 +69,10 @@ int ocall_shutdown (int sockfd, int how);
 
 int ocall_resume_thread (void * tcs);
 
+int ocall_sched_setaffinity(uint64_t tid, uint64_t cpu_num, void * cpu_mask);
+
+int ocall_sched_getaffinity(uint64_t tid, uint64_t cpu_num, void * cpu_mask);
+
 int ocall_clone_thread (void);
 
 int ocall_create_process(const char* uri, int nargs, const char** args, int* stream_fd, unsigned int* pid);

--- a/Pal/src/host/Linux-SGX/ocall_types.h
+++ b/Pal/src/host/Linux-SGX/ocall_types.h
@@ -173,13 +173,13 @@ typedef struct {
 
 typedef struct {
     int ms_tid;
-    uint64_t ms_cpu_len;
+    size_t ms_cpu_len;
     void* ms_cpu_mask;
 } ms_ocall_sched_setaffinity_t;
 
 typedef struct {
     int ms_tid;
-    uint64_t ms_cpu_len;
+    size_t ms_cpu_len;
     void* ms_cpu_mask;
 } ms_ocall_sched_getaffinity_t;
 

--- a/Pal/src/host/Linux-SGX/ocall_types.h
+++ b/Pal/src/host/Linux-SGX/ocall_types.h
@@ -172,15 +172,15 @@ typedef struct {
 } ms_ocall_create_process_t;
 
 typedef struct {
-    uint64_t ms_tid;
+    int ms_tid;
     uint64_t ms_cpu_num;
-    void * ms_cpu_mask;
+    void* ms_cpu_mask;
 } ms_ocall_sched_setaffinity_t;
 
 typedef struct {
-    uint64_t ms_tid;
+    int ms_tid;
     uint64_t ms_cpu_num;
-    void * ms_cpu_mask;
+    void* ms_cpu_mask;
 } ms_ocall_sched_getaffinity_t;
 
 typedef struct {

--- a/Pal/src/host/Linux-SGX/ocall_types.h
+++ b/Pal/src/host/Linux-SGX/ocall_types.h
@@ -173,13 +173,13 @@ typedef struct {
 
 typedef struct {
     int ms_tid;
-    uint64_t ms_cpu_num;
+    uint64_t ms_cpu_len;
     void* ms_cpu_mask;
 } ms_ocall_sched_setaffinity_t;
 
 typedef struct {
     int ms_tid;
-    uint64_t ms_cpu_num;
+    uint64_t ms_cpu_len;
     void* ms_cpu_mask;
 } ms_ocall_sched_getaffinity_t;
 

--- a/Pal/src/host/Linux-SGX/ocall_types.h
+++ b/Pal/src/host/Linux-SGX/ocall_types.h
@@ -173,13 +173,13 @@ typedef struct {
 
 typedef struct {
     int ms_tid;
-    size_t ms_cpu_len;
+    size_t ms_cpu_mask_size;
     void* ms_cpu_mask;
 } ms_ocall_sched_setaffinity_t;
 
 typedef struct {
     int ms_tid;
-    size_t ms_cpu_len;
+    size_t ms_cpu_mask_size;
     void* ms_cpu_mask;
 } ms_ocall_sched_getaffinity_t;
 

--- a/Pal/src/host/Linux-SGX/ocall_types.h
+++ b/Pal/src/host/Linux-SGX/ocall_types.h
@@ -40,6 +40,8 @@ enum {
     OCALL_MKDIR,
     OCALL_GETDENTS,
     OCALL_RESUME_THREAD,
+    OCALL_SCHED_SETAFFINITY,
+    OCALL_SCHED_GETAFFINITY,
     OCALL_CLONE_THREAD,
     OCALL_CREATE_PROCESS,
     OCALL_FUTEX,
@@ -168,6 +170,18 @@ typedef struct {
     int ms_nargs;
     const char * ms_args[];
 } ms_ocall_create_process_t;
+
+typedef struct {
+    uint64_t ms_tid;
+    uint64_t ms_cpu_num;
+    void * ms_cpu_mask;
+} ms_ocall_sched_setaffinity_t;
+
+typedef struct {
+    uint64_t ms_tid;
+    uint64_t ms_cpu_num;
+    void * ms_cpu_mask;
+} ms_ocall_sched_getaffinity_t;
 
 typedef struct {
     uint32_t* ms_futex;

--- a/Pal/src/host/Linux-SGX/sgx_enclave.c
+++ b/Pal/src/host/Linux-SGX/sgx_enclave.c
@@ -270,7 +270,7 @@ static long sgx_ocall_sched_setaffinity(void* pms)
     ms_ocall_sched_setaffinity_t* ms = (ms_ocall_sched_setaffinity_t*) pms;
     ODEBUG(OCALL_SCHED_SETAFFINITY, ms);
     long ret = INLINE_SYSCALL(sched_setaffinity, 3,
-                              ms->ms_tid, ms->ms_cpu_num, ms->ms_cpu_mask);
+                              ms->ms_tid, ms->ms_cpu_len, ms->ms_cpu_mask);
     return ret;
 }
 
@@ -279,7 +279,7 @@ static long sgx_ocall_sched_getaffinity(void* pms)
     ms_ocall_sched_getaffinity_t* ms = (ms_ocall_sched_getaffinity_t*) pms;
     ODEBUG(OCALL_SCHED_GETAFFINITY, ms);
     long ret = INLINE_SYSCALL(sched_getaffinity, 3,
-                              ms->ms_tid, ms->ms_cpu_num, ms->ms_cpu_mask);
+                              ms->ms_tid, ms->ms_cpu_len, ms->ms_cpu_mask);
     return ret;
 }
 

--- a/Pal/src/host/Linux-SGX/sgx_enclave.c
+++ b/Pal/src/host/Linux-SGX/sgx_enclave.c
@@ -265,6 +265,24 @@ static long sgx_ocall_resume_thread(void * pms)
     return interrupt_thread(pms);
 }
 
+static long sgx_ocall_sched_setaffinity(void * pms)
+{
+    ms_ocall_sched_setaffinity_t * ms = (ms_ocall_sched_setaffinity_t *) pms;
+    ODEBUG(OCALL_SCHED_SETAFFINITY, ms);
+    long ret = INLINE_SYSCALL(sched_setaffinity, 3,
+                              ms->ms_tid, ms->ms_cpu_num, ms->ms_cpu_mask);
+    return ret;
+}
+
+static long sgx_ocall_sched_getaffinity(void * pms)
+{
+    ms_ocall_sched_getaffinity_t * ms = (ms_ocall_sched_getaffinity_t *) pms;
+    ODEBUG(OCALL_SCHED_GETAFFINITY, ms);
+    long ret = INLINE_SYSCALL(sched_getaffinity, 3,
+                              ms->ms_tid, ms->ms_cpu_num, ms->ms_cpu_mask);
+    return ret;
+}
+
 static long sgx_ocall_clone_thread(void * pms)
 {
     __UNUSED(pms);
@@ -684,6 +702,8 @@ sgx_ocall_fn_t ocall_table[OCALL_NR] = {
         [OCALL_MKDIR]            = sgx_ocall_mkdir,
         [OCALL_GETDENTS]         = sgx_ocall_getdents,
         [OCALL_RESUME_THREAD]    = sgx_ocall_resume_thread,
+        [OCALL_SCHED_SETAFFINITY] = sgx_ocall_sched_setaffinity,
+        [OCALL_SCHED_GETAFFINITY] = sgx_ocall_sched_getaffinity,
         [OCALL_CLONE_THREAD]     = sgx_ocall_clone_thread,
         [OCALL_CREATE_PROCESS]   = sgx_ocall_create_process,
         [OCALL_FUTEX]            = sgx_ocall_futex,

--- a/Pal/src/host/Linux-SGX/sgx_enclave.c
+++ b/Pal/src/host/Linux-SGX/sgx_enclave.c
@@ -265,18 +265,18 @@ static long sgx_ocall_resume_thread(void * pms)
     return interrupt_thread(pms);
 }
 
-static long sgx_ocall_sched_setaffinity(void * pms)
+static long sgx_ocall_sched_setaffinity(void* pms)
 {
-    ms_ocall_sched_setaffinity_t * ms = (ms_ocall_sched_setaffinity_t *) pms;
+    ms_ocall_sched_setaffinity_t* ms = (ms_ocall_sched_setaffinity_t*) pms;
     ODEBUG(OCALL_SCHED_SETAFFINITY, ms);
     long ret = INLINE_SYSCALL(sched_setaffinity, 3,
                               ms->ms_tid, ms->ms_cpu_num, ms->ms_cpu_mask);
     return ret;
 }
 
-static long sgx_ocall_sched_getaffinity(void * pms)
+static long sgx_ocall_sched_getaffinity(void* pms)
 {
-    ms_ocall_sched_getaffinity_t * ms = (ms_ocall_sched_getaffinity_t *) pms;
+    ms_ocall_sched_getaffinity_t* ms = (ms_ocall_sched_getaffinity_t*) pms;
     ODEBUG(OCALL_SCHED_GETAFFINITY, ms);
     long ret = INLINE_SYSCALL(sched_getaffinity, 3,
                               ms->ms_tid, ms->ms_cpu_num, ms->ms_cpu_mask);

--- a/Pal/src/host/Linux-SGX/sgx_enclave.c
+++ b/Pal/src/host/Linux-SGX/sgx_enclave.c
@@ -265,21 +265,19 @@ static long sgx_ocall_resume_thread(void * pms)
     return interrupt_thread(pms);
 }
 
-static long sgx_ocall_sched_setaffinity(void* pms)
-{
-    ms_ocall_sched_setaffinity_t* ms = (ms_ocall_sched_setaffinity_t*) pms;
+static long sgx_ocall_sched_setaffinity(void* pms) {
+    ms_ocall_sched_setaffinity_t* ms = (ms_ocall_sched_setaffinity_t*)pms;
     ODEBUG(OCALL_SCHED_SETAFFINITY, ms);
     long ret = INLINE_SYSCALL(sched_setaffinity, 3,
-                              ms->ms_tid, ms->ms_cpu_len, ms->ms_cpu_mask);
+                              ms->ms_tid, ms->ms_cpu_mask_size, ms->ms_cpu_mask);
     return ret;
 }
 
-static long sgx_ocall_sched_getaffinity(void* pms)
-{
-    ms_ocall_sched_getaffinity_t* ms = (ms_ocall_sched_getaffinity_t*) pms;
+static long sgx_ocall_sched_getaffinity(void* pms) {
+    ms_ocall_sched_getaffinity_t* ms = (ms_ocall_sched_getaffinity_t*)pms;
     ODEBUG(OCALL_SCHED_GETAFFINITY, ms);
     long ret = INLINE_SYSCALL(sched_getaffinity, 3,
-                              ms->ms_tid, ms->ms_cpu_len, ms->ms_cpu_mask);
+                              ms->ms_tid, ms->ms_cpu_mask_size, ms->ms_cpu_mask);
     return ret;
 }
 

--- a/Pal/src/host/Linux/db_threading.c
+++ b/Pal/src/host/Linux/db_threading.c
@@ -301,7 +301,7 @@ int _DkThreadGetCpuAffinity(PAL_HANDLE thread, PAL_NUM cpu_mask_size, PAL_PTR cp
     if (IS_ERR(ret))
         return -PAL_ERROR_DENIED;
 
-    return 0;
+    return ret;
 }
 
 struct handle_ops thread_ops = {

--- a/Pal/src/host/Linux/db_threading.c
+++ b/Pal/src/host/Linux/db_threading.c
@@ -295,13 +295,8 @@ int _DkThreadSetCPUAffinity(PAL_HANDLE thread, PAL_NUM cpu_num, PAL_PTR cpu_mask
 
 int _DkThreadGetCPUAffinity(PAL_HANDLE thread, PAL_NUM cpu_num, PAL_PTR cpu_mask)
 {
-    PAL_NUM tid = 0;
-    if (thread != NULL ) {
-        return -PAL_ERROR_NOTIMPLEMENTED;
-    }
-
     int ret = INLINE_SYSCALL(sched_getaffinity, 3,
-                             tid,
+                             thread->thread.tid,
                              cpu_num,
                              cpu_mask);
 

--- a/Pal/src/host/Linux/db_threading.c
+++ b/Pal/src/host/Linux/db_threading.c
@@ -280,14 +280,10 @@ int _DkThreadResume (PAL_HANDLE threadHandle)
     return 0;
 }
 
-int _DkThreadSetCPUAffinity(PAL_HANDLE thread, PAL_NUM cpu_num, PAL_PTR cpu_mask) {
-    PAL_NUM tid = 0;
-    if (thread != NULL ) {
-        return -PAL_ERROR_NOTIMPLEMENTED;
-    }
-
+int _DkThreadSetCPUAffinity(PAL_HANDLE thread, PAL_NUM cpu_num, PAL_PTR cpu_mask)
+{
     int ret = INLINE_SYSCALL(sched_setaffinity, 3,
-                             tid,
+                             thread->thread.tid,
                              cpu_num,
                              cpu_mask);
 
@@ -297,7 +293,8 @@ int _DkThreadSetCPUAffinity(PAL_HANDLE thread, PAL_NUM cpu_num, PAL_PTR cpu_mask
     return 0;
 }
 
-int _DkThreadGetCPUAffinity(PAL_HANDLE thread, PAL_NUM cpu_num, PAL_PTR cpu_mask) {
+int _DkThreadGetCPUAffinity(PAL_HANDLE thread, PAL_NUM cpu_num, PAL_PTR cpu_mask)
+{
     PAL_NUM tid = 0;
     if (thread != NULL ) {
         return -PAL_ERROR_NOTIMPLEMENTED;

--- a/Pal/src/host/Linux/db_threading.c
+++ b/Pal/src/host/Linux/db_threading.c
@@ -280,6 +280,40 @@ int _DkThreadResume (PAL_HANDLE threadHandle)
     return 0;
 }
 
+int _DkThreadSetCPUAffinity(PAL_HANDLE thread, PAL_NUM cpu_num, PAL_PTR cpu_mask) {
+    PAL_NUM tid = 0;
+    if (thread != NULL ) {
+        return -PAL_ERROR_NOTIMPLEMENTED;
+    }
+
+    int ret = INLINE_SYSCALL(sched_setaffinity, 3,
+                             tid,
+                             cpu_num,
+                             cpu_mask);
+
+    if (IS_ERR(ret))
+        return -PAL_ERROR_DENIED;
+
+    return 0;
+}
+
+int _DkThreadGetCPUAffinity(PAL_HANDLE thread, PAL_NUM cpu_num, PAL_PTR cpu_mask) {
+    PAL_NUM tid = 0;
+    if (thread != NULL ) {
+        return -PAL_ERROR_NOTIMPLEMENTED;
+    }
+
+    int ret = INLINE_SYSCALL(sched_getaffinity, 3,
+                             tid,
+                             cpu_num,
+                             cpu_mask);
+
+    if (IS_ERR(ret))
+        return -PAL_ERROR_DENIED;
+
+    return 0;
+}
+
 struct handle_ops thread_ops = {
     /* nothing */
 };

--- a/Pal/src/host/Linux/db_threading.c
+++ b/Pal/src/host/Linux/db_threading.c
@@ -280,11 +280,11 @@ int _DkThreadResume (PAL_HANDLE threadHandle)
     return 0;
 }
 
-int _DkThreadSetCPUAffinity(PAL_HANDLE thread, PAL_NUM cpu_num, PAL_PTR cpu_mask)
+int _DkThreadSetCPUAffinity(PAL_HANDLE thread, PAL_NUM cpu_len, PAL_PTR cpu_mask)
 {
     int ret = INLINE_SYSCALL(sched_setaffinity, 3,
                              thread->thread.tid,
-                             cpu_num,
+                             cpu_len,
                              cpu_mask);
 
     if (IS_ERR(ret))
@@ -293,11 +293,11 @@ int _DkThreadSetCPUAffinity(PAL_HANDLE thread, PAL_NUM cpu_num, PAL_PTR cpu_mask
     return 0;
 }
 
-int _DkThreadGetCPUAffinity(PAL_HANDLE thread, PAL_NUM cpu_num, PAL_PTR cpu_mask)
+int _DkThreadGetCPUAffinity(PAL_HANDLE thread, PAL_NUM cpu_len, PAL_PTR cpu_mask)
 {
     int ret = INLINE_SYSCALL(sched_getaffinity, 3,
                              thread->thread.tid,
-                             cpu_num,
+                             cpu_len,
                              cpu_mask);
 
     if (IS_ERR(ret))

--- a/Pal/src/host/Linux/db_threading.c
+++ b/Pal/src/host/Linux/db_threading.c
@@ -280,11 +280,10 @@ int _DkThreadResume (PAL_HANDLE threadHandle)
     return 0;
 }
 
-int _DkThreadSetCPUAffinity(PAL_HANDLE thread, PAL_NUM cpu_len, PAL_PTR cpu_mask)
-{
+int _DkThreadSetCpuAffinity(PAL_HANDLE thread, PAL_NUM cpu_mask_size, PAL_PTR cpu_mask) {
     int ret = INLINE_SYSCALL(sched_setaffinity, 3,
                              thread->thread.tid,
-                             cpu_len,
+                             cpu_mask_size,
                              cpu_mask);
 
     if (IS_ERR(ret))
@@ -293,11 +292,10 @@ int _DkThreadSetCPUAffinity(PAL_HANDLE thread, PAL_NUM cpu_len, PAL_PTR cpu_mask
     return 0;
 }
 
-int _DkThreadGetCPUAffinity(PAL_HANDLE thread, PAL_NUM cpu_len, PAL_PTR cpu_mask)
-{
+int _DkThreadGetCpuAffinity(PAL_HANDLE thread, PAL_NUM cpu_mask_size, PAL_PTR cpu_mask) {
     int ret = INLINE_SYSCALL(sched_getaffinity, 3,
                              thread->thread.tid,
-                             cpu_len,
+                             cpu_mask_size,
                              cpu_mask);
 
     if (IS_ERR(ret))

--- a/Pal/src/host/Skeleton/db_threading.c
+++ b/Pal/src/host/Skeleton/db_threading.c
@@ -43,6 +43,16 @@ int _DkThreadResume(PAL_HANDLE threadHandle) {
     return -PAL_ERROR_NOTIMPLEMENTED;
 }
 
+int _DkThreadSetCPUAffinity(PAL_HANDLE thread, PAL_NUM cpu_num, PAL_PTR cpu_mask)
+{
+    return -PAL_ERROR_NOTIMPLEMENTED;
+}
+
+int _DkThreadGetCPUAffinity(PAL_HANDLE thread, PAL_NUM cpu_num, PAL_PTR cpu_mask)
+{
+    return -PAL_ERROR_NOTIMPLEMENTED;
+}
+
 struct handle_ops thread_ops = {
     /* nothing */
 };

--- a/Pal/src/host/Skeleton/db_threading.c
+++ b/Pal/src/host/Skeleton/db_threading.c
@@ -43,13 +43,11 @@ int _DkThreadResume(PAL_HANDLE threadHandle) {
     return -PAL_ERROR_NOTIMPLEMENTED;
 }
 
-int _DkThreadSetCPUAffinity(PAL_HANDLE thread, PAL_NUM cpu_len, PAL_PTR cpu_mask)
-{
+int _DkThreadSetCpuAffinity(PAL_HANDLE thread, PAL_NUM cpu_mask_size, PAL_PTR cpu_mask) {
     return -PAL_ERROR_NOTIMPLEMENTED;
 }
 
-int _DkThreadGetCPUAffinity(PAL_HANDLE thread, PAL_NUM cpu_len, PAL_PTR cpu_mask)
-{
+int _DkThreadGetCpuAffinity(PAL_HANDLE thread, PAL_NUM cpu_mask_size, PAL_PTR cpu_mask) {
     return -PAL_ERROR_NOTIMPLEMENTED;
 }
 

--- a/Pal/src/host/Skeleton/db_threading.c
+++ b/Pal/src/host/Skeleton/db_threading.c
@@ -43,12 +43,12 @@ int _DkThreadResume(PAL_HANDLE threadHandle) {
     return -PAL_ERROR_NOTIMPLEMENTED;
 }
 
-int _DkThreadSetCPUAffinity(PAL_HANDLE thread, PAL_NUM cpu_num, PAL_PTR cpu_mask)
+int _DkThreadSetCPUAffinity(PAL_HANDLE thread, PAL_NUM cpu_len, PAL_PTR cpu_mask)
 {
     return -PAL_ERROR_NOTIMPLEMENTED;
 }
 
-int _DkThreadGetCPUAffinity(PAL_HANDLE thread, PAL_NUM cpu_num, PAL_PTR cpu_mask)
+int _DkThreadGetCPUAffinity(PAL_HANDLE thread, PAL_NUM cpu_len, PAL_PTR cpu_mask)
 {
     return -PAL_ERROR_NOTIMPLEMENTED;
 }

--- a/Pal/src/pal-symbols
+++ b/Pal/src/pal-symbols
@@ -6,6 +6,8 @@ DkThreadDelayExecution
 DkThreadYieldExecution
 DkThreadExit
 DkThreadResume
+DkThreadSetCPUAffinity
+DkThreadGetCPUAffinity
 DkMutexCreate
 DkNotificationEventCreate
 DkSynchronizationEventCreate

--- a/Pal/src/pal-symbols
+++ b/Pal/src/pal-symbols
@@ -6,8 +6,8 @@ DkThreadDelayExecution
 DkThreadYieldExecution
 DkThreadExit
 DkThreadResume
-DkThreadSetCPUAffinity
-DkThreadGetCPUAffinity
+DkThreadSetCpuAffinity
+DkThreadGetCpuAffinity
 DkMutexCreate
 DkNotificationEventCreate
 DkSynchronizationEventCreate

--- a/Pal/src/pal_internal.h
+++ b/Pal/src/pal_internal.h
@@ -239,6 +239,8 @@ noreturn void _DkThreadExit(int* clear_child_tid);
 int _DkThreadDelayExecution (unsigned long * duration);
 void _DkThreadYieldExecution (void);
 int _DkThreadResume (PAL_HANDLE threadHandle);
+int _DkThreadSetCPUAffinity(PAL_HANDLE thread, PAL_NUM cpu_num, PAL_PTR cpu_mask);
+int _DkThreadGetCPUAffinity(PAL_HANDLE thread, PAL_NUM cpu_num, PAL_PTR cpu_mask);
 int _DkProcessCreate (PAL_HANDLE * handle, const char * uri,
                       const char ** args);
 noreturn void _DkProcessExit (int exitCode);

--- a/Pal/src/pal_internal.h
+++ b/Pal/src/pal_internal.h
@@ -239,8 +239,8 @@ noreturn void _DkThreadExit(int* clear_child_tid);
 int _DkThreadDelayExecution (unsigned long * duration);
 void _DkThreadYieldExecution (void);
 int _DkThreadResume (PAL_HANDLE threadHandle);
-int _DkThreadSetCPUAffinity(PAL_HANDLE thread, PAL_NUM cpu_num, PAL_PTR cpu_mask);
-int _DkThreadGetCPUAffinity(PAL_HANDLE thread, PAL_NUM cpu_num, PAL_PTR cpu_mask);
+int _DkThreadSetCPUAffinity(PAL_HANDLE thread, PAL_NUM cpu_len, PAL_PTR cpu_mask);
+int _DkThreadGetCPUAffinity(PAL_HANDLE thread, PAL_NUM cpu_len, PAL_PTR cpu_mask);
 int _DkProcessCreate (PAL_HANDLE * handle, const char * uri,
                       const char ** args);
 noreturn void _DkProcessExit (int exitCode);

--- a/Pal/src/pal_internal.h
+++ b/Pal/src/pal_internal.h
@@ -239,8 +239,8 @@ noreturn void _DkThreadExit(int* clear_child_tid);
 int _DkThreadDelayExecution (unsigned long * duration);
 void _DkThreadYieldExecution (void);
 int _DkThreadResume (PAL_HANDLE threadHandle);
-int _DkThreadSetCPUAffinity(PAL_HANDLE thread, PAL_NUM cpu_len, PAL_PTR cpu_mask);
-int _DkThreadGetCPUAffinity(PAL_HANDLE thread, PAL_NUM cpu_len, PAL_PTR cpu_mask);
+int _DkThreadSetCpuAffinity(PAL_HANDLE thread, PAL_NUM cpu_mask_size, PAL_PTR cpu_mask);
+int _DkThreadGetCpuAffinity(PAL_HANDLE thread, PAL_NUM cpu_mask_size, PAL_PTR cpu_mask);
 int _DkProcessCreate (PAL_HANDLE * handle, const char * uri,
                       const char ** args);
 noreturn void _DkProcessExit (int exitCode);


### PR DESCRIPTION
## Affected components

- [ ] README and global configuration
- [x] Linux PAL
- [x] SGX PAL
- [ ] FreeBSD PAL
- [ ] Common PAL code
- [ ] Library OS (i.e., SHIM), including GLIBC

Related to:
https://github.com/oscarlab/graphene/issues/1563

## Description of the changes
 This patch adds the feature of setting/getting cpu affinity for current thread.
 Applications in Graphene+SGX now is able to retrieve correct cpu topoloy via
 CPUID w/ leaf 0BH instruction.
 Note that the GSGX limits the number of SGX threads,
 the CPUID can only retrieve the Apic ID that the calling thread is running on.

Fixes #788.
Fixes #1563.

## How to test this PR?
Please refer to 
LibOS/shim/test/regression/sched_set_get_cpuaffinity.c

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1580)
<!-- Reviewable:end -->
