### PR TITLE
[Examples] Fix Pytorch accessing file file:/etc/fstab denied issue

### DIFF
--- a/Examples/pytorch/pytorch.manifest.template
+++ b/Examples/pytorch/pytorch.manifest.template
@@ -170,6 +170,9 @@ sgx.allowed_files.hosts    = file:/etc/hosts
 sgx.allowed_files.gaiconf  = file:/etc/gai.conf
 sgx.allowed_files.resolv   = file:/etc/resolv.conf
 
+# System's file system table
+sgx.allowed_files.fstab   = file:/etc/fstab
+
 # Graphene optionally provides patched OpenMP runtime library that runs faster
 # inside SGX enclaves (execute `make -C LibOS gcc` to generate it). Uncomment
 # the lines below to use the patched library. PyTorch's SGX perf overhead


### PR DESCRIPTION
## Description of the changes 
This patch fix makes the file /etc/fstab to be accessible when running in SGX mode.

## How to test this PR?
The following command can be used to test this PR
```SGX=1 ./pal_loader ./pytorch.manifest ./pytorchexample.py```

Fixes #1804

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1805)
<!-- Reviewable:end -->
