### PR TITLE
Fix compilation error with PRINT_ENCLAVE_STAT enabled

### DIFF
--- a/Pal/src/host/Linux-SGX/db_process.c
+++ b/Pal/src/host/Linux-SGX/db_process.c
@@ -348,13 +348,8 @@ int init_child_process (PAL_HANDLE * parent_handle)
     return 0;
 }
 
-void print_alloced_pages (void);
-
 noreturn void _DkProcessExit (int exitcode)
 {
-#if PRINT_ENCLAVE_STAT
-    print_alloced_pages();
-#endif
     if (exitcode)
         SGX_DBG(DBG_I, "DkProcessExit: Returning exit code %d\n", exitcode);
     ocall_exit(exitcode, /*is_exitgroup=*/true);


### PR DESCRIPTION
Remove reference to print_alloced_pages() which no longer exists.

<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://graphene.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->
Remove calling of print_alloced_pages() from _DkProcessExit()
## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1738)
<!-- Reviewable:end -->
