### PR TITLE
[LibOS] Rework sending memory content in checkpoints

### DIFF
--- a/LibOS/shim/include/shim_checkpoint.h
+++ b/LibOS/shim/include/shim_checkpoint.h
@@ -55,11 +55,9 @@ struct shim_cp_entry {
 };
 
 struct shim_mem_entry {
-    struct shim_mem_entry* prev;
+    struct shim_mem_entry* next;
     void* addr;
     size_t size;
-    void** paddr;
-    void* data;
     int prot;     /* combination of PAL_PROT_* flags */
 };
 
@@ -84,9 +82,8 @@ struct shim_cp_store {
     size_t bound;
 
     /* VMA entries */
-    struct shim_mem_entry* last_mem_entry;
+    struct shim_mem_entry* first_mem_entry;
     size_t mem_entries_cnt;
-    size_t mem_size;
 
     /* PAL-handle entries */
     struct shim_palhdl_entry* last_palhdl_entry;

--- a/LibOS/shim/src/fs/shim_fs.c
+++ b/LibOS/shim/src/fs/shim_fs.c
@@ -570,10 +570,9 @@ BEGIN_CP_FUNC(mount) {
         *new_mount = *mount;
 
         if (mount->cpdata) {
-            struct shim_mem_entry* entry;
-            DO_CP_SIZE(memory, mount->cpdata, mount->cpsize, &entry);
-            new_mount->cpdata = NULL;
-            entry->paddr = &new_mount->cpdata;
+            size_t cp_off = ADD_CP_OFFSET(mount->cpsize);
+            memcpy((char*)base + cp_off, mount->cpdata, mount->cpsize);
+            new_mount->cpdata = (char*)base + cp_off;
         }
 
         new_mount->data        = NULL;

--- a/LibOS/shim/src/shim_checkpoint.c
+++ b/LibOS/shim/src/shim_checkpoint.c
@@ -131,14 +131,11 @@ BEGIN_CP_FUNC(memory) {
 
     entry->addr  = obj;
     entry->size  = size;
-    entry->paddr = NULL;
     entry->prot  = PAL_PROT_READ | PAL_PROT_WRITE;
-    entry->data  = NULL;
-    entry->prev  = store->last_mem_entry;
+    entry->next  = store->first_mem_entry;
 
-    store->last_mem_entry = entry;
+    store->first_mem_entry = entry;
     store->mem_entries_cnt++;
-    store->mem_size += size;
 
     if (objp)
         *objp = entry;
@@ -169,21 +166,18 @@ BEGIN_CP_FUNC(migratable) {
     __UNUSED(size);
     __UNUSED(objp);
 
-    struct shim_mem_entry* mem_entry;
-
-    DO_CP_SIZE(memory, &__migratable, &__migratable_end - &__migratable, &mem_entry);
-
-    struct shim_cp_entry* entry = ADD_CP_FUNC_ENTRY(0);
-    mem_entry->paddr = (void**)&entry->cp_val;
+    size_t len = &__migratable_end - &__migratable;
+    size_t off = ADD_CP_OFFSET(len);
+    memcpy((char*)base + off, &__migratable, len);
+    ADD_CP_FUNC_ENTRY(off);
 }
 END_CP_FUNC(migratable)
 
 BEGIN_RS_FUNC(migratable) {
-    __UNUSED(base);
     __UNUSED(offset);
+    __UNUSED(rebase);
 
-    void* data = (void*)GET_CP_FUNC_ENTRY();
-    CP_REBASE(data);
+    const char* data = (char*)base + GET_CP_FUNC_ENTRY();
     memcpy(&__migratable, data, &__migratable_end - &__migratable);
 }
 END_RS_FUNC(migratable)
@@ -299,74 +293,61 @@ BEGIN_RS_FUNC(qstr) {
 }
 END_RS_FUNC(qstr)
 
-static int send_checkpoint_on_stream(PAL_HANDLE stream, struct shim_cp_store* store) {
-    int ret = 0;
-    struct shim_mem_entry** mem_entries = NULL;
+static int read_exact(PAL_HANDLE handle, void* buf, size_t size) {
+    size_t bytes = 0;
 
-    size_t mem_entries_cnt = store->mem_entries_cnt;
-
-    if (mem_entries_cnt) {
-        mem_entries = malloc(sizeof(*mem_entries) * mem_entries_cnt);
-
-        /* memory entries were added in reverse order, let's first populate them */
-        struct shim_mem_entry* mem_entry = store->last_mem_entry;
-        for (size_t i = mem_entries_cnt; i > 0; i--) {
-            assert(mem_entry);
-            mem_entries[i - 1] = mem_entry;
-            mem_entry = mem_entry->prev;
+    while (bytes < size) {
+        PAL_NUM x = DkStreamRead(handle, 0, size - bytes, (char*)buf + bytes, NULL, 0);
+        if (x == PAL_STREAM_ERROR) {
+            int err = PAL_ERRNO();
+            if (err == EINTR || err == EAGAIN || err == EWOULDBLOCK) {
+                continue;
+            }
+            return -err;
         }
-        assert(!mem_entry);
 
-        /* now we can traverse memory entries in correct order and assign checkpoint addresses */
-        void* mem_addr = (void*)store->base + store->offset;
-        for (size_t i = 0; i < mem_entries_cnt; i++) {
-            mem_entries[i]->data = mem_addr;
-            mem_addr += mem_entries[i]->size;
-        }
+        bytes += x;
     }
 
-    /* first send non-memory entries found at [store->base, store->base + store->offset) */
-    size_t total_bytes = store->offset;
+    return 0;
+}
+
+static int write_exact(PAL_HANDLE handle, void* buf, size_t size) {
     size_t bytes = 0;
-    PAL_NUM written;
 
-    do {
-        written = DkStreamWrite(stream, 0, total_bytes - bytes, (void*)store->base + bytes, NULL);
-        if (written == PAL_STREAM_ERROR) {
-            if (PAL_ERRNO() == EINTR || PAL_ERRNO() == EAGAIN || PAL_ERRNO() == EWOULDBLOCK)
+    while (bytes < size) {
+        PAL_NUM x = DkStreamWrite(handle, 0, size - bytes, (char*)buf + bytes, NULL);
+        if (x == PAL_STREAM_ERROR) {
+            int err = PAL_ERRNO();
+            if (err == EINTR || err == EAGAIN || err == EWOULDBLOCK) {
                 continue;
-            ret = -PAL_ERRNO();
-            goto out;
+            }
+            return -err;
         }
-        bytes += written;
-    } while (bytes < total_bytes);
 
-    /* next send all memory entries collected above */
-    for (size_t i = 0; i < mem_entries_cnt; i++) {
-        size_t mem_size = mem_entries[i]->size;
-        void* mem_addr  = mem_entries[i]->addr;
-        int mem_prot    = mem_entries[i]->prot;
+        bytes += x;
+    }
+
+    return 0;
+}
+
+static int send_memory_on_stream(PAL_HANDLE stream, struct shim_cp_store* store) {
+    int ret = 0;
+
+    struct shim_mem_entry* entry = store->first_mem_entry;
+    while (entry) {
+        size_t mem_size = entry->size;
+        void* mem_addr  = entry->addr;
+        int mem_prot    = entry->prot;
 
         if (!(mem_prot & PAL_PROT_READ) && mem_size > 0) {
             /* make the area readable */
             if (!DkVirtualMemoryProtect(mem_addr, mem_size, mem_prot | PAL_PROT_READ)) {
-                ret = -PAL_ERRNO();
-                goto out;
+                return -PAL_ERRNO();
             }
         }
 
-        bytes = 0;
-        do {
-            written = DkStreamWrite(stream, 0, mem_size - bytes, mem_addr + bytes, NULL);
-            if (written == PAL_STREAM_ERROR) {
-                if (PAL_ERRNO() == EINTR || PAL_ERRNO() == EAGAIN || PAL_ERRNO() == EWOULDBLOCK)
-                    continue;
-                ret = -PAL_ERRNO();
-                break;
-            }
-
-            bytes += written;
-        } while (bytes < mem_size);
+        ret = write_exact(stream, mem_addr, mem_size);
 
         if (!(mem_prot & PAL_PROT_READ) && mem_size > 0) {
             /* the area was made readable above; revert to original permissions */
@@ -376,14 +357,24 @@ static int send_checkpoint_on_stream(PAL_HANDLE stream, struct shim_cp_store* st
             }
         }
 
-        if (ret < 0)
-            goto out;
+        if (ret < 0) {
+            return ret;
+        }
+
+        entry = entry->next;
     }
 
-    ret = 0;
-out:
-    free(mem_entries);
-    return ret;
+    return 0;
+}
+
+static int send_checkpoint_on_stream(PAL_HANDLE stream, struct shim_cp_store* store) {
+    /* first send non-memory entries found at [store->base, store->base + store->offset) */
+    int ret = write_exact(stream, (void*)store->base, store->offset);
+    if (ret < 0) {
+        return ret;
+    }
+
+    return send_memory_on_stream(stream, store);
 }
 
 static int send_handles_on_stream(PAL_HANDLE stream, struct shim_cp_store* store) {
@@ -421,30 +412,19 @@ out:
     return ret;
 }
 
-static int restore_checkpoint(struct checkpoint_hdr* hdr, uintptr_t base) {
-    size_t cpoffset = hdr->offset;
-    size_t* offset  = &cpoffset;
-
+static int receive_memory_on_stream(PAL_HANDLE handle, struct checkpoint_hdr* hdr, uintptr_t base) {
     ssize_t rebase = base - (uintptr_t)hdr->addr;
-
-    debug("restoring checkpoint at 0x%08lx rebased from %p\n", base, hdr->addr);
 
     if (hdr->mem_entries_cnt) {
         struct shim_mem_entry* entry = (struct shim_mem_entry*)(base + hdr->mem_offset);
 
-        for (; entry; entry = entry->prev) {
-            CP_REBASE(entry->prev);
-            CP_REBASE(entry->paddr);
-
-            if (entry->paddr) {
-                *entry->paddr = entry->data;
-                continue;
-            }
+        for (; entry; entry = entry->next) {
+            CP_REBASE(entry->next);
 
             debug("memory entry [%p]: %p-%p\n", entry, entry->addr, entry->addr + entry->size);
 
             PAL_PTR addr = ALLOC_ALIGN_DOWN_PTR(entry->addr);
-            PAL_NUM size = ALLOC_ALIGN_UP_PTR(entry->addr + entry->size) - (void*)addr;
+            PAL_NUM size = (char*)ALLOC_ALIGN_UP_PTR(entry->addr + entry->size) - (char*)addr;
             PAL_FLG prot = entry->prot;
 
             if (!DkVirtualMemoryAlloc(addr, size, 0, prot | PAL_PROT_WRITE)) {
@@ -452,16 +432,29 @@ static int restore_checkpoint(struct checkpoint_hdr* hdr, uintptr_t base) {
                 return -PAL_ERRNO();
             }
 
-            CP_REBASE(entry->data);
-            memcpy(entry->addr, entry->data, entry->size);
+            int ret = read_exact(handle, entry->addr, entry->size);
+            if (ret < 0) {
+                return ret;
+            }
 
-            if (!(entry->prot & PAL_PROT_WRITE) && !DkVirtualMemoryProtect(addr, size, prot)) {
-                debug("failed protecting %p-%p (ignored)\n", addr, addr + size);
+            if (!(prot & PAL_PROT_WRITE) && !DkVirtualMemoryProtect(addr, size, prot)) {
+                debug("failed protecting %p-%p\n", addr, addr + size);
+                return -PAL_ERRNO();
             }
         }
     }
 
+    return 0;
+}
+
+static int restore_checkpoint(struct checkpoint_hdr* hdr, uintptr_t base) {
+    size_t cpoffset = hdr->offset;
+    size_t* offset  = &cpoffset;
+
+    debug("restoring checkpoint at 0x%08lx rebased from %p\n", base, hdr->addr);
+
     struct shim_cp_entry* cpent = NEXT_CP_ENTRY();
+    ssize_t rebase = base - (uintptr_t)hdr->addr;
 
     while (cpent) {
         if (cpent->cp_type < CP_FUNC_BASE) {
@@ -629,17 +622,16 @@ int create_process_and_send_checkpoint(migrate_func_t migrate_func, struct shim_
         goto out;
     }
 
-    size_t checkpoint_size = cpstore.offset + cpstore.mem_size;
-    debug("checkpoint of %lu bytes created\n", checkpoint_size);
+    debug("checkpoint of %lu bytes created\n", cpstore.offset);
 
     struct checkpoint_hdr hdr;
     memset(&hdr, 0, sizeof(hdr));
 
     hdr.addr = (void*)cpstore.base;
-    hdr.size = checkpoint_size;
+    hdr.size = cpstore.offset;
 
     if (cpstore.mem_entries_cnt) {
-        hdr.mem_offset      = (uintptr_t)cpstore.last_mem_entry - cpstore.base;
+        hdr.mem_offset      = (uintptr_t)cpstore.first_mem_entry - cpstore.base;
         hdr.mem_entries_cnt = cpstore.mem_entries_cnt;
     }
 
@@ -649,14 +641,9 @@ int create_process_and_send_checkpoint(migrate_func_t migrate_func, struct shim_
     }
 
     /* send a checkpoint header to child process to notify it to start receiving checkpoint */
-    PAL_NUM bytes;
-    bytes = DkStreamWrite(pal_process, 0, sizeof(hdr), &hdr, NULL);
-    if (bytes == PAL_STREAM_ERROR) {
-        ret = -PAL_ERRNO();
+    ret = write_exact(pal_process, &hdr, sizeof(hdr));
+    if (ret < 0) {
         debug("failed writing checkpoint header to child process (ret = %d)\n", ret);
-        goto out;
-    } else if (bytes < sizeof(hdr)) {
-        ret = -EACCES;
         goto out;
     }
 
@@ -683,12 +670,8 @@ int create_process_and_send_checkpoint(migrate_func_t migrate_func, struct shim_
 
     /* wait for final ack from child process (contains VMID of child) */
     IDTYPE child_vmid = 0;
-    bytes = DkStreamRead(pal_process, 0, sizeof(child_vmid), &child_vmid, NULL, 0);
-    if (bytes == PAL_STREAM_ERROR) {
-        ret = -PAL_ERRNO();
-        goto out;
-    } else if (bytes != sizeof(child_vmid)) {
-        ret = -EACCES;
+    ret = read_exact(pal_process, &child_vmid, sizeof(child_vmid));
+    if (ret < 0) {
         goto out;
     }
 
@@ -783,26 +766,21 @@ int receive_checkpoint_and_restore(struct checkpoint_hdr* hdr) {
     }
     assert(mapaddr == mapped);
 
+    ret = read_exact(PAL_CB(parent_process), base, hdr->size);
+    if (ret < 0) {
+        goto out;
+    }
+    debug("read checkpoint of %lu bytes from parent\n", hdr->size);
+
+    ret = receive_memory_on_stream(PAL_CB(parent_process), hdr, (uintptr_t)base);
+    if (ret < 0) {
+        goto out;
+    }
+    debug("restored memory from checkpoint\n");
+
     /* if checkpoint is loaded at a different address in child from where it was created in parent,
      * need to rebase the pointers in the checkpoint */
     ssize_t rebase = (ssize_t)(base - hdr->addr);
-
-    size_t total_bytes = 0;
-    while (total_bytes < hdr->size) {
-        PAL_NUM bytes = DkStreamRead(PAL_CB(parent_process), 0, hdr->size - total_bytes,
-                                     base + total_bytes, NULL, 0);
-
-        if (bytes == PAL_STREAM_ERROR) {
-            if (PAL_ERRNO() == EINTR || PAL_ERRNO() == EAGAIN || PAL_ERRNO() == EWOULDBLOCK)
-                continue;
-            ret = -PAL_ERRNO();
-            goto out;
-        }
-
-        total_bytes += bytes;
-    }
-
-    debug("read checkpoint of %lu bytes from parent\n", total_bytes);
 
     ret = receive_handles_on_stream(hdr, base, rebase);
     if (ret < 0) {


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://graphene.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->
Previously memory content was sent inside a checkpoint and counted
towards the checkpoint size in the child process, but not in the parent
process. The child allocated the checkpoint at the same address as in
the parent, but it had a different size, so it could colide with another
memory mapping. This commmit fixes it by making checkpointing code
receive the memory directly to destination addresses (which additionally
saves an unnecessary copy).

## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1788)
<!-- Reviewable:end -->
