### PR TITLE
Add Python3 multi-process (python -> shell ->python) example

### DIFF
--- a/Examples/python-sh-insecure/.gitignore
+++ b/Examples/python-sh-insecure/.gitignore
@@ -1,0 +1,2 @@
+*.pyc
+/OUTPUT

--- a/Examples/python-sh-insecure/Makefile
+++ b/Examples/python-sh-insecure/Makefile
@@ -1,0 +1,95 @@
+# Use one of the following commands to build the manifests for Python:
+#
+# - make                Building for Linux
+# - make DEBUG=1        Building for Linux (with Graphene debug output)
+# - make SGX=1          Building for SGX
+# - make SGX=1 DEBUG=1  Building for SGX (with Graphene debug output)
+#
+# Use `make clean` to remove Graphene-generated files.
+
+include ../../Scripts/Makefile.configs
+
+# Python constants are declared in Makefile.python
+# We want to use Python 3.6 (default on Ubuntu 18.04)
+PYTHONVERSION = python3.6
+include ../../Scripts/Makefile.python
+
+# Relative path to Graphene root
+GRAPHENEDIR ?= ../..
+SGX_SIGNER_KEY ?= $(GRAPHENEDIR)/Pal/src/host/Linux-SGX/signer/enclave-key.pem
+
+ifeq ($(DEBUG),1)
+GRAPHENEDEBUG = inline
+else
+GRAPHENEDEBUG = none
+endif
+
+.PHONY: all
+all: python3.6.manifest sh.manifest python3.manifest pal_loader
+ifeq ($(SGX),1)
+all: python3.6.manifest.sgx python3.6.sig python3.6.token sh.manifest.sgx sh.sig sh.token python3.manifest.sgx python3.sig python3.token
+endif
+
+python3.6.manifest: python3.6.manifest.template
+	sed -e 's|$$(GRAPHENEDIR)|'"$(GRAPHENEDIR)"'|g' \
+	    -e 's|$$(GRAPHENEDEBUG)|'"$(GRAPHENEDEBUG)"'|g' \
+	    -e 's|$$(PYTHONDISTHOME)|'"$(PYTHONDISTHOME)"'|g' \
+	    -e 's|$$(PYTHONHOME)|'"$(PYTHONHOME)"'|g' \
+	    -e 's|$$(PYTHONEXEC)|'"$(PYTHONEXEC)"'|g' \
+	    -e 's|$$(ARCH_LIBDIR)|'"$(ARCH_LIBDIR)"'|g' \
+	    -e 's|$$(SYS)|'"$(SYS)"'|g' \
+	    $< > $@
+
+python3.manifest: python3.manifest.template
+	sed -e 's|$$(GRAPHENEDIR)|'"$(GRAPHENEDIR)"'|g' \
+	    -e 's|$$(GRAPHENEDEBUG)|'"$(GRAPHENEDEBUG)"'|g' \
+	    -e 's|$$(PYTHONDISTHOME)|'"$(PYTHONDISTHOME)"'|g' \
+	    -e 's|$$(PYTHONHOME)|'"$(PYTHONHOME)"'|g' \
+	    -e 's|$$(PYTHONEXEC)|'"$(PYTHONEXEC)"'|g' \
+	    -e 's|$$(ARCH_LIBDIR)|'"$(ARCH_LIBDIR)"'|g' \
+	    -e 's|$$(SYS)|'"$(SYS)"'|g' \
+	    $< > $@
+
+sh.manifest: sh.manifest.template
+	sed -e 's|$$(GRAPHENEDIR)|'"$(GRAPHENEDIR)"'|g' \
+	    -e 's|$$(GRAPHENEDEBUG)|'"$(GRAPHENEDEBUG)"'|g' \
+	    $< > $@
+
+# Python/sh manifests for SGX:
+#   Generating the SGX-specific manifest (*.manifest.sgx), the enclave signature,
+#   and the token for enclave initialization.
+
+%.manifest.sgx: %.manifest
+	$(GRAPHENEDIR)/Pal/src/host/Linux-SGX/signer/pal-sgx-sign \
+		-libpal $(GRAPHENEDIR)/Runtime/libpal-Linux-SGX.so \
+		-key $(SGX_SIGNER_KEY) \
+		-manifest $< -output $@
+
+python3.6.sig: python3.6.manifest.sgx
+python3.sig: python3.manifest.sgx
+sh.sig: sh.manifest.sgx
+
+%.token: %.sig
+	$(GRAPHENEDIR)/Pal/src/host/Linux-SGX/signer/pal-sgx-get-token -output $@ -sig $<
+
+python3.6.manifest.sgx: sh.sig
+sh.manifest.sgx: python3.sig
+
+# Extra executables
+pal_loader:
+	ln -s $(GRAPHENEDIR)/Runtime/pal_loader $@
+
+.PHONY: check
+check: all
+	./pal_loader python3.6.manifest scripts/callprocess.py > OUTPUT 2> /dev/null
+	@grep -q "helloworld" OUTPUT && echo "[ Success 1/2 ]"
+	@grep -q "exit code of child process: 0" OUTPUT && echo "[ Success 2/2 ]"
+	@rm OUTPUT
+
+.PHONY: clean
+clean:
+	$(RM) *.manifest *.manifest.sgx *.token *.sig pal_loader OUTPUT*
+	$(RM) -r scripts/__pycache__
+
+.PHONY: distclean
+distclean: clean

