### PR TITLE
[Pal/{Linux,Linux-SGX}] Remove ALLOW_BIND_ANY and check_any_addr() logic

### DIFF
--- a/LibOS/shim/test/regression/.gitignore
+++ b/LibOS/shim/test/regression/.gitignore
@@ -37,6 +37,7 @@
 /futex_wake_op
 /getcwd
 /getdents
+/getsockname
 /getsockopt
 /host_root_fs
 /init_fail

--- a/LibOS/shim/test/regression/Makefile
+++ b/LibOS/shim/test/regression/Makefile
@@ -33,6 +33,7 @@ c_executables = \
 	futex_wake_op \
 	getcwd \
 	getdents \
+	getsockname \
 	getsockopt \
 	host_root_fs \
 	init_fail \

--- a/LibOS/shim/test/regression/getsockname.c
+++ b/LibOS/shim/test/regression/getsockname.c
@@ -1,0 +1,106 @@
+#include <arpa/inet.h>
+#include <errno.h>
+#include <ifaddrs.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#define PORT 1088
+
+int main() {
+    struct sockaddr_in bind_addr, connected_addr;
+    int sockfd;
+    socklen_t len = sizeof(struct sockaddr);
+
+    bind_addr.sin_family = AF_INET;
+    bind_addr.sin_addr.s_addr = inet_addr("127.0.0.1");
+
+    /* test 1: bind to static port PORT */
+    sockfd = socket(AF_INET, SOCK_STREAM, 0);
+
+    if (sockfd < 0) {
+        printf("getsockname: error in socket %d\n", errno);
+        return 1;
+    }
+
+    bind_addr.sin_port = htons(PORT);
+
+    if (bind(sockfd, (struct sockaddr*)&bind_addr, sizeof(bind_addr)) < 0) {
+        printf("getsockname: error in bind %d\n", errno);
+        goto fail;
+    }
+
+    if (listen(sockfd, 3) < 0) {
+        printf("getsockname: error in listen %d\n", errno);
+        goto fail;
+    }
+
+    len = sizeof(connected_addr);
+    if (getsockname(sockfd, (struct sockaddr*)&connected_addr, &len) < 0) {
+        printf("getsockname: error in getsockname %d\n", errno);
+        goto fail;
+    }
+
+    if (len != sizeof(connected_addr)) {
+        printf("getsockname: unexpected length of sockaddr\n");
+        goto fail;
+    }
+
+    if (ntohs(connected_addr.sin_port) != PORT) {
+        printf("getsockname: port returned from getsockname is %d != %d\n", ntohs(connected_addr.sin_port), PORT);
+        goto fail;
+    }
+
+    printf("getsockname: Local IP address is: %s:%d\n", inet_ntoa(connected_addr.sin_addr), ntohs(connected_addr.sin_port));
+    printf("getsockname: Got socket name with static port OK\n");
+
+    close(sockfd);
+
+    /* test 2: bind to arbitrary port */
+    sockfd = socket(AF_INET, SOCK_STREAM, 0);
+
+    if (sockfd < 0) {
+        printf("getsockname: error in socket %d\n", errno);
+        return 1;
+    }
+
+    bind_addr.sin_port = 0;
+
+    if (bind(sockfd, (struct sockaddr*)&bind_addr, sizeof(bind_addr)) < 0) {
+        printf("getsockname: error in bind %d\n", errno);
+        goto fail;
+    }
+
+    if (listen(sockfd, 3) < 0) {
+        printf("getsockname: error in listen %d\n", errno);
+        goto fail;
+    }
+
+    len = sizeof(connected_addr);
+    if (getsockname(sockfd, (struct sockaddr*)&connected_addr, &len) < 0) {
+        printf("getsockname: error in getsockname %d\n", errno);
+        goto fail;
+    }
+
+    if (len != sizeof(connected_addr)) {
+        printf("getsockname: unexpected length of sockaddr\n");
+        goto fail;
+    }
+
+    if (connected_addr.sin_port == 0) {
+        printf("getsockname: port returned from getsockname is %d == 0\n", ntohs(connected_addr.sin_port));
+        goto fail;
+    }
+
+    close(sockfd);
+
+    printf("getsockname: Local IP address is: %s:%d\n", inet_ntoa(connected_addr.sin_addr), ntohs(connected_addr.sin_port));
+    printf("getsockname: Got socket name with arbitrary port OK\n");
+    return 0;
+
+fail:
+    close(sockfd);
+    return 1;
+}

--- a/LibOS/shim/test/regression/test_libos.py
+++ b/LibOS/shim/test/regression/test_libos.py
@@ -601,6 +601,11 @@ class TC_80_Socket(RegressionTestCase):
         self.assertIn('pselect() on write event returned 1 file descriptors', stdout)
         self.assertIn('pselect() on read event returned 1 file descriptors', stdout)
 
+    def test_060_getsockname(self):
+        stdout, _ = self.run_binary(['getsockname'])
+        self.assertIn('getsockname: Got socket name with static port OK', stdout)
+        self.assertIn('getsockname: Got socket name with arbitrary port OK', stdout)
+
     def test_090_pipe(self):
         stdout, _ = self.run_binary(['pipe'], timeout=60)
         self.assertIn('read on pipe: Hello from write end of pipe!', stdout)

--- a/Pal/src/pal_defs.h
+++ b/Pal/src/pal_defs.h
@@ -7,7 +7,4 @@
 /* maximum length of URIs */
 #define URI_MAX 4096
 
-/* allow binding sockets to ANY addresses (e.g., 0.0.0.0:0) */
-#define ALLOW_BIND_ANY 1
-
 #endif /* PAL_DEFS_H */


### PR DESCRIPTION


<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://graphene.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

This PR removes `ALLOW_BIND_ANY` and `check_any_addr()` logic. Removing this logic also fixes the bug in Linux PAL of binding on port 0 (previously it stayed as "0" instead of actual new port).

Fixes https://github.com/oscarlab/graphene/issues/1713.

Closes https://github.com/oscarlab/graphene/pull/1714. (This PR is a recreation of that PR with all fixes applied.)

## How to test this PR? <!-- (if applicable) -->

New test is added to LibOS regression.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1798)
<!-- Reviewable:end -->
