### PR TITLE
Fix stack walking in Linux

### DIFF
--- a/LibOS/glibc-patches/syscalldb-api.patch
+++ b/LibOS/glibc-patches/syscalldb-api.patch
@@ -53,7 +53,7 @@ new file mode 100644
 index 0000000000000000000000000000000000000000..4914e280d8cd6a62ab1ea4c9aa41601763167e7d
 --- /dev/null
 +++ b/syscalldb.h
-@@ -0,0 +1,33 @@
+@@ -0,0 +1,37 @@
 +#ifndef _SYSCALLDB_H_
 +#define _SYSCALLDB_H_
 +
@@ -64,8 +64,10 @@ index 0000000000000000000000000000000000000000..4914e280d8cd6a62ab1ea4c9aa416017
 +# if defined(PSEUDO) && defined(SYSCALL_NAME) && defined(SYSCALL_SYMBOL)
 +#  define SYSCALLDB                     \
 +    subq $128, %rsp;                    \
++    .cfi_adjust_cfa_offset 128;         \
 +    callq *syscalldb@GOTPCREL(%rip);    \
-+    addq $128, %rsp
++    addq $128, %rsp;                    \
++    .cfi_adjust_cfa_offset -128
 +# else
 +#  define SYSCALLDB                             \
 +    callq *syscalldb@GOTPCREL(%rip)
@@ -78,8 +80,10 @@ index 0000000000000000000000000000000000000000..4914e280d8cd6a62ab1ea4c9aa416017
 +
 +#define SYSCALLDB                           \
 +    "subq $128, %%rsp\n\t"                  \
++    ".cfi_adjust_cfa_offset 128\n\t"        \
 +    "callq *syscalldb@GOTPCREL(%%rip)\n\t"  \
-+    "addq $128, %%rsp\n\t"
++    "addq $128, %%rsp\n\t"                  \
++    ".cfi_adjust_cfa_offset -128\n\t"
 +
 +#define SYSCALLDB_ASM                       \
 +    "callq *syscalldb@GOTPCREL(%rip)\n\t"

--- a/Pal/src/db_rtld.c
+++ b/Pal/src/db_rtld.c
@@ -908,9 +908,9 @@ void DkDebugAttachBinary(PAL_STR uri, PAL_PTR start_addr) {
     for (ph = phdr; ph < &phdr[l->l_phnum]; ++ph)
         if (ph->p_type == PT_PHDR) {
             if (!map_start || ph->p_vaddr < map_start)
-                map_start = ph->p_vaddr;
+                map_start = ALLOC_ALIGN_DOWN(ph->p_vaddr);
             if (!map_end || ph->p_vaddr + ph->p_memsz > map_end)
-                map_end = ph->p_vaddr + ph->p_memsz;
+                map_end = ALLOC_ALIGN_UP(ph->p_vaddr + ph->p_memsz);
         }
 
     l->l_addr    = l->l_map_start - map_start;


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

This fixes the backtrace in Linux when calling LibOS syscalls (though not Linux-SGX yet, there is some issue with CFI mentioned in #1814).

## How to test this PR? <!-- (if applicable) -->

* Prepare a program that uses `getchar()` (or `read()`, for a simpler stack)
* Run in GDB, hit Ctrl-C while the program is waiting
* Run `backtrace`, the backtrace should be unbroken from `char_read` all the way to `main`, `__libc__start_main` and `_start`.
  (On master, the backtrace ends on `__GI___libc_read`).
* Run `disassemble __GI__libc_read`, on my system it starts with `mov %fs:0x18,%eax` and `test %eax, %eax`. (On master, the debug information is misaligned and GDB claims that the function starts earlier).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1864)
<!-- Reviewable:end -->
