### PR TITLE
[Pal] add AT_HWCAP2 to elf.h

### DIFF
--- a/Pal/include/elf/elf.h
+++ b/Pal/include/elf/elf.h
@@ -924,6 +924,8 @@ typedef struct {
 
 #define AT_RANDOM 25 /* Address of 16 random bytes.  */
 
+#define AT_HWCAP2 26 /* More machine-dependent hints about processor capabilities.  */
+
 #define AT_EXECFN 31 /* Filename of executable.  */
 
 /* Pointer to the global system page used for system calls and other


### PR DESCRIPTION
when compiling sgx_main.c this directory is preferred over glibc,
with as a result will lead to glibc's elf.h skipped during
header inclusion. Since sgx_main.c also requires AT_HWCAP2, include
it in this header.

Fixes the following bug:

```
make[3]: Entering directory '/home/joerg/git/graphene/Pal/src/host/Linux-SGX'
  gcc -MD -MP -Wall -std=c11 -Wmissing-prototypes -gdwarf-2 -g3 -DDEBUG -fPIC -maes -Wp,-U_FORTIFY_SOURCE -fno-stack-protector -fno-builtin -Wtrampolines -Wextra -Wnull-dereference -DCRYPTO_USE_MBEDTLS -I. -Iinclude -I../.. -I../../../include -I../../../include/pal -I../../../include/arch/x86_64 -I../../../include/arch/x86_64/Linux -I../../../include/host/Linux-SGX -I../../../include/host/Linux-common -I../../../include/lib -I../../../lib/crypto/mbedtls/include -I../../../lib/crypto/mbedtls/crypto/include -Isgx-driver -DIN_PAL -DPAL_DIR=/home/joerg/git/graphene/Pal/src -DRUNTIME_DIR=/home/joerg/git/graphene/Pal/src/../../Runtime  -c -o sgx_main.o sgx_main.c
HARDENING: disabled flags: pie
HARDENING: Is active (not completely disabled with "all" flag)
HARDENING: enabling fortify
HARDENING: enabling stackprotector
HARDENING: enabling strictoverflow
HARDENING: enabling format
HARDENING: enabling pic
extra flags before to /nix/store/lh2sslfz4l6mac9xgwyy155hq3ab8y8x-gcc-9.3.0/bin/gcc:
  -O2
  -D_FORTIFY_SOURCE=2
  -fstack-protector-strong
  --param
  ssp-buffer-size=4
  -fno-strict-overflow
  -Wformat
  -Wformat-security
  -Werror=format-security
  -fPIC
original flags to /nix/store/lh2sslfz4l6mac9xgwyy155hq3ab8y8x-gcc-9.3.0/bin/gcc:
  -MD
  -MP
  -Wall
  -std=c11
  -Wmissing-prototypes
  -gdwarf-2
  -g3
  -DDEBUG
  -fPIC
  -maes
  -Wp\,-U_FORTIFY_SOURCE
  -fno-stack-protector
  -fno-builtin
  -Wtrampolines
  -Wextra
  -Wnull-dereference
  -DCRYPTO_USE_MBEDTLS
  -I.
  -Iinclude
  -I../..
  -I../../../include
  -I../../../include/pal
  -I../../../include/arch/x86_64
  -I../../../include/arch/x86_64/Linux
  -I../../../include/host/Linux-SGX
  -I../../../include/host/Linux-common
  -I../../../include/lib
  -I../../../lib/crypto/mbedtls/include
  -I../../../lib/crypto/mbedtls/crypto/include
  -Isgx-driver
  -DIN_PAL
  -DPAL_DIR=/home/joerg/git/graphene/Pal/src
  -DRUNTIME_DIR=/home/joerg/git/graphene/Pal/src/../../Runtime
  -c
  -o
  sgx_main.o
  sgx_main.c
extra flags after to /nix/store/lh2sslfz4l6mac9xgwyy155hq3ab8y8x-gcc-9.3.0/bin/gcc:
  -B/nix/store/z42y868c19lsxl4pnhdpyyc9s490nys0-gcc-9.3.0-lib/lib
  -B/nix/store/c2rlh7xa8fcgg7qz8pl76ipvvb172c6k-glibc-2.30/lib/
  -idirafter
  /nix/store/al9wk2c1l2j6fdpclj4k9cnxyc4i0k3b-glibc-2.30-dev/include
  -idirafter
  /nix/store/lh2sslfz4l6mac9xgwyy155hq3ab8y8x-gcc-9.3.0/lib/gcc/x86_64-unknown-linux-gnu/9.3.0/include-fixed
  -B/nix/store/v1hcd1cswjgd11gan4czq7hada69iqkq-gcc-wrapper-9.3.0/bin/
  -isystem
  /nix/store/jli50q24fvik6pfsnjs1jd90g3dy4p6y-python3-3.8.3/include
  -isystem
  /nix/store/7r7izda15f26z4lnvjf1alpgnv0dxmba-protobuf-3.8.0/include
  -isystem
  /nix/store/pii947kyrww379ii7hdbfbaybp7zm93g-protobuf-c-1.3.3/include
  -isystem
  /nix/store/jli50q24fvik6pfsnjs1jd90g3dy4p6y-python3-3.8.3/include
  -isystem
  /nix/store/7r7izda15f26z4lnvjf1alpgnv0dxmba-protobuf-3.8.0/include
  -isystem
  /nix/store/pii947kyrww379ii7hdbfbaybp7zm93g-protobuf-c-1.3.3/include
sgx_main.c: In function ‘main’:
sgx_main.c:968:19: error: ‘AT_HWCAP2’ undeclared (first use in this function); did you mean ‘AT_HWCAP’?
  968 |     if (getauxval(AT_HWCAP2) & 0x2) {
      |                   ^~~~~~~~~
      |                   AT_HWCAP
sgx_main.c:968:19: note: each undeclared identifier is reported only once for each function it appears in
```

<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://graphene.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1632)
<!-- Reviewable:end -->