--- a/Examples/python-sh-insecure/README.md
+++ b/Examples/python-sh-insecure/README.md
@@ -1,0 +1,44 @@
+# Python multi-process example
+
+This directory contains an example for running Python 3.6 on Ubuntu 18.04 with
+spawned child processes, including the Makefile and templates for generating the
+manifests. The application is tested on Ubuntu 18.04, with both normal Linux and
+SGX platforms.
+
+This example is *insecure*: the manifest file uses `sgx.allowed_files` to allow
+all Python libraries/scripts without any integrity checks. This example simply
+shows the functionality of Graphene but *does not* prevent the attacker from
+silently modifying Python files. For secure Python usage, see the
+`python-simple` example.
+
+## Trick for Python -> Shell -> Python invocation
+
+When Python script contains something like `os.system('python3 ...')`, the
+application actually forks Python, the forked child performs `execve('sh')`, the
+resulting shell forks again, and the final child performs `execve('python3')`.
+
+This means that the chain of processes is Python -> Shell -> Python. This
+contradicts the current way of specifying `sgx.trusted_children` in Graphene
+manifests: the sh manifest must know the SGX measurement of Python, but Python
+manifest must know the SGX measurement of sh. This creates an endless loop.
+
+To break this loop, we use the trick of symlinks. Python3 already an actual
+binary which is `/usr/bin/python3.6` and its symlink `/usr/bin/python3`. In the
+Python script, we specify `python3` as the target. So the child of sh is
+`python3`, and we can use `python3.6` as the first (main) binary in Graphene.
+The loop thus becomes Python3.6 -> Shell -> Python3. *This is a hacky solution*;
+Graphene manifest syntax will be re-worked to allow such chains in the future.
+
+## Build
+
+- without SGX: Run `make` (non-debug) or `make DEBUG=1` (debug) in the
+  directory.
+
+- with SGX: Run `make SGX=1` (non-debug) or `make SGX=1 DEBUG=1` (debug) in the
+  directory.
+
+## Run
+
+- without SGX: `./pal_loader ./python3.6.manifest scripts/callprocess.py`
+
+- with SGX: `SGX=1 ./pal_loader ./python3.6.manifest scripts/callprocess.py`

