### PR TITLE
[LibOS] glibc: Overwrite instead of appending to build.log

### DIFF
--- a/LibOS/Makefile
+++ b/LibOS/Makefile
@@ -49,7 +49,7 @@ ifeq ($(findstring x86_64,$(SYS))$(findstring linux,$(SYS)),x86_64linux)
 
 $(BUILD_DIR)/Build.success: $(BUILD_DIR)/Makefile
 	@echo "Building glibc, may take a while to finish. Warning messages may show up. If this process terminates with failures, see \"$(BUILD_DIR)/build.log\" for more information."
-	($(MAKE) -C $(BUILD_DIR) 2>&1 >> build.log) && touch $@
+	($(MAKE) -C $(BUILD_DIR) 2>&1 > build.log) && touch $@
 
 $(GLIBC_TARGET): $(BUILD_DIR)/Build.success
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

That isn't the best idea, especially when a single build generates 13MB of logs :)

## How to test this PR? <!-- (if applicable) -->

Build a few different versions of GLIBC (or modify one of our patches to cause it to rebuild itself).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1670)
<!-- Reviewable:end -->
