### PR TITLE
[LibOS] Make list of supplementary group ids dynamically allocated

### DIFF
--- a/LibOS/shim/src/sys/shim_exec.c
+++ b/LibOS/shim/src/sys/shim_exec.c
@@ -166,6 +166,7 @@ static BEGIN_MIGRATION_DEF(execve, struct shim_thread* thread, struct shim_proce
     DEFINE_MIGRATE(migratable, NULL, 0);
     DEFINE_MIGRATE(arguments, argv, 0);
     DEFINE_MIGRATE(environ, envp, 0);
+    DEFINE_MIGRATE(groups_info, NULL, 0);
 }
 END_MIGRATION_DEF(execve)
 

--- a/LibOS/shim/src/sys/shim_fork.c
+++ b/LibOS/shim/src/sys/shim_fork.c
@@ -33,6 +33,7 @@ static BEGIN_MIGRATION_DEF(fork, struct shim_thread* thread, struct shim_process
 #ifdef DEBUG
     DEFINE_MIGRATE(gdb_map, NULL, 0);
 #endif
+    DEFINE_MIGRATE(groups_info, NULL, 0);
 }
 END_MIGRATION_DEF(fork)
 

--- a/LibOS/shim/test/regression/.gitignore
+++ b/LibOS/shim/test/regression/.gitignore
@@ -39,6 +39,7 @@
 /getdents
 /getsockname
 /getsockopt
+/groups
 /host_root_fs
 /init_fail
 /large_dir_read

--- a/LibOS/shim/test/regression/Makefile
+++ b/LibOS/shim/test/regression/Makefile
@@ -35,6 +35,7 @@ c_executables = \
 	getdents \
 	getsockname \
 	getsockopt \
+	groups \
 	host_root_fs \
 	init_fail \
 	large_mmap \

--- a/LibOS/shim/test/regression/groups.c
+++ b/LibOS/shim/test/regression/groups.c
@@ -1,0 +1,62 @@
+#define _GNU_SOURCE
+#include <err.h>
+#include <grp.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#define ARRAY_LEN(x) (sizeof(x) / sizeof(x[0]))
+
+static gid_t test_groups[] = { 0, 1337, 1337, 0 };
+
+int main(void) {
+    setbuf(stdout, NULL);
+    setbuf(stderr, NULL);
+
+    int x = getgroups(0, NULL);
+    if (x < 0) {
+        err(1, "getgroups");
+    }
+
+    gid_t groups[ARRAY_LEN(test_groups)];
+    memcpy(groups, test_groups, sizeof(groups));
+
+    x = setgroups(ARRAY_LEN(groups), groups);
+    if (x != 0) {
+        err(1, "setgroups");
+    }
+
+    memset(groups, 0, sizeof(groups));
+
+    pid_t pid = fork();
+    if (pid < 0) {
+        err(1, "fork");
+    } else if (pid > 0) {
+        int status = 0;
+        if (waitpid(pid, &status, 0) < 0) {
+            err(1, "waitpid");
+        }
+        if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) {
+            errx(1, "invalid child return status: %d", status);
+        }
+    }
+
+    x = getgroups(ARRAY_LEN(groups), groups);
+    if (x < 0) {
+        err(1, "getgroups");
+    } else if (x != ARRAY_LEN(groups)) {
+        errx(1, "getgroups returned invalid length: %d (expected: %zu)", x, ARRAY_LEN(groups));
+    }
+
+    for (size_t i = 0; i < ARRAY_LEN(groups); i++) {
+        if (groups[i] != test_groups[i]) {
+            errx(1, "invalid group: %d (expected: %d)", groups[i], test_groups[i]);
+        }
+    }
+
+    printf("%s OK\n", pid == 0 ? "child" : "parent");
+    return 0;
+}
+

--- a/LibOS/shim/test/regression/test_libos.py
+++ b/LibOS/shim/test/regression/test_libos.py
@@ -492,6 +492,12 @@ class TC_30_Syscall(RegressionTestCase):
         stdout, _ = self.run_binary(['signal_multithread'])
         self.assertIn('TEST OK', stdout)
 
+    def test_100_get_set_groups(self):
+        stdout, _ = self.run_binary(['groups'])
+        self.assertIn('child OK', stdout);
+        self.assertIn('parent OK', stdout);
+
+
 @unittest.skipUnless(HAS_SGX,
     'This test is only meaningful on SGX PAL because only SGX catches raw '
     'syscalls and redirects to Graphene\'s LibOS. If we will add seccomp to '


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://graphene.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->
Supplementary groups IDs are not often used inside Graphene, yet there was a global statically allocated buffer for them, which unnecessarily took a lot of space in binaries and was sent in checkpointing code.
This PR fixes that by making this buffer dynamically allocated on demand.

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->
Added a new test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1850)
<!-- Reviewable:end -->
