### PR TITLE
[LibOS] Regression tests fixes

### DIFF
--- a/LibOS/shim/src/sys/shim_open.c
+++ b/LibOS/shim/src/sys/shim_open.c
@@ -98,9 +98,6 @@ int shim_do_open (const char * file, int flags, mode_t mode)
     if (!file || test_user_string(file))
         return -EFAULT;
 
-    if (file[0] == '\0')
-        return -EINVAL;
-
     if (!(flags & O_CREAT)) {
         /* `mode` should be ignored if O_CREAT is not specified, according to man */
         mode = 0;

--- a/LibOS/shim/test/regression/test_libos.py
+++ b/LibOS/shim/test/regression/test_libos.py
@@ -98,9 +98,10 @@ class TC_01_Bootstrap(RegressionTestCase):
             stdout)
 
     def test_201_exec_same(self):
-        args = [str(i) for i in range(50)]
+        args = ['arg_#%d' % i for i in range(50)]
         stdout, _ = self.run_binary(['exec_same'] + args, timeout=40)
-        self.assertIn('\n'.join(args), stdout)
+        for arg in args:
+            self.assertIn(arg + '\n', stdout)
 
     def test_202_fork_and_exec(self):
         stdout, _ = self.run_binary(['fork_and_exec'], timeout=60)


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

This fixes two things:
- LibOS regressions wasn't passing on Glibc 2.23 which uses `open` syscall to implement C's `open()` function. Newer Glibcs use `openat` syscall instead. Turns out our `shim_do_open` doesn't handle empty paths correctly (but `shim_do_openat` does).
- `test_201_exec_same` test was failing if the output was interleaved with debug logs. Current fix is rather a workaround until we split Graphene logs from app output.

## How to test this PR? <!-- (if applicable) -->

Run LibOS regression with glibc 2.23 (`GLIBC_VERSION=2.23` specified to `make`) and with `loader.debug_type = none` in `manifest.template`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1648)
<!-- Reviewable:end -->
