### PR TITLE
[LibOS] Do not recursively send KILL messages via Graphene's IPC

### DIFF
--- a/LibOS/shim/src/ipc/shim_ipc_pid.c
+++ b/LibOS/shim/src/ipc/shim_ipc_pid.c
@@ -118,7 +118,7 @@ int ipc_pid_kill_callback(struct shim_ipc_msg* msg, struct shim_ipc_port* port) 
             break;
         case KILL_ALL:
             broadcast_ipc(msg, IPC_PORT_DIRCLD | IPC_PORT_DIRPRT, port);
-            ret = do_kill_proc(msgin->sender, msgin->id, msgin->signum, true);
+            ret = do_kill_proc(msgin->sender, msgin->id, msgin->signum, false);
             break;
     }
     return ret;

--- a/LibOS/shim/src/ipc/shim_ipc_pid.c
+++ b/LibOS/shim/src/ipc/shim_ipc_pid.c
@@ -108,17 +108,17 @@ int ipc_pid_kill_callback(struct shim_ipc_msg* msg, struct shim_ipc_port* port) 
 
     switch (msgin->type) {
         case KILL_THREAD:
-            ret = do_kill_thread(msgin->sender, 0, msgin->id, msgin->signum, true);
+            ret = do_kill_thread(msgin->sender, 0, msgin->id, msgin->signum, /*use_ipc=*/true);
             break;
         case KILL_PROCESS:
-            ret = do_kill_proc(msgin->sender, msgin->id, msgin->signum, true);
+            ret = do_kill_proc(msgin->sender, msgin->id, msgin->signum, /*use_ipc=*/true);
             break;
         case KILL_PGROUP:
-            ret = do_kill_pgroup(msgin->sender, msgin->id, msgin->signum, true);
+            ret = do_kill_pgroup(msgin->sender, msgin->id, msgin->signum, /*use_ipc=*/true);
             break;
         case KILL_ALL:
             broadcast_ipc(msg, IPC_PORT_DIRCLD | IPC_PORT_DIRPRT, port);
-            ret = do_kill_proc(msgin->sender, msgin->id, msgin->signum, false);
+            ret = do_kill_proc(msgin->sender, msgin->id, msgin->signum, /*use_ipc=*/false);
             break;
     }
     return ret;

--- a/LibOS/shim/src/sys/shim_sigaction.c
+++ b/LibOS/shim/src/sys/shim_sigaction.c
@@ -376,7 +376,7 @@ int shim_do_kill(pid_t pid, int sig) {
         /* If `pid` equals -1, then signal is sent to every process for which the calling process
          * has permission to send, which means all processes in Graphene. */
         ipc_pid_kill_send(cur->tid, /*target=*/0, KILL_ALL, sig);
-        return do_kill_proc(cur->tid, cur->tgid, sig, true);
+        return do_kill_proc(cur->tid, cur->tgid, sig, false);
     } else if (pid == 0) {
         /* If `pid` equals 0, then signal is sent to every process in the process group of
          * the calling process. */

--- a/LibOS/shim/src/sys/shim_sigaction.c
+++ b/LibOS/shim/src/sys/shim_sigaction.c
@@ -371,20 +371,20 @@ int shim_do_kill(pid_t pid, int sig) {
 
     if (pid > 0) {
         /* If `pid` is positive, then signal is sent to the process with that pid. */
-        return do_kill_proc(cur->tid, pid, sig, true);
+        return do_kill_proc(cur->tid, pid, sig, /*use_ipc=*/true);
     } else if (pid == -1) {
         /* If `pid` equals -1, then signal is sent to every process for which the calling process
          * has permission to send, which means all processes in Graphene. */
         ipc_pid_kill_send(cur->tid, /*target=*/0, KILL_ALL, sig);
-        return do_kill_proc(cur->tid, cur->tgid, sig, false);
+        return do_kill_proc(cur->tid, cur->tgid, sig, /*use_ipc=*/false);
     } else if (pid == 0) {
         /* If `pid` equals 0, then signal is sent to every process in the process group of
          * the calling process. */
-        return do_kill_pgroup(cur->tid, 0, sig, true);
+        return do_kill_pgroup(cur->tid, 0, sig, /*use_ipc=*/true);
     } else { // pid < -1
         /* If `pid` is less than -1, then signal is sent to every process in the process group
          * `-pid`. */
-        return do_kill_pgroup(cur->tid, -pid, sig, true);
+        return do_kill_pgroup(cur->tid, -pid, sig, /*use_ipc=*/true);
     }
 }
 
@@ -450,7 +450,7 @@ int shim_do_tkill(pid_t tid, int sig) {
         return 0;
     }
 
-    return do_kill_thread(cur->tgid, 0, tid, sig, true);
+    return do_kill_thread(cur->tgid, 0, tid, sig, /*use_ipc=*/true);
 }
 
 int shim_do_tgkill(pid_t tgid, pid_t tid, int sig) {
@@ -473,5 +473,5 @@ int shim_do_tgkill(pid_t tgid, pid_t tid, int sig) {
         return 0;
     }
 
-    return do_kill_thread(cur->tgid, tgid, tid, sig, true);
+    return do_kill_thread(cur->tgid, tgid, tid, sig, /*use_ipc=*/true);
 }

