### PR TITLE
[Docs,Pal/Linux-SGX] Allow to use the in-kernel SGX driver

### DIFF
--- a/Documentation/building.rst
+++ b/Documentation/building.rst
@@ -167,7 +167,8 @@ To install the Graphene SGX driver, run the following commands::
 
    cd Pal/src/host/Linux-SGX/sgx-driver
    make
-   # The console will be prompted to ask for the path of Intel SGX driver code
+   # the console will prompt you for the path to the Intel SGX driver code
+   # (simply press ENTER if you use the in-kernel Intel SGX driver)
    sudo insmod gsgx.ko
 
 

--- a/Documentation/quickstart.rst
+++ b/Documentation/quickstart.rst
@@ -68,6 +68,7 @@ second command should list the process status of :command:`aesm_service`.
       cd $GRAPHENE_DIR
       make SGX=1
       # the console will prompt you for the path to the Intel SGX driver code
+      # (simply press ENTER if you use the in-kernel Intel SGX driver)
 
 #. Set ``vm.mmap_min_addr=0`` in the system (*only required for the legacy SGX
    driver and not needed for newer DCAP/in-kernel drivers*)::


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://graphene.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

This PR allows to use the in-kernel Intel SGX driver, by simply skipping the prompt (by pressing ENTER).

See the corresponding PR https://github.com/oscarlab/graphene-sgx-driver/pull/27.

## How to test this PR? <!-- (if applicable) -->

Clone and build Graphene on a machine with in-kernel SGX driver.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1737)
<!-- Reviewable:end -->
