### PR TITLE
[Pal/Linux-SGX] Remove unneeded manifest option `sgx.zero_heap_on_demand`

### DIFF
--- a/Documentation/manifest-syntax.rst
+++ b/Documentation/manifest-syntax.rst
@@ -445,18 +445,3 @@ This syntax specifies whether to enable SGX enclave-specific statistics:
 *Note:* this option is insecure and cannot be used with production enclaves
 (``sgx.debug = 0``). If the production enclave is started with this option set,
 Graphene will fail initialization of the enclave.
-
-Zero out heap on demand vs during enclave init
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-::
-
-    sgx.zero_heap_on_demand=[1|0]
-    (Default: 0)
-
-This syntax specifies whether to zero out the heap on demand (when new enclave
-pages are requested) or during enclave initialization. If this option is set to
-``1``, then the initial heap space is uninitialized; this improves start-up
-performance but worsens run-time performance. If this option is set to ``0``,
-then the whole heap is zeroed out before enclave starts app execution; this
-worsens start-up performance but improves run-time performance.

--- a/Documentation/perf-practices.rst
+++ b/Documentation/perf-practices.rst
@@ -119,45 +119,6 @@ If you need additional statistics, you can check this unofficial patch:
 
 * https://github.com/oscarlab/graphene/tree/dimakuv/DONTMERGE-more-perf-stats-tweaks
 
-Zero out heap on demand vs during enclave init
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Graphene by default zeroes out the whole enclave heap during enclave
-initialization (``sgx.zero_heap_on_demand = 0``). This improves security (the
-attacker cannot put arbitrary content in the enclave's heap) and runtime
-performance (Graphene doesn't need to zero out the requested heap region on mmap
-user requests). However, it may increase start-up time: typical enclave sizes
-can be up to 8GB, so Graphene will zero out approximately 8GB of enclave pages
-during start-up, which is slow. To improve start-up time – at the cost of
-slightly worse runtime performance – you can specify ``sgx.zero_heap_on_demand =
-1`` manifest option.
-
-Here is an example:
-
-::
-
-   # manifest contains: `sgx.enclave_size = 16G` and `sgx.zero_heap_on_demand = 0`
-   LibOS/shim/test/native$ SGX=1 perf stat ~/graphene/Runtime/pal_loader helloworld
-   Hello world (helloworld)!
-
-         50.411676437 seconds time elapsed
-
-   # manifest contains: `sgx.enclave_size = 16G` and `sgx.zero_heap_on_demand = 1`
-   LibOS/shim/test/native$ SGX=1 perf stat ~/graphene/Runtime/pal_loader helloworld
-   Hello world (helloworld)!
-
-         42.816185504 seconds time elapsed
-
-As you can see, zeroing the heap on demand shaved off 8 seconds from the
-start-up time of a 16GB enclave. The difference is not very significant, but it
-may help achieve the best possible performance for e.g. Function-as-a-Service
-(FaaS) workloads.
-
-You can find additional information and context here:
-
-* https://github.com/oscarlab/graphene/pull/1640
-* https://github.com/oscarlab/graphene/pull/1668
-
 Effects of system calls / ocalls
 --------------------------------
 

--- a/Examples/bash/manifest.template
+++ b/Examples/bash/manifest.template
@@ -81,5 +81,3 @@ $(TRUSTED_LIBS)
 $(TRUSTED_CHILDREN)
 
 sgx.allowed_files.scripts = file:scripts
-
-sgx.zero_heap_on_demand = 1

--- a/Examples/busybox/busybox.manifest.template
+++ b/Examples/busybox/busybox.manifest.template
@@ -139,5 +139,3 @@ sgx.allowed_files.passwd    = file:/etc/passwd
 # Busybox uses timezone settings, which are located in /etc/localtime for
 # glibc-based host systems.
 sgx.allowed_files.localtime = file:/etc/localtime
-
-sgx.zero_heap_on_demand = 1

--- a/Examples/capnproto/addressbook.manifest.template
+++ b/Examples/capnproto/addressbook.manifest.template
@@ -54,5 +54,3 @@ sgx.trusted_files.libc = file:$(GRAPHENEDIR)/Runtime/libc.so.6
 sgx.trusted_files.libm = file:$(GRAPHENEDIR)/Runtime/libm.so.6
 sgx.trusted_files.libpthread = file:$(GRAPHENEDIR)/Runtime/libpthread.so.0
 $(TRUSTEDLIBS)
-
-sgx.zero_heap_on_demand = 1

--- a/Examples/curl/curl.manifest.template
+++ b/Examples/curl/curl.manifest.template
@@ -77,5 +77,3 @@ sgx.allowed_files.hosts      = file:/etc/hosts
 sgx.allowed_files.group      = file:/etc/group
 sgx.allowed_files.passwd     = file:/etc/passwd
 sgx.allowed_files.gaiconf    = file:/etc/gai.conf
-
-sgx.zero_heap_on_demand = 1

--- a/Examples/nodejs/nodejs.manifest.template
+++ b/Examples/nodejs/nodejs.manifest.template
@@ -58,5 +58,3 @@ $(NODEJS_TRUSTED_LIBS)
 
 # JavaScript (trusted)
 sgx.trusted_files.javascript = file:helloworld.js
-
-sgx.zero_heap_on_demand = 1

--- a/Examples/python-scipy-insecure/python.manifest.template
+++ b/Examples/python-scipy-insecure/python.manifest.template
@@ -109,5 +109,3 @@ sgx.allowed_files.tmp = file:/tmp
 sgx.allowed_files.etc = file:/etc
 sgx.allowed_files.pyhome = file:$(PYTHONHOME)
 sgx.allowed_files.pydisthome = file:$(PYTHONDISTHOME)
-
-sgx.zero_heap_on_demand = 1

--- a/Examples/python-simple/python.manifest.template
+++ b/Examples/python-simple/python.manifest.template
@@ -266,5 +266,3 @@ sgx.allowed_files.passwd    = file:/etc/passwd
 sgx.allowed_files.gaiconf   = file:/etc/gai.conf
 sgx.allowed_files.hostconf  = file:/etc/host.conf
 sgx.allowed_files.resolv    = file:/etc/resolv.conf
-
-sgx.zero_heap_on_demand = 1

--- a/Examples/r/R.manifest.template
+++ b/Examples/r/R.manifest.template
@@ -102,5 +102,3 @@ sgx.allowed_files.r_lib = file:$(R_HOME)/library
 
 sgx.trusted_files.sh = file:/bin/sh
 sgx.trusted_children.sh = file:sh.sig
-
-sgx.zero_heap_on_demand = 1

--- a/Examples/r/rm.manifest.template
+++ b/Examples/r/rm.manifest.template
@@ -28,5 +28,3 @@ sgx.thread_num = 4
 
 sgx.trusted_files.ld = file:$(GRAPHENEDIR)/Runtime/ld-linux-x86-64.so.2
 sgx.trusted_files.libc = file:$(GRAPHENEDIR)/Runtime/libc.so.6
-
-sgx.zero_heap_on_demand = 1

--- a/Examples/r/sh.manifest.template
+++ b/Examples/r/sh.manifest.template
@@ -55,5 +55,3 @@ sgx.trusted_files.libc = file:$(GRAPHENEDIR)/Runtime/libc.so.6
 
 sgx.trusted_files.rm = file:/bin/rm
 sgx.trusted_children.rm = file:rm.sig
-
-sgx.zero_heap_on_demand = 1

--- a/Examples/ra-tls-mbedtls/server.manifest.template
+++ b/Examples/ra-tls-mbedtls/server.manifest.template
@@ -53,5 +53,3 @@ sgx.allowed_files.hosts     = file:/etc/hosts
 sgx.allowed_files.group     = file:/etc/group
 sgx.allowed_files.passwd    = file:/etc/passwd
 sgx.allowed_files.gaiconf   = file:/etc/gai.conf
-
-sgx.zero_heap_on_demand = 1

--- a/Examples/ra-tls-secret-prov/secret_prov_client.manifest.template
+++ b/Examples/ra-tls-secret-prov/secret_prov_client.manifest.template
@@ -60,5 +60,3 @@ sgx.allowed_files.group     = file:/etc/group
 sgx.allowed_files.passwd    = file:/etc/passwd
 sgx.allowed_files.gaiconf   = file:/etc/gai.conf
 sgx.allowed_files.resolv    = file:/etc/resolv.conf
-
-sgx.zero_heap_on_demand = 1

--- a/Examples/ra-tls-secret-prov/secret_prov_min_client.manifest.template
+++ b/Examples/ra-tls-secret-prov/secret_prov_min_client.manifest.template
@@ -67,5 +67,3 @@ sgx.allowed_files.group     = file:/etc/group
 sgx.allowed_files.passwd    = file:/etc/passwd
 sgx.allowed_files.gaiconf   = file:/etc/gai.conf
 sgx.allowed_files.resolv    = file:/etc/resolv.conf
-
-sgx.zero_heap_on_demand = 1

--- a/LibOS/shim/test/fs/manifest.template
+++ b/LibOS/shim/test/fs/manifest.template
@@ -36,5 +36,3 @@ sgx.allowed_files.tmp_dir = file:tmp/
 sgx.protected_files_key = ffeeddccbbaa99887766554433221100
 sgx.protected_files.input = file:tmp/pf_input
 sgx.protected_files.output = file:tmp/pf_output
-
-sgx.zero_heap_on_demand = 1

--- a/LibOS/shim/test/ltp/manifest.template
+++ b/LibOS/shim/test/ltp/manifest.template
@@ -40,5 +40,3 @@ sgx.trusted_files.librt = file:$(LIBCDIR)/librt.so.1
 sgx.trusted_files.libstdbuf = file:/usr/$(ARCH_LIBDIR)/coreutils/libstdbuf.so
 
 sgx.allowed_files.tmp = file:/tmp
-
-sgx.zero_heap_on_demand = 1

--- a/LibOS/shim/test/regression/argv_from_file.manifest.template
+++ b/LibOS/shim/test/regression/argv_from_file.manifest.template
@@ -17,4 +17,3 @@ sgx.trusted_files.ld = file:../../../../Runtime/ld-linux-x86-64.so.2
 sgx.trusted_files.libc = file:../../../../Runtime/libc.so.6
 
 sgx.static_address = 1
-sgx.zero_heap_on_demand = 1

--- a/LibOS/shim/test/regression/attestation.manifest.template
+++ b/LibOS/shim/test/regression/attestation.manifest.template
@@ -22,4 +22,3 @@ sgx.trusted_files.libm = file:$(LIBCDIR)/libm.so.6
 sgx.remote_attestation = 1
 sgx.ra_client_spid = $(RA_CLIENT_SPID)
 sgx.ra_client_linkable = $(RA_CLIENT_LINKABLE)
-sgx.zero_heap_on_demand = 1

--- a/LibOS/shim/test/regression/echo.manifest.template
+++ b/LibOS/shim/test/regression/echo.manifest.template
@@ -29,4 +29,3 @@ sgx.trusted_files.ld = file:../../../../Runtime/ld-linux-x86-64.so.2
 sgx.trusted_files.libc = file:../../../../Runtime/libc.so.6
 
 sgx.static_address = 1
-sgx.zero_heap_on_demand = 1

--- a/LibOS/shim/test/regression/env_from_file.manifest.template
+++ b/LibOS/shim/test/regression/env_from_file.manifest.template
@@ -17,4 +17,3 @@ sgx.trusted_files.ld = file:../../../../Runtime/ld-linux-x86-64.so.2
 sgx.trusted_files.libc = file:../../../../Runtime/libc.so.6
 
 sgx.static_address = 1
-sgx.zero_heap_on_demand = 1

--- a/LibOS/shim/test/regression/env_from_host.manifest.template
+++ b/LibOS/shim/test/regression/env_from_host.manifest.template
@@ -15,4 +15,3 @@ sgx.trusted_files.ld = file:../../../../Runtime/ld-linux-x86-64.so.2
 sgx.trusted_files.libc = file:../../../../Runtime/libc.so.6
 
 sgx.static_address = 1
-sgx.zero_heap_on_demand = 1

--- a/LibOS/shim/test/regression/eventfd.manifest.template
+++ b/LibOS/shim/test/regression/eventfd.manifest.template
@@ -17,4 +17,3 @@ sgx.trusted_files.libm = file:../../../../Runtime/libm.so.6
 sgx.trusted_files.libpthread = file:../../../../Runtime/libpthread.so.0
 
 sgx.static_address = 1
-sgx.zero_heap_on_demand = 1

--- a/LibOS/shim/test/regression/exec_victim.manifest.template
+++ b/LibOS/shim/test/regression/exec_victim.manifest.template
@@ -18,4 +18,3 @@ sgx.trusted_files.ld = file:../../../../Runtime/ld-linux-x86-64.so.2
 sgx.trusted_files.libc = file:../../../../Runtime/libc.so.6
 
 sgx.static_address = 1
-sgx.zero_heap_on_demand = 1

--- a/LibOS/shim/test/regression/exit_group.manifest.template
+++ b/LibOS/shim/test/regression/exit_group.manifest.template
@@ -16,4 +16,3 @@ sgx.trusted_files.libpthread = file:../../../../Runtime/libpthread.so.0
 sgx.thread_num = 7
 
 sgx.static_address = 1
-sgx.zero_heap_on_demand = 1

--- a/LibOS/shim/test/regression/file_check_policy_allow_all_but_log.manifest.template
+++ b/LibOS/shim/test/regression/file_check_policy_allow_all_but_log.manifest.template
@@ -17,4 +17,3 @@ sgx.trusted_files.libc = file:$(LIBCDIR)/libc.so.6
 sgx.trusted_files.test = file:trusted_testfile
 
 sgx.static_address = 1
-sgx.zero_heap_on_demand = 1

--- a/LibOS/shim/test/regression/file_check_policy_strict.manifest.template
+++ b/LibOS/shim/test/regression/file_check_policy_strict.manifest.template
@@ -17,4 +17,3 @@ sgx.trusted_files.libc = file:$(LIBCDIR)/libc.so.6
 sgx.trusted_files.test = file:trusted_testfile
 
 sgx.static_address = 1
-sgx.zero_heap_on_demand = 1

--- a/LibOS/shim/test/regression/futex_bitset.manifest.template
+++ b/LibOS/shim/test/regression/futex_bitset.manifest.template
@@ -23,4 +23,3 @@ sgx.trusted_files.libpthread = file:../../../../Runtime/libpthread.so.0
 sgx.thread_num = 16
 
 sgx.static_address = 1
-sgx.zero_heap_on_demand = 1

--- a/LibOS/shim/test/regression/futex_requeue.manifest.template
+++ b/LibOS/shim/test/regression/futex_requeue.manifest.template
@@ -18,4 +18,3 @@ sgx.trusted_files.libpthread = file:../../../../Runtime/libpthread.so.0
 sgx.thread_num = 16
 
 sgx.static_address = 1
-sgx.zero_heap_on_demand = 1

--- a/LibOS/shim/test/regression/futex_wake_op.manifest.template
+++ b/LibOS/shim/test/regression/futex_wake_op.manifest.template
@@ -18,4 +18,3 @@ sgx.trusted_files.libpthread = file:../../../../Runtime/libpthread.so.0
 sgx.thread_num = 16
 
 sgx.static_address = 1
-sgx.zero_heap_on_demand = 1

--- a/LibOS/shim/test/regression/getdents.manifest.template
+++ b/LibOS/shim/test/regression/getdents.manifest.template
@@ -13,4 +13,3 @@ sgx.trusted_files.libc = file:$(LIBCDIR)/libc.so.6
 sgx.allowed_files.test = file:root
 
 sgx.static_address = 1
-sgx.zero_heap_on_demand = 1

--- a/LibOS/shim/test/regression/host_root_fs.manifest.template
+++ b/LibOS/shim/test/regression/host_root_fs.manifest.template
@@ -17,4 +17,3 @@ sgx.trusted_files.libc = file:../../../../Runtime/libc.so.6
 sgx.trusted_files.libdl = file:../../../../Runtime/libdl.so.2
 
 sgx.static_address = 1
-sgx.zero_heap_on_demand = 1

--- a/LibOS/shim/test/regression/init_fail.manifest.template
+++ b/LibOS/shim/test/regression/init_fail.manifest.template
@@ -16,4 +16,3 @@ sgx.trusted_files.ld = file:$(LIBCDIR)/ld-linux-x86-64.so.2
 sgx.trusted_files.libc = file:$(LIBCDIR)/libc.so.6
 
 sgx.static_address = 1
-sgx.zero_heap_on_demand = 1

--- a/LibOS/shim/test/regression/init_fail2.manifest.template
+++ b/LibOS/shim/test/regression/init_fail2.manifest.template
@@ -12,7 +12,6 @@ sgx.trusted_files.ld = file:$(LIBCDIR)/ld-linux-x86-64.so.2
 sgx.trusted_files.libc = file:$(LIBCDIR)/libc.so.6
 
 sgx.static_address = 1
-sgx.zero_heap_on_demand = 1
 
 # this is an impossible combination of options, LibOS must fail very early in init process
 sgx.enclave_size = 256M

--- a/LibOS/shim/test/regression/large_mmap.manifest.template
+++ b/LibOS/shim/test/regression/large_mmap.manifest.template
@@ -20,4 +20,3 @@ sgx.allowed_files.testfile = file:testfile
 sgx.enclave_size = 8G
 
 sgx.static_address = 1
-sgx.zero_heap_on_demand = 1

--- a/LibOS/shim/test/regression/manifest.template
+++ b/LibOS/shim/test/regression/manifest.template
@@ -46,5 +46,3 @@ sgx.static_address = 1
 
 sgx.trusted_files.sh = file:/bin/sh
 sgx.trusted_children.sh = file:sh.sig
-
-sgx.zero_heap_on_demand = 1

--- a/LibOS/shim/test/regression/mmap_file.manifest.template
+++ b/LibOS/shim/test/regression/mmap_file.manifest.template
@@ -23,4 +23,3 @@ sgx.trusted_files.libc = file:../../../../Runtime/libc.so.6
 sgx.allowed_files.testfile = file:testfile
 
 sgx.static_address = 1
-sgx.zero_heap_on_demand = 1

--- a/LibOS/shim/test/regression/multi_pthread.manifest.template
+++ b/LibOS/shim/test/regression/multi_pthread.manifest.template
@@ -17,4 +17,3 @@ sgx.thread_num = 8
 
 sgx.static_address = 1
 sgx.enable_stats = 1
-sgx.zero_heap_on_demand = 1

--- a/LibOS/shim/test/regression/multi_pthread_exitless.manifest.template
+++ b/LibOS/shim/test/regression/multi_pthread_exitless.manifest.template
@@ -20,4 +20,3 @@ sgx.rpc_thread_num = 8
 
 sgx.static_address = 1
 sgx.enable_stats = 1
-sgx.zero_heap_on_demand = 1

--- a/LibOS/shim/test/regression/openmp.manifest.template
+++ b/LibOS/shim/test/regression/openmp.manifest.template
@@ -25,4 +25,3 @@ sgx.trusted_files.libdl = file:../../../../Runtime/libdl.so.2
 sgx.trusted_files.libgomp = file:/usr$(ARCH_LIBDIR)/libgomp.so.1
 
 sgx.static_address = 1
-sgx.zero_heap_on_demand = 1

--- a/LibOS/shim/test/regression/proc_path.manifest.template
+++ b/LibOS/shim/test/regression/proc_path.manifest.template
@@ -17,4 +17,3 @@ sgx.trusted_files.ld = file:../../../../Runtime/ld-linux-x86-64.so.2
 sgx.trusted_files.libc = file:../../../../Runtime/libc.so.6
 
 sgx.static_address = 1
-sgx.zero_heap_on_demand = 1

--- a/LibOS/shim/test/regression/sh.manifest.template
+++ b/LibOS/shim/test/regression/sh.manifest.template
@@ -32,4 +32,3 @@ sgx.trusted_files.echo = file:/bin/echo
 sgx.trusted_children.echo = file:echo.sig
 
 sgx.static_address = 1
-sgx.zero_heap_on_demand = 1

--- a/LibOS/shim/test/regression/shared_object.manifest.template
+++ b/LibOS/shim/test/regression/shared_object.manifest.template
@@ -11,4 +11,3 @@ sgx.trusted_files.ld = file:$(LIBCDIR)/ld-linux-x86-64.so.2
 sgx.trusted_files.libc = file:$(LIBCDIR)/libc.so.6
 
 sgx.static_address = 1
-sgx.zero_heap_on_demand = 1

--- a/Pal/include/pal/pal.h
+++ b/Pal/include/pal/pal.h
@@ -191,7 +191,7 @@ enum PAL_PROT {
 
 
 /*!
- * \brief Allocate virtual memory for the library OS.
+ * \brief Allocate virtual memory for the library OS and zero it out.
  *
  * \param addr
  *  can be either `NULL` or any valid address aligned at the allocation alignment. When `addr` is

--- a/Pal/regression/Bootstrap2.manifest.template
+++ b/Pal/regression/Bootstrap2.manifest.template
@@ -1,4 +1,2 @@
 loader.debug_type = inline
 loader.argv0_override = Bootstrap2
-
-sgx.zero_heap_on_demand = 1

--- a/Pal/regression/Bootstrap3.manifest.template
+++ b/Pal/regression/Bootstrap3.manifest.template
@@ -1,5 +1,3 @@
 loader.debug_type = inline
 loader.preload = file:Preload1.so,file:Preload2.so
 loader.argv0_override = Bootstrap3
-
-sgx.zero_heap_on_demand = 1

--- a/Pal/regression/Bootstrap4.manifest.template
+++ b/Pal/regression/Bootstrap4.manifest.template
@@ -1,4 +1,2 @@
 loader.exec = file:Bootstrap
 loader.argv0_override = Bootstrap
-
-sgx.zero_heap_on_demand = 1

--- a/Pal/regression/Bootstrap5.manifest.template
+++ b/Pal/regression/Bootstrap5.manifest.template
@@ -2,5 +2,3 @@ loader.debug_type = inline
 loader.preload = file:Preload1.so,file:Preload2.so
 # This example doesn't use any binary, this line is only to stop argv protection from complaining.
 loader.argv0_override = Bootstrap
-
-sgx.zero_heap_on_demand = 1

--- a/Pal/regression/Bootstrap6.manifest.template
+++ b/Pal/regression/Bootstrap6.manifest.template
@@ -6,5 +6,3 @@ loader.argv0_override = Bootstrap
 fs.mount.root.uri = file:
 
 sgx.enclave_size = 8192M
-
-sgx.zero_heap_on_demand = 1

--- a/Pal/regression/Bootstrap7.manifest.template
+++ b/Pal/regression/Bootstrap7.manifest.template
@@ -1001,5 +1001,3 @@ loader.env.key997 = na
 loader.env.key998 = na
 loader.env.key999 = na
 loader.env.key1000 = na
-
-sgx.zero_heap_on_demand = 1

--- a/Pal/regression/File.manifest.template
+++ b/Pal/regression/File.manifest.template
@@ -11,5 +11,3 @@ sgx.trusted_files.tmp1 = file:File
 sgx.trusted_files.tmp2 = file:../regression/File
 sgx.allowed_files.tmp3 = file:file_nonexist.tmp
 sgx.allowed_files.tmp4 = file:file_delete.tmp
-
-sgx.zero_heap_on_demand = 1

--- a/Pal/regression/Process.manifest.template
+++ b/Pal/regression/Process.manifest.template
@@ -6,5 +6,3 @@ fs.mount.root.uri = file:
 
 net.allow_bind.1 = 127.0.0.1:8000
 net.allow_peer.1 = 127.0.0.1:8000
-
-sgx.zero_heap_on_demand = 1

--- a/Pal/regression/Process2.manifest.template
+++ b/Pal/regression/Process2.manifest.template
@@ -2,5 +2,3 @@ loader.argv0_override = Process2
 loader.debug_type = inline
 
 sgx.trusted_children.1 = file:Bootstrap.sig
-
-sgx.zero_heap_on_demand = 1

--- a/Pal/regression/Process3.manifest.template
+++ b/Pal/regression/Process3.manifest.template
@@ -1,5 +1,3 @@
 loader.debug_type = inline
 loader.preload = file:Preload1.so,file:Preload2.so
 loader.insecure__use_cmdline_argv = 1
-
-sgx.zero_heap_on_demand = 1

--- a/Pal/regression/SendHandle.manifest.template
+++ b/Pal/regression/SendHandle.manifest.template
@@ -6,5 +6,3 @@ net.allow_bind.1 = 127.0.0.1:8000
 net.allow_peer.1 = 127.0.0.1:8000
 
 sgx.allowed_files.tmp = file:to_send.tmp
-
-sgx.zero_heap_on_demand = 1

--- a/Pal/regression/Thread2.manifest.template
+++ b/Pal/regression/Thread2.manifest.template
@@ -2,4 +2,3 @@ loader.argv0_override = Thread2
 
 sgx.thread_num = 2
 sgx.enable_stats = 1
-sgx.zero_heap_on_demand = 1

--- a/Pal/regression/Thread2_exitless.manifest.template
+++ b/Pal/regression/Thread2_exitless.manifest.template
@@ -4,4 +4,3 @@ loader.argv0_override = Thread2
 sgx.thread_num = 2
 sgx.rpc_thread_num = 2
 sgx.enable_stats = 1
-sgx.zero_heap_on_demand = 1

--- a/Pal/regression/manifest.template
+++ b/Pal/regression/manifest.template
@@ -5,5 +5,3 @@ fs.mount.root.uri = file:
 
 net.allow_bind.1 = 127.0.0.1:8000
 net.allow_peer.1 = 127.0.0.1:8000
-
-sgx.zero_heap_on_demand = 1

--- a/Pal/regression/nonelf_binary.manifest.template
+++ b/Pal/regression/nonelf_binary.manifest.template
@@ -1,4 +1,2 @@
 loader.exec = file:./nonelf_binary
 loader.debug_type = inline
-
-sgx.zero_heap_on_demand = 1

--- a/Pal/src/host/Linux-SGX/db_main.c
+++ b/Pal/src/host/Linux-SGX/db_main.c
@@ -209,27 +209,6 @@ noreturn void pal_linux_main(char* uptr_libpal_uri, size_t libpal_uri_len, char*
     g_pal_sec.exec_addr = GET_ENCLAVE_TLS(exec_addr);
     g_pal_sec.exec_size = GET_ENCLAVE_TLS(exec_size);
 
-    g_pal_sec.zero_heap_on_demand = sec_info.zero_heap_on_demand;
-
-    if (!g_pal_sec.zero_heap_on_demand) {
-        /* zero the heap during init; we need to take care to not zero the exec area */
-        void* zero1_start = g_pal_sec.heap_min;
-        void* zero1_end   = g_pal_sec.heap_max;
-
-        void* zero2_start = g_pal_sec.heap_max;
-        void* zero2_end   = g_pal_sec.heap_max;
-
-        if (g_pal_sec.exec_addr != NULL) {
-            zero1_end   = g_pal_sec.exec_addr;
-            zero2_start = g_pal_sec.exec_addr + g_pal_sec.exec_size;
-            assert(zero1_start <= zero1_end);
-            assert(zero2_start <= zero2_end);
-        }
-
-        memset(zero1_start, 0, zero1_end - zero1_start);
-        memset(zero2_start, 0, zero2_end - zero2_start);
-    }
-
     /* Skip URI_PREFIX_FILE. */
     if (libpal_uri_len < URI_PREFIX_FILE_LEN) {
         SGX_DBG(DBG_E, "Invalid libpal_uri length (missing \"%s\" prefix?)\n", URI_PREFIX_FILE);

--- a/Pal/src/host/Linux-SGX/db_memory.c
+++ b/Pal/src/host/Linux-SGX/db_memory.c
@@ -54,6 +54,7 @@ int _DkVirtualMemoryAlloc(void** paddr, uint64_t size, int alloc_type, int prot)
     if (!mem)
         return addr ? -PAL_ERROR_DENIED : -PAL_ERROR_NOMEM;
 
+    /* initialize contents of new memory region to zero (LibOS layer expects zeroed-out memory) */
     memset(mem, 0, size);
 
     *paddr = mem;

--- a/Pal/src/host/Linux-SGX/enclave_pages.c
+++ b/Pal/src/host/Linux-SGX/enclave_pages.c
@@ -162,11 +162,6 @@ static void* __create_vma_and_merge(void* addr, size_t size, bool is_pal_interna
     vma->top             = addr + size;
     vma->is_pal_internal = is_pal_internal;
 
-    if (g_pal_sec.zero_heap_on_demand) {
-        /* initialize the contents of the new VMA to zero */
-        memset(vma->bottom, 0, vma->top - vma->bottom);
-    }
-
     /* how much memory was freed because [addr, addr + size) overlapped with VMAs */
     size_t freed = 0;
 

--- a/Pal/src/host/Linux-SGX/pal_security.h
+++ b/Pal/src/host/Linux-SGX/pal_security.h
@@ -20,9 +20,8 @@ struct pal_sec {
     sgx_measurement_t  mr_signer;
     sgx_attributes_t   enclave_attributes;
 
-    /* remaining heap usable by application and whether to zero it on demand/during init */
+    /* remaining heap usable by application */
     PAL_PTR         heap_min, heap_max;
-    PAL_BOL         zero_heap_on_demand;
 
     /* executable name, addr and size */
     PAL_SEC_STR     exec_name;

--- a/Pal/src/host/Linux-SGX/sgx_main.c
+++ b/Pal/src/host/Linux-SGX/sgx_main.c
@@ -945,14 +945,6 @@ static int load_enclave(struct pal_enclave* enclave, int manifest_fd, char* mani
             return ret;
     }
 
-    pal_sec->zero_heap_on_demand = false;
-    if (get_config(enclave->config, "sgx.zero_heap_on_demand", cfgbuf, sizeof(cfgbuf)) > 0
-            && cfgbuf[0] == '1') {
-        /* zero enclave heap on demand vs once during enclave init; this option does not affect
-         * security (only startup vs runtime performance), so can be passed from untrusted host */
-        pal_sec->zero_heap_on_demand = true;
-    }
-
     void* alt_stack = (void*)INLINE_SYSCALL(mmap, 6, NULL, ALT_STACK_SIZE,
                                             PROT_READ | PROT_WRITE,
                                             MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);

--- a/Pal/src/host/Linux-SGX/signer/pal_sgx_sign.py
+++ b/Pal/src/host/Linux-SGX/signer/pal_sgx_sign.py
@@ -860,9 +860,6 @@ def main_sign(args):
     if manifest.get('sgx.enable_stats', None) is None:
         manifest['sgx.enable_stats'] = '0'
 
-    if manifest.get('sgx.zero_heap_on_demand', None) is None:
-        manifest['sgx.zero_heap_on_demand'] = '0'
-
     output_manifest(args['output'], manifest, manifest_layout)
 
     memory_areas = [


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Previously, we introduced `sgx.zero_heap_on_demand` in Linux-SGX as a knob to trade off runtime degradation on memory allocations for faster enclave start-up times. This was an incorrect fix because Linux-SGX's `_DkVirtualMemoryAlloc()` always zeros the requested memory region, so there was a double-zero of the heap at runtime. Note that POSIX requires `_DkVirtualMemoryAlloc()` to zero-out the memory, and many applications rely on this (Apache, Blender in my experiments). Thus, this commit keeps the zero-out in `_DkVirtualMemoryAlloc()` and removes zero-outs on enclave init and in `get_enclave_pages()`.

This renders `sgx.zero_heap_on_demand` useless, so this manifest option is also removed. Also note that this commit doesn't introduce any performance degradation (in fact, now Graphene behaves as if `sgx.zero_heap_on_demand = 1` always).

See the following PRs for the context and history:

- https://github.com/oscarlab/graphene/pull/1640
- https://github.com/oscarlab/graphene/pull/1668
- https://github.com/oscarlab/graphene/pull/1689
- https://github.com/oscarlab/graphene/pull/1740

(This PR basically undoes the first three.)

## How to test this PR? <!-- (if applicable) -->

All tests must pass. There must be no performance degradation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1741)
<!-- Reviewable:end -->
