### PR TITLE
Manifest-related cleanups

### DIFF
--- a/Documentation/manifest-syntax.rst
+++ b/Documentation/manifest-syntax.rst
@@ -52,13 +52,13 @@ Executable Name
 
 ::
 
-   loader.execname=[STRING]
+   loader.argv0_override=[STRING]
 
 This syntax specifies an arbitrary string (typically the executable name) that
-will be passed as the first argument (``argv[0]``) to the executable only if it
-is run via the manifest (e.g. ``./app.manifest arg1 arg2 ...``). If the string
-is not specified in the manifest, the PAL will use the path to the manifest
-itself (standard UNIX convention).
+will be passed as the first argument (``argv[0]``) to the executable.
+
+If the string is not specified in the manifest, the application will get
+``argv[0]`` from :program:`pal_loader` invocation.
 
 Command-Line Arguments
 ^^^^^^^^^^^^^^^^^^^^^^

--- a/Examples/apache/httpd.manifest.template
+++ b/Examples/apache/httpd.manifest.template
@@ -8,7 +8,7 @@
 
 # The executable to load in Graphene.
 loader.exec = file:$(INSTALL_DIR)/bin/httpd
-loader.execname = httpd
+loader.argv0_override = httpd
 
 # Read application arguments directly from the command line. Don't use this on production!
 loader.insecure__use_cmdline_argv = 1

--- a/Examples/bash/Makefile
+++ b/Examples/bash/Makefile
@@ -67,7 +67,7 @@ trusted-children:
 bash.manifest: manifest.template trusted-children bash.trusted-libs
 	sed -e 's|$$(GRAPHENEDIR)|'"$(GRAPHENEDIR)"'|g' \
 		-e 's|$$(GRAPHENEDEBUG)|'"$(GRAPHENEDEBUG)"'|g' \
-		-e 's|$$(EXECNAME)|bash|g' \
+		-e 's|$$(ARGV0_OVERRIDE)|bash|g' \
 		-e 's|$$(EXECPATH)|'"$(shell which bash)"'|g' \
 		-e 's|$$(EXECDIR)|'"$(shell dirname $(shell which bash))"'|g' \
 		-e 's|$$(TRUSTED_LIBS)|'"`cat bash.trusted-libs`"'|g' \
@@ -78,7 +78,7 @@ bash.manifest: manifest.template trusted-children bash.trusted-libs
 $(addsuffix .manifest,$(PROGRAMS)): %.manifest: manifest.template %.trusted-libs
 	sed -e 's|$$(GRAPHENEDIR)|'"$(GRAPHENEDIR)"'|g' \
 		-e 's|$$(GRAPHENEDEBUG)|'"$(GRAPHENEDEBUG)"'|g' \
-		-e 's|$$(EXECNAME)|'"$(basename $@)"'|g' \
+		-e 's|$$(ARGV0_OVERRIDE)|'"$(basename $@)"'|g' \
 		-e 's|$$(EXECPATH)|'"$(shell which $(basename $@))"'|g' \
 		-e 's|$$(EXECDIR)|'"$(shell dirname $(shell which $(basename $@)))"'|g' \
 		-e 's|$$(TRUSTED_LIBS)|'"`cat $(basename $@).trusted-libs`"'|g' \

--- a/Examples/bash/manifest.template
+++ b/Examples/bash/manifest.template
@@ -3,10 +3,10 @@
 #
 # This manifest was prepared and tested on Ubuntu 16.04.
 
-# The executable to load in Graphene. We replace EXECPATH and EXECNAME for
+# The executable to load in Graphene. We replace EXECPATH and ARGV0_OVERRIDE for
 # each program that a manifest is generated for.
 loader.exec = file:$(EXECPATH)
-loader.execname = $(EXECNAME)
+loader.argv0_override = $(ARGV0_OVERRIDE)
 
 # Read application arguments directly from the command line. Don't use this on production!
 loader.insecure__use_cmdline_argv = 1

--- a/Examples/blender/blender.manifest.template
+++ b/Examples/blender/blender.manifest.template
@@ -12,7 +12,7 @@ sgx.allowed_files.blender_output = file:$(DATA_DIR)/images/
 
 
 loader.exec = file:$(BLENDER_DIR)/blender
-loader.execname = blender
+loader.argv0_override = blender
 
 # Read application arguments directly from the command line. Don't use this on production!
 loader.insecure__use_cmdline_argv = 1

--- a/Examples/busybox/busybox.manifest.template
+++ b/Examples/busybox/busybox.manifest.template
@@ -9,7 +9,7 @@ loader.exec = file:busybox
 
 # Name of the executable e.g. as visible through argv[0] when ran as manifest
 # file (`./pal_loader busybox.manifest`).
