### PR TITLE
LibOS: Initialize shim->pal_context to avoid crashes

### DIFF
--- a/LibOS/shim/src/bookkeep/shim_signal.c
+++ b/LibOS/shim/src/bookkeep/shim_signal.c
@@ -849,6 +849,7 @@ int append_signal(struct shim_thread* thread, siginfo_t* info) {
     /* save in signal */
     __store_info(info, signal);
     signal->context_stored = false;
+    signal->pal_context = NULL;
 
     if (thread) {
         if (append_thread_signal(thread, signal)) {


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://graphene.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

Avoid random crashes in getcwd04 LTP test (on ppc64 at least) using
this fix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1624)
<!-- Reviewable:end -->
