### PR TITLE
Examples: Upgrade to redis 6.0.5 to avoid linker issues

### DIFF
--- a/Examples/redis/Makefile
+++ b/Examples/redis/Makefile
@@ -21,8 +21,8 @@ GRAPHENEDIR = ../..
 SGX_SIGNER_KEY ?= $(GRAPHENEDIR)/Pal/src/host/Linux-SGX/signer/enclave-key.pem
 
 SRCDIR = src
-COMMIT = 5.0.5
-TAR_SHA256 = 3313d5e09938dc6e16c6911efa4a24b1c494bacb5a917a8e7925ebd55e56be85
+COMMIT = 6.0.5
+TAR_SHA256 = f7ded6c27d48c20bc78e797046c79b6bc411121f0c2d7eead9fea50d6b0b6290
 
 ifeq ($(DEBUG),1)
 GRAPHENEDEBUG = inline


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://graphene.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

Using redis 6.0.5 on more recent distros (Fedora 32) avoids linker
issues like the following ones:

    LINK redis-server
/usr/bin/ld: server.o:/home/stefanb/pef-dev/graphene/Examples/redis/src/src/sds.h:37: multiple definition of `SDS_NOINIT'; quicklist.o:/home/stefanb/pef-dev/graphene/Examples/redis/src/src/sds.h:37: first defined here
/usr/bin/ld: sds.o:/home/stefanb/pef-dev/graphene/Examples/redis/src/src/sds.h:37: multiple definition of `SDS_NOINIT'; quicklist.o:/home/stefanb/pef-dev/graphene/Examples/redis/src/src/sds.h:37: first defined here
[...]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1682)
<!-- Reviewable:end -->
