### PR TITLE
[SGX] The gsgx.h header is not needed in db_misc

### DIFF
--- a/Pal/src/host/Linux-SGX/db_misc.c
+++ b/Pal/src/host/Linux-SGX/db_misc.c
@@ -11,7 +11,6 @@
 #include <linux/time.h>
 
 #include "api.h"
-#include "gsgx.h"
 #include "pal.h"
 #include "pal_debug.h"
 #include "pal_defs.h"
@@ -20,6 +19,12 @@
 #include "pal_linux.h"
 #include "pal_linux_defs.h"
 #include "pal_security.h"
+/* sgx.h is required to define SGX_DCAP,
+ * and doesn't have a definition for __packed */
+#ifndef __packed
+#define __packed __attribute__((packed))
+#endif
+#include "sgx.h"
 #include "sgx_api.h"
 #include "sgx_attest.h"
 


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://graphene.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

The gsgx.h header is not actually needed to compile db_misc.c under SGX.  Remove this requirement,
pruning needless dependencies on the gsgx driver.

## How to test this PR? <!-- (if applicable) -->

Build graphene for SGX

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1620)
<!-- Reviewable:end -->
