### PR TITLE
[Pal/Linux-SGX] Optimize the system time function using TSC cycles

### DIFF
--- a/Pal/include/arch/x86_64/cpu.h
+++ b/Pal/include/arch/x86_64/cpu.h
@@ -3,6 +3,8 @@
 #ifndef CPU_H
 #define CPU_H
 
+#include <stdint.h>
+
 static inline void cpu_pause(void) {
     __asm__ volatile("pause");
 }
@@ -27,6 +29,12 @@ static inline void cpuid(unsigned int leaf, unsigned int subleaf, unsigned int w
                "c" (subleaf));
 }
 
+
+static inline uint64_t get_tsc(void) {
+    unsigned long lo, hi;
+    __asm__ volatile("rdtsc" : "=a" (lo), "=d" (hi));
+    return lo | ((uint64_t)hi << 32);
+}
 
 #define CPU_RELAX() __asm__ __volatile__("rep; nop" ::: "memory")
 

--- a/Pal/src/db_misc.c
+++ b/Pal/src/db_misc.c
@@ -15,8 +15,14 @@
 
 PAL_NUM DkSystemTimeQuery(void) {
     ENTER_PAL_CALL(DkSystemTimeQuery);
-    unsigned long time = _DkSystemTimeQuery();
-    return time;
+    uint64_t time;
+    int ret = _DkSystemTimeQuery(&time);
+    if (ret < 0) {
+        _DkRaiseFailure(-ret);
+        // TODO: Fix this interface to allow returning errors.
+        time = 0;
+    }
+    LEAVE_PAL_CALL_RETURN(time);
 }
 
 PAL_NUM DkRandomBitsRead(PAL_PTR buffer, PAL_NUM size) {

--- a/Pal/src/host/Linux-SGX/db_exception.c
+++ b/Pal/src/host/Linux-SGX/db_exception.c
@@ -116,8 +116,13 @@ static void emulate_rdtsc_and_print_warning(sgx_cpu_context_t* uc) {
                        "gettime() syscall.\n");
     }
 
+    uint64_t usec;
+    int res = _DkSystemTimeQuery(&usec);
+    if (res < 0) {
+        SGX_DBG(DBG_E, "_DkSystemTimeQuery() failed in unrecoverable context, exiting.\n");
+        _DkProcessExit(1);
+    }
     /* FIXME: Ideally, we would like to scale microseconds back to RDTSC clock cycles */
-    uint64_t usec = _DkSystemTimeQuery();
     uc->rdx = (uint32_t)(usec >> 32);
     uc->rax = (uint32_t)usec;
 }

--- a/Pal/src/host/Linux-SGX/db_main-x86_64.c
+++ b/Pal/src/host/Linux-SGX/db_main-x86_64.c
@@ -30,6 +30,9 @@
 #define BIT_EXTRACT_LE(value, start, after) \
     (((unsigned long)(value) & RIGHTMASK(after)) >> start)
 
