### PR TITLE
[PAL] protected files: Remove too-noisy debug prints

### DIFF
--- a/Pal/src/host/Linux-SGX/db_files.c
+++ b/Pal/src/host/Linux-SGX/db_files.c
@@ -34,9 +34,6 @@ static int file_open(PAL_HANDLE* handle, const char* type, const char* uri, int 
     if (strcmp_static(type, URI_TYPE_FILE))
         return -PAL_ERROR_INVAL;
 
-    SGX_DBG(DBG_D, "file_open: uri %s, access 0x%x, share 0x%x, create 0x%x, options 0x%x\n",
-            uri, access, share, create, options);
-
     /* prepare the file handle */
     size_t len     = strlen(uri) + 1;
     PAL_HANDLE hdl = calloc(1, HANDLE_SIZE(file) + len);

--- a/Pal/src/host/Linux-SGX/enclave_pf.c
+++ b/Pal/src/host/Linux-SGX/enclave_pf.c
@@ -220,7 +220,6 @@ struct protected_file* get_protected_file(const char* path) {
     }
 
 out:
-    SGX_DBG(DBG_D, "get_pf(%s) = %p\n", path, pf);
     return pf;
 }
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Current code generates tons of not-too-useful debug logs about files being opened, even with `loader.debug_type = none`.

This is because `SGX_DBG` macro disrespects debug logging settings from the manifest, but fixing this properly is a much bigger task (the whole logging subsystem should be redesigned), so I just dropped these annoying prints.

## How to test this PR? <!-- (if applicable) -->

Run something compiled with DEBUG=1 but with `loader.debug_type = none` in the manifest.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1699)
<!-- Reviewable:end -->
