### PR TITLE
LibOS: Null terminate buffer before printing

### DIFF
--- a/LibOS/shim/test/regression/proc_common.c
+++ b/LibOS/shim/test/regression/proc_common.c
@@ -194,12 +194,12 @@ int main(int argc, char** argv) {
         return 1;
     }
 
-    memset(buf, 0, sizeof(buf));
-    ret = fread(buf, 1, sizeof(buf), f);
+    ret = fread(buf, 1, sizeof(buf) - 1, f);
     if (ferror(f)) {
         perror("fread /proc/cpuinfo");
         return 1;
     }
+    buf[ret] = 0;
 
     printf("%s\n", buf);
 


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://graphene.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

Null terminate buffer before printing

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1676)
<!-- Reviewable:end -->
