### PR TITLE
[LibOS,Pal/lib] Partially refactor slabmgr and memmgr in Pal/lib

### DIFF
--- a/LibOS/shim/include/shim_utils.h
+++ b/LibOS/shim/include/shim_utils.h
@@ -138,24 +138,12 @@ static inline int qstrcmpstr(const struct shim_qstr* qstr, const char* str, size
     return memcmp(qstrgetstr(qstr), str, size);
 }
 
-//#define SLAB_DEBUG_PRINT
-//#define SLAB_DEBUG_TRACE
-
 /* heap allocation functions */
 int init_slab(void);
 
-#if defined(SLAB_DEBUG_PRINT) || defined(SLAB_DEBUG_TRACE)
-void* __malloc_debug(size_t size, const char* file, int line);
-#define malloc(size) __malloc_debug(size, __FILE__, __LINE__)
-void __free_debug(void* mem, const char* file, int line);
-#define free(mem) __free_debug(mem, __FILE__, __LINE__)
-void* __malloc_copy_debug(const void* mem, size_t size, const char* file, int line);
-#define malloc_copy(mem, size) __malloc_copy_debug(mem, size, __FILE__, __LINE__)
-#else
 void* malloc(size_t size);
 void free(void* mem);
 void* malloc_copy(const void* mem, size_t size);
-#endif
 
 static inline __attribute__((always_inline)) char* qstrtostr(struct shim_qstr* qstr, bool on_stack) {
     int len   = qstr->len;

--- a/LibOS/shim/src/shim_malloc.c
+++ b/LibOS/shim/src/shim_malloc.c
@@ -25,10 +25,6 @@ static struct shim_lock slab_mgr_lock;
 #define SYSTEM_UNLOCK() unlock(&slab_mgr_lock)
 #define SYSTEM_LOCKED() locked(&slab_mgr_lock)
 
-#ifdef SLAB_DEBUG_TRACE
-#define SLAB_DEBUG
-#endif
-
 #define SLAB_CANARY
 #define STARTUP_SIZE 16
 
@@ -94,17 +90,8 @@ int init_slab(void) {
 
 EXTERN_ALIAS(init_slab);
 
-#if defined(SLAB_DEBUG_PRINT) || defined(SLABD_DEBUG_TRACE)
-void* __malloc_debug(size_t size, const char* file, int line)
-#else
-void* malloc(size_t size)
-#endif
-{
-#ifdef SLAB_DEBUG_TRACE
-    void* mem = slab_alloc_debug(slab_mgr, size, file, line);
-#else
+void* malloc(size_t size) {
     void* mem = slab_alloc(slab_mgr, size);
-#endif
 
     if (!mem) {
         /*
@@ -116,14 +103,9 @@ void* malloc(size_t size)
         __abort();
     }
 
-#ifdef SLAB_DEBUG_PRINT
-    debug("malloc(%d) = %p (%s:%d)\n", size, mem, file, line);
-#endif
     return mem;
 }
-#if !defined(SLAB_DEBUG_PRINT) && !defined(SLAB_DEBUG_TRACE)
 EXTERN_ALIAS(malloc);
-#endif
 
 void* calloc(size_t nmemb, size_t size) {
     // This overflow checking is not a UB, because the operands are unsigned.
@@ -137,77 +119,47 @@ void* calloc(size_t nmemb, size_t size) {
 }
 EXTERN_ALIAS(calloc);
 
-#if 0 /* Temporarily disabling this code */
-void * realloc(void * ptr, size_t new_size)
-{
-    /* TODO: We can't deal with this case right now */
+#if 0
+void* realloc(void* ptr, size_t new_size) {
+    /* TODO: decide how to deal with migrated-memory case */
     assert(!memory_migrated(ptr));
 
     size_t old_size = slab_get_buf_size(slab_mgr, ptr);
 
-    /*
-     * TODO: this realloc() implementation follows the GLIBC design, which
-     * will avoid reallocation when the buffer is large enough. Potentially
-     * this design can cause memory draining if user resizes an extremely
-     * large object to much smaller.
-     */
+    /* TODO: this realloc() implementation follows the Glibc design, which will avoid reallocation
+     *       when the buffer is large enough. Potentially this design can cause memory draining if
+     *       user resizes an extremely large object to much smaller. */
     if (old_size >= new_size)
         return ptr;
 
-    void * new_buf = malloc(new_size);
+    void* new_buf = malloc(new_size);
     if (!new_buf)
         return NULL;
 
-    memcpy(new_buf, ptr, old_size);
     /* realloc() does not zero the rest of the object */
+    memcpy(new_buf, ptr, old_size);
+
     free(ptr);
     return new_buf;
 }
 EXTERN_ALIAS(realloc);
 #endif
 
+
 // Copies data from `mem` to a newly allocated buffer of a specified size.
-#if defined(SLAB_DEBUG_PRINT) || defined(SLABD_DEBUG_TRACE)
-void* __malloc_copy_debug(const void* mem, size_t size, const char* file, int line)
-#else
-void* malloc_copy(const void* mem, size_t size)
-#endif
-{
-#if defined(SLAB_DEBUG_PRINT) || defined(SLABD_DEBUG_TRACE)
-    void* buff = __malloc_debug(size, file, line);
-#else
+void* malloc_copy(const void* mem, size_t size) {
     void* buff = malloc(size);
-#endif
     if (buff)
         memcpy(buff, mem, size);
     return buff;
 }
-#if !defined(SLAB_DEBUG_PRINT) && !defined(SLABD_DEBUG_TRACE)
 EXTERN_ALIAS(malloc_copy);
-#endif
 
-#if defined(SLAB_DEBUG_PRINT) || defined(SLABD_DEBUG_TRACE)
-void __free_debug(void* mem, const char* file, int line)
-#else
-void free(void* mem)
-#endif
-{
-    if (!mem)
-        return;
+void free(void* mem) {
     if (memory_migrated(mem)) {
         return;
     }
 
-#ifdef SLAB_DEBUG_PRINT
-    debug("free(%p) (%s:%d)\n", mem, file, line);
-#endif
-
-#ifdef SLAB_DEBUG_TRACE
-    slab_free_debug(slab_mgr, mem, file, line);
-#else
     slab_free(slab_mgr, mem);
-#endif
 }
-#if !defined(SLAB_DEBUG_PRINT) && !defined(SLABD_DEBUG_TRACE)
 EXTERN_ALIAS(free);
-#endif


### PR DESCRIPTION


<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://graphene.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

In particular, this PR:
- Removes SLAB_DEBUG macros and corresponding code.
- Removes unused, commented out and outdated `realloc()` code.
- Fixes memory leak in memmgr's enlarge_mem_mgr() by removing  `__set_free_mem_area()` call.
- Fixes bug of double-free of the very first memmgr area in `destroy_mem_mgr()`.
- De-duplicates "get new memory object" code by changing `get_mem_obj_from_mgr()` to call `get_mem_obj_from_mgr_enlarge()`.
- Simplifies and improves performance of `free_mem_obj_to_mgr()` since there is no need to double-check that the object belongs to one of the memmgr's areas because we already check `memory_migrated()`.
- Fixes bug of free of wrong object in slabmgr's `destroy_slab_mgr()`.

This is a partial recreation of #1347. Unfortunately, that PR became too stale and too complicated to review and modify, so I decided to take only some of its changes/fixes and apply them in this new PR.

I plan to create another PR after this one is merged to continue with the work started in #1347.

## How to test this PR? <!-- (if applicable) -->

Run Jenkins several times to check I didn't introduce any memory management bugs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1776)
<!-- Reviewable:end -->
