### PR TITLE
[LibOS] Correctly set/unset PAL handles for IPC objects on exec()

### DIFF
--- a/Examples/r/Makefile
+++ b/Examples/r/Makefile
@@ -68,7 +68,7 @@ R-trusted-libs: R-deps
 	@R_LIBS="$(R_TARGETS)" && \
 	for F in `cat R-deps`; do \
 		P=`ldd $$R_LIBS | grep $$F | awk '{print $$3; exit}'`; \
-		N=`echo $$F | tr --delete '-'`; \
+		N=`echo $$F | tr --delete '.' | tr --delete '-' | tr --delete '+'`; \
 		echo -n "sgx.trusted_files.$$N = file:$$P\\\\n"; \
 	done > $@
 

--- a/Examples/r/Makefile
+++ b/Examples/r/Makefile
@@ -117,9 +117,15 @@ sh.manifest.sgx: rm.sig
 pal_loader:
 	ln -s $(GRAPHENEDIR)/Runtime/pal_loader $@
 
+.PHONY: check
+check: all
+	./pal_loader R.manifest --slave --vanilla -f scripts/sample.r > OUTPUT 2> /dev/null
+	@grep -q "success" OUTPUT && echo "[ Success 1/1 ]"
+	@$(RM) OUTPUT
+
 .PHONY: clean
 clean:
-	$(RM) *.manifest *.manifest.sgx *.token *.sig pal_loader
+	$(RM) *.manifest *.manifest.sgx *.token *.sig pal_loader OUTPUT
 
 .PHONY: distclean
 distclean: clean

--- a/Examples/r/R.manifest.template
+++ b/Examples/r/R.manifest.template
@@ -61,6 +61,9 @@ fs.mount.bin.type = chroot
 fs.mount.bin.path = /bin
 fs.mount.bin.uri = file:/bin
 
+# Workload `scripts/R-benchmark-25.R` requires large stack
+sys.stack.size = 8M
+
 # SGX general options
 
 # Set the virtual memory size of the SGX enclave. For SGX v1, the enclave

--- a/Examples/r/scripts/sample.r
+++ b/Examples/r/scripts/sample.r
@@ -2,3 +2,4 @@ print(sample(1:3))
 print(sample(1:3, size=3, replace=FALSE))  # same as previous line
 print(sample(c(2,5,3), size=4, replace=TRUE))
 print(sample(1:2, size=10, prob=c(1,3), replace=TRUE))
+print("success")

