### PR TITLE
[Pal/Linux-SGX] Fix "initializer element is not constant" error

### DIFF
--- a/Pal/src/host/Linux-SGX/sgx_enclave.c
+++ b/Pal/src/host/Linux-SGX/sgx_enclave.c
@@ -724,9 +724,9 @@ static int rpc_thread_loop(void* arg) {
     g_rpc_queue->rpc_threads_cnt++;
     spinlock_unlock(&g_rpc_queue->lock);
 
-    static const uint64_t SPIN_ATTEMPTS_MAX = 10000;                /* rather arbitrary */
-    static const uint64_t SLEEP_TIME_MAX    = 100000000;            /* nanoseconds (0.1 seconds) */
-    static const uint64_t SLEEP_TIME_STEP   = SLEEP_TIME_MAX / 100; /* 100 steps before capped */
+    static const uint64_t SPIN_ATTEMPTS_MAX = 10000;      /* rather arbitrary */
+    static const uint64_t SLEEP_TIME_MAX    = 100000000;  /* nanoseconds (0.1 seconds) */
+    static const uint64_t SLEEP_TIME_STEP   = 1000000;    /* 100 steps before capped */
 
     /* no races possible since vars are thread-local and RPC threads don't receive signals */
     uint64_t spin_attempts = 0;


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Newer GCC complained about non-constant initialization:
```
  sgx_enclave.c: In function ‘rpc_thread_loop’:
  sgx_enclave.c:729:47: error: initializer element is not constant
       static const uint64_t SLEEP_TIME_STEP   = SLEEP_TIME_MAX / 100;
```

## How to test this PR? <!-- (if applicable) -->

All tests must pass.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1596)
<!-- Reviewable:end -->
