### PR TITLE
[Pal/Linux] Fix "invalid attempt to declare..." with newer as

### DIFF
--- a/Pal/src/host/Linux/db_rtld.c
+++ b/Pal/src/host/Linux/db_rtld.c
@@ -28,26 +28,22 @@
 
 #include "elf-arch.h"
 
-/* This structure communicates dl state to the debugger.  The debugger
-   normally finds it via the DT_DEBUG entry in the dynamic section, but in
-   a statically-linked program there is no dynamic section for the debugger
-   to examine and it looks for this particular symbol name.  */
-struct r_debug g_pal_r_debug = { 1, NULL, (ElfW(Addr))&pal_dl_debug_state, RT_CONSISTENT, 0 };
-
-/* This function exists solely to have a breakpoint set on it by the
-   debugger.  The debugger is supposed to find this function's address by
-   examining the r_brk member of struct r_debug, but GDB 4.15 in fact looks
-   for this particular symbol name in the PT_INTERP file.  */
-
-/* The special symbol name is set as breakpoint in gdb */
-void __attribute__((noinline)) pal_dl_debug_state (void)
-{
+/* This function exists solely to have a breakpoint set on it by the debugger. The debugger is
+ * supposed to find this function's address by examining the r_brk member of struct r_debug, but GDB
+ * 4.15 in fact looks for this particular symbol name in the PT_INTERP file.  */
+static void __attribute__((noinline)) pal_dl_debug_state(void) {
     if (g_pal_sec._dl_debug_state)
         g_pal_sec._dl_debug_state();
 }
 
 extern __typeof(pal_dl_debug_state) _dl_debug_state
-    __attribute ((alias ("pal_dl_debug_state")));
+    __attribute((alias("pal_dl_debug_state")));
+
+/* This structure communicates dl state to the debugger.  The debugger normally finds it via the
+ * DT_DEBUG entry in the dynamic section, but in a statically-linked program there is no dynamic
+ * section for the debugger to examine and it looks for this particular symbol name.  */
+struct r_debug g_pal_r_debug = {1, NULL, (ElfW(Addr))&pal_dl_debug_state, RT_CONSISTENT, 0};
+symbol_version_default(g_pal_r_debug, _r_debug, PAL);
 
 void _DkDebugAddMap (struct link_map * map)
 {

--- a/Pal/src/host/Linux/pal_security.h
+++ b/Pal/src/host/Linux/pal_security.h
@@ -35,15 +35,6 @@ struct r_debug {
     ElfW(Addr) r_ldbase; /* Base address the linker is loaded at.  */
 };
 
-void pal_dl_debug_state(void);
-
-/* This structure communicates dl state to the debugger.  The debugger
-   normally finds it via the DT_DEBUG entry in the dynamic section, but in
-   a statically-linked program there is no dynamic section for the debugger
-   to examine and it looks for this particular symbol name.  */
-extern struct r_debug g_pal_r_debug;
-symbol_version_default(g_pal_r_debug, _r_debug, PAL);
-
 extern struct pal_sec {
     /* system variables */
     unsigned int process_id;


### PR DESCRIPTION

<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://graphene.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

Linux PAL communicates the newly loaded libraries to GDB via the `_r_debug` special symbol. This symbol is actually an alias to Linux PAL's `g_pal_r_debug`. The alias is created via macro `symbol_version_default()` which injects assembly `.symver @@`.

This asm directive `.symver name, name2@@nodename` is defined as "the symbol name must exist and be defined within the file being assembled". However, this injected assembly ended up in files that did not have symbol `g_pal_r_debug` defined. Older versions of as (GCC's utility to generate object code from assembly) didn't
care about this missing symbol, but newer versions loudly fail with "invalid attempt to declare external version name as default". This commit fixes this bug by moving `symbol_version_default()` to the only relevant file -- `db_rtld.c`.

This fix has a side effect that Graphene builds do not conflict with Intel SGX SDK builds anymore (also, Graphene becomes buildable on newer GCC versions). See https://github.com/intel/linux-sgx/issues/520.

For more context, see https://code.woboq.org/userspace/glibc/elf/link.h.html and http://web.mit.edu/rhel-doc/3/rhel-as-en-3/symver.html.

Closes #1690. Fixes #1685.

## How to test this PR? <!-- (if applicable) -->

All tests must run. Manually check that GDB on Linux PAL still works (works for me).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1778)
<!-- Reviewable:end -->
