### PR TITLE
[LibOS] use addq/subq $-128 instead of subq/addq $128

### DIFF
--- a/LibOS/glibc-patches/syscalldb-api.patch
+++ b/LibOS/glibc-patches/syscalldb-api.patch
@@ -63,9 +63,9 @@ index 0000000000000000000000000000000000000000..4914e280d8cd6a62ab1ea4c9aa416017
 +
 +# if defined(PSEUDO) && defined(SYSCALL_NAME) && defined(SYSCALL_SYMBOL)
 +#  define SYSCALLDB                     \
-+    subq $128, %rsp;                    \
++    addq $-128, %rsp;                   \
 +    callq *syscalldb@GOTPCREL(%rip);    \
-+    addq $128, %rsp
++    subq $-128, %rsp
 +# else
 +#  define SYSCALLDB                             \
 +    callq *syscalldb@GOTPCREL(%rip)
@@ -77,9 +77,9 @@ index 0000000000000000000000000000000000000000..4914e280d8cd6a62ab1ea4c9aa416017
 +".type syscalldb, @function\r\n");
 +
 +#define SYSCALLDB                           \
-+    "subq $128, %%rsp\n\t"                  \
++    "addq $-128, %%rsp\n\t"                 \
 +    "callq *syscalldb@GOTPCREL(%%rip)\n\t"  \
-+    "addq $128, %%rsp\n\t"
++    "subq $-128, %%rsp\n\t"
 +
 +#define SYSCALLDB_ASM                       \
 +    "callq *syscalldb@GOTPCREL(%rip)\n\t"

--- a/LibOS/shim/src/syscallas-x86_64.S
+++ b/LibOS/shim/src/syscallas-x86_64.S
@@ -126,11 +126,11 @@ syscall_wrapper:
         .cfi_register %rip, %rcx
         # %r11 is used as input to keep %rflags
         .cfi_register %rflags, %r11
-        subq $RED_ZONE_SIZE, %rsp
+        addq $-RED_ZONE_SIZE, %rsp
         .cfi_adjust_cfa_offset RED_ZONE_SIZE
         callq *syscalldb@GOTPCREL(%rip)
 syscall_wrapper_after_syscalldb:
-        addq $RED_ZONE_SIZE, %rsp
+        subq $-RED_ZONE_SIZE, %rsp
         .cfi_adjust_cfa_offset -RED_ZONE_SIZE
         # restore %rflags for syscall abi compatibility.
         # This must be done after "addq $RED_ZONE_SIZE, %rsp" above


### PR DESCRIPTION
They produce shorter opecode because the range of 8bit immediate is
[-128, 127].

addq $-128, %rsp
subq $-128, %rsp
48 83 c4 80                  addq   $0xffffffffffffff80,%rsp
48 83 ec 80                  subq   $0xffffffffffffff80,%rsp

subq $128, %rsp
addq $128, %rsp
48 81 ec 80 00 00 00         subq   $0x80,%rsp
48 81 c4 80 00 00 00         addq   $0x80,%rsp

Signed-off-by: Isaku Yamahata <isaku.yamahata@intel.com>

<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://graphene.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1735)
<!-- Reviewable:end -->
