### PR TITLE
[Pal/Linux-SGX] Add manifest option `sgx.internal_size`

### DIFF
--- a/Documentation/libos/shim-init.rst
+++ b/Documentation/libos/shim-init.rst
@@ -7,5 +7,5 @@ LibOS documentation
 
 There is a |~| random function:
 
-.. doxygenfunction:: parse_int
+.. doxygenfunction:: handle_signals
    :project: libos

--- a/Documentation/manifest-syntax.rst
+++ b/Documentation/manifest-syntax.rst
@@ -141,6 +141,25 @@ This specifies whether to disable Address Space Layout Randomization (ASLR).
 Since disabling ASLR worsens security of the application, ASLR is enabled by
 default.
 
+Graphene internal metadata size
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+::
+
+    loader.pal_internal_mem_size=[SIZE]
+    (default: 0)
+
+This syntax specifies how much additional memory Graphene reserves for its
+internal use (e.g., metadata for trusted/protected files, internal handles,
+etc.). By default, Graphene pre-allocates 64MB of internal memory for this
+metadata, but for huge workloads this limit may be not enough. In this case,
+Graphene loudly fails with "out of PAL memory" error. To run huge workloads,
+increase this limit by setting this option to e.g. ``64M`` (this would result in
+a total of 128MB used by Graphene for internal metadata). Note that this limit
+is included in ``sgx.enclave_size``, so if your enclave size is e.g. 512MB and
+you specify ``loader.pal_internal_mem_size = 64MB``, then your application is
+left with 384MB of usable memory.
+
 Stack size
 ^^^^^^^^^^
 

--- a/LibOS/shim/include/shim_internal.h
+++ b/LibOS/shim/include/shim_internal.h
@@ -609,8 +609,6 @@ extern void* __load_address_end;
 extern void* __code_address;
 extern void* __code_address_end;
 
-unsigned long parse_int(const char* str);
-
 extern const char** migrated_argv;
 extern const char** migrated_envp;
 

