### PR TITLE
[LibOS] Allow but ignore MSG_DONTWAIT flag on recvfrom/sendto

### DIFF
--- a/LibOS/shim/include/shim_types.h
+++ b/LibOS/shim/include/shim_types.h
@@ -219,10 +219,14 @@ struct __kernel_ustat
 /* bits/socket.h */
 enum
 {
-    MSG_OOB  = 0x01, /* Process out-of-band data. */
-    MSG_PEEK = 0x02, /* Peek at incoming messages. */
+    MSG_OOB      = 0x01,   /* Process out-of-band data. */
+    MSG_PEEK     = 0x02,   /* Peek at incoming messages. */
+    MSG_DONTWAIT = 0x40,   /* Nonblocking IO. */
+    MSG_NOSIGNAL = 0x4000, /* Do not generate SIGPIPE. */
 #define MSG_OOB MSG_OOB
 #define MSG_PEEK MSG_PEEK
+#define MSG_DONTWAIT MSG_DONTWAIT
+#define MSG_NOSIGNAL MSG_NOSIGNAL
 };
 
 struct msghdr {

--- a/LibOS/shim/src/sys/shim_socket.c
+++ b/LibOS/shim/src/sys/shim_socket.c
@@ -1004,9 +1004,6 @@ int shim_do_accept4(int fd, struct sockaddr* addr, int* addrlen, int flags) {
 
 static ssize_t do_sendmsg(int fd, struct iovec* bufs, int nbufs, int flags,
                           const struct sockaddr* addr, int addrlen) {
-    // Issue #752 - https://github.com/oscarlab/graphene/issues/752
-    __UNUSED(flags);
-
     struct shim_handle* hdl = get_fd_handle(fd, NULL, NULL);
     if (!hdl)
         return -EBADF;
@@ -1029,7 +1026,22 @@ static ssize_t do_sendmsg(int fd, struct iovec* bufs, int nbufs, int flags,
             goto out;
     }
 
+    if (flags & ~(MSG_NOSIGNAL | MSG_DONTWAIT)) {
+        debug("sendmsg()/sendmmsg()/sendto(): unknown flag (only MSG_NOSIGNAL and MSG_DONTWAIT"
+              " are supported).\n");
+        ret = -EOPNOTSUPP;
+        goto out;
+    }
+
     lock(&hdl->lock);
+
+    if (flags & MSG_DONTWAIT) {
+        if (!(hdl->flags & O_NONBLOCK)) {
+            debug("Warning: MSG_DONTWAIT on blocking socket is ignored, may lead to a write that"
+                  " unexpectedly blocks.\n");
+        }
+        flags &= ~MSG_DONTWAIT;
+    }
 
     PAL_HANDLE pal_hdl = hdl->pal_handle;
     char* uri          = NULL;
@@ -1103,7 +1115,7 @@ static ssize_t do_sendmsg(int fd, struct iovec* bufs, int nbufs, int flags,
         PAL_NUM pal_ret = DkStreamWrite(pal_hdl, 0, bufs[i].iov_len, bufs[i].iov_base, uri);
 
         if (pal_ret == PAL_STREAM_ERROR) {
-            if (PAL_ERRNO() == EPIPE) {
+            if (PAL_ERRNO() == EPIPE && !(flags & MSG_NOSIGNAL)) {
                 struct shim_thread* cur = get_cur_thread();
                 assert(cur);
                 (void)do_kill_proc(cur->tid, cur->tgid, SIGPIPE, /*use_ipc=*/false);
@@ -1213,13 +1225,23 @@ static ssize_t do_recvmsg(int fd, struct iovec* bufs, size_t nbufs, int flags,
         expected_size += bufs[i].iov_len;
     }
 
-    if (flags & ~MSG_PEEK) {
-        debug("recvmsg()/recvmmsg()/recvfrom(): unknown flag (only MSG_PEEK is supported).\n");
+    if (flags & ~(MSG_PEEK | MSG_DONTWAIT)) {
+        debug("recvmsg()/recvmmsg()/recvfrom(): unknown flag (only MSG_PEEK and MSG_DONTWAIT are"
+              " supported).\n");
         ret = -EOPNOTSUPP;
         goto out;
     }
 
     lock(&hdl->lock);
+
+    if (flags & MSG_DONTWAIT) {
+        if (!(hdl->flags & O_NONBLOCK)) {
+            debug("Warning: MSG_DONTWAIT on blocking socket is ignored, may lead to a read that"
+                  " unexpectedly blocks.\n");
+        }
+        flags &= ~MSG_DONTWAIT;
+    }
+
     peek_buffer        = sock->peek_buffer;
     sock->peek_buffer  = NULL;
     PAL_HANDLE pal_hdl = hdl->pal_handle;

--- a/LibOS/shim/test/regression/tcp_msg_peek.c
+++ b/LibOS/shim/test/regression/tcp_msg_peek.c
@@ -89,7 +89,9 @@ static void server(void) {
     ssize_t written = 0;
     while (written < sizeof(buffer)) {
         ssize_t n;
-        if ((n = sendto(client_socket, buffer + written, sizeof(buffer) - written, 0, 0, 0)) < 0) {
+        /* we specify dummy MSG_DONTWAIT just to test this flag */
+        if ((n = sendto(client_socket, buffer + written, sizeof(buffer) - written, MSG_DONTWAIT,
+                        /*dest_addr=*/0, /*addrlen=*/0)) < 0) {
             if (errno == EINTR || errno == EAGAIN)
                 continue;
             perror("sendto to client");
@@ -171,16 +173,17 @@ static void client(void) {
         exit(1);
     }
 
+    /* we specify dummy MSG_DONTWAIT just to test this flag */
     printf("[client] receiving with MSG_PEEK: ");
-    count = client_recv(server_socket, buffer, sizeof(buffer), MSG_PEEK);
+    count = client_recv(server_socket, buffer, sizeof(buffer), MSG_DONTWAIT | MSG_PEEK);
     fwrite(buffer, count, 1, stdout);
 
     printf("[client] receiving without MSG_PEEK: ");
-    count = client_recv(server_socket, buffer, sizeof(buffer), 0);
+    count = client_recv(server_socket, buffer, sizeof(buffer), MSG_DONTWAIT);
     fwrite(buffer, count, 1, stdout);
 
     printf("[client] checking how many bytes are left unread: ");
-    count = client_recv(server_socket, buffer, sizeof(buffer), 0);
+    count = client_recv(server_socket, buffer, sizeof(buffer), MSG_DONTWAIT);
     printf("%zu\n", count);
 
     if (close(server_socket) < 0) {


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

This PR adds dummy emulation (simply ignoring) the flag `MSG_DONTWAIT` in `recv/recvmsg/recvmmsg`. This logic is partially taken from #1511 .

It is much more complicated (probably impossible?) to add the real emulation of `MSG_DONTWAIT` in Graphene. So for now we ignore this flag to make applications like Erlang and Apache Flink to work.

This PR also adds checks for supported flags in sendto/sendmsg and allows only MSG_DONTWAIT and MSG_NOSIGNAL.

Fixes #1764. See this issue for more context.

Fixes #752.

## How to test this PR? <!-- (if applicable) -->

`tcp_msg_peek` LibOS test was augmented with this flag, just for testing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1766)
<!-- Reviewable:end -->
