### PR TITLE
[GSC] Support build-time variable via --build-arg.

### DIFF
--- a/Documentation/manpages/gsc.rst
+++ b/Documentation/manpages/gsc.rst
@@ -124,6 +124,11 @@ Synopsis:
    Remove intermediate Docker images created by :command:`gsc build`, if the
    image build is successful.
 
+.. option:: --build-arg
+
+   Set build-time variables during :command:`gsc build` (same as `docker build
+   --build-arg`).
+
 .. option:: IMAGE-NAME
 
    Name of the application Docker image

--- a/Tools/gsc/gsc.py
+++ b/Tools/gsc/gsc.py
@@ -203,8 +203,19 @@ def gsc_build(args):
 
     prepare_build_context(image, user_manifests, env, binary)
 
+    buildargs_dict = {}
+    for item in args.build_arg:
+        if '=' in item:
+            key, value = item.split('=', 1)
+            buildargs_dict[key] = value
+        else:
+            # user specified a --build-arg flag with key and without value, let's retrieve value
+            # from environment
+            if item in os.environ:
+                buildargs_dict[item] = os.environ[item]
+
     build_docker_image(gsc_image_name(image), gsc_unsigned_image_name(image), 'Dockerfile.build',
-                       rm=args.rm, nocache=args.no_cache)
+                       rm=args.rm, nocache=args.no_cache, buildargs=buildargs_dict)
 
     # Check if docker build failed
     if get_docker_image(docker_socket, gsc_unsigned_image_name(image)) is None:
@@ -282,6 +293,8 @@ sub_build.add_argument('-nc', '--no-cache', action='store_true',
     help='Build graphenized Docker image without any cached images.')
 sub_build.add_argument('--rm', action='store_true',
     help='Remove intermediate Docker images when build is successful.')
+sub_build.add_argument('--build-arg', action='append', default=[],
+    help='Set build-time variables (same as "docker build --build-arg").')
 sub_build.add_argument('image',
     help='Name of the application Docker image.')
 sub_build.add_argument('manifests',

--- a/Tools/gsc/test/Makefile
+++ b/Tools/gsc/test/Makefile
@@ -57,7 +57,7 @@ gsc-%-pytorch: %-pytorch %-pytorch.manifest
 .PRECIOUS: gsc-%
 gsc-%: %
 	echo "Building graphenized image $@..."
-	cd .. && ./gsc build --insecure-args $(BUILD_FLAGS) $(addsuffix $(IMAGE_SUFFIX), $*) test/$(*:gsc-%=%).manifest
+	cd .. && ./gsc build --insecure-args $(GSC_BUILD_FLAGS) $(addsuffix $(IMAGE_SUFFIX), $*) test/$(*:gsc-%=%).manifest
 	cd .. && ./gsc sign-image $(addsuffix $(IMAGE_SUFFIX), $*) $(notdir $(KEY_FILE))
 	touch $@
 


### PR DESCRIPTION
When building graphenized docker image, some build-time variables
like http_proxy, https_proxy, no_proxy are required for private
network behind proxy.
So this commit enable --build-arg for proxy configurations via
GSC_BUILD_FLAGS.

<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://graphene.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->
When building graphenized docker image, some build-time variables
like http_proxy, https_proxy, no_proxy are required for private
network behind proxy.

## How to test this PR? <!-- (if applicable) -->
1. On a development machine behind firewall, assume the "http_proxy=http://<some-http-proxy>, https_proxy=http://<some-https-proxy>, no_proxy=<no-proxy>"
2. set the envornment variable GSC_BUILD_FLAGS via command "export GSC_BUILD_FLAGS=--rm --no-cache --build-arg http_proxy=${http_proxy} --build-arg https_proxy=${https_proxy}"
3. Build graphenized docker image via "make" under the directory Tools/gsc/test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1758)
<!-- Reviewable:end -->
