### PR TITLE
[LibOS] Hide arguments from host OS and send them in checkpoint

### DIFF
--- a/LibOS/shim/include/arch/x86_64/shim_internal-arch.h
+++ b/LibOS/shim/include/arch/x86_64/shim_internal-arch.h
@@ -26,14 +26,14 @@ static_always_inline void* current_stack(void) {
     return _rsp;
 }
 
-#define CALL_ELF_ENTRY(ENTRY, ARGCP)     \
+#define CALL_ELF_ENTRY(ENTRY, ARGP)      \
     __asm__ volatile(                    \
         "pushq $0\r\n"                   \
         "popfq\r\n"                      \
         "movq %%rbx, %%rsp\r\n"          \
         "jmp *%%rax\r\n"                 \
         :                                \
-        : "a"(ENTRY), "b"(ARGCP), "d"(0) \
+        : "a"(ENTRY), "b"(ARGP), "d"(0)  \
         : "memory", "cc")
 
 #endif /* _SHIM_INTERNAL_ARCH_H_ */

--- a/LibOS/shim/include/shim_checkpoint.h
+++ b/LibOS/shim/include/shim_checkpoint.h
@@ -346,7 +346,6 @@ typedef int (*migrate_func_t)(struct shim_cp_store*, struct shim_thread*, struct
  *
  * \param migrate_func Migration function defined by the caller.
  * \param exec         Executable to load in the child process.
- * \param argv         Arguments passed to the child process.
  * \param thread       Main-thread handle to be migrated to the child process.
  *
  * The remaining arguments are passed into the migration function.
@@ -354,7 +353,7 @@ typedef int (*migrate_func_t)(struct shim_cp_store*, struct shim_thread*, struct
  * \return             0 on success, negative POSIX error code on failure.
  */
 int create_process_and_send_checkpoint(migrate_func_t migrate_func, struct shim_handle* exec,
-                                       const char** argv, struct shim_thread* thread, ...);
+                                       struct shim_thread* thread, ...);
 
 /*!
  * \brief Receive a checkpoint from parent process and restore state based on it.

--- a/LibOS/shim/include/shim_internal.h
+++ b/LibOS/shim/include/shim_internal.h
@@ -702,8 +702,8 @@ extern void * __code_address, * __code_address_end;
 
 unsigned long parse_int (const char * str);
 
-extern void * initial_stack;
-extern const char ** initial_envp;
+extern const char** migrated_argv;
+extern const char** migrated_envp;
 
 struct shim_handle;
 int init_brk_from_executable (struct shim_handle * exec);

--- a/LibOS/shim/include/shim_thread.h
+++ b/LibOS/shim/include/shim_thread.h
@@ -359,8 +359,7 @@ bool check_on_stack (struct shim_thread * cur_thread, void * mem)
     return (mem <= cur_thread->stack_top && mem > cur_thread->stack);
 }
 
-int init_stack (const char ** argv, const char ** envp,
-                int ** argcpp, const char *** argpp,
-                elf_auxv_t ** auxpp);
+int init_stack(const char** argv, const char** envp, const char*** out_argp,
+               elf_auxv_t** out_auxv);
 
 #endif /* _SHIM_THREAD_H_ */

--- a/LibOS/shim/include/shim_utils.h
+++ b/LibOS/shim/include/shim_utils.h
@@ -195,8 +195,7 @@ int check_elf_object(struct shim_handle* file);
 int load_elf_object(struct shim_handle* file, void* addr, size_t mapped);
 int load_elf_interp(struct shim_handle* exec);
 int free_elf_interp(void);
-noreturn void execute_elf_object(struct shim_handle* exec, int* argcp, const char** argp,
-                                 elf_auxv_t* auxp);
+noreturn void execute_elf_object(struct shim_handle* exec, void* argp, elf_auxv_t* auxp);
 int remove_loaded_libraries(void);
 
 /* gdb debugging support */

--- a/LibOS/shim/src/elf/shim_rtld.c
+++ b/LibOS/shim/src/elf/shim_rtld.c
@@ -1548,7 +1548,7 @@ noreturn void execute_elf_object(struct shim_handle* exec, void* argp, ElfW(auxv
     struct link_map* exec_map = __search_map_by_handle(exec);
     assert(exec_map);
 
-    /* at this point, stack looks like this (here stacks grow towards lower addresses):
+    /* at this point, stack looks like this:
      *
      *               +-------------------+
      *   argp +--->  |  argc             | long

--- a/LibOS/shim/src/elf/shim_rtld.c
+++ b/LibOS/shim/src/elf/shim_rtld.c
@@ -1538,9 +1538,7 @@ int register_library(const char* name, unsigned long load_address) {
     return 0;
 }
 
-noreturn void execute_elf_object(struct shim_handle* exec, int* argcp, const char** argp,
-                                 ElfW(auxv_t)* auxp) {
-    __UNUSED(argp);
+noreturn void execute_elf_object(struct shim_handle* exec, void* argp, ElfW(auxv_t)* auxp) {
     int ret = vdso_map_init();
     if (ret < 0) {
         SYS_PRINTF("Could not initialize vDSO (error code = %d)", ret);
@@ -1549,8 +1547,25 @@ noreturn void execute_elf_object(struct shim_handle* exec, int* argcp, const cha
 
     struct link_map* exec_map = __search_map_by_handle(exec);
     assert(exec_map);
-    assert(IS_ALIGNED_PTR(argcp, 16)); /* stack must be 16B-aligned */
-    assert((void*)argcp + sizeof(long) == argp || argp == NULL);
+
+    /* at this point, stack looks like this (here stacks grow towards lower addresses):
+     *
+     *               +-------------------+
+     *   argp +--->  |  argc             | long
+     *               |  ptr to argv[0]   | char*
+     *               |  ...              | char*
+     *               |  NULL             | char*
+     *               |  ptr to envp[0]   | char*
+     *               |  ...              | char*
+     *               |  NULL             | char*
+     *               |  <space for auxv> |
+     *               |  envp[0] string   |
+     *               |  ...              |
+     *               |  argv[0] string   |
+     *               |  ...              |
+     *               +-------------------+
+     */
+    assert(IS_ALIGNED_PTR(argp, 16)); /* stack must be 16B-aligned */
 
     static_assert(REQUIRED_ELF_AUXV >= 8, "not enough space on stack for auxv");
     auxp[0].a_type     = AT_PHDR;
@@ -1594,7 +1609,7 @@ noreturn void execute_elf_object(struct shim_handle* exec, int* argcp, const cha
     shim_tcb_t* tcb = shim_get_tcb();
     __enable_preempt(tcb);
 
-    CALL_ELF_ENTRY(entry, argcp);
+    CALL_ELF_ENTRY(entry, argp);
 
     while (true)
         /* nothing */;

--- a/LibOS/shim/src/sys/shim_clone.c
+++ b/LibOS/shim/src/sys/shim_clone.c
@@ -357,8 +357,7 @@ int shim_do_clone (int flags, void * user_stack_addr, int * parent_tidptr,
         add_thread(thread);
         set_as_child(self, thread);
 
-        ret = create_process_and_send_checkpoint(&migrate_fork, /*exec=*/NULL, /*argv=*/NULL,
-                                                 thread);
+        ret = create_process_and_send_checkpoint(&migrate_fork, /*exec=*/NULL, thread);
         thread->shim_tcb = NULL; /* cpu context of forked thread isn't
                                   * needed any more */
         if (parent_stack)

--- a/LibOS/shim/src/sys/shim_exec.c
+++ b/LibOS/shim/src/sys/shim_exec.c
@@ -59,17 +59,13 @@ static int close_cloexec_handle(struct shim_handle_map* map) {
 }
 
 struct execve_rtld_arg {
-    const char** new_argp;
-    int* new_argcp;
-    elf_auxv_t* new_auxp;
+    void* new_argp;       /* pointer to beginning of first stack frame (argc, argv[0], ...) */
+    elf_auxv_t* new_auxv; /* pointer inside first stack frame (auxv[0], auxv[1], ...) */
 };
 
 noreturn static void __shim_do_execve_rtld(struct execve_rtld_arg* __arg) {
     struct execve_rtld_arg arg;
     memcpy(&arg, __arg, sizeof(arg));
-    const char** new_argp = arg.new_argp;
-    int* new_argcp        = arg.new_argcp;
-    elf_auxv_t* new_auxp  = arg.new_auxp;
 
     struct shim_thread* cur_thread = get_cur_thread();
     int ret = 0;
@@ -118,7 +114,7 @@ noreturn static void __shim_do_execve_rtld(struct execve_rtld_arg* __arg) {
     cur_thread->robust_list = NULL;
 
     debug("execve: start execution\n");
-    execute_elf_object(cur_thread->exec, new_argcp, new_argp, new_auxp);
+    execute_elf_object(cur_thread->exec, arg.new_argp, arg.new_auxv);
     /* NOTREACHED */
 
 error:
@@ -142,24 +138,20 @@ static int shim_do_execve_rtld(struct shim_handle* hdl, const char** argv, const
     cur_thread->stack_red = NULL;
 
     initial_envp = NULL;
-    int new_argc = 0;
-    for (const char** a = argv; *a; a++, new_argc++)
-        ;
 
-    int* new_argcp = &new_argc;
     const char** new_argp;
-    elf_auxv_t* new_auxp;
-    if ((ret = init_stack(argv, envp, &new_argcp, &new_argp, &new_auxp)) < 0)
+    elf_auxv_t* new_auxv;
+    ret = init_stack(argv, envp, &new_argp, &new_auxv);
+    if (ret < 0)
         return ret;
 
     __disable_preempt(shim_get_tcb());  // Temporarily disable preemption during execve().
 
     struct execve_rtld_arg arg = {
-        .new_argp      = new_argp,
-        .new_argcp     = new_argcp,
-        .new_auxp      = new_auxp
+        .new_argp = new_argp,
+        .new_auxv = new_auxv
     };
-    __SWITCH_STACK(new_argcp, &__shim_do_execve_rtld, &arg);
+    __SWITCH_STACK(new_argp, &__shim_do_execve_rtld, &arg);
     return 0;
 }
 

--- a/LibOS/shim/src/sys/shim_fork.c
+++ b/LibOS/shim/src/sys/shim_fork.c
@@ -71,8 +71,7 @@ int shim_do_fork(void) {
     add_thread(new_thread);
     set_as_child(cur_thread, new_thread);
 
-    ret = create_process_and_send_checkpoint(&migrate_fork, /*exec=*/NULL, /*argv=*/NULL,
-                                             new_thread);
+    ret = create_process_and_send_checkpoint(&migrate_fork, /*exec=*/NULL, new_thread);
     if (ret < 0) {
         put_thread(new_thread);
         return ret;


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Previously, Graphene sent arguments to a child process (spawned via `execve()` syscall) in the clear. This was insecure. This PR fixes it by always spawning a new child process without arguments and then sending the arguments in the checkpoint (which is securely encrypted on Linux-SGX PAL). The new logic is the same as with environ.

This PR also refactors stack initialization on new process and on execve as a pre-requisite.

Fixes #1561.

## How to test this PR? <!-- (if applicable) -->

All tests must pass. You can manually check that `execve()` spawns a child without the arguments now.

Here is an example without this PR:
```
SGX=1 strace -s 256 -ff ./pal_loader ./exec 2>&1 | tee log
# vim log
...
[pid 20115] execve("/home/dimakuv/graphene/Pal/src/../../Runtime/pal-Linux-SGX", 
  ["/home/dimakuv/graphene/Pal/src/../../Runtime/pal-Linux-SGX", 
  "child", "18", "./exec_victim", "3"], ...
# oops, args in the clear!
```

With this PR:
```
SGX=1 strace -s 256 -ff ./pal_loader ./exec 2>&1 | tee log
# vim log
...
[pid 14314] execve("/home/dimakuv/graphene/Pal/src/../../Runtime/pal-Linux-SGX", 
  ["/home/dimakuv/graphene/Pal/src/../../Runtime/pal-Linux-SGX", "child", "18"], 
  ...
# hurray, no args!
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1609)
<!-- Reviewable:end -->
