### PR TITLE
[LibOS] Fix setting O_NONBLOCK flag in pipe2

### DIFF
--- a/LibOS/shim/include/shim_handle.h
+++ b/LibOS/shim/include/shim_handle.h
@@ -348,6 +348,9 @@ void flush_handle(struct shim_handle* hdl);
 void get_handle(struct shim_handle* hdl);
 void put_handle(struct shim_handle* hdl);
 
+/* Set handle in non-blocking mode. */
+int set_handle_nonblocking(struct shim_handle* hdl);
+
 /* file descriptor table */
 struct shim_fd_handle {
     FDTYPE vfd; /* virtual file descriptor */

--- a/LibOS/shim/src/sys/shim_ioctl.c
+++ b/LibOS/shim/src/sys/shim_ioctl.c
@@ -328,10 +328,7 @@ int shim_do_ioctl(int fd, unsigned long cmd, unsigned long arg) {
             ret = ioctl_termios(hdl, cmd, arg);
             break;
         case FIONBIO:
-            if (hdl->fs && hdl->fs->fs_ops && hdl->fs->fs_ops->setflags)
-                hdl->fs->fs_ops->setflags(hdl, hdl->flags | O_NONBLOCK);
-            hdl->flags |= O_NONBLOCK;
-            ret = 0;
+            ret = set_handle_nonblocking(hdl);
             break;
         case FIONCLEX:
             hdl->flags &= ~FD_CLOEXEC;

--- a/LibOS/shim/test/regression/.gitignore
+++ b/LibOS/shim/test/regression/.gitignore
@@ -49,6 +49,7 @@
 /multi_pthread
 /openmp
 /pipe
+/pipe_nonblocking
 /poll
 /poll_closed_fd
 /poll_many_types

--- a/LibOS/shim/test/regression/Makefile
+++ b/LibOS/shim/test/regression/Makefile
@@ -45,6 +45,7 @@ c_executables = \
 	multi_pthread \
 	openmp \
 	pipe \
+	pipe_nonblocking \
 	poll \
 	poll_closed_fd \
 	poll_many_types \

--- a/LibOS/shim/test/regression/pipe_nonblocking.c
+++ b/LibOS/shim/test/regression/pipe_nonblocking.c
@@ -1,0 +1,42 @@
+#define _GNU_SOURCE
+#include <err.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <unistd.h>
+
+int main(void) {
+    int p[2];
+
+    if (pipe2(p, O_NONBLOCK | O_CLOEXEC) < 0) {
+        err(1, "pipe2");
+    }
+
+    ssize_t ret = write(p[1], "a", 1);
+    if (ret < 0) {
+        err(1, "write");
+    } else if (ret != 1) {
+        errx(1, "invalid return value from write: %zd\n", ret);
+    }
+
+    char c;
+    ret = read(p[0], &c, 1);
+    if (ret < 0) {
+        err(1, "read");
+    } else if (ret != 1) {
+        errx(1, "invalid return value from read: %zd\n", ret);
+    }
+
+    ret = read(p[0], &c, 1);
+    if (ret > 0) {
+        errx(1, "read returned unexpected data: %zd\n", ret);
+    } else if (ret == 0) {
+        errx(1, "read returned 0 instead of EAGAIN\n");
+    } else if (errno != EAGAIN && errno != EWOULDBLOCK) {
+        err(1, "unexpected read failure");
+    }
+
+    puts("TEST OK");
+    return 0;
+}
+

--- a/LibOS/shim/test/regression/test_libos.py
+++ b/LibOS/shim/test/regression/test_libos.py
@@ -605,6 +605,10 @@ class TC_80_Socket(RegressionTestCase):
         stdout, _ = self.run_binary(['pipe'], timeout=60)
         self.assertIn('read on pipe: Hello from write end of pipe!', stdout)
 
+    def test_091_pipe_nonblocking(self):
+        stdout, _ = self.run_binary(['pipe_nonblocking'])
+        self.assertIn('TEST OK', stdout)
+
     def test_095_mkfifo(self):
         stdout, _ = self.run_binary(['mkfifo'], timeout=60)
         self.assertIn('read on FIFO: Hello from write end of FIFO!', stdout)


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->
Specifying O_NONBLOCK flag in the call to pipe2 applied it only to one
end of the pipe.

Fixes #1752

## How to test this PR? <!-- (if applicable) -->
New regression test added

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1754)
<!-- Reviewable:end -->
