### PR TITLE
[Pal/Linux-SGX] Improve debug message on fatal exception in PAL code

### DIFF
--- a/Pal/src/host/Linux-SGX/db_exception.c
+++ b/Pal/src/host/Linux-SGX/db_exception.c
@@ -214,15 +214,22 @@ void _DkExceptionHandler(unsigned int exit_info, sgx_cpu_context_t* uc,
         event_num != PAL_EVENT_QUIT &&
         event_num != PAL_EVENT_SUSPEND &&
         event_num != PAL_EVENT_RESUME) {
-        printf("*** Unexpected AEX vector occurred inside PAL! ***\n"
-               "(vector = 0x%x, type = 0x%x valid = %d, RIP = +0x%08lx)\n"
-               "rax: 0x%08lx rcx: 0x%08lx rdx: 0x%08lx rbx: 0x%08lx\n"
+        printf("*** Unexpected exception occurred inside PAL at RIP = +0x%08lx! ***\n",
+               uc->rip - (uintptr_t)TEXT_START);
+
+        if (ei.info.valid) {
+            /* EXITINFO field: vector = exception number, exit_type = 0x3 for HW / 0x6 for SW */
+            printf("(SGX HW reported AEX vector 0x%x with exit_type = 0x%x)\n",
+                   ei.info.vector, ei.info.exit_type);
+        } else {
+            printf("(untrusted PAL sent PAL event 0x%x)\n", ei.intval);
+        }
+
+        printf("rax: 0x%08lx rcx: 0x%08lx rdx: 0x%08lx rbx: 0x%08lx\n"
                "rsp: 0x%08lx rbp: 0x%08lx rsi: 0x%08lx rdi: 0x%08lx\n"
                "r8 : 0x%08lx r9 : 0x%08lx r10: 0x%08lx r11: 0x%08lx\n"
                "r12: 0x%08lx r13: 0x%08lx r14: 0x%08lx r15: 0x%08lx\n"
                "rflags: 0x%08lx rip: 0x%08lx\n",
-               ei.info.vector, ei.info.exit_type, ei.info.valid,
-               uc->rip - (uintptr_t)TEXT_START,
                uc->rax, uc->rcx, uc->rdx, uc->rbx,
                uc->rsp, uc->rbp, uc->rsi, uc->rdi,
                uc->r8, uc->r9, uc->r10, uc->r11,


### PR DESCRIPTION

## Description of the changes <!-- (reasons and measures) -->

Previously, Graphene-SGX printed a confusing error messages if some exception happened inside the PAL code (which is fatal in Graphene). The error message always printed out the SSA.EXITINFO information even when the exception happened due to software (and thus SGX HW didn't populate SSA.EXITINFO).

This PR improves the error message so that it distinguishes between SGX HW-recognized exception (and prints out SSA.EXITINFO) and SW-sent signal (and prints just the signal number).

## How to test this PR? <!-- (if applicable) -->

N/A.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1697)
<!-- Reviewable:end -->
