### PR TITLE
[Examples,Pal/Linux-SGX] Replace LD_PRELOAD with dlopen in RA-TLS

### DIFF
--- a/Examples/ra-tls-mbedtls/Makefile
+++ b/Examples/ra-tls-mbedtls/Makefile
@@ -79,7 +79,7 @@ mbedtls/CMakeLists.txt: $(MBEDTLS_SRC) $(MBEDCRYPTO_SRC)
 ######################### CLIENT/SERVER EXECUTABLES ###########################
 
 CFLAGS += -I./mbedtls/install/include -I./mbedtls/crypto/include
-LFLAGS += -Wl,-rpath,. -L. -lmbedcrypto -lmbedtls -lmbedx509
+LFLAGS += -Wl,-rpath,. -L. -ldl -lmbedcrypto -lmbedtls -lmbedx509
 
 server: src/server.c libmbedcrypto.so libmbedtls.so libmbedx509.so
 	$(CC) $< $(CFLAGS) $(LFLAGS) -o $@
@@ -138,10 +138,10 @@ server.manifest.sgx: server.manifest server libra_tls_attest.so
 
 .PHONY: check_epid
 check_epid: app epid
-	SGX=1 ./pal_loader server >/dev/null & SERVER_ID=$$!; \
+	SGX=1 ./pal_loader server epid >/dev/null & SERVER_ID=$$!; \
 	sleep 30; \
-	LD_PRELOAD="libra_tls_verify_epid.so" ./client > OUTPUT; \
-	LD_PRELOAD="libra_tls_verify_epid.so" ./client 0 0 0 0 >> OUTPUT; \
+	./client epid > OUTPUT; \
+	./client epid 0 0 0 0 >> OUTPUT; \
 	kill -9 $$SERVER_ID
 	@grep -q "using default SGX-measurement verification callback" OUTPUT && echo "[ Success 1/4 ]"
 	@grep -q "using our own SGX-measurement verification callback" OUTPUT && echo "[ Success 2/4 ]"
@@ -151,17 +151,17 @@ check_epid: app epid
 
 .PHONY: check_epid_fail
 check_epid_fail: app epid
-	SGX=1 ./pal_loader server dummy-option >/dev/null & SERVER_ID=$$!; \
+	SGX=1 ./pal_loader server epid dummy-option >/dev/null & SERVER_ID=$$!; \
 	sleep 30; \
-	LD_PRELOAD="libra_tls_verify_epid.so" ./client && exit 1 || echo "[ Success 1/1 ]"; \
+	./client epid && exit 1 || echo "[ Success 1/1 ]"; \
 	kill -9 $$SERVER_ID
 
 .PHONY: check_dcap
 check_dcap: app dcap
-	SGX=1 ./pal_loader server >/dev/null & SERVER_ID=$$!; \
+	SGX=1 ./pal_loader server dcap >/dev/null & SERVER_ID=$$!; \
 	sleep 30; \
-	LD_PRELOAD="libsgx_urts.so libra_tls_verify_dcap.so" ./client > OUTPUT; \
-	LD_PRELOAD="libsgx_urts.so libra_tls_verify_dcap.so" ./client 0 0 0 0 >> OUTPUT; \
+	./client dcap > OUTPUT; \
+	./client dcap 0 0 0 0 >> OUTPUT; \
 	kill -9 $$SERVER_ID
 	@grep -q "using default SGX-measurement verification callback" OUTPUT && echo "[ Success 1/4 ]"
 	@grep -q "using our own SGX-measurement verification callback" OUTPUT && echo "[ Success 2/4 ]"
@@ -171,9 +171,9 @@ check_dcap: app dcap
 
 .PHONY: check_dcap_fail
 check_dcap_fail: app dcap
-	SGX=1 ./pal_loader server dummy-option >/dev/null & SERVER_ID=$$!; \
+	SGX=1 ./pal_loader server dcap dummy-option >/dev/null & SERVER_ID=$$!; \
 	sleep 30; \
-	LD_PRELOAD="libsgx_urts.so libra_tls_verify_dcap.so" ./client && exit 1 || echo "[ Success 1/1 ]"; \
+	./client dcap && exit 1 || echo "[ Success 1/1 ]"; \
 	kill -9 $$SERVER_ID
 
 ################################## CLEANUP ####################################

