### PR TITLE
[Pal/Linux-SGX] Lazily zero-out the heap instead of proactively on init

### DIFF
--- a/Pal/src/host/Linux-SGX/db_main.c
+++ b/Pal/src/host/Linux-SGX/db_main.c
@@ -207,23 +207,6 @@ void pal_linux_main(char* uptr_args, uint64_t args_size, char* uptr_env, uint64_
     g_pal_sec.exec_addr = GET_ENCLAVE_TLS(exec_addr);
     g_pal_sec.exec_size = GET_ENCLAVE_TLS(exec_size);
 
-    /* Zero the heap. We need to take care to not zero the exec area. */
-
-    void* zero1_start = g_pal_sec.heap_min;
-    void* zero1_end = g_pal_sec.heap_max;
-
-    void* zero2_start = g_pal_sec.heap_max;
-    void* zero2_end = g_pal_sec.heap_max;
-
-    if (g_pal_sec.exec_addr != NULL) {
-        zero1_end = MIN(zero1_end, SATURATED_P_SUB(g_pal_sec.exec_addr, MEMORY_GAP, 0));
-        zero2_start = SATURATED_P_ADD(g_pal_sec.exec_addr + g_pal_sec.exec_size, MEMORY_GAP,
-                                      zero2_end);
-    }
-
-    memset(zero1_start, 0, zero1_end - zero1_start);
-    memset(zero2_start, 0, zero2_end - zero2_start);
-
     /* relocate PAL itself */
     g_pal_map.l_addr = elf_machine_load_address();
     g_pal_map.l_name = ENCLAVE_PAL_FILENAME;

--- a/Pal/src/host/Linux-SGX/enclave_pages.c
+++ b/Pal/src/host/Linux-SGX/enclave_pages.c
@@ -163,6 +163,9 @@ static void* __create_vma_and_merge(void* addr, size_t size, bool is_pal_interna
     vma->top             = addr + size;
     vma->is_pal_internal = is_pal_internal;
 
+    /* initialize the contents of the new VMA to zero */
+    memset(vma->bottom, 0, vma->top - vma->bottom);
+
     /* how much memory was freed because [addr, addr + size) overlapped with VMAs */
     size_t freed = 0;
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Previously, Linux-SGX PAL initialized the whole heap to zero from within the enclave at startup. This led to significant slowdown on large-sized enclaves. This commit removes the old proactive logic and instead zeroes-out the heap lazily, when enclave pages are actually requested.

This does not change the security guarantees because the whole heap is anyway RWX on SGX v1, and the attacker may exploit app vulnerabilities (if any) by supplying malicious data within the enclave during runtime.

## How to test this PR? <!-- (if applicable) -->

All tests must pass. Below are some of my quick tests. Enclave sizes: 8GB for `Bootstrap6`, 2x 256MB for `fork_and_exec`, and 1GB for `Redis`.

### Using older Skylake system and non-DCAP Intel SGX driver

The CPU has 128MB of EPC. The SGX driver adds *one* page per IOCTL.

- Without this PR:
```
        Command being timed: "/home/dimakuv/graphene/Runtime/pal_loader ./Bootstrap6.manifest.sgx"
        User time (seconds): 11.79
        System time (seconds): 58.32
        Elapsed (wall clock) time (h:mm:ss or m:ss): 1:10.91
        Minor (reclaiming a frame) page faults: 2081992

        Command being timed: "./pal_loader ./fork_and_exec"
        User time (seconds): 0.51
        System time (seconds): 2.36
        Elapsed (wall clock) time (h:mm:ss or m:ss): 0:08.59
        Minor (reclaiming a frame) page faults: 66759

        Command being timed: "./pal_loader redis-server --help"
        User time (seconds): 1.51
        System time (seconds): 7.90
        Elapsed (wall clock) time (h:mm:ss or m:ss): 0:10.05
        Minor (reclaiming a frame) page faults: 252220
```

- With this PR:
```
        Command being timed: "/home/dimakuv/graphene/Runtime/pal_loader ./Bootstrap6.manifest.sgx"
        User time (seconds): 0.17
        System time (seconds): 30.13
        Elapsed (wall clock) time (h:mm:ss or m:ss): 0:31.14
        Minor (reclaiming a frame) page faults: 2265

        Command being timed: "./pal_loader ./fork_and_exec"
        User time (seconds): 0.23
        System time (seconds): 1.78
        Elapsed (wall clock) time (h:mm:ss or m:ss): 0:05.97
        Minor (reclaiming a frame) page faults: 25047

        Command being timed: "./pal_loader redis-server --help"
        User time (seconds): 0.27
        System time (seconds): 4.50
        Elapsed (wall clock) time (h:mm:ss or m:ss): 0:05.42
        Minor (reclaiming a frame) page faults: 9043
```

### Using newer Mehlow system and DCAP Intel SGX driver

The CPU has 256MB of EPC. The SGX driver (v1.33) adds *all* pages in one IOCTL.

- Without this PR:
```
        Command being timed: "/home/dimakuv/graphene/Runtime/pal_loader Bootstrap6.manifest.sgx"
        User time (seconds): 10.90
        System time (seconds): 30.83
        Elapsed (wall clock) time (h:mm:ss or m:ss): 0:41.78
        Minor (reclaiming a frame) page faults: 4180021

        Command being timed: "/home/dimakuv/graphene/Runtime/pal_loader ./fork_and_exec"
        User time (seconds): 0.32
        System time (seconds): 1.32
        Elapsed (wall clock) time (h:mm:ss or m:ss): 0:05.28
        Minor (reclaiming a frame) page faults: 125632

        Command being timed: "./pal_loader ./redis-server --help"
        User time (seconds): 1.45
        System time (seconds): 4.23
        Elapsed (wall clock) time (h:mm:ss or m:ss): 0:06.23
        Minor (reclaiming a frame) page faults: 515006
```

- With this PR:
```
	Command being timed: "/home/dimakuv/graphene/Runtime/pal_loader Bootstrap6.manifest.sgx"
        User time (seconds): 0.02
        System time (seconds): 14.62
        Elapsed (wall clock) time (h:mm:ss or m:ss): 0:14.68
        Minor (reclaiming a frame) page faults: 2098065

        Command being timed: "/home/dimakuv/graphene/Runtime/pal_loader ./fork_and_exec"
        User time (seconds): 0.18
        System time (seconds): 0.94
        Elapsed (wall clock) time (h:mm:ss or m:ss): 0:03.70
        Minor (reclaiming a frame) page faults: 77356

        Command being timed: "./pal_loader ./redis-server --help"
        User time (seconds): 0.20
        System time (seconds): 2.40
        Elapsed (wall clock) time (h:mm:ss or m:ss): 0:03.17
        Minor (reclaiming a frame) page faults: 269092
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1640)
<!-- Reviewable:end -->
