### PR TITLE
[Pal/lib] Increase pre-allocated size of slab allocator from 64MB to 96MB

### DIFF
--- a/Pal/src/pal_defs.h
+++ b/Pal/src/pal_defs.h
@@ -1,9 +1,6 @@
 #ifndef PAL_DEFS_H
 #define PAL_DEFS_H
 
-/* statically allocate slab manager */
-#define STATIC_SLAB 1
-
 /* maximum length of URIs */
 #define URI_MAX 4096
 


### PR DESCRIPTION

<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://graphene.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

Currently, our slab allocator used for internal Graphene objects (like thread metadata, trusted files metadata, etc.) allocates only from the pre-allocated pool. Previously, it was 64MB in size which is not enough even for simplest GSC workloads because they have hundreds of thousands trusted files, and thus consume more than 64MB of metadata. This commit simply increases this limit to 96MB which is enough for all current GSC workloads.

## How to test this PR? <!-- (if applicable) -->

GSC workloads.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1782)
<!-- Reviewable:end -->
