### PR TITLE
[LibOS, Pal/Linux-SGX] Signal handling bug fixes

### DIFF
--- a/LibOS/shim/src/sys/shim_exit.c
+++ b/LibOS/shim/src/sys/shim_exit.c
@@ -67,8 +67,8 @@ int thread_destroy(struct shim_thread* thread, bool send_ipc) {
             info.si_status = (exit_code & 0xff) << 8;
 
             if (append_signal(parent, &info) >= 0) {
-                thread_wakeup(thread);
-                DkThreadResume(thread->pal_handle);
+                thread_wakeup(parent);
+                DkThreadResume(parent->pal_handle);
             }
         }
 

--- a/LibOS/shim/test/regression/.gitignore
+++ b/LibOS/shim/test/regression/.gitignore
@@ -68,6 +68,7 @@
 /shared_object
 /sigaction_per_process
 /sigaltstack
+/sighandler_divbyzero
 /sighandler_reset
 /sighandler_sigpipe
 /signal_multithread

--- a/LibOS/shim/test/regression/Makefile
+++ b/LibOS/shim/test/regression/Makefile
@@ -3,7 +3,8 @@ include ../../../../Scripts/Makefile.configs
 c_executables-x86_64 = \
 	attestation \
 	cpuid \
-	rdtsc
+	rdtsc \
+	sighandler_divbyzero
 
 c_executables = \
 	abort \

--- a/LibOS/shim/test/regression/sighandler_divbyzero.c
+++ b/LibOS/shim/test/regression/sighandler_divbyzero.c
@@ -1,0 +1,62 @@
+#define _GNU_SOURCE
+#include <emmintrin.h> // Intel SSE2 (XMM) intrinsics
+#include <err.h>
+#include <errno.h>
+#include <signal.h>
+#include <stdatomic.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <ucontext.h>
+
+static atomic_int sigfpe_ctr = 0;
+
+static void sigfpe_handler(int signum, siginfo_t* si, void* uc) {
+    printf("Got signal %d\n", signum);
+    if (signum == SIGFPE) {
+        ((ucontext_t*)uc)->uc_mcontext.gregs[REG_RBX] = 1; /* fix divisor */
+        sigfpe_ctr++;
+    }
+}
+
+int main(int argc, char** argv) {
+    int ret;
+
+    const struct sigaction act = {
+        .sa_sigaction = sigfpe_handler,
+        .sa_flags = SA_SIGINFO,
+    };
+
+    ret = sigaction(SIGFPE, &act, NULL);
+    if (ret < 0) {
+        err(EXIT_FAILURE, "sigaction failed");
+    }
+
+    int16_t in[8] __attribute__((aligned(16))) = {0, 1, 2, 3, 4, 5, 6, 7};
+    int16_t out[8] __attribute__((aligned(16))) = {0};
+
+    __asm__ volatile("pxor %%xmm0, %%xmm0\n" /* clear xmm0 for sanity */
+                     "movdqa %1, %%xmm0\n"   /* move `in` into xmm0 */
+                     "movq $1, %%rax\n"      /* force div-by-zero exception via 1/0 */
+                     "cqo\n"
+                     "movq $0, %%rbx\n"
+                     "divq %%rbx\n"
+                     "movdqa %%xmm0, %0\n"   /* move xmm0 into `out` */
+                     "pxor %%xmm0, %%xmm0\n" /* clear xmm0 for sanity */
+                     :"=m"(out) : "m"(in) : "xmm0", "rax", "rbx", "rdx", "cc", "memory");
+
+    for (int i = 0; i < 8; i++) {
+        if (out[i] != in[i]) {
+            errx(EXIT_FAILURE, "XSAVE state (XMM registers' values) was lost!");
+        }
+    }
+
+    if (sigfpe_ctr != 1) {
+        errx(EXIT_FAILURE, "Expected exactly 1 SIGFPE signal but received %d!", sigfpe_ctr);
+    }
+
+    printf("Got %d SIGFPE signal(s)\n", sigfpe_ctr);
+    puts("TEST OK");
+    exit(EXIT_SUCCESS);
+}

--- a/LibOS/shim/test/regression/test_libos.py
+++ b/LibOS/shim/test/regression/test_libos.py
@@ -488,7 +488,14 @@ class TC_30_Syscall(RegressionTestCase):
             self.assertIn('Got 1 SIGPIPE signal(s)', stdout)
             self.assertIn('Could not write to pipe: Broken pipe', stdout)
 
-    def test_093_signal_multithread(self):
+    @unittest.skipUnless(ON_X86, "x86-specific")
+    def test_093_sighandler_divbyzero(self):
+        stdout, _ = self.run_binary(['sighandler_divbyzero'])
+        self.assertIn('Got signal 8', stdout)
+        self.assertIn('Got 1 SIGFPE signal(s)', stdout)
+        self.assertIn('TEST OK', stdout)
+
+    def test_094_signal_multithread(self):
         stdout, _ = self.run_binary(['signal_multithread'])
         self.assertIn('TEST OK', stdout)
 

--- a/Pal/src/host/Linux-SGX/enclave_entry.S
+++ b/Pal/src/host/Linux-SGX/enclave_entry.S
@@ -466,11 +466,18 @@ enclave_entry:
 	leaq _DkExceptionHandler(%rip), %rdi
 	movq %rdi, SGX_GPR_RIP(%rbx)
 
+	# dump the XSAVE region (XMM/YMM/etc part of context); SGX saves it at the
+	# very beginning of the SSA frame; note that __restore_xregs / __save_xregs
+	# clobber RDX so need to stash it in RBX
 	movq %rdx, %rbx
-	leaq SGX_CPU_CONTEXT_SIZE + 8(%rsi), %rdi
+	movq %gs:SGX_SSA, %rdi
 	leaq 1f(%rip), %r11
-	jmp __save_xregs
+	jmp __restore_xregs
 1:
+	leaq SGX_CPU_CONTEXT_SIZE + 8(%rsi), %rdi
+	leaq 2f(%rip), %r11
+	jmp __save_xregs
+2:
 	movq %rbx, %rdx
 
 .Leexit_exception:


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

This PR has two bug fixes:

1. [LibOS] Wake up parent thread on SIGCHLD from child. Previously, Graphene had a bug of trying to wake up the (remote) child thread on SIGCHLD. This was a nop. It also meant that the parent thread, who was waiting on the child, wasn't interrupted and continued hanging instead of handling SIGCHLD.

2. [Pal/Linux-SGX] Save XSAVE area of normal app context on sync signals. Previously, when a synchronous signal like SIGFPE/SIGILL happened in the application (e.g., due to div-by-zero or SGX-prohibited SYSCALL instruction), Linux-SGX assembly routine incorrectly saved the XSAVE area (containing among other things FP/SSE/AVX registers) of the signal context. This commit fixes this bug by extracting the XSAVE area of the normal app context, i.e., XSAVE of SSA 0.

This was detected on a large statically built application. Kudos to @thiagomacieira for help in debugging and analyzing the issues.

## How to test this PR? <!-- (if applicable) -->

New LibOS regression test is added to test bug fix 2. The test is x64-only and assumes an SSE2 enabled CPU.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1852)
<!-- Reviewable:end -->