--- a/Examples/ra-tls-mbedtls/README.md
+++ b/Examples/ra-tls-mbedtls/README.md
@@ -5,10 +5,10 @@ client written against the mbedTLS 2.21.0 library.  This was tested on a machine
 Ubuntu 18.04.
 
 The server and client are based on `ssl_server.c` and `ssl_client.c` example programs shipped with
-mbedTLS. We modified them to allow using RA-TLS flows if the programs detect this library is
-preloaded via the `LD_PRELOAD` trick.  In particular, the server uses a self-signed RA-TLS cert
-with the SGX quote embedded in it via `ra_tls_create_key_and_crt()`. The client uses an RA-TLS
-verification callback to verify the server RA-TLS certificate via `ra_tls_verify_callback()`.
+mbedTLS. We modified them to allow using RA-TLS flows if the programs are given the command-line
+argument `epid`/`dcap`.  In particular, the server uses a self-signed RA-TLS cert with the SGX quote
+embedded in it via `ra_tls_create_key_and_crt()`. The client uses an RA-TLS verification callback to
+verify the server RA-TLS certificate via `ra_tls_verify_callback()`.
 
 This example uses the RA-TLS libraries `ra_tls_attest.so` for server and `ra_tls_verify_epid.so`/
 `ra_tls_verify_dcap.so` for client. These libraries are found under
@@ -22,23 +22,25 @@ more documentation, refer to `Pal/src/host/Linux-SGX/tools/README.rst`.
 
 ## RA-TLS server
 
-The server is supposed to run in the SGX enclave with Graphene and RA-TLS preloaded. If RA-TLS
-library `ra_tls_attest.so` is not preloaded, the server falls back to using normal X.509 PKI flows.
+The server is supposed to run in the SGX enclave with Graphene and RA-TLS dlopen-loaded. If RA-TLS
+library `ra_tls_attest.so` is not requested by user via `epid`/`dcap` command-line argument, the
+server falls back to using normal X.509 PKI flows (specified as `native` command-line argument).
 
-If server is run with any command-line options (the only important thing is to have at least one
-option), then the server will maliciously modify the SGX quote before sending to the client. This
-is useful for testing purposes.
+If server is run with more command-line arguments (the only important thing is to have at least one
+additional argument), then the server will maliciously modify the SGX quote before sending to the
+client. This is useful for testing purposes.
 
 ## RA-TLS client
 
 The client is supposed to run on a trusted machine (*not* in an SGX enclave). If RA-TLS library
-`ra_tls_verify_epid.so` or `ra_tls_verify_dcap.so` is not preloaded, the client falls back to using
-normal X.509 PKI flows.
+`ra_tls_verify_epid.so` or `ra_tls_verify_dcap.so` is not requested by user via `epid` or `dcap`
+command-line arguments respectively, the client falls back to using normal X.509 PKI flows
+(specified as `native` command-line argument).
 
-If client is run without command-line options, it uses default RA-TLS verification callback that
-compares `MRENCLAVE`, `MRSIGNER`, `ISV_PROD_ID` and `ISV_SVN` against the corresonding `RA_TLS_*`
-environment variables. To run the client with its own verification callback, execute it with four
-command-line options (see the source code for details).
+If client is run without additional command-line arguments, it uses default RA-TLS verification
+callback that compares `MRENCLAVE`, `MRSIGNER`, `ISV_PROD_ID` and `ISV_SVN` against the corresonding
+`RA_TLS_*` environment variables. To run the client with its own verification callback, execute it
+with four additional command-line arguments (see the source code for details).
 
 
 # Quick Start
@@ -47,8 +49,8 @@ command-line options (see the source code for details).
 
 ```sh
 make app
-./server &
-./client
+./server native &
+./client native
 # client will successfully connect to the server via normal x.509 PKI flows
 kill %%
 ```
@@ -60,14 +62,14 @@ kill %%
 make clean
 RA_CLIENT_SPID=12345678901234567890123456789012 RA_CLIENT_LINKABLE=0 make app epid
 
-SGX=1 ./pal_loader ./server &
+SGX=1 ./pal_loader ./server epid &
 
 RA_TLS_EPID_API_KEY=12345678901234567890123456789012 \
 RA_TLS_ALLOW_OUTDATED_TCB_INSECURE=1 \
 RA_TLS_MRENCLAVE=1234567890123456789012345678901234567890123456789012345678901234 \
 RA_TLS_MRSIGNER=1234567890123456789012345678901234567890123456789012345678901234 \
 RA_TLS_ISV_PROD_ID=0 RA_TLS_ISV_SVN=0 \
