### PR TITLE
[Pal] Loudly fail if depleted POOL_SIZE in slab memory allocator

### DIFF
--- a/Pal/src/slab.c
+++ b/Pal/src/slab.c
@@ -22,7 +22,7 @@ static PAL_LOCK g_slab_mgr_lock = LOCK_INIT;
 #define SYSTEM_LOCKED() _DkInternalIsLocked(&g_slab_mgr_lock)
 
 #if STATIC_SLAB == 1
-#define POOL_SIZE 64 * 1024 * 1024 /* 64MB by default */
+#define POOL_SIZE 64 * 1024 * 1024
 static char g_mem_pool[POOL_SIZE];
 static void* g_bump = g_mem_pool;
 static void* g_mem_pool_end = &g_mem_pool[POOL_SIZE];
@@ -39,20 +39,35 @@ static inline void __free(void* addr, int size);
 
 #include "slabmgr.h"
 
-
-/* This function is protected by g_slab_mgr_lock. */
+/* caller (slabmgr.h) releases g_slab_mgr_lock before calling this function (this must be reworked
+ * in the future), so grab the lock again to protect g_bump */
 static inline void* __malloc(int size) {
     void* addr = NULL;
 
 #if STATIC_SLAB == 1
+    SYSTEM_LOCK();
     if (g_bump + size <= g_mem_pool_end) {
         addr = g_bump;
         g_bump += size;
+        SYSTEM_UNLOCK();
         return addr;
     }
+    SYSTEM_UNLOCK();
 #endif
 
+#if 1
+    /* FIXME: At this point, we depleted the pre-allocated memory pool of POOL_SIZE. Previously,
+     *        PAL would allocate more pages (for its internal purposes e.g. for event objects),
+     *        but LibOS had no idea about it. This led to LibOS allocating pages at same addresses
+     *        and ultimately to subtle memory corruptions. Fixing it requires complete re-write of
+     *        PAL memory allocation; loudly terminate for now. For more details, see issue
+     *        https://github.com/oscarlab/graphene/issues/1072. */
+    printf("*** Out-of-memory in PAL (try increasing POOL_SIZE and rebuilding Graphene) ***\n");
+    _DkProcessExit(-ENOMEM);
+#else
+    size = ALLOC_ALIGN_UP(size);
     _DkVirtualMemoryAlloc(&addr, size, PAL_ALLOC_INTERNAL, PAL_PROT_READ | PAL_PROT_WRITE);
+#endif
     return addr;
 }
 
@@ -64,6 +79,7 @@ static inline void __free(void* addr, int size) {
         return;
 #endif
 
+    size = ALLOC_ALIGN_UP(size);
     _DkVirtualMemoryFree(addr, size);
 }
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

If PAL memory allocator depleted the pre-allocated memory pool of `POOL_SIZE`, then previously PAL would allocate more pages (for its internal purposes e.g. for event objects), but LibOS had no idea about it. This led to LibOS allocating pages at same addresses and ultimately to subtle memory corruptions.

Fixing it requires complete re-write of PAL memory allocation. This PR simply modifies slab allocator to loudly terminate.

It also fixes small bug of lock-unprotected search in memory pool.

See https://github.com/oscarlab/graphene/issues/1072 for additional context.

## How to test this PR? <!-- (if applicable) -->

This was found (again) on a very intensive PyTorch workload with many threads created and destroyed many-many times. This is hard to reproduce.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1768)
<!-- Reviewable:end -->
