### PR TITLE
[LibOS] Add support for PROT_GROWSDOWN

### DIFF
--- a/LibOS/shim/include/shim_flags_conv.h
+++ b/LibOS/shim/include/shim_flags_conv.h
@@ -20,7 +20,8 @@
 #include "pal.h"
 
 static inline int LINUX_PROT_TO_PAL(int prot, int map_flags) {
-    assert(WITHIN_MASK(prot, PROT_READ | PROT_WRITE | PROT_EXEC));
+    assert(WITHIN_MASK(prot, PROT_NONE | PROT_READ | PROT_WRITE | PROT_EXEC
+                                | PROT_GROWSDOWN | PROT_GROWSUP));
     return (prot & PROT_READ  ? PAL_PROT_READ  : 0) |
            (prot & PROT_WRITE ? PAL_PROT_WRITE : 0) |
            (prot & PROT_EXEC  ? PAL_PROT_EXEC  : 0) |

--- a/LibOS/shim/src/shim_init.c
+++ b/LibOS/shim/src/shim_init.c
@@ -171,7 +171,7 @@ void* allocate_stack(size_t size, size_t protect_size, bool user) {
     size = ALLOC_ALIGN_UP(size);
     protect_size = ALLOC_ALIGN_UP(protect_size);
 
-    int flags = MAP_PRIVATE | MAP_ANONYMOUS | (user ? 0 : VMA_INTERNAL);
+    int flags = MAP_PRIVATE | MAP_ANONYMOUS | (user ? 0 : VMA_INTERNAL) | MAP_GROWSDOWN;
 
     if (user) {
         /* reserve non-readable non-writable page below the user stack to catch stack overflows */

--- a/LibOS/shim/src/shim_parser.c
+++ b/LibOS/shim/src/shim_parser.c
@@ -715,9 +715,9 @@ static void parse_mmap_prot(va_list* ap) {
     int prot   = va_arg(*ap, int);
     int nflags = 0;
 
-    if (prot == PROT_NONE) {
+    if (!(prot & (PROT_READ | PROT_WRITE | PROT_EXEC))) {
+        nflags++;
         PUTS("PROT_NONE");
-        return;
     }
 
     if (prot & PROT_READ) {
@@ -738,17 +738,27 @@ static void parse_mmap_prot(va_list* ap) {
 
         PUTS("PROT_EXEC");
     }
+
+    if (prot & PROT_GROWSDOWN) {
+        PUTS("|PROT_GROWSDOWN");
+    }
+
+    if (prot & PROT_GROWSUP) {
+        PUTS("|PROT_GROWSUP");
+    }
 }
 
 static void parse_mmap_flags(va_list* ap) {
     int flags = va_arg(*ap, int);
 
-    if (flags & MAP_SHARED) {
+    if (flags & MAP_SHARED_VALIDATE) {
+        PUTS("MAP_SHARED_VALIDATE");
+        flags &= ~MAP_SHARED_VALIDATE;
+    } else if (flags & MAP_SHARED) {
         PUTS("MAP_SHARED");
         flags &= ~MAP_SHARED;
-    }
-
-    if (flags & MAP_PRIVATE) {
+    } else {
+        assert(flags & MAP_PRIVATE);
         PUTS("MAP_PRIVATE");
         flags &= ~MAP_PRIVATE;
     }
@@ -766,6 +776,11 @@ static void parse_mmap_flags(va_list* ap) {
     if (flags & MAP_FIXED) {
         PUTS("|MAP_FIXED");
         flags &= ~MAP_FIXED;
+    }
+
+    if (flags & MAP_GROWSDOWN) {
+        PUTS("|MAP_GROWSDOWN");
+        flags &= ~MAP_GROWSDOWN;
     }
 
 #ifdef CONFIG_MMAP_ALLOW_UNINITIALIZED

--- a/LibOS/shim/test/regression/.gitignore
+++ b/LibOS/shim/test/regression/.gitignore
@@ -45,6 +45,7 @@
 /mkfifo
 /mmap_file
 /mprotect_file_fork
+/mprotect_prot_growsdown
 /multi_pthread
 /openmp
 /pipe

--- a/LibOS/shim/test/regression/Makefile
+++ b/LibOS/shim/test/regression/Makefile
@@ -36,6 +36,7 @@ c_executables = \
 	mkfifo \
 	mmap_file \
 	mprotect_file_fork \
+	mprotect_prot_growsdown \
 	multi_pthread \
 	openmp \
 	pipe \

--- a/LibOS/shim/test/regression/mprotect_prot_growsdown.c
+++ b/LibOS/shim/test/regression/mprotect_prot_growsdown.c
@@ -1,0 +1,52 @@
+#define _GNU_SOURCE
+#include <err.h>
+#include <errno.h>
+#include <stdio.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+int main(void) {
+    errno = 0;
+    long page_size = sysconf(_SC_PAGESIZE);
+    if (page_size == -1 && errno) {
+        err(1, "sysconf");
+    }
+
+    char* ptr = mmap(NULL, 3 * page_size, PROT_READ, MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
+    if (ptr == MAP_FAILED) {
+        err(1, "mmap");
+    }
+
+    int x = mprotect(ptr + page_size, page_size, PROT_READ | PROT_WRITE | PROT_GROWSDOWN);
+    if (x >= 0) {
+        printf("mprotect succeeded unexpectedly!\n");
+        return 1;
+    }
+    if (errno != EINVAL) {
+        printf("Wrong errno value: %d\n", errno);
+        return 1;
+    }
+
+    if (munmap(ptr, 3 * page_size) < 0) {
+        err(1, "munmap");
+    }
+
+    ptr = mmap(NULL, 3 * page_size, PROT_READ, MAP_ANONYMOUS | MAP_PRIVATE | MAP_GROWSDOWN, -1, 0);
+    if (ptr == MAP_FAILED) {
+        err(1, "mmap");
+    }
+
+    if (mprotect(ptr + page_size, page_size, PROT_READ | PROT_WRITE | PROT_GROWSDOWN) < 0) {
+        err(1, "mprotect");
+    }
+
+    *(volatile char*)ptr = 'a';
+
+    if (*(volatile char*)ptr != 'a') {
+        printf("Value was not written to memory!\n");
+        return 1;
+    }
+
+    puts("TEST OK");
+    return 0;
+}

--- a/LibOS/shim/test/regression/test_libos.py
+++ b/LibOS/shim/test/regression/test_libos.py
@@ -381,6 +381,11 @@ class TC_30_Syscall(RegressionTestCase):
 
         self.assertIn('Test successful!', stdout)
 
+    def test_054_mprotect_prot_growsdown(self):
+        stdout, _ = self.run_binary(['mprotect_prot_growsdown'])
+
+        self.assertIn('TEST OK', stdout)
+
     @unittest.skip('sigaltstack isn\'t correctly implemented')
     def test_060_sigaltstack(self):
         stdout, _ = self.run_binary(['sigaltstack'])


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://graphene.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->
This PR adds support for `PROT_GROWSDOWN` to `mprotect`. Not this does not implement `MAP_GROWSDOWN` itself, i.e. memory won't get automatically extended.

Closes #1615
Fixes #1612

## How to test this PR? <!-- (if applicable) -->
New test added.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1636)
<!-- Reviewable:end -->
