### PR TITLE
Fix GSC testing Makefile and build template

### DIFF
--- a/Tools/gsc/templates/Dockerfile.ubuntu18.04.build.template
+++ b/Tools/gsc/templates/Dockerfile.ubuntu18.04.build.template
@@ -36,7 +36,7 @@ RUN cd /graphene && ISGX_DRIVER_PATH=/graphene/Pal/src/host/Linux-SGX/sgx-driver
     {% if linux %} && make -s -j4 WERROR=1 {% if debug %} DEBUG=1 {% endif %} {% else %} && true {%endif %}
 
 # Translate runtime symlinks to files
-RUN for f in $(find /graphene/Runtime -type l); do cp --remove-destination $(readlink $f) $f; done
+RUN for f in $(find /graphene/Runtime -type l); do cp --remove-destination $(realpath $f) $f; done
 
 # Finished building Graphene
 

--- a/Tools/gsc/templates/Dockerfile.ubuntu18.04.build.template
+++ b/Tools/gsc/templates/Dockerfile.ubuntu18.04.build.template
@@ -21,7 +21,7 @@ RUN git clone {{Graphene.Repository}} /graphene
 # Init submodules
 RUN cd /graphene \
     && git fetch origin {{Graphene.Branch}} \
-    && git checkout origin/{{Graphene.Branch}} \
+    && git checkout {{Graphene.Branch}} \
     && git submodule update --init -- Pal/src/host/Linux-SGX/sgx-driver/
 
 # Create SGX driver for header files

--- a/Tools/gsc/test/Makefile
+++ b/Tools/gsc/test/Makefile
@@ -1,5 +1,6 @@
 TESTCASES ?= python3 hello-world nodejs bash numpy pytorch
 DISTRIBUTIONS ?= ubuntu18.04
+GRAPHENE_BRANCH ?= master
 DOCKER_BUILD_FLAGS ?= --rm --no-cache
 GSC_BUILD_FLAGS ?= --rm --no-cache
 TESTS = $(foreach D,$(DISTRIBUTIONS),$(foreach T,$(TESTCASES),$D-$T))
@@ -17,7 +18,8 @@ IMAGE_SUFFIX ?=
 .PHONY: all
 all: $(KEY_FILE) $(TESTS)
 	for d in $(DISTRIBUTIONS); do \
-		sed -e 's/\"Distro\": \".*\"/\"Distro\": \"'$${d}'\"/' \
+		sed -e 's/Distro: \".*\"/Distro: \"'$${d}'\"/' \
+		    -e 's/Branch: \"master\"/Branch: \"'$(GRAPHENE_BRANCH)'\"/' \
 			../config.yaml.template > ../config.yaml; \
 		$(MAKE) $(addprefix gsc-$${d}-, $(TESTCASES)) || exit 1; \
 	done


### PR DESCRIPTION
This PR fixes two issues.

1. A recent change which made all Runtime folder Symlinks relative results in `gsc build` command failing. As part of `gsc build` command all symlinks in /graphene/Runtime are converted to real files by iterating over all symlinks and copying them over. When the change was made to make the symlinks relative, the copy command no longer finds the file to copy and hence, the Docker `build` fails.
2. The failure of 1. was not discovered, since the Jenkins test ran on the master branch instead of the PR. The test makefile of GSC includes a `sed` command to create the required GSC `config.yaml`. This `sed` command was ignoring the Graphene branch input which is set in the Jenkins script.

## Description of the changes 

To fix 1.:
Changed `Tools/gsc/templates/Dockerfile.build.ubuntu18.04.template` to read the symlink and add the prefix path `/graphene/Runtime` to it. 

To fix 2.:
Changed `Tools/gsc/test/Makefile` to correctly update the configuration file with the Graphene branch.

## How to test this PR? 

Run Jenkins GSC pipeline and check the output includes the following line:
```
RUN cd /graphene && git fetch origin <commit #> && git checkout <commit #> ...
```

The correct commit hash can be found via the PR and should match a shell variable which is exported (look for `export COMMIT=`)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1725)
<!-- Reviewable:end -->
