### PR TITLE
[NEVER MERGE] Adding output to GSC's test-1 and test-2 to test Linux-SGX-gsc Jenkins pipeline

### DIFF
--- a/Tools/gsc/test/Makefile
+++ b/Tools/gsc/test/Makefile
@@ -75,15 +75,11 @@ test-distro-%:
 
 .PHONY: test-1-%
 test-1-%: gsc-%-python3
-	docker run $(DEVICES_VOLUMES) $(addsuffix $(IMAGE_SUFFIX), gsc-$*-python3) -c 'print("HelloWorld!")' >out 2>/dev/null
-	grep -q "HelloWorld!" out
-	$(RM) out
+	docker run $(DEVICES_VOLUMES) $(addsuffix $(IMAGE_SUFFIX), gsc-$*-python3) -c 'print("HelloWorld!")'
 
 .PHONY: test-2-%
 test-2-%: gsc-%-python3
-	docker run $(DEVICES_VOLUMES) $(addsuffix $(IMAGE_SUFFIX), gsc-$*-python3) /graphene/Examples/scripts/helloworld.py >out 2>&1
-	grep -q "Hello World" out
-	$(RM) out
+	docker run $(DEVICES_VOLUMES) $(addsuffix $(IMAGE_SUFFIX), gsc-$*-python3) /graphene/Examples/scripts/helloworld.py
 
 .PHONY: test-3-%
 test-3-%: gsc-%-python3


### PR DESCRIPTION
**This PR is not meant to be merged at any point!** 

Its purpose is to provide additional output during Linux-SGX-gsc Jenkins pipeline and hint towards an existing issue when test GSC on Jenkins.

## Description of the changes 

Removed redirection of outputs to `out` for makefile targets test-1 and test-2 in `Tools/gsc/test/Makefile`.

## How to test this PR?

Run Linux-SGX-gsc Jenkins pipeline.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1710)
<!-- Reviewable:end -->
