### PR TITLE
[Examples] Force make to download the model in PyTorch by default

### DIFF
--- a/Examples/pytorch/Makefile
+++ b/Examples/pytorch/Makefile
@@ -32,9 +32,9 @@ UBUNTU_VERSION = $(DISTRIB_ID)$(DISTRIB_RELEASE)
 
 .PHONY: all
 ifeq ($(SGX),1)
-all: pytorch.token python3.token pal_loader
+all: pytorch.token python3.token pal_loader alexnet-pretrained.pt
 else
-all: pytorch.manifest python3.manifest pal_loader
+all: pytorch.manifest python3.manifest pal_loader alexnet-pretrained.pt
 endif
 
 include ../../Scripts/Makefile.configs
@@ -77,6 +77,8 @@ pal_loader:
 
 download_model:
 	$(PYTHON3) download-pretrained-model.py
+
+alexnet-pretrained.pt: download_model
 
 .PHONY: clean
 clean:

--- a/Examples/pytorch/Makefile
+++ b/Examples/pytorch/Makefile
@@ -75,6 +75,7 @@ python3.sig: python3.manifest
 pal_loader:
 	ln -s $(GRAPHENEDIR)/Runtime/pal_loader $@
 
+.PHONY: download_model
 download_model:
 	$(PYTHON3) download-pretrained-model.py
 


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://graphene.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

PyTorch example works on a pre-downloaded model. There is a special target in the build `make download-model` to do this, but the target was not invoked by default. This was annoying during PyTorch rebuilds.

## How to test this PR? <!-- (if applicable) -->

N/A.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1687)
<!-- Reviewable:end -->
