### PR TITLE
[LibOS] regression: Don't leave a 4GB file on FS after tests

### DIFF
--- a/LibOS/shim/test/regression/test_libos.py
+++ b/LibOS/shim/test/regression/test_libos.py
@@ -410,14 +410,18 @@ class TC_30_Syscall(RegressionTestCase):
         self.assertIn('mmap test 8 passed', stdout)
 
     def test_052_large_mmap(self):
-        stdout, _ = self.run_binary(['large_mmap'], timeout=480)
+        try:
+            stdout, _ = self.run_binary(['large_mmap'], timeout=480)
 
-        # Ftruncate
-        self.assertIn('large_mmap: ftruncate OK', stdout)
+            # Ftruncate
+            self.assertIn('large_mmap: ftruncate OK', stdout)
 
-        # Large mmap
-        self.assertIn('large_mmap: mmap 1 completed OK', stdout)
-        self.assertIn('large_mmap: mmap 2 completed OK', stdout)
+            # Large mmap
+            self.assertIn('large_mmap: mmap 1 completed OK', stdout)
+            self.assertIn('large_mmap: mmap 2 completed OK', stdout)
+        finally:
+            # This test generates a 4 GB file, don't leave it in FS.
+            os.remove('testfile')
 
     def test_053_mprotect_file_fork(self):
         stdout, _ = self.run_binary(['mprotect_file_fork'])


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Previously, running LibOS regression tests left a 4 GB file in FS until calling `make clean`. This PR fixes the problem.

## How to test this PR? <!-- (if applicable) -->

Run LibOS regression and look at the regression directory.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1826)
<!-- Reviewable:end -->
