### PR TITLE
Clang fixes: get Linux-18.04 to compile and test

### DIFF
--- a/LibOS/shim/src/Makefile
+++ b/LibOS/shim/src/Makefile
@@ -22,6 +22,10 @@ CFLAGS += -Wextra
 # Silence Clang - it complains but does support it.
 CFLAGS += -Wno-gnu-alignof-expression
 
+# TODO: This is due to use of packed structs in IPC code, which triggers "taking address of a packed
+# member" warning in Clang and newer GCC. That code needs to be rewritten.
+CFLAGS += -Wno-address-of-packed-member
+
 ASFLAGS += -Wa,--noexecstack -x assembler-with-cpp -I../include
 
 LDFLAGS += -shared -nostdlib -z combreloc -z relro -z now -z defs \

--- a/LibOS/shim/test/benchmark/test_start.c
+++ b/LibOS/shim/test/benchmark/test_start.c
@@ -26,6 +26,12 @@ static void get_time(char* time_arg, unsigned long overhead) {
     snprintf(time_arg, 30, "%llu", msec + overhead);
 }
 
+static int compar(const void* arg1, const void* arg2) {
+    register unsigned long long a1 = *((unsigned long long*)arg1);
+    register unsigned long long a2 = *((unsigned long long*)arg2);
+    return a1 < a2 ? -1 : (a1 == a2 ? 0 : 1);
+}
+
 int main(int argc, char** argv, char** envp) {
     char* new_argv[argc + 2];
     char time_arg[30];
@@ -85,12 +91,6 @@ int main(int argc, char** argv, char** envp) {
         ssum += times[i] * times[i];
 
         close(pipes[0]);
-    }
-
-    int compar(const void* arg1, const void* arg2) {
-        register unsigned long long a1 = *((unsigned long long*)arg1);
-        register unsigned long long a2 = *((unsigned long long*)arg2);
-        return a1 < a2 ? -1 : (a1 == a2 ? 0 : 1);
     }
 
     qsort(times, TEST_TIMES, sizeof(unsigned long long), compar);

--- a/Pal/regression/Makefile
+++ b/Pal/regression/Makefile
@@ -110,16 +110,12 @@ CFLAGS-AttestationReport = -I../src/host/Linux-SGX
 	@true
 
 LDLIBS-preloads = ../crt_init/user_shared_start.o $(graphene_lib) $(pal_lib)
-$(preloads): CFLAGS += -shared -fPIC
-$(preloads): LDLIBS = $(LDLIBS-preloads)
 $(preloads): %.so: %.c $(LDLIBS-preloads)
-	$(call cmd,csingle)
+	$(call cmd,csingle) -shared -fPIC $(LDLIBS-preloads)
 
 LDLIBS-executables = ../crt_init/user_start.o $(graphene_lib) $(pal_lib) $(preloads)
-$(executables): CFLAGS += -no-pie
-$(executables): LDLIBS = $(LDLIBS-executables)
 $(executables): %: %.c $(LDLIBS-executables)
-	$(call cmd,csingle)
+	$(call cmd,csingle) -no-pie $(LDLIBS-executables)
 
 ifeq ($(filter %clean,$(MAKECMDGOALS)),)
 include $(wildcard *.d)

--- a/Pal/src/host/Linux-SGX/Makefile
+++ b/Pal/src/host/Linux-SGX/Makefile
@@ -17,6 +17,10 @@ CFLAGS += \
 	-Iprotected-files \
 	-Isgx-driver
 
+# Some of the code uses alignof on expressions, which is a GNU extension.
+# Silence Clang - it complains but does support it.
+CFLAGS += -Wno-gnu-alignof-expression
+
 ASFLAGS += \
 	-I. \
 	-I../.. \

--- a/Pal/src/host/Linux-SGX/db_files.c
+++ b/Pal/src/host/Linux-SGX/db_files.c
@@ -554,8 +554,8 @@ static inline void file_attrcopy(PAL_STREAM_ATTR* attr, struct stat* stat) {
 
 static int pf_file_attrquery(struct protected_file* pf, int fd_from_attrquery, const char* path,
                              uint64_t real_size, PAL_STREAM_ATTR* attr) {
-    pf = load_protected_file(path, &fd_from_attrquery, real_size, PAL_PROT_READ, /*create=*/false,
-                             pf);
+    pf = load_protected_file(path, &fd_from_attrquery, real_size, PF_FILE_MODE_READ,
+                             /*create=*/false, pf);
     if (!pf) {
         SGX_DBG(DBG_E, "pf_file_attrquery: load_protected_file(%s, %d) failed\n", path,
                 fd_from_attrquery);

--- a/Pal/src/host/Linux-SGX/tools/ias-request/Makefile
+++ b/Pal/src/host/Linux-SGX/tools/ias-request/Makefile
@@ -3,11 +3,11 @@ include ../../../../../../Scripts/Makefile.rules
 
 CFLAGS += -I../.. \
           -I../common \
-          -L../common \
-          -L../../../../../lib/crypto/mbedtls/install/lib \
           -D_GNU_SOURCE
 
-LDLIBS += -lsgx_util -lmbedcrypto
+LDLIBS += -L../common \
+          -L../../../../../lib/crypto/mbedtls/install/lib \
+          -lsgx_util -lmbedcrypto
 
 PREFIX ?= /usr/local
 

--- a/Pal/src/host/Linux-SGX/tools/pf_crypt/Makefile
+++ b/Pal/src/host/Linux-SGX/tools/pf_crypt/Makefile
@@ -4,11 +4,11 @@ include ../../../../../../Scripts/Makefile.rules
 CFLAGS += -I../.. \
           -I../common \
           -I../../protected-files \
-          -L../common \
-          -L../../../../../lib/crypto/mbedtls/install/lib \
           -D_GNU_SOURCE
 
-LDLIBS += -lsgx_util -lmbedcrypto
+LDLIBS += -L../common \
+          -L../../../../../lib/crypto/mbedtls/install/lib \
+          -lsgx_util -lmbedcrypto
 
 PREFIX ?= /usr/local
 

--- a/Pal/src/host/Linux-SGX/tools/quote-dump/Makefile
+++ b/Pal/src/host/Linux-SGX/tools/quote-dump/Makefile
@@ -3,11 +3,11 @@ include ../../../../../../Scripts/Makefile.rules
 
 CFLAGS += -I../.. \
           -I../common \
-          -L../common \
-          -L../../../../../lib/crypto/mbedtls/install/lib \
           -D_GNU_SOURCE
 
-LDLIBS += -lsgx_util -lmbedcrypto
+LDLIBS += -L../common \
+          -L../../../../../lib/crypto/mbedtls/install/lib \
+          -lsgx_util -lmbedcrypto
 
 PREFIX ?= /usr/local
 

--- a/Pal/src/host/Linux-SGX/tools/verify-ias-report/Makefile
+++ b/Pal/src/host/Linux-SGX/tools/verify-ias-report/Makefile
@@ -3,11 +3,11 @@ include ../../../../../../Scripts/Makefile.rules
 
 CFLAGS += -I../.. \
           -I../common \
-          -L../common \
-          -L../../../../../lib/crypto/mbedtls/install/lib \
           -D_GNU_SOURCE
 
-LDLIBS += -lsgx_util -lmbedcrypto
+LDLIBS += -L../common \
+          -L../../../../../lib/crypto/mbedtls/install/lib \
+          -lsgx_util -lmbedcrypto
 
 PREFIX ?= /usr/local
 

--- a/Scripts/Makefile.configs
+++ b/Scripts/Makefile.configs
@@ -20,7 +20,14 @@ CXX = g++
 endif
 OBJCOPY ?= objcopy
 
-SYS ?= $(shell $(CC) -dumpmachine)
+# Workaround for clang: unlike gcc, 'clang -dumpmachine' reports 'machine-vendor-operatingsystem'
+# and we want 'machine-operatingsystem'.
+# See e.g. https://bugs.launchpad.net/ubuntu/+source/clang/+bug/1827175
+ifeq ($(findstring clang,$(CC)),clang)
+    SYS ?= $(shell $(CC) -dumpmachine | cut -d- -f1,3-)
+else
+    SYS ?= $(shell $(CC) -dumpmachine)
+endif
 export SYS
 
 ARCH := $(word 1,$(subst -, -, $(SYS)))


### PR DESCRIPTION
Issue: https://github.com/oscarlab/graphene/issues/1794.

After this batch of fixes:
* both Linux and Linux-SGX compile without warnings,
* Linux passes all tests,
* Linux-SGX still fails a few tests: https://leeroy.cs.unc.edu/job/graphene-sgx-18.04/3461/#showFailuresLink

All of this works under Ubuntu 18.04, because you can install Clang 10 there without adding any extra repositories.

I recommend **enabling Clang builds for Linux** on Jenkins now, and leave Linux-SGX until we manage to debug it.

However, I'm a bit hesitant to propose copy-pasting another set of Jenkinsfiles... I tried using a matrix build:
* [Matrix feature introduction](https://www.jenkins.io/blog/2019/11/22/welcome-to-the-matrix/) on Jenkins blog
* [Jenkinsfile](https://github.com/pwmarcz/graphene/blob/de8ed1560fc0baa913dcc43d20c5fb5ef81f939e/Jenkinsfiles/Linux-18.04) parametrized by `COMPILER` being `clang` or `gcc`
* [Build result on Jenkins](https://leeroy.cs.unc.edu/job/graphene-18.04/3517/) for the above

As you can see on Jenkins, both Clang and GCC are on single page, the console output is displayed section by section, and test results are in two variants. Potentially that could be extended to other configuration switches (at least `DEBUG=1`) so that we don't maintain so many separate files. However, I'm not sure if the end result is readable. What do you think?

@mkow @woju

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1830)
<!-- Reviewable:end -->
