### PR TITLE
[Pal] Loudly fail if no manifest file found for executable

### DIFF
--- a/Pal/src/db_main.c
+++ b/Pal/src/db_main.c
@@ -251,8 +251,7 @@ noreturn void pal_main(
             ret = _DkStreamOpen(&manifest_handle, manifest_uri, PAL_ACCESS_RDONLY,
                                 0, 0, 0);
             if (ret) {
-                /* well, there is no manifest file, leave it alone */
-                printf("Can't find any manifest, will run without one.\n");
+                INIT_FAIL(PAL_ERROR_DENIED, "cannot find manifest file");
             }
         }
     }
@@ -321,7 +320,7 @@ noreturn void pal_main(
         if (success) {
             exec_uri = malloc(exec_strlen + 1);
             if (!exec_uri)
-                INIT_FAIL(-PAL_ERROR_NOMEM, "Cannot allocate URI buf");
+                INIT_FAIL(PAL_ERROR_NOMEM, "Cannot allocate URI buf");
             memcpy (exec_uri, manifest_uri, exec_strlen);
             exec_uri[exec_strlen] = '\0';
             ret = _DkStreamOpen(&exec_handle, exec_uri, PAL_ACCESS_RDONLY,
@@ -451,7 +450,7 @@ noreturn void pal_main(
         }
 
         if (ret < 0)
-            INIT_FAIL(ret, pal_strerror(ret));
+            INIT_FAIL(-ret, pal_strerror(ret));
     }
 
     set_debug_type();


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Previously, if running like `pal_loader /bin/true` without a corresponding manifest file, Graphene would try to continue execution without a manifest. This led to segfaults. This commit loudly fails in such cases.

## How to test this PR? <!-- (if applicable) -->

With this PR:
```
$ ./pal_loader /bin/true
PAL failed at db_main.c:pal_main:254 (exitcode = 6, reason=cannot find manifest file)
```

Without this PR the same would segfault.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1587)
<!-- Reviewable:end -->
