### PR TITLE
[PAL/Linux] Fix the failure of declaring '_r_debug@@PAL' as default

### DIFF
--- a/Pal/include/pal/pal.h
+++ b/Pal/include/pal/pal.h
@@ -789,11 +789,8 @@ PAL_BOL DkAttestationQuote(PAL_PTR user_report_data, PAL_NUM user_report_data_si
 #ifdef __GNUC__
 # define symbol_version_default(real, name, version) \
     __asm__ (".symver " #real "," #name "@@" #version "\n")
-# define symbol_version(real, name, version) \
-    __asm__ (".symver " #real "," #name "@" #version "\n")
 #else
 # define symbol_version_default(real, name, version)
-# define symbol_version(real, name, version)
 #endif
 
 #if defined(__i386__) || defined(__x86_64__)

--- a/Pal/include/pal/pal.h
+++ b/Pal/include/pal/pal.h
@@ -789,8 +789,11 @@ PAL_BOL DkAttestationQuote(PAL_PTR user_report_data, PAL_NUM user_report_data_si
 #ifdef __GNUC__
 # define symbol_version_default(real, name, version) \
     __asm__ (".symver " #real "," #name "@@" #version "\n")
+# define symbol_version(real, name, version) \
+    __asm__ (".symver " #real "," #name "@" #version "\n")
 #else
 # define symbol_version_default(real, name, version)
+# define symbol_version(real, name, version)
 #endif
 
 #if defined(__i386__) || defined(__x86_64__)

--- a/Pal/src/host/Linux/db_rtld.c
+++ b/Pal/src/host/Linux/db_rtld.c
@@ -33,6 +33,7 @@
    a statically-linked program there is no dynamic section for the debugger
    to examine and it looks for this particular symbol name.  */
 struct r_debug g_pal_r_debug = { 1, NULL, (ElfW(Addr))&pal_dl_debug_state, RT_CONSISTENT, 0 };
+symbol_version_default(g_pal_r_debug, _r_debug, PAL);
 
 /* This function exists solely to have a breakpoint set on it by the
    debugger.  The debugger is supposed to find this function's address by

--- a/Pal/src/host/Linux/pal_security.h
+++ b/Pal/src/host/Linux/pal_security.h
@@ -37,13 +37,6 @@ struct r_debug {
 
 void pal_dl_debug_state(void);
 
-/* This structure communicates dl state to the debugger.  The debugger
-   normally finds it via the DT_DEBUG entry in the dynamic section, but in
-   a statically-linked program there is no dynamic section for the debugger
-   to examine and it looks for this particular symbol name.  */
-extern struct r_debug g_pal_r_debug;
-symbol_version(g_pal_r_debug, _r_debug, PAL);
-
 extern struct pal_sec {
     /* system variables */
     unsigned int process_id;

--- a/Pal/src/host/Linux/pal_security.h
+++ b/Pal/src/host/Linux/pal_security.h
@@ -42,7 +42,7 @@ void pal_dl_debug_state(void);
    a statically-linked program there is no dynamic section for the debugger
    to examine and it looks for this particular symbol name.  */
 extern struct r_debug g_pal_r_debug;
-symbol_version_default(g_pal_r_debug, _r_debug, PAL);
+symbol_version(g_pal_r_debug, _r_debug, PAL);
 
 extern struct pal_sec {
     /* system variables */


### PR DESCRIPTION
## Description of the changes
This PR fixes the building error as follows
Error: invalid attempt to declare external version name as default in symbol `_r_debug@@pal'
the latest version of dynamic linker strictly checks the default symbol version.

Fixes #1685

## How to test this PR? 
make 

on platform

> VERSION="18.04.3 LTS (Bionic Beaver)"
> ID=ubuntu
> ID_LIKE=debian
> PRETTY_NAME="Ubuntu 18.04.3 LTS"
> gcc (Ubuntu 7.5.0-3ubuntu1~18.04) 7.5.0
> GNU ld (GNU Binutils) 2.34.50.20200426
>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1690)
<!-- Reviewable:end -->
