### PR TITLE
Speed up all tests using sgx.zero_heap_on_demand

### DIFF
--- a/Examples/bash/manifest.template
+++ b/Examples/bash/manifest.template
@@ -81,3 +81,5 @@ $(TRUSTED_LIBS)
 $(TRUSTED_CHILDREN)
 
 sgx.allowed_files.scripts = file:scripts
+
+sgx.zero_heap_on_demand = 1

--- a/Examples/busybox/busybox.manifest.template
+++ b/Examples/busybox/busybox.manifest.template
@@ -140,3 +140,4 @@ sgx.allowed_files.passwd    = file:/etc/passwd
 # glibc-based host systems.
 sgx.allowed_files.localtime = file:/etc/localtime
 
+sgx.zero_heap_on_demand = 1

--- a/Examples/capnproto/addressbook.manifest.template
+++ b/Examples/capnproto/addressbook.manifest.template
@@ -54,3 +54,5 @@ sgx.trusted_files.libc = file:$(GRAPHENEDIR)/Runtime/libc.so.6
 sgx.trusted_files.libm = file:$(GRAPHENEDIR)/Runtime/libm.so.6
 sgx.trusted_files.libpthread = file:$(GRAPHENEDIR)/Runtime/libpthread.so.0
 $(TRUSTEDLIBS)
+
+sgx.zero_heap_on_demand = 1

--- a/Examples/curl/curl.manifest.template
+++ b/Examples/curl/curl.manifest.template
@@ -77,3 +77,5 @@ sgx.allowed_files.hosts      = file:/etc/hosts
 sgx.allowed_files.group      = file:/etc/group
 sgx.allowed_files.passwd     = file:/etc/passwd
 sgx.allowed_files.gaiconf    = file:/etc/gai.conf
+
+sgx.zero_heap_on_demand = 1

--- a/Examples/nodejs/nodejs.manifest.template
+++ b/Examples/nodejs/nodejs.manifest.template
@@ -58,3 +58,5 @@ $(NODEJS_TRUSTED_LIBS)
 
 # JavaScript (trusted)
 sgx.trusted_files.javascript = file:helloworld.js
+
+sgx.zero_heap_on_demand = 1

--- a/Examples/python-scipy-insecure/python.manifest.template
+++ b/Examples/python-scipy-insecure/python.manifest.template
@@ -109,3 +109,5 @@ sgx.allowed_files.tmp = file:/tmp
 sgx.allowed_files.etc = file:/etc
 sgx.allowed_files.pyhome = file:$(PYTHONHOME)
 sgx.allowed_files.pydisthome = file:$(PYTHONDISTHOME)
+
+sgx.zero_heap_on_demand = 1

--- a/Examples/python-simple/python.manifest.template
+++ b/Examples/python-simple/python.manifest.template
@@ -266,3 +266,5 @@ sgx.allowed_files.passwd    = file:/etc/passwd
 sgx.allowed_files.gaiconf   = file:/etc/gai.conf
 sgx.allowed_files.hostconf  = file:/etc/host.conf
 sgx.allowed_files.resolv    = file:/etc/resolv.conf
+
+sgx.zero_heap_on_demand = 1

--- a/Examples/r/R.manifest.template
+++ b/Examples/r/R.manifest.template
@@ -96,3 +96,5 @@ sgx.allowed_files.r_lib = file:$(R_HOME)/library
 # Allow creating child enclaves for sh
 sgx.trusted_files.sh = file:/bin/sh
 sgx.trusted_children.sh = file:sh.sig
+
+sgx.zero_heap_on_demand = 1

--- a/Examples/r/sh.manifest.template
+++ b/Examples/r/sh.manifest.template
@@ -42,3 +42,5 @@ sgx.thread_num = 2
 # SGX trusted libraries
 sgx.trusted_files.ld = file:$(GRAPHENEDIR)/Runtime/ld-linux-x86-64.so.2
 sgx.trusted_files.libc = file:$(GRAPHENEDIR)/Runtime/libc.so.6
+
+sgx.zero_heap_on_demand = 1

--- a/Examples/ra-tls-mbedtls/server.manifest.template
+++ b/Examples/ra-tls-mbedtls/server.manifest.template
@@ -53,3 +53,5 @@ sgx.allowed_files.hosts     = file:/etc/hosts
 sgx.allowed_files.group     = file:/etc/group
 sgx.allowed_files.passwd    = file:/etc/passwd
 sgx.allowed_files.gaiconf   = file:/etc/gai.conf
+
+sgx.zero_heap_on_demand = 1

