### PR TITLE
[LibOS] Do not try to send signal 0 in kill()/tkill()

### DIFF
--- a/LibOS/shim/test/regression/sigaction_per_process.c
+++ b/LibOS/shim/test/regression/sigaction_per_process.c
@@ -80,6 +80,12 @@ int main() {
 
     printf("parent tid: %d\n", tid);
 
+    /* the below dummy tkill (no signal is sent) is for sanity */
+    if (tkill(tid, /*sig=*/0)) {
+        fprintf(stderr, "tkill(sig=0) failed: %m\n");
+        return 1;
+    }
+
     if (tkill(tid, SIGTERM)) {
         fprintf(stderr, "tkill failed: %m\n");
         return 1;

--- a/LibOS/shim/test/regression/signal_multithread.c
+++ b/LibOS/shim/test/regression/signal_multithread.c
@@ -51,6 +51,12 @@ int main() {
 
     wait_for(1);
 
+    /* the below dummy kill (no signal is sent) is for sanity */
+    if (kill(getpid(), /*sig=*/0)) {
+        fprintf(stderr, "kill(sig=0) failed: %m\n");
+        return 1;
+    }
+
     if (kill(getpid(), SIGTERM)) {
         fprintf(stderr, "kill failed: %m\n");
         return 1;


### PR DESCRIPTION

## Description of the changes <!-- (reasons and measures) -->

Previously, Graphene didn't handle special case of kill()/tkill() with signal equal to zero. This signal is used to check for existence of processes and threads. However, Graphene tried to send/append it
which led to segfaults. This PR correctly handles signal equal to zero and improves LibOS tests to verify this fix.

## How to test this PR? <!-- (if applicable) -->

This PR adds some more cases in LibOS tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1584)
<!-- Reviewable:end -->
