### PR TITLE
[LIBOS] Speed up the project building about x[Cores] times.

### DIFF
--- a/LibOS/Makefile
+++ b/LibOS/Makefile
@@ -49,7 +49,7 @@ ifeq ($(findstring x86_64,$(SYS))$(findstring linux,$(SYS)),x86_64linux)
 
 $(BUILD_DIR)/Build.success: $(BUILD_DIR)/Makefile
 	@echo "Building glibc, may take a while to finish. Warning messages may show up. If this process terminates with failures, see \"$(BUILD_DIR)/build.log\" for more information."
-	($(MAKE) -C $(BUILD_DIR) 2>&1 >> build.log) && touch $@
+	(PARALLELMFLAGS="-j" $(MAKE) -C $(BUILD_DIR) 2>&1 >> build.log) && touch $@
 
 $(GLIBC_TARGET): $(BUILD_DIR)/Build.success
 


### PR DESCRIPTION
## Description of the changes 
This patch added flags to make command to speed up
the compilation of glibc buid. it automatically
detects the core number, it significant shorten
the compilation time.
related to issue:
https://github.com/oscarlab/graphene/issues/1626

## How to test this PR? <!-- (if applicable) -->
time make

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1627)
<!-- Reviewable:end -->
