### PR TITLE
[Pal/Linux-SGX] Fix bugs in protected files that broke large files

### DIFF
--- a/Pal/src/host/Linux-SGX/protected-files/protected_files.c
+++ b/Pal/src/host/Linux-SGX/protected-files/protected_files.c
@@ -550,13 +550,12 @@ static bool ipf_update_all_data_and_mht_nodes(pf_context_t* pf) {
         data = lruc_get_next(pf->cache);
     }
 
-    // sort the list from the last node to the first (bottom layers first)
     if (dirty_count > 0)
         sort_nodes(mht_array, 0, dirty_count - 1);
 
-    // update the gmacs in the parents
-    for (dirty_idx = 0; dirty_idx < dirty_count; dirty_idx++) {
-        file_mht_node = mht_array[dirty_idx];
+    // update the gmacs in the parents from last node to first (bottom layers first)
+    for (dirty_idx = dirty_count; dirty_idx > 0; dirty_idx--) {
+        file_mht_node = mht_array[dirty_idx - 1];
 
         gcm_crypto_data_t* gcm_crypto_data = &file_mht_node->parent->decrypted.mht
             .mht_nodes_crypto[(file_mht_node->node_number - 1) % CHILD_MHT_NODES_COUNT];


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://graphene.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

This PR fixes two bugs in Protected Files:
- mbedTLS source of entropy (`mbedtls_entropy_context`) was allocated on the stack and thus destroyed after return from init function; in reality, this object must live for the whole duration of execution (this bug led to spurious segfaults due to overwritten stack).
- MHT nodes of protected files must be updated and flushed to disk in reverse order of sorting, from bottom layers to upper layers (this bug led to outdated MHT key/MAC values in resulting encrypted file, so the file could not be correctly decrypted).

Note that both bugs crept into our port of Intel SGX SDK. The first bug is absent from SDK because it doesn't use mbedTLS. The second bug is actually a blunder of porting (we even had the comment to sort in reverse order!), and SDK does the reverse sort correctly: https://github.com/intel/linux-sgx/blob/d1029a5821acffae31d66efde06589617a3df9c6/sdk/protected_fs/sgx_tprotected_fs/file_flush.cpp#L369.

## How to test this PR? <!-- (if applicable) -->

It only happens on rather big files (in our case, 250MB). So just test manually:
```bash
graphene/Pal/src/host/Linux-SGX/tools/pf_crypt/pf_crypt encrypt -w key -i big-file -o big-file.enc
graphene/Pal/src/host/Linux-SGX/tools/pf_crypt/pf_crypt decrypt -w key -i big-file.enc -o big-file.dec
md5sum big-file*  # original and dec must be the same
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1686)
<!-- Reviewable:end -->
