### PR TITLE
[Pal/Linux-SGX] Introduce manifest option "sgx.zero_heap_on_demand"

### DIFF
--- a/Documentation/manifest-syntax.rst
+++ b/Documentation/manifest-syntax.rst
@@ -392,3 +392,18 @@ This syntax specifies whether to enable SGX enclave-specific statistics:
 *Note:* this option is insecure and cannot be used with production enclaves
 (``sgx.debug = 0``). If the production enclave is started with this option set,
 Graphene will fail initialization of the enclave.
+
+Zero out heap on demand vs during enclave init
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+::
+
+    sgx.zero_heap_on_demand=[1|0]
+    (Default: 0)
+
+This syntax specifies whether to zero out the heap on demand (when new enclave
+pages are requested) or during enclave initialization. If this option is set to
+``1``, then the initial heap space is uninitialized; this improves start-up
+performance but worsens run-time performance. If this option is set to ``0``,
+then the whole heap is zeroed out before enclave starts app execution; this
+worsens start-up performance but improves run-time performance.

--- a/Pal/regression/Bootstrap6.manifest.template
+++ b/Pal/regression/Bootstrap6.manifest.template
@@ -6,3 +6,5 @@ loader.argv0_override = Bootstrap
 fs.mount.root.uri = file:
 
 sgx.enclave_size = 8192M
+
+sgx.zero_heap_on_demand = 1

--- a/Pal/src/host/Linux-SGX/db_main.c
+++ b/Pal/src/host/Linux-SGX/db_main.c
@@ -207,6 +207,26 @@ void pal_linux_main(char* uptr_args, uint64_t args_size, char* uptr_env, uint64_
     g_pal_sec.exec_addr = GET_ENCLAVE_TLS(exec_addr);
     g_pal_sec.exec_size = GET_ENCLAVE_TLS(exec_size);
 
+    g_pal_sec.zero_heap_on_demand = sec_info.zero_heap_on_demand;
+
+    if (!g_pal_sec.zero_heap_on_demand) {
+        /* zero the heap during init; we need to take care to not zero the exec area */
+        void* zero1_start = g_pal_sec.heap_min;
+        void* zero1_end   = g_pal_sec.heap_max;
+
+        void* zero2_start = g_pal_sec.heap_max;
+        void* zero2_end   = g_pal_sec.heap_max;
+
+        if (g_pal_sec.exec_addr != NULL) {
+            zero1_end   = MIN(zero1_end, SATURATED_P_SUB(g_pal_sec.exec_addr, MEMORY_GAP, 0));
+            zero2_start = SATURATED_P_ADD(g_pal_sec.exec_addr + g_pal_sec.exec_size, MEMORY_GAP,
+                          zero2_end);
+        }
+
+        memset(zero1_start, 0, zero1_end - zero1_start);
+        memset(zero2_start, 0, zero2_end - zero2_start);
+    }
+
     /* relocate PAL itself */
     g_pal_map.l_addr = elf_machine_load_address();
     g_pal_map.l_name = ENCLAVE_PAL_FILENAME;

--- a/Pal/src/host/Linux-SGX/enclave_pages.c
+++ b/Pal/src/host/Linux-SGX/enclave_pages.c
@@ -163,8 +163,10 @@ static void* __create_vma_and_merge(void* addr, size_t size, bool is_pal_interna
     vma->top             = addr + size;
     vma->is_pal_internal = is_pal_internal;
 
-    /* initialize the contents of the new VMA to zero */
-    memset(vma->bottom, 0, vma->top - vma->bottom);
+    if (g_pal_sec.zero_heap_on_demand) {
+        /* initialize the contents of the new VMA to zero */
+        memset(vma->bottom, 0, vma->top - vma->bottom);
+    }
 
     /* how much memory was freed because [addr, addr + size) overlapped with VMAs */
     size_t freed = 0;

--- a/Pal/src/host/Linux-SGX/pal_security.h
+++ b/Pal/src/host/Linux-SGX/pal_security.h
@@ -20,8 +20,9 @@ struct pal_sec {
     sgx_measurement_t  mr_signer;
     sgx_attributes_t   enclave_attributes;
 
-    /* remaining heap usable by application */
+    /* remaining heap usable by application and whether to zero it on demand/during init */
     PAL_PTR         heap_min, heap_max;
+    PAL_BOL         zero_heap_on_demand;
 
     /* executable name, addr and size */
     PAL_SEC_STR     exec_name;

--- a/Pal/src/host/Linux-SGX/sgx_main.c
+++ b/Pal/src/host/Linux-SGX/sgx_main.c
@@ -947,6 +947,14 @@ static int load_enclave(struct pal_enclave* enclave, int manifest_fd, char* mani
             return ret;
     }
 
+    pal_sec->zero_heap_on_demand = false;
+    if (get_config(enclave->config, "sgx.zero_heap_on_demand", cfgbuf, sizeof(cfgbuf)) > 0
+            && cfgbuf[0] == '1') {
+        /* zero enclave heap on demand vs once during enclave init; this option does not affect
+         * security (only startup vs runtime performance), so can be passed from untrusted host */
+        pal_sec->zero_heap_on_demand = true;
+    }
+
     void* alt_stack = (void*)INLINE_SYSCALL(mmap, 6, NULL, ALT_STACK_SIZE,
                                             PROT_READ | PROT_WRITE,
                                             MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);

--- a/Pal/src/host/Linux-SGX/signer/pal_sgx_sign.py
+++ b/Pal/src/host/Linux-SGX/signer/pal_sgx_sign.py
@@ -865,6 +865,9 @@ def main_sign(args):
     if manifest.get('sgx.enable_stats', None) is None:
         manifest['sgx.enable_stats'] = '0'
 
+    if manifest.get('sgx.zero_heap_on_demand', None) is None:
+        manifest['sgx.zero_heap_on_demand'] = '0'
+
     output_manifest(args['output'], manifest, manifest_layout)
 
     memory_areas = [


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://graphene.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

Commit 647bca34 changed the old logic of "zero the whole heap during enclave initialization" to "zero the heap pages on demand". This led to better start-up times of enclaves (without any significant security drawbacks). However, this change has a trade-off: some applications (Redis in particular) have worse run-time performance.

To allow users to choose between faster start-up time vs better run-time performance, this commit introduces "sgx.zero_heap_on_demand" manifest option. It is zero by default, meaning zero-out of whole heap during enclave initialization; i.e., by default enclaves take longer to start, but have better run-time performance.

See https://github.com/oscarlab/graphene/pull/1640 for the context.

## How to test this PR? <!-- (if applicable) -->

We observed 5-10% runtime performance overhead with highly-loaded Redis instance if heap zero out happens "on demand" (`sgx.zero_heap_on_demand = 1`). This is not acceptable for our purposes (for Redis, it is better to have longer start-up times but the best possible run-time throughput/latency performance). With `sgx.zero_heap_on_demand = 0`, we are back to the best possible Redis performance.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1668)
<!-- Reviewable:end -->
