### PR TITLE
[Pal/Linux-SGX] Allocate min required memory for file's filename

### DIFF
--- a/Pal/src/host/Linux-SGX/enclave_framework.c
+++ b/Pal/src/host/Linux-SGX/enclave_framework.c
@@ -11,6 +11,7 @@
 #include <stdbool.h>
 
 #include "enclave_pages.h"
+#include "hex.h"
 
 __sgx_mem_aligned struct pal_enclave_state g_pal_enclave_state;
 
@@ -222,11 +223,11 @@ DEFINE_LIST(trusted_file);
 struct trusted_file {
     LIST_TYPE(trusted_file) list;
     uint64_t size;
-    size_t uri_len;
-    char uri[URI_MAX];
     bool allowed;
     sgx_checksum_t checksum;
-    sgx_stub_t * stubs;
+    sgx_stub_t* stubs;
+    size_t uri_len;
+    char uri[]; /* must be NULL-terminated */
 };
 
 DEFINE_LISTP(trusted_file);
@@ -626,15 +627,20 @@ failed:
 }
 
 static int register_trusted_file(const char* uri, const char* checksum_str, bool check_duplicates) {
-    struct trusted_file * tf = NULL, * new;
-    size_t uri_len = strlen(uri);
     int ret;
+
+    size_t uri_len = strlen(uri);
+    if (uri_len >= URI_MAX) {
+        SGX_DBG(DBG_E, "Size of file exceeds maximum %dB: %s\n", URI_MAX, uri);
+        return -PAL_ERROR_INVAL;
+    }
 
     if (check_duplicates) {
         /* this check is only done during runtime (when creating a new file) and not needed during
          * initialization (because manifest is assumed to have no duplicates); skipping this check
          * significantly improves startup time */
         spinlock_lock(&g_trusted_file_lock);
+        struct trusted_file* tf;
         LISTP_FOR_EACH_ENTRY(tf, &g_trusted_file_list, list) {
             if (tf->uri_len == uri_len && !memcmp(tf->uri, uri, uri_len)) {
                 spinlock_unlock(&g_trusted_file_lock);
@@ -644,63 +650,42 @@ static int register_trusted_file(const char* uri, const char* checksum_str, bool
         spinlock_unlock(&g_trusted_file_lock);
     }
 
-    new = malloc(sizeof(struct trusted_file));
+    struct trusted_file* new = malloc(sizeof(*new) + uri_len + 1);
     if (!new)
         return -PAL_ERROR_NOMEM;
 
     INIT_LIST_HEAD(new, list);
+    new->size    = 0;
+    new->stubs   = NULL;
+    new->allowed = false;
     new->uri_len = uri_len;
     memcpy(new->uri, uri, uri_len + 1);
-    new->size = 0;
-    new->stubs = NULL;
-    new->allowed = false;
 
     if (checksum_str) {
         PAL_STREAM_ATTR attr;
         ret = _DkStreamAttributesQuery(uri, &attr);
-        if (!ret)
-            new->size = attr.pending_size;
-
-        char checksum_text[sizeof(sgx_checksum_t) * 2 + 1] = "\0";
-        size_t nbytes = 0;
-        for (; nbytes < sizeof(sgx_checksum_t) ; nbytes++) {
-            char byte1 = checksum_str[nbytes * 2];
-            char byte2 = checksum_str[nbytes * 2 + 1];
-            unsigned char val = 0;
-
-            if (byte1 == 0 || byte2 == 0) {
-                break;
-            }
-            if (!(byte1 >= '0' && byte1 <= '9') &&
-                !(byte1 >= 'a' && byte1 <= 'f')) {
-                break;
-            }
-            if (!(byte2 >= '0' && byte2 <= '9') &&
-                !(byte2 >= 'a' && byte2 <= 'f')) {
-                break;
-            }
-
-            if (byte1 >= '0' && byte1 <= '9')
-                val = byte1 - '0';
-            if (byte1 >= 'a' && byte1 <= 'f')
-                val = byte1 - 'a' + 10;
-            val *= 16;
-            if (byte2 >= '0' && byte2 <= '9')
-                val += byte2 - '0';
-            if (byte2 >= 'a' && byte2 <= 'f')
-                val += byte2 - 'a' + 10;
-
-            new->checksum.bytes[nbytes] = val;
-            snprintf(checksum_text + nbytes * 2, 3, "%02x", val);
-        }
-
-        if (nbytes < sizeof(sgx_checksum_t)) {
+        if (ret < 0) {
+            SGX_DBG(DBG_E, "Could not find size of file: %s\n", uri);
             free(new);
-            return -PAL_ERROR_INVAL;
+            return ret;
+        }
+        new->size = attr.pending_size;
+
+        assert(strlen(checksum_str) >= sizeof(sgx_checksum_t) * 2);
+        for (size_t i = 0; i < sizeof(sgx_checksum_t); i++) {
+            int8_t byte1 = hex2dec(checksum_str[i * 2]);
+            int8_t byte2 = hex2dec(checksum_str[i * 2 + 1]);
+
+            if (byte1 < 0 || byte2 < 0) {
+                SGX_DBG(DBG_E, "Could not parse checksum of file: %s\n", uri);
+                free(new);
+                return -PAL_ERROR_INVAL;
+            }
+
+            new->checksum.bytes[i] = byte1 * 16 + byte2;
         }
 
-        SGX_DBG(DBG_S, "trusted: %s %s\n",
-                checksum_text, new->uri);
+        SGX_DBG(DBG_S, "trusted: %s\n", new->uri);
     } else {
         memset(&new->checksum, 0, sizeof(sgx_checksum_t));
         new->allowed = true;
@@ -712,6 +697,7 @@ static int register_trusted_file(const char* uri, const char* checksum_str, bool
     if (check_duplicates) {
         /* this check is only done during runtime and not needed during initialization (see above);
          * we check again because same file could have been added by another thread in meantime */
+        struct trusted_file* tf;
         LISTP_FOR_EACH_ENTRY(tf, &g_trusted_file_list, list) {
             if (tf->uri_len == uri_len && !memcmp(tf->uri, uri, uri_len)) {
                 spinlock_unlock(&g_trusted_file_lock);

--- a/Tools/gsc/finalize_manifests.py
+++ b/Tools/gsc/finalize_manifests.py
@@ -21,6 +21,7 @@ def generate_trusted_files(root_dir):
                                 r'boot/.*'
                                 r'|dev/.*'
                                 r'|etc/rc(\d|.)\.d/.*'
+                                r'|graphene/signer/.*'
                                 r'|proc/.*'
                                 r'|sys/.*'
                                 r'|var/.*)'


### PR DESCRIPTION


<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://graphene.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

Previously, Linux-SGX PAL allocated 4KB of memory for URI (filename) of any trusted/allowed file or directory. This led to "out of PAL memory" errors in Graphene if there are 100,000s of trusted files, as is the case for complex workloads in GSC/Docker. This PR removes the static 4KB buffer in file's metadata and instead
allocates the minimum required buffer. This PR also cleans up `register_trusted_file()` code a bit.

## How to test this PR? <!-- (if applicable) -->

@vahldiek must test this with Python Docker image in GSC.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1786)
<!-- Reviewable:end -->
