### PR TITLE
support applications running in Graphene-SGX to process FIFO files which exist in host

### DIFF
--- a/Pal/src/host/Linux-SGX/enclave_framework.c
+++ b/Pal/src/host/Linux-SGX/enclave_framework.c
@@ -364,6 +364,10 @@ int load_trusted_file (PAL_HANDLE file, sgx_stub_t ** stubptr,
         return 0;
     }
 
+    /* trusted file must be a regular file (seekable) */
+    if (!file->file.seekable)
+        return -PAL_ERROR_DENIED;
+
     sgx_stub_t* stubs = NULL;
     /* mmap the whole trusted file in untrusted memory for future reads/writes; it is
      * caller's responsibility to unmap those areas after use */

--- a/Pal/src/host/Linux-SGX/pal_host.h
+++ b/Pal/src/host/Linux-SGX/pal_host.h
@@ -83,6 +83,7 @@ typedef struct pal_handle
             /* below fields are used only for trusted files */
             PAL_PTR stubs;    /* contains hashes of file chunks */
             PAL_PTR umem;     /* valid only when stubs != NULL */
+            PAL_BOL seekable; /* regular files are seekable, FIFO pipes are not */
         } file;
 
         struct {

--- a/Pal/src/host/Linux/pal_host.h
+++ b/Pal/src/host/Linux/pal_host.h
@@ -73,6 +73,7 @@ typedef struct pal_handle
              * determined by parent process.
              */
             PAL_PTR map_start;
+            PAL_BOL seekable; /* regular files are seekable, FIFO pipes are not */
         } file;
 
         struct {


### PR DESCRIPTION
This patch aims to support applications running in Graphene-SGX to process FIFO files which exist in host.

## Description of the changes <!-- (reasons and measures) -->
I have two test applications which use FIFO to communicate with each other. The FIFO file has been created on the host OS with mknod. When trying to run the two applications in Graphene "Linux-SGX" PAL, I meet below problems, which cause communication failure:
a. when application running in Graphene-SGX ("Linux-SGX" PAL) tries to open FIFO file (which exists in host) with O_WRONLY access, Graphene-SGX instance would get hang. This is because PAL would try to open the file with all-zero flag so to get file stat, but this API would get hung when the file is FIFO.
b. when application running in Graphene-SGX tries to read on FIFO file, PAL would would call pread(), however, this API would return ESPIPE error, as a result, it fails to read the file. Same issue exists when the application tries to write FIFO file.
When running the two applications in Graphene "Linux" PAL, there is not such issue and the communication can succeed.

## How to test this PR? 
The test application is in https://github.com/AntonioDan/graphene.git, under "Examples/fifotest". After pulling the code, you can test like below:
a. go to "Example/fifotest", run "SGX=1 make"
b. after build is complete, run "SGX=1 ./pal_loader readpipe testpipe"
c. open a new console, go to same directory, run "SGX=1 ./pal_loader writepipe testpipe"
When it runs successfully, the first console would print "Hello, Peer!".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1673)
<!-- Reviewable:end -->