--- a/Examples/ra-tls-secret-prov/secret_prov_client.manifest.template
+++ b/Examples/ra-tls-secret-prov/secret_prov_client.manifest.template
@@ -60,3 +60,5 @@ sgx.allowed_files.group     = file:/etc/group
 sgx.allowed_files.passwd    = file:/etc/passwd
 sgx.allowed_files.gaiconf   = file:/etc/gai.conf
 sgx.allowed_files.resolv    = file:/etc/resolv.conf
+
+sgx.zero_heap_on_demand = 1

--- a/Examples/ra-tls-secret-prov/secret_prov_min_client.manifest.template
+++ b/Examples/ra-tls-secret-prov/secret_prov_min_client.manifest.template
@@ -67,3 +67,5 @@ sgx.allowed_files.group     = file:/etc/group
 sgx.allowed_files.passwd    = file:/etc/passwd
 sgx.allowed_files.gaiconf   = file:/etc/gai.conf
 sgx.allowed_files.resolv    = file:/etc/resolv.conf
+
+sgx.zero_heap_on_demand = 1

--- a/LibOS/shim/test/fs/manifest.template
+++ b/LibOS/shim/test/fs/manifest.template
@@ -36,3 +36,5 @@ sgx.allowed_files.tmp_dir = file:tmp/
 sgx.protected_files_key = ffeeddccbbaa99887766554433221100
 sgx.protected_files.input = file:tmp/pf_input
 sgx.protected_files.output = file:tmp/pf_output
+
+sgx.zero_heap_on_demand = 1

--- a/LibOS/shim/test/ltp/manifest.template
+++ b/LibOS/shim/test/ltp/manifest.template
@@ -40,3 +40,5 @@ sgx.trusted_files.librt = file:$(LIBCDIR)/librt.so.1
 sgx.trusted_files.libstdbuf = file:/usr/$(ARCH_LIBDIR)/coreutils/libstdbuf.so
 
 sgx.allowed_files.tmp = file:/tmp
+
+sgx.zero_heap_on_demand = 1

--- a/LibOS/shim/test/regression/argv_from_file.manifest.template
+++ b/LibOS/shim/test/regression/argv_from_file.manifest.template
@@ -17,3 +17,4 @@ sgx.trusted_files.ld = file:../../../../Runtime/ld-linux-x86-64.so.2
 sgx.trusted_files.libc = file:../../../../Runtime/libc.so.6
 
 sgx.static_address = 1
+sgx.zero_heap_on_demand = 1

--- a/LibOS/shim/test/regression/attestation.manifest.template
+++ b/LibOS/shim/test/regression/attestation.manifest.template
@@ -22,3 +22,4 @@ sgx.trusted_files.libm = file:$(LIBCDIR)/libm.so.6
 sgx.remote_attestation = 1
 sgx.ra_client_spid = $(RA_CLIENT_SPID)
 sgx.ra_client_linkable = $(RA_CLIENT_LINKABLE)
+sgx.zero_heap_on_demand = 1

--- a/LibOS/shim/test/regression/echo.manifest.template
+++ b/LibOS/shim/test/regression/echo.manifest.template
@@ -29,3 +29,4 @@ sgx.trusted_files.ld = file:../../../../Runtime/ld-linux-x86-64.so.2
 sgx.trusted_files.libc = file:../../../../Runtime/libc.so.6
 
 sgx.static_address = 1
+sgx.zero_heap_on_demand = 1

--- a/LibOS/shim/test/regression/env_from_file.manifest.template
+++ b/LibOS/shim/test/regression/env_from_file.manifest.template
@@ -17,3 +17,4 @@ sgx.trusted_files.ld = file:../../../../Runtime/ld-linux-x86-64.so.2
 sgx.trusted_files.libc = file:../../../../Runtime/libc.so.6
 
 sgx.static_address = 1
+sgx.zero_heap_on_demand = 1

--- a/LibOS/shim/test/regression/env_from_host.manifest.template
+++ b/LibOS/shim/test/regression/env_from_host.manifest.template
@@ -15,3 +15,4 @@ sgx.trusted_files.ld = file:../../../../Runtime/ld-linux-x86-64.so.2
 sgx.trusted_files.libc = file:../../../../Runtime/libc.so.6
 
 sgx.static_address = 1
+sgx.zero_heap_on_demand = 1

--- a/LibOS/shim/test/regression/eventfd.manifest.template
+++ b/LibOS/shim/test/regression/eventfd.manifest.template
@@ -17,3 +17,4 @@ sgx.trusted_files.libm = file:../../../../Runtime/libm.so.6
 sgx.trusted_files.libpthread = file:../../../../Runtime/libpthread.so.0
 
 sgx.static_address = 1
