### PR TITLE
[Pal/Linux-SGX] Allow starting enclave address space with non-zero

### DIFF
--- a/Documentation/cloud-deployment.rst
+++ b/Documentation/cloud-deployment.rst
@@ -63,13 +63,6 @@ Build and Test
             ISGX_DRIVER_PATH=/usr/src/linux-azure-headers-`uname -r`/arch/x86/ \
                   make SGX=1
 
-#. Set ``vm.mmap_min_addr=0`` in the system:
-
-      .. code-block:: sh
-
-            # WARNING: read "Security Implications" section before running this command
-            sudo sysctl vm.mmap_min_addr=0
-
 #. Build and Run :program:`helloworld`:
 
       .. code-block:: sh
@@ -83,19 +76,12 @@ Security Implications
 ^^^^^^^^^^^^^^^^^^^^^
 
 Note that this guide assumes that you deploy Graphene on an untrusted cloud VM.
-The two steps in this guide significantly weaken the security of the cloud VM's
-Linux kernel.
-
-In particular, ``sudo insmod gsgx.ko`` introduces a local privilege escalation
+One step in this guide significantly weakens the security of the cloud VM's
+Linux kernel: ``sudo insmod gsgx.ko`` introduces a local privilege escalation
 vulnerability. This kernel module enables the FSGSBASE processor feature
 without proper enabling in the host Linux kernel. Please refer to the
 documentation under ``Pal/src/host/Linux-SGX/sgx-driver`` for more information.
 
-Also, ``sudo sysctl vm.mmap_min_addr=0`` weakens the security of the Linux
-kernel. This kernel tunable specifies the minimum virtual address that a
-process is allowed to mmap. Setting it to zero makes it easier for attackers to
-exploit "kernel NULL pointer dereference" defects.
-
-Both these steps are temporary workarounds and will not be required in the
-future. Be aware that the current guide must not be used to set up production
-environments.
+This step is a temporary workaround and will not be required in the future
+(starting from Linux 5.9). Be aware that the current guide must not be used to
+set up production environments.

--- a/Documentation/quickstart.rst
+++ b/Documentation/quickstart.rst
@@ -69,12 +69,12 @@ second command should list the process status of :command:`aesm_service`.
       make SGX=1
       # the console will prompt you for the path to the Intel SGX driver code
 
-#. Set ``vm.mmap_min_addr=0`` in the system::
+#. Set ``vm.mmap_min_addr=0`` in the system (*only required for the legacy SGX
+   driver and not needed for newer DCAP/in-kernel drivers*)::
 
       sudo sysctl vm.mmap_min_addr=0
 
-   Note that this is an inadvisable configuration for production systems. This
-   temporary workaround will not be required in the future.
+   Note that this is an inadvisable configuration for production systems.
 
 #. Build and run :program:`helloworld`::
 

--- a/Pal/src/host/Linux-SGX/sgx_framework.c
+++ b/Pal/src/host/Linux-SGX/sgx_framework.c
@@ -148,7 +148,19 @@ int create_enclave(sgx_arch_secs_t * secs,
      * SIGSTRUCT during EINIT (see pp21 for ECREATE and pp34 for
      * EINIT in https://software.intel.com/sites/default/files/managed/48/88/329298-002.pdf). */
 
-    uint64_t addr = INLINE_SYSCALL(mmap, 6, secs->base, secs->size,
+    uint64_t request_mmap_addr = secs->base;
+    uint64_t request_mmap_size = secs->size;
+
+#ifdef SGX_DCAP_16_OR_LATER
+    /* newer DCAP/in-kernel SGX drivers allow starting enclave address space with non-zero;
+     * the below trick to start from DEFAULT_HEAP_MIN is to avoid vm.mmap_min_addr==0 issue */
+    if (request_mmap_addr < DEFAULT_HEAP_MIN) {
+        request_mmap_size -= DEFAULT_HEAP_MIN - request_mmap_addr;
+        request_mmap_addr  = DEFAULT_HEAP_MIN;
+    }
+#endif
+
+    uint64_t addr = INLINE_SYSCALL(mmap, 6, request_mmap_addr, request_mmap_size,
                                    PROT_NONE, /* newer DCAP driver requires such initial mmap */
 #ifdef SGX_DCAP_16_OR_LATER
                                    MAP_FIXED | MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
@@ -166,7 +178,7 @@ int create_enclave(sgx_arch_secs_t * secs,
         return -ENOMEM;
     }
 
-    assert(secs->base == addr);
+    assert(addr == request_mmap_addr);
 
     struct sgx_enclave_create param = {
         .src = (uint64_t) secs,


### PR DESCRIPTION

## Description of the changes <!-- (reasons and measures) -->

Previously, Graphene-SGX required `vm.mmap_min_addr` equal to `0x0` for non-PIE executables (this is due to the SGX hardware requirement of enclave base being aligned on enclave size, coupled with non-PIE requirement of starting the code section at address `0x400000`).

The legacy Intel SGX driver required a device-file-backed mmap starting at address `0x0`. The newer DCAP/in-kernel SGX drivers don't require this, so Graphene-SGX can create the enclave at non-zero starting address and deprecate the hack of `vm.mmap_min_addr == 0x0`.

## How to test this PR? <!-- (if applicable) -->

1. Use a machine with DCAP/in-kernel driver (DCAP v1.6+ and in-kernel v1.32+).

2. Reset `mmap_min_addr` like this: `echo 65535 | sudo tee /proc/sys/vm/mmap_min_addr`.

3. Manually build and run one of the LibOS regression tests (they are built with `sgx.static_address = 1` so their enclaves will be forced to have `enclave_base = 0x0`).

4. Do strace and you'll see stuff like this:
```
mmap(0x10000, 268369920, PROT_NONE, MAP_PRIVATE|MAP_FIXED|MAP_ANONYMOUS, -1, 0) = 0x10000
```

This means that the enclave address space starts with `0x10000 = 65535` (even though enclave base is `0x0`). And the enclave still works! Now you don't need the hack of `echo 0 | sudo tee /proc/sys/vm/mmap_min_addr`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1746)
<!-- Reviewable:end -->
