### PR TITLE
LibOS: Only compile cpuid and attestation test cases on x86

### DIFF
--- a/LibOS/shim/test/regression/Makefile
+++ b/LibOS/shim/test/regression/Makefile
@@ -1,13 +1,16 @@
 include ../../../../Scripts/Makefile.configs
 
+c_executables-x86_64 = \
+	attestation \
+	cpuid \
+	rdtsc
+
 c_executables = \
 	abort \
 	abort_multithread \
-	attestation \
 	bootstrap \
 	bootstrap_pie \
 	bootstrap_static \
-	cpuid \
 	dev \
 	epoll_wait_timeout \
 	eventfd \
@@ -69,12 +72,8 @@ c_executables = \
 	tcp_msg_peek \
 	udp \
 	unix \
-	vfork_and_exec
-
-ifeq ($(ARCH),x86_64)
-c_executables += \
-	rdtsc
-endif
+	vfork_and_exec \
+	$(c_executables-$(ARCH))
 
 cxx_executables = bootstrap_c++
 


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://graphene.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

Only compile cpuid and attestation test cases on x86

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1675)
<!-- Reviewable:end -->
