### PR TITLE
[LibOS] Fix incorrect argument check in socketpair

### DIFF
--- a/LibOS/shim/src/sys/shim_pipe.c
+++ b/LibOS/shim/src/sys/shim_pipe.c
@@ -152,7 +152,7 @@ int shim_do_socketpair(int domain, int type, int protocol, int* sv) {
     if (domain != AF_UNIX)
         return -EAFNOSUPPORT;
 
-    if (type != SOCK_STREAM)
+    if ((type & ~(SOCK_NONBLOCK | SOCK_CLOEXEC)) != SOCK_STREAM)
         return -EPROTONOSUPPORT;
 
     if (!sv || test_user_memory(sv, 2 * sizeof(int), true))


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://graphene.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->
Although Graphene supports `SOCK_NONBLOCK` and `SOCK_CLOEXEC`, it disallowed for those flags in `type` argument to `socketpair`.

## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1704)
<!-- Reviewable:end -->
