### PR TITLE
portable bash shebangs

### DIFF
--- a/Scripts/clean-check
+++ b/Scripts/clean-check
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eu -o pipefail
 

--- a/Scripts/clean-check-prepare
+++ b/Scripts/clean-check-prepare
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eu -o pipefail
 

--- a/Scripts/clean-check-test-copy
+++ b/Scripts/clean-check-test-copy
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eu -o pipefail
 

--- a/Scripts/download
+++ b/Scripts/download
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eu -o pipefail
 

--- a/Scripts/gitignore-test
+++ b/Scripts/gitignore-test
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eu -o pipefail
 


### PR DESCRIPTION
Unlike /usr/bin/env which is a Posix standard, there is no guarentee
that /bin/bash exists. This is the case for operating systems such
as FreeBSD, NixOS and Guix. By using /usr/bin/env we also give
the user the option to provide their own bash in a different path
by setting the $PATH environemnt variable.
Distributions usually provide their own packaging wrappers
to fixup shebangs upon installation, however those are not convienent
to use when developing in the source tree.

See also other upstream discussions about the topic:

- https://github.com/systemd/systemd/pull/5816

<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://graphene.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1616)
<!-- Reviewable:end -->
