### PR TITLE
Jrbergsten/sgx signer app versus python

### DIFF
--- a/Pal/src/host/Linux-SGX/signer/pal-sgx-get-token
+++ b/Pal/src/host/Linux-SGX/signer/pal-sgx-get-token
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python3.6
 # pylint: disable=invalid-name
 
 import argparse

--- a/Pal/src/host/Linux-SGX/signer/pal-sgx-sign
+++ b/Pal/src/host/Linux-SGX/signer/pal-sgx-sign
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python3.6
 
 # This is just a wrapper that provides the cmdline tool. All code should go
 # into pal_sgx_sign.py.


### PR DESCRIPTION
<!--
l -->

## Description of the changes <!-- SGX signing apps require Python 3.6 to operate properly.  They do not work with Python 3.8.  Changed the scripts to explicitly run 3.6 rather than just 3.  Better solution would be to fix the scripts to be compatible with both Python versions, but, well. -->

## How to test this PR? <!-- Run any SGX signing. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1595)
<!-- Reviewable:end -->