-LD_PRELOAD="$PWD/libra_tls_verify_epid.so" ./client
+./client epid
 
 # client will successfully connect to the server via RA-TLS/EPID flows
 kill %%
@@ -80,14 +82,13 @@ kill %%
 make clean
 make app dcap
 
-SGX=1 ./pal_loader ./server &
+SGX=1 ./pal_loader ./server dcap &
 
 RA_TLS_ALLOW_OUTDATED_TCB_INSECURE=1 \
 RA_TLS_MRENCLAVE=1234567890123456789012345678901234567890123456789012345678901234 \
 RA_TLS_MRSIGNER=1234567890123456789012345678901234567890123456789012345678901234 \
 RA_TLS_ISV_PROD_ID=0 RA_TLS_ISV_SVN=0 \
-LD_PRELOAD="libsgx_urts.so $PWD/libra_tls_verify_dcap.so" \
-./client
+./client dcap
 
 # client will successfully connect to the server via RA-TLS/DCAP flows
 kill %%
@@ -100,10 +101,10 @@ kill %%
 make clean
 make app dcap
 
-SGX=1 ./pal_loader ./server &
+SGX=1 ./pal_loader ./server dcap &
 
 # arguments are: MRENCLAVE in hex, MRSIGNER in hex, ISV_PROD_ID as dec, ISV_SVN as dec
-LD_PRELOAD="libsgx_urts.so $PWD/libra_tls_verify_dcap.so" ./client \
+RA_TLS_ALLOW_OUTDATED_TCB_INSECURE=1 ./client dcap \
     1234567890123456789012345678901234567890123456789012345678901234 \
     1234567890123456789012345678901234567890123456789012345678901234 \
     0 0
@@ -118,8 +119,8 @@ kill %%
 make clean
 make app dcap
 
-SGX=1 ./pal_loader ./server dummy-option &
-LD_PRELOAD="libsgx_urts.so $PWD/libra_tls_verify_dcap.so" ./client
+SGX=1 ./pal_loader ./server dcap dummy-option &
+./client dcap
 
 # client will fail to verify the malicious SGX quote and will *not* connect to the server
 kill %%

--- a/Examples/ra-tls-mbedtls/server.manifest.template
+++ b/Examples/ra-tls-mbedtls/server.manifest.template
@@ -9,9 +9,6 @@ loader.debug_type = $(GRAPHENEDEBUG)
 
 loader.env.LD_LIBRARY_PATH = /lib:/lib/x86_64-linux-gnu
 
-# RA-TLS library is preloaded (without it, server uses normal X.509 PKI flows)
-loader.env.LD_PRELOAD = libra_tls_attest.so
-
 # Read application arguments directly from the command line. Don't use this on production!
 loader.insecure__use_cmdline_argv = 1
 
@@ -37,6 +34,7 @@ fs.mount.etc.uri = file:/etc
 sgx.trusted_files.ld = file:$(GRAPHENEDIR)/Runtime/ld-linux-x86-64.so.2
 sgx.trusted_files.libc = file:$(GRAPHENEDIR)/Runtime/libc.so.6
 sgx.trusted_files.libm = file:$(GRAPHENEDIR)/Runtime/libm.so.6
+sgx.trusted_files.libdl = file:$(GRAPHENEDIR)/Runtime/libdl.so.2
 
 sgx.trusted_files.libnsscompat = file:/lib/x86_64-linux-gnu/libnss_compat.so.2
 sgx.trusted_files.libnssfiles  = file:/lib/x86_64-linux-gnu/libnss_files.so.2

