### PR TITLE
[LibOS] regression: Fix OpenMP test on systems with a lot of cores

### DIFF
--- a/LibOS/shim/test/regression/openmp.c
+++ b/LibOS/shim/test/regression/openmp.c
@@ -6,7 +6,10 @@
 int v[10];
 
 int main(void) {
-#pragma omp parallel for
+    /* We need to limit the number of threads, otherwise OpenMP spawns as many threads as available
+     * logical cores on the machine, which may exceed the TCS count specified in the manifest.
+     */
+#pragma omp parallel for num_threads(10)
     for (int i = 0; i < 10; i++) {
         v[i] = i;
     }


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Seems that `test_libos.py::TC_02_OpenMP::test_000_simple_for_loop` didn't work on systems with too many cores - OpenMP tried to spawn too many workers, thus exceeding the TCS limit hardcoded in the test's manifest.

## How to test this PR? <!-- (if applicable) -->

Run LibOS regression with SGX on a system with more than 32 logical cores.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1854)
<!-- Reviewable:end -->
