### PR TITLE
[Pal/Linux-SGX] Remove "sgx.allow_file_creation" and always allow it

### DIFF
--- a/Documentation/cloud-deployment.rst
+++ b/Documentation/cloud-deployment.rst
@@ -114,7 +114,6 @@ cluster.
 
 #. Create the application-specific Manifest file :file:`python.manifest`::
 
-       sgx.allow_file_creation = 1
        sgx.enclave_size = 256M
        sgx.thread_num = 4
 

--- a/Documentation/manifest-syntax.rst
+++ b/Documentation/manifest-syntax.rst
@@ -367,19 +367,6 @@ size is limited to 260 bytes.
 be used only for debugging purposes. In production environments, this key must
 be provisioned to the enclave using local/remote attestation.
 
-Allowing file creation
-^^^^^^^^^^^^^^^^^^^^^^
-
-::
-
-    sgx.allow_file_creation=[1|0]
-    (Default: 0)
-
-This syntax specifies whether file creation is allowed from within the enclave.
-Set it to ``1`` to allow enclaves to create files and to ``0`` otherwise. Files
-created during enclave execution do not need to be marked as ``allowed_files``
-or ``trusted_files``.
-
 File check policy
 ^^^^^^^^^^^^^^^^^
 

--- a/Documentation/tutorials/pytorch/index.rst
+++ b/Documentation/tutorials/pytorch/index.rst
@@ -286,13 +286,6 @@ these allowed files only for simplicity. A next tutorial on PyTorch (with Docker
 integration) replaces all allowed files with trusted/protected files (that
 tutorial is work in progress).
 
-There is also the following line in the manifest template::
-
-   sgx.allow_file_creation = 1
-
-This allows the enclave to generate new files. We need this since the PyTorch
-Python script writes the result to ``result.txt``.
-
 Now we desribed how the manifest template looks like and what the SGX-specific
 manifest entries represent. Let's prepare all the files needed to run PyTorch in
 an SGX enclave::

--- a/Examples/openvino/openvino.manifest.template
+++ b/Examples/openvino/openvino.manifest.template
@@ -66,9 +66,6 @@ sgx.enclave_size = 2G
 # We (somewhat arbitrarily) specify 16 threads since OpenVINO is multithreaded.
 sgx.thread_num = 16
 
-# Allow Graphene-SGX to create files (needed for output image out_0.bmp)
-sgx.allow_file_creation  = 1
-
 # SGX trusted libraries
 
 # Glibc libraries

--- a/Examples/pytorch/pytorch.manifest.template
+++ b/Examples/pytorch/pytorch.manifest.template
@@ -140,9 +140,6 @@ sgx.trusted_files.model   = file:alexnet-pretrained.pt
 # Scratch space
 sgx.allowed_files.tmp     = file:/tmp
 
-# Output file
-sgx.allow_file_creation   = 1
-
 # The workload needs to fork/execve; this allows it to do so
 sgx.trusted_children.fork = file:python3.sig
 

--- a/LibOS/shim/test/regression/fopen_cornercases.c
+++ b/LibOS/shim/test/regression/fopen_cornercases.c
@@ -39,7 +39,7 @@ int main(int argc, char** argv) {
         return 1;
     }
 
