### PR TITLE
[Docs] Clarify build requirements

### DIFF
--- a/Documentation/devel/howto-doc.rst
+++ b/Documentation/devel/howto-doc.rst
@@ -41,18 +41,21 @@ not published.
 Building documentation
 ----------------------
 
-To build documentation, change directory to ``Documentation``, install
-prerequisites, and use ``make``, specifying the appropriate target. The output
-is in the ``_build`` directory:
+To build documentation, change directory to ``Documentation``, install prerequisites, and use
+``make``, specifying the appropriate target. The documentation is built with python3; if you have
+similar packages in python2, it may create problems; we recommend removing any similar packages in
+python2. Similarly, the documentation requires version 1.8 of sphinx.
+
+The output is in the ``_build`` directory:
 
 .. code-block:: sh
 
    # change directory to Documentation
    cd Documentation
 
-   # install prerequisites (use pip3 for Python3)
+   # install prerequisites
    sudo apt-get install doxygen
-   pip install -r requirements.txt
+   python3 -m pip install -r requirements.txt
 
    # build targets "html" and "man"
    make html man

--- a/Documentation/requirements.txt
+++ b/Documentation/requirements.txt
@@ -1,3 +1,4 @@
 sphinx==1.8.0
 breathe<4.13.0
 recommonmark
+sphinx_rtd_theme


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://graphene.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

In trying to build the html docs on my system, I ran into several issues following the current docs.  A lot boiled down to (a) that python2 just doesn't work and I had some conflicting packages installed (b) sphinx needs to be 1.8 or higher, and (c) I needed to install sphinx_rtd_theme.

I updated the instructions to be more clear about this, and added sphinx_rtd_theme to requirements.txt.

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->

Documentation only.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1867)
<!-- Reviewable:end -->
