### PR TITLE
[CI, SGX] Migrate the pipeline to a patched 2.6 Intel driver

### DIFF
--- a/Jenkinsfiles/Linux-SGX
+++ b/Jenkinsfiles/Linux-SGX
@@ -1,7 +1,7 @@
 pipeline {
         agent {
             dockerfile { filename 'Jenkinsfiles/ubuntu-16.04.dockerfile'
-                         label 'sgx_slave'
+                         label 'sgx_slave_2.6'
                          args "-v /lib/modules:/lib/modules:ro -v /usr/src:/usr/src:ro -v /var/run/aesmd/aesm.socket:/var/run/aesmd/aesm.socket --device=/dev/gsgx:/dev/gsgx --device=/dev/isgx:/dev/isgx"
                        }
         }
@@ -23,9 +23,9 @@ pipeline {
                         '''
                         sh '''
                            cd /opt/intel
-                           git clone https://github.com/01org/linux-sgx-driver.git
+                           git clone https://github.com/intel/linux-sgx-driver.git
                            cd linux-sgx-driver
-                           git checkout sgx_driver_1.9
+                           git checkout 276c5c6a064d22358542f5e0aa96b1c0ace5d695
                            make -j8
                         '''
                         sh '''

--- a/Jenkinsfiles/Linux-SGX-18.04
+++ b/Jenkinsfiles/Linux-SGX-18.04
@@ -1,7 +1,7 @@
 pipeline {
         agent {
             dockerfile { filename 'Jenkinsfiles/ubuntu-18.04.dockerfile'
-                         label 'sgx_slave'
+                         label 'sgx_slave_2.6'
                          args "-v /lib/modules:/lib/modules:ro -v /usr/src:/usr/src:ro -v /var/run/aesmd/aesm.socket:/var/run/aesmd/aesm.socket --device=/dev/gsgx:/dev/gsgx --device=/dev/isgx:/dev/isgx"
                        }
         }
@@ -26,9 +26,9 @@ pipeline {
                         '''
                         sh '''
                            cd /opt/intel
-                           git clone https://github.com/01org/linux-sgx-driver.git
+                           git clone https://github.com/intel/linux-sgx-driver.git
                            cd linux-sgx-driver
-                           git checkout sgx_driver_1.9
+                           git checkout 276c5c6a064d22358542f5e0aa96b1c0ace5d695
                            make -j8
 
                            cd /opt/intel

--- a/Jenkinsfiles/Linux-SGX-18.04-apps
+++ b/Jenkinsfiles/Linux-SGX-18.04-apps
@@ -1,7 +1,7 @@
 pipeline {
         agent {
             dockerfile { filename 'Jenkinsfiles/ubuntu-18.04.dockerfile'
-                         label 'sgx_slave'
+                         label 'sgx_slave_2.6'
                          args "-v /lib/modules:/lib/modules:ro -v /usr/src:/usr/src:ro -v /var/run/aesmd/aesm.socket:/var/run/aesmd/aesm.socket --device=/dev/gsgx:/dev/gsgx --device=/dev/isgx:/dev/isgx"
                        }
         }
@@ -26,9 +26,9 @@ pipeline {
                         '''
                         sh '''
                            cd /opt/intel
-                           git clone https://github.com/01org/linux-sgx-driver.git
+                           git clone https://github.com/intel/linux-sgx-driver.git
                            cd linux-sgx-driver
-                           git checkout sgx_driver_1.9
+                           git checkout 276c5c6a064d22358542f5e0aa96b1c0ace5d695
                            make -j8
 
                            cd /opt/intel

--- a/Jenkinsfiles/Linux-SGX-apps
+++ b/Jenkinsfiles/Linux-SGX-apps
@@ -1,7 +1,7 @@
 pipeline {
         agent {
             dockerfile { filename 'Jenkinsfiles/ubuntu-16.04.dockerfile'
-                         label 'sgx_slave'
+                         label 'sgx_slave_2.6'
                          args "-v /lib/modules:/lib/modules:ro -v /usr/src:/usr/src:ro -v /var/run/aesmd/aesm.socket:/var/run/aesmd/aesm.socket --device=/dev/gsgx:/dev/gsgx --device=/dev/isgx:/dev/isgx"
                        }
         }
@@ -23,9 +23,9 @@ pipeline {
                         '''
                         sh '''
                            cd /opt/intel
-                           git clone https://github.com/01org/linux-sgx-driver.git
+                           git clone https://github.com/intel/linux-sgx-driver.git
                            cd linux-sgx-driver
-                           git checkout sgx_driver_1.9
+                           git checkout 276c5c6a064d22358542f5e0aa96b1c0ace5d695
                            make -j8
                         '''
                         sh '''


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://graphene.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

We are still using v1.9 of the Intel SGX driver; there is no good reason not to test with the latest v2.6.  

Moreover, the OOT SGX driver is not well-maintained.  To compile against a 5.8 kernel or newer, the isgx driver needs some patches.  Although I have sent a PR several weeks ago, it has gotten no attention from any maintainers.

This PR moves us to a local mirror repo, and includes the needed build fixes.  

The PR also includes an agent label for machines with 2.6 installed, so that we can gradually migrate SGX machines to v 2.6.  The host configuration and the pipeline need to move in lockstep.  Initially, we just have uncledeadly on isgx v2.6; after this lands we may need to keep one non-v2.6 worker for older PRs or ask them to rebase to master.

## How to test this PR? <!-- (if applicable) -->

Run a jenkins pipeline.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1715)
<!-- Reviewable:end -->