+sgx.zero_heap_on_demand = 1

--- a/LibOS/shim/test/regression/exec_victim.manifest.template
+++ b/LibOS/shim/test/regression/exec_victim.manifest.template
@@ -18,3 +18,4 @@ sgx.trusted_files.ld = file:../../../../Runtime/ld-linux-x86-64.so.2
 sgx.trusted_files.libc = file:../../../../Runtime/libc.so.6
 
 sgx.static_address = 1
+sgx.zero_heap_on_demand = 1

--- a/LibOS/shim/test/regression/exit_group.manifest.template
+++ b/LibOS/shim/test/regression/exit_group.manifest.template
@@ -16,3 +16,4 @@ sgx.trusted_files.libpthread = file:../../../../Runtime/libpthread.so.0
 sgx.thread_num = 7
 
 sgx.static_address = 1
+sgx.zero_heap_on_demand = 1

--- a/LibOS/shim/test/regression/file_check_policy_allow_all_but_log.manifest.template
+++ b/LibOS/shim/test/regression/file_check_policy_allow_all_but_log.manifest.template
@@ -17,3 +17,4 @@ sgx.trusted_files.libc = file:$(LIBCDIR)/libc.so.6
 sgx.trusted_files.test = file:trusted_testfile
 
 sgx.static_address = 1
+sgx.zero_heap_on_demand = 1

--- a/LibOS/shim/test/regression/file_check_policy_strict.manifest.template
+++ b/LibOS/shim/test/regression/file_check_policy_strict.manifest.template
@@ -17,3 +17,4 @@ sgx.trusted_files.libc = file:$(LIBCDIR)/libc.so.6
 sgx.trusted_files.test = file:trusted_testfile
 
 sgx.static_address = 1
+sgx.zero_heap_on_demand = 1

--- a/LibOS/shim/test/regression/futex_bitset.manifest.template
+++ b/LibOS/shim/test/regression/futex_bitset.manifest.template
@@ -23,3 +23,4 @@ sgx.trusted_files.libpthread = file:../../../../Runtime/libpthread.so.0
 sgx.thread_num = 16
 
 sgx.static_address = 1
+sgx.zero_heap_on_demand = 1

--- a/LibOS/shim/test/regression/futex_requeue.manifest.template
+++ b/LibOS/shim/test/regression/futex_requeue.manifest.template
@@ -18,3 +18,4 @@ sgx.trusted_files.libpthread = file:../../../../Runtime/libpthread.so.0
 sgx.thread_num = 16
 
 sgx.static_address = 1
+sgx.zero_heap_on_demand = 1

--- a/LibOS/shim/test/regression/futex_wake_op.manifest.template
+++ b/LibOS/shim/test/regression/futex_wake_op.manifest.template
@@ -18,3 +18,4 @@ sgx.trusted_files.libpthread = file:../../../../Runtime/libpthread.so.0
 sgx.thread_num = 16
 
 sgx.static_address = 1
+sgx.zero_heap_on_demand = 1

--- a/LibOS/shim/test/regression/getdents.manifest.template
+++ b/LibOS/shim/test/regression/getdents.manifest.template
@@ -13,3 +13,4 @@ sgx.trusted_files.libc = file:$(LIBCDIR)/libc.so.6
 sgx.allowed_files.test = file:root
 
 sgx.static_address = 1
+sgx.zero_heap_on_demand = 1

--- a/LibOS/shim/test/regression/host_root_fs.manifest.template
+++ b/LibOS/shim/test/regression/host_root_fs.manifest.template
@@ -17,3 +17,4 @@ sgx.trusted_files.libc = file:../../../../Runtime/libc.so.6
 sgx.trusted_files.libdl = file:../../../../Runtime/libdl.so.2
 
 sgx.static_address = 1
+sgx.zero_heap_on_demand = 1

--- a/LibOS/shim/test/regression/init_fail.manifest.template
+++ b/LibOS/shim/test/regression/init_fail.manifest.template
@@ -16,3 +16,4 @@ sgx.trusted_files.ld = file:$(LIBCDIR)/ld-linux-x86-64.so.2
 sgx.trusted_files.libc = file:$(LIBCDIR)/libc.so.6
 
 sgx.static_address = 1
+sgx.zero_heap_on_demand = 1

