### PR TITLE
LibOS: Define struct __kernel_itimerspec for kernel < 4.19.0

### DIFF
--- a/LibOS/shim/include/shim_types.h
+++ b/LibOS/shim/include/shim_types.h
@@ -56,7 +56,9 @@ struct __kernel_timespec {
     __kernel_time_t tv_sec;         /* seconds */
     long            tv_nsec;        /* nanoseconds */
 };
+#endif
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 19, 0)
 struct __kernel_itimerspec {
     struct __kernel_timespec it_interval;    /* timer period */
     struct __kernel_timespec it_value;       /* timer expiration */


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://graphene.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

Define struct __kernel_itimerspec for kernel < 4.19.0 rather than < 4.18.0

This patch fixes #1718. It now builds on RHEL/CentOS 8.2.

## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1733)
<!-- Reviewable:end -->