--- a/Pal/src/host/Linux-SGX/tools/ra-tls/ra_tls.h
+++ b/Pal/src/host/Linux-SGX/tools/ra-tls/ra_tls.h
@@ -66,7 +66,7 @@ int verify_quote_against_envvar_measurements(const void* quote, size_t quote_siz
  *
  * \return          0 on success, specific error code (negative int) otherwise.
  */
-__attribute__ ((visibility("default"))) __attribute__((weak))
+__attribute__ ((visibility("default")))
 void ra_tls_set_measurement_callback(verify_measurements_cb_t f_cb);
 
 /*!
@@ -84,7 +84,7 @@ void ra_tls_set_measurement_callback(verify_measurements_cb_t f_cb);
  *
  * \return           0 on success, specific mbedTLS error code (negative int) otherwise.
  */
-__attribute__ ((visibility("default"))) __attribute__((weak))
+__attribute__ ((visibility("default")))
 int ra_tls_verify_callback(void* data, mbedtls_x509_crt* crt, int depth, uint32_t* flags);
 
 /*!
@@ -101,7 +101,7 @@ int ra_tls_verify_callback(void* data, mbedtls_x509_crt* crt, int depth, uint32_
  *
  * \return                  0 on success, specific mbedTLS error code (negative int) otherwise.
  */
-__attribute__ ((visibility("default"))) __attribute__((weak))
+__attribute__ ((visibility("default")))
 int ra_tls_verify_callback_der(uint8_t* der_crt, size_t der_crt_size);
 
 /*!
@@ -117,7 +117,7 @@ int ra_tls_verify_callback_der(uint8_t* der_crt, size_t der_crt_size);
  *
  * \return           0 on success, specific mbedTLS error code (negative int) otherwise.
  */
-__attribute__ ((visibility("default"))) __attribute__((weak))
+__attribute__ ((visibility("default")))
 int ra_tls_create_key_and_crt(mbedtls_pk_context* key, mbedtls_x509_crt* crt);
 
 /*!
@@ -134,6 +134,6 @@ int ra_tls_create_key_and_crt(mbedtls_pk_context* key, mbedtls_x509_crt* crt);
  *
  * \return                   0 on success, specific mbedTLS error code (negative int) otherwise.
  */
-__attribute__ ((visibility("default"))) __attribute__((weak))
+__attribute__ ((visibility("default")))
 int ra_tls_create_key_and_crt_der(uint8_t** der_key, size_t* der_key_size, uint8_t** der_crt,
                                   size_t* der_crt_size);

--- a/Pal/src/host/Linux-SGX/tools/ra-tls/secret_prov_attest.c
+++ b/Pal/src/host/Linux-SGX/tools/ra-tls/secret_prov_attest.c
@@ -170,11 +170,6 @@ int secret_provision_start(const char* in_servers, const char* in_ca_chain_path,
     mbedtls_ssl_conf_authmode(&g_conf, MBEDTLS_SSL_VERIFY_REQUIRED);
     mbedtls_ssl_conf_ca_chain(&g_conf, &g_verifier_ca_chain, NULL);
 
-    if (!ra_tls_create_key_and_crt) {
-        ret = -EINVAL;
-        goto out;
-    }
-
     ret = ra_tls_create_key_and_crt(&g_my_ratls_key, &g_my_ratls_cert);
     if (ret < 0) {
         goto out;

--- a/Pal/src/host/Linux-SGX/tools/ra-tls/secret_prov_verify.c
+++ b/Pal/src/host/Linux-SGX/tools/ra-tls/secret_prov_verify.c
@@ -204,11 +204,6 @@ int secret_provision_start_server(uint8_t* secret, size_t secret_size, const cha
     /* the below CA chain is a dummy (RA-TLS verify callback ignores it) but required by mbedTLS */
     mbedtls_ssl_conf_ca_chain(&conf, &srvcert, NULL);
 
-    if (!ra_tls_verify_callback || !ra_tls_set_measurement_callback) {
-        ret = -EINVAL;
-        goto out;
-    }
-
     ra_tls_set_measurement_callback(m_cb);
     mbedtls_ssl_conf_verify(&conf, ra_tls_verify_callback, NULL);
 


### PR DESCRIPTION

## Description of the changes <!-- (reasons and measures) -->

Previously, RA-TLS was recommended to be used with LD_PRELOAD trick. However, LD_PRELOAD is too hacky and shouldn't be used to preload libraries to an executable (in contrast to its normal use of replacing functions from one library with another).

This PR removes any mentions of LD_PRELOAD trick from RA-TLS, and replaces LD_PRELOAD with `dlopen()` in ra-tls-mbedtls example.

## How to test this PR? <!-- (if applicable) -->

All tests must pass (including the ra-tls-mbedtls example).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1655)
<!-- Reviewable:end -->