--- a/Examples/python-sh-insecure/python3.6.manifest.template
+++ b/Examples/python-sh-insecure/python3.6.manifest.template
@@ -1,0 +1,113 @@
+# Python3 main manifest example
+#
+# This manifest was prepared and tested on Ubuntu 18.04.
+#
+# Python must be run with the pal_loader:
+#
+# ./pal_loader python3.6.manifest <script>
+
+# The executable to load in Graphene. By default, PYTHONHOME points to the
+# system installation. To run Python from a local installation, specify PYTHONHOME
+# when running `make` in this directory.
+loader.exec = file:$(PYTHONEXEC)
+
+# Graphene environment, including the path of the library OS and the debug
+# option (inline/none).
+loader.preload = file:$(GRAPHENEDIR)/Runtime/libsysdb.so
+loader.debug_type = $(GRAPHENEDEBUG)
+
+# Read application arguments directly from the command line. Don't use this on production!
+loader.insecure__use_cmdline_argv = 1
+
+# Environment variables for Python
+loader.env.LD_LIBRARY_PATH = $(PYTHONHOME)/lib:/lib:$(ARCH_LIBDIR):/usr/lib:/usr/$(ARCH_LIBDIR)
+loader.env.PATH = $(PYTHONHOME)/bin:/usr/bin:/bin
+loader.env.PYTHONHOME = $(PYTHONHOME)
+loader.env.PYTHONPATH = $(PYTHONHOME):$(PYTHONHOME)/plat-$(SYS):$(PYTHONDISTHOME):$(PYTHONHOME)/lib-dynload
+loader.env.HOME = /home/user
+
+# Mounted FSes. The following "chroot" FSes mount a part of the host FS into the
+# guest. Other parts of the host FS will not be available in the guest.
+
+# Default glibc files, mounted from the Runtime directory in GRAPHENEDIR.
+fs.mount.lib.type = chroot
+fs.mount.lib.path = /lib
+fs.mount.lib.uri = file:$(GRAPHENEDIR)/Runtime
+
+# Host-level libraries (e.g., /lib/x86_64-linux-gnu) required by the Python executable
+fs.mount.lib2.type = chroot
+fs.mount.lib2.path = $(ARCH_LIBDIR)
+fs.mount.lib2.uri = file:$(ARCH_LIBDIR)
+
+# Host-level directory (/usr) required by the Python executable
+fs.mount.usr.type = chroot
+fs.mount.usr.path = /usr
+fs.mount.usr.uri = file:/usr
+
+# Mount $PYTHONHOME
+fs.mount.pyhome.type = chroot
+fs.mount.pyhome.path = $(PYTHONHOME)
+fs.mount.pyhome.uri = file:$(PYTHONHOME)
+
+# Mount $PYTHONDISTHOME
+fs.mount.pydisthome.type = chroot
+fs.mount.pydisthome.path = $(PYTHONDISTHOME)
+fs.mount.pydisthome.uri = file:$(PYTHONDISTHOME)
+
+# Mount /tmp
+fs.mount.tmp.type = chroot
+fs.mount.tmp.path = /tmp
+fs.mount.tmp.uri = file:/tmp
+
+# Mount /etc
+fs.mount.etc.type = chroot
+fs.mount.etc.path = /etc
+fs.mount.etc.uri = file:/etc
+
+# Mount /bin
+fs.mount.bin.type = chroot
+fs.mount.bin.path = /bin
+fs.mount.bin.uri = file:/bin
+
+# SGX general options
+
+# Set the virtual memory size of the SGX enclave. For SGX v1, the enclave
+# size must be specified during signing. If Python needs more virtual memory
+# than the enclave size, Graphene will not be able to allocate it.
+sgx.enclave_size = 1G
+
+# Set the maximum number of enclave threads. For SGX v1, the number of enclave
+# TCSes must be specified during signing, so the application cannot use more
+# threads than the number of TCSes. Note that Graphene also creates an internal
+# thread for handling inter-process communication (IPC), and potentially another
+# thread for asynchronous events. Therefore, the actual number of threads that
+# the application can create is (sgx.thread_num - 2).
+sgx.thread_num = 4
+
+# SGX trusted libraries
+
+# Glibc libraries
+sgx.trusted_files.ld = file:$(GRAPHENEDIR)/Runtime/ld-linux-x86-64.so.2
+sgx.trusted_files.libc = file:$(GRAPHENEDIR)/Runtime/libc.so.6
+sgx.trusted_files.libm = file:$(GRAPHENEDIR)/Runtime/libm.so.6
+sgx.trusted_files.libdl = file:$(GRAPHENEDIR)/Runtime/libdl.so.2
+sgx.trusted_files.librt = file:$(GRAPHENEDIR)/Runtime/librt.so.1
+sgx.trusted_files.libutil = file:$(GRAPHENEDIR)/Runtime/libutil.so.1
+sgx.trusted_files.libpthread = file:$(GRAPHENEDIR)/Runtime/libpthread.so.0
+
+# Other libraries
+sgx.trusted_files.libz = file:$(ARCH_LIBDIR)/libz.so.1
+sgx.trusted_files.libbz2 = file:$(ARCH_LIBDIR)/libbz2.so.1.0
+sgx.trusted_files.liblzma = file:$(ARCH_LIBDIR)/liblzma.so.5
+sgx.trusted_files.libexpat = file:$(ARCH_LIBDIR)/libexpat.so.1
+
+# SGX untrusted (allowed) files/directories
+sgx.allowed_files.scripts = file:scripts
+sgx.allowed_files.tmp = file:/tmp
+sgx.allowed_files.etc = file:/etc
+sgx.allowed_files.pyhome = file:$(PYTHONHOME)
+sgx.allowed_files.pydisthome = file:$(PYTHONDISTHOME)
+
+# SGX trusted children
+sgx.trusted_files.sh = file:/bin/sh
+sgx.trusted_children.sh = file:sh.sig

