### PR TITLE
PAL: Fix non-x86 implementation of memcpy

### DIFF
--- a/Pal/lib/string/memcpy.c
+++ b/Pal/lib/string/memcpy.c
@@ -28,8 +28,9 @@ void* memcpy(void* restrict dst, const void* restrict src, size_t n) {
      * previous implementation taken from Glibc 2.23. */
     __asm__ volatile("rep movsb" : "+D" (d) : "c"(n), "S"(src) : "cc", "memory");
 #else
+    const char* s = src;
     for (; n; n--)
-        *d++ = *src++;
+        *d++ = *s++;
 #endif
     return dst;
 }


### PR DESCRIPTION
This patch fixes the following compile error:

string/memcpy.c: In function \u2018memcpy\u2019:
string/memcpy.c:32:16: warning: dereferencing \u2018void *\u2019 pointer
         *d++ = *src++;
                ^~~~~~
string/memcpy.c:32:14: error: void value not ignored as it ought to be
         *d++ = *src++;

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1646)
<!-- Reviewable:end -->
