### PR TITLE
 [LibOS] test/ltp: Try to deobfuscate Makefiles 

### DIFF
--- a/.ci/run-pylint
+++ b/.ci/run-pylint
@@ -14,8 +14,9 @@ find . -name \*.py \
     -and -not -path ./Pal/lib/crypto/mbedtls/\* \
     -and -not -path ./LibOS/glibc-build/\* \
     -and -not -path ./LibOS/glibc-\?.\?\?/\* \
-    -and -not -path ./LibOS/shim/test/ltp/opt/\* \
     -and -not -path ./LibOS/shim/test/ltp/src/\* \
+    -and -not -path ./LibOS/shim/test/ltp/build/\* \
+    -and -not -path ./LibOS/shim/test/ltp/install/\* \
     -and -not -path ./Examples/pytorch/\* \
 | sed 's/./\\&/g' \
 | xargs "${PYLINT}" "$@" \

--- a/LibOS/shim/test/ltp/.gitignore
+++ b/LibOS/shim/test/ltp/.gitignore
@@ -1,3 +1,4 @@
-opt/
-ltp*.xml
+/build/
+/install/
+/ltp*.xml
 /pal_loader

--- a/LibOS/shim/test/ltp/Makefile
+++ b/LibOS/shim/test/ltp/Makefile
@@ -1,9 +1,9 @@
 include makevars.mk
 
-target = $(TESTCASEDIR)/pal_loader build-manifest
+target = $(INSTALLDIR)/INSTALL_SUCCESS build-manifest
 exec_target =
 
-clean-extra = clean-build
+clean-extra += clean-build
 
 include ../../../../Scripts/Makefile.configs
 # Make ARCH_LIBDIR visible in Makefile.Test
@@ -14,26 +14,33 @@ $(SRCDIR)/Makefile:
 	$(error "$(SRCDIR) is empty. Please run `git submodule update --init $(SRCDIR)` or download the LTP source code (https://github.com/linux-test-project/ltp) into $(SRCDIR).")
 
 $(SRCDIR)/configure: $(SRCDIR)/Makefile
-	cd $(SRCDIR) && $(MAKE) autotools
+	$(MAKE) -C $(SRCDIR) autotools
 
-$(BUILDDIR)/runltp: $(SRCDIR)/configure
-	cd $(SRCDIR) && ./configure
-	cd $(SRCDIR) && $(MAKE) FILTER_OUT_DIRS=delete_module -C testcases/kernel/syscalls
-	cd $(SRCDIR) && $(MAKE) FILTER_OUT_DIRS=delete_module "DESTDIR=$(PWD)" -C runtest SKIP_IDCHECK=1 install
-	cd $(SRCDIR) && $(MAKE) FILTER_OUT_DIRS=delete_module "DESTDIR=$(PWD)" -C testcases/kernel/syscalls SKIP_IDCHECK=1 install
+.SECONDARY: $(BUILDDIR)/BUILD_SUCCESS
+$(BUILDDIR)/BUILD_SUCCESS: $(SRCDIR)/configure
+	# Out-of-tree build steps were taken from ltp/INSTALL.
+	# The instructions below assume that SRCDIR and BUILDDIR are absolute.
+	mkdir -p $(BUILDDIR)
+	# Kernel module tests are not meaningful for our LibOS and building them causes troubles on
+	# incompatible host kernels.
+	cd $(BUILDDIR) && $(SRCDIR)/configure --without-modules --prefix $(INSTALLDIR)
+	$(MAKE) -C $(BUILDDIR) -f $(SRCDIR)/Makefile top_srcdir=$(SRCDIR) top_builddir=$(BUILDDIR) all
+	touch $@
 
-$(TESTCASEDIR)/pal_loader: $(BUILDDIR)/runltp
-	ln -sf $(call relative-to,$(dir $@),../../Runtime/pal_loader) $@
+.SECONDARY: $(INSTALLDIR)/INSTALL_SUCCESS
+$(INSTALLDIR)/INSTALL_SUCCESS: $(BUILDDIR)/BUILD_SUCCESS
+	$(MAKE) -C $(BUILDDIR) -f $(SRCDIR)/Makefile top_srcdir=$(SRCDIR) top_builddir=$(BUILDDIR) SKIP_IDCHECK=1 install
+	ln -sf $(call relative-to,$(TESTCASEDIR),../../../Runtime/pal_loader) $(TESTCASEDIR)/pal_loader
+	ln -sf $(abspath Makefile.testcases) $(TESTCASEDIR)/Makefile
+	touch $@
 
-build-manifest: $(TESTCASEDIR)/manifest.template $(TESTCASEDIR)/Makefile
-	cd $(TESTCASEDIR) && $(MAKE)
+.PHONY: build-manifest
+build-manifest: $(TESTCASEDIR)/manifest.template $(INSTALLDIR)/INSTALL_SUCCESS
+	$(MAKE) -C $(TESTCASEDIR)
 
-$(TESTCASEDIR)/manifest.template: manifest.template
+$(TESTCASEDIR)/manifest.template: manifest.template $(INSTALLDIR)/INSTALL_SUCCESS
 	sed -e 's|$$(ARCH_LIBDIR)|'"$(ARCH_LIBDIR)"'|g' \
 		$< > $@
-
-$(TESTCASEDIR)/Makefile: Makefile.testcases
-	ln -sf $(abspath $<) $@
 
 .PHONY: sgx-tokens
 sgx-tokens: build-manifest
@@ -41,13 +48,13 @@ sgx-tokens: build-manifest
 
 .PHONY: regression
 regression:
