### PR TITLE
[Pal/Linux-SGX] Support DCAP 1.35 driver

### DIFF
--- a/Pal/src/host/Linux-SGX/sgx_framework.c
+++ b/Pal/src/host/Linux-SGX/sgx_framework.c
@@ -132,8 +132,6 @@ int create_enclave(sgx_arch_secs_t * secs,
     assert(secs->size && IS_POWER_OF_2(secs->size));
     assert(IS_ALIGNED(secs->base, secs->size));
 
-    int flags = MAP_SHARED;
-
     secs->ssa_frame_size = get_ssaframesize(token->body.attributes.xfrm) / g_page_size;
     secs->misc_select = token->masked_misc_select_le;
     memcpy(&secs->attributes, &token->body.attributes, sizeof(sgx_attributes_t));
@@ -146,15 +144,19 @@ int create_enclave(sgx_arch_secs_t * secs,
 
     uint64_t addr = INLINE_SYSCALL(mmap, 6, secs->base, secs->size,
                                    PROT_NONE, /* newer DCAP driver requires such initial mmap */
-                                   flags|MAP_FIXED, g_isgx_device, 0);
+#ifdef SGX_DCAP_16_OR_LATER
+                                   MAP_FIXED | MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+#else
+                                   MAP_FIXED | MAP_SHARED, g_isgx_device, 0);
+#endif
 
     if (IS_ERR_P(addr)) {
-        if (ERRNO_P(addr) == 1 && (flags | MAP_FIXED))
+        if (ERRNO_P(addr) == EPERM) {
             pal_printf("Permission denied on mapping enclave. "
                        "You may need to set sysctl vm.mmap_min_addr to zero\n");
+        }
 
-        SGX_DBG(DBG_I, "enclave ECREATE failed in allocating EPC memory "
-                "(errno = %ld)\n", ERRNO_P(addr));
+        SGX_DBG(DBG_I, "ECREATE failed in allocating EPC memory (errno = %ld)\n", ERRNO_P(addr));
         return -ENOMEM;
     }
 
@@ -166,12 +168,12 @@ int create_enclave(sgx_arch_secs_t * secs,
     int ret = INLINE_SYSCALL(ioctl, 3, g_isgx_device, SGX_IOC_ENCLAVE_CREATE, &param);
 
     if (IS_ERR(ret)) {
-        SGX_DBG(DBG_I, "enclave ECREATE failed in enclave creation ioctl - %d\n", ERRNO(ret));
+        SGX_DBG(DBG_I, "ECREATE failed in enclave creation ioctl (errno = %d)\n", ERRNO(ret));
         return -ERRNO(ret);
     }
 
     if (ret) {
-        SGX_DBG(DBG_I, "enclave ECREATE failed - %d\n", ret);
+        SGX_DBG(DBG_I, "ECREATE failed (errno = %d)\n", ret);
         return -EPERM;
     }
 
@@ -288,6 +290,14 @@ int add_pages_to_enclave(sgx_arch_secs_t * secs,
                 param.count, param.length);
         return -ERRNO(ret);
     }
+
+    /* ask Intel SGX driver to actually mmap the added enclave pages */
+    uint64_t mapped = INLINE_SYSCALL(mmap, 6, secs->base + addr, size, prot,
+                                     MAP_FIXED | MAP_SHARED, g_isgx_device, 0);
+    if (IS_ERR_P(mapped)) {
+        SGX_DBG(DBG_I, "Cannot map enclave pages %ld\n", ERRNO_P(mapped));
+        return -EACCES;
+    }
 #else
     /* older drivers (DCAP v1.5- and old out-of-tree) only supports adding one page at a time */
     struct sgx_enclave_add_page param = {
@@ -310,15 +320,14 @@ int add_pages_to_enclave(sgx_arch_secs_t * secs,
             param.src += g_page_size;
         added_size += g_page_size;
     }
-#endif /* SGX_DCAP_16_OR_LATER */
 
-    /* need to change permissions for EADDed pages; actual permissions are capped by
-     * permissions specified in SECINFO so here we specify the broadest set */
-    ret = mprotect(secs->base + addr, size, PROT_READ | PROT_WRITE | PROT_EXEC);
+    /* need to change permissions for EADDed pages since the initial mmap was with PROT_NONE */
+    ret = mprotect(secs->base + addr, size, prot);
     if (IS_ERR(ret)) {
         SGX_DBG(DBG_I, "Changing protections of EADDed pages returned %d\n", ret);
         return -ERRNO(ret);
     }
+#endif /* SGX_DCAP_16_OR_LATER */
 
     return 0;
 }

--- a/Pal/src/host/Linux-SGX/sgx_main.c
+++ b/Pal/src/host/Linux-SGX/sgx_main.c
@@ -401,7 +401,7 @@ static int initialize_enclave(struct pal_enclave* enclave) {
     areas[area_num] = (struct mem_area) {
         .desc = "tcs", .skip_eextend = false, .fd = -1,
         .is_binary = false, .addr = 0, .size = enclave->thread_num * g_page_size,
-        .prot = 0, .type = SGX_PAGE_TCS
+        .prot = PROT_READ | PROT_WRITE, .type = SGX_PAGE_TCS
     };
     struct mem_area* tcs_area = &areas[area_num++];
 


### PR DESCRIPTION
## Description of the changes 

This PR adds support for the DCAP 1.35 driver (https://github.com/intel/SGXDataCenterAttestationPrimitives/tree/e3998c5fbd5d3fd065436b934b53822120e67be6/driver/linux). The PR makes changes to mmap and mprotect to support newer protection setting requirements. Supposed to be backward compatible with prior releases of other Intel SDK drivers.

More context: the DCAP driver (https://github.com/intel/SGXDataCenterAttestationPrimitives/tree/master/driver/linux) follows the upstreaming Intel SGX driver for Linux (https://lkml.org/lkml/2020/6/1/165). It was recently rebased to v32 of the upstreaming driver (see links), which has changes to mmap and mprotect. Thus, Graphene failed to correctly create, add-pages, and init the SGX enclave. This PR fixes these problems.

## How to test this PR?

Run any Graphene app using SGX and DCAP 1.35.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1594)
<!-- Reviewable:end -->
