### PR TITLE
[GSC] Fix argument extraction from Docker image

### DIFF
--- a/Tools/gsc/gsc.py
+++ b/Tools/gsc/gsc.py
@@ -101,7 +101,7 @@ def extract_binary_cmd_from_image_config(config):
         last_bin_arg = num_starting_entrypoint_items
         escaped_args = [s.replace('\\', '\\\\').replace('"', '\\"')
                         for s in entrypoint[1:last_bin_arg]]
-        binary_arguments = '"' + '", "'.join(escaped_args) + '"'
+        binary_arguments = '"' + '" "'.join(escaped_args) + '"'
     else:
         last_bin_arg = 0
         binary_arguments = ''


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://graphene.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

This set of patches removes a comma which caused issues during use of insecure arguments which are specified as part of the Docker image. I have not found a reason for this comma and hence, it should be removed.

## How to test this PR? <!-- (if applicable) -->

Typical Jenkins GSC tests, since they evaluate both insecure and secure arguments.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1831)
<!-- Reviewable:end -->