--- a/LibOS/shim/test/regression/large_mmap.manifest.template
+++ b/LibOS/shim/test/regression/large_mmap.manifest.template
@@ -20,3 +20,4 @@ sgx.allowed_files.testfile = file:testfile
 sgx.enclave_size = 8G
 
 sgx.static_address = 1
+sgx.zero_heap_on_demand = 1

--- a/LibOS/shim/test/regression/manifest.template
+++ b/LibOS/shim/test/regression/manifest.template
@@ -46,3 +46,5 @@ sgx.static_address = 1
 
 sgx.trusted_files.sh = file:/bin/sh
 sgx.trusted_children.sh = file:sh.sig
+
+sgx.zero_heap_on_demand = 1

--- a/LibOS/shim/test/regression/mmap_file.manifest.template
+++ b/LibOS/shim/test/regression/mmap_file.manifest.template
@@ -23,3 +23,4 @@ sgx.trusted_files.libc = file:../../../../Runtime/libc.so.6
 sgx.allowed_files.testfile = file:testfile
 
 sgx.static_address = 1
+sgx.zero_heap_on_demand = 1

--- a/LibOS/shim/test/regression/multi_pthread.manifest.template
+++ b/LibOS/shim/test/regression/multi_pthread.manifest.template
@@ -17,3 +17,4 @@ sgx.thread_num = 8
 
 sgx.static_address = 1
 sgx.enable_stats = 1
+sgx.zero_heap_on_demand = 1

--- a/LibOS/shim/test/regression/multi_pthread_exitless.manifest.template
+++ b/LibOS/shim/test/regression/multi_pthread_exitless.manifest.template
@@ -20,3 +20,4 @@ sgx.rpc_thread_num = 8
 
 sgx.static_address = 1
 sgx.enable_stats = 1
+sgx.zero_heap_on_demand = 1

--- a/LibOS/shim/test/regression/openmp.manifest.template
+++ b/LibOS/shim/test/regression/openmp.manifest.template
@@ -25,3 +25,4 @@ sgx.trusted_files.libdl = file:../../../../Runtime/libdl.so.2
 sgx.trusted_files.libgomp = file:/usr$(ARCH_LIBDIR)/libgomp.so.1
 
 sgx.static_address = 1
+sgx.zero_heap_on_demand = 1

--- a/LibOS/shim/test/regression/proc_path.manifest.template
+++ b/LibOS/shim/test/regression/proc_path.manifest.template
@@ -17,3 +17,4 @@ sgx.trusted_files.ld = file:../../../../Runtime/ld-linux-x86-64.so.2
 sgx.trusted_files.libc = file:../../../../Runtime/libc.so.6
 
 sgx.static_address = 1
+sgx.zero_heap_on_demand = 1

--- a/LibOS/shim/test/regression/sh.manifest.template
+++ b/LibOS/shim/test/regression/sh.manifest.template
@@ -32,3 +32,4 @@ sgx.trusted_files.echo = file:/bin/echo
 sgx.trusted_children.echo = file:echo.sig
 
 sgx.static_address = 1
+sgx.zero_heap_on_demand = 1

--- a/LibOS/shim/test/regression/shared_object.manifest.template
+++ b/LibOS/shim/test/regression/shared_object.manifest.template
@@ -11,3 +11,4 @@ sgx.trusted_files.ld = file:$(LIBCDIR)/ld-linux-x86-64.so.2
 sgx.trusted_files.libc = file:$(LIBCDIR)/libc.so.6
 
 sgx.static_address = 1
+sgx.zero_heap_on_demand = 1

--- a/Pal/regression/AvxDisable.manifest.template
+++ b/Pal/regression/AvxDisable.manifest.template
@@ -3,3 +3,4 @@ loader.argv0_override = AvxDisable
 sgx.require_avx = 0
 sgx.require_avx512 = 0
 sgx.allowed_files.res = file:avxRes
+sgx.zero_heap_on_demand = 1

--- a/Pal/regression/Bootstrap2.manifest.template
+++ b/Pal/regression/Bootstrap2.manifest.template
@@ -1,2 +1,4 @@
 loader.debug_type = inline
 loader.argv0_override = Bootstrap2
+
+sgx.zero_heap_on_demand = 1

--- a/Pal/regression/Bootstrap3.manifest.template
+++ b/Pal/regression/Bootstrap3.manifest.template
@@ -1,3 +1,5 @@
 loader.debug_type = inline
 loader.preload = file:Preload1.so,file:Preload2.so
 loader.argv0_override = Bootstrap3
+
+sgx.zero_heap_on_demand = 1