--- a/LibOS/shim/src/sys/shim_sigaction.c
+++ b/LibOS/shim/src/sys/shim_sigaction.c
@@ -374,7 +374,8 @@ int shim_do_kill(pid_t pid, int sig) {
         return do_kill_proc(cur->tid, pid, sig, /*use_ipc=*/true);
     } else if (pid == -1) {
         /* If `pid` equals -1, then signal is sent to every process for which the calling process
-         * has permission to send, which means all processes in Graphene. */
+         * has permission to send, which means all processes in Graphene. NOTE: On Linux, kill(-1)
+         * does not signal the calling process. */
         ipc_pid_kill_send(cur->tid, /*target=*/0, KILL_ALL, sig);
         return do_kill_proc(cur->tid, cur->tgid, sig, /*use_ipc=*/false);
     } else if (pid == 0) {


### PR DESCRIPTION


<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://graphene.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

Previously, Graphene not only broadcasted the KILL_ALL message via its IPC mechanism to direct children and parent (and they broadcasted to their children and parent in turn), but also sent additional KILL messages to all processes. These additional KILL messages triggered the FINDNS/TELLNS IPC mechanism to find the corresponding PID leaders. However, FINDNS/TELLNS are sent with acknowledgements, forcing the sending thread to wait on futex. This led to segfaults/hangs due to recursive IPC (e.g., in Apache web server after user sends SIGINT to terminate the process).

This PR fixes this bug by *not* sending additional KILL messages to other processes (the process already broadcasted KILL_ALL).

## How to test this PR? <!-- (if applicable) -->

Manually start our Apache web server example:
```sh
# without this PR
~/graphene/Examples/apache$ make start-graphene-server
./pal_loader httpd.manifest -D FOREGROUND \
        -f conf/httpd-graphene.conf \
        -C "LoadModule mpm_prefork_module modules/mod_mpm_prefork.so" \
        -C "Listen 127.0.0.1:8001" \
        -C "ServerName 127.0.0.1" \
        -C "PidFile logs/httpd-127.0.0.1-8001.pid"
...
^C  (I pressed Ctrl-C)
*** Unexpected memory fault occurred inside PAL (PID = 11937, TID = 11938, RIP = +0x00007f70)! ***
*** Unexpected memory fault occurred inside PAL (PID = 11939, TID = 11940, RIP = +0x00007f70)! ***
*** Unexpected memory fault occurred inside PAL (PID = 11935, TID = 11936, RIP = +0x00007f70)! ***
*** Unexpected memory fault occurred inside PAL (PID = 11933, TID = 11934, RIP = +0x00007f70)! ***

# with this PR
~/graphene/Examples/apache$ make start-graphene-server
./pal_loader httpd.manifest -D FOREGROUND \
        -f conf/httpd-graphene.conf \
        -C "LoadModule mpm_prefork_module modules/mod_mpm_prefork.so" \
        -C "Listen 127.0.0.1:8001" \
        -C "ServerName 127.0.0.1" \
        -C "PidFile logs/httpd-127.0.0.1-8001.pid"
...
^C  (I pressed Ctrl-C)
# no errors
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1781)
<!-- Reviewable:end -->
