### PR TITLE
PAL: Use executables-x86_64 for x86_64-specific executables

### DIFF
--- a/Pal/regression/Makefile
+++ b/Pal/regression/Makefile
@@ -13,6 +13,13 @@ preloads = \
 	Preload1.so \
 	Preload2.so
 
+executables-x86_64 = \
+        AvxDisable \
+        Exception \
+        Exception2 \
+        Segment \
+        Thread
+
 executables = \
 	..Bootstrap \
 	AttestationReport \
@@ -49,16 +56,8 @@ executables = \
 	Udp \
 	Wait \
 	Yield \
-	normalize_path
-
-ifeq ($(ARCH),x86_64)
-executables += \
-        AvxDisable \
-        Exception \
-        Exception2 \
-        Segment \
-        Thread
-endif
+	normalize_path \
+	$(executables-$(ARCH))
 
 manifests = \
 	manifest \


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://graphene.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

Use executables-x86_64 for x86_64-specific executables

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1677)
<!-- Reviewable:end -->