-loader.execname = busybox
+loader.argv0_override = busybox
 
 # Read application arguments directly from the command line. Don't use this on production!
 loader.insecure__use_cmdline_argv = 1

--- a/Examples/curl/curl.manifest.template
+++ b/Examples/curl/curl.manifest.template
@@ -4,7 +4,7 @@
 
 # Executable to load into Graphene and run.
 loader.exec = file:$(CURL_DIR)curl
-loader.execname = curl
+loader.argv0_override = curl
 
 # LibOS layer library of Graphene. There is currently only one implementation,
 # so it is always set to libsysdb.so. 

--- a/Examples/gcc/as.manifest.template
+++ b/Examples/gcc/as.manifest.template
@@ -1,6 +1,6 @@
 loader.preload = file:$(GRAPHENEDIR)/Runtime/libsysdb.so
 loader.exec = file:/usr/bin/as
-loader.execname = /usr/bin/as
+loader.argv0_override = /usr/bin/as
 loader.env.LD_LIBRARY_PATH = /lib:$(ARCH_LIBDIR):/usr/lib:/usr/$(ARCH_LIBDIR)
 loader.env.PATH = /bin:/usr/bin
 loader.debug_type = $(GRAPHENEDEBUG)

--- a/Examples/gcc/cc1.manifest.template
+++ b/Examples/gcc/cc1.manifest.template
@@ -1,6 +1,6 @@
 loader.preload = file:$(GRAPHENEDIR)/Runtime/libsysdb.so
 loader.exec = file:$(GCC_LIB_PATH)/$(GCC_MAJOR_VERSION)/cc1
-loader.execname = cc1
+loader.argv0_override = cc1
 loader.env.LD_LIBRARY_PATH = /lib:$(ARCH_LIBDIR):/usr/lib:/usr/$(ARCH_LIBDIR)
 loader.env.PATH = /bin:/usr/bin
 loader.debug_type = $(GRAPHENEDEBUG)

--- a/Examples/gcc/collect2.manifest.template
+++ b/Examples/gcc/collect2.manifest.template
@@ -1,6 +1,6 @@
 loader.preload = file:$(GRAPHENEDIR)/Runtime/libsysdb.so
 loader.exec = file:$(GCC_LIB_PATH)/$(GCC_MAJOR_VERSION)/collect2
-loader.execname = collect2
+loader.argv0_override = collect2
 loader.env.LD_LIBRARY_PATH = /lib:$(ARCH_LIBDIR):/usr/lib:/usr/$(ARCH_LIBDIR)
 loader.env.PATH = /bin:/usr/bin
 loader.debug_type = $(GRAPHENEDEBUG)

--- a/Examples/gcc/gcc.manifest.template
+++ b/Examples/gcc/gcc.manifest.template
@@ -1,6 +1,6 @@
 loader.preload = file:$(GRAPHENEDIR)/Runtime/libsysdb.so
 loader.exec = file:/usr/bin/gcc
-loader.execname = /usr/bin/gcc
+loader.argv0_override = /usr/bin/gcc
 loader.env.LD_LIBRARY_PATH = /lib:$(ARCH_LIBDIR):/usr/lib:/usr/$(ARCH_LIBDIR)
 loader.env.PATH = /bin:/usr/bin
 loader.debug_type = $(GRAPHENEDEBUG)

--- a/Examples/gcc/ld.manifest.template
+++ b/Examples/gcc/ld.manifest.template
@@ -1,6 +1,6 @@
 loader.preload = file:$(GRAPHENEDIR)/Runtime/libsysdb.so
 loader.exec = file:/usr/bin/ld
-loader.execname = /usr/bin/ld
+loader.argv0_override = /usr/bin/ld
 loader.env.LD_LIBRARY_PATH = /lib:$(ARCH_LIBDIR):/usr/lib:/usr/$(ARCH_LIBDIR)
 loader.env.PATH = /bin:/usr/bin
 loader.debug_type = $(GRAPHENEDEBUG)

--- a/Examples/lighttpd/lighttpd.manifest.template
+++ b/Examples/lighttpd/lighttpd.manifest.template
@@ -8,7 +8,7 @@
 
 # The executable to load in Graphene.
 loader.exec = file:$(INSTALL_DIR)/sbin/lighttpd
-loader.execname = lighttpd
+loader.argv0_override = lighttpd
 
 # Graphene environment, including the path of the library OS and the debug
 # option (inline/none).

--- a/Examples/nginx/nginx.manifest.template
+++ b/Examples/nginx/nginx.manifest.template
@@ -8,7 +8,7 @@
 
 # The executable to load in Graphene.
 loader.exec = file:$(INSTALL_DIR)/sbin/nginx
