### PR TITLE
[LibOS] Increase timeout params of Async helper thread

### DIFF
--- a/LibOS/shim/src/shim_async.c
+++ b/LibOS/shim/src/shim_async.c
@@ -13,8 +13,8 @@
 #include <shim_thread.h>
 #include <shim_utils.h>
 
-#define IDLE_SLEEP_TIME 1000
-#define MAX_IDLE_CYCLES 100
+#define IDLE_SLEEP_TIME 1000000
+#define MAX_IDLE_CYCLES 10000
 
 DEFINE_LIST(async_event);
 struct async_event {


### PR DESCRIPTION

<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://graphene.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

Async helper thread self-destructs after some idle time (when it is unused). The timeout was previously set to too-low values so that Async helper thread sporadically died even when it was supposed to stay alive. This PR increases the timeout values slightly.

## How to test this PR? <!-- (if applicable) -->

One can check when the Async helper thread terminates manually when looking at the debug output of `multi_pthread` LibOS test.