### PR TITLE
[Examples] Add option to run RA TLS client in SGX

### DIFF
--- a/Examples/ra-tls-mbedtls/Makefile
+++ b/Examples/ra-tls-mbedtls/Makefile
@@ -14,6 +14,8 @@
 GRAPHENEDIR ?= ../..
 GRAPHENEKEY ?= $(GRAPHENEDIR)/Pal/src/host/Linux-SGX/signer/enclave-key.pem
 
+ARCH_LIBDIR ?= /lib/x86_64-linux-gnu
+
 # Specify your SPID and linkable/unlinkable attestation policy (only for EPID);
 # these variables will not be used if this example is built for ECDSA/DCAP
 RA_CLIENT_SPID ?= AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
@@ -116,6 +118,9 @@ libra_tls_verify_epid.so: libmbedcrypto.so libmbedx509.so libsgx_util.so
 libra_tls_verify_dcap.so: libmbedcrypto.so libmbedx509.so libsgx_util.so
 	cp $(GRAPHENEDIR)/Pal/src/host/Linux-SGX/tools/ra-tls/$@ .
 
+libra_tls_verify_dcap_graphene.so: libmbedcrypto.so libmbedx509.so libsgx_util.so
+	cp $(GRAPHENEDIR)/Pal/src/host/Linux-SGX/tools/ra-tls/$@ .
+
 ############################### SERVER MANIFEST ###############################
 
 server.manifest: server.manifest.template
@@ -133,6 +138,94 @@ server.manifest.sgx: server.manifest server libra_tls_attest.so
 		-exec server
 	$(GRAPHENEDIR)/Pal/src/host/Linux-SGX/signer/pal-sgx-get-token \
 		-output server.token -sig server.sig
+
+########################### CLIENT (DCAP) MANIFEST ############################
+
+# DCAP dependencies (generated from ldd). For SGX, the manifest needs to list all the libraries
+# loaded during execution, so that the signer can include the file hashes.
+
+# We need to replace Glibc dependencies with Graphene-specific Glibc. The Glibc binaries are
+# already listed in the manifest template, so we can skip them from the ldd results.
+GLIBC_DEPS = linux-vdso.so.1 /lib64/ld-linux-x86-64.so.2 libc.so.6 libm.so.6 librt.so.1 \
+			 libdl.so.2 libpthread.so.0 libutil.so.1 libresolv.so.2 libnss_dns.so.2
+
+# List all the dcap dependencies, besides Glibc libraries
+.INTERMEDIATE: client_dcap-list
+client_dcap-list: client libra_tls_verify_dcap_graphene.so
+	@ldd client > $@
+	@ldd libra_tls_verify_dcap_graphene.so >> $@
+	@ldd /usr/$(ARCH_LIBDIR)/libdcap_quoteprov.so >> $@
+
+.INTERMEDIATE: client_dcap-deps
+client_dcap-deps: client_dcap-list
+	@cat $< | \
+		awk '{if ($$2 =="=>") {print $$3}}' | \
+		sort | uniq | grep -v $(patsubst %,-e %,$(GLIBC_DEPS)) > $@
+	@echo "/usr/$(ARCH_LIBDIR)/libdcap_quoteprov.so.1" >> $@
+
+# Generate manifest rules for dcap dependencies
+.INTERMEDIATE: client_dcap-trusted-libs
+client_dcap-trusted-libs: client_dcap-deps
+	@for F in `cat $<`; do \
+		N=`basename $$F | tr --delete '.' | tr --delete '-' | tr --delete '+'`; \
+		echo -n "sgx.trusted_files.$$N = file:$$F\\\\n"; \
+	done > $@
+
+client_dcap.manifest: client.manifest.template client_dcap-trusted-libs
+	sed -e 's|$$(GRAPHENEDIR)|'"$(GRAPHENEDIR)"'|g' \
+		-e 's|$$(GRAPHENEDEBUG)|'"$(GRAPHENEDEBUG)"'|g' \
+		-e 's|$$(CLIENT_TRUSTED_LIBS)|'"`cat client_dcap-trusted-libs`"'|g' \
+		-e 's|$$(RA_TLS_VERIFY_LIB)|'"libra_tls_verify_dcap_graphene.so"'|g' \
+		-e 's|$$(ARCH_LIBDIR)|'"$(ARCH_LIBDIR)"'|g' \
+		$< > $@
+
+client_dcap.manifest.sgx: client_dcap.manifest
+	$(GRAPHENEDIR)/Pal/src/host/Linux-SGX/signer/pal-sgx-sign \
+		-libpal $(GRAPHENEDIR)/Runtime/libpal-Linux-SGX.so \
+		-key $(GRAPHENEKEY) \
+		-manifest $< -output $@ \
+		-exec client
+	$(GRAPHENEDIR)/Pal/src/host/Linux-SGX/signer/pal-sgx-get-token \
+		-output client_dcap.token -sig client_dcap.sig
+
+########################### CLIENT (EPID) MANIFEST ############################
+
+# List all the epid dependencies, besides Glibc libraries
+.INTERMEDIATE: client_epid-list
+client_epid-list: client libra_tls_verify_epid.so
+	@ldd client > $@
+	@ldd libra_tls_verify_epid.so >> $@
+
+.INTERMEDIATE: client_epid-deps
+client_epid-deps: client_epid-list
+	@cat $< | \
+		awk '{if ($$2 =="=>") {print $$3}}' | \
+		sort | uniq | grep -v $(patsubst %,-e %,$(GLIBC_DEPS)) > $@
+
+# Generate manifest rules for epid dependencies
+.INTERMEDIATE: client_epid-trusted-libs
+client_epid-trusted-libs: client_epid-deps
+	@for F in `cat $<`; do \
+		N=`basename $$F | tr --delete '.' | tr --delete '-' | tr --delete '+'`; \
+		echo -n "sgx.trusted_files.$$N = file:$$F\\\\n"; \
+	done > $@
+
+client_epid.manifest: client.manifest.template client_epid-trusted-libs
+	sed -e 's|$$(GRAPHENEDIR)|'"$(GRAPHENEDIR)"'|g' \
+		-e 's|$$(GRAPHENEDEBUG)|'"$(GRAPHENEDEBUG)"'|g' \
+		-e 's|$$(CLIENT_TRUSTED_LIBS)|'"`cat client_epid-trusted-libs`"'|g' \
+		-e 's|$$(RA_TLS_VERIFY_LIB)|'"libra_tls_verify_epid.so"'|g' \
+		-e 's|$$(ARCH_LIBDIR)|'"$(ARCH_LIBDIR)"'|g' \
+		$< > $@
+
+client_epid.manifest.sgx: client_epid.manifest
+	$(GRAPHENEDIR)/Pal/src/host/Linux-SGX/signer/pal-sgx-sign \
+		-libpal $(GRAPHENEDIR)/Runtime/libpal-Linux-SGX.so \
+		-key $(GRAPHENEKEY) \
+		-manifest $< -output $@ \
+		-exec client
+	$(GRAPHENEDIR)/Pal/src/host/Linux-SGX/signer/pal-sgx-get-token \
+		-output client_epid.token -sig client_epid.sig
 
 ############################### SGX CHECKS FOR CI #############################
 

