### PR TITLE
[Pal/Linux-SGX] Fix and refactor untrusted API code

### DIFF
--- a/Pal/src/host/Linux-SGX/db_main.c
+++ b/Pal/src/host/Linux-SGX/db_main.c
@@ -130,7 +130,7 @@ static const char** make_argv_list(void* uptr_src, size_t src_size) {
     const char** argv;
 
     if (src_size == 0) {
-        argv = malloc(sizeof(char *));
+        argv = malloc(sizeof(char*));
         if (argv)
             argv[0] = NULL;
         return argv;
@@ -182,7 +182,7 @@ extern void* g_enclave_base;
 extern void* g_enclave_top;
 
 noreturn void pal_linux_main(char* uptr_libpal_uri, size_t libpal_uri_len, char* uptr_args,
-                             uint64_t args_size, char* uptr_env, uint64_t env_size,
+                             size_t args_size, char* uptr_env, size_t env_size,
                              struct pal_sec* uptr_sec_info) {
     /*
      * Our arguments are coming directly from the urts. We are responsible to check them.
@@ -199,7 +199,7 @@ noreturn void pal_linux_main(char* uptr_libpal_uri, size_t libpal_uri_len, char*
     }
 
     struct pal_sec sec_info;
-    if (!sgx_copy_to_enclave(&sec_info, sizeof(sec_info), uptr_sec_info, sizeof(sec_info))) {
+    if (!sgx_copy_to_enclave(&sec_info, sizeof(sec_info), uptr_sec_info, sizeof(*uptr_sec_info))) {
         SGX_DBG(DBG_E, "Copying sec_info into the enclave failed\n");
         ocall_exit(1, /*is_exitgroup=*/true);
     }

--- a/Pal/src/host/Linux-SGX/enclave_ecalls.c
+++ b/Pal/src/host/Linux-SGX/enclave_ecalls.c
@@ -1,11 +1,13 @@
-#include "pal_linux.h"
-#include "pal_security.h"
-#include "pal_internal.h"
-#include <api.h>
+#include <stdalign.h>
 
+#include "api.h"
 #include "ecall_types.h"
 #include "enclave_ecalls.h"
+#include "pal_internal.h"
+#include "pal_linux.h"
+#include "pal_security.h"
 #include "rpc_queue.h"
+#include "sgx_arch.h"
 
 #define SGX_CAST(type, item) ((type)(item))
 
@@ -85,8 +87,7 @@ void handle_ecall(long ecall_index, void* ecall_args, void* exit_target, void* e
             return;
         }
 
-        ms_ecall_enclave_start_t * ms =
-                (ms_ecall_enclave_start_t *) ecall_args;
+        ms_ecall_enclave_start_t* ms = (ms_ecall_enclave_start_t*)ecall_args;
 
         if (!ms || !sgx_is_completely_outside_enclave(ms, sizeof(*ms))) {
             return;
@@ -95,14 +96,26 @@ void handle_ecall(long ecall_index, void* ecall_args, void* exit_target, void* e
         if (verify_and_init_rpc_queue(READ_ONCE(ms->rpc_queue)))
             return;
 
-        /* xsave size must be initialized early */
-        init_xsave_size(READ_ONCE(READ_ONCE(ms->ms_sec_info)->enclave_attributes.xfrm));
+        struct pal_sec* pal_sec = READ_ONCE(ms->ms_sec_info);
+        if (!pal_sec || !sgx_is_completely_outside_enclave(pal_sec, sizeof(*pal_sec)))
+            return;
+
+        /* xsave size must be initialized early, from a trusted source (EREPORT result) */
+        // TODO: This eats 1KB of a stack frame which lives for the whole lifespan of this enclave.
+        //       We should move it somewhere else and deallocate right after use.
+        __sgx_mem_aligned sgx_target_info_t target_info;
+        alignas(128) char report_data[64] = { 0 };
+        __sgx_mem_aligned sgx_report_t report;
+        memset(&report, 0, sizeof(report));
+        memset(&target_info, 0, sizeof(target_info));
+        sgx_report(&target_info, &report_data, &report);
+        init_xsave_size(report.body.attributes.xfrm);
 
         /* pal_linux_main is responsible to check the passed arguments */
         pal_linux_main(READ_ONCE(ms->ms_libpal_uri), READ_ONCE(ms->ms_libpal_uri_len),
                        READ_ONCE(ms->ms_args), READ_ONCE(ms->ms_args_size),
                        READ_ONCE(ms->ms_env), READ_ONCE(ms->ms_env_size),
-                       READ_ONCE(ms->ms_sec_info));
+                       pal_sec);
     } else {
         // ENCLAVE_START already called (maybe successfully, maybe not), so
         // only valid ecall is THREAD_START.

--- a/Pal/src/host/Linux-SGX/enclave_ocalls.h
+++ b/Pal/src/host/Linux-SGX/enclave_ocalls.h
@@ -46,7 +46,7 @@ int ocall_ftruncate (int fd, uint64_t length);
 
 int ocall_mkdir (const char *pathname, unsigned short mode);
 
-int ocall_getdents (int fd, struct linux_dirent64 *dirp, unsigned int size);
+int ocall_getdents(int fd, struct linux_dirent64* dirp, size_t size);
 
 int ocall_listen(int domain, int type, int protocol, int ipv6_v6only, struct sockaddr* addr,
                  size_t* addrlen, struct sockopt* sockopt);

--- a/Pal/src/host/Linux-SGX/ocall_types.h
+++ b/Pal/src/host/Linux-SGX/ocall_types.h
@@ -70,14 +70,14 @@ typedef struct {
 typedef struct {
     int ms_fd;
     uint64_t ms_offset;
-    uint64_t ms_size;
+    size_t ms_size;
     unsigned short ms_prot;
-    void * ms_mem;
+    void* ms_mem;
 } ms_ocall_mmap_untrusted_t;
 
 typedef struct {
-    const void * ms_mem;
-    uint64_t ms_size;
+    const void* ms_mem;
+    size_t ms_size;
 } ms_ocall_munmap_untrusted_t;
 
 typedef struct {
@@ -158,7 +158,7 @@ typedef struct {
 typedef struct {
     int ms_fd;
     struct linux_dirent64 * ms_dirp;
-    unsigned int ms_size;
+    size_t ms_size;
 } ms_ocall_getdents_t;
 
 typedef struct {

--- a/Pal/src/host/Linux-SGX/sgx_api.h
+++ b/Pal/src/host/Linux-SGX/sgx_api.h
@@ -18,8 +18,8 @@ void* sgx_alloc_on_ustack(uint64_t size);
 void* sgx_copy_to_ustack(const void* ptr, uint64_t size);
 void sgx_reset_ustack(const void* old_ustack);
 
-bool sgx_copy_ptr_to_enclave(void** ptr, void* uptr, uint64_t size);
-uint64_t sgx_copy_to_enclave(const void* ptr, uint64_t maxsize, const void* uptr, uint64_t usize);
+bool sgx_copy_ptr_to_enclave(void** ptr, void* uptr, size_t size);
+bool sgx_copy_to_enclave(const void* ptr, size_t maxsize, const void* uptr, size_t usize);
 
 /*!
  * \brief Low-level wrapper around EREPORT instruction leaf.

--- a/Pal/src/host/Linux-SGX/sgx_enclave.c
+++ b/Pal/src/host/Linux-SGX/sgx_enclave.c
@@ -78,17 +78,16 @@ static long sgx_ocall_exit(void* pms)
     return 0;
 }
 
-static long sgx_ocall_mmap_untrusted(void * pms)
-{
-    ms_ocall_mmap_untrusted_t * ms = (ms_ocall_mmap_untrusted_t *) pms;
-    void * addr;
+static long sgx_ocall_mmap_untrusted(void* pms) {
+    ms_ocall_mmap_untrusted_t* ms = (ms_ocall_mmap_untrusted_t*)pms;
+    void* addr;
 
     ODEBUG(OCALL_MMAP_UNTRUSTED, ms);
-    addr = (void *) INLINE_SYSCALL(mmap, 6, NULL, ms->ms_size,
-                                   ms->ms_prot,
-                                   (ms->ms_fd == -1) ? MAP_ANONYMOUS | MAP_PRIVATE
-                                                     : MAP_FILE | MAP_SHARED,
-                                   ms->ms_fd, ms->ms_offset);
+    addr = (void*)INLINE_SYSCALL(mmap, 6, NULL, ms->ms_size,
+                                 ms->ms_prot,
+                                 (ms->ms_fd == -1) ? MAP_ANONYMOUS | MAP_PRIVATE
+                                                   : MAP_FILE | MAP_SHARED,
+                                 ms->ms_fd, ms->ms_offset);
     if (IS_ERR_P(addr))
         return -ERRNO_P(addr);
 
@@ -96,9 +95,8 @@ static long sgx_ocall_mmap_untrusted(void * pms)
     return 0;
 }
 
-static long sgx_ocall_munmap_untrusted(void * pms)
-{
-    ms_ocall_munmap_untrusted_t * ms = (ms_ocall_munmap_untrusted_t *) pms;
+static long sgx_ocall_munmap_untrusted(void* pms) {
+    ms_ocall_munmap_untrusted_t* ms = (ms_ocall_munmap_untrusted_t*)pms;
     ODEBUG(OCALL_MUNMAP_UNTRUSTED, ms);
     INLINE_SYSCALL(munmap, 2, ALLOC_ALIGN_DOWN_PTR(ms->ms_mem),
                    ALLOC_ALIGN_UP_PTR(ms->ms_mem + ms->ms_size) -
@@ -250,12 +248,12 @@ static long sgx_ocall_mkdir(void * pms)
     return ret;
 }
 
-static long sgx_ocall_getdents(void * pms)
-{
-    ms_ocall_getdents_t * ms = (ms_ocall_getdents_t *) pms;
+static long sgx_ocall_getdents(void* pms) {
+    ms_ocall_getdents_t* ms = (ms_ocall_getdents_t*)pms;
     long ret;
     ODEBUG(OCALL_GETDENTS, ms);
-    ret = INLINE_SYSCALL(getdents64, 3, ms->ms_fd, ms->ms_dirp, ms->ms_size);
+    unsigned int count = ms->ms_size <= UINT_MAX ? ms->ms_size : UINT_MAX;
+    ret = INLINE_SYSCALL(getdents64, 3, ms->ms_fd, ms->ms_dirp, count);
     return ret;
 }
 

--- a/Pal/src/host/Linux-SGX/sgx_tls.h
+++ b/Pal/src/host/Linux-SGX/sgx_tls.h
@@ -7,8 +7,9 @@
 
 struct untrusted_area {
     void* mem;
-    uint64_t size;
-    uint64_t in_use;
+    size_t size;
+    uint64_t in_use; /* must be uint64_t, because SET_ENCLAVE_TLS() currently supports only 8-byte
+                      * types. TODO: fix this. */
     bool valid;
 };
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Problems fixed:
* handle_ecall incorrectly checked ms_sec_info argument (missing address verification and potential TOCTOU problem).
* init_xsave_size argument was taken from an untrusted source, while it can be retrieved from the CPU directly.
* A lot of ocalls used wrong types for sizes.
* `noinline` hack for sgx_copy_to_enclave and sgx_copy_ptr_to_enclave is not needed anymore as we use READ_ONCE and WRITE_ONCE now.

## How to test this PR? <!-- (if applicable) -->

Read the code carefully.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1750)
<!-- Reviewable:end -->