--- a/Examples/python-sh-insecure/python3.manifest.template
+++ b/Examples/python-sh-insecure/python3.manifest.template
@@ -1,0 +1,101 @@
+# Python3 (child process) manifest example. Same as python3.6 main manifest, but without
+# trusted children.
+#
+# This manifest was prepared and tested on Ubuntu 18.04.
+
+# The executable to load in Graphene. By default, PYTHONHOME points to the
+# system installation. To run Python from a local installation, specify PYTHONHOME
+# when running `make` in this directory.
+loader.exec = file:$(PYTHONEXEC)
+
+# Graphene environment, including the path of the library OS and the debug
+# option (inline/none).
+loader.preload = file:$(GRAPHENEDIR)/Runtime/libsysdb.so
+loader.debug_type = $(GRAPHENEDEBUG)
+
+# Read application arguments directly from the command line. Don't use this on production!
+loader.insecure__use_cmdline_argv = 1
+
+# Environment variables for Python
+loader.env.LD_LIBRARY_PATH = $(PYTHONHOME)/lib:/lib:$(ARCH_LIBDIR):/usr/lib:/usr/$(ARCH_LIBDIR)
+loader.env.PATH = $(PYTHONHOME)/bin:/usr/bin:/bin
+loader.env.PYTHONHOME = $(PYTHONHOME)
+loader.env.PYTHONPATH = $(PYTHONHOME):$(PYTHONHOME)/plat-$(SYS):$(PYTHONDISTHOME):$(PYTHONHOME)/lib-dynload
+loader.env.HOME = /home/user
+
+# Mounted FSes. The following "chroot" FSes mount a part of the host FS into the
+# guest. Other parts of the host FS will not be available in the guest.
+
+# Default glibc files, mounted from the Runtime directory in GRAPHENEDIR.
+fs.mount.lib.type = chroot
+fs.mount.lib.path = /lib
+fs.mount.lib.uri = file:$(GRAPHENEDIR)/Runtime
+
+# Host-level libraries (e.g., /lib/x86_64-linux-gnu) required by the Python executable
+fs.mount.lib2.type = chroot
+fs.mount.lib2.path = $(ARCH_LIBDIR)
+fs.mount.lib2.uri = file:$(ARCH_LIBDIR)
+
+# Host-level directory (/usr) required by the Python executable
+fs.mount.usr.type = chroot
+fs.mount.usr.path = /usr
+fs.mount.usr.uri = file:/usr
+
+# Mount $PYTHONHOME
+fs.mount.pyhome.type = chroot
+fs.mount.pyhome.path = $(PYTHONHOME)
+fs.mount.pyhome.uri = file:$(PYTHONHOME)
+
+# Mount $PYTHONDISTHOME
+fs.mount.pydisthome.type = chroot
+fs.mount.pydisthome.path = $(PYTHONDISTHOME)
+fs.mount.pydisthome.uri = file:$(PYTHONDISTHOME)
+
+# Mount /tmp
+fs.mount.tmp.type = chroot
+fs.mount.tmp.path = /tmp
+fs.mount.tmp.uri = file:/tmp
+
+# Mount /etc
+fs.mount.etc.type = chroot
+fs.mount.etc.path = /etc
+fs.mount.etc.uri = file:/etc
+
+# SGX general options
+
+# Set the virtual memory size of the SGX enclave. For SGX v1, the enclave
+# size must be specified during signing. If Python needs more virtual memory
+# than the enclave size, Graphene will not be able to allocate it.
+sgx.enclave_size = 1G
+
+# Set the maximum number of enclave threads. For SGX v1, the number of enclave
+# TCSes must be specified during signing, so the application cannot use more
+# threads than the number of TCSes. Note that Graphene also creates an internal
+# thread for handling inter-process communication (IPC), and potentially another
+# thread for asynchronous events. Therefore, the actual number of threads that
+# the application can create is (sgx.thread_num - 2).
+sgx.thread_num = 4
+
+# SGX trusted libraries
+
+# Glibc libraries
+sgx.trusted_files.ld = file:$(GRAPHENEDIR)/Runtime/ld-linux-x86-64.so.2
+sgx.trusted_files.libc = file:$(GRAPHENEDIR)/Runtime/libc.so.6
+sgx.trusted_files.libm = file:$(GRAPHENEDIR)/Runtime/libm.so.6
+sgx.trusted_files.libdl = file:$(GRAPHENEDIR)/Runtime/libdl.so.2
+sgx.trusted_files.librt = file:$(GRAPHENEDIR)/Runtime/librt.so.1
+sgx.trusted_files.libutil = file:$(GRAPHENEDIR)/Runtime/libutil.so.1
+sgx.trusted_files.libpthread = file:$(GRAPHENEDIR)/Runtime/libpthread.so.0
+
+# Other libraries
+sgx.trusted_files.libz = file:$(ARCH_LIBDIR)/libz.so.1
+sgx.trusted_files.libbz2 = file:$(ARCH_LIBDIR)/libbz2.so.1.0
+sgx.trusted_files.liblzma = file:$(ARCH_LIBDIR)/liblzma.so.5
+sgx.trusted_files.libexpat = file:$(ARCH_LIBDIR)/libexpat.so.1
+
+# SGX untrusted (allowed) files/directories
+sgx.allowed_files.scripts = file:scripts
+sgx.allowed_files.tmp = file:/tmp
+sgx.allowed_files.etc = file:/etc
+sgx.allowed_files.pyhome = file:$(PYTHONHOME)
+sgx.allowed_files.pydisthome = file:$(PYTHONDISTHOME)

