### PR TITLE
[LIBOS] Fix errlist.c error counting not matching issue

### DIFF
--- a/LibOS/glibc-patches/glibc-2.23.patch
+++ b/LibOS/glibc-patches/glibc-2.23.patch
@@ -35,6 +35,19 @@ index 7fc92ae3a278e5014b4dc1c5ccccb799cc378fdd..75811230906df19d159ca780102a656f
  
  # Since stubs.h is never needed when building the library, we simplify the
  # hairy installation process by producing it in place only as the last part
+diff --git a/Makerules b/Makerules
+index 53eabfaba82a127221089112b40a51dc5e6949ea..fcb9f92ccee70fdaf5d4acd2430668e5964d57e3 100644
+--- a/Makerules
++++ b/Makerules
+@@ -802,7 +802,7 @@ verbose	:=
+ endif						# not -s
+ 
+ ARFLAGS := r$(verbose)
+-CREATE_ARFLAGS := cru$(verbose)
++CREATE_ARFLAGS := cr$(verbose)
+ 
+ # This makes all the object files in the parent library archive.
+ 
 diff --git a/elf/Makefile b/elf/Makefile
 index 63a535502c15e32eb4f21feaefa3cbf5be6d8afa..f27aeaf665cb2d7a4c0b9a1a0d025aba6e303556 100644
 --- a/elf/Makefile
@@ -144,6 +157,21 @@ index fa3cf1da44807240b15f7e4d4da3fde43abeca0c..6cc5524eee60b6415dfc38700a7085a5
  # So far the -lutil interface is the same on all platforms, except for the
  # `struct utmp' format, which depends on libc.
  libutil=1