--- a/LibOS/shim/src/shim_init.c
+++ b/LibOS/shim/src/shim_init.c
@@ -283,7 +283,7 @@ int init_stack(const char** argv, const char** envp, const char*** out_argp,
     if (root_config) {
         char stack_cfg[CONFIG_MAX];
         if (get_config(root_config, "sys.stack.size", stack_cfg, sizeof(stack_cfg)) > 0) {
-            stack_size = ALLOC_ALIGN_UP(parse_int(stack_cfg));
+            stack_size = ALLOC_ALIGN_UP(parse_size_str(stack_cfg));
             set_rlimit_cur(RLIMIT_STACK, stack_size);
         }
     }

--- a/LibOS/shim/src/shim_init.c
+++ b/LibOS/shim/src/shim_init.c
@@ -95,55 +95,6 @@ long convert_pal_errno(long err) {
     return (err >= 0 && err <= PAL_ERROR_NATIVE_COUNT) ? pal_errno_to_unix_errno[err] : EACCES;
 }
 
-/*!
- * \brief Parse a number into an unsigned long.
- *
- * \param str A string containing a non-negative number.
- *
- * By default the number should be decimal, but if it starts with 0x it is
- * parsed as hexadecimal and if it otherwise starts with 0, it is parsed as
- * octal.
- */
-unsigned long parse_int (const char * str)
-{
-    unsigned long num = 0;
-    int radix = 10;
-    char c;
-
-    if (str[0] == '0') {
-        str++;
-        radix = 8;
-        if (str[0] == 'x') {
-            str++;
-            radix = 16;
-        }
-    }
-
-    while ((c = *(str++))) {
-        int val;
-        if (c >= 'A' && c <= 'F')
-            val = c - 'A' + 10;
-        else if (c >= 'a' && c <= 'f')
-            val = c - 'a' + 10;
-        else if (c >= '0' && c <= '9')
-            val = c - '0';
-        else
-            break;
-        if (val >= radix)
-            break;
-        num = num * radix + val;
-    }
-
-    if (c == 'G' || c == 'g')
-        num *= 1024 * 1024 * 1024;
-    else if (c == 'M' || c == 'm')
-        num *= 1024 * 1024;
-    else if (c == 'K' || c == 'k')
-        num *= 1024;
-
-    return num;
-}
-
 void* migrated_memory_start;
 void* migrated_memory_end;
 

--- a/LibOS/shim/src/sys/shim_brk.c
+++ b/LibOS/shim/src/sys/shim_brk.c
@@ -45,7 +45,7 @@ int init_brk_region(void* brk_start, size_t data_segment_size) {
     if (root_config) {
         char brk_cfg[CONFIG_MAX];
         if (get_config(root_config, "sys.brk.max_size", brk_cfg, sizeof(brk_cfg)) > 0)
-            brk_max_size = parse_int(brk_cfg);
+            brk_max_size = parse_size_str(brk_cfg);
     }
 
     if (brk_start && !IS_ALLOC_ALIGNED_PTR(brk_start)) {

--- a/Pal/include/lib/api.h
+++ b/Pal/include/lib/api.h
@@ -253,6 +253,7 @@ int get_config_entries(struct config_store* cfg, const char* key, char* key_buf,
                        size_t key_bufsize);
 ssize_t get_config_entries_size(struct config_store* cfg, const char* key);
 int set_config(struct config_store* cfg, const char* key, const char* val);
+uint64_t parse_int(const char* str);
 
 #define CONFIG_MAX 4096
 

--- a/Pal/include/lib/api.h
+++ b/Pal/include/lib/api.h
@@ -253,7 +253,17 @@ int get_config_entries(struct config_store* cfg, const char* key, char* key_buf,
                        size_t key_bufsize);
 ssize_t get_config_entries_size(struct config_store* cfg, const char* key);
 int set_config(struct config_store* cfg, const char* key, const char* val);
-uint64_t parse_int(const char* str);
+
+/*!
+ * \brief Parse a number into an unsigned long.
+ *
+ * \param str A string containing a non-negative number. The string may end with "G"/"g" suffix
+ *            denoting value in GBs, "M"/"m" for MBs, or "K"/"k" for KBs.
+ *
+ * By default the number should be decimal, but if it starts with 0x it is parsed as hexadecimal
+ * and if it otherwise starts with 0, it is parsed as octal.
+ */
+uint64_t parse_size_str(const char* str);
 
 #define CONFIG_MAX 4096
 

--- a/Pal/lib/graphene/config.c
+++ b/Pal/lib/graphene/config.c
@@ -9,6 +9,7 @@
  */
 
 #include "api.h"
+#include "hex.h"
 #include "list.h"
 #include "pal_error.h"
 
@@ -534,4 +535,37 @@ int write_config(void* f, int (*write)(void*, void*, int), struct config_store* 
     unsigned long offset = 0;
 
     return __write_config(f, write, store, &store->root, buf, 0, &offset);
+}
+
+uint64_t parse_int(const char* str) {
+    uint64_t num = 0;
+    uint64_t radix = 10;
+    char c;
+
+    if (str[0] == '0') {
+        str++;
+        radix = 8;
+        if (str[0] == 'x') {
+            str++;
+            radix = 16;
+        }
+    }
+
+    while ((c = *(str++))) {
+        int8_t val = hex2dec(c);
+        if (val < 0)
+            break;
+        if ((uint8_t) val >= radix)
+            break;
+        num = num * radix + (uint8_t) val;
+    }
+
+    if (c == 'G' || c == 'g')
+        num *= 1024 * 1024 * 1024;
+    else if (c == 'M' || c == 'm')
+        num *= 1024 * 1024;
+    else if (c == 'K' || c == 'k')
+        num *= 1024;
+
+    return num;
 }

--- a/Pal/lib/graphene/config.c
+++ b/Pal/lib/graphene/config.c
@@ -537,7 +537,7 @@ int write_config(void* f, int (*write)(void*, void*, int), struct config_store* 
     return __write_config(f, write, store, &store->root, buf, 0, &offset);
 }
 
-uint64_t parse_int(const char* str) {
+uint64_t parse_size_str(const char* str) {
     uint64_t num = 0;
     uint64_t radix = 10;
     char c;
@@ -555,9 +555,9 @@ uint64_t parse_int(const char* str) {
         int8_t val = hex2dec(c);
         if (val < 0)
             break;
-        if ((uint8_t) val >= radix)
+        if ((uint8_t)val >= radix)
             break;
-        num = num * radix + (uint8_t) val;
+        num = num * radix + (uint8_t)val;
     }
 
     if (c == 'G' || c == 'g')

--- a/Pal/src/host/Linux-SGX/db_main.c
+++ b/Pal/src/host/Linux-SGX/db_main.c
@@ -37,6 +37,11 @@ struct pal_sec g_pal_sec;
 
 PAL_SESSION_KEY g_master_key = {0};
 
+/* for internal PAL objects, Graphene first uses pre-allocated g_mem_pool and then falls back to
+ * _DkVirtualMemoryAlloc(PAL_ALLOC_INTERNAL); the amount of available PAL internal memory is
+ * limited by the variable below */
+size_t g_pal_internal_mem_size = 0;
+
 size_t g_page_size = PRESET_PAGESIZE;
 
 unsigned long _DkGetAllocationAlignment(void) {
@@ -47,10 +52,12 @@ void _DkGetAvailableUserAddressRange(PAL_PTR* start, PAL_PTR* end) {
     *start = (PAL_PTR)g_pal_sec.heap_min;
     *end   = (PAL_PTR)get_enclave_heap_top();
 
-    /* FIXME: hack to keep some heap for internal PAL objects allocated at runtime (recall that
-     * LibOS does not keep track of PAL memory, so without this hack it could overwrite internal
-     * PAL memory). This hack is probabilistic and brittle. */
-    *end = SATURATED_P_SUB(*end, 2 * 1024 * g_page_size, *start); /* 8MB reserved for PAL stuff */
+    /* Keep some heap for internal PAL objects allocated at runtime (recall that LibOS does not keep
+     * track of PAL memory, so without this limit it could overwrite internal PAL memory). This
+     * relies on the fact that our memory management allocates memory from higher addresses to lower
+     * addresses (see also enclave_pages.c). */
+    *end = SATURATED_P_SUB(*end, g_pal_internal_mem_size, *start);
+
     if (*end <= *start) {
         SGX_DBG(DBG_E, "Not enough enclave memory, please increase enclave size!\n");
         ocall_exit(1, /*is_exitgroup=*/true);
@@ -387,6 +394,13 @@ noreturn void pal_linux_main(char* uptr_libpal_uri, size_t libpal_uri_len, char*
     g_pal_state.root_config = root_config;
     g_pal_control.manifest_preload.start = (PAL_PTR)manifest_addr;
     g_pal_control.manifest_preload.end   = (PAL_PTR)manifest_addr + manifest_size;
+
+    char cfgbuf[CONFIG_MAX];
+    ssize_t len = get_config(g_pal_state.root_config, "loader.pal_internal_mem_size", cfgbuf,
+                             sizeof(cfgbuf));
+    if (len > 0) {
+        g_pal_internal_mem_size = parse_size_str(cfgbuf);
+    }
 
     if ((rv = init_trusted_files()) < 0) {
         SGX_DBG(DBG_E, "Failed to load the checksums of trusted files: %d\n", rv);

--- a/Pal/src/host/Linux-SGX/pal_linux.h
+++ b/Pal/src/host/Linux-SGX/pal_linux.h
@@ -57,6 +57,7 @@ bool stataccess(struct stat* stats, int acc);
 int init_child_process(PAL_HANDLE* parent);
 
 #ifdef IN_ENCLAVE
+extern size_t g_pal_internal_mem_size;
 
 struct pal_sec;
 noreturn void pal_linux_main(char* uptr_libpal_uri, size_t libpal_uri_len, char* uptr_args,

--- a/Pal/src/host/Linux-SGX/sgx_main.c
+++ b/Pal/src/host/Linux-SGX/sgx_main.c
@@ -227,7 +227,7 @@ static int initialize_enclave(struct pal_enclave* enclave) {
         goto out;
     }
 
-    enclave->size = parse_int(cfgbuf);
+    enclave->size = parse_size_str(cfgbuf);
     if (!enclave->size || !IS_POWER_OF_2(enclave->size)) {
         SGX_DBG(DBG_E, "Enclave size not a power of two (an SGX-imposed requirement)\n");
         ret = -EINVAL;
@@ -236,7 +236,7 @@ static int initialize_enclave(struct pal_enclave* enclave) {
 
     /* Reading sgx.thread_num from manifest */
     if (get_config(enclave->config, "sgx.thread_num", cfgbuf, sizeof(cfgbuf)) > 0) {
-        enclave->thread_num = parse_int(cfgbuf);
+        enclave->thread_num = parse_size_str(cfgbuf);
 
         if (enclave->thread_num > MAX_DBG_THREADS) {
             SGX_DBG(DBG_E, "Too many threads to debug\n");
@@ -248,7 +248,7 @@ static int initialize_enclave(struct pal_enclave* enclave) {
     }
 
     if (get_config(enclave->config, "sgx.rpc_thread_num", cfgbuf, sizeof(cfgbuf)) > 0) {
-        enclave->rpc_thread_num = parse_int(cfgbuf);
+        enclave->rpc_thread_num = parse_size_str(cfgbuf);
 
         if (enclave->rpc_thread_num > MAX_RPC_THREADS) {
             SGX_DBG(DBG_E, "Too many RPC threads specified\n");

--- a/Pal/src/host/Linux-SGX/sgx_main.c
+++ b/Pal/src/host/Linux-SGX/sgx_main.c
@@ -52,40 +52,6 @@ static inline char* alloc_concat(const char* p, size_t plen, const char* s, size
     return buf;
 }
 
-static unsigned long parse_int (const char * str)
-{
-    unsigned long num = 0;
-    int radix = 10;
-    char c;
-
-    if (str[0] == '0') {
-        str++;
-        radix = 8;
-        if (str[0] == 'x') {
-            str++;
-            radix = 16;
-        }
-    }
-
-    while ((c = *(str++))) {
-        int8_t val = hex2dec(c);
-        if (val < 0)
-            break;
-        if ((uint8_t) val >= radix)
-            break;
-        num = num * radix + (uint8_t) val;
-    }
-
-    if (c == 'G' || c == 'g')
-        num *= 1024 * 1024 * 1024;
-    else if (c == 'M' || c == 'm')
-        num *= 1024 * 1024;
-    else if (c == 'K' || c == 'k')
-        num *= 1024;
-
-    return num;
-}
-
 static char* resolve_uri(const char* uri, const char** errstring) {
     if (!strstartswith_static(uri, URI_PREFIX_FILE)) {
         *errstring = "Invalid URI";

--- a/Pal/src/slab.c
+++ b/Pal/src/slab.c
@@ -54,19 +54,16 @@ static inline void* __malloc(int size) {
     SYSTEM_UNLOCK();
 #endif
 
-#if 1
-    /* FIXME: At this point, we depleted the pre-allocated memory pool of POOL_SIZE. Previously,
-     *        PAL would allocate more pages (for its internal purposes e.g. for event objects),
-     *        but LibOS had no idea about it. This led to LibOS allocating pages at same addresses
-     *        and ultimately to subtle memory corruptions. Fixing it requires complete re-write of
-     *        PAL memory allocation; loudly terminate for now. For more details, see issue
-     *        https://github.com/oscarlab/graphene/issues/1072. */
-    printf("*** Out-of-memory in PAL (try increasing POOL_SIZE and rebuilding Graphene) ***\n");
-    _DkProcessExit(-ENOMEM);
-#else
-    size = ALLOC_ALIGN_UP(size);
-    _DkVirtualMemoryAlloc(&addr, size, PAL_ALLOC_INTERNAL, PAL_PROT_READ | PAL_PROT_WRITE);
-#endif
+    /* At this point, we depleted the pre-allocated memory pool of POOL_SIZE. Let's fall back to
+     * PAL-internal allocations. PAL allocator must be careful though because LibOS doesn't know
+     * about PAL-internal memory, limited via manifest option `loader.pal_internal_mem_size` and
+     * thus this malloc may return -ENOMEM. */
+    int ret = _DkVirtualMemoryAlloc(&addr, ALLOC_ALIGN_UP(size), PAL_ALLOC_INTERNAL,
+              PAL_PROT_READ | PAL_PROT_WRITE);
+    if (ret < 0) {
+        printf("*** Out-of-memory in PAL (try increasing `loader.pal_internal_mem_size`) ***\n");
+        _DkProcessExit(-ENOMEM);
+    }
     return addr;
 }
 
@@ -78,8 +75,7 @@ static inline void __free(void* addr, int size) {
         return;
 #endif
 
-    size = ALLOC_ALIGN_UP(size);
-    _DkVirtualMemoryFree(addr, size);
+    _DkVirtualMemoryFree(addr, ALLOC_ALIGN_UP(size));
 }
 
 static SLAB_MGR g_slab_mgr = NULL;


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

**UPDATE:** Renamed `sgx.internal_size` to `loader.pal_internal_mem_size`.

Previously, Graphene preallocated 64MB for PAL internal metadata like trusted/protected files metadata, handles metadata, etc. If this limit was depleted, Graphene loudly failed, and the user had no option but to change constant in source code and rebuild Graphene.

This PR adds the manifest option `sgx.internal_size` to allow increasing this limit in the manifest.

See https://github.com/oscarlab/graphene/issues/1792 and https://github.com/oscarlab/graphene/pull/1768 and https://github.com/oscarlab/graphene/issues/1072 for more context.

Fixes https://github.com/oscarlab/graphene/issues/1792.

This solution is still not the best. Ideally, we want LibOS to be aware of what memory regions PAL takes for itself during runtime (in contrast to how it is done now: PAL gets a limit on the memory it can use). However, the ideal solution is really hard to implement...

## How to test this PR? <!-- (if applicable) -->

I didn't add any new tests because they take quite some time. I tested on our Protected Files regression tests with this patch:
```
diff --git a/LibOS/shim/test/fs/manifest.template b/LibOS/shim/test/fs/manifest.template
@@ -36,3 +36,6 @@ sgx.allowed_files.tmp_dir = file:tmp/
 sgx.protected_files.output = file:tmp/pf_output
+
+sgx.enclave_size  = 512M
+sgx.internal_size = 64M
diff --git a/LibOS/shim/test/fs/test_fs.py b/LibOS/shim/test/fs/test_fs.py
@@ -16,7 +16,7 @@ class TC_00_FileSystem(RegressionTestCase):
         cls.FILE_SIZES = [0, 1, 2, 15, 16, 17, 255, 256, 257, 1023, 1024, 1025, 65535, 65536, 65537,
-                          1048575, 1048576, 1048577]
+                          1048575, 1048576, 1048577, 64*1024*1024]
         cls.TEST_DIR = 'tmp'
```

Here I created a 64MB protected file. Tests fail if `sgx.internal_size = 0` (or not specified) and pass if `sgx.internal_size = 64M`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1797)
<!-- Reviewable:end -->