--- a/Examples/python-sh-insecure/scripts/callprocess.py
+++ b/Examples/python-sh-insecure/scripts/callprocess.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python3
+
+import os
+RESULT = os.system('python3 scripts/helloworld.py')
+print('exit code of child process: {}'.format(RESULT))

--- a/Examples/python-sh-insecure/scripts/helloworld.py
+++ b/Examples/python-sh-insecure/scripts/helloworld.py
@@ -1,0 +1,3 @@
+#!/usr/bin/env python3
+
+print('helloworld')

--- a/Examples/python-sh-insecure/sh.manifest.template
+++ b/Examples/python-sh-insecure/sh.manifest.template
@@ -1,0 +1,58 @@
+# sh manifest example
+#
+# This manifest was prepared and tested on Ubuntu 18.04.
+
+# The executable to load in Graphene.
+loader.exec = file:/bin/sh
+
+# Graphene environment, including the path of the library OS and the debug
+# option (inline/none).
+loader.preload = file:$(GRAPHENEDIR)/Runtime/libsysdb.so
+loader.debug_type = $(GRAPHENEDEBUG)
+
+# Read application arguments directly from the command line. Don't use this on production!
+loader.insecure__use_cmdline_argv = 1
+
+# Environment variables
+loader.env.LD_LIBRARY_PATH = /lib
+
+# Mounted FSes. The following "chroot" FSes mount a part of the host FS into the
+# guest. Other parts of the host FS will not be available in the guest.
+
+# Default glibc files, mounted from the Runtime directory in GRAPHENEDIR.
+fs.mount.lib.type = chroot
+fs.mount.lib.path = /lib
+fs.mount.lib.uri = file:$(GRAPHENEDIR)/Runtime
+
+# Mount /tmp
+fs.mount.tmp.type = chroot
+fs.mount.tmp.path = /tmp
+fs.mount.tmp.uri = file:/tmp
+
+# Mount host's /bin
+fs.mount.bin.type = chroot
+fs.mount.bin.path = /bin
+fs.mount.bin.uri = file:/bin
+
+# SGX general options
+
+# Set the virtual memory size of the SGX enclave. For SGX v1, the enclave size
+# must be specified during signing. If sh needs more virtual memory than the
+# enclave size, Graphene will not be able to allocate it.
+sgx.enclave_size = 1G
+
+# Set the maximum number of enclave threads. For SGX v1, the number of enclave
+# TCSes must be specified during signing, so the application cannot use more
+# threads than the number of TCSes. Note that Graphene also creates an internal
+# thread for handling inter-process communication (IPC), and potentially another
+# thread for asynchronous events. Therefore, the actual number of threads that
+# the application can create is (sgx.thread_num - 2).
+sgx.thread_num = 4
+
+# SGX trusted libraries
+sgx.trusted_files.ld = file:$(GRAPHENEDIR)/Runtime/ld-linux-x86-64.so.2
+sgx.trusted_files.libc = file:$(GRAPHENEDIR)/Runtime/libc.so.6
+
+# SGX trusted children
+sgx.trusted_files.python = file:/usr/bin/python3
+sgx.trusted_children.python = file:python3.sig

