### PR TITLE
[LibOS,Pal/Linux-SGX] Fix sendfile() on protected files

### DIFF
--- a/LibOS/shim/test/fs/.gitignore
+++ b/LibOS/shim/test/fs/.gitignore
@@ -8,6 +8,7 @@
 /copy_mmap_seq
 /copy_mmap_whole
 /copy_rev
+/copy_sendfile
 /copy_seq
 /copy_whole
 /delete

--- a/LibOS/shim/test/fs/Makefile
+++ b/LibOS/shim/test/fs/Makefile
@@ -6,6 +6,7 @@ copy_mmap_execs = \
 copy_execs = \
 	$(copy_mmap_execs) \
 	copy_rev \
+	copy_sendfile \
 	copy_seq \
 	copy_whole
 

--- a/LibOS/shim/test/fs/README.md
+++ b/LibOS/shim/test/fs/README.md
@@ -9,6 +9,7 @@ These tests perform common FS operations in various ways to exercise the Graphen
 - read/change size
 - seek/tell
 - memory-mapped read/write
+- sendfile
 - copy directory in different ways
 
 How to execute

--- a/LibOS/shim/test/fs/common.c
+++ b/LibOS/shim/test/fs/common.c
@@ -77,6 +77,18 @@ void write_fd(const char* path, int fd, const void* buffer, size_t size) {
     }
 }
 
+void sendfile_fd(const char* input_path, const char* output_path, int fi, int fo, size_t size) {
+    while (size > 0) {
+        ssize_t ret = sendfile(fo, fi, /*offset=*/NULL, size);
+        if (ret == -EAGAIN)
+            continue;
+        if (ret < 0)
+            fatal_error("Failed to sendfile from %s to %s: %s\n", input_path, output_path,
+                        strerror(errno));
+        size -= ret;
+    }
+}
+
 void close_fd(const char* path, int fd) {
     if (fd >= 0 && close(fd) != 0)
         fatal_error("Failed to close file %s: %s\n", path, strerror(errno));

--- a/LibOS/shim/test/fs/common.h
+++ b/LibOS/shim/test/fs/common.h
@@ -14,11 +14,12 @@
 #include <stdlib.h>
 #include <stdnoreturn.h>
 #include <string.h>
-#include <time.h>
-#include <unistd.h>
 #include <sys/mman.h>
+#include <sys/sendfile.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <time.h>
+#include <unistd.h>
 
 noreturn void fatal_error(const char* fmt, ...);
 void setup(void);
@@ -28,6 +29,7 @@ void seek_fd(const char* path, int fd, off_t offset, int mode);
 off_t tell_fd(const char* path, int fd);
 int open_output_fd(const char* path, bool rdwr);
 void write_fd(const char* path, int fd, const void* buffer, size_t size);
+void sendfile_fd(const char* input_path, const char* output_path, int fi, int fo, size_t size);
 void close_fd(const char* path, int fd);
 void* mmap_fd(const char* path, int fd, int protection, size_t offset, size_t size);
 void munmap_fd(const char* path, void* address, size_t size);

--- a/LibOS/shim/test/fs/copy_sendfile.c
+++ b/LibOS/shim/test/fs/copy_sendfile.c
@@ -1,0 +1,6 @@
+#include "common.h"
+
+void copy_data(int fi, int fo, const char* input_path, const char* output_path, size_t size) {
+    sendfile_fd(input_path, output_path, fi, fo, size);
+    printf("sendfile_fd(%zu) OK\n", size);
+}

--- a/LibOS/shim/test/fs/test_fs.py
+++ b/LibOS/shim/test/fs/test_fs.py
@@ -258,6 +258,8 @@ class TC_00_FileSystem(RegressionTestCase):
             if executable == 'copy_whole':
                 self.assertIn('read_fd(' + size + ') input OK', stdout)
                 self.assertIn('write_fd(' + size + ') output OK', stdout)
+            if executable == 'copy_sendfile':
+                self.assertIn('sendfile_fd(' + size + ') OK', stdout)
             if size != '0':
                 if 'copy_mmap' in executable:
                     self.assertIn('mmap_fd(' + size + ') input OK', stdout)
@@ -287,16 +289,19 @@ class TC_00_FileSystem(RegressionTestCase):
     def test_202_copy_dir_rev(self):
         self.do_copy_test('copy_rev', 60)
 
+    def test_203_copy_dir_sendfile(self):
+        self.do_copy_test('copy_sendfile', 60)
+
     @expectedFailureIf(HAS_SGX)
-    def test_203_copy_dir_mmap_whole(self):
+    def test_204_copy_dir_mmap_whole(self):
         self.do_copy_test('copy_mmap_whole', 30)
 
     @expectedFailureIf(HAS_SGX)
-    def test_204_copy_dir_mmap_seq(self):
+    def test_205_copy_dir_mmap_seq(self):
         self.do_copy_test('copy_mmap_seq', 60)
 
     @expectedFailureIf(HAS_SGX)
-    def test_205_copy_dir_mmap_rev(self):
+    def test_206_copy_dir_mmap_rev(self):
         self.do_copy_test('copy_mmap_rev', 60)
 
     def test_210_copy_dir_mounted(self):

--- a/LibOS/shim/test/fs/test_pf.py
+++ b/LibOS/shim/test/fs/test_pf.py
@@ -172,15 +172,15 @@ class TC_50_ProtectedFiles(TC_00_FileSystem):
         self.verify_copy(stdout, stderr, self.ENCRYPTED_DIR, executable)
 
     # overrides TC_00_FileSystem to not skip this on SGX
-    def test_203_copy_dir_mmap_whole(self):
+    def test_204_copy_dir_mmap_whole(self):
         self.do_copy_test('copy_mmap_whole', 30)
 
     # overrides TC_00_FileSystem to not skip this on SGX
-    def test_204_copy_dir_mmap_seq(self):
+    def test_205_copy_dir_mmap_seq(self):
         self.do_copy_test('copy_mmap_seq', 60)
 
     # overrides TC_00_FileSystem to not skip this on SGX
-    def test_205_copy_dir_mmap_rev(self):
+    def test_206_copy_dir_mmap_rev(self):
         self.do_copy_test('copy_mmap_rev', 60)
 
     # overrides TC_00_FileSystem to change dirs (from plaintext to encrypted)


### PR DESCRIPTION

<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://graphene.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

Previously, Graphene would fail if application uses `sendfile()` on a protected file. This happened because LibOS's emulation of sendfile relies on PAL to allocate a temporary buffer for mmapped contents, however mmap implementation in PFs did not allocate this buffer. This commit adds logic in PFs to allocate the buffer (it is the
responsibility of LibOS to free it later). Also, since PFs propagate changes to writable files only on flush/close, sendfile is augmented with a forced flush.

Fixes https://github.com/oscarlab/graphene/issues/1769.

## How to test this PR? <!-- (if applicable) -->

A sendfile test is added to FS/PF tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1774)
<!-- Reviewable:end -->
