### PR TITLE
[LibOS] Remove stack allocation from dentry_get_path()

### DIFF
--- a/LibOS/shim/include/shim_fs.h
+++ b/LibOS/shim/include/shim_fs.h
@@ -399,48 +399,19 @@ void get_dentry(struct shim_dentry* dent);
 /* Decrement the reference count on dent */
 void put_dentry(struct shim_dentry* dent);
 
-static inline __attribute__((always_inline)) char* dentry_get_path(struct shim_dentry* dent, bool on_stack, size_t* sizeptr) {
-    struct shim_mount* fs = dent->fs;
-    char* buffer;
-    char* c;
-    size_t bufsize = dent->rel_path.len + 1;
+/* Size of the path constructed by dentry_get_path(), including null terminator. */
+size_t dentry_get_path_size(struct shim_dentry* dent);
 
-    if (fs)
-        bufsize += fs->path.len + 1;
+/* Get path (FS path + relpath). The path size can be checked by calling dentry_get_path_size(dent),
+ * and the buffer needs to have space for at least that many bytes.
+ */
+char* dentry_get_path(struct shim_dentry* dent, char* buffer);
 
-    if (on_stack) {
-        c = buffer = __alloca(bufsize);
-    } else {
-        if (!(c = buffer = malloc(bufsize)))
-            return NULL;
-    }
-
-    if (fs && !qstrempty(&fs->path)) {
-        memcpy(c, qstrgetstr(&fs->path), fs->path.len);
-        c += fs->path.len;
-    }
-
-    if (dent->rel_path.len) {
-        const char* path = qstrgetstr(&dent->rel_path);
-        int len          = dent->rel_path.len;
-
-        if (c > buffer && *(c - 1) == '/') {
-            if (*path == '/')
-                path++;
-        } else {
-            if (*path != '/')
-                *(c++) = '/';
-        }
-
-        memcpy(c, path, len);
-        c += len;
-    }
-
-    if (sizeptr)
-        *sizeptr = c - buffer;
-
-    *c = 0;
-    return buffer;
+static inline char* dentry_get_path_into_qstr(struct shim_dentry* dent, struct shim_qstr* str) {
+    size_t size = dentry_get_path_size(dent);
+    char buffer[size];
+    dentry_get_path(dent, buffer);
+    return qstrsetstr(str, buffer, size - 1);
 }
 
 static inline const char* dentry_get_name(struct shim_dentry* dent) {

--- a/LibOS/shim/src/bookkeep/shim_handle.c
+++ b/LibOS/shim/src/bookkeep/shim_handle.c
@@ -54,13 +54,7 @@ static inline int init_tty_handle(struct shim_handle* hdl, bool write) {
     hdl->dentry = dent;
     hdl->flags  = O_RDWR | O_APPEND | 0100000;
 
-    size_t size;
-    char* path = dentry_get_path(dent, true, &size);
-    if (path)
-        qstrsetstr(&hdl->path, path, size);
-    else
-        qstrsetstr(&hdl->path, "/dev/tty", 8);
-
+    dentry_get_path_into_qstr(dent, &hdl->path);
     return 0;
 }
 
@@ -90,11 +84,8 @@ static inline int init_exec_handle(struct shim_thread* thread) {
         }
         path_lookupat(fs->root, p, 0, &exec->dentry, fs);
         set_handle_fs(exec, fs);
-        if (exec->dentry) {
-            size_t len;
-            const char* path = dentry_get_path(exec->dentry, true, &len);
-            qstrsetstr(&exec->path, path, len);
-        }
+        if (exec->dentry)
+            dentry_get_path_into_qstr(exec->dentry, &exec->path);
         put_mount(fs);
     } else {
         set_handle_fs(exec, &chroot_builtin_fs);

--- a/LibOS/shim/src/fs/proc/thread.c
+++ b/LibOS/shim/src/fs/proc/thread.c
@@ -118,8 +118,10 @@ static int find_thread_link(const char* name, struct shim_qstr* link, struct shi
         dent = next_dent;
     }
 
-    if (link)
-        dentry_get_path_into_qstr(dent, link);
+    if (link && !dentry_get_path_into_qstr(dent, link)) {
+        ret = -ENOMEM;
+        goto out;
+    }
 
     if (dentptr) {
         get_dentry(dent);
@@ -361,8 +363,10 @@ static int find_thread_each_fd(const char* name, struct shim_qstr* link,
         dent = next_dent;
     }
 
-    if (link)
-        dentry_get_path_into_qstr(dent, link);
+    if (link && !dentry_get_path_into_qstr(dent, link)) {
+        ret = -ENOMEM;
+        goto out;
+    }
 
     if (dentptr) {
         get_dentry(dent);

--- a/LibOS/shim/src/fs/proc/thread.c
+++ b/LibOS/shim/src/fs/proc/thread.c
@@ -118,11 +118,8 @@ static int find_thread_link(const char* name, struct shim_qstr* link, struct shi
         dent = next_dent;
     }
 
-    if (link) {
-        size_t size;
-        char* path = dentry_get_path(dent, true, &size);
-        qstrsetstr(link, path, size);
-    }
+    if (link)
+        dentry_get_path_into_qstr(dent, link);
 
     if (dentptr) {
         get_dentry(dent);
@@ -364,11 +361,8 @@ static int find_thread_each_fd(const char* name, struct shim_qstr* link,
         dent = next_dent;
     }
 
-    if (link) {
-        size_t size;
-        char* path = dentry_get_path(dent, true, &size);
-        qstrsetstr(link, path, size);
-    }
+    if (link)
+        dentry_get_path_into_qstr(dent, link);
 
     if (dentptr) {
         get_dentry(dent);

--- a/LibOS/shim/src/fs/shim_dcache.c
+++ b/LibOS/shim/src/fs/shim_dcache.c
@@ -414,7 +414,10 @@ BEGIN_RS_FUNC(dentry) {
         get_mount(dent->mounted);
     }
 
-    DEBUG_RS("hash=%08lx,path=%s,fs=%s", dent->rel_path.hash, dentry_get_path(dent, true, NULL),
+#if DEBUG_RESUME == 1
+    char buffer[dentry_get_path_size(dent)];
+#endif
+    DEBUG_RS("hash=%08lx,path=%s,fs=%s", dent->rel_path.hash, dentry_get_path(dent, buffer),
              dent->fs ? qstrgetstr(&dent->fs->path) : NULL);
 }
 END_RS_FUNC(dentry)

--- a/LibOS/shim/src/fs/shim_namei.c
+++ b/LibOS/shim/src/fs/shim_namei.c
@@ -612,8 +612,6 @@ int dentry_open (struct shim_handle * hdl, struct shim_dentry * dent,
                  int flags)
 {
     int ret = 0;
-    size_t size;
-    char *path;
     struct shim_mount * fs = dent->fs;
 
     /* I think missing functionality should be treated as EINVAL, or maybe
@@ -654,12 +652,11 @@ int dentry_open (struct shim_handle * hdl, struct shim_dentry * dent,
         hdl->dir_info.buf = (void *)-1;
         hdl->dir_info.ptr = (void *)-1;
     }
-    path = dentry_get_path(dent, true, &size);
-    if (!path) {
+
+    if (!dentry_get_path_into_qstr(dent, &hdl->path)) {
         ret = -ENOMEM;
         goto out;
     }
-    qstrsetstr(&hdl->path, path, size);
 
     /* truncate regular writable file if O_TRUNC is given */
     if ((flags & O_TRUNC) &&

--- a/LibOS/shim/src/sys/shim_exec.c
+++ b/LibOS/shim/src/sys/shim_exec.c
@@ -271,9 +271,7 @@ reopen:
         return -EACCES;
     }
 
-    size_t pathlen;
-    char* path = dentry_get_path(dent, true, &pathlen);
-    qstrsetstr(&exec->path, path, pathlen);
+    dentry_get_path_into_qstr(dent, &exec->path);
 
     if ((ret = check_elf_object(exec)) < 0 && ret != -EINVAL) {
         put_handle(exec);

--- a/LibOS/shim/src/sys/shim_getcwd.c
+++ b/LibOS/shim/src/sys/shim_getcwd.c
@@ -33,8 +33,7 @@ int shim_do_getcwd(char* buf, size_t len) {
 
     struct shim_dentry* cwd = thread->cwd;
 
-    size_t plen;
-    const char* path = dentry_get_path(cwd, true, &plen);
+    size_t plen = dentry_get_path_size(cwd) - 1;
 
     int ret;
     if (plen >= MAX_PATH) {
@@ -43,7 +42,7 @@ int shim_do_getcwd(char* buf, size_t len) {
         ret = -ERANGE;
     } else {
         ret = plen + 1;
-        memcpy(buf, path, plen + 1);
+        dentry_get_path(cwd, buf);
     }
     return ret;
 }
@@ -70,7 +69,8 @@ int shim_do_chdir(const char* filename) {
         return -ENOENT;
 
     if (!(dent->state & DENTRY_ISDIRECTORY)) {
-        debug("%s is not a directory\n", dentry_get_path(dent, false, NULL));
+        char buffer[dentry_get_path_size(dent)];
+        debug("%s is not a directory\n", dentry_get_path(dent, buffer));
         put_dentry(dent);
         return -ENOTDIR;
     }
@@ -91,7 +91,8 @@ int shim_do_fchdir(int fd) {
     struct shim_dentry* dent = hdl->dentry;
 
     if (!(dent->state & DENTRY_ISDIRECTORY)) {
-        debug("%s is not a directory\n", dentry_get_path(dent, false, NULL));
+        char buffer[dentry_get_path_size(dent)];
+        debug("%s is not a directory\n", dentry_get_path(dent, buffer));
         put_handle(hdl);
         return -ENOTDIR;
     }


### PR DESCRIPTION
Instead, require the user to always provide a big enough buffer.

For clang support, see #1794.

- Create a convenience "into qstr" wrapper
- Eliminate the only instances where the function was called with
  on_stack == false (they were leaking memory)
- Remove a few null checks that are impossible now
- Fix possible overflow in unix_copy_addr() (truncate the address
  instead)

<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://graphene.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1800)
<!-- Reviewable:end -->