--- a/Jenkinsfiles/Linux-18.04
+++ b/Jenkinsfiles/Linux-18.04
@@ -67,6 +67,13 @@ pipeline {
                         }
                         timeout(time: 5, unit: 'MINUTES') {
                             sh '''
+                                cd Examples/python-sh-insecure
+                                PYTHONVERSION=python3.6 make -j8 all
+                                PYTHONVERSION=python3.6 make check
+                            '''
+                        }
+                        timeout(time: 5, unit: 'MINUTES') {
+                            sh '''
                                 cd Examples/bash
                                 make -j8 all
                                 make regression
@@ -151,6 +158,7 @@ pipeline {
 
                            make -C Examples/python-simple clean
                            make -C Examples/python-scipy-insecure clean
+                           make -C Examples/python-sh-insecure clean
                            make -C Examples/bash clean
                            make -C Examples/curl clean
                            make -C Examples/gcc distclean

--- a/Jenkinsfiles/Linux-Debug-18.04
+++ b/Jenkinsfiles/Linux-Debug-18.04
@@ -63,6 +63,13 @@ pipeline {
                         }
                         timeout(time: 5, unit: 'MINUTES') {
                             sh '''
+                                cd Examples/python-sh-insecure
+                                PYTHONVERSION=python3.6 make -j8 all
+                                PYTHONVERSION=python3.6 make check
+                            '''
+                        }
+                        timeout(time: 5, unit: 'MINUTES') {
+                            sh '''
                                 cd Examples/bash
                                 make -j8 all
                                 make regression
@@ -144,6 +151,7 @@ pipeline {
 
                            make -C Examples/python-simple clean
                            make -C Examples/python-scipy-insecure clean
+                           make -C Examples/python-sh-insecure clean
                            make -C Examples/bash clean
                            make -C Examples/curl clean
                            make -C Examples/gcc distclean

--- a/Jenkinsfiles/Linux-SGX-18.04-apps
+++ b/Jenkinsfiles/Linux-SGX-18.04-apps
@@ -75,6 +75,13 @@ pipeline {
                         }
                         timeout(time: 5, unit: 'MINUTES') {
                             sh '''
+                                cd Examples/python-sh-insecure
+                                PYTHONVERSION=python3.6 make -j8 SGX=1
+                                PYTHONVERSION=python3.6 make SGX=1 check
+                            '''
+                        }
+                        timeout(time: 5, unit: 'MINUTES') {
+                            sh '''
                                 cd Examples/bash
                                 make -j8 SGX=1 all
                                 make SGX=1 regression
@@ -183,6 +190,7 @@ pipeline {
 
                            make -C Examples/python-simple SGX=1 clean
                            make -C Examples/python-scipy-insecure SGX=1 clean
+                           make -C Examples/python-sh-insecure SGX=1 clean
                            make -C Examples/bash SGX=1 clean
                            make -C Examples/curl SGX=1 clean
                            make -C Examples/gcc SGX=1 distclean

--- a/LibOS/shim/src/bookkeep/shim_handle.c
+++ b/LibOS/shim/src/bookkeep/shim_handle.c
@@ -733,8 +733,15 @@ BEGIN_CP_FUNC(handle) {
             new_hdl->fs = NULL;
         }
 
-        if (hdl->dentry)
+        if (hdl->dentry) {
+            if (hdl->dentry->state & DENTRY_ISDIRECTORY) {
+                /* we don't checkpoint children dentries of a directory dentry, so need to list
+                 * directory again in child process; mark handle to indicate no cached dentries */
+                hdl->dir_info.buf = (void*)-1;
+                hdl->dir_info.ptr = (void*)-1;
+            }
             DO_CP_MEMBER(dentry, hdl, new_hdl, dentry);
+        }
 
         if (new_hdl->pal_handle) {
             struct shim_palhdl_entry* entry;

--- a/LibOS/shim/src/fs/shim_dcache.c
+++ b/LibOS/shim/src/fs/shim_dcache.c
@@ -344,6 +344,9 @@ BEGIN_CP_FUNC(dentry) {
         clear_lock(&new_dent->lock);
         REF_SET(new_dent->ref_count, 0);
 
+        /* we don't checkpoint children dentries, so need to list directory again */
+        new_dent->state &= ~DENTRY_LISTED;
+
         if (new_dent->fs == &fifo_builtin_fs) {
             /* FIFO pipe, do not try to checkpoint its fs */
             new_dent->fs = NULL;


### PR DESCRIPTION

## Description of the changes <!-- (reasons and measures) -->

This PR adds the Python multi-process example and fixes the bug triggered by this example (incorrect checkpointing of "directory" handles/dentries). The two commits are:

- [LibOS] Mark checkpointed dir handle and dentry as not listed. The "directory" shim_handle and its associated dentry are marked as "listed" on `getdents()`, caching the contents of the directory as a list of dentries. However, Graphene doesn't checkpoint these contents (unless they were actually opened). Previously, there was a bug of not cleaning up the "listed" state of dir dentry and associated pointers of dir shim_handle on fork/clone. This led to `getdents()` in the child process showing empty directory contents. This commit fixes this bug.

- [Examples] Add Python3 multi-process (python -> shell ->python) example. This example shows how to write manifests for multi-process applications and highlights the trick of breaking an endless loop of SGX trusted children by using symlinks. This example also stresses the FS checkpointing system of Graphene.

Fixes #1757. Closes #1736.

## How to test this PR? <!-- (if applicable) -->

The new Python test is added to Jenkins 18.04 pipelines.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1771)
<!-- Reviewable:end -->
