### PR TITLE
PAL:Fix poll() syscall to return POLLHUP on closed FD

### DIFF
--- a/LibOS/shim/test/regression/.gitignore
+++ b/LibOS/shim/test/regression/.gitignore
@@ -49,6 +49,7 @@
 /openmp
 /pipe
 /poll
+/poll_closed_fd
 /poll_many_types
 /ppoll
 /proc_common

--- a/LibOS/shim/test/regression/Makefile
+++ b/LibOS/shim/test/regression/Makefile
@@ -40,6 +40,7 @@ c_executables = \
 	openmp \
 	pipe \
 	poll \
+	poll_closed_fd \
 	poll_many_types \
 	ppoll \
 	proc_common \

--- a/LibOS/shim/test/regression/poll_closed_fd.c
+++ b/LibOS/shim/test/regression/poll_closed_fd.c
@@ -1,0 +1,83 @@
+#include <poll.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+int main(int argc, char** argv) {
+    int ret;
+    int pipefds[2];
+    char buffer[1024];
+    size_t bufsize = sizeof(buffer);
+    ssize_t bytes;
+
+    if (pipe(pipefds) < 0) {
+        perror("pipe error\n");
+        return 1;
+    }
+
+    int pid = fork();
+
+    if (pid < 0) {
+        perror("fork error\n");
+        return 1;
+    } else if (pid == 0) {
+        /* client */
+        close(pipefds[0]);
+
+        snprintf(buffer, bufsize, "Hello from write end of pipe!");
+        if (write(pipefds[1], &buffer, strlen(buffer) + 1) < 0) {
+            perror("write error\n");
+            close(pipefds[1]);
+            return 1;
+        }
+        close(pipefds[1]);
+    } else {
+        /* server */
+        close(pipefds[1]);
+
+        struct pollfd infds[] = {
+            {.fd = pipefds[0], .events = POLLIN},
+        };
+        /* parent (server) expects to receive one message from client (via POLLIN) and
+         * then get an error (via POLLHUP) because the client connection was closed */
+        for (;;) {
+            ret = poll(infds, 1, -1);
+            if (ret <= 0) {
+                perror("poll with POLLIN failed\n");
+                close(pipefds[0]);
+                return 1;
+            }
+
+            if (infds[0].revents & POLLIN) {
+                bytes = read(pipefds[0], &buffer, bufsize - 1);
+                if (bytes  < 0) {
+                    perror("read error\n");
+                    close(pipefds[0]);
+                    return 1;
+                } else if (bytes > 0) {
+                    buffer[bytes] = '\0';
+                    printf("read on pipe: %s\n", buffer);
+                }
+            }
+            if (infds[0].revents & (POLLHUP | POLLERR | POLLNVAL)) {
+                printf("the peer closed its end of the pipe\n");
+                break;
+            }
+        }
+        int wstatus;
+        if (wait(&wstatus) < 0) {
+            perror("wait error\n");
+            close(pipefds[0]);
+            return 1;
+        } else if (!WIFEXITED(wstatus) || WEXITSTATUS(wstatus)){
+            perror("child process didn't exit successfully\n");
+            close(pipefds[0]);
+            return 1;
+        }
+        close(pipefds[0]);
+    }
+
+    return 0;
+}

--- a/LibOS/shim/test/regression/test_libos.py
+++ b/LibOS/shim/test/regression/test_libos.py
@@ -532,6 +532,12 @@ class TC_80_Socket(RegressionTestCase):
         stdout, _ = self.run_binary(['poll_many_types'])
         self.assertIn('poll(POLLIN) returned 3 file descriptors', stdout)
 
+    def test_022_poll_closed_fd(self):
+        stdout, _ = self.run_binary(['poll_closed_fd'], timeout=60)
+        self.assertNotIn('poll with POLLIN failed', stdout)
+        self.assertIn('read on pipe: Hello from write end of pipe!', stdout)
+        self.assertIn('the peer closed its end of the pipe', stdout)
+
     def test_030_ppoll(self):
         stdout, _ = self.run_binary(['ppoll'])
         self.assertIn('ppoll(POLLOUT) returned 1 file descriptors', stdout)


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->
poll() syscall on Linux and Linux-SGX have different behavior from native program. See #1600.
It also blocks multi-thread Python script. See #1539.
This PR updates poll() to find FD marked as failed then return positive number and pollfd with proper revents field.

Fixes #1600.

## How to test this PR? <!-- (if applicable) -->
`poll_closed_fd` regression test

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1607)
<!-- Reviewable:end -->