--- a/Pal/regression/Bootstrap4.manifest.template
+++ b/Pal/regression/Bootstrap4.manifest.template
@@ -1,2 +1,4 @@
 loader.exec = file:Bootstrap
 loader.argv0_override = Bootstrap
+
+sgx.zero_heap_on_demand = 1

--- a/Pal/regression/Bootstrap5.manifest.template
+++ b/Pal/regression/Bootstrap5.manifest.template
@@ -2,3 +2,5 @@ loader.debug_type = inline
 loader.preload = file:Preload1.so,file:Preload2.so
 # This example doesn't use any binary, this line is only to stop argv protection from complaining.
 loader.argv0_override = Bootstrap
+
+sgx.zero_heap_on_demand = 1

--- a/Pal/regression/Bootstrap7.manifest.template
+++ b/Pal/regression/Bootstrap7.manifest.template
@@ -1001,3 +1001,5 @@ loader.env.key997 = na
 loader.env.key998 = na
 loader.env.key999 = na
 loader.env.key1000 = na
+
+sgx.zero_heap_on_demand = 1

--- a/Pal/regression/File.manifest.template
+++ b/Pal/regression/File.manifest.template
@@ -11,3 +11,5 @@ sgx.trusted_files.tmp1 = file:File
 sgx.trusted_files.tmp2 = file:../regression/File
 sgx.allowed_files.tmp3 = file:file_nonexist.tmp
 sgx.allowed_files.tmp4 = file:file_delete.tmp
+
+sgx.zero_heap_on_demand = 1

--- a/Pal/regression/Process.manifest.template
+++ b/Pal/regression/Process.manifest.template
@@ -6,3 +6,5 @@ fs.mount.root.uri = file:
 
 net.allow_bind.1 = 127.0.0.1:8000
 net.allow_peer.1 = 127.0.0.1:8000
+
+sgx.zero_heap_on_demand = 1

--- a/Pal/regression/Process2.manifest.template
+++ b/Pal/regression/Process2.manifest.template
@@ -2,3 +2,5 @@ loader.argv0_override = Process2
 loader.debug_type = inline
 
 sgx.trusted_children.1 = file:Bootstrap.sig
+
+sgx.zero_heap_on_demand = 1

--- a/Pal/regression/Process3.manifest.template
+++ b/Pal/regression/Process3.manifest.template
@@ -1,3 +1,5 @@
 loader.debug_type = inline
 loader.preload = file:Preload1.so,file:Preload2.so
 loader.insecure__use_cmdline_argv = 1
+
+sgx.zero_heap_on_demand = 1

--- a/Pal/regression/SendHandle.manifest.template
+++ b/Pal/regression/SendHandle.manifest.template
@@ -6,3 +6,5 @@ net.allow_bind.1 = 127.0.0.1:8000
 net.allow_peer.1 = 127.0.0.1:8000
 
 sgx.allowed_files.tmp = file:to_send.tmp
+
+sgx.zero_heap_on_demand = 1

--- a/Pal/regression/Thread2.manifest.template
+++ b/Pal/regression/Thread2.manifest.template
@@ -2,3 +2,4 @@ loader.argv0_override = Thread2
 
 sgx.thread_num = 2
 sgx.enable_stats = 1
+sgx.zero_heap_on_demand = 1

--- a/Pal/regression/Thread2_exitless.manifest.template
+++ b/Pal/regression/Thread2_exitless.manifest.template
@@ -4,3 +4,4 @@ loader.argv0_override = Thread2
 sgx.thread_num = 2
 sgx.rpc_thread_num = 2
 sgx.enable_stats = 1
+sgx.zero_heap_on_demand = 1

--- a/Pal/regression/manifest.template
+++ b/Pal/regression/manifest.template
@@ -5,3 +5,5 @@ fs.mount.root.uri = file:
 
 net.allow_bind.1 = 127.0.0.1:8000
 net.allow_peer.1 = 127.0.0.1:8000
+
+sgx.zero_heap_on_demand = 1

--- a/Pal/regression/nonelf_binary.manifest.template
+++ b/Pal/regression/nonelf_binary.manifest.template
@@ -1,2 +1,4 @@
 loader.exec = file:./nonelf_binary
 loader.debug_type = inline
+
+sgx.zero_heap_on_demand = 1


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Time comparison on SGX: (before -> after, min:sec)

    LibOS regression: 5:57 -> 4:35
    PAL regression: 1:58 -> 1:26
    LTP: 6:01 -> 4:48

## How to test this PR? <!-- (if applicable) -->

Jenkins.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1689)
<!-- Reviewable:end -->