-	if test "$(SGX)" -eq 1; then \
-		$(RM) ltp-sgx.xml; \
-		$(MAKE) ltp-sgx.xml; \
-	else \
-		$(RM) ltp.xml; \
-		$(MAKE) ltp.xml; \
-	fi
+ifeq ($(SGX),"1")
+	$(RM) ltp-sgx.xml
+	$(MAKE) ltp-sgx.xml
+else
+	$(RM) ltp.xml
+	$(MAKE) ltp.xml
+endif
 
 %.xml: %.cfg ltp-bug-1248.cfg ltp-bug-1075.cfg $(LTPSCENARIO) $(target)
 	./contrib/conf_lint.py < $<
@@ -55,6 +62,7 @@ regression:
 
 ltp-sgx.xml: RUNLTPOPTS += -c ltp-bug-1075.cfg
 
+.PHONY: clean-build
 clean-build:
-	cd $(SRCDIR) && $(MAKE) clean
-	rm -rf opt ltp*.xml
+	$(MAKE) -C $(SRCDIR) clean
+	$(RM) -r $(BUILDDIR) $(INSTALLDIR) ltp*.xml

--- a/LibOS/shim/test/ltp/Makefile.Test
+++ b/LibOS/shim/test/ltp/Makefile.Test
@@ -136,4 +136,4 @@ endif
 
 .PHONY: clean
 clean: $(clean-extra)
-	rm -rf pal_loader $(exec_target) *.token *.sig *.manifest.sgx $(target) $(wildcard *.d) .output.*
+	$(RM) -r pal_loader $(exec_target) *.token *.sig *.manifest.sgx $(target) $(wildcard *.d) .output.*

--- a/LibOS/shim/test/ltp/Makefile.testcases
+++ b/LibOS/shim/test/ltp/Makefile.testcases
@@ -1,4 +1,4 @@
-include ../../../../makevars.mk
+include ../../../makevars.mk
 
 manifests = $(wildcard $(ROOTDIR)/*.manifest.template) manifest
 testcases = $(shell cd $(ROOTDIR); \
@@ -9,7 +9,7 @@ target = $(manifests) $(testcases) etc/nsswitch.conf etc/passwd
 
 include $(ROOTDIR)/Makefile.Test
 
-$(addsuffix .template,$(manifests)): %: ../../../../%
+$(addsuffix .template,$(manifests)): %: ../../../%
 	ln -sf $< $@
 
 etc/nsswitch.conf:

--- a/LibOS/shim/test/ltp/README.rst
+++ b/LibOS/shim/test/ltp/README.rst
@@ -8,7 +8,7 @@ is for consumption in Jenkins. There is also rudimentary logging.
 
 To run a single testcase, execute the following commands::
 
-    cd <LTP_REPO>/opt/ltp/testcases/bin/
+    cd <LTP_REPO>/install/testcases/bin/
     <GRAPHENE_DIR>/Runtime/pal_loader [SGX] <TEST_BINARY>
 
 In this way, one can debug one particular syscall testcase.
@@ -29,7 +29,7 @@ Global options:
   become unstable if more than one test is running concurrently under SGX
 - ``junit-classname``: classname to be shown in JUnit-XML report (``LTP``)
 - ``loader``: path to ``pal_loader`` (default: ``./pal_loader``)
-- ``ltproot``: path to LTP (default: ``./opt/ltp``)
+- ``ltproot``: path to LTP (default: ``./install``)
 
 Per-binary options:
 - ``skip``: if true-ish, do not attempt to run the binary (default: false).

--- a/LibOS/shim/test/ltp/makevars.mk
+++ b/LibOS/shim/test/ltp/makevars.mk
@@ -1,6 +1,9 @@
+# Everything here must be absolute because other Makefiles assume this.
 ROOTDIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+
 SRCDIR = $(ROOTDIR)/src
-BUILDDIR = $(ROOTDIR)/opt/ltp
-TESTCASEDIR = $(BUILDDIR)/testcases/bin
-LTPSCENARIO = $(BUILDDIR)/runtest/syscalls
+BUILDDIR = $(ROOTDIR)/build
+INSTALLDIR = $(ROOTDIR)/install
+TESTCASEDIR = $(INSTALLDIR)/testcases/bin
+LTPSCENARIO = $(INSTALLDIR)/runtest/syscalls
 RUNLTPOPTS = -c ltp-bug-1248.cfg

--- a/LibOS/shim/test/ltp/runltp_xml.py
+++ b/LibOS/shim/test/ltp/runltp_xml.py
@@ -546,7 +546,7 @@ def load_config(files):
             'timeout': '30',
             'sgx': 'false',
             'loader': './pal_loader',
-            'ltproot': './opt/ltp',
+            'ltproot': './install',
             'junit-classname': 'apps.LTP',
         })
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Our LTP makefiles are a huge and complicated mess. I tried to fix them, but gave up at some point and did just a few changes.

Changes:
- `make all` previously rebuilt everything each time, now it doesn't.
- Using out-of-tree build.
- Unfortunately we have to build the whole LTP now (minus modules), so the build is slower.
- But: `make -jX` works, previously was broken because of missing dependencies.
- Not using symlinks as targets anymore - Make is broken and checks the timestamp of the *destination*, not the symlink itself. Previously the links were recreated on each `make` call.
- `make regression` printed `/bin/sh: 1: test: Illegal number: ` and now it doesn't.

I'll create a follow-up PR which adds more parallelism to our Jenkinsfiles (but only to building tests, not running). This should generate a significant speed-up, e.g. building and running LTP tests as done in our Jenkinsfiles on SGX previously took 7m 24s, after this PR + the follow-up with parallelism it takes 5m 01s.

## How to test this PR? <!-- (if applicable) -->

CI + play manually with LTP

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1695)
<!-- Reviewable:end -->
