### PR TITLE
[Pal/Linux-SGX] Remove redundant memset in _DkVirtualMemoryAlloc()

### DIFF
--- a/Pal/src/host/Linux-SGX/db_memory.c
+++ b/Pal/src/host/Linux-SGX/db_memory.c
@@ -54,8 +54,6 @@ int _DkVirtualMemoryAlloc(void** paddr, uint64_t size, int alloc_type, int prot)
     if (!mem)
         return addr ? -PAL_ERROR_DENIED : -PAL_ERROR_NOMEM;
 
-    memset(mem, 0, size);
-
     *paddr = mem;
     return 0;
 }


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

There is already one memset in `get_enclave_pages()` controlled by manifest option `sgx.zero_heap_on_demand`. So the explicit memset in `_DkVirtualMemoryAlloc()` is not needed. Observed perf improvement is 30% on a worst-case micro-benchmark with `mmap()`.

## How to test this PR? <!-- (if applicable) -->

This is a perf improvement, so I didn't add any tests to CI. However, this tiny micro-benchmark is the worst-case for the bug fixed in this PR:
```
for (size_t i = 0; i < 3; i++) {
    addr = mmap(NULL, 1024 * 1024 * 256, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
    *addr = 0;
}
```

Running it on a Skylake machine with 128MB of EPC gave me:
```
# without this PR (with redundant memset)
        User time (seconds): 3.77
        Minor (reclaiming a frame) page faults: 707887

# with this PR (no redundant memset)
        User time (seconds): 2.62
        Minor (reclaiming a frame) page faults: 511154
```

I also did some quick tests with Redis. I observed no performance change (I assume because my Redis workload didn't create/re-create too many memory mappings).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1740)
<!-- Reviewable:end -->
