### PR TITLE
[SGX] Update error message if fsgsbase support is not present

### DIFF
--- a/Pal/src/host/Linux-SGX/sgx_framework.c
+++ b/Pal/src/host/Linux-SGX/sgx_framework.c
@@ -18,8 +18,11 @@ int open_sgx_driver(bool need_gsgx) {
     if (need_gsgx) {
         g_gsgx_device = INLINE_SYSCALL(open, 3, GSGX_FILE, O_RDWR | O_CLOEXEC, 0);
         if (IS_ERR(g_gsgx_device)) {
-            SGX_DBG(DBG_E, "Cannot open device " GSGX_FILE ". Please make sure the"
-                    " Graphene SGX kernel module is loaded.\n");
+            SGX_DBG(DBG_E, "\n\tSystem does not support FSGSBASE instructions, which Graphene requires on SGX.\n\n"
+                    "\tThe best option is to move to a newer Linux kernel with FSGSBASE support (5.9+), or\n"
+                    "\ta kernel with a back-ported patch to support FSGSBASE.\n"
+                    "\tOne may also load the Graphene SGX kernel, although this is insecure.\n"
+                    "\tIf the Graphene SGX module is loaded, check permissions on the device " GSGX_FILE ", as we cannot open this file.\n\n");
             return -ERRNO(g_gsgx_device);
         }
     }


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://graphene.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

At the suggestion of @woju, I manually tested the error message on a system with a 5.8+rc1 kernel with v13 of fsgsbase patch (and no gsgx module and fsgsbase support disabled at the kernel command line).  The current message encourages people to load the gsgx module without mentioning the security issues.

This patch updates the text that one sees to be more informative/clear about the issues.  Probably opportunities to improve this further.

## How to test this PR? <!-- (if applicable) -->

On a system without fsgsbase support (just unload gsgx on most systems), run a pal unit test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1694)
<!-- Reviewable:end -->