+diff --git a/sysdeps/gnu/errlist-compat.awk b/sysdeps/gnu/errlist-compat.awk
+index 202de93cc5b94ca161322e978ffa3b6ea8286c98..105479cce4e15b3d544ac3bdb4b8e3b4d47d2695 100644
+--- a/sysdeps/gnu/errlist-compat.awk
++++ b/sysdeps/gnu/errlist-compat.awk
+@@ -56,7 +56,9 @@ END {
+     exit 0;
+   }
+ 
+-  count = maxerr + 1;
++  # This prevents `*** errlist.c count 134 inflated to GLIBC_2.12 count 135 (old errno.h?)` warning
++  # from being generated, which happens even without our patches.
++  count = maxerr + 2;
+ 
+   if (highest < count) {
+     printf "*** errlist.c count %d vs Versions sys_errlist@%s count %d\n", \
 diff --git a/sysdeps/unix/sysv/linux/x86_64/____longjmp_chk.S b/sysdeps/unix/sysv/linux/x86_64/____longjmp_chk.S
 index fca9dc08e2470c5e31c9008d4ea4222bc75b8d37..bddf501d72a1fa3febcb77b7afc1ba1cfc390cf4 100644
 --- a/sysdeps/unix/sysv/linux/x86_64/____longjmp_chk.S
@@ -603,16 +631,3 @@ index 2b061a07c6c59575e93de08d699b7c69720faf03..e0fea4445f43dad1b812381da4afbd42
  		   : "=a" (_result)					      \
  		   : "0" ((unsigned long int) __NR_arch_prctl),		      \
  		     "D" ((unsigned long int) ARCH_SET_FS),		      \
-diff --git a/Makerules b/Makerules
-index 53eabfaba82a127221089112b40a51dc5e6949ea..fcb9f92ccee70fdaf5d4acd2430668e5964d57e3 100644
---- a/Makerules
-+++ b/Makerules
-@@ -802,7 +802,7 @@ verbose	:=
- endif						# not -s
- 
- ARFLAGS := r$(verbose)
--CREATE_ARFLAGS := cru$(verbose)
-+CREATE_ARFLAGS := cr$(verbose)
- 
- # This makes all the object files in the parent library archive.
- 

--- a/LibOS/glibc-patches/glibc-2.27.patch
+++ b/LibOS/glibc-patches/glibc-2.27.patch
@@ -35,6 +35,19 @@ index bea4e27f8db4981dbd0eb39e06b4f6297cb5179d..2a5be51298c248f71682542355eccf27
  
  # Since stubs.h is never needed when building the library, we simplify the
  # hairy installation process by producing it in place only as the last part
+diff --git a/Makerules b/Makerules
+index ef6abeac6d9dd0e9bb1aa68db7f1b64e64f9c9eb..e4872b3d632383b6d771a26cf6fbf745ce5ce06d 100644
+--- a/Makerules
++++ b/Makerules
+@@ -895,7 +895,7 @@ verbose	:=
+ endif						# not -s
+ 
+ ARFLAGS := r$(verbose)
+-CREATE_ARFLAGS := cru$(verbose)
++CREATE_ARFLAGS := cr$(verbose)
+ 
+ # This makes all the object files in the parent library archive.
+ 
 diff --git a/elf/Makefile b/elf/Makefile
 index 2a432d8beebcd207af7643af67379f0a9f527f3a..78657bce12eec7a4af6618c98fee2677e0814cde 100644
 --- a/elf/Makefile
@@ -144,6 +157,21 @@ index b9cb99d2fbb07f302aee85e6c367fe2c74d7705c..2d91a6c7f757cbc3ab9b9a77bbc649ea
  # So far the -lutil interface is the same on all platforms, except for the
  # `struct utmp' format, which depends on libc.
  libutil=1
+diff --git a/sysdeps/gnu/errlist-compat.awk b/sysdeps/gnu/errlist-compat.awk
+index ba1257ffabafdf536daee41c1d6afdf6ca61c684..1a35f4b80d9044c9a7866fffaf3ca9bb8056390e 100644
+--- a/sysdeps/gnu/errlist-compat.awk
++++ b/sysdeps/gnu/errlist-compat.awk
+@@ -56,7 +56,9 @@ END {
+     exit 0;
+   }
+ 
+-  count = maxerr + 1;
++  # This prevents `*** errlist.c count 134 inflated to GLIBC_2.12 count 135 (old errno.h?)` warning
++  # from being generated, which happens even without our patches.
++  count = maxerr + 2;
+ 
+   if (highest < count) {
+     printf "*** errlist.c count %d vs Versions sys_errlist@%s count %d\n", \
 diff --git a/sysdeps/unix/sysv/linux/x86_64/____longjmp_chk.S b/sysdeps/unix/sysv/linux/x86_64/____longjmp_chk.S
 index 8a9f2e1a3c624bb43702009a5e13de872a5031a1..6cdc1a42ac3102c2061dfb336af0f6c9b8726333 100644
 --- a/sysdeps/unix/sysv/linux/x86_64/____longjmp_chk.S
@@ -456,16 +484,3 @@ index bdd02376f985b102ea76b54fb5b4f0f4fcbc19bb..762f188b6ed340dbb2cd13852b636b31
  		   : "=a" (_result)					      \
  		   : "0" ((unsigned long int) __NR_arch_prctl),		      \
  		     "D" ((unsigned long int) ARCH_SET_FS),		      \
-diff --git a/Makerules b/Makerules
-index ef6abeac6d9dd0e9bb1aa68db7f1b64e64f9c9eb..e4872b3d632383b6d771a26cf6fbf745ce5ce06d 100644
---- a/Makerules
-+++ b/Makerules
-@@ -895,7 +895,7 @@ verbose	:=
- endif						# not -s
- 
- ARFLAGS := r$(verbose)
--CREATE_ARFLAGS := cru$(verbose)
-+CREATE_ARFLAGS := cr$(verbose)
- 
- # This makes all the object files in the parent library archive.
- 

--- a/LibOS/glibc-patches/glibc-2.31.patch
+++ b/LibOS/glibc-patches/glibc-2.31.patch
@@ -35,6 +35,19 @@ index 8f0a93aceb824e556f519847d322cbe5ee5eec7d..37c6356629cfe430fc667a4ca4793993
  
  # Since stubs.h is never needed when building the library, we simplify the
  # hairy installation process by producing it in place only as the last part
+diff --git a/Makerules b/Makerules
+index 1e9c18f0d866731910d29327b975e359dbb3ea33..3fa0d4a52489b6d05111e76ade0a68cc618f2679 100644
+--- a/Makerules
++++ b/Makerules
+@@ -829,7 +829,7 @@ verbose	:=
+ endif						# not -s
+ 
+ ARFLAGS := r$(verbose)
+-CREATE_ARFLAGS := cru$(verbose)
++CREATE_ARFLAGS := cr$(verbose)
+ 
+ # This makes all the object files in the parent library archive.
+ 
 diff --git a/elf/Makefile b/elf/Makefile
 index 632a4d8b0f6a30e5be7e9d675a81b6e3fd0fdcad..d9def31d16c6e0f64b8410dbe01931cf3bb0f106 100644
 --- a/elf/Makefile
@@ -145,6 +158,21 @@ index b9cb99d2fbb07f302aee85e6c367fe2c74d7705c..2d91a6c7f757cbc3ab9b9a77bbc649ea
  # So far the -lutil interface is the same on all platforms, except for the
  # `struct utmp' format, which depends on libc.
  libutil=1
+diff --git a/sysdeps/gnu/errlist-compat.awk b/sysdeps/gnu/errlist-compat.awk
+index 07334c63d81cb3b0dca848aa28c6a80292059bfb..2093438c050443920da0fcafe3083d7270f9bb24 100644
+--- a/sysdeps/gnu/errlist-compat.awk
++++ b/sysdeps/gnu/errlist-compat.awk
+@@ -56,7 +56,9 @@ END {
+     exit 0;
+   }
+ 
+-  count = maxerr + 1;
++  # This prevents `*** errlist.c count 134 inflated to GLIBC_2.12 count 135 (old errno.h?)` warning
++  # from being generated, which happens even without our patches.
++  count = maxerr + 2;
+ 
+   if (highest < count) {
+     printf "*** errlist.c count %d vs Versions sys_errlist@%s count %d\n", \
 diff --git a/sysdeps/unix/sysv/linux/x86_64/____longjmp_chk.S b/sysdeps/unix/sysv/linux/x86_64/____longjmp_chk.S
 index cbce00832cfbb3ab56c27b4887170dbc54480671..ac5d209ccfabd89db49eb1ea1283ec316c85a68d 100644
 --- a/sysdeps/unix/sysv/linux/x86_64/____longjmp_chk.S
@@ -447,16 +475,3 @@ index e7c1416eec4a490312ed56cc51a03a33eaa8e222..0d3b7babb0827f6abb9828e87f5982a4
  		   : "=a" (_result)					      \
  		   : "0" ((unsigned long int) __NR_arch_prctl),		      \
  		     "D" ((unsigned long int) ARCH_SET_FS),		      \
-diff --git a/Makerules b/Makerules
-index 1e9c18f0d866731910d29327b975e359dbb3ea33..3fa0d4a52489b6d05111e76ade0a68cc618f2679 100644
---- a/Makerules
-+++ b/Makerules
-@@ -829,7 +829,7 @@ verbose	:=
- endif						# not -s
- 
- ARFLAGS := r$(verbose)
--CREATE_ARFLAGS := cru$(verbose)
-+CREATE_ARFLAGS := cr$(verbose)
- 
- # This makes all the object files in the parent library archive.
- 


### PR DESCRIPTION
## Description of the changes
The LibOS managed glibc compiling reports the following message
during glibc building.
```*** errlist.c count 134 inflated to GLIBC_2.12 count 135 (old errno.h?)```
It may confuses user as the GSGX compilation issue.
The defined error counting is greater than actual one from it.
it is just used for future expansion.

Fixes #1653

## How to test this PR? <!-- (if applicable) -->
make

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1654)
<!-- Reviewable:end -->
