### PR TITLE
[LibOS] Do not clean-up if LibOS initialization failed

### DIFF
--- a/LibOS/shim/src/shim_init.c
+++ b/LibOS/shim/src/shim_init.c
@@ -494,7 +494,7 @@ fail:
         int _err = CALL_INIT(func, ##__VA_ARGS__);                      \
         if (_err < 0) {                                                 \
             SYS_PRINTF("shim_init() in " #func " (%d)\n", _err);        \
-            shim_clean_and_exit(_err);                                  \
+            DkProcessExit(_err);                                        \
         }                                                               \
     } while (0)
 

--- a/LibOS/shim/test/regression/Makefile
+++ b/LibOS/shim/test/regression/Makefile
@@ -95,6 +95,7 @@ manifests = \
 	getdents.manifest \
 	host_root_fs.manifest \
 	init_fail.manifest \
+	init_fail2.manifest \
 	large_mmap.manifest \
 	mmap_file.manifest \
 	multi_pthread.manifest \
@@ -108,11 +109,12 @@ exec_target = \
 	$(c_executables) \
 	$(cxx_executables) \
 	argv_from_file.manifest \
+	echo.manifest \
 	env_from_file.manifest \
 	env_from_host.manifest \
-	echo.manifest \
 	file_check_policy_allow_all_but_log.manifest \
 	file_check_policy_strict.manifest \
+	init_fail2.manifest \
 	multi_pthread_exitless.manifest \
 	sh.manifest
 

--- a/LibOS/shim/test/regression/init_fail2.manifest.template
+++ b/LibOS/shim/test/regression/init_fail2.manifest.template
@@ -1,0 +1,19 @@
+loader.exec = file:init_fail
+loader.preload = file:$(SHIMPATH)
+loader.env.LD_LIBRARY_PATH = /lib
+loader.debug_type = none
+loader.argv0_override = init_fail
+
+fs.mount.lib.type = chroot
+fs.mount.lib.path = /lib
+fs.mount.lib.uri = file:$(LIBCDIR)
+
+sgx.trusted_files.ld = file:$(LIBCDIR)/ld-linux-x86-64.so.2
+sgx.trusted_files.libc = file:$(LIBCDIR)/libc.so.6
+
+sgx.static_address = 1
+sgx.zero_heap_on_demand = 1
+
+# this is an impossible combination of options, LibOS must fail very early in init process
+sgx.enclave_size = 256M
+sys.brk.max_size = 512M

--- a/LibOS/shim/test/regression/test_libos.py
+++ b/LibOS/shim/test/regression/test_libos.py
@@ -212,6 +212,15 @@ class TC_01_Bootstrap(RegressionTestCase):
         except subprocess.CalledProcessError as e:
             self.assertNotEqual(e.returncode, 42, 'expected returncode != 42')
 
+    @unittest.skipUnless(HAS_SGX, 'This test relies on SGX-specific manifest options.')
+    def test_501_init_fail2(self):
+        try:
+            manifest = self.get_manifest('init_fail2')
+            self.run_binary([manifest], timeout=60)
+            self.fail('expected to return nonzero (and != 42)')
+        except subprocess.CalledProcessError as e:
+            self.assertNotEqual(e.returncode, 42, 'expected returncode != 42')
+
     def test_600_multi_pthread(self):
         stdout, _ = self.run_binary(['multi_pthread'])
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

See https://github.com/oscarlab/graphene/issues/1688. Graphene hanged if an error was detected very early (before IPC initialization) in the LibOS init process. With this PR, Graphene doesn't attempt to do cleanup and simply loudly exits the process.

Fixes #1688.

## How to test this PR? <!-- (if applicable) -->

All tests must pass. New test `init_fail2` is added to LibOS regression suite.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1691)
<!-- Reviewable:end -->