-    /* creating file within Graphene (requires sgx.allow_file_creation = 1) */
+    /* creating file within Graphene */
     int fd = openat(AT_FDCWD, "tmp/filecreatedbygraphene", O_WRONLY | O_CREAT | O_TRUNC, 0666);
     if (fd < 0) {
         perror("failed to create file from within Graphene");

--- a/LibOS/shim/test/regression/manifest.template
+++ b/LibOS/shim/test/regression/manifest.template
@@ -31,8 +31,6 @@ sgx.trusted_files.libstdcxx = file:/usr$(ARCH_LIBDIR)/libstdc++.so.6
 sgx.trusted_files.victim = file:exec_victim
 sgx.trusted_children.victim = file:exec_victim.sig
 
-sgx.allow_file_creation = 1
-
 sgx.allowed_files.tmp_dir = file:tmp/
 
 sgx.thread_num = 6

--- a/Pal/regression/File.c
+++ b/Pal/regression/File.c
@@ -126,14 +126,6 @@ int main(int argc, char** argv, char** envp) {
         DkObjectClose(file6);
     }
 
-    file6 = DkStreamOpen("file:file_nonexist_disallowed.tmp", PAL_ACCESS_RDWR,
-                         PAL_SHARE_OWNER_R | PAL_SHARE_OWNER_W, PAL_CREATE_ALWAYS, 0);
-    if (!file6) {
-        pal_printf("File Creation Test 4 OK\n");
-    } else {
-        DkObjectClose(file6);
-    }
-
     if (file4) {
         /* test file writing */
 

--- a/Pal/regression/File.manifest.template
+++ b/Pal/regression/File.manifest.template
@@ -3,7 +3,6 @@ loader.debug_type = inline
 
 fs.mount.root.uri = file:
 
-sgx.allow_file_creation = 0
 sgx.trusted_files.tmp1 = file:File
 sgx.trusted_files.tmp2 = file:../regression/File
 sgx.allowed_files.tmp3 = file:file_nonexist.tmp

--- a/Pal/regression/test_pal.py
+++ b/Pal/regression/test_pal.py
@@ -412,19 +412,6 @@ class TC_20_SingleProcess(RegressionTestCase):
         # File Deletion
         self.assertFalse(pathlib.Path('file_delete.tmp').exists())
 
-    @unittest.skipUnless(HAS_SGX, 'this test requires SGX')
-    def test_101_nonexist_file(self):
-        # Explicitly remove the file file_nonexist_disallowed.tmp before
-        # running binary. Otherwise this test will fail if these tests are
-        # run repeatedly.
-        os.remove('file_nonexist_disallowed.tmp')
-
-        _, stderr = self.run_binary(['File'])
-
-        # Run file creation for non-existing file. This behavior is
-        # disallowed unless sgx.allow_file_creation is explicitly set to 1.
-        self.assertIn('File Creation Test 4 OK', stderr)
-
     def test_110_directory(self):
         for path in ['dir_exist.tmp', 'dir_nonexist.tmp', 'dir_delete.tmp']:
             try:

--- a/Pal/src/host/Linux-SGX/enclave_framework.c
+++ b/Pal/src/host/Linux-SGX/enclave_framework.c
@@ -231,7 +231,6 @@ struct trusted_file {
 DEFINE_LISTP(trusted_file);
 static LISTP_TYPE(trusted_file) g_trusted_file_list = LISTP_INIT;
 static spinlock_t g_trusted_file_lock = INIT_SPINLOCK_UNLOCKED;
-static bool g_allow_file_creation = 0;
 static int g_file_check_policy = FILE_CHECK_POLICY_STRICT;
 
 /* Assumes `path` is normalized */
@@ -288,9 +287,8 @@ int load_trusted_file(PAL_HANDLE file, sgx_stub_t** stubptr, uint64_t* sizeptr, 
         return ret;
     }
 
-    /* Allow to create the file when g_allow_file_creation is turned on;
-       The created file is added to allowed_file list for later access */
-    if (create && g_allow_file_creation) {
+    /* always allow creating files */
+    if (create) {
         register_trusted_file(uri, NULL, /*check_duplicates=*/true);
         return 0;
     }
@@ -865,11 +863,6 @@ no_trusted:
 
 no_allowed:
     ret = 0;
-
-    if (get_config(store, "sgx.allow_file_creation", cfgbuf, cfgsize) > 0 && cfgbuf[0] == '1')
-        g_allow_file_creation = true;
-    else
-        g_allow_file_creation = false;
 
 out:
     free(cfgbuf);

--- a/Pal/src/host/Linux-SGX/signer/pal_sgx_sign.py
+++ b/Pal/src/host/Linux-SGX/signer/pal_sgx_sign.py
@@ -856,9 +856,6 @@ def main_sign(args):
         enclave_base_addr = attr['enclave_size']
         enclave_heap_min = 0
 
-    if manifest.get('sgx.allow_file_creation', None) is None:
-        manifest['sgx.allow_file_creation'] = '0'
-
     if manifest.get('sgx.enable_stats', None) is None:
         manifest['sgx.enable_stats'] = '0'
 

--- a/Tools/gsc/test/ubuntu18.04-nodejs.manifest
+++ b/Tools/gsc/test/ubuntu18.04-nodejs.manifest
@@ -1,3 +1,2 @@
-sgx.allow_file_creation = 1
 sgx.enclave_size = 2G
 sgx.thread_num = 16

--- a/Tools/gsc/test/ubuntu18.04-numpy.manifest
+++ b/Tools/gsc/test/ubuntu18.04-numpy.manifest
@@ -1,4 +1,3 @@
-sgx.allow_file_creation = 1
 sgx.enclave_size = 2G
 sgx.thread_num = 32
 sys.stack.size = 2M

--- a/Tools/gsc/test/ubuntu18.04-python3.manifest
+++ b/Tools/gsc/test/ubuntu18.04-python3.manifest
@@ -1,3 +1,2 @@
-sgx.allow_file_creation = 1
 sgx.enclave_size = 4G
 sgx.thread_num = 8

--- a/Tools/gsc/test/ubuntu18.04-pytorch.manifest
+++ b/Tools/gsc/test/ubuntu18.04-pytorch.manifest
@@ -1,4 +1,3 @@
-sgx.allow_file_creation = 1
 sgx.enclave_size = 4G
 sgx.thread_num = 32
 sys.stack.size = 2M


### PR DESCRIPTION

<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://graphene.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

The manifest option "sgx.allow_file_creation" is useless (most real-world apps will set it to "1" anyway). So this PR simply removes this option and always allows to create files.


<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->

All tests must pass (removed this option from some regression tests). Also I manually tested PyTorch, it still works.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1865)
<!-- Reviewable:end -->
