### PR TITLE
[LibOS] Add missing check for user_address.start in shim_do_mmap

### DIFF
--- a/LibOS/shim/src/sys/shim_mmap.c
+++ b/LibOS/shim/src/sys/shim_mmap.c
@@ -144,7 +144,8 @@ void* shim_do_mmap(void* addr, size_t length, int prot, int flags, int fd, off_t
         }
     } else {
         /* We know that `addr + length` does not overflow (`access_ok` above). */
-        if (addr && ((uintptr_t)addr + length <= (uintptr_t)PAL_CB(user_address.end))) {
+        if (addr && (uintptr_t)PAL_CB(user_address.start) <= (uintptr_t)addr
+                && (uintptr_t)addr + length <= (uintptr_t)PAL_CB(user_address.end)) {
             ret = bkeep_mmap_any_in_range(PAL_CB(user_address.start), (char*)addr + length, length,
                                           prot, flags, hdl, offset, NULL, &addr);
         } else {


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://graphene.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->
Address hint should be ignored if it's lower than `PAL_CB(user_address.start)` in `shim_do_mmap`

Fixes #1743

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1747)
<!-- Reviewable:end -->
