### PR TITLE
[Pal/Linux-SGX] Allow reads of less bytes than requested in protected files

### DIFF
--- a/Pal/src/host/Linux-SGX/protected-files/protected_files.c
+++ b/Pal/src/host/Linux-SGX/protected-files/protected_files.c
@@ -805,10 +805,10 @@ static size_t ipf_write(pf_context_t* pf, const void* ptr, size_t size) {
 }
 
 static size_t ipf_read(pf_context_t* pf, void* ptr, size_t size) {
-    if (ptr == NULL || size == 0)
+    if (ptr == NULL) {
+        pf->last_error = PF_STATUS_INVALID_PARAMETER;
         return 0;
-
-    size_t data_left_to_read = size;
+    }
 
     if (PF_FAILURE(pf->file_status)) {
         pf->last_error = pf->file_status;
@@ -820,17 +820,7 @@ static size_t ipf_read(pf_context_t* pf, void* ptr, size_t size) {
         return 0;
     }
 
-    if (pf->end_of_file) {
-        // not an error
-        return 0;
-    }
-
-    // this check is not really needed, can go on with the code and it will do nothing until the end,
-    // but it's more 'right' to check it here
-    if (pf->offset == pf->encrypted_part_plain.size) {
-        pf->end_of_file = true;
-        return 0;
-    }
+    size_t data_left_to_read = size;
 
     if (((uint64_t)data_left_to_read) > (uint64_t)(pf->encrypted_part_plain.size - pf->offset)) {
         // the request is bigger than what's left in the file
@@ -1267,15 +1257,30 @@ pf_status_t pf_set_size(pf_context_t* pf, uint64_t size) {
     return PF_STATUS_NOT_IMPLEMENTED;
 }
 
-pf_status_t pf_read(pf_context_t* pf, uint64_t offset, size_t size, void* output) {
+pf_status_t pf_read(pf_context_t* pf, uint64_t offset, size_t size, void* output,
+                    size_t* bytes_read) {
     if (!g_initialized)
         return PF_STATUS_UNINITIALIZED;
+
+    if (!size) {
+        *bytes_read = 0;
+        return PF_STATUS_SUCCESS;
+    }
 
     if (!ipf_seek(pf, offset))
         return pf->last_error;
 
-    if (ipf_read(pf, output, size) != size)
+    if (pf->end_of_file || pf->offset == pf->encrypted_part_plain.size) {
+        pf->end_of_file = true;
+        *bytes_read = 0;
+        return PF_STATUS_SUCCESS;
+    }
+
+    size_t bytes = ipf_read(pf, output, size);
+    if (!bytes)
         return pf->last_error;
+
+    *bytes_read = bytes;
     return PF_STATUS_SUCCESS;
 }
 

--- a/Pal/src/host/Linux-SGX/protected-files/protected_files.h
+++ b/Pal/src/host/Linux-SGX/protected-files/protected_files.h
@@ -199,9 +199,11 @@ pf_status_t pf_close(pf_context_t* pf);
  * \param [in] offset Data offset to read from
  * \param [in] size Number of bytes to read
  * \param [out] output Destination buffer
+ * \param [out] bytes_read Number of bytes actually read
  * \return PF status
  */
-pf_status_t pf_read(pf_context_t* pf, uint64_t offset, size_t size, void* output);
+pf_status_t pf_read(pf_context_t* pf, uint64_t offset, size_t size, void* output,
+                    size_t* bytes_read);
 
 /*!
  * \brief Write to a protected file

--- a/Pal/src/host/Linux-SGX/tools/common/pf_util.c
+++ b/Pal/src/host/Linux-SGX/tools/common/pf_util.c
@@ -394,7 +394,11 @@ int pf_decrypt_file(const char* input_path, const char* output_path, bool verify
         if (chunk_size == 0)
             break;
 
-        pfs = pf_read(pf, input_offset, chunk_size, chunk);
+        size_t bytes_read = 0;
+        pfs = pf_read(pf, input_offset, chunk_size, chunk, &bytes_read);
+        if (bytes_read != chunk_size) {
+            pfs = PF_STATUS_CORRUPTED;
+        }
         if (PF_FAILURE(pfs)) {
             ERROR("Read from protected file failed (offset %" PRIu64 ", size %" PRIu64 "): %d\n",
                   input_offset, chunk_size, pfs);


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://graphene.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

Previously, `pf_file_read()`/`pf_read()` in Protected Files disallowed reading less than the requested number of bytes. This is incorrect semantics, and these functions must return the actually read number of bytes instead of loudly failing. This bug leads to e.g. errors in Python scripts (Python's `read()` reads one byte past the end of file
for whatever reason).

Thanks to @dayeol for finding this issue and pair-debugging it.

## How to test this PR? <!-- (if applicable) -->

We found it when working on the PyTorch examples with protected-files input and output. The example will soon be submitted.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1693)
<!-- Reviewable:end -->
