### PR TITLE
[Examples] Update openVINO benchmark to 2020.4 version

### DIFF
--- a/Examples/openvino/Makefile
+++ b/Examples/openvino/Makefile
@@ -16,7 +16,7 @@ MODEL_COMMIT ?= acf297c73db8cb3f68791ae1fad4a7cc4a6039e5     # corresponds to ta
 MODEL_NAME ?= VGG_VOC0712Plus_SSD_300x300_ft_iter_160000
 
 OPENVINO_DIR ?= $(THIS_DIR)openvino
-OPENVINO_COMMIT ?= ba6e22b1b5ee4cbefcc30e8d9493cddb0bb3dfdf  # corresponds to tag "2019_R2"
+OPENVINO_COMMIT ?= 023e7c2c3f8a8ac83564db09799d2049115d9cf6  # corresponds to tag "2020.4"
 
 # Relative path to Graphene root and key for enclave signing
 GRAPHENE_DIR ?= ../..
@@ -53,14 +53,13 @@ $(MODEL_DIR)/$(MODEL_NAME).bin: $(MODEL_DIR)/README.md
 		--output_dir $(abspath $(MODEL_DIR))
 
 $(OPENVINO_DIR)/README.md:
-	git clone https://github.com/opencv/dldt.git $(OPENVINO_DIR)
+	git clone https://github.com/openvinotoolkit/openvino.git $(OPENVINO_DIR)
 	git -C $(OPENVINO_DIR) checkout $(OPENVINO_COMMIT)
-	git -C $(OPENVINO_DIR)/inference-engine submodule init
-	git -C $(OPENVINO_DIR)/inference-engine submodule update --recursive
+	git -C $(OPENVINO_DIR)/inference-engine submodule update --init --recursive
 
 $(OPENVINO_DIR)/inference-engine/bin/intel64/$(OPENVINO_BUILD)/object_detection_sample_ssd: $(OPENVINO_DIR)/README.md
 	cd $(OPENVINO_DIR)/inference-engine && mkdir -p build
-	cd $(OPENVINO_DIR)/inference-engine/build && cmake -DCMAKE_BUILD_TYPE=$(OPENVINO_BUILD) ..
+	cd $(OPENVINO_DIR)/inference-engine/build && cmake -DTHREADING=OMP -DCMAKE_BUILD_TYPE=$(OPENVINO_BUILD) ../..
 	$(MAKE) -C $(OPENVINO_DIR)/inference-engine/build
 
 openvino.manifest: openvino.manifest.template

--- a/Examples/openvino/README.md
+++ b/Examples/openvino/README.md
@@ -1,11 +1,11 @@
 # OpenVINO
 
 This directory contains a Makefile and a template manifest for the most
-recent version of OpenVINO toolkit (as of this writing, version 2019_R2).
+recent version of OpenVINO toolkit (as of this writing, version 2020.4).
 We use the "Object Detection C++ Sample SSD" (object_detection_sample_ssd)
 example from the OpenVINO distribution as a concrete application running
 under Graphene-SGX. We test only the CPU backend (i.e., no GPU or FPGA). This
-was tested on a machine with SGX v1 and Ubuntu 16.04.
+was tested on a machine with SGX v1 and Ubuntu 18.04.
 
 The Makefile and the template manifest contain extensive comments. Please review
 them to understand the requirements for OpenVINO/object_detection_sample_ssd
@@ -19,12 +19,14 @@ model from it. **Note:** the model zoo requires ~350MB of disk space.
 
 # Prerequisites
 
-For Ubuntu 16.04, install the following prerequisite packages:
+For Ubuntu 18.04, install the following prerequisite packages:
 
