### PR TITLE
Change print behavior of GSC tests to print any intermediate test results

### DIFF
--- a/Tools/gsc/test/Makefile
+++ b/Tools/gsc/test/Makefile
@@ -75,31 +75,31 @@ test-distro-%:
 
 .PHONY: test-1-%
 test-1-%: gsc-%-python3
-	docker run $(DEVICES_VOLUMES) $(addsuffix $(IMAGE_SUFFIX), gsc-$*-python3) -c 'print("HelloWorld!")' >out 2>/dev/null
+	docker run $(DEVICES_VOLUMES) $(addsuffix $(IMAGE_SUFFIX), gsc-$*-python3) -c 'print("HelloWorld!")' 2>&1 | tee out
 	grep -q "HelloWorld!" out
 	$(RM) out
 
 .PHONY: test-2-%
 test-2-%: gsc-%-python3
-	docker run $(DEVICES_VOLUMES) $(addsuffix $(IMAGE_SUFFIX), gsc-$*-python3) /graphene/Examples/scripts/helloworld.py >out 2>&1
+	docker run $(DEVICES_VOLUMES) $(addsuffix $(IMAGE_SUFFIX), gsc-$*-python3) /graphene/Examples/scripts/helloworld.py  2>&1 | tee out
 	grep -q "Hello World" out
 	$(RM) out
 
 .PHONY: test-3-%
 test-3-%: gsc-%-python3
-	docker run $(DEVICES_VOLUMES) $(addsuffix $(IMAGE_SUFFIX), gsc-$*-python3) /graphene/Examples/scripts/fibonacci.py >out 2>&1
+	docker run $(DEVICES_VOLUMES) $(addsuffix $(IMAGE_SUFFIX), gsc-$*-python3) /graphene/Examples/scripts/fibonacci.py  2>&1 | tee out
 	grep -q "fib2              55" out
 	$(RM) out
 
 .PHONY: test-4-%
 test-4-%: gsc-%-python3
-	docker run $(DEVICES_VOLUMES) $(addsuffix $(IMAGE_SUFFIX), gsc-$*-python3) -c 'import os;os.system("ls")' >out 2>&1
+	docker run $(DEVICES_VOLUMES) $(addsuffix $(IMAGE_SUFFIX), gsc-$*-python3) -c 'import os;os.system("ls")' 2>&1 | tee out
 	grep -q "ls.manifest.sgx" out
 	$(RM) out
 
 .PHONY: test-5-%
 test-5-%: gsc-%-python3
-	docker run $(DEVICES_VOLUMES) -d -p 8005:8005 $(addsuffix $(IMAGE_SUFFIX), gsc-$*-python3) /graphene/Examples/scripts/dummy-web-server.py 8005 >c.id 2>/dev/null
+	docker run $(DEVICES_VOLUMES) -d -p 8005:8005 $(addsuffix $(IMAGE_SUFFIX), gsc-$*-python3) /graphene/Examples/scripts/dummy-web-server.py 8005 | tee c.id
 	sleep 30
 	wget -q http://localhost:8005/ -O output
 	grep -q "hi!" output
@@ -108,31 +108,31 @@ test-5-%: gsc-%-python3
 
 .PHONY: test-6-%
 test-6-%: gsc-%-hello-world
-	docker run $(DEVICES_VOLUMES) $(addsuffix $(IMAGE_SUFFIX), gsc-$*-hello-world) > out 2>/dev/null
+	docker run $(DEVICES_VOLUMES) $(addsuffix $(IMAGE_SUFFIX), gsc-$*-hello-world)  2>&1 | tee out
 	grep -q "Hello World!" out
 	$(RM) out
 
 .PHONY: test-7-%
 test-7-%: gsc-%-nodejs
-	docker run $(DEVICES_VOLUMES) $(addsuffix $(IMAGE_SUFFIX), gsc-$*-nodejs) -e 'console.log("HelloWorld");' >out 2>/dev/null
+	docker run $(DEVICES_VOLUMES) $(addsuffix $(IMAGE_SUFFIX), gsc-$*-nodejs) -e 'console.log("HelloWorld");' 2>&1 | tee out
 	grep -q "HelloWorld" out
 	$(RM) out
 
 .PHONY: test-8-%
 test-8-%: gsc-%-nodejs
-	docker run $(DEVICES_VOLUMES) $(addsuffix $(IMAGE_SUFFIX), gsc-$*-nodejs) /graphene/Examples/helloworld.js >out 2>/dev/null
+	docker run $(DEVICES_VOLUMES) $(addsuffix $(IMAGE_SUFFIX), gsc-$*-nodejs) /graphene/Examples/helloworld.js 2>&1 | tee out
 	grep -q "Hello World" out
 	$(RM) out
 
 .PHONY: test-9-%
 test-9-%: gsc-%-numpy
-	docker run $(DEVICES_VOLUMES) $(addsuffix $(IMAGE_SUFFIX), gsc-$*-numpy) /graphene/Examples/scripts/test-numpy.py >out 2>/dev/null
+	docker run $(DEVICES_VOLUMES) $(addsuffix $(IMAGE_SUFFIX), gsc-$*-numpy) /graphene/Examples/scripts/test-numpy.py 2>&1 | tee out
 	grep -q "numpy version:" out
 	$(RM) out
 
 .PHONY: test-10-%
 test-10-%: gsc-%-bash
-	docker run $(DEVICES_VOLUMES) $(addsuffix $(IMAGE_SUFFIX), gsc-$*-bash) -c 'ls' >out 2>/dev/null
+	docker run $(DEVICES_VOLUMES) $(addsuffix $(IMAGE_SUFFIX), gsc-$*-bash) -c 'ls' 2>&1 | tee out
 	grep -q "ls.manifest.sgx" out
 	$(RM) out
 


### PR DESCRIPTION
Prints intermediate files during GSC testing

Closes #1710 .

## Description of the changes <!-- (reasons and measures) -->

Changed `Tools/gsc/test/Makefile` to print intermediate output files immediately to display possible failures.

## How to test this PR? <!-- (if applicable) -->

Run regular GSC Jenkins pipeline

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1719)
<!-- Reviewable:end -->