+#define CPUID_LEAF_INVARIANT_TSC 0x80000007
+#define CPUID_LEAF_TSC_FREQ 0x15
+
 static char* cpu_flags[] = {
     "fpu",    // "x87 FPU on chip"
     "vme",    // "virtual-8086 mode enhancement"
@@ -89,6 +92,28 @@ static double get_bogomips(void) {
     buf[len] = 0;
 
     return sanitize_bogomips_value(get_bogomips_from_cpuinfo_buf(buf));
+}
+
+bool is_tsc_usable(void) {
+    uint32_t words[PAL_CPUID_WORD_NUM];
+
+    _DkCpuIdRetrieve(CPUID_LEAF_INVARIANT_TSC, 0, words);
+    return words[PAL_CPUID_WORD_EDX] & 1 << 8;
+}
+
+uint64_t get_tsc_hz(void) {
+    uint32_t words[PAL_CPUID_WORD_NUM];
+    uint64_t crys_hz;
+
+    _DkCpuIdRetrieve(CPUID_LEAF_TSC_FREQ, 0, words);
+    if (words[PAL_CPUID_WORD_EBX] > 0 && words[PAL_CPUID_WORD_EAX] > 0) {
+        /* nominal frequency of the core crystal clock in kHz */
+        crys_hz = words[PAL_CPUID_WORD_ECX];
+        if (crys_hz > 0) {
+            return crys_hz * words[PAL_CPUID_WORD_EBX] / words[PAL_CPUID_WORD_EAX];
+        }
+    }
+    return 0;
 }
 
 int _DkGetCPUInfo (PAL_CPU_INFO* ci) {

--- a/Pal/src/host/Linux-SGX/enclave_ocalls.c
+++ b/Pal/src/host/Linux-SGX/enclave_ocalls.c
@@ -1233,10 +1233,9 @@ int ocall_shutdown (int sockfd, int how)
     return retval;
 }
 
-int ocall_gettime (unsigned long * microsec)
-{
+int ocall_gettime(uint64_t* microsec) {
     int retval = 0;
-    ms_ocall_gettime_t * ms;
+    ms_ocall_gettime_t* ms;
 
     void* old_ustack = sgx_prepare_ustack();
     ms = sgx_alloc_on_ustack_aligned(sizeof(*ms), alignof(*ms));

--- a/Pal/src/host/Linux-SGX/enclave_ocalls.h
+++ b/Pal/src/host/Linux-SGX/enclave_ocalls.h
@@ -75,7 +75,7 @@ int ocall_create_process(const char* uri, int nargs, const char** args, int* str
 
 int ocall_futex(uint32_t *uaddr, int op, int val, int64_t timeout_us);
 
-int ocall_gettime (unsigned long * microsec);
+int ocall_gettime(uint64_t* microsec);
 
 int ocall_sleep (unsigned long * microsec);
 

--- a/Pal/src/host/Linux-SGX/ocall_types.h
+++ b/Pal/src/host/Linux-SGX/ocall_types.h
@@ -243,7 +243,7 @@ typedef struct {
 } ms_ocall_shutdown_t;
 
 typedef struct {
-    unsigned long ms_microsec;
+    uint64_t ms_microsec;
 } ms_ocall_gettime_t;
 
 typedef struct {

--- a/Pal/src/host/Linux-SGX/pal_linux.h
+++ b/Pal/src/host/Linux-SGX/pal_linux.h
@@ -111,6 +111,10 @@ void _DkHandleExternalEvent(PAL_NUM event, sgx_cpu_context_t* uc, PAL_XREGS_STAT
 int init_trusted_files (void);
 void init_cpuid(void);
 
+bool is_tsc_usable(void);
+uint64_t get_tsc_hz(void);
+void init_tsc(void);
+
 /* Function: load_trusted_file
  * checks if the file to be opened is trusted or allowed,
  * according to the setting in manifest

--- a/Pal/src/host/Linux-SGX/sgx_enclave.c
+++ b/Pal/src/host/Linux-SGX/sgx_enclave.c
@@ -569,7 +569,7 @@ static long sgx_ocall_gettime(void * pms)
     ODEBUG(OCALL_GETTIME, ms);
     struct timeval tv;
     INLINE_SYSCALL(gettimeofday, 2, &tv, NULL);
-    ms->ms_microsec = tv.tv_sec * 1000000UL + tv.tv_usec;
+    ms->ms_microsec = tv.tv_sec * (uint64_t)1000000 + tv.tv_usec;
     return 0;
 }
 

--- a/Pal/src/host/Linux/db_misc.c
+++ b/Pal/src/host/Linux/db_misc.c
@@ -49,7 +49,7 @@ unsigned long _DkSystemTimeQueryEarly(void) {
 #endif
 }
 
-unsigned long _DkSystemTimeQuery(void) {
+int _DkSystemTimeQuery(uint64_t* out_usec) {
 #if USE_CLOCK_GETTIME == 1
     struct timespec time;
     int ret;
@@ -64,12 +64,12 @@ unsigned long _DkSystemTimeQuery(void) {
     }
 #endif
 
-    /* Come on, gettimeofday mostly never fails */
     if (IS_ERR(ret))
-        return 0;
+        return ret;
 
     /* in microseconds */
-    return 1000000ULL * time.tv_sec + time.tv_nsec / 1000;
+    *out_usec = 1000000 * (uint64_t)time.tv_sec + time.tv_nsec / 1000;
+    return 0;
 #else
     struct timeval time;
     int ret;
@@ -88,12 +88,12 @@ unsigned long _DkSystemTimeQuery(void) {
     }
 #endif
 
-    /* Come on, gettimeofday mostly never fails */
     if (IS_ERR(ret))
-        return 0;
+        return ret;
 
     /* in microseconds */
-    return 1000000ULL * time.tv_sec + time.tv_usec;
+    *out_usec = 1000000 * (uint64_t)time.tv_sec + time.tv_usec;
+    return 0;
 #endif
 }
 

--- a/Pal/src/host/Skeleton/db_misc.c
+++ b/Pal/src/host/Skeleton/db_misc.c
@@ -26,8 +26,8 @@ bool _DkInternalIsLocked(PAL_LOCK* lock) {
     __abort();
 }
 
-unsigned long _DkSystemTimeQuery(void) {
-    return 0;
+int _DkSystemTimeQuery(uint64_t* out_usec) {
+    return -PAL_ERROR_NOTIMPLEMENTED;
 }
 
 size_t _DkRandomBitsRead(void* buffer, size_t size) {

--- a/Pal/src/pal_internal.h
+++ b/Pal/src/pal_internal.h
@@ -279,7 +279,7 @@ void _DkExceptionReturn (void * event);
 void _DkInternalLock(PAL_LOCK* mut);
 void _DkInternalUnlock(PAL_LOCK* mut);
 bool _DkInternalIsLocked(PAL_LOCK* mut);
-unsigned long _DkSystemTimeQuery (void);
+int _DkSystemTimeQuery(uint64_t* out_usec);
 
 /*
  * Cryptographically secure random.


### PR DESCRIPTION
## Description of the changes 
This patch optimizes the function _DkSystemTimeQuery()
by using RDTSC instead of gettimeofday ocall/syscall.
This optimization won't take effect if there is no reliable
TSC source available to use i.e. nonstop TSC.
The TSC drift has been bound by resetting baseline timestamp
and tsc cycle aligned with system clock periodically.

Fixes #1598 

## How to test this PR? 
the existing time related test cases

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1621)
<!-- Reviewable:end -->
