### PR TITLE
[LibOS,Pal] Add "loader.insecure__use_cmdline_argv" to more manifests

### DIFF
--- a/LibOS/shim/test/benchmark/manifest.template
+++ b/LibOS/shim/test/benchmark/manifest.template
@@ -2,6 +2,7 @@ loader.preload = file:../../src/libsysdb.so
 loader.env.LD_LIBRARY_PATH = /lib
 loader.debug_type = none
 loader.syscall_symbol = syscalldb
+loader.insecure__use_cmdline_argv = 1
 
 fs.mount.lib.type = chroot
 fs.mount.lib.path = /lib

--- a/LibOS/shim/test/inline/manifest.template
+++ b/LibOS/shim/test/inline/manifest.template
@@ -1,2 +1,3 @@
 loader.preload = file:../../src/libsysdb_debug.so
 loader.debug_type = inline
+loader.insecure__use_cmdline_argv = 1

--- a/LibOS/shim/test/native/exec_fork.manifest.template
+++ b/LibOS/shim/test/native/exec_fork.manifest.template
@@ -2,6 +2,7 @@ loader.preload = file:$(SHIMPATH)
 loader.env.LD_LIBRARY_PATH = /lib
 loader.debug_type = inline
 loader.syscall_symbol = syscalldb
+loader.insecure__use_cmdline_argv = 1
 
 fs.mount.lib.type = chroot
 fs.mount.lib.path = /lib

--- a/LibOS/shim/test/native/ls.manifest.template
+++ b/LibOS/shim/test/native/ls.manifest.template
@@ -2,6 +2,7 @@ loader.preload = file:$(SHIMPATH)
 loader.exec = file:/bin/ls
 loader.env.LD_LIBRARY_PATH = /lib:$(ARCH_LIBDIR)
 loader.debug_type = none
+loader.insecure__use_cmdline_argv = 1
 
 fs.mount.lib.type = chroot
 fs.mount.lib.path = /lib

--- a/LibOS/shim/test/native/manifest.template
+++ b/LibOS/shim/test/native/manifest.template
@@ -2,6 +2,7 @@ loader.preload = file:$(SHIMPATH)
 loader.env.LD_LIBRARY_PATH = /lib
 loader.debug_type = inline
 loader.syscall_symbol = syscalldb
+loader.insecure__use_cmdline_argv = 1
 
 fs.mount.lib.type = chroot
 fs.mount.lib.path = /lib

--- a/LibOS/shim/test/native/script.manifest.template
+++ b/LibOS/shim/test/native/script.manifest.template
@@ -2,6 +2,7 @@ loader.preload = file:$(SHIMPATH)
 loader.env.LD_LIBRARY_PATH = /lib
 loader.debug_type = inline
 loader.syscall_symbol = syscalldb
+loader.insecure__use_cmdline_argv = 1
 
 fs.mount.lib.type = chroot
 fs.mount.lib.path = /lib

--- a/LibOS/shim/test/native/static.manifest.template
+++ b/LibOS/shim/test/native/static.manifest.template
@@ -1,6 +1,7 @@
 loader.preload = file:$(SHIMPATH)
 loader.env.LD_LIBRARY_PATH = /lib
 loader.debug_type = inline
+loader.insecure__use_cmdline_argv = 1
 
 fs.mount.lib.type = chroot
 fs.mount.lib.path = /lib


### PR DESCRIPTION

## Description of the changes <!-- (reasons and measures) -->

As part of Protected Argv feature, Graphene now requires an explicit manifest option to pass command-line arguments, either `loader.argv_src_file` or `loader.insecure__use_cmdline_argv`. As
part of that change, most manifests were updated to include these options, but not all. This PR fixes this for the rest of manifests.

## How to test this PR? <!-- (if applicable) -->

All tests must run. With this PR, manually running HelloWorld from `LibOS/shim/test/native/` would fail. With this PR, it correctly prints `Hello world (helloworld)!`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1592)
<!-- Reviewable:end -->