--- a/Jenkinsfiles/Linux
+++ b/Jenkinsfiles/Linux
@@ -128,6 +128,13 @@ pipeline {
                                 make check
                             '''
                         }
+                        timeout(time: 5, unit: 'MINUTES') {
+                            sh '''
+                                cd Examples/r
+                                make -j8 all
+                                make check
+                            '''
+                        }
                         sh '''
                            # Workaround LTP bug (see https://github.com/linux-test-project/ltp/issues/560 for upstream fix):
                            git -C LibOS/shim/test/ltp/src checkout -- utils/ffsb-6.0-rc2/config.h.in utils/ffsb-6.0-rc2/configure
@@ -157,6 +164,7 @@ pipeline {
                            make -C Examples/nginx distclean
                            make -C Examples/apache distclean
                            make -C Examples/blender distclean
+                           make -C Examples/r distclean
                            make -C Pal/src PAL_HOST=Skeleton clean
 
                            ./Scripts/clean-check

--- a/Jenkinsfiles/Linux-18.04
+++ b/Jenkinsfiles/Linux-18.04
@@ -137,6 +137,13 @@ pipeline {
                                 make check
                            '''
                         }
+                        timeout(time: 5, unit: 'MINUTES') {
+                            sh '''
+                                cd Examples/r
+                                make -j8 all
+                                make check
+                            '''
+                        }
                         sh '''
                            # Workaround LTP bug (see https://github.com/linux-test-project/ltp/issues/560 for upstream fix):
                            git -C LibOS/shim/test/ltp/src checkout -- utils/ffsb-6.0-rc2/config.h.in utils/ffsb-6.0-rc2/configure
@@ -167,6 +174,7 @@ pipeline {
                            make -C Examples/nginx distclean
                            make -C Examples/apache distclean
                            make -C Examples/blender distclean
+                           make -C Examples/r distclean
 
                            ./Scripts/clean-check
                         '''

--- a/Jenkinsfiles/Linux-Debug
+++ b/Jenkinsfiles/Linux-Debug
@@ -127,6 +127,13 @@ pipeline {
                                 make check
                             '''
                         }
+                        timeout(time: 5, unit: 'MINUTES') {
+                            sh '''
+                                cd Examples/r
+                                make -j8 all
+                                make check
+                            '''
+                        }
                         sh '''
                            # Workaround LTP bug (see https://github.com/linux-test-project/ltp/issues/560 for upstream fix):
                            git -C LibOS/shim/test/ltp/src checkout -- utils/ffsb-6.0-rc2/config.h.in utils/ffsb-6.0-rc2/configure
@@ -154,6 +161,7 @@ pipeline {
                            make -C Examples/nginx distclean
                            make -C Examples/apache distclean
                            make -C Examples/blender distclean
+                           make -C Examples/r distclean
                            make -C Pal/src PAL_HOST=Skeleton clean
 
                            ./Scripts/clean-check

--- a/Jenkinsfiles/Linux-Debug-18.04
+++ b/Jenkinsfiles/Linux-Debug-18.04
@@ -132,6 +132,13 @@ pipeline {
                                 make check
                             '''
                         }
+                        timeout(time: 5, unit: 'MINUTES') {
+                            sh '''
+                                cd Examples/r
+                                make -j8 all
+                                make check
+                            '''
+                        }
                         sh '''
                            # Workaround LTP bug (see https://github.com/linux-test-project/ltp/issues/560 for upstream fix):
                            git -C LibOS/shim/test/ltp/src checkout -- utils/ffsb-6.0-rc2/config.h.in utils/ffsb-6.0-rc2/configure
@@ -160,6 +167,7 @@ pipeline {
                            make -C Examples/nginx distclean
                            make -C Examples/apache distclean
                            make -C Examples/blender distclean
+                           make -C Examples/r distclean
 
                            ./Scripts/clean-check
                         '''

--- a/Jenkinsfiles/Linux-SGX-18.04-apps
+++ b/Jenkinsfiles/Linux-SGX-18.04-apps
@@ -147,6 +147,13 @@ pipeline {
                         }
                         timeout(time: 5, unit: 'MINUTES') {
                             sh '''
+                                cd Examples/r
+                                make -j8 SGX=1
+                                make SGX=1 check
+                            '''
+                        }
+                        timeout(time: 5, unit: 'MINUTES') {
+                            sh '''
                                 cd Examples/ra-tls-mbedtls
                                 if [ "${ra_client_spid}" != "" ] && [ "${ra_client_key}" != "" ]; \
                                 then \
@@ -199,6 +206,7 @@ pipeline {
                            make -C Examples/nginx SGX=1 distclean
                            make -C Examples/apache SGX=1 distclean
                            make -C Examples/blender SGX=1 distclean
+                           make -C Examples/r SGX=1 distclean
                            make -C Examples/ra-tls-mbedtls SGX=1 distclean
                            make -C Examples/ra-tls-secret-prov SGX=1 distclean
 

--- a/Jenkinsfiles/Linux-SGX-apps
+++ b/Jenkinsfiles/Linux-SGX-apps
@@ -119,6 +119,13 @@ pipeline {
                                 make SGX=1 check
                             '''
                         }
+                        timeout(time: 5, unit: 'MINUTES') {
+                            sh '''
+                                cd Examples/r
+                                make -j8 SGX=1
+                                make SGX=1 check
+                            '''
+                        }
                         sh '''
                            ./Scripts/gitignore-test
                         '''
@@ -138,6 +145,7 @@ pipeline {
                            make -C Examples/nginx SGX=1 distclean
                            make -C Examples/apache SGX=1 distclean
                            make -C Examples/blender SGX=1 distclean
+                           make -C Examples/r SGX=1 distclean
 
                            # Currently used release of LTP contains broken symlinks under
                            # utils/ffsb-6.0-rc2/ (config.guess and config.sub); without explicit

--- a/Jenkinsfiles/ubuntu-16.04.dockerfile
+++ b/Jenkinsfiles/ubuntu-16.04.dockerfile
@@ -42,6 +42,7 @@ RUN apt-get update \
        python3-pip \
        python3-pytest \
        python3-scipy \
+       r-base-core \
        shellcheck \
        texinfo \
        wget \

--- a/Jenkinsfiles/ubuntu-18.04.dockerfile
+++ b/Jenkinsfiles/ubuntu-18.04.dockerfile
@@ -44,6 +44,7 @@ RUN apt-get update && env DEBIAN_FRONTEND=noninteractive apt-get install -y \
     python3-protobuf \
     python3-pytest \
     python3-scipy \
+    r-base-core \
     shellcheck \
     texinfo \
     wget \


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://graphene.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

Previously, when Graphene migrated process metadata to a new host-OS process on `exec()` syscalls, the logic simply copied IPC information from the parent to the child via new object `shim_process* process`, including PAL handles for "self" and "parent" communication pipes. However, Graphene's LibOS doesn't have a notion of refcounts for corresponding PAL handles, so the copied PAL handles were still freed when freeing the not-used-anymore `process` object.

This PR fixes this by explicitly copying the PAL handles' pointers before migration and clearing them after migration. This PR also contains tiny bug fixes in the R example.

Fixes #1724. Fixes #1390.

## How to test this PR? <!-- (if applicable) -->

Run R example manually.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1799)
<!-- Reviewable:end -->
