### PR TITLE
[Pal/Linux-SGX] Enable TCS.FLAGS.DBGOPTIN for HW perf monitoring

### DIFF
--- a/Documentation/manifest-syntax.rst
+++ b/Documentation/manifest-syntax.rst
@@ -369,16 +369,26 @@ EPID based attestation, ``ra_client_linkable`` and ``ra_client_spid`` must
 be additionally specified (linkable/unlinkable mode and SPID of the client
 respectively).
 
-Printing per-thread and process-wide SGX stats
+Enabling per-thread and process-wide SGX stats
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 ::
 
-    sgx.print_stats=[1|0]
+    sgx.enable_stats=[1|0]
     (Default: 0)
 
-This syntax specifies whether to print SGX enclave-specific statistics. The
-currently supported stats are: number of EENTERs (corresponds to ECALLs plus
-returns from OCALLs), number of EEXITs (corresponds to OCALLs plus returns from
-ECALLs) and number of AEXs (corresponds to interrupts/exceptions/signals during
-enclave execution). Set it to ``1`` to print per-thread and per-process stats.
+This syntax specifies whether to enable SGX enclave-specific statistics:
+
+#. ``TCS.FLAGS.DBGOPTIN`` flag. This flag is set in all enclave threads and
+   enables certain debug and profiling features with enclaves, including
+   breakpoints, performance counters, Intel PT, etc.
+
+#. Printing the stats on SGX-specific events. Currently supported stats are:
+   number of EENTERs (corresponds to ECALLs plus returns from OCALLs), number
+   of EEXITs (corresponds to OCALLs plus returns from ECALLs) and number of
+   AEXs (corresponds to interrupts/exceptions/signals during enclave
+   execution). Prints per-thread and per-process stats.
+
+*Note:* this option is insecure and cannot be used with production enclaves
+(``sgx.debug = 0``). If the production enclave is started with this option set,
+Graphene will fail initialization of the enclave.

--- a/LibOS/shim/test/regression/multi_pthread.manifest.template
+++ b/LibOS/shim/test/regression/multi_pthread.manifest.template
@@ -16,4 +16,4 @@ sgx.trusted_files.libpthread = file:../../../../Runtime/libpthread.so.0
 sgx.thread_num = 8
 
 sgx.static_address = 1
-sgx.print_stats = 1
+sgx.enable_stats = 1

--- a/LibOS/shim/test/regression/multi_pthread_exitless.manifest.template
+++ b/LibOS/shim/test/regression/multi_pthread_exitless.manifest.template
@@ -19,4 +19,4 @@ sgx.thread_num = 8
 sgx.rpc_thread_num = 8
 
 sgx.static_address = 1
-sgx.print_stats = 1
+sgx.enable_stats = 1

--- a/Pal/regression/Thread2.manifest.template
+++ b/Pal/regression/Thread2.manifest.template
@@ -1,4 +1,4 @@
 loader.argv0_override = Thread2
 
 sgx.thread_num = 2
-sgx.print_stats = 1
+sgx.enable_stats = 1

--- a/Pal/regression/Thread2_exitless.manifest.template
+++ b/Pal/regression/Thread2_exitless.manifest.template
@@ -3,4 +3,4 @@ loader.argv0_override = Thread2
 
 sgx.thread_num = 2
 sgx.rpc_thread_num = 2
-sgx.print_stats = 1
+sgx.enable_stats = 1

--- a/Pal/src/host/Linux-SGX/sgx_thread.c
+++ b/Pal/src/host/Linux-SGX/sgx_thread.c
@@ -22,14 +22,14 @@ static sgx_arch_tcs_t * enclave_tcs;
 static int enclave_thread_num;
 static struct thread_map * enclave_thread_map;
 
-bool g_sgx_print_stats = false;
+bool g_sgx_enable_stats = false;
 
 void update_and_print_stats(bool process_wide) {
     static atomic_ulong g_eenter_cnt = 0;
     static atomic_ulong g_eexit_cnt  = 0;
     static atomic_ulong g_aex_cnt    = 0;
 
-    if (!g_sgx_print_stats)
+    if (!g_sgx_enable_stats)
         return;
 
     PAL_TCB_URTS* tcb = get_tcb_urts();

--- a/Pal/src/host/Linux-SGX/sgx_tls.h
+++ b/Pal/src/host/Linux-SGX/sgx_tls.h
@@ -101,7 +101,7 @@ static inline PAL_TCB_URTS* get_tcb_urts(void) {
     return tcb;
 }
 
-extern bool g_sgx_print_stats;
+extern bool g_sgx_enable_stats;
 void update_and_print_stats(bool process_wide);
 # endif
 

--- a/Pal/src/host/Linux-SGX/signer/pal_sgx_sign.py
+++ b/Pal/src/host/Linux-SGX/signer/pal_sgx_sign.py
@@ -862,8 +862,8 @@ def main_sign(args):
     if manifest.get('sgx.allow_file_creation', None) is None:
         manifest['sgx.allow_file_creation'] = '0'
 
-    if manifest.get('sgx.print_stats', None) is None:
-        manifest['sgx.print_stats'] = '0'
+    if manifest.get('sgx.enable_stats', None) is None:
+        manifest['sgx.enable_stats'] = '0'
 
     output_manifest(args['output'], manifest, manifest_layout)
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

This commit renames manifest option `sgx.print_stats` into `sgx.enable_stats` and adds enabling `TCS.FLAGS.DBGOPTIN` for all enclave threads when this manifest option is set. This allows to collect performance counters and generally enable debug and profiling features of enclaves (built in debug SGX mode).

## How to test this PR? <!-- (if applicable) -->

All tests must pass.

I modified `multi_pthread` locally to do a busy loop in threads (to have a clear distinction between no-debug-optin enclaves and debug-optin enclaves). Here are the results:
```
# sgx.enable_stats = 1
 Performance counter stats for '/home/dimakuv/graphene/Runtime/pal_loader ./multi_pthread':

    91,814,185,486      cycles                    #    4.379 GHz
     4,097,663,570      instructions              #    0.04  insn per cycle
       659,929,532      branches                  #   31.472 M/sec
       826,187,694      L1-dcache-loads           #   39.401 M/sec

# sgx.enable_stats = 0
 Performance counter stats for '/home/dimakuv/graphene/Runtime/pal_loader ./multi_pthread':

     5,938,023,681      cycles                    #    0.213 GHz
       786,472,765      instructions              #    0.13  insn per cycle
       151,632,713      branches                  #    5.446 M/sec
       198,926,392      L1-dcache-loads           #    7.144 M/sec
```

As expected, when `sgx.enable_stats` is enabled, we observe significantly more cycles, instructions, etc. This implies that perf counters indeed work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1622)
<!-- Reviewable:end -->
 