### PR TITLE
[LibOS] Correct logging of mmap with MAP_ANONYMOUS

### DIFF
--- a/LibOS/shim/src/shim_parser.c
+++ b/LibOS/shim/src/shim_parser.c
@@ -768,7 +768,7 @@ static void parse_mmap_flags(va_list* ap) {
     }
 
     if (flags & MAP_ANONYMOUS) {
-        PUTS("|MAP_ANON");
+        PUTS("|MAP_ANONYMOUS");
         flags &= ~MAP_ANONYMOUS;
     }
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Previously the syscall logging used a wrong name for this flag.

## How to test this PR? <!-- (if applicable) -->

Run anything with debug type set to "inline" and look at the output.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1744)
<!-- Reviewable:end -->
