### PR TITLE
[Testing] Only build the part of LTP we care about

### DIFF
--- a/LibOS/shim/test/ltp/Makefile
+++ b/LibOS/shim/test/ltp/Makefile
@@ -16,8 +16,9 @@ $(SRCDIR)/configure: $(SRCDIR)/Makefile
 
 $(BUILDDIR)/runltp: $(SRCDIR)/configure
 	cd $(SRCDIR) && ./configure
-	cd $(SRCDIR) && $(MAKE) all
-	cd $(SRCDIR) && $(MAKE) "DESTDIR=$(PWD)" SKIP_IDCHECK=1 install
+	cd $(SRCDIR) && $(MAKE) FILTER_OUT_DIRS=delete_module -C testcases/kernel/syscalls
+	cd $(SRCDIR) && $(MAKE) FILTER_OUT_DIRS=delete_module "DESTDIR=$(PWD)" -C runtest SKIP_IDCHECK=1 install
+	cd $(SRCDIR) && $(MAKE) FILTER_OUT_DIRS=delete_module "DESTDIR=$(PWD)" -C testcases/kernel/syscalls SKIP_IDCHECK=1 install
 
 $(TESTCASEDIR)/pal_loader: $(BUILDDIR)/runltp
 	ln -sf $(call relative-to,$(dir $@),../../Runtime/pal_loader) $@


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://graphene.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

Currently, we build all of LTP, even though we only use the syscall tests.  On a 5.7 kernel, some the test cases we don't use also do not build.

The simple answer is to be more targeted in our makefile, and not build code that is neither ours nor code we particularly care about.

## How to test this PR? <!-- (if applicable) -->

Just run the CI pipeline.  Or build and run LTP manually

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1608)
<!-- Reviewable:end -->
