### PR TITLE
[Pal] don't depend on absolute PATH for tools

### DIFF
--- a/Runtime/pal_loader
+++ b/Runtime/pal_loader
@@ -17,9 +17,9 @@ do
 	shift
 done
 
-RUNTIME_DIR=$(/usr/bin/dirname "$(readlink -f "${BASH_SOURCE[0]}")")
+RUNTIME_DIR=$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")
 if [ -z "$PAL_HOST" ]; then
-    if [ ! -f /usr/bin/make ]; then
+    if ! command -v make >/dev/null; then
         libpal="$RUNTIME_DIR/libpal-*.so"
         libpal="$(echo -n "$libpal")"
         libpal="${libpal//$RUNTIME_DIR\//}"
@@ -37,7 +37,7 @@ if [ -z "$PAL_HOST" ]; then
         PAL_HOST="${libpal%.so}"
         PAL_HOST="${PAL_HOST#libpal-}"
     else
-        PAL_HOST=$(/usr/bin/make --no-print-directory --quiet -f "$RUNTIME_DIR/../Scripts/Makefile.configs" print_host 2>&1)
+        PAL_HOST=$(make --no-print-directory --quiet -f "$RUNTIME_DIR/../Scripts/Makefile.configs" print_host 2>&1)
     fi
 fi
 
@@ -48,7 +48,7 @@ PAL_CMD=$RUNTIME_DIR/pal-$PAL_HOST
 if [ "$GDB" == "1" ]; then
 	GDB=$RUNTIME_DIR/pal_gdb-$PAL_HOST
 	if [ ! -f "$GDB" ]; then
-		GDB="/usr/bin/gdb"
+		GDB="gdb"
 	fi
 fi
 


### PR DESCRIPTION
On NixOS/Guix tools are not installed into /usr/bin but come from
are composed as symlink trees from immutable packages in the /nix/store:

  i.e. /home/joerg/.nix-profile/bin/bash -> /nix/store/hgplspyw16amnbhlbi7qa2938w8i0rz6-bash-interactive-4.4-p23/bin/bash

Due it's immutable nature they are a perfect fit for graphene-sgx since
libraries store paths won't change unlike their traditional /usr/lib
equalivalents and hence don't break code signing.

One might argue that using for absolute paths makes it possible without a PATH
set, however this is not really true, since make in this case relies on other
tools. Also the whole script relies on bash to be in PATH for it's shebang.

<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://graphene.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1638)
<!-- Reviewable:end -->
