### PR TITLE
[Pal/Linux-SGX] Fix super-subtle bugs in SGX enter/exit/AEX flows

### DIFF
--- a/Pal/src/host/Linux-SGX/enclave_entry.S
+++ b/Pal/src/host/Linux-SGX/enclave_entry.S
@@ -453,6 +453,11 @@ enclave_entry:
 	subq $8, %rsi
 	movq %rsi, SGX_GPR_RSP(%rbx)
 
+	# clear SSA.GPRSGX.EXITINFO; we used it to identify HW exception (if any),
+	# and a scenario is possible where the same SSA is re-used to handle more
+	# signals that arrive right after this exception, so we must clear state
+	movq $0, SGX_GPR_EXITINFO(%rbx)
+
 	# clear RFLAGS.DF to conform to the SysV ABI, clear RFLAGS.AC to prevent
 	# the #AC-fault side channel
 	andq $(~(RFLAGS_DF | RFLAGS_AC)), SGX_GPR_RFLAGS(%rbx)

--- a/Pal/src/host/Linux-SGX/sgx_entry.S
+++ b/Pal/src/host/Linux-SGX/sgx_entry.S
@@ -59,6 +59,11 @@ async_exit_pointer:
 eresume_pointer:
 	ENCLU   # perform ERESUME
 
+	.global async_exit_pointer_end
+	.type async_exit_pointer_end, @function
+
+async_exit_pointer_end:
+
 	.global sgx_raise
 	.type sgx_raise, @function
 

--- a/Pal/src/host/Linux-SGX/sgx_internal.h
+++ b/Pal/src/host/Linux-SGX/sgx_internal.h
@@ -122,6 +122,7 @@ int sgx_raise (int event);
 
 void async_exit_pointer(void);
 void eresume_pointer(void);
+void async_exit_pointer_end(void);
 
 int interrupt_thread (void * tcs);
 int clone_thread (void);


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

This PR fixes two very subtle bugs in our assembly code for SGX EENTER/EEXIT/AEX flows:

### [Pal/Linux-SGX] Check for the whole range of AEP/ERESUME trampoline

Previously, Linux-SGX PAL checked RIP of the interrupted normal context only against the first instruction of the AEP trampoline code (recall that SGX passes control to AEP on AEX). In Graphene, this is the asm function `async_exit_pointer()`. However, Linux may deliver signal (as response to AEX) at any point during AEP trampoline. Thus,PAL code incorrectly checked RIP and wrongly assumed that there was no AEX but instead an exception in PAL code itself, which led to rare Graphene failures. This commit fixes this bug by checking RIP against the whole range of function `async_exit_pointer()`.

### [Pal/Linux-SGX] Clear SSA.GPRSGX.EXITINFO after it was used once

Previously, Linux-SGX PAL did not clear `SSA.GPRSGX.EXITINFO` while in signal handler (which Graphene enters in response to AEX). Note that Graphene first checks trustworthy EXITINFO (filled by SGX HW on AEX) to identify the reason for signal/exception, and only then falls back to possibly malicious `sgx_raise()` argument (filled by Linux kernel and propagated by untrusted PAL).

Not clearing EXITINFO led to a subtle racey failure of OpenMP test (and possibly others): main thread sends SIGCONT async signal to child thread, and child thread executes forbidden SYSCALL instruction and gets AEX(SIGILL) at the same time. Now if SIGILL due to SYSCALL arrives first, EXITINFO is filled with SIGILL information. Then SIGCONT is queued on the enclave signal stack, in the same SSA (see `enclave_entry.S:Lsetup_exception_handler`). After SIGILL is correctly handled using the first signal-stack frame, SIGCONT is handled next. However, since EXITINFO was not cleared, SIGCONT's signal-stack frame contains wrong EXITINFO = SIGILL. This confused Graphene: it tried to handle SIGILL instead of SIGCONT.

This commit fixes this bug by simply clearing EXITINFO after it was checked once. This works because it is impossible to have two SGX HW exceptions on the same thread at the same time, so we do not lose any vital information by clearing EXITINFO.

## How to test this PR? <!-- (if applicable) -->

OpenMP LibOS test never fails now! I tested like follows:
```
# build Graphene in release mode

# in first tmux pane, start openmp forever
i=0; while [[ $i == 0 ]]; do SGX=1 ~/graphene/Runtime/pal_loader ./openmp; i=$?; done

# in second tmux pane, start regression suite -- to stress SGX and openmp
i=0; while [[ $i == 0 ]]; do make SGX=1 regression; i=$?; done
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1663)
<!-- Reviewable:end -->
