### PR TITLE
[CI] Add a label to non-SGX jobs

### DIFF
--- a/Jenkinsfiles/Linux
+++ b/Jenkinsfiles/Linux
@@ -1,6 +1,8 @@
 pipeline {
         agent {
-              dockerfile { filename 'Jenkinsfiles/ubuntu-16.04.dockerfile' }
+              dockerfile { filename 'Jenkinsfiles/ubuntu-16.04.dockerfile'
+                           label 'nonsgx_slave'
+              }
         }
         stages {
                 stage('Lint') {

--- a/Jenkinsfiles/Linux-18.04
+++ b/Jenkinsfiles/Linux-18.04
@@ -1,6 +1,8 @@
 pipeline {
         agent {
-              dockerfile { filename 'Jenkinsfiles/ubuntu-18.04.dockerfile' }
+              dockerfile { filename 'Jenkinsfiles/ubuntu-18.04.dockerfile'
+                           label 'nonsgx_slave'
+              }
         }
         stages {
                 stage('Lint') {

--- a/Jenkinsfiles/Linux-Debug
+++ b/Jenkinsfiles/Linux-Debug
@@ -1,6 +1,8 @@
 pipeline {
         agent {
-              dockerfile { filename 'Jenkinsfiles/ubuntu-16.04.dockerfile' }
+              dockerfile { filename 'Jenkinsfiles/ubuntu-16.04.dockerfile'
+                           label 'nonsgx_slave'
+              }
         }
         stages {
                 stage('Lint') {

--- a/Jenkinsfiles/Linux-Debug-18.04
+++ b/Jenkinsfiles/Linux-Debug-18.04
@@ -1,6 +1,8 @@
 pipeline {
         agent {
-              dockerfile { filename 'Jenkinsfiles/ubuntu-18.04.dockerfile' }
+              dockerfile { filename 'Jenkinsfiles/ubuntu-18.04.dockerfile'
+                           label 'nonsgx_slave'
+              }
         }
         stages {
                 stage('Lint') {


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://graphene.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

I noticed that "normal" CI jobs were being run on a test machine where we were experimenting with a different kernel.  This was mostly fine, but I cannot easily reboot and mess with the machine while unrelated jobs are running.

To fix this, we need to add an explicit agent label to every pipeline and to the workers; the non-sgx jobs are unconstrained and have no label.  I have already added a 'nonsgx_slave' label to any workers we expect to be stable, and this PR adds it to the pipeline definition as well.

This may take a bit to percolate through all of the pending PRs.

## How to test this PR? <!-- (if applicable) -->

Just run the non-SGX Jenkins pipelines.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1662)
<!-- Reviewable:end -->
