### PR TITLE
[Pal/Linux-SGX] Rewrite GDB symbol file updates

### DIFF
--- a/Pal/src/host/Linux-SGX/db_rtld.c
+++ b/Pal/src/host/Linux-SGX/db_rtld.c
@@ -10,6 +10,8 @@
  * Library.
  */
 
+#include <assert.h>
+
 #include "api.h"
 #include "elf-x86_64.h"
 #include "elf/elf.h"
@@ -22,7 +24,108 @@
 #include "pal_linux_defs.h"
 #include "pal_rtld.h"
 #include "pal_security.h"
+#include "sgx_rtld.h"
+#include "spinlock.h"
 #include "sysdeps/generic/ldsodefs.h"
+
+/* Global debug map. To simplify setup, the pointer to g_debug_map is passed outside with
+ * ocall_update_debugger().
+ * (Note that we pass a pointer to g_debug_map, not its current value, to avoid race conditions). */
+static struct debug_map* _Atomic g_debug_map = NULL;
+
+/* Lock for modifying g_debug_map on our end. Even though the list can be read at any
+ * time, we need to prevent concurrent modification. */
+static spinlock_t g_debug_map_lock = INIT_SPINLOCK_UNLOCKED;
+
+static struct debug_map* debug_map_alloc(const char* file_name, void* load_addr) {
+    struct debug_map* map;
+
+    if (!(map = malloc(sizeof(*map))))
+        return NULL;
+
+    if (!(map->file_name = strdup(file_name))) {
+        free(map);
+        return NULL;
+    }
+
+    map->load_addr = load_addr;
+    map->section = NULL;
+    map->next = NULL;
+    return map;
+}
+
+static struct debug_section* debug_map_add_section(struct debug_map* map, const char* section_name,
+                                                   void* addr) {
+    struct debug_section* section;
+
+    if (!(section = malloc(sizeof(*section))))
+        return NULL;
+
+    if (!(section->name = strdup(section_name))) {
+        free(section);
+        return NULL;
+    }
+
+    section->addr = addr;
+    section->next = map->section;
+    map->section = section;
+    return section;
+}
+
+static void debug_map_free(struct debug_map* map) {
+    struct debug_section* section = map->section;
+    while (section) {
+        struct debug_section* next = section->next;
+        free(section->name);
+        free(section);
+        section = next;
+    }
+    free(map->file_name);
+    free(map);
+}
+
+static void debug_map_add(struct debug_map* map) {
+    spinlock_lock(&g_debug_map_lock);
+
+    map->next = g_debug_map;
+    g_debug_map = map;
+
+    spinlock_unlock(&g_debug_map_lock);
+
+    ocall_update_debugger(&g_debug_map);
+}
+
+static bool debug_map_del(void* load_addr) {
+    assert(g_debug_map);
+
+    spinlock_lock(&g_debug_map_lock);
+
+    struct debug_map* prev = NULL;
+    struct debug_map* map = g_debug_map;
+    while (map) {
+        if (map->load_addr == load_addr)
+            break;
+        prev = map;
+        map = map->next;
+    }
+
+    if (!map) {
+        spinlock_unlock(&g_debug_map_lock);
+        return false;
+    }
+
+    if (prev == NULL)
+        g_debug_map = map->next;
+    else
+        prev->next = map->next;
+
+    spinlock_unlock(&g_debug_map_lock);
+
+    debug_map_free(map);
+
+    ocall_update_debugger(&g_debug_map);
+    return true;
+}
 
 void _DkDebugAddMap(struct link_map* map) {
     const ElfW(Ehdr)* ehdr = (void*)map->l_map_start;
@@ -76,47 +179,33 @@ void _DkDebugAddMap(struct link_map* map) {
 
     ocall_close(fd);
 
-    ElfW(Addr) text_addr = 0;
-    for (ElfW(Shdr)* s = shdr; s < shdrend; s++)
-        if (!strcmp_static(shstrtab + s->sh_name, ".text")) {
-            text_addr = map->l_addr + s->sh_addr;
-            break;
-        }
-
-    if (!text_addr)
+    struct debug_map* debug_map = debug_map_alloc(map->l_name, (void*)map->l_addr);
+    if (!debug_map) {
+        SGX_DBG(DBG_E, "_DkDebugAddMap: error allocating new map\n");
         return;
-
-#define BUFFER_LENGTH 4096
-
-    char buffer[BUFFER_LENGTH];
-    char* ptr = buffer;
-
-    snprintf(ptr, BUFFER_LENGTH - (ptr - buffer), "add-symbol-file %s 0x%016lx -readnow",
-             map->l_name, text_addr);
-    ptr += strlen(ptr);
+    }
 
     for (ElfW(Shdr)* s = shdr; s < shdrend; s++) {
         if (!s->sh_name || !s->sh_addr)
-            continue;
-        if (!strcmp_static(shstrtab + s->sh_name, ".text"))
             continue;
         if (s->sh_type == SHT_NULL)
             continue;
         if (strstartswith_static(shstrtab + s->sh_name, ".debug_"))
             continue;
 
-        snprintf(ptr, BUFFER_LENGTH - (ptr - buffer), " -s %s 0x%016lx", shstrtab + s->sh_name,
-                 map->l_addr + s->sh_addr);
-        ptr += strlen(ptr);
+        if (!debug_map_add_section(debug_map, shstrtab + s->sh_name,
+                                   (void*)(map->l_addr + s->sh_addr))) {
+            SGX_DBG(DBG_E, "_DkDebugAddMap: error allocating new section\n");
+            debug_map_free(debug_map);
+            return;
+        }
     }
 
-    ocall_load_debug(buffer);
+    debug_map_add(debug_map);
 }
 
 void _DkDebugDelMap(struct link_map* map) {
-    char buffer[BUFFER_LENGTH];
-    snprintf(buffer, BUFFER_LENGTH, "remove-symbol-file %s", map->l_name);
-    ocall_load_debug(buffer);
+    debug_map_del((void*)map->l_addr);
 }
 
 extern void* g_section_text;
@@ -135,14 +224,31 @@ void setup_pal_map(struct link_map* pal_map) {
     pal_map->l_phnum   = header->e_phnum;
     setup_elf_hash(pal_map);
 
-    char buffer[BUFFER_LENGTH];
-    snprintf(buffer, BUFFER_LENGTH,
-             "add-symbol-file %s %p -readnow -s .rodata %p "
-             "-s .dynamic %p -s .data %p -s .bss %p",
-             pal_map->l_name, &g_section_text, &g_section_rodata, &g_section_dynamic,
-             &g_section_data, &g_section_bss);
-
-    ocall_load_debug(buffer);
     pal_map->l_prev = pal_map->l_next = NULL;
     g_loaded_maps = pal_map;
+
+    struct debug_map* debug_map = debug_map_alloc(pal_map->l_name, &g_section_text);
+    if (!debug_map) {
+        SGX_DBG(DBG_E, "setup_pal_map: error allocating new map\n");
+        return;
+    }
+
+    if (!debug_map_add_section(debug_map, ".rodata", &g_section_rodata))
+        goto fail;
+
+    if (!debug_map_add_section(debug_map, ".dynamic", &g_section_dynamic))
+        goto fail;
+
+    if (!debug_map_add_section(debug_map, ".data", &g_section_data))
+        goto fail;
+
+    if (!debug_map_add_section(debug_map, ".bss", &g_section_bss))
+        goto fail;
+
+    debug_map_add(debug_map);
+    return;
+
+fail:
+    SGX_DBG(DBG_E, "setup_pal_map: error allocating new section\n");
+    debug_map_free(debug_map);
 }

--- a/Pal/src/host/Linux-SGX/enclave_ocalls.h
+++ b/Pal/src/host/Linux-SGX/enclave_ocalls.h
@@ -10,6 +10,7 @@
 #include "linux_types.h"
 #include "pal_linux.h"
 #include "sgx_attest.h"
+#include "sgx_rtld.h"
 
 noreturn void ocall_exit(int exitcode, int is_exitgroup);
 
@@ -87,7 +88,7 @@ int ocall_rename(const char* oldpath, const char* newpath);
 
 int ocall_delete(const char* pathname);
 
-int ocall_load_debug(const char* command);
+int ocall_update_debugger(struct debug_map* _Atomic* debug_map);
 
 int ocall_eventfd(unsigned int initval, int flags);
 

--- a/Pal/src/host/Linux-SGX/gdb_integration/graphene_sgx.gdb
+++ b/Pal/src/host/Linux-SGX/gdb_integration/graphene_sgx.gdb
@@ -35,7 +35,6 @@ set follow-exec-mode same
 set follow-fork-mode child
 set displaced-stepping off
 
-
 # CPUID/RDTSC SIGILL skipping. See [2] above.
 
 catch signal SIGILL

--- a/Pal/src/host/Linux-SGX/gdb_integration/graphene_sgx_gdb.py
+++ b/Pal/src/host/Linux-SGX/gdb_integration/graphene_sgx_gdb.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later */
 # Copyright (C) 2020 Intel Corporation
 #                    Michał Kowalczyk <mkow@invisiblethingslab.com>
+#                    Paweł Marczewski <pawel@invisiblethingslab.com>
 
 import os
 
@@ -9,6 +10,94 @@ import gdb # pylint: disable=import-error
 # pylint: disable=no-self-use,too-few-public-methods
 
 _g_paginations = []
+
+
+def retrieve_debug_maps():
+    '''
+    Retrieve the debug_map structure from the inferior process. The result is a dict with the
+    following structure:
+
+    {load_addr: (file_name, {name: addr})}
+    '''
+
+    if int(gdb.parse_and_eval('g_pal_enclave.debug_map')) == 0:
+        # Not initialized yet
+        return {}
+
+    debug_maps = {}
+    val_map = gdb.parse_and_eval('*g_pal_enclave.debug_map')
+    while int(val_map) != 0:
+        file_name = val_map['file_name'].string()
+        file_name = os.path.abspath(file_name)
+
+        load_addr = int(val_map['load_addr'])
+
+        sections = {}
+        val_section = val_map['section']
+        while int(val_section) != 0:
+            name = val_section['name'].string()
+            addr = int(val_section['addr'])
+
+            sections[name] = addr
+            val_section = val_section['next']
+
+        # We need the text_addr to use add-symbol-file (at least until GDB 8.2).
+        if '.text' in sections:
+            debug_maps[load_addr] = (file_name, sections)
+
+        val_map = val_map['next']
+
+    return debug_maps
+
+
+class UpdateDebugMaps(gdb.Command):
+    """Update debug maps for the inferior process."""
+
+    def __init__(self):
+        super().__init__('update-debug-maps', gdb.COMMAND_USER)
+
+    def invoke(self, arg, _from_tty):
+        self.dont_repeat()
+        assert arg == ''
+
+        # Store the currently loaded maps inside the Progspace object, so that we can compare
+        # old and new states. See:
+        # https://sourceware.org/gdb/current/onlinedocs/gdb/Progspaces-In-Python.html
+        progspace = gdb.current_progspace()
+        if not hasattr(progspace, 'sgx_debug_maps'):
+            progspace.sgx_debug_maps = {}
+
+        old = progspace.sgx_debug_maps
+        new = retrieve_debug_maps()
+        for load_addr in set(old) | set(new):
+            # Skip unload/reload if the map is unchanged
+            if old.get(load_addr) == new.get(load_addr):
+                continue
+
+            # Note that this doesn't escape the file names.
+
+            if load_addr in old:
+                # Log the removing, because remove-symbol-file itself doesn't produce helpful output
+                # on errors.
+                file_name, sections = old[load_addr]
+                print("Removing symbol file (was {}) from addr: 0x{:x}".format(
+                    file_name, load_addr))
+                try:
+                    gdb.execute('remove-symbol-file -a 0x{:x}'.format(load_addr))
+                except gdb.error:
+                    print('warning: failed to remove symbol file')
+
+            if load_addr in new:
+                file_name, sections = new[load_addr]
+                text_addr = sections['.text']
+                cmd = 'add-symbol-file {} 0x{:x} '.format(file_name, text_addr)
+                cmd += ' '.join('-s {} 0x{:x}'.format(name, addr)
+                                for name, addr in sections.items()
+                                if name != '.text')
+                gdb.execute(cmd)
+
+        progspace.sgx_debug_maps = new
+
 
 class PushPagination(gdb.Command):
     """Temporarily changing pagination and saving the old state.
@@ -46,18 +135,34 @@ class PopPagination(gdb.Command):
         gdb.execute('set pagination ' + ('on' if pagination else 'off'))
 
 
-class LoadCommandBreakpoint(gdb.Breakpoint):
+class UpdateBreakpoint(gdb.Breakpoint):
     def __init__(self):
-        gdb.Breakpoint.__init__(self, spec="execute_gdb_command", internal=1)
+        gdb.Breakpoint.__init__(self, spec="update_debugger", internal=1)
 
     def stop(self):
-        command = gdb.parse_and_eval("(const char*)$rdi").string()
-        gdb.execute(command)
+        gdb.execute('update-debug-maps')
         return False
+
+
+def stop_handler(_event):
+    # Make sure we handle connecting to a new process correctly:
+    # update the debug maps if we never did it before.
+    progspace = gdb.current_progspace()
+    if not hasattr(progspace, 'sgx_debug_maps'):
+        gdb.execute('update-debug-maps')
+
+
+def clear_objfiles_handler(event):
+    # Record that symbol files has been cleared on GDB's side (e.g. on program exit), so that we do
+    # not try to remove them again.
+    if hasattr(event.progspace, 'sgx_debug_maps'):
+        delattr(event.progspace, 'sgx_debug_maps')
+
 
 def main():
     PushPagination()
     PopPagination()
+    UpdateDebugMaps()
 
     # Some of the things we want to do can't be done using gdb Python API, we need to fall back to a
     # standard gdb script.
@@ -65,7 +170,9 @@ def main():
     print("[%s] Loading %s..." % (os.path.basename(__file__), gdb_script))
     gdb.execute("source " + gdb_script)
 
-    LoadCommandBreakpoint()
+    UpdateBreakpoint()
+    gdb.events.stop.connect(stop_handler)
+    gdb.events.clear_objfiles.connect(clear_objfiles_handler)
 
 if __name__ == "__main__":
     main()

--- a/Pal/src/host/Linux-SGX/ocall_types.h
+++ b/Pal/src/host/Linux-SGX/ocall_types.h
@@ -10,6 +10,7 @@
 #include "pal.h"
 #include "sgx_arch.h"
 #include "sgx_attest.h"
+#include "sgx_rtld.h"
 
 /*
  * GCC's structure padding may cause leaking from uninialized
@@ -57,7 +58,7 @@ enum {
     OCALL_POLL,
     OCALL_RENAME,
     OCALL_DELETE,
-    OCALL_LOAD_DEBUG,
+    OCALL_UPDATE_DEBUGGER,
     OCALL_EVENTFD,
     OCALL_GET_QUOTE,
     OCALL_NR,
@@ -265,6 +266,10 @@ typedef struct {
 typedef struct {
     const char* ms_pathname;
 } ms_ocall_delete_t;
+
+typedef struct {
+    struct debug_map* _Atomic* ms_debug_map;
+} ms_ocall_update_debugger_t;
 
 typedef struct {
     unsigned int ms_initval;

--- a/Pal/src/host/Linux-SGX/sgx_enclave.c
+++ b/Pal/src/host/Linux-SGX/sgx_enclave.c
@@ -629,10 +629,16 @@ static long sgx_ocall_eventfd(void* pms) {
     return ret;
 }
 
-static long sgx_ocall_load_debug(void* pms) {
-    const char* command = (const char*)pms;
-    ODEBUG(OCALL_LOAD_DEBUG, (void*)command);
-    execute_gdb_command(command);
+static long sgx_ocall_update_debugger(void* pms) {
+    ms_ocall_update_debugger_t* ms = (ms_ocall_update_debugger_t*)pms;
+    ODEBUG(OCALL_UPDATE_DEBUGGER, ms);
+
+#ifdef DEBUG
+    g_pal_enclave.debug_map = ms->ms_debug_map;
+    update_debugger();
+#else
+    __UNUSED(ms);
+#endif
     return 0;
 }
 
@@ -679,7 +685,7 @@ sgx_ocall_fn_t ocall_table[OCALL_NR] = {
     [OCALL_POLL]             = sgx_ocall_poll,
     [OCALL_RENAME]           = sgx_ocall_rename,
     [OCALL_DELETE]           = sgx_ocall_delete,
-    [OCALL_LOAD_DEBUG]       = sgx_ocall_load_debug,
+    [OCALL_UPDATE_DEBUGGER]  = sgx_ocall_update_debugger,
     [OCALL_EVENTFD]          = sgx_ocall_eventfd,
     [OCALL_GET_QUOTE]        = sgx_ocall_get_quote,
 };

--- a/Pal/src/host/Linux-SGX/sgx_gdb_info.c
+++ b/Pal/src/host/Linux-SGX/sgx_gdb_info.c
@@ -7,8 +7,7 @@
 #include "sgx_internal.h"
 
 /* This function is hooked by our gdb integration script and should be left as is. */
-__attribute__((__noinline__)) void execute_gdb_command(const char* command) {
-    __UNUSED(command);
+__attribute__((__noinline__)) void update_debugger(void) {
     __asm__ volatile(""); // Required in addition to __noinline__ to prevent deleting this function.
                           // See GCC docs.
 }

--- a/Pal/src/host/Linux-SGX/sgx_internal.h
+++ b/Pal/src/host/Linux-SGX/sgx_internal.h
@@ -16,6 +16,7 @@
 #include "api.h"
 #include "pal_linux.h"
 #include "pal_security.h"
+#include "sgx_rtld.h"
 #include "sysdep-arch.h"
 
 #define IS_ERR   INTERNAL_SYSCALL_ERROR
@@ -68,6 +69,12 @@ extern struct pal_enclave {
 
     /* Path to the PAL binary */
     char* libpal_uri;
+
+#ifdef DEBUG
+    /* Pointer to information for GDB inside the enclave (see sgx_rtld.h).
+     * Set up using update_debugger() ocall. */
+    struct debug_map* _Atomic* debug_map;
+#endif
 
     /* security information */
     struct pal_sec pal_sec;
@@ -138,6 +145,6 @@ int sgx_signal_setup(void);
 int block_signals(bool block, const int* sigs, int nsig);
 int block_async_signals(bool block);
 
-void execute_gdb_command(const char* command);
+void update_debugger(void);
 
 #endif

--- a/Pal/src/host/Linux-SGX/sgx_main.c
+++ b/Pal/src/host/Linux-SGX/sgx_main.c
@@ -783,6 +783,8 @@ static int load_enclave(struct pal_enclave* enclave, int manifest_fd, char* mani
 
         env_i += strnlen(&env[env_i], env_size - env_i) + 1;
     }
+
+    enclave->debug_map = NULL;
 #endif
 
     enclave->manifest = manifest_fd;

--- a/Pal/src/host/Linux-SGX/sgx_rtld.h
+++ b/Pal/src/host/Linux-SGX/sgx_rtld.h
@@ -1,0 +1,48 @@
+/* SPDX-License-Identifier: LGPL-3.0-or-later */
+/* Copyright (C) 2020 Intel Corporation
+ *                    Paweł Marczewski <pawel@invisiblethingslab.com>
+ */
+
+/*
+ * Internal debug maps, used for SGX to communicate with debugger. We maintain it so that it is in a
+ * consistent state any time the process is stopped (any add/delete is an atomic modification of one
+ * pointer).
+ *
+ * The debug map is maintained inside the enclave, and the debugger is notified using
+ * ocall_update_debugger().
+ */
+
+#ifndef SGX_RTLD_H
+#define SGX_RTLD_H
+
+/*
+ * TODO: (GDB 8.2)
+ *
+ * To add the files in GDB, we use the 'add-symbol-file' command. In the GDB versions we support,
+ * that command requires specifying a text section address (and, apparently, all the other
+ * sections). In GDB 8.2, the 'text_addr' parameter is optional, and there is a new '-o offset'
+ * option which allows to just specify load address for the whole file, and that's enough to load
+ * all the sections.
+ *
+ * Once we are able to rely on newer GDB, we can get rid the section list (struct debug_section).
+ * It's also possible that we will be able to use the r_debug structure instead, so that the same
+ * mechanism is
+ * used in Linux and Linux-SGX (even though in Linux-SGX we parse the structure manually in Python).
+ */
+
+struct debug_section {
+    char* name;
+    void* addr;
+
+    struct debug_section* next;
+};
+
+struct debug_map {
+    char* file_name;
+    void* load_addr;
+    struct debug_section* section;
+
+    struct debug_map* _Atomic next;
+};
+
+#endif /* SGX_RTLD_H */


### PR DESCRIPTION
See https://github.com/oscarlab/graphene/issues/1814.

The old integration was based on directly executing GDB commands.
Instead, we maintain a linked list of debug sections, and notify
GDB using a breakpointed function.

In addition, make sure to read the structure when we attach to a
new process, by hooking the GDB stop event.

From my testing, this also solves the problem with breakpoints not
working until you break (Ctrl-C) inside an enclave. Adding a
breakpoint to a specific file (`break foo.c:main`) also seems to
work correctly, even before the process is started (the breakpoint
is conditional on a file load).

## How to test this PR?

Starting a new process:
* Compile Graphene with `SGX=1 DEBUG=1`
* Compile LibOS/test/regression with `SGX=1 DEBUG=1`
* Start GDB: `GDB=1 SGX=1 ./pal_loader bootstrap`
* Add a breakpoint: `break bootstrap.c:main`, confirm that it's conditional on library load
* Run: `run`
* Verify that the debug information is there: `list`, `info files`
* Continue: `continue`, check if it exits cleanly

Attaching to an existing process:
* Compile as above
* Run a program that pauses (I'm adding a `getchar()` to `bootstrap.c`)
* Check the PID with `pgrep pal-Linux-SGX`
* Start GDB: `GDB=1 SGX=1 ./pal_loader bootstrap`
* Attach to existing process: `attach <pid>`
* Verify that the debug information is there: `list bootstrap.c:main`, `info files`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1853)
<!-- Reviewable:end -->
