### PR TITLE
[Examples] Fix tensorflow Makefile

### DIFF
--- a/Examples/tensorflow/Makefile
+++ b/Examples/tensorflow/Makefile
@@ -62,8 +62,8 @@ label_image.manifest.sgx: label_image label_image.manifest inception_v3.tflite l
 	$(GRAPHENEDIR)/Pal/src/host/Linux-SGX/signer/pal-sgx-sign \
 		-libpal $(GRAPHENEDIR)/Runtime/libpal-Linux-SGX.so \
 		-key $(SGX_SIGNER_KEY) \
-		-manifest $< -output $@ \
-		-exec label_image
+		-manifest $<.manifest -output $@ \
+		-exec $<
 	$(GRAPHENEDIR)/Pal/src/host/Linux-SGX/signer/pal-sgx-get-token \
 		-output label_image.token -sig label_image.sig
 


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://graphene.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->
This is a repost of #1759.

The commit f895e0d below updates Makefile prerequisites, and accordingly $< needs to be updated.
```diff
diff --git a/Examples/tensorflow/Makefile b/Examples/tensorflow/Makefile
index 2439a1bc..247397d4 100644
--- a/Examples/tensorflow/Makefile
+++ b/Examples/tensorflow/Makefile
@@ -58,7 +58,7 @@ label_image.manifest: label_image.manifest.template
                -e 's|$$(GRAPHENEDEBUG)|'"$(GRAPHENEDEBUG)"'|g' \
                $< > $@

-label_image.manifest.sgx: label_image.manifest
+label_image.manifest.sgx: label_image label_image.manifest inception_v3.tflite labels.txt
        $(GRAPHENEDIR)/Pal/src/host/Linux-SGX/signer/pal-sgx-sign \
                -libpal $(GRAPHENEDIR)/Runtime/libpal-Linux-SGX.so \
                -key $(SGX_SIGNER_KEY) \
```


## How to test this PR? <!-- (if applicable) -->
Run make SGX=1 in Examples/tensorflow.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1761)
<!-- Reviewable:end -->