--- a/Examples/ra-tls-mbedtls/README.md
+++ b/Examples/ra-tls-mbedtls/README.md
@@ -37,6 +37,10 @@ The client is supposed to run on a trusted machine (*not* in an SGX enclave). If
 command-line arguments respectively, the client falls back to using normal X.509 PKI flows
 (specified as `native` command-line argument).
 
+It is also possible to run the client in an SGX enclave. This will create a secure channel between
+two Graphene SGX processes, possibly running on different machines. It can be used as an example
+of in-enclave remote attestation and verification.
+
 If client is run without additional command-line arguments, it uses default RA-TLS verification
 callback that compares `MRENCLAVE`, `MRSIGNER`, `ISV_PROD_ID` and `ISV_SVN` against the corresonding
 `RA_TLS_*` environment variables. To run the client with its own verification callback, execute it
@@ -123,5 +127,37 @@ SGX=1 ./pal_loader ./server dcap dummy-option &
 ./client dcap
 
 # client will fail to verify the malicious SGX quote and will *not* connect to the server
+kill %%
+```
+
+- RA-TLS flows with SGX and with Graphene, running EPID client in SGX:
+
+Note: you may also add environment variables to client.manifest.template, such as
+`RA_TLS_ALLOW_OUTDATED_TCB_INSECURE`, `RA_TLS_MRENCLAVE`, `RA_TLS_MRSIGNER`, `RA_TLS_ISV_PROD_ID`
+and `RA_TLS_ISV_SVN`.
+
+```sh
+make clean
+RA_CLIENT_SPID=12345678901234567890123456789012 RA_CLIENT_LINKABLE=0 make app client_epid.manifest.sgx
+
+SGX=1 ./pal_loader ./server epid &
+
+RA_TLS_EPID_API_KEY=12345678901234567890123456789012 SGX=1 ./pal_loader client_epid.manifest.sgx epid
+
+# client will successfully connect to the server via RA-TLS/EPID flows
+kill %%
+```
+
+- RA-TLS flows with SGX and with Graphene, running DCAP client in SGX:
+
+```sh
+make clean
+make app client_dcap.manifest.sgx
+
+SGX=1 ./pal_loader ./server dcap &
+
+SGX=1 ./pal_loader client_dcap.manifest.sgx dcap
+
+# client will successfully connect to the server via RA-TLS/DCAP flows
 kill %%
 ```

--- a/Examples/ra-tls-mbedtls/client.manifest.template
+++ b/Examples/ra-tls-mbedtls/client.manifest.template
@@ -1,0 +1,90 @@
+# Client manifest file (both for EPID and DCAP)
+#
+# This manifest was prepared and tested on Ubuntu 18.04.
+
+# Executable to load into Graphene and run.
+loader.exec = file:./client
+loader.argv0_override = client
+
+# LibOS layer library of Graphene. There is currently only one implementation,
+# so it is always set to libsysdb.so.
+loader.preload = file:$(GRAPHENEDIR)/Runtime/libsysdb.so
+
+# Show/hide debug log of Graphene ('inline' or 'none' respectively).
+loader.debug_type = $(GRAPHENEDEBUG)
+
+# Read application arguments directly from the command line. Don't use this on production!
+loader.insecure__use_cmdline_argv = 1
+
+loader.insecure__use_host_env = 1
+
+# Specify paths to search for libraries. The usual LD_LIBRARY_PATH syntax
+# applies. Paths must be in-Graphene visible paths, not host-OS paths (i.e.,
+# paths must be taken from fs.mount.xxx.path, not fs.mount.xxx.uri).
+loader.env.LD_LIBRARY_PATH = /lib:$(ARCH_LIBDIR):/usr/$(ARCH_LIBDIR)
+loader.env.RA_TLS_CLIENT_INSIDE_SGX = 1
+
+# Needed by quote verification routine
+loader.env.LC_ALL = C
+
+# Mount host-OS directory to required libraries (in 'uri') into in-Graphene
+# visible directory /lib (in 'path').
+fs.mount.lib.type = chroot
+fs.mount.lib.path = /lib
+fs.mount.lib.uri = file:$(GRAPHENEDIR)/Runtime
+
+fs.mount.lib2.type = chroot
+fs.mount.lib2.path = $(ARCH_LIBDIR)
+fs.mount.lib2.uri = file:$(ARCH_LIBDIR)
+
+fs.mount.lib3.type = chroot
+fs.mount.lib3.path = /usr$(ARCH_LIBDIR)
+fs.mount.lib3.uri = file:/usr/$(ARCH_LIBDIR)
+
+fs.mount.etc.type = chroot
+fs.mount.etc.path = /etc
+fs.mount.etc.uri = file:/etc
+
+# Set enclave size (somewhat arbitrarily) to 256MB. Recall that SGX v1 requires
+# to specify enclave size at enclave creation time.
+sgx.enclave_size = 256M
+
+# Set maximum number of in-enclave threads (somewhat arbitrarily) to 4. Recall
+# that SGX v1 requires to specify the maximum number of simultaneous threads at
+# enclave creation time.
+sgx.thread_num = 4
+
+# Specify all libraries used by dcap and its dependencies (including all libs
+# which can be loaded at runtime via dlopen).
+sgx.trusted_files.ld = file:$(GRAPHENEDIR)/Runtime/ld-linux-x86-64.so.2
+sgx.trusted_files.libc = file:$(GRAPHENEDIR)/Runtime/libc.so.6
+sgx.trusted_files.libm = file:$(GRAPHENEDIR)/Runtime/libm.so.6
+sgx.trusted_files.libdl = file:$(GRAPHENEDIR)/Runtime/libdl.so.2
+sgx.trusted_files.librt = file:$(GRAPHENEDIR)/Runtime/librt.so.1
+sgx.trusted_files.libutil = file:$(GRAPHENEDIR)/Runtime/libutil.so.1
+sgx.trusted_files.libpthread = file:$(GRAPHENEDIR)/Runtime/libpthread.so.0
+sgx.trusted_files.libresolv = file:$(GRAPHENEDIR)/Runtime/libresolv.so.2
+sgx.trusted_files.libnssdns = file:$(GRAPHENEDIR)/Runtime/libnss_dns.so.2
+sgx.trusted_files.libnss_files = file:$(ARCH_LIBDIR)/libnss_files.so.2
+
+sgx.trusted_files.libratlsattest = file:$(RA_TLS_VERIFY_LIB)
+
+$(CLIENT_TRUSTED_LIBS)
+
+# Name Service Switch (NSS) files. Glibc reads these files as part of name-
+# service information gathering. For more info, see 'man nsswitch.conf'.
+sgx.allowed_files.nsswitch   = file:/etc/nsswitch.conf
+sgx.allowed_files.hostconf   = file:/etc/host.conf
+sgx.allowed_files.resolvconf = file:/etc/resolv.conf
+sgx.allowed_files.ethers     = file:/etc/ethers
+sgx.allowed_files.hosts      = file:/etc/hosts
+sgx.allowed_files.group      = file:/etc/group
+sgx.allowed_files.passwd     = file:/etc/passwd
+sgx.allowed_files.gaiconf    = file:/etc/gai.conf
+sgx.allowed_files.cacerts    = file:/etc/ssl/certs/ca-certificates.crt
+
+# DCAP config file
+sgx.allowed_files.sgx_default_qcnl = file:/etc/sgx_default_qcnl.conf
+
+# Enable quote generation in Graphene
+sgx.remote_attestation = 1

--- a/Pal/src/host/Linux-SGX/tools/ra-tls/Makefile
+++ b/Pal/src/host/Linux-SGX/tools/ra-tls/Makefile
@@ -16,7 +16,7 @@ epid: libra_tls_attest.so libra_tls_verify_epid.so \
       libsecret_prov_attest.so libsecret_prov_verify_epid.so
 
 .PHONY: dcap
-dcap: libra_tls_attest.so libra_tls_verify_dcap.so \
+dcap: libra_tls_attest.so libra_tls_verify_dcap.so libra_tls_verify_dcap_graphene.so \
       libsecret_prov_attest.so libsecret_prov_verify_dcap.so
 
 libra_tls_attest.so: ra_tls_attest.o
@@ -26,6 +26,9 @@ libra_tls_verify_epid.so: ra_tls_verify_common.o ra_tls_verify_epid.o
 	$(CC) $^ $(LDFLAGS) -L../common -lsgx_util -lmbedcrypto -lmbedx509 -shared -o $@
 
 libra_tls_verify_dcap.so: ra_tls_verify_common.o ra_tls_verify_dcap.o
+	$(CC) $^ $(LDFLAGS) -L../common -lsgx_util -lmbedcrypto -lmbedx509 -lsgx_dcap_quoteverify -shared -o $@
+
+libra_tls_verify_dcap_graphene.so: ra_tls_verify_common.o ra_tls_verify_dcap.o ra_tls_verify_dcap_urts.o
 	$(CC) $^ $(LDFLAGS) -L../common -lsgx_util -lmbedcrypto -lmbedx509 -lsgx_dcap_quoteverify -shared -o $@
 
 libsecret_prov_attest.so: ra_tls_attest.o secret_prov_common.o secret_prov_attest.o

--- a/Pal/src/host/Linux-SGX/tools/ra-tls/ra_tls_verify_dcap_urts.c
+++ b/Pal/src/host/Linux-SGX/tools/ra-tls/ra_tls_verify_dcap_urts.c
@@ -1,0 +1,23 @@
+/* SPDX-License-Identifier: LGPL-3.0-or-later */
+/* Copyright (C) 2020 Intel Corporation */
+
+/*
+ * To load libsgx_dcap_quoteverify.so, it needs some symbols which are normally
+ * provided by libsgx_urts.so (or libsgx_urts_sim.so). To use it in Graphene,
+ * there are two workarounds to solve this: 1) load libsgx_urts.so or 2) create
+ * dummy functions and always return failure. In this example we use 2).
+ */
+#define DUMMY_FUNCTION(f)       __attribute__ ((visibility ("default"))) int f(void);   \
+                                int f(void) {return /*SGX_ERROR_UNEXPECTED*/1;}
+
+/* Provide these dummies since we are not using libsgx_urts.so. */
+DUMMY_FUNCTION(sgx_create_enclave)
+DUMMY_FUNCTION(sgx_destroy_enclave)
+DUMMY_FUNCTION(sgx_ecall)
+/* ocalls in sgx_tstdc.edl */
+DUMMY_FUNCTION(sgx_oc_cpuidex)
+DUMMY_FUNCTION(sgx_thread_set_untrusted_event_ocall)
+DUMMY_FUNCTION(sgx_thread_setwait_untrusted_events_ocall)
+DUMMY_FUNCTION(sgx_thread_set_multiple_untrusted_events_ocall)
+DUMMY_FUNCTION(sgx_thread_wait_untrusted_event_ocall)
+


### PR DESCRIPTION
Add options to allow RA TLS client to run in SGX as well. It can be used as an example of in-enclave remote attestation and verification, both EPID and ECDSA.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1657)
<!-- Reviewable:end -->
