### PR TITLE
[Pal/Linux-SGX] Preserve wrap key for protected files across forks

### DIFF
--- a/Examples/ra-tls-secret-prov/Makefile
+++ b/Examples/ra-tls-secret-prov/Makefile
@@ -215,9 +215,10 @@ check_epid: app epid files/input.txt
 	SGX=1 ./pal_loader ./secret_prov_client >> OUTPUT; \
 	SGX=1 ./pal_loader ./secret_prov_pf_client >> OUTPUT; \
 	kill -9 $$SERVER_ID;
-	@grep "Received secret = 'ffeeddccbbaa99887766554433221100'" OUTPUT && echo "[ Success 1/3 ]"
-	@grep "Received secret1 = 'ffeeddccbbaa99887766554433221100', secret2 = '42'" OUTPUT && echo "[ Success 2/3 ]"
-	@grep "Read from protected file: 'helloworld'" OUTPUT && echo "[ Success 3/3 ]"
+	@grep "Received secret = 'ffeeddccbbaa99887766554433221100'" OUTPUT && echo "[ Success 1/4 ]"
+	@grep "Received secret1 = 'ffeeddccbbaa99887766554433221100', secret2 = '42'" OUTPUT && echo "[ Success 2/4 ]"
+	@grep "\[parent\] Read from protected file: 'helloworld'" OUTPUT && echo "[ Success 3/4 ]"
+	@grep "\[child\] Read from protected file: 'helloworld'" OUTPUT && echo "[ Success 4/4 ]"
 	@rm OUTPUT
 
 .PHONY: check_dcap
@@ -228,9 +229,10 @@ check_dcap: app dcap files/input.txt
 	SGX=1 ./pal_loader ./secret_prov_client >> OUTPUT; \
 	SGX=1 ./pal_loader ./secret_prov_pf_client >> OUTPUT; \
 	kill -9 $$SERVER_ID;
-	@grep "Received secret = 'ffeeddccbbaa99887766554433221100'" OUTPUT && echo "[ Success 1/3 ]"
-	@grep "Received secret1 = 'ffeeddccbbaa99887766554433221100', secret2 = '42'" OUTPUT && echo "[ Success 2/3 ]"
-	@grep "Read from protected file: 'helloworld'" OUTPUT && echo "[ Success 3/3 ]"
+	@grep "Received secret = 'ffeeddccbbaa99887766554433221100'" OUTPUT && echo "[ Success 1/4 ]"
+	@grep "Received secret1 = 'ffeeddccbbaa99887766554433221100', secret2 = '42'" OUTPUT && echo "[ Success 2/4 ]"
+	@grep "\[parent\] Read from protected file: 'helloworld'" OUTPUT && echo "[ Success 3/4 ]"
+	@grep "\[child\] Read from protected file: 'helloworld'" OUTPUT && echo "[ Success 4/4 ]"
 	@rm OUTPUT
 
 ################################## CLEANUP ####################################

--- a/Pal/src/host/Linux-SGX/protected-files/protected_files.h
+++ b/Pal/src/host/Linux-SGX/protected-files/protected_files.h
@@ -27,6 +27,9 @@ typedef uint8_t pf_mac_t[PF_MAC_SIZE];
 typedef uint8_t pf_key_t[PF_KEY_SIZE];
 typedef uint8_t pf_keyid_t[32]; /* key derivation material */
 
+extern pf_key_t g_pf_wrap_key;
+extern bool g_pf_wrap_key_set;
+
 typedef enum _pf_status_t {
     PF_STATUS_SUCCESS              = 0,
     PF_STATUS_UNKNOWN_ERROR        = -1,


### PR DESCRIPTION


<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://graphene.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

Trusted child enclaves must inherit the provisioned master (wrap) key for protected files from the parent enclave on fork/clone. This commit adds this functionality and modifies the RA-TLS secret provisioning PF client to test this (including in Jenkins).

Kudos to Li Xun for reporting this bug and proposing a solution. See #1762 for more details.

Fixes #1762.

## How to test this PR? <!-- (if applicable) -->

`Examples/ra-tls-secret-prov` test in Jenkins is modified to test this in parent and child enclaves.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1765)
<!-- Reviewable:end -->
