### PR TITLE
Remove always_inline where not needed

### DIFF
--- a/LibOS/shim/include/arch/x86_64/shim_internal-arch.h
+++ b/LibOS/shim/include/arch/x86_64/shim_internal-arch.h
@@ -20,12 +20,6 @@
             ::"r"(__stack_top), "r"(func), "D"(arg): "memory"); \
     } while (0)
 
-static_always_inline void* current_stack(void) {
-    void* _rsp;
-    __asm__ volatile ("movq %%rsp, %0" : "=r"(_rsp) :: "memory");
-    return _rsp;
-}
-
 #define CALL_ELF_ENTRY(ENTRY, ARGP)      \
     __asm__ volatile(                    \
         "pushq $0\r\n"                   \

--- a/LibOS/shim/include/shim_internal.h
+++ b/LibOS/shim/include/shim_internal.h
@@ -19,8 +19,6 @@
 #define EXTERN_ALIAS(name) \
     extern __typeof__(name) shim_##name __attribute ((alias (ALIAS_STR(name))))
 
-#define static_always_inline static inline __attribute__((always_inline))
-
 #include <api.h>
 #include <assert.h>
 #include <atomic.h>

--- a/LibOS/shim/include/shim_ipc.h
+++ b/LibOS/shim/include/shim_ipc.h
@@ -428,12 +428,12 @@ struct shim_ipc_info* create_ipc_info_in_list(IDTYPE vmid, const char* uri, size
 void put_ipc_info_in_list(struct shim_ipc_info* info);
 struct shim_ipc_info* lookup_ipc_info(IDTYPE vmid);
 
-static_always_inline size_t get_ipc_msg_size(size_t payload) {
+static inline size_t get_ipc_msg_size(size_t payload) {
     size_t size = sizeof(struct shim_ipc_msg) + payload;
     return (size > IPC_MSG_MINIMAL_SIZE) ? size : IPC_MSG_MINIMAL_SIZE;
 }
 
-static_always_inline size_t get_ipc_msg_duplex_size(size_t payload) {
+static inline size_t get_ipc_msg_duplex_size(size_t payload) {
     static_assert(sizeof(struct shim_ipc_msg_duplex) >= sizeof(struct shim_ipc_msg),
                   "Incorrect shim_ipc_msg_duplex size");
     return get_ipc_msg_size(payload) +

--- a/LibOS/shim/include/shim_thread.h
+++ b/LibOS/shim/include/shim_thread.h
@@ -137,10 +137,7 @@ void put_thread (struct shim_thread * thread);
 
 void debug_setprefix (shim_tcb_t * tcb);
 
-static inline
-__attribute__((always_inline))
-void debug_setbuf (shim_tcb_t * tcb, bool on_stack)
-{
+static inline __attribute__((always_inline)) void debug_setbuf(shim_tcb_t* tcb, bool on_stack) {
     if (!debug_handle)
         return;
 
@@ -150,17 +147,12 @@ void debug_setbuf (shim_tcb_t * tcb, bool on_stack)
     debug_setprefix(tcb);
 }
 
-static inline
-__attribute__((always_inline))
-struct shim_thread* get_cur_thread (void) {
+static inline struct shim_thread* get_cur_thread(void) {
     return SHIM_TCB_GET(tp);
 }
 
-static inline
-__attribute__((always_inline))
-void set_cur_thread (struct shim_thread * thread)
-{
-    shim_tcb_t * tcb = shim_get_tcb();
+static inline void set_cur_thread(struct shim_thread* thread) {
+    shim_tcb_t* tcb = shim_get_tcb();
     IDTYPE tid = 0;
 
     if (thread) {
@@ -293,19 +285,14 @@ void get_handle_map (struct shim_handle_map * map);
 void put_handle_map (struct shim_handle_map * map);
 
 /* retriving handle mapping */
-static inline __attribute__((always_inline))
-struct shim_handle_map * get_cur_handle_map (struct shim_thread * thread)
-{
+static inline struct shim_handle_map* get_cur_handle_map(struct shim_thread* thread) {
     if (!thread)
         thread = get_cur_thread();
 
     return thread ? thread->handle_map : NULL;
 }
 
-static inline __attribute__((always_inline))
-void set_handle_map (struct shim_thread * thread,
-                     struct shim_handle_map * map)
-{
+static inline void set_handle_map(struct shim_thread* thread, struct shim_handle_map* map) {
     get_handle_map(map);
 
     if (!thread)
@@ -334,30 +321,6 @@ struct shim_clone_args {
 };
 
 void * allocate_stack (size_t size, size_t protect_size, bool user);
-
-static inline __attribute__((always_inline))
-bool check_stack_size (struct shim_thread * cur_thread, int size)
-{
-    if (!cur_thread)
-        cur_thread = get_cur_thread();
-
-    void * rsp;
-    __asm__ volatile ("movq %%rsp, %0" : "=r"(rsp) :: "memory");
-
-    if (rsp <= cur_thread->stack_top && rsp > cur_thread->stack)
-        return size < rsp - cur_thread->stack;
-
-    return false;
-}
-
-static inline __attribute__((always_inline))
-bool check_on_stack (struct shim_thread * cur_thread, void * mem)
-{
-    if (!cur_thread)
-        cur_thread = get_cur_thread();
-
-    return (mem <= cur_thread->stack_top && mem > cur_thread->stack);
-}
 
 int init_stack(const char** argv, const char** envp, const char*** out_argp,
                elf_auxv_t** out_auxv);

--- a/LibOS/shim/include/shim_utils.h
+++ b/LibOS/shim/include/shim_utils.h
@@ -157,7 +157,7 @@ void free(void* mem);
 void* malloc_copy(const void* mem, size_t size);
 #endif
 
-static_always_inline char* qstrtostr(struct shim_qstr* qstr, bool on_stack) {
+static inline __attribute__((always_inline)) char* qstrtostr(struct shim_qstr* qstr, bool on_stack) {
     int len   = qstr->len;
     char* buf = on_stack ? __alloca(len + 1) : malloc(len + 1);
 

--- a/Pal/include/lib/hex.h
+++ b/Pal/include/lib/hex.h
@@ -17,13 +17,8 @@
  * size is the number of bytes pointed to by hex.
  * str is the caller-provided buffer, len is the length of the buffer.
  * The len must be at least (size * 2)+1.
- *
- * Note that it does not normalize for endianness, and pads to the
- * size the compiler things the string is.
  */
-static inline __attribute__((always_inline))
-char * __bytes2hexstr(void * hex, size_t size, char *str, size_t len)
-{
+static inline char* __bytes2hexstr(void* hex, size_t size, char* str, size_t len) {
     static const char* ch = "0123456789abcdef";
     __UNUSED(len);
     assert(len >= size * 2 + 1);
@@ -41,8 +36,7 @@ char * __bytes2hexstr(void * hex, size_t size, char *str, size_t len)
 #define IS_INDEXABLE(arg) (sizeof((arg)[0]))
 #define IS_ARRAY(arg) (IS_INDEXABLE(arg) > 0 && (((void *) &(arg)) == ((void *) (arg))))
 
-static inline __attribute__((always_inline))
-int8_t hex2dec(char c) {
+static inline int8_t hex2dec(char c) {
     if (c >= 'A' && c <= 'F')
         return c - 'A' + 10;
     else if (c >= 'a' && c <= 'f')

--- a/Pal/src/pal_internal.h
+++ b/Pal/src/pal_internal.h
@@ -325,10 +325,7 @@ void free (void * mem);
 # define __attribute_unused __attribute__((unused))
 # define __attribute_noinline __attribute__((noinline))
 #else
-# define __attribute_hidden
-# define __attribute_always_inline
-# define __attribute_unused
-# define __attribute_noinline
+# error Unsupported compiler
 #endif
 
 #define ALIAS_STR(name) #name


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

No reason to force inline in those places. There are also some functions allocating buffers on parent's stack frame (sic!) which require this, but unhacking them requires more work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1644)
<!-- Reviewable:end -->
