### PR TITLE
[LibOS] Disable preemption at process exit

### DIFF
--- a/LibOS/shim/src/sys/shim_exit.c
+++ b/LibOS/shim/src/sys/shim_exit.c
@@ -143,6 +143,9 @@ noreturn void thread_exit(int error_code, int term_signal) {
         /* UNREACHABLE */
     }
 
+    /* We are exiting the whole process - disable preemption as soon we won't be able to process
+     * signals. */
+    disable_preempt(NULL);
     /* At this point other threads might be still in the middle of an exit routine, but we don't
      * care since the below will call `exit_group` eventually. */
     libos_exit(error_code, term_signal);


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://graphene.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->
This PR disables handling signals when the whole process is exiting. Previously we could get a signal (e.g. SIGCHLD) after ipc_helper thread was killed, which lead to crashes.

## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1789)
<!-- Reviewable:end -->
