### PR TITLE
LibOS: Display missing PROT flags

### DIFF
--- a/LibOS/shim/src/shim_parser.c
+++ b/LibOS/shim/src/shim_parser.c
@@ -739,6 +739,10 @@ static void parse_mmap_prot(va_list* ap) {
         PUTS("PROT_EXEC");
     }
 
+    if (prot & PROT_SEM) {
+        PUTS("|PROT_SEM");
+    }
+
     if (prot & PROT_GROWSDOWN) {
         PUTS("|PROT_GROWSDOWN");
     }


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://graphene.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

Display missing PROT flags, such as PROT_GROWSDOWN.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1613)
<!-- Reviewable:end -->
