### PR TITLE
[LibOS] Correctly mask exit codes in exit{,_group} syscalls

### DIFF
--- a/LibOS/shim/src/sys/shim_exit.c
+++ b/LibOS/shim/src/sys/shim_exit.c
@@ -212,6 +212,8 @@ noreturn void process_exit(int error_code, int term_signal) {
 noreturn int shim_do_exit_group(int error_code) {
     assert(!is_internal(get_cur_thread()));
 
+    error_code &= 0xFF;
+
     if (debug_handle)
         sysparser_printf("---- shim_exit_group (returning %d)\n", error_code);
 
@@ -220,6 +222,8 @@ noreturn int shim_do_exit_group(int error_code) {
 
 noreturn int shim_do_exit(int error_code) {
     assert(!is_internal(get_cur_thread()));
+
+    error_code &= 0xFF;
 
     if (debug_handle)
         sysparser_printf("---- shim_exit (returning %d)\n", error_code);

--- a/LibOS/shim/test/ltp/ltp.cfg
+++ b/LibOS/shim/test/ltp/ltp.cfg
@@ -304,9 +304,6 @@ skip = yes
 must-pass =
     1
 
-[exit01]
-timeout = 40
-
 [faccessat01]
 timeout = 80
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Linux masks exit codes in `exit` and `exit_group` syscalls, so we should do the same. This should lower the count of `Saturation error in exit code -1, getting rounded down to 255` warnings in the logs.

Also, I removed the timeout extension from LTP's exit test, no idea why it was there.

## How to test this PR? <!-- (if applicable) -->

CI.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1855)
<!-- Reviewable:end -->
