### PR TITLE
[GSC] Fix link to AKS guide in cloud deployment documentation

### DIFF
--- a/Documentation/cloud-deployment.rst
+++ b/Documentation/cloud-deployment.rst
@@ -98,7 +98,7 @@ Prerequisites
 ^^^^^^^^^^^^^
 
 Follow the instructions on the `AKS Confidential Computing Quick Start guide
-<https://docs.microsoft.com/en-us/azure/confidential-computing/confidential-nodes-aks-getstarted>`__
+<https://docs.microsoft.com/en-us/azure/confidential-computing/confidential-nodes-aks-get-started>`__
 to provision an AKS cluster with Intel SGX enabled worker nodes.
 
 Follow the `instructions


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://graphene.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

We used the wrong link to an AKS guide in our documentation for cloud deployments. This PR changes the link to the correct version.

## How to test this PR? <!-- (if applicable) -->

Usual Jenkins tests. It is only a documentation change, no source code changes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1836)
<!-- Reviewable:end -->
