### PR TITLE
[LibOS] Makefile: Revert commit 'Make sure to build GCC with GCC'

### DIFF
--- a/LibOS/Makefile
+++ b/LibOS/Makefile
@@ -125,7 +125,10 @@ $(GLIBC_SRC)/dlfcn/Versions: $(GLIBC_SRC)/.configured
 # makes sense only on x86_64 platforms. NOTE: We'd prefer to build libgomp.so.1 alone but it is
 # impossible (the only way to build it is as part of the complete GCC build).
 #
-# Override CC, CXX, AS in case we're compiling the rest of the project with clang.
+# We explicitly unset CC, CXX, AS environment variables for the case we're compiling the rest of the
+# project with clang. This is because in GCC build, "defining certain environment variables such as
+# CC can interfere with the functioning of make" (https://gcc.gnu.org/install/build.html). Indeed,
+# defining CC=gcc or CC=clang leads to errors during GCC build.
 # ------------------------------------------------------------------------------------------------
 GCC_VERSION ?= 10.2.0
 GCC_SRC = gcc-$(GCC_VERSION)
@@ -139,14 +142,14 @@ GCC_RUNTIME = $(addprefix $(RUNTIME_DIR)/, $(notdir $(GCC_TARGET)))
 
 $(GCC_BUILD_DIR)/Build.success: $(GCC_BUILD_DIR)/Makefile
 	@echo "Building gcc, may take a while to finish. Warning messages may show up. If this process terminates with failures, see \"$(GCC_BUILD_DIR)/gcc-build.log\" for more information."
-	(CC=gcc CXX=g++ AS=gcc $(MAKE) -C $(GCC_BUILD_DIR) 2>&1 > gcc-build.log) && touch $@
+	(unset CC CXX AS; $(MAKE) -C $(GCC_BUILD_DIR) 2>&1 > gcc-build.log) && touch $@
 
 $(GCC_TARGET): $(GCC_BUILD_DIR)/Build.success
 
 $(GCC_BUILD_DIR)/Makefile: $(GCC_SRC)/.configured
 	mkdir -p $(GCC_BUILD_DIR)
 	(cd $(GCC_BUILD_DIR) || exit 1; \
-	CC=gcc CXX=g++ AS=gcc \
+	unset CC CXX AS; \
 	../$(GCC_SRC)/configure --prefix=$(RUNTIME_DIR) \
 		--enable-languages=c \
 		--disable-multilib \


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Unfortunately, specifying environment variables like CC, CXX, AS during GCC build leads to strange errors. The official GCC docs simply state "defining certain environment variables such as CC can interfere with the functioning of make". See https://gcc.gnu.org/install/build.html.

That particular change (that broke GCC builds) was introduced recently in https://github.com/oscarlab/graphene/commit/2a1859184841f1ab902e6cf8d3aaacc008b75260. This PR simply reverts this change.

## How to test this PR? <!-- (if applicable) -->

Try `make -C LibOS gcc` in the root dir of Graphene. Without this PR (and after commit 2a1859184), it fails with funny errors. With this PR, the build of GCC is successful.

Kudos to Shih-han (Hans) Wang for reporting the bug and testing it!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1862)
<!-- Reviewable:end -->