-* Install CMake version >= 3.7.2 (on Ubuntu 16.04, this may require installing
+* Install CMake version >= 3.11 (on Ubuntu 18.04, this may require installing
   Cmake from a non-official APT repository like Kitware).
 
 * Install libusb version >= 1.0.0.
+
+* Install libtbb-dev
 
 * Install packages for Python3:
   `pip3 install pyyaml numpy networkx test-generator defusedxml protobuf>=3.6.1`
@@ -39,7 +41,7 @@ make SGX=1
 
 # run original OpenVINO/object_detection_sample_ssd
 # note that this assumes the Release build of OpenVINO (no DEBUG=1)
-./openvino/inference-engine/bin/intel64/Release/object_detection_sample_ssd -i images/horses.jpg -m model/VGG_VOC0712Plus_SSD_300x300_ft_iter_160000.xml -d CPU
+./openvino/bin/intel64/Release/object_detection_sample_ssd -i images/horses.jpg -m model/VGG_VOC0712Plus_SSD_300x300_ft_iter_160000.xml -d CPU
 
 # run OpenVINO/object_detection_sample_ssd in non-SGX Graphene
 ./pal_loader openvino.manifest -i images/horses.jpg -m model/VGG_VOC0712Plus_SSD_300x300_ft_iter_160000.xml -d CPU

--- a/Examples/openvino/openvino.manifest.template
+++ b/Examples/openvino/openvino.manifest.template
@@ -1,13 +1,13 @@
 # OpenVINO (object_detection_sample_ssd) manifest example
 #
-# This manifest was prepared and tested on Ubuntu 16.04.
+# This manifest was prepared and tested on Ubuntu 18.04.
 #
 # OpenVINO must be run with the pal_loader:
 #
 # ./pal_loader openvino.manifest -i input/image.bmp -m model.xml -d CPU
 
 # The executable to load in Graphene.
-loader.exec = file:$(OPENVINO_DIR)/inference-engine/bin/intel64/$(OPENVINO_BUILD)/object_detection_sample_ssd
+loader.exec = file:$(OPENVINO_DIR)/bin/intel64/$(OPENVINO_BUILD)/object_detection_sample_ssd
 loader.argv0_override = object_detection_sample_ssd
 
 # Graphene environment, including the path to the library OS and the debug
@@ -92,27 +92,37 @@ sgx.trusted_files.libnsl = file:$(ARCH_LIBDIR)/libnsl.so.1
 sgx.trusted_files.libcpp = file:/usr/$(ARCH_LIBDIR)/libstdc++.so.6
 sgx.trusted_files.libgcc = file:$(ARCH_LIBDIR)/libgcc_s.so.1
 
-# OpenVINO main libraries
-sgx.trusted_files.libformatreader    = file:$(OPENVINO_DIR)/inference-engine/bin/intel64/$(OPENVINO_BUILD)/lib/libformat_reader.so
-sgx.trusted_files.libcpuextension    = file:$(OPENVINO_DIR)/inference-engine/bin/intel64/$(OPENVINO_BUILD)/lib/libcpu_extension.so
-sgx.trusted_files.libinferencenegine = file:$(OPENVINO_DIR)/inference-engine/bin/intel64/$(OPENVINO_BUILD)/lib/libinference_engine.so
-sgx.trusted_files.libmkldnnplugin    = file:$(OPENVINO_DIR)/inference-engine/bin/intel64/$(OPENVINO_BUILD)/lib/libMKLDNNPlugin.so
-sgx.trusted_files.libgnapplugin      = file:$(OPENVINO_DIR)/inference-engine/bin/intel64/$(OPENVINO_BUILD)/lib/libGNAPlugin.so
-sgx.trusted_files.libcldnnpplugin    = file:$(OPENVINO_DIR)/inference-engine/bin/intel64/$(OPENVINO_BUILD)/lib/libclDNNPlugin.so
-sgx.trusted_files.libmyriadplugin    = file:$(OPENVINO_DIR)/inference-engine/bin/intel64/$(OPENVINO_BUILD)/lib/libmyriadPlugin.so
-
-# OpenVINO OpenCV libraries
-sgx.trusted_files.libimgcodecs  = file:$(OPENVINO_DIR)/inference-engine/temp/opencv_4.1.1_ubuntu16/lib/libopencv_imgcodecs.so.4.1
-sgx.trusted_files.libimgproc    = file:$(OPENVINO_DIR)/inference-engine/temp/opencv_4.1.1_ubuntu16/lib/libopencv_imgproc.so.4.1
-sgx.trusted_files.libopencvcore = file:$(OPENVINO_DIR)/inference-engine/temp/opencv_4.1.1_ubuntu16/lib/libopencv_core.so.4.1
-
-# OpenVINO TBB libraries
-sgx.trusted_files.libtbbmalloc = file:$(OPENVINO_DIR)/inference-engine/temp/tbb/lib/libtbbmalloc.so.2
-sgx.trusted_files.libtbb       = file:$(OPENVINO_DIR)/inference-engine/temp/tbb/lib/libtbb.so.2
+# OpenVINO TBB dependencies
+sgx.trusted_files.libtbbmalloc = file:/usr/$(ARCH_LIBDIR)/libtbbmalloc.so.2
+sgx.trusted_files.libtbb       = file:/usr/$(ARCH_LIBDIR)/libtbb.so.2
 $(LIBTBB_DEBUG)
 
+# OpenVINO main libraries
+sgx.trusted_files.libformatreader                         = file:$(OPENVINO_DIR)/bin/intel64/$(OPENVINO_BUILD)/lib/libformat_reader.so
+sgx.trusted_files.libinferencenegine                      = file:$(OPENVINO_DIR)/bin/intel64/$(OPENVINO_BUILD)/lib/libinference_engine.so
+sgx.trusted_files.libmkldnnplugin                         = file:$(OPENVINO_DIR)/bin/intel64/$(OPENVINO_BUILD)/lib/libMKLDNNPlugin.so
+sgx.trusted_files.libgnapplugin                           = file:$(OPENVINO_DIR)/bin/intel64/$(OPENVINO_BUILD)/lib/libGNAPlugin.so
+sgx.trusted_files.libcldnnpplugin                         = file:$(OPENVINO_DIR)/bin/intel64/$(OPENVINO_BUILD)/lib/libclDNNPlugin.so
+sgx.trusted_files.libmyriadplugin                         = file:$(OPENVINO_DIR)/bin/intel64/$(OPENVINO_BUILD)/lib/libmyriadPlugin.so
+sgx.trusted_files.libngraph                               = file:$(OPENVINO_DIR)/bin/intel64/$(OPENVINO_BUILD)/lib/libngraph.so
+sgx.trusted_files.libHeteroPlugin                         = file:$(OPENVINO_DIR)/bin/intel64/$(OPENVINO_BUILD)/lib/libHeteroPlugin.so
+sgx.trusted_files.libMultiDevicePlugin                    = file:$(OPENVINO_DIR)/bin/intel64/$(OPENVINO_BUILD)/lib/libMultiDevicePlugin.so
+sgx.trusted_files.libinferenceengine_onnx_reader          = file:$(OPENVINO_DIR)/bin/intel64/$(OPENVINO_BUILD)/lib/libinference_engine_onnx_reader.so
+sgx.trusted_files.libinferenceengine_ir_reader            = file:$(OPENVINO_DIR)/bin/intel64/$(OPENVINO_BUILD)/lib/libinference_engine_ir_reader.so
+sgx.trusted_files.libinferenceengine_legacy               = file:$(OPENVINO_DIR)/bin/intel64/$(OPENVINO_BUILD)/lib/libinference_engine_legacy.so
+sgx.trusted_files.libinferenceengine_transformations      = file:$(OPENVINO_DIR)/bin/intel64/$(OPENVINO_BUILD)/lib/libinference_engine_transformations.so
+sgx.trusted_files.libinferenceengine_lptransformations    = file:$(OPENVINO_DIR)/bin/intel64/$(OPENVINO_BUILD)/lib/libinference_engine_lp_transformations.so
+
+# OpenVINO OpenCV libraries
+sgx.trusted_files.libimgcodecs  = file:$(OPENVINO_DIR)/inference-engine/temp/opencv_4.3.0_ubuntu18/opencv/lib/libopencv_imgcodecs.so.4.3
+sgx.trusted_files.libimgproc    = file:$(OPENVINO_DIR)/inference-engine/temp/opencv_4.3.0_ubuntu18/opencv/lib/libopencv_imgproc.so.4.3
+sgx.trusted_files.libopencvcore = file:$(OPENVINO_DIR)/inference-engine/temp/opencv_4.3.0_ubuntu18/opencv/lib/libopencv_core.so.4.3
+
+# OpenVINO OMP libraries
+sgx.trusted_files.libiomp5     = file:$(OPENVINO_DIR)/inference-engine/temp/omp/lib/libiomp5.so
+
 # OpenVINO SSD300 model
-sgx.trusted_files.pluginsxml = file:$(OPENVINO_DIR)/inference-engine/bin/intel64/$(OPENVINO_BUILD)/lib/plugins.xml
+sgx.trusted_files.pluginsxml = file:$(OPENVINO_DIR)/bin/intel64/$(OPENVINO_BUILD)/lib/plugins.xml
 sgx.trusted_files.modelxml   = file:$(MODEL_DIR)/VGG_VOC0712Plus_SSD_300x300_ft_iter_160000.xml
 sgx.trusted_files.modelbin   = file:$(MODEL_DIR)/VGG_VOC0712Plus_SSD_300x300_ft_iter_160000.bin
 


### PR DESCRIPTION
Signed-off-by: Vijay Dhanraj <vijay.dhanraj@intel.com>

## Description of the changes <!-- (reasons and measures) -->
Current version of openVINO present in the code base is more than a year old and there has been some major updates to the benchmark. On ICX server the newer version 2020.4 shows ~63% improvement in frames/sec and ~5% improvement in latency vs 2019_R2 version.

One thing to note is that the latest version uses TBB/HWLOC libraries to get the platform topology. But due to this issue https://github.com/oscarlab/graphene/issues/1783, this PR forces openVINO to use OMP thread library instead of TBB. Once the issue is resolved, plan to update the makefiles to use TBB.

## How to test this PR? <!-- (if applicable) -->
Please follow README file on how to test the changes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1784)
<!-- Reviewable:end -->
