### PR TITLE
[Examples] tensorflow: Fix non-existing target 'default'

### DIFF
--- a/Examples/tensorflow/Makefile
+++ b/Examples/tensorflow/Makefile
@@ -68,15 +68,15 @@ label_image.manifest.sgx: label_image label_image.manifest inception_v3.tflite l
 		-output label_image.token -sig label_image.sig
 
 .PHONY: check
-check: default
+check: all
 	$(GRAPHENEDIR)/Runtime/pal_loader ./label_image -m inception_v3.tflite -i image.bmp -t 4
 
 .PHONY: run-native
-run-native: default
+run-native: all
 	./label_image -m inception_v3.tflite -i image.bmp -t 4
 
 .PHONY: run-graphene
-run-graphene: default
+run-graphene: all
 	$(GRAPHENEDIR)/Runtime/pal_loader ./label_image -m inception_v3.tflite -i image.bmp -t 4
 
 .PHONY: clean


### PR DESCRIPTION
The commit: [Examples] tensorflow: Fix default `make` target
replaced the target 'default' with 'all'.

However, the targets 'run-graphene', 'run-native' and 'check'
still depend on 'default', so it is not possible to run
  make run-native
  make run-graphene
  make run-graphene SGX=1
as documented in the README.md file.

To fix this, modify these targets to depend on 'all' instead, as the target
'default' was replaced by 'all'.

<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://graphene.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1711)
<!-- Reviewable:end -->