-loader.execname = nginx
+loader.argv0_override = nginx
 
 # Graphene environment, including the path to the library OS and the debug
 # option (inline/none).

--- a/Examples/nodejs-express-server/nodejs.manifest.template
+++ b/Examples/nodejs-express-server/nodejs.manifest.template
@@ -4,7 +4,7 @@
 
 # Executable to load into Graphene and run.
 loader.exec = file:$(NODEJS_DIR)nodejs
-loader.execname = nodejs
+loader.argv0_override = nodejs
 
 # LibOS layer library of Graphene. There is currently only one implementation,
 # so it is always set to libsysdb.so.

--- a/Examples/nodejs/nodejs.manifest.template
+++ b/Examples/nodejs/nodejs.manifest.template
@@ -4,7 +4,7 @@
 
 # Executable to load into Graphene and run.
 loader.exec = file:$(NODEJS_DIR)nodejs
-loader.execname = nodejs
+loader.argv0_override = nodejs
 
 # LibOS layer library of Graphene. There is currently only one implementation,
 # so it is always set to libsysdb.so.

--- a/Examples/openvino/openvino.manifest.template
+++ b/Examples/openvino/openvino.manifest.template
@@ -8,7 +8,7 @@
 
 # The executable to load in Graphene.
 loader.exec = file:$(OPENVINO_DIR)/inference-engine/bin/intel64/$(OPENVINO_BUILD)/object_detection_sample_ssd
-loader.execname = object_detection_sample_ssd
+loader.argv0_override = object_detection_sample_ssd
 
 # Graphene environment, including the path to the library OS and the debug
 # option (inline/none).

--- a/Examples/pytorch/pytorch.manifest.template
+++ b/Examples/pytorch/pytorch.manifest.template
@@ -7,8 +7,8 @@
 # ./pal_loader pytorch.manifest pytorchexample.py
 
 # The executable to load in Graphene
-loader.exec     = file:/usr/bin/python3
-loader.execname = python3
+loader.exec = file:/usr/bin/python3
+loader.argv0_override = python3
 
 # Graphene environment, including the path to the library OS and the debug
 # option (inline/none)

--- a/Examples/ra-tls-mbedtls/server.manifest.template
+++ b/Examples/ra-tls-mbedtls/server.manifest.template
@@ -3,7 +3,7 @@
 # This manifest was prepared and tested on Ubuntu 18.04.
 
 loader.exec = file:server
-loader.execname = server
+loader.argv0_override = server
 loader.preload = file:$(GRAPHENEDIR)/Runtime/libsysdb.so
 loader.debug_type = $(GRAPHENEDEBUG)
 

--- a/Examples/tensorflow/Makefile
+++ b/Examples/tensorflow/Makefile
@@ -10,10 +10,10 @@ BAZEL_BIN ?= $(HOME)/bin/bazel
 GIT_COMMIT ?= v1.9.0
 TAR_SHA256 ?= ffc3151b06823d57b4a408261ba8efe53601563dfe93af0866751d4f6ca5068c
 
-.PHONY: default
-default: label_image.manifest
+.PHONY: all
+all: label_image.manifest
 ifeq ($(SGX),1)
-default: label_image.manifest.sgx
+all: label_image.manifest.sgx
 endif
 
 include ../../Scripts/Makefile.configs

--- a/Examples/tensorflow/label_image.manifest.template
+++ b/Examples/tensorflow/label_image.manifest.template
@@ -1,5 +1,3 @@
-#!$(PAL)
-
 loader.preload = file:$(GRAPHENEDIR)/Runtime/libsysdb.so
 loader.exec = file:label_image
 loader.env.LD_LIBRARY_PATH = /lib:.

--- a/LibOS/shim/test/ltp/Makefile.Test
+++ b/LibOS/shim/test/ltp/Makefile.Test
@@ -48,7 +48,6 @@ endif
 
 ifeq ($(ABSPATH_IN_MANIFEST),yes)
 manifest_rules = \
-	-e 's:\$$(PAL):$(abspath $(RUNTIME))/$(PAL_LOADER):g' \
 	-e 's:\$$(PWD):$(PWD):g' \
 	-e 's:\$$(BIN):$(subst .manifest,,$(notdir $@)):g' \
 	-e 's:\$$(SHIMPATH):$(abspath $(RUNTIME))/libsysdb.so:g' \
@@ -57,7 +56,6 @@ manifest_rules = \
 	$(extra_rules)
 else
 manifest_rules= \
