### PR TITLE
Remove all mentions of unimplemented net.* manifest options

### DIFF
--- a/Examples/memcached/memcached.manifest.template
+++ b/Examples/memcached/memcached.manifest.template
@@ -102,13 +102,6 @@ fs.mount.etc.type = chroot
 fs.mount.etc.path = /etc
 fs.mount.etc.uri = file:/etc
 
-################################## NETWORK ####################################
-
-# Allow binding on any network interface but only on port 11211. This is the
-# default port used by Memcached. Note how a missing interface name means "any
-# interface".
-net.allow_bind.memcachedport = :11211
-
 ############################### SGX: GENERAL ##################################
 
 # Set enclave size (somewhat arbitrarily) to 1024MB. Recall that SGX v1 requires

--- a/Examples/redis/redis-server.manifest.template
+++ b/Examples/redis/redis-server.manifest.template
@@ -72,13 +72,6 @@ fs.mount.etc.type = chroot
 fs.mount.etc.path = /etc
 fs.mount.etc.uri = file:/etc
 
-################################## NETWORK ####################################
-
-# Allow binding on any network interface but only on port 6379. This is the
-# default port used by Redis. Note how a missing interface name means "any
-# interface".
-net.allow_bind.redisport = :6379
-
 ############################### SGX: GENERAL ##################################
 
 # Set enclave size (somewhat arbitrarily) to 1024MB. Recall that SGX v1 requires

--- a/LibOS/shim/test/benchmark/manifest.template
+++ b/LibOS/shim/test/benchmark/manifest.template
@@ -11,10 +11,3 @@ fs.mount.lib.uri = file:../../../../Runtime
 fs.mount.bin.type = chroot
 fs.mount.bin.path = /bin
 fs.mount.bin.uri = file:/bin
-
-# allow to bind on port 8000
-net.rules.1 = 127.0.0.1:8000:0.0.0.0:0-65535
-# allow to connect to port 8000
-net.rules.2 = 0.0.0.0:0-65535:127.0.0.1:8000
-
-# sys.ask_for_checkpoint = 1

--- a/LibOS/shim/test/native/manifest.template
+++ b/LibOS/shim/test/native/manifest.template
@@ -15,11 +15,6 @@ fs.mount.bin.uri = file:/bin
 sys.brk.max_size = 32M
 sys.stack.size = 4M
 
-# allow to bind on port 8000
-net.allow_bind.1 = 127.0.0.1:8000
-# allow to connect to port 8000
-net.allow_peer.1 = 127.0.0.1:8000
-
 sgx.trusted_files.ld = file:$(LIBCDIR)/ld-linux-x86-64.so.2
 sgx.trusted_files.libc = file:$(LIBCDIR)/libc.so.6
 sgx.trusted_files.libdl = file:$(LIBCDIR)/libdl.so.2

--- a/LibOS/shim/test/regression/futex_bitset.manifest.template
+++ b/LibOS/shim/test/regression/futex_bitset.manifest.template
@@ -12,11 +12,6 @@ fs.mount.bin.type = chroot
 fs.mount.bin.path = /bin
 fs.mount.bin.uri = file:/bin
 
-# allow to bind on port 8000
-net.rules.1 = 127.0.0.1:8000:0.0.0.0:0-65535
-# allow to connect to port 8000
-net.rules.2 = 0.0.0.0:0-65535:127.0.0.1:8000
-
 sgx.trusted_files.ld = file:../../../../Runtime/ld-linux-x86-64.so.2
 sgx.trusted_files.libc = file:../../../../Runtime/libc.so.6
 sgx.trusted_files.libpthread = file:../../../../Runtime/libpthread.so.0

--- a/LibOS/shim/test/regression/manifest.template
+++ b/LibOS/shim/test/regression/manifest.template
@@ -20,11 +20,6 @@ fs.mount.bin.type = chroot
 fs.mount.bin.path = /bin
 fs.mount.bin.uri = file:/bin
 
-# allow to bind on port 8000
-net.rules.1 = 127.0.0.1:8000:0.0.0.0:0-65535
-# allow to connect to port 8000
-net.rules.2 = 0.0.0.0:0-65535:127.0.0.1:8000
-
 sgx.trusted_files.ld = file:../../../../Runtime/ld-linux-x86-64.so.2
 sgx.trusted_files.libc = file:../../../../Runtime/libc.so.6
 sgx.trusted_files.libdl = file:../../../../Runtime/libdl.so.2

--- a/LibOS/shim/test/regression/mmap_file.manifest.template
+++ b/LibOS/shim/test/regression/mmap_file.manifest.template
@@ -12,11 +12,6 @@ fs.mount.bin.type = chroot
 fs.mount.bin.path = /bin
 fs.mount.bin.uri = file:/bin
 
-# allow to bind on port 8000
-net.rules.1 = 127.0.0.1:8000:0.0.0.0:0-65535
-# allow to connect to port 8000
-net.rules.2 = 0.0.0.0:0-65535:127.0.0.1:8000
-
 sgx.trusted_files.ld = file:../../../../Runtime/ld-linux-x86-64.so.2
 sgx.trusted_files.libc = file:../../../../Runtime/libc.so.6
 

--- a/Pal/regression/File.manifest.template
+++ b/Pal/regression/File.manifest.template
@@ -3,9 +3,6 @@ loader.debug_type = inline
 
 fs.mount.root.uri = file:
 
-net.allow_bind.1 = 127.0.0.1:8000
-net.allow_peer.1 = 127.0.0.1:8000
-
 sgx.allow_file_creation = 0
 sgx.trusted_files.tmp1 = file:File
 sgx.trusted_files.tmp2 = file:../regression/File

--- a/Pal/regression/Process.manifest.template
+++ b/Pal/regression/Process.manifest.template
@@ -3,6 +3,3 @@ loader.insecure__use_cmdline_argv = 1
 loader.debug_type = inline
 
 fs.mount.root.uri = file:
-
-net.allow_bind.1 = 127.0.0.1:8000
-net.allow_peer.1 = 127.0.0.1:8000

--- a/Pal/regression/SendHandle.manifest.template
+++ b/Pal/regression/SendHandle.manifest.template
@@ -2,7 +2,4 @@ loader.debug_type = inline
 loader.argv0_override = SendHandle
 loader.insecure__use_cmdline_argv = 1
 
-net.allow_bind.1 = 127.0.0.1:8000
-net.allow_peer.1 = 127.0.0.1:8000
-
 sgx.allowed_files.tmp = file:to_send.tmp

--- a/Pal/regression/manifest.template
+++ b/Pal/regression/manifest.template
@@ -2,6 +2,3 @@ loader.debug_type = inline
 loader.insecure__use_cmdline_argv = 1
 
 fs.mount.root.uri = file:
-
-net.allow_bind.1 = 127.0.0.1:8000
-net.allow_peer.1 = 127.0.0.1:8000


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

There were some lingering mentions of `net.{allow_bind,allow_peer,rules}` left from the times when reference monitor was a part of the codebase.
Graphene is not a sandbox and such rules most likely will never be implemented.

Closes #63.

## How to test this PR? <!-- (if applicable) -->

CI. The changes should have no effect on anything.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1812)
<!-- Reviewable:end -->
