### PR TITLE
[LibOS,Pal] Introduce "loader.insecure__disable_aslr" manifest option

### DIFF
--- a/Documentation/manifest-syntax.rst
+++ b/Documentation/manifest-syntax.rst
@@ -86,6 +86,18 @@ is ``none``, no debug output will be printed to standard output. If the debug
 type is ``inline``, a dmesg-like debug output will be printed inlined with
 standard output.
 
+Disabling ASLR
+^^^^^^^^^^^^^^
+
+::
+
+    loader.insecure__disable_aslr=[1|0]
+    (Default: 0)
+
+This specifies whether to disable Address Space Layout Randomization (ASLR).
+Since disabling ASLR worsens security of the application, ASLR is enabled by
+default.
+
 
 System-related (Required by LibOS)
 ----------------------------------

--- a/LibOS/shim/include/shim_defs.h
+++ b/LibOS/shim/include/shim_defs.h
@@ -16,8 +16,6 @@
 
 #define CP_INIT_VMA_SIZE            (64 * 1024 * 1024)  /* 64MB */
 
-#define ENABLE_ASLR                 1
-
 /* debug message printout */
 #define DEBUGBUF_SIZE               256
 #define DEBUGBUF_BREAK              0

--- a/LibOS/shim/src/sys/shim_brk.c
+++ b/LibOS/shim/src/sys/shim_brk.c
@@ -72,18 +72,21 @@ int init_brk_region(void* brk_start, size_t data_segment_size) {
     if (brk_start && brk_start <= PAL_CB(user_address.end)
             && brk_max_size <= (uintptr_t)PAL_CB(user_address.end)
             && (uintptr_t)brk_start < (uintptr_t)PAL_CB(user_address.end) - brk_max_size) {
+        int ret;
         size_t offset = 0;
-#if ENABLE_ASLR == 1
-        int ret = DkRandomBitsRead(&offset, sizeof(offset));
-        if (ret < 0) {
-            return -convert_pal_errno(-ret);
+
+        if (!PAL_CB(disable_aslr)) {
+            ret = DkRandomBitsRead(&offset, sizeof(offset));
+            if (ret < 0) {
+                return -convert_pal_errno(-ret);
+            }
+            /* Linux randomizes brk at offset from 0 to 0x2000000 from main executable data section
+             * https://elixir.bootlin.com/linux/v5.6.3/source/arch/x86/kernel/process.c#L914 */
+            offset %= MIN((size_t)0x2000000, (size_t)((char*)PAL_CB(user_address.end) -
+                                             brk_max_size - (char*)brk_start));
+            offset = ALLOC_ALIGN_DOWN(offset);
         }
-        /* Linux randomizes brk at offset from 0 to 0x2000000 from main executable data section
-         * https://elixir.bootlin.com/linux/v5.6.3/source/arch/x86/kernel/process.c#L914 */
-        offset %= MIN((size_t)0x2000000,
-                      (size_t)((char*)PAL_CB(user_address.end) - brk_max_size - (char*)brk_start));
-        offset = ALLOC_ALIGN_DOWN(offset);
-#endif
+
         brk_start = (char*)brk_start + offset;
 
         ret = bkeep_mmap_fixed(brk_start, brk_max_size, PROT_NONE,
@@ -103,12 +106,8 @@ int init_brk_region(void* brk_start, size_t data_segment_size) {
 
     if (!brk_start) {
         int ret;
-#if ENABLE_ASLR == 1
-        ret = bkeep_mmap_any_aslr
-#else
-        ret = bkeep_mmap_any
-#endif
-                            (brk_max_size, PROT_NONE, VMA_UNMAPPED, NULL, 0, "heap", &brk_start);
+        ret = bkeep_mmap_any_aslr(brk_max_size, PROT_NONE, VMA_UNMAPPED, NULL, 0, "heap",
+                                  &brk_start);
         if (ret < 0) {
             return ret;
         }

--- a/LibOS/shim/test/regression/large_mmap.manifest.template
+++ b/LibOS/shim/test/regression/large_mmap.manifest.template
@@ -3,18 +3,13 @@ loader.env.LD_LIBRARY_PATH = /lib
 loader.debug_type = none
 loader.syscall_symbol = syscalldb
 
+# application allocates 2GB and 4GB memory regions which may occasionally fail
+# in an SGX enclave restricted to 8GB of virtual space if ASLR is enabled
+loader.insecure__disable_aslr = 1
+
 fs.mount.lib.type = chroot
 fs.mount.lib.path = /lib
 fs.mount.lib.uri = file:../../../../Runtime
-
-fs.mount.bin.type = chroot
-fs.mount.bin.path = /bin
-fs.mount.bin.uri = file:/bin
-
-# allow to bind on port 8000
-net.rules.1 = 127.0.0.1:8000:0.0.0.0:0-65535
-# allow to connect to port 8000
-net.rules.2 = 0.0.0.0:0-65535:127.0.0.1:8000
 
 sgx.trusted_files.ld = file:../../../../Runtime/ld-linux-x86-64.so.2
 sgx.trusted_files.libc = file:../../../../Runtime/libc.so.6

--- a/Pal/include/pal/pal.h
+++ b/Pal/include/pal/pal.h
@@ -160,6 +160,7 @@ typedef struct PAL_CONTROL_ {
     /*
      * Memory layout
      */
+    PAL_BOL disable_aslr; /*!< disable ASLR (may be necessary for restricted environments) */
     PAL_PTR_RANGE user_address; /*!< The range of user addresses */
 
     PAL_PTR_RANGE executable_range; /*!< address where executable is loaded */

--- a/Pal/src/db_main.c
+++ b/Pal/src/db_main.c
@@ -362,6 +362,14 @@ noreturn void pal_main(
     pal_state.exec            = exec_uri;
     pal_state.exec_handle     = exec_handle;
 
+    bool disable_aslr = false;
+    if (pal_state.root_config) {
+        char aslr_cfg[2];
+        ssize_t len = get_config(pal_state.root_config, "loader.insecure__disable_aslr", aslr_cfg,
+                                 sizeof(aslr_cfg));
+        disable_aslr = len == 1 && aslr_cfg[0] == '1';
+    }
+
     if (pal_state.root_config && *arguments
         && (strendswith(*arguments, ".manifest") || strendswith(*arguments, ".manifest.sgx"))) {
         /* Run as a manifest file,
@@ -397,6 +405,7 @@ noreturn void pal_main(
     __pal_control.executable         = exec_uri;
     __pal_control.parent_process     = parent_process;
     __pal_control.first_thread       = first_thread;
+    __pal_control.disable_aslr       = disable_aslr;
 
     _DkGetAvailableUserAddressRange(&__pal_control.user_address.start,
                                     &__pal_control.user_address.end,


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Previously, Graphene always performed ASLR at the LibOS layer. ASLR may lead to a situation when one mmap allocates an object in the middle of address space, and there is no space for a later mmap of a large object. This is problematic in restricted environments such as SGX enclaves. In particular, `large_mmap` LibOS test failed occasionally because it only has 8GB of enclave size and it may mmap first objects somewhere in the middle (around 4GB address) and then fail to find any space for a large 4GB mmap.

This commit adds "loader.insecure__disable_aslr" manifest option. If it set to one, ASLR is disabled and mappings become deterministic which guarantees programs like `large_mmap` never fail due to ENOMEM.

## How to test this PR? <!-- (if applicable) -->

`large_mmap` should always pass now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1581)
<!-- Reviewable:end -->
