### PR TITLE
[Pal/Linux-SGX] Don't cast off `const` in sgx_copy_to_enclave

### DIFF
--- a/Pal/src/host/Linux-SGX/enclave_framework.c
+++ b/Pal/src/host/Linux-SGX/enclave_framework.c
@@ -88,13 +88,13 @@ bool sgx_copy_ptr_to_enclave(void** ptr, void* uptr, size_t size) {
     return true;
 }
 
-bool sgx_copy_to_enclave(const void* ptr, size_t maxsize, const void* uptr, size_t usize) {
+bool sgx_copy_to_enclave(void* ptr, size_t maxsize, const void* uptr, size_t usize) {
     if (usize > maxsize ||
         !sgx_is_completely_outside_enclave(uptr, usize) ||
         !sgx_is_completely_within_enclave(ptr, usize)) {
         return false;
     }
-    memcpy((void*)ptr, uptr, usize);
+    memcpy(ptr, uptr, usize);
     return true;
 }
 

--- a/Pal/src/host/Linux-SGX/sgx_api.h
+++ b/Pal/src/host/Linux-SGX/sgx_api.h
@@ -19,7 +19,7 @@ void* sgx_copy_to_ustack(const void* ptr, uint64_t size);
 void sgx_reset_ustack(const void* old_ustack);
 
 bool sgx_copy_ptr_to_enclave(void** ptr, void* uptr, size_t size);
-bool sgx_copy_to_enclave(const void* ptr, size_t maxsize, const void* uptr, size_t usize);
+bool sgx_copy_to_enclave(void* ptr, size_t maxsize, const void* uptr, size_t usize);
 
 /*!
  * \brief Low-level wrapper around EREPORT instruction leaf.


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

See #646. Turns out that there's no need to drop consts from the structs, only `sgx_copy_to_enclave()` needs to be fixed. I guess the ticket was created when this wasn't possible, but our code has changed a lot since then.

Fixes #646.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1813)
<!-- Reviewable:end -->