-	-e 's:\$$(PAL):$(abspath $(RUNTIME))/$(PAL_LOADER):g' \
 	-e 's:\$$(PWD):$(PWD):g' \
 	-e 's:\$$(BIN):$(subst .manifest,,$(notdir $@)):g' \
 	-e 's:\$$(SHIMPATH):'$$RELDIR'$(RUNTIME)/libsysdb.so:g' \
@@ -75,7 +73,6 @@ relative-to = $(shell python -c "import os.path; print os.path.relpath(\"$(abspa
 	@echo [ $@ ]
 	RELDIR=$(filter-out ./,$(call relative-to,$(dir $@),$(shell pwd))/) && \
 	sed $(manifest_rules) $< > $@
-	(grep -q '^#!' $@ && chmod +x $@) || true
 
 manifest: manifest.template
 	@echo [ $@ ]

--- a/LibOS/shim/test/regression/argv_from_file.manifest.template
+++ b/LibOS/shim/test/regression/argv_from_file.manifest.template
@@ -1,5 +1,5 @@
 loader.exec = file:bootstrap
-loader.execname = bootstrap
+loader.argv0_override = bootstrap
 
 loader.preload = file:../../src/libsysdb.so
 loader.env.LD_LIBRARY_PATH = /lib

--- a/LibOS/shim/test/regression/attestation.manifest.template
+++ b/LibOS/shim/test/regression/attestation.manifest.template
@@ -2,7 +2,7 @@ loader.preload = file:$(SHIMPATH)
 loader.env.LD_LIBRARY_PATH = /lib
 loader.debug_type = none
 loader.syscall_symbol = syscalldb
-loader.execname = attestation
+loader.argv0_override = attestation
 loader.insecure__use_cmdline_argv = 1
 
 fs.mount.lib.type = chroot

--- a/LibOS/shim/test/regression/echo.manifest.template
+++ b/LibOS/shim/test/regression/echo.manifest.template
@@ -1,7 +1,7 @@
 # This file is used by test_204_system test
 
 loader.exec = file:/bin/echo
-loader.execname = echo
+loader.argv0_override = echo
 loader.insecure__use_cmdline_argv = 1
 
 loader.preload = file:../../src/libsysdb.so

--- a/LibOS/shim/test/regression/eventfd.manifest.template
+++ b/LibOS/shim/test/regression/eventfd.manifest.template
@@ -2,7 +2,7 @@ loader.preload = file:../../src/libsysdb.so
 loader.env.LD_LIBRARY_PATH = /lib
 loader.debug_type = none
 loader.syscall_symbol = syscalldb
-loader.execname = eventfd
+loader.argv0_override = eventfd
 
 sys.insecure__allow_eventfd = 1
 

--- a/LibOS/shim/test/regression/exec_victim.manifest.template
+++ b/LibOS/shim/test/regression/exec_victim.manifest.template
@@ -2,7 +2,7 @@ loader.preload = file:$(SHIMPATH)
 loader.env.LD_LIBRARY_PATH = /lib
 loader.debug_type = none
 loader.syscall_symbol = syscalldb
-loader.execname = exec_victim
+loader.argv0_override = exec_victim
 loader.insecure__use_cmdline_argv = 1
 
 fs.mount.lib.type = chroot

--- a/LibOS/shim/test/regression/exit_group.manifest.template
+++ b/LibOS/shim/test/regression/exit_group.manifest.template
@@ -2,7 +2,7 @@ loader.preload = file:../../src/libsysdb.so
 loader.env.LD_LIBRARY_PATH = /lib
 loader.debug_type = none
 loader.syscall_symbol = syscalldb
-loader.execname = exit_group
+loader.argv0_override = exit_group
 
 fs.mount.lib.type = chroot
 fs.mount.lib.path = /lib

--- a/LibOS/shim/test/regression/file_check_policy_allow_all_but_log.manifest.template
+++ b/LibOS/shim/test/regression/file_check_policy_allow_all_but_log.manifest.template
@@ -1,7 +1,7 @@
 #!$(PAL)
 
 loader.exec = file:file_check_policy
-loader.execname = file_check_policy
+loader.argv0_override = file_check_policy
 loader.preload = file:$(SHIMPATH)
 loader.env.LD_LIBRARY_PATH = /lib
 loader.debug_type = none

--- a/LibOS/shim/test/regression/file_check_policy_allow_all_but_log.manifest.template
+++ b/LibOS/shim/test/regression/file_check_policy_allow_all_but_log.manifest.template
@@ -1,5 +1,3 @@
-#!$(PAL)
-
 loader.exec = file:file_check_policy
 loader.argv0_override = file_check_policy
 loader.preload = file:$(SHIMPATH)

--- a/LibOS/shim/test/regression/file_check_policy_strict.manifest.template
+++ b/LibOS/shim/test/regression/file_check_policy_strict.manifest.template
@@ -1,7 +1,7 @@
 #!$(PAL)
 
 loader.exec = file:file_check_policy
-loader.execname = file_check_policy
+loader.argv0_override = file_check_policy
 loader.preload = file:$(SHIMPATH)
 loader.env.LD_LIBRARY_PATH = /lib
 loader.debug_type = none

--- a/LibOS/shim/test/regression/file_check_policy_strict.manifest.template
+++ b/LibOS/shim/test/regression/file_check_policy_strict.manifest.template
@@ -1,5 +1,3 @@
-#!$(PAL)
-
 loader.exec = file:file_check_policy
 loader.argv0_override = file_check_policy
 loader.preload = file:$(SHIMPATH)

--- a/LibOS/shim/test/regression/futex_bitset.manifest.template
+++ b/LibOS/shim/test/regression/futex_bitset.manifest.template
@@ -2,7 +2,7 @@ loader.preload = file:../../src/libsysdb.so
 loader.env.LD_LIBRARY_PATH = /lib
 loader.debug_type = none
 loader.syscall_symbol = syscalldb
-loader.execname = futex_bitset
+loader.argv0_override = futex_bitset
 
 fs.mount.lib.type = chroot
 fs.mount.lib.path = /lib

--- a/LibOS/shim/test/regression/futex_requeue.manifest.template
+++ b/LibOS/shim/test/regression/futex_requeue.manifest.template
@@ -2,7 +2,7 @@ loader.preload = file:../../src/libsysdb.so
 loader.env.LD_LIBRARY_PATH = /lib
 loader.debug_type = none
 loader.syscall_symbol = syscalldb
-loader.execname = futex_requeue
+loader.argv0_override = futex_requeue
 
 fs.mount.lib.type = chroot
 fs.mount.lib.path = /lib

--- a/LibOS/shim/test/regression/futex_wake_op.manifest.template
+++ b/LibOS/shim/test/regression/futex_wake_op.manifest.template
@@ -2,7 +2,7 @@ loader.preload = file:../../src/libsysdb.so
 loader.env.LD_LIBRARY_PATH = /lib
 loader.debug_type = none
 loader.syscall_symbol = syscalldb
-loader.execname = futex_wake_op
+loader.argv0_override = futex_wake_op
 
 fs.mount.lib.type = chroot
 fs.mount.lib.path = /lib

--- a/LibOS/shim/test/regression/getdents.manifest.template
+++ b/LibOS/shim/test/regression/getdents.manifest.template
@@ -1,7 +1,7 @@
 loader.preload = file:$(SHIMPATH)
 loader.env.LD_LIBRARY_PATH = /lib
 loader.debug_type = inline
-loader.execname = getdents
+loader.argv0_override = getdents
 
 fs.mount.lib.type = chroot
 fs.mount.lib.path = /lib

--- a/LibOS/shim/test/regression/host_root_fs.manifest.template
+++ b/LibOS/shim/test/regression/host_root_fs.manifest.template
@@ -2,7 +2,7 @@ loader.preload = file:../../src/libsysdb.so
 loader.env.LD_LIBRARY_PATH = /lib
 loader.debug_type = none
 loader.syscall_symbol = syscalldb
-loader.execname = host_root_fs
+loader.argv0_override = host_root_fs
 
 fs.root.type = chroot
 fs.root.path = /

--- a/LibOS/shim/test/regression/init_fail.manifest.template
+++ b/LibOS/shim/test/regression/init_fail.manifest.template
@@ -1,7 +1,7 @@
 loader.preload = file:$(SHIMPATH)
 loader.env.LD_LIBRARY_PATH = /lib
 loader.debug_type = none
-loader.execname = init_fail
+loader.argv0_override = init_fail
 
 fs.mount.lib.type = chroot
 fs.mount.lib.path = /lib

--- a/LibOS/shim/test/regression/large_mmap.manifest.template
+++ b/LibOS/shim/test/regression/large_mmap.manifest.template
@@ -2,7 +2,7 @@ loader.preload = file:../../src/libsysdb.so
 loader.env.LD_LIBRARY_PATH = /lib
 loader.debug_type = none
 loader.syscall_symbol = syscalldb
-loader.execname = large_mmap
+loader.argv0_override = large_mmap
 
 # application allocates 2GB and 4GB memory regions which may occasionally fail
 # in an SGX enclave restricted to 8GB of virtual space if ASLR is enabled

--- a/LibOS/shim/test/regression/mmap_file.manifest.template
+++ b/LibOS/shim/test/regression/mmap_file.manifest.template
@@ -2,7 +2,7 @@ loader.preload = file:../../src/libsysdb.so
 loader.env.LD_LIBRARY_PATH = /lib
 loader.debug_type = none
 loader.syscall_symbol = syscalldb
-loader.execname = mmap_file
+loader.argv0_override = mmap_file
 
 fs.mount.lib.type = chroot
 fs.mount.lib.path = /lib

--- a/LibOS/shim/test/regression/multi_pthread.manifest.template
+++ b/LibOS/shim/test/regression/multi_pthread.manifest.template
@@ -2,7 +2,7 @@ loader.preload = file:../../src/libsysdb.so
 loader.env.LD_LIBRARY_PATH = /lib
 loader.debug_type = none
 loader.syscall_symbol = syscalldb
-loader.execname = multi_pthread
+loader.argv0_override = multi_pthread
 
 fs.mount.lib.type = chroot
 fs.mount.lib.path = /lib

--- a/LibOS/shim/test/regression/multi_pthread_exitless.manifest.template
+++ b/LibOS/shim/test/regression/multi_pthread_exitless.manifest.template
@@ -1,5 +1,5 @@
 loader.exec = file:multi_pthread
-loader.execname = multi_pthread
+loader.argv0_override = multi_pthread
 
 loader.preload = file:../../src/libsysdb.so
 loader.env.LD_LIBRARY_PATH = /lib

--- a/LibOS/shim/test/regression/openmp.manifest.template
+++ b/LibOS/shim/test/regression/openmp.manifest.template
@@ -2,7 +2,7 @@ loader.preload = file:../../src/libsysdb.so
 loader.env.LD_LIBRARY_PATH = /lib:/usrlib
 loader.debug_type = none
 loader.syscall_symbol = syscalldb
-loader.execname = openmp
+loader.argv0_override = openmp
 
 fs.mount.lib.type = chroot
 fs.mount.lib.path = /lib

--- a/LibOS/shim/test/regression/proc_path.manifest.template
+++ b/LibOS/shim/test/regression/proc_path.manifest.template
@@ -2,7 +2,7 @@ loader.preload = file:../../src/libsysdb.so
 loader.env.LD_LIBRARY_PATH = /lib
 loader.debug_type = none
 loader.syscall_symbol = syscalldb
-loader.execname = proc_path
+loader.argv0_override = proc_path
 
 fs.mount.lib.type = chroot
 fs.mount.lib.path = /lib

--- a/LibOS/shim/test/regression/sh.manifest.template
+++ b/LibOS/shim/test/regression/sh.manifest.template
@@ -1,7 +1,7 @@
 # This file is used by test_204_system test
 
 loader.exec = file:/bin/sh
-loader.execname = sh
+loader.argv0_override = sh
 loader.insecure__use_cmdline_argv = 1
 
 loader.preload = file:../../src/libsysdb.so

--- a/LibOS/shim/test/regression/shared_object.manifest.template
+++ b/LibOS/shim/test/regression/shared_object.manifest.template
@@ -1,7 +1,7 @@
 loader.preload = file:$(SHIMPATH)
 loader.env.LD_LIBRARY_PATH = /lib
 loader.debug_type = none
-loader.execname = shared_object
+loader.argv0_override = shared_object
 
 fs.mount.lib.type = chroot
 fs.mount.lib.path = /lib

--- a/Pal/regression/AvxDisable.manifest.template
+++ b/Pal/regression/AvxDisable.manifest.template
@@ -1,4 +1,4 @@
-loader.execname = AvxDisable
+loader.argv0_override = AvxDisable
 
 sgx.require_avx = 0
 sgx.require_avx512 = 0

--- a/Pal/regression/Bootstrap2.manifest.template
+++ b/Pal/regression/Bootstrap2.manifest.template
@@ -1,2 +1,2 @@
 loader.debug_type = inline
-loader.execname = Bootstrap2
+loader.argv0_override = Bootstrap2

--- a/Pal/regression/Bootstrap3.manifest.template
+++ b/Pal/regression/Bootstrap3.manifest.template
@@ -1,3 +1,3 @@
 loader.debug_type = inline
 loader.preload = file:Preload1.so,file:Preload2.so
-loader.execname = Bootstrap3
+loader.argv0_override = Bootstrap3

--- a/Pal/regression/Bootstrap4.manifest.template
+++ b/Pal/regression/Bootstrap4.manifest.template
@@ -1,4 +1,4 @@
 #!$(PAL)
 
 loader.exec = file:Bootstrap
-loader.execname = Bootstrap
+loader.argv0_override = Bootstrap

--- a/Pal/regression/Bootstrap4.manifest.template
+++ b/Pal/regression/Bootstrap4.manifest.template
@@ -1,4 +1,2 @@
-#!$(PAL)
-
 loader.exec = file:Bootstrap
 loader.argv0_override = Bootstrap

--- a/Pal/regression/Bootstrap5.manifest.template
+++ b/Pal/regression/Bootstrap5.manifest.template
@@ -1,4 +1,4 @@
 loader.debug_type = inline
 loader.preload = file:Preload1.so,file:Preload2.so
 # This example doesn't use any binary, this line is only to stop argv protection from complaining.
-loader.execname = Bootstrap
+loader.argv0_override = Bootstrap

--- a/Pal/regression/Bootstrap6.manifest.template
+++ b/Pal/regression/Bootstrap6.manifest.template
@@ -1,7 +1,7 @@
 loader.exec = file:./Bootstrap
 loader.debug_type = inline
 loader.preload = file:Preload1.so,file:Preload2.so
-loader.execname = Bootstrap
+loader.argv0_override = Bootstrap
 
 fs.mount.root.uri = file:
 

--- a/Pal/regression/Bootstrap7.manifest.template
+++ b/Pal/regression/Bootstrap7.manifest.template
@@ -1,7 +1,7 @@
 #!$(PAL)
 
 loader.exec = file:Bootstrap7
-loader.execname = Bootstrap7
+loader.argv0_override = Bootstrap7
 
 loader.env.key1 = na
 loader.env.key2 = na

--- a/Pal/regression/Bootstrap7.manifest.template
+++ b/Pal/regression/Bootstrap7.manifest.template
@@ -1,5 +1,3 @@
-#!$(PAL)
-
 loader.exec = file:Bootstrap7
 loader.argv0_override = Bootstrap7
 

--- a/Pal/regression/File.manifest.template
+++ b/Pal/regression/File.manifest.template
@@ -1,4 +1,4 @@
-loader.execname = File
+loader.argv0_override = File
 loader.debug_type = inline
 
 fs.mount.root.uri = file:

--- a/Pal/regression/Makefile
+++ b/Pal/regression/Makefile
@@ -90,7 +90,6 @@ all: $(target) $(call expand_target_to_sig,$(target)) $(call expand_target_to_sg
 sgx-tokens: $(call expand_target_to_token,$(target))
 
 manifest_rules = \
-	-e 's:\$$(PAL):$(abspath ../../Runtime/pal_loader):g' \
 	-e 's:\$$(PWD):$(shell pwd)/:g' \
 	-e 's:\$$(RA_CLIENT_SPID):$(RA_CLIENT_SPID):g' \
 	-e 's:\$$(RA_CLIENT_LINKABLE):$(if $(RA_CLIENT_LINKABLE),$(RA_CLIENT_LINKABLE),0):g'

--- a/Pal/regression/Process.manifest.template
+++ b/Pal/regression/Process.manifest.template
@@ -1,4 +1,4 @@
-loader.execname = Process
+loader.argv0_override = Process
 loader.insecure__use_cmdline_argv = 1
 loader.debug_type = inline
 

--- a/Pal/regression/Process2.manifest.template
+++ b/Pal/regression/Process2.manifest.template
@@ -1,4 +1,4 @@
-loader.execname = Process2
+loader.argv0_override = Process2
 loader.debug_type = inline
 
 sgx.trusted_children.1 = file:Bootstrap.sig

--- a/Pal/regression/SendHandle.manifest.template
+++ b/Pal/regression/SendHandle.manifest.template
@@ -1,5 +1,5 @@
 loader.debug_type = inline
-loader.execname = SendHandle
+loader.argv0_override = SendHandle
 loader.insecure__use_cmdline_argv = 1
 
 net.allow_bind.1 = 127.0.0.1:8000

--- a/Pal/regression/Thread2.manifest.template
+++ b/Pal/regression/Thread2.manifest.template
@@ -1,4 +1,4 @@
-loader.execname = Thread2
+loader.argv0_override = Thread2
 
 sgx.thread_num = 2
 sgx.print_stats = 1

--- a/Pal/regression/Thread2_exitless.manifest.template
+++ b/Pal/regression/Thread2_exitless.manifest.template
@@ -1,5 +1,5 @@
 loader.exec = file:Thread2
-loader.execname = Thread2
+loader.argv0_override = Thread2
 
 sgx.thread_num = 2
 sgx.rpc_thread_num = 2

--- a/Pal/regression/test_pal.py
+++ b/Pal/regression/test_pal.py
@@ -210,15 +210,8 @@ class TC_01_Bootstrap(RegressionTestCase):
         self.assertIn('Loaded Manifest: file:' + manifest, stderr)
         self.assertIn('Loaded Executable: file:Bootstrap', stderr)
 
-    def test_106_manifest_with_shebang(self):
-        manifest = self.get_manifest('Bootstrap4')
-        _, stderr = self.run_binary(['./' + manifest])
-        self.assertIn('Loaded Manifest: file:' + manifest, stderr)
-        self.assertIn('Loaded Executable: file:Bootstrap', stderr)
-        self.assertIn('argv[0] = Bootstrap', stderr)
-
     @unittest.skipUnless(HAS_SGX, 'need SGX')
-    def test_107_manifest_with_nonelf_binary(self):
+    def test_106_manifest_with_nonelf_binary(self):
         manifest = self.get_manifest('nonelf_binary')
         # Expected return code is -ENOEXEC (248 as unsigned char)
         with self.expect_returncode(248):

--- a/Pal/src/db_main.c
+++ b/Pal/src/db_main.c
@@ -362,15 +362,14 @@ noreturn void pal_main(
     /* Load argv */
     /* TODO: Add an option to specify argv inline in the manifest. This requires an upgrade to the
      * manifest syntax. See https://github.com/oscarlab/graphene/issues/870 (Use YAML or TOML syntax
-     * for manifests). 'loader.execname' won't be needed after implementing this feature and
+     * for manifests). 'loader.argv0_override' won't be needed after implementing this feature and
      * resolving https://github.com/oscarlab/graphene/issues/1053 (RFC: graphene invocation).
      */
-    bool using_loader_execname = false;
+    bool argv0_overridden = false;
     if (pal_state.root_config) {
-        ret = get_config(pal_state.root_config, "loader.execname", cfgbuf, sizeof(cfgbuf));
+        ret = get_config(pal_state.root_config, "loader.argv0_override", cfgbuf, sizeof(cfgbuf));
         if (ret > 0) {
-            /* loader.execname specified, override argv[0] */
-            using_loader_execname = true;
+            argv0_overridden = true;
             if (!arguments[0]) {
                 arguments = malloc(sizeof(const char*) * 2);
                 if (!arguments)
@@ -432,7 +431,7 @@ noreturn void pal_main(
             if (buf[i] == '\0')
                 *(argv_it++) = buf + i + 1;
         arguments = argv;
-    } else if (!using_loader_execname || (arguments[0] && arguments[1])) {
+    } else if (!argv0_overridden || (arguments[0] && arguments[1])) {
         INIT_FAIL(PAL_ERROR_INVAL, "argv handling wasn't configured in the manifest, but cmdline "
                   "arguments were specified.");
     }

--- a/Scripts/Makefile.Test
+++ b/Scripts/Makefile.Test
@@ -33,7 +33,6 @@ sgx-tokens: $(call expand_target_to_token,$(exec_target))
 
 ifeq ($(ABSPATH_IN_MANIFEST),yes)
 manifest_rules = \
-	-e 's:\$$(PAL):$(abspath $(RUNTIME))/pal_loader:g' \
 	-e 's:\$$(PWD):$(PWD):g' \
 	-e 's:\$$(BIN):$(subst .manifest,,$(notdir $@)):g' \
 	-e 's:\$$(SHIMPATH):$(abspath $(RUNTIME))/libsysdb.so:g' \
@@ -42,7 +41,6 @@ manifest_rules = \
 	$(extra_rules)
 else
 manifest_rules= \
-	-e 's:\$$(PAL):$(abspath $(RUNTIME))/pal_loader:g' \
 	-e 's:\$$(PWD):$(PWD):g' \
 	-e 's:\$$(BIN):$(subst .manifest,,$(notdir $@)):g' \
 	-e 's:\$$(SHIMPATH):$(RUNTIME)/libsysdb.so:g' \

--- a/Scripts/Makefile.rules
+++ b/Scripts/Makefile.rules
@@ -150,8 +150,7 @@ quiet_cmd_sgx_sign_depend = [ $@ ]
 # manifest
 quiet_cmd_manifest = [ $@ ]
       cmd_manifest = \
-	$(if $(2),sed $(2) $< > $@,cp -f $< $@); \
-	(grep -q "\#\\!" $@ && chmod +x $@) || true
+	$(if $(2),sed $(2) $< > $@,cp -f $< $@)
 
 # pal map
 PAL_SYMBOL_FILE := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))/../Pal/src/pal-symbols


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Just a few random fixes/cleanups after protected argv PR:
- `loader.execname` now has straightforward semantic, so it can be renamed to much more informative and precise `loader.argv0_override`.
- TensorFlow's default target was broken.
- Shebangs in our test manifests didn't actually work and weren't tested, so I removed them. We'll introduce a proper test for them after implementing #1053 (RFC: graphene invocation).

## How to test this PR? <!-- (if applicable) -->

CI.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1589)
<!-- Reviewable:end -->
