### PR TITLE
PAL: Compile DkSegmentRegister only on x86_64 and adapt test case

### DIFF
--- a/Pal/regression/Makefile
+++ b/Pal/regression/Makefile
@@ -17,7 +17,6 @@ executables = \
 	..Bootstrap \
 	AtomicMath \
 	AttestationReport \
-	AvxDisable \
 	avl_tree_test \
 	Bootstrap \
 	Bootstrap2 \
@@ -26,8 +25,6 @@ executables = \
 	Directory \
 	Event \
 	Event2 \
-	Exception \
-	Exception2 \
 	Exit \
 	Failure \
 	File \
@@ -42,7 +39,6 @@ executables = \
 	Process2 \
 	Process3 \
 	Process4 \
-	Segment \
 	Select \
 	Semaphore \
 	SendHandle \
@@ -50,12 +46,20 @@ executables = \
 	Socket \
 	Symbols \
 	Tcp \
-	Thread \
 	Thread2 \
 	Udp \
 	Wait \
 	Yield \
 	normalize_path
+
+ifeq ($(ARCH),x86_64)
+executables += \
+        AvxDisable \
+        Exception \
+        Exception2 \
+        Segment \
+        Thread
+endif
 
 manifests = \
 	manifest \

--- a/Pal/regression/Symbols.c
+++ b/Pal/regression/Symbols.c
@@ -58,7 +58,9 @@ int main(int argc, char** argv, char** envp) {
     PRINT_SYMBOL(DkSystemTimeQuery);
     PRINT_SYMBOL(DkRandomBitsRead);
     PRINT_SYMBOL(DkInstructionCacheFlush);
+#if defined(__x86_64__)
     PRINT_SYMBOL(DkSegmentRegister);
+#endif
     PRINT_SYMBOL(DkMemoryAvailableQuota);
 
     return 0;

--- a/Pal/regression/test_pal.py
+++ b/Pal/regression/test_pal.py
@@ -14,6 +14,7 @@ import unittest
 
 from regression import (
     HAS_SGX,
+    ON_X86,
     RegressionTestCase,
     expectedFailureIf,
 )
@@ -293,9 +294,10 @@ class TC_02_Symbols(RegressionTestCase):
         'DkSystemTimeQuery',
         'DkRandomBitsRead',
         'DkInstructionCacheFlush',
-        'DkSegmentRegister',
         'DkMemoryAvailableQuota',
     ]
+    if ON_X86:
+        ALL_SYMBOLS.append('DkSegmentRegister')
 
     def test_000_symbols(self):
         _, stderr = self.run_binary(['Symbols'])

--- a/Pal/regression/test_pal.py
+++ b/Pal/regression/test_pal.py
@@ -55,6 +55,7 @@ class TC_00_BasicSet2(RegressionTestCase):
         self.assertIn('In thread 1', stderr)
         self.assertIn('Success, leave main thread', stderr)
 
+    @unittest.skipUnless(ON_X86, "x86-specific")
     def test_Exception2(self):
         _, stderr = self.run_binary(['Exception2'])
         self.assertIn('Enter Main Thread', stderr)
@@ -89,6 +90,7 @@ class TC_00_BasicSet2(RegressionTestCase):
         for i in range(100):
             self.assertIn('In process: Process4 %d ' % i, stderr)
 
+    @unittest.skipUnless(ON_X86, "x86-specific")
     def test_Segment(self):
         _, stderr = self.run_binary(['Segment'])
         self.assertIn('TLS = 0x', stderr)
@@ -323,6 +325,7 @@ class TC_10_Exception(RegressionTestCase):
             return False
         return True
 
+    @unittest.skipUnless(ON_X86, "x86-specific")
     def test_000_exception(self):
         _, stderr = self.run_binary(['Exception'])
 
@@ -570,6 +573,7 @@ class TC_20_SingleProcess(RegressionTestCase):
         self.assertIn('UDP Write 4 OK', stderr)
         self.assertIn('UDP Read 4: Hello World 2', stderr)
 
+    @unittest.skipUnless(ON_X86, "x86-specific")
     def test_500_thread(self):
         _, stderr = self.run_binary(['Thread'])
 

--- a/Pal/src/db_misc.c
+++ b/Pal/src/db_misc.c
@@ -27,6 +27,7 @@ PAL_NUM DkRandomBitsRead(PAL_PTR buffer, PAL_NUM size) {
     LEAVE_PAL_CALL_RETURN(ret);
 }
 
+#if defined(__x86_64__)
 PAL_PTR DkSegmentRegister(PAL_FLG reg, PAL_PTR addr) {
     ENTER_PAL_CALL(DkSegmentRegister);
     void* seg_addr = (void*)addr;
@@ -45,6 +46,7 @@ PAL_PTR DkSegmentRegister(PAL_FLG reg, PAL_PTR addr) {
 
     LEAVE_PAL_CALL_RETURN((PAL_PTR)seg_addr);
 }
+#endif
 
 PAL_BOL DkInstructionCacheFlush(PAL_PTR addr, PAL_NUM size) {
     ENTER_PAL_CALL(DkInstructionCacheFlush);

--- a/Scripts/regression.py
+++ b/Scripts/regression.py
@@ -6,6 +6,7 @@ import subprocess
 import unittest
 
 HAS_SGX = os.environ.get('SGX') == '1'
+ON_X86 = os.uname().machine in ['x86_64']
 
 def expectedFailureIf(predicate):
     if predicate:


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://graphene.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

Compile the DkSegmentRegister function only on x86_64 and adapt a test case looking for this symbol.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1619)
<!-- Reviewable:end -->
