### PR TITLE
[LibOS] Unify logic of counting handles in epoll

### DIFF
--- a/LibOS/shim/include/shim_handle.h
+++ b/LibOS/shim/include/shim_handle.h
@@ -292,7 +292,6 @@ struct shim_epoll_item {
     uint64_t data;
     unsigned int events;
     unsigned int revents;
-    bool connected;
     /* The two references below are not ref-counted (to prevent cycles). When a handle is dropped
      * (ref-count goes to 0) it is also removed from all epoll instances. When an epoll instance is
      * destroyed, all handles that it traced are removed from it. */
@@ -303,9 +302,10 @@ struct shim_epoll_item {
 };
 
 struct shim_epoll_handle {
-    int waiter_cnt;
+    size_t waiter_cnt;
 
-    int pal_cnt;
+    /* Number of items on fds list. */
+    size_t fds_count;
 
     AEVENTTYPE event;
     LISTP_TYPE(shim_epoll_item) fds;

--- a/LibOS/shim/include/shim_internal.h
+++ b/LibOS/shim/include/shim_internal.h
@@ -633,6 +633,7 @@ int object_wait_with_retry(PAL_HANDLE handle);
 
 void release_clear_child_tid(int* clear_child_tid);
 
+void _update_epolls(struct shim_handle* handle);
 void delete_from_epoll_handles(struct shim_handle* handle);
 
 #endif /* _SHIM_INTERNAL_H_ */

--- a/LibOS/shim/src/bookkeep/shim_handle.c
+++ b/LibOS/shim/src/bookkeep/shim_handle.c
@@ -743,9 +743,9 @@ BEGIN_CP_FUNC(handle) {
 
         switch (hdl->type) {
             case TYPE_EPOLL:
-                /* `new_hdl->info.epoll.pal_cnt` stays the same - copied above. */
+                /* `new_hdl->info.epoll.fds_count` stays the same - copied above. */
                 DO_CP(epoll_item, &hdl->info.epoll.fds, &new_hdl->info.epoll.fds);
-                new_hdl->info.epoll.waiter_cnt = 0;
+                __atomic_store_n(&new_hdl->info.epoll.waiter_cnt, 0, __ATOMIC_RELAXED);
                 memset(&new_hdl->info.epoll.event, '\0', sizeof(new_hdl->info.epoll.event));
                 break;
             case TYPE_SOCK:
@@ -807,9 +807,12 @@ BEGIN_RS_FUNC(handle) {
         case TYPE_EPOLL:
             create_event(&hdl->info.epoll.event);
             struct shim_epoll_item* epoll_item;
+            size_t count = 0;
             LISTP_FOR_EACH_ENTRY(epoll_item, &hdl->info.epoll.fds, list) {
                 epoll_item->epoll = hdl;
+                count++;
             }
+            assert(hdl->info.epoll.fds_count == count);
             break;
         default:
             break;

--- a/LibOS/shim/src/sys/shim_socket.c
+++ b/LibOS/shim/src/sys/shim_socket.c
@@ -551,6 +551,7 @@ int shim_do_bind(int sockfd, struct sockaddr* addr, int _addrlen) {
 
     hdl->pal_handle = pal_hdl;
     __process_pending_options(hdl);
+    _update_epolls(hdl);
     ret = 0;
 
 out:
@@ -713,6 +714,7 @@ int shim_do_connect(int sockfd, struct sockaddr* addr, int _addrlen) {
     lock(&hdl->lock);
     enum shim_sock_state state = sock->sock_state;
     int ret = -EINVAL;
+    bool pal_handle_updated = false;
 
     if (state == SOCK_CONNECTED) {
         if (addr->sa_family == AF_UNSPEC) {
@@ -721,6 +723,7 @@ int shim_do_connect(int sockfd, struct sockaddr* addr, int _addrlen) {
                 DkStreamDelete(hdl->pal_handle, 0);
                 DkObjectClose(hdl->pal_handle);
                 hdl->pal_handle = NULL;
+                pal_handle_updated = true;
             }
             debug("shim_connect: reconnect on a stream socket\n");
             ret = 0;
@@ -778,6 +781,7 @@ int shim_do_connect(int sockfd, struct sockaddr* addr, int _addrlen) {
         DkStreamDelete(hdl->pal_handle, 0);
         DkObjectClose(hdl->pal_handle);
         hdl->pal_handle = NULL;
+        pal_handle_updated = true;
     }
 
     if (sock->domain != AF_UNIX) {
@@ -801,6 +805,7 @@ int shim_do_connect(int sockfd, struct sockaddr* addr, int _addrlen) {
     }
 
     hdl->pal_handle = pal_hdl;
+    pal_handle_updated = true;
 
     if (sock->domain == AF_UNIX) {
         struct shim_dentry* dent = sock->addr.un.dentry;
@@ -841,6 +846,10 @@ out:
             if (sock->addr.un.dentry)
                 put_dentry(sock->addr.un.dentry);
         }
+    }
+
+    if (pal_handle_updated) {
+        _update_epolls(hdl);
     }
 
     unlock(&hdl->lock);
@@ -1072,6 +1081,7 @@ static ssize_t do_sendmsg(int fd, struct iovec* bufs, int nbufs, int flags,
             }
 
             hdl->pal_handle = pal_hdl;
+            _update_epolls(hdl);
         }
 
         if (addr && addr->sa_family != sock->domain) {


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://graphene.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->
This PR unifies logic of counting handles in an epoll instance. Additionally adds a callback function used at every update to a `handle->pal_handle`, to wakup potential threads blocked at `epoll`.

Kudos to @lejunzhu for pinpointing the issue. 

Fixes #1810

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1849)
<!-- Reviewable:end -->
