### PR TITLE
[GSC] Fix LD_LIBRARY_PATH generation

### DIFF
--- a/Tools/gsc/finalize_manifests.py
+++ b/Tools/gsc/finalize_manifests.py
@@ -60,7 +60,7 @@ def generate_library_paths():
 
     ld_library_paths = os.getenv('LD_LIBRARY_PATH')
 
-    return ''.join(ld_paths) + (ld_library_paths[1:] if ld_library_paths is not None else '')
+    return ''.join(ld_paths) + (ld_library_paths if ld_library_paths is not None else '')
 
 def get_binary_path(executable):
     path = subprocess.check_output(f'which {executable}',


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://graphene.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

GSC falsely removed the first character from the OS provided LD_LIBRARY_PATH. Under some circumstances this removed '/' from LD_LIBRARY_PATH. Initially it was used to avoid several consecutive ':'. This is not an issue and hence, the suggested implementation allows multiple ':' and fixes the issue with '/'.

## How to test this PR? <!-- (if applicable) -->

Usual Jenkins tests. If you'd like to exercise the LD_LIBRARY_PATH generation, you have to separately generate Docker images with various LD_LIBRARY_PATH variants.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1827)
<!-- Reviewable:end -->
