### PR TITLE
[LibOS] ltp: Enable lseek02 test and remove non-existing lseek* tests

### DIFF
--- a/LibOS/shim/test/ltp/ltp-sgx.cfg
+++ b/LibOS/shim/test/ltp/ltp-sgx.cfg
@@ -1523,9 +1523,6 @@ skip = yes
 [llseek01]
 skip = yes
 
-[llseek02]
-skip = yes
-
 [llseek03]
 skip = yes
 
@@ -1535,17 +1532,7 @@ skip = yes
 [lseek01]
 skip = yes
 
-[lseek02]
-skip = yes
-timeout = 60
-
 [lseek07]
-skip = yes
-
-[lseek08]
-skip = yes
-
-[lseek10]
 skip = yes
 
 [lseek11]

--- a/LibOS/shim/test/ltp/ltp.cfg
+++ b/LibOS/shim/test/ltp/ltp.cfg
@@ -1216,13 +1216,6 @@ skip = yes
 [lremovexattr01]
 skip = yes
 
-[lseek02]
-skip = yes
-timeout = 40
-
-[lseek10]
-skip = yes
-
 [lseek11]
 skip = yes
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

This PR simply enables now-working `lseek02` test. It also removes mentions of non-existing tests.

Closes #1027.

## How to test this PR? <!-- (if applicable) -->

LTP must pass.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1614)
<!-- Reviewable:end -->
