### PR TITLE
clang fixes

### DIFF
--- a/LibOS/Makefile
+++ b/LibOS/Makefile
@@ -57,15 +57,17 @@ ifeq ($(findstring x86_64,$(SYS))$(findstring linux,$(SYS)),x86_64linux)
 
 .SECONDARY: $(BUILD_DIR)/Build.success
 
+# Override CC, CXX, AS in case we're compiling the rest of the project with clang.
 $(BUILD_DIR)/Build.success: $(BUILD_DIR)/Makefile
 	@echo "Building glibc, may take a while to finish. Warning messages may show up. If this process terminates with failures, see \"$(BUILD_DIR)/build.log\" for more information."
-	($(MAKE) -C $(BUILD_DIR) 2>&1 > build.log) && touch $@
+	(CC=gcc CXX=g++ AS=gcc $(MAKE) -C $(BUILD_DIR) 2>&1 > build.log) && touch $@
 
 $(GLIBC_TARGET): $(BUILD_DIR)/Build.success
 
 $(BUILD_DIR)/Makefile: $(GLIBC_SRC)/.configured
 	mkdir -p $(BUILD_DIR)
 	(cd $(BUILD_DIR) || exit 1; \
+	CC=gcc CXX=g++ AS=gcc \
 	CFLAGS=$$GLIBC_CFLAGS ../$(GLIBC_SRC)/configure --prefix=$(RUNTIME_DIR) \
 		--with-tls \
 		--without-selinux \

--- a/LibOS/Makefile
+++ b/LibOS/Makefile
@@ -16,6 +16,8 @@ GNU_MIRRORS ?= https://ftp.gnu.org/gnu/ \
 # Glibc build: patch libc.so and other C standard libraries to replace raw SYSCALL instructions
 # with function calls into Graphene (plus some smaller patches for Graphene). The resulting
 # libraries are symlinked under $RUNTIME_DIR.
+#
+# Override CC, CXX, AS in case we're compiling the rest of the project with clang.
 # ------------------------------------------------------------------------------------------------
 GLIBC_VERSION ?= 2.31
 GLIBC_SRC = glibc-$(GLIBC_VERSION)
@@ -57,7 +59,6 @@ ifeq ($(findstring x86_64,$(SYS))$(findstring linux,$(SYS)),x86_64linux)
 
 .SECONDARY: $(BUILD_DIR)/Build.success
 
-# Override CC, CXX, AS in case we're compiling the rest of the project with clang.
 $(BUILD_DIR)/Build.success: $(BUILD_DIR)/Makefile
 	@echo "Building glibc, may take a while to finish. Warning messages may show up. If this process terminates with failures, see \"$(BUILD_DIR)/build.log\" for more information."
 	(CC=gcc CXX=g++ AS=gcc $(MAKE) -C $(BUILD_DIR) 2>&1 > build.log) && touch $@
@@ -123,6 +124,8 @@ $(GLIBC_SRC)/dlfcn/Versions: $(GLIBC_SRC)/.configured
 # to build it. The resulting libgomp.so.1 is symlinked under $RUNTIME_DIR. This patched version
 # makes sense only on x86_64 platforms. NOTE: We'd prefer to build libgomp.so.1 alone but it is
 # impossible (the only way to build it is as part of the complete GCC build).
+#
+# Override CC, CXX, AS in case we're compiling the rest of the project with clang.
 # ------------------------------------------------------------------------------------------------
 GCC_VERSION ?= 10.2.0
 GCC_SRC = gcc-$(GCC_VERSION)
@@ -136,13 +139,14 @@ GCC_RUNTIME = $(addprefix $(RUNTIME_DIR)/, $(notdir $(GCC_TARGET)))
 
 $(GCC_BUILD_DIR)/Build.success: $(GCC_BUILD_DIR)/Makefile
 	@echo "Building gcc, may take a while to finish. Warning messages may show up. If this process terminates with failures, see \"$(GCC_BUILD_DIR)/gcc-build.log\" for more information."
-	($(MAKE) -C $(GCC_BUILD_DIR) 2>&1 > gcc-build.log) && touch $@
+	(CC=gcc CXX=g++ AS=gcc $(MAKE) -C $(GCC_BUILD_DIR) 2>&1 > gcc-build.log) && touch $@
 
 $(GCC_TARGET): $(GCC_BUILD_DIR)/Build.success
 
 $(GCC_BUILD_DIR)/Makefile: $(GCC_SRC)/.configured
 	mkdir -p $(GCC_BUILD_DIR)
 	(cd $(GCC_BUILD_DIR) || exit 1; \
+	CC=gcc CXX=g++ AS=gcc \
 	../$(GCC_SRC)/configure --prefix=$(RUNTIME_DIR) \
 		--enable-languages=c \
 		--disable-multilib \

--- a/LibOS/shim/include/shim_thread.h
+++ b/LibOS/shim/include/shim_thread.h
@@ -137,12 +137,12 @@ void put_thread (struct shim_thread * thread);
 
 void debug_setprefix (shim_tcb_t * tcb);
 
-static inline __attribute__((always_inline)) void debug_setbuf(shim_tcb_t* tcb, bool on_stack) {
+static inline void debug_setbuf(shim_tcb_t* tcb,
+                                struct debug_buf* debug_buf) {
     if (!debug_handle)
         return;
 
-    tcb->debug_buf = on_stack ? __alloca(sizeof(struct debug_buf)) :
-                     malloc(sizeof(struct debug_buf));
+    tcb->debug_buf = debug_buf ? debug_buf : malloc(sizeof(struct debug_buf));
 
     debug_setprefix(tcb);
 }

--- a/LibOS/shim/include/shim_utils.h
+++ b/LibOS/shim/include/shim_utils.h
@@ -145,19 +145,6 @@ void* malloc(size_t size);
 void free(void* mem);
 void* malloc_copy(const void* mem, size_t size);
 
-static inline __attribute__((always_inline)) char* qstrtostr(struct shim_qstr* qstr, bool on_stack) {
-    int len   = qstr->len;
-    char* buf = on_stack ? __alloca(len + 1) : malloc(len + 1);
-
-    if (!buf)
-        return NULL;
-
-    memcpy(buf, qstrgetstr(qstr), len);
-
-    buf[len] = 0;
-    return buf;
-}
-
 /* typedef a 32 bit type */
 #ifndef UINT4
 #define UINT4 uint32_t

--- a/LibOS/shim/src/bookkeep/shim_thread.c
+++ b/LibOS/shim/src/bookkeep/shim_thread.c
@@ -706,7 +706,7 @@ static int resume_wrapper (void * param)
     shim_tcb_t* tcb = shim_get_tcb();
     tcb->context.regs = saved_tcb->context.regs;
     tcb->context.preempt = saved_tcb->context.preempt;
-    debug_setbuf(tcb, false);
+    debug_setbuf(tcb, NULL);
     debug("set fs_base to 0x%lx\n", fs_base);
 
     object_wait_with_retry(thread_start_event);
@@ -752,7 +752,7 @@ BEGIN_RS_FUNC(running_thread)
             update_fs_base(tcb->context.fs_base);
             /* Temporarily disable preemption until the thread resumes. */
             __disable_preempt(tcb);
-            debug_setbuf(tcb, false);
+            debug_setbuf(tcb, NULL);
             debug("after resume, set tcb to 0x%lx\n", tcb->context.fs_base);
         } else {
             /*
@@ -768,7 +768,7 @@ BEGIN_RS_FUNC(running_thread)
                 thread_sigaction_reset_on_execve(thread);
 
             set_cur_thread(thread);
-            debug_setbuf(thread->shim_tcb, false);
+            debug_setbuf(thread->shim_tcb, NULL);
         }
 
         thread->in_vm = thread->is_alive = true;

--- a/LibOS/shim/src/ipc/shim_ipc_helper.c
+++ b/LibOS/shim/src/ipc/shim_ipc_helper.c
@@ -826,7 +826,9 @@ static void shim_ipc_helper_prepare(void* arg) {
     shim_tcb_init();
     set_cur_thread(self);
     update_fs_base(0);
-    debug_setbuf(shim_get_tcb(), true);
+
+    struct debug_buf debug_buf;
+    debug_setbuf(shim_get_tcb(), &debug_buf);
 
     lock(&ipc_helper_lock);
     bool notme = (self != ipc_helper_thread);

--- a/LibOS/shim/src/ipc/shim_ipc_ranges.c
+++ b/LibOS/shim/src/ipc/shim_ipc_ranges.c
@@ -1504,8 +1504,13 @@ retry:
         if (!p->port) {
             IDTYPE type                = IPC_PORT_OWNER | IPC_PORT_LISTEN;
             IDTYPE owner               = p->vmid;
-            char* uri                  = qstrtostr(&p->uri, true);
             struct shim_ipc_port* port = NULL;
+            size_t uri_len             = p->uri.len;
+            char uri[uri_len + 1];
+
+            memcpy(&uri, qstrgetstr(&p->uri), uri_len);
+            uri[uri_len] = 0;
+
             unlock(&range_map_lock);
 
             PAL_HANDLE pal_handle = DkStreamOpen(uri, 0, 0, 0, 0);

--- a/LibOS/shim/src/shim_async.c
+++ b/LibOS/shim/src/shim_async.c
@@ -143,7 +143,9 @@ static void shim_async_helper(void* arg) {
     shim_tcb_init();
     set_cur_thread(self);
     update_fs_base(0);
-    debug_setbuf(shim_get_tcb(), true);
+
+    struct debug_buf debug_buf;
+    debug_setbuf(shim_get_tcb(), &debug_buf);
 
     lock(&async_helper_lock);
     bool notme = (self != async_helper_thread);

--- a/LibOS/shim/src/shim_init.c
+++ b/LibOS/shim/src/shim_init.c
@@ -509,7 +509,9 @@ noreturn void* shim_init(int argc, void* args) {
     update_fs_base(0);
     __disable_preempt(shim_get_tcb()); // Temporarily disable preemption for delaying any signal
                                        // that arrives during initialization
-    debug_setbuf(shim_get_tcb(), true);
+
+    struct debug_buf debug_buf;
+    debug_setbuf(shim_get_tcb(), &debug_buf);
 
     debug("host: %s\n", PAL_CB(host_type));
 

--- a/LibOS/shim/src/sys/shim_clone.c
+++ b/LibOS/shim/src/sys/shim_clone.c
@@ -97,7 +97,10 @@ static int clone_implementation_wrapper(struct shim_clone_args * arg)
 
     __disable_preempt(tcb); // Temporarily disable preemption, because the preemption
                             // will be re-enabled when the thread starts.
-    debug_setbuf(tcb, true);
+
+    struct debug_buf debug_buf;
+    debug_setbuf(tcb, &debug_buf);
+
     debug("set fs_base to 0x%lx\n", tcb->context.fs_base);
 
     struct shim_regs regs = *arg->parent->shim_tcb->context.regs;

--- a/LibOS/shim/test/native/get_time.c
+++ b/LibOS/shim/test/native/get_time.c
@@ -26,6 +26,12 @@ static void get_time(char* time_arg, unsigned long overhead) {
     snprintf(time_arg, 30, "%llu", msec + overhead);
 }
 
+static int compar(const void* arg1, const void* arg2) {
+    register unsigned long long a1 = *((unsigned long long*)arg1);
+    register unsigned long long a2 = *((unsigned long long*)arg2);
+    return a1 < a2 ? -1 : (a1 == a2 ? 0 : 1);
+}
+
 int main(int argc, char** argv, char** envp) {
     char* new_argv[argc + 1];
     char time_arg[30];
@@ -91,12 +97,6 @@ int main(int argc, char** argv, char** envp) {
         ssum += times[i] * times[i];
 
         close(pipes[0]);
-    }
-
-    int compar(const void* arg1, const void* arg2) {
-        register unsigned long long a1 = *((unsigned long long*)arg1);
-        register unsigned long long a2 = *((unsigned long long*)arg2);
-        return a1 < a2 ? -1 : (a1 == a2 ? 0 : 1);
     }
 
     qsort(times, TEST_TIMES, sizeof(unsigned long long), compar);

--- a/LibOS/shim/test/native/test_start_pthread_m.c
+++ b/LibOS/shim/test/native/test_start_pthread_m.c
@@ -26,6 +26,12 @@ static void get_time(char* time_arg, unsigned long overhead) {
     snprintf(time_arg, 30, "%llu", msec + overhead);
 }
 
+static int compar(const void* arg1, const void* arg2) {
+    register unsigned long long a1 = *((unsigned long long*)arg1);
+    register unsigned long long a2 = *((unsigned long long*)arg2);
+    return a1 < a2 ? -1 : (a1 == a2 ? 0 : 1);
+}
+
 int main(int argc, char** argv, char** envp) {
     char* new_argv[argc + 2];
     char time_arg[30];
@@ -85,12 +91,6 @@ int main(int argc, char** argv, char** envp) {
         ssum += times[i] * times[i];
 
         close(pipes[0]);
-    }
-
-    int compar(const void* arg1, const void* arg2) {
-        register unsigned long long a1 = *((unsigned long long*)arg1);
-        register unsigned long long a2 = *((unsigned long long*)arg2);
-        return a1 < a2 ? -1 : (a1 == a2 ? 0 : 1);
     }
 
     qsort(times, TEST_TIMES, sizeof(unsigned long long), compar);


### PR DESCRIPTION
See #1794.

Remaining:

- remove use of alloca in `dentry_get_path`
- segmentation fault when running `getdents` regression tests under gdb (likely because of the above)
- `IS_ARRAY` macro: clang complains about `static_assert` with `((void *) &(arg)) == ((void *) (arg))`
- `generated_offsets`: clang does not recognize `%p0` in assembly, generates source with a tab (`.ascii\tGENERATED_INTEGER`)
- `cfi_offset` (and others) does not work with `%rflags` ([bug](https://bugs.llvm.org/show_bug.cgi?id=33633)), need `#ifdef`
- clang does not recognize `-Wtrampolines`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1795)
<!-- Reviewable:end -->
