### PR TITLE
Fix stack walking in Linux-SGX + add test for GDB

### DIFF
--- a/Jenkinsfiles/ubuntu-16.04.dockerfile
+++ b/Jenkinsfiles/ubuntu-16.04.dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update \
        curl \
        flex \
        gawk \
+       gdb \
        gettext \
        git \
        libapr1-dev \

--- a/Jenkinsfiles/ubuntu-18.04.dockerfile
+++ b/Jenkinsfiles/ubuntu-18.04.dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update && env DEBIAN_FRONTEND=noninteractive apt-get install -y \
     curl \
     flex \
     gawk \
+    gdb \
     gettext \
     git \
     libapr1-dev \

--- a/LibOS/shim/test/fs/test_pf.py
+++ b/LibOS/shim/test/fs/test_pf.py
@@ -39,7 +39,8 @@ class TC_50_ProtectedFiles(TC_00_FileSystem):
         for i in cls.INDEXES:
             cmd = [cls.PF_CRYPT, 'encrypt', '-w', cls.WRAP_KEY, '-i', cls.INPUT_FILES[i], '-o',
                    cls.ENCRYPTED_FILES[i]]
-            cls.run_native_binary(cls, cmd, libpath=os.path.join(os.getcwd(), 'lib'))
+
+            cls.run_native_binary(cmd, libpath=os.path.join(os.getcwd(), 'lib'))
 
     def __pf_crypt(self, args):
         args.insert(0, self.PF_CRYPT)

--- a/LibOS/shim/test/regression/.gitignore
+++ b/LibOS/shim/test/regression/.gitignore
@@ -14,6 +14,7 @@
 /bootstrap_pie
 /bootstrap_static
 /cpuid
+/debug
 /dev
 /epoll_wait_timeout
 /eventfd

--- a/LibOS/shim/test/regression/Makefile
+++ b/LibOS/shim/test/regression/Makefile
@@ -12,6 +12,7 @@ c_executables = \
 	bootstrap \
 	bootstrap_pie \
 	bootstrap_static \
+	debug \
 	dev \
 	epoll_wait_timeout \
 	eventfd \
@@ -138,6 +139,7 @@ include ../../../../Scripts/Makefile.Test
 
 CFLAGS-bootstrap_static = -static
 CFLAGS-bootstrap_pie = -fPIC -pie
+CFLAGS-debug = -g3
 CFLAGS-exec_same = -pthread
 CFLAGS-shared_object = -fPIC -pie
 CFLAGS-syscall += -I$(PALDIR)/../include -I$(PALDIR)/host/$(PAL_HOST) -I$(PALDIR)/../include/arch/$(ARCH)/Linux
@@ -167,6 +169,7 @@ LDLIBS-attestation += $(PALDIR)/../lib/crypto/mbedtls/install/lib/libmbedcrypto.
 
 export PAL_LOADER = $(RUNTIME)/pal-$(PAL_HOST)
 export LIBPAL_PATH = $(RUNTIME)/libpal-$(PAL_HOST).so
+export HOST_PAL_PATH = $(RUNTIME)/../Pal/src/host/$(PAL_HOST)
 export PYTHONPATH=../../../../Scripts
 
 .PHONY: regression

--- a/LibOS/shim/test/regression/debug.c
+++ b/LibOS/shim/test/regression/debug.c
@@ -1,0 +1,13 @@
+#include <stdio.h>
+
+__attribute__((noinline)) static void func(void) {
+    printf("hello\n");
+    fflush(stdout);
+    /* Prevent tail call, so that we get a stack trace including func(). */
+    __asm__ volatile("");
+}
+
+int main(void) {
+    func();
+    return 0;
+}

--- a/LibOS/shim/test/regression/debug.gdb
+++ b/LibOS/shim/test/regression/debug.gdb
@@ -1,0 +1,35 @@
+set breakpoint pending on
+set pagination off
+
+# Check if debug sources are loaded in our program, and we can break inside.
+
+tbreak func
+commands
+  echo \n<backtrace 1 start>\n
+  backtrace
+  echo <backtrace 1 end>\n\n
+
+  # Check if we can break inside PAL and get a full backtrace (across glibc).
+
+  tbreak char_write
+  commands
+    echo \n<backtrace 2 start>\n
+    backtrace
+    echo <backtrace 2 end>\n\n
+    continue
+  end
+
+  # Check if we can break inside OCALL (SGX only).
+
+  tbreak sgx_ocall_write
+  commands
+    echo \n<backtrace 3 start>\n
+    backtrace
+    echo <backtrace 3 end>\n\n
+    continue
+  end
+
+  continue
+end
+
+run

--- a/Pal/src/host/Linux-SGX/db_rtld.c
+++ b/Pal/src/host/Linux-SGX/db_rtld.c
@@ -227,11 +227,14 @@ void setup_pal_map(struct link_map* pal_map) {
     pal_map->l_prev = pal_map->l_next = NULL;
     g_loaded_maps = pal_map;
 
-    struct debug_map* debug_map = debug_map_alloc(pal_map->l_name, &g_section_text);
+    struct debug_map* debug_map = debug_map_alloc(pal_map->l_name, (void*)pal_map->l_addr);
     if (!debug_map) {
         SGX_DBG(DBG_E, "setup_pal_map: error allocating new map\n");
         return;
     }
+
+    if (!debug_map_add_section(debug_map, ".text", &g_section_text))
+        goto fail;
 
     if (!debug_map_add_section(debug_map, ".rodata", &g_section_rodata))
         goto fail;

--- a/Pal/src/host/Linux-SGX/enclave_entry.S
+++ b/Pal/src/host/Linux-SGX/enclave_entry.S
@@ -22,6 +22,8 @@
 	.type enclave_entry, @function
 
 enclave_entry:
+	.cfi_startproc
+
 	# On EENTER, RAX is the current SSA index (aka CSSA), RBX is the address of
 	# TCS, RCX is the address of IP following EENTER. Other regs are not trusted.
 
@@ -488,6 +490,8 @@ enclave_entry:
 	# exit address in RDX, mov it to RBX
 	movq %rdx, %rbx
 	jmp .Lclear_and_eexit
+
+	.cfi_endproc
 
 	.global sgx_ocall
 	.type sgx_ocall, @function

--- a/Pal/src/host/Linux-SGX/enclave_entry.S
+++ b/Pal/src/host/Linux-SGX/enclave_entry.S
@@ -622,9 +622,16 @@ sgx_ocall:
 	.global __morestack
 	.type __morestack, @function
 __morestack:
-#endif
 
 	.cfi_startproc
+
+	# Parse trusted stack frame from (saved) RBP.
+	.cfi_def_cfa %rbp, 0
+	.cfi_offset %rip, 8
+	.cfi_offset %rbp, 0
+#else
+	.cfi_startproc
+#endif
 
 	# Clear "extended" state (FPU aka x87, SSE, AVX, ...).
 

--- a/Pal/src/host/Linux-SGX/sgx_entry.S
+++ b/Pal/src/host/Linux-SGX/sgx_entry.S
@@ -9,6 +9,8 @@
 	.type sgx_ecall, @function
 
 sgx_ecall:
+	.cfi_startproc
+
 	# put entry address in RDX
 	leaq .Lsgx_entry(%rip), %rdx
 
@@ -16,11 +18,17 @@ sgx_ecall:
 
 .Ldo_ecall_callee_save:
 	pushq %rbx
+	.cfi_adjust_cfa_offset 8
 	pushq %rbp
+	.cfi_adjust_cfa_offset 8
 	pushq %r12
+	.cfi_adjust_cfa_offset 8
 	pushq %r13
+	.cfi_adjust_cfa_offset 8
 	pushq %r14
+	.cfi_adjust_cfa_offset 8
 	pushq %r15
+	.cfi_adjust_cfa_offset 8
 
 .Ldo_ecall:
 	# increment per-thread EENTER counter for stats
@@ -38,12 +46,19 @@ sgx_ecall:
 	# currently only ECALL_THREAD_RESET returns
 .Lafter_resume:
 	popq %r15
+	.cfi_adjust_cfa_offset -8
 	popq %r14
+	.cfi_adjust_cfa_offset -8
 	popq %r13
+	.cfi_adjust_cfa_offset -8
 	popq %r12
+	.cfi_adjust_cfa_offset -8
 	popq %rbp
+	.cfi_adjust_cfa_offset -8
 	popq %rbx
+	.cfi_adjust_cfa_offset -8
 	retq
+	.cfi_endproc
 
 	.global async_exit_pointer
 	.type async_exit_pointer, @function

--- a/Runtime/pal_loader
+++ b/Runtime/pal_loader
@@ -60,9 +60,13 @@ if [ "$GDB" == "1" ]; then
 	fi
 	if [ -v SGX ]; then
 		PREFIX+=("-x" "$HOST_PAL_PATH/gdb_integration/graphene_sgx_gdb.py")
-		ENVS+=("LD_PRELOAD=$HOST_PAL_PATH/gdb_integration/sgx_gdb.so")
+		ENVS+=("LD_PRELOAD=$HOST_PAL_PATH/gdb_integration/sgx_gdb.so:$LD_PRELOAD")
 	else
 		PREFIX+=("-x" "$HOST_PAL_PATH/gdb_integration/graphene_gdb.py")
+	fi
+	if [ "$GDB_SCRIPT" != "" ]; then
+        # Run a script in batch mode, and without TTY (so that it can be piped, redirected etc.)
+		PREFIX+=("-x" "$GDB_SCRIPT" "-batch" "-tty=/dev/null")
 	fi
 	PREFIX+=("--args")
 fi

--- a/Scripts/Makefile.configs
+++ b/Scripts/Makefile.configs
@@ -56,6 +56,7 @@ CXXFLAGS += -gdwarf-2 -g3
 ASFLAGS += -gdwarf-2 -g3
 CFLAGS += -DDEBUG
 ASFLAGS += -DDEBUG
+CXXFLAGS += -DDEBUG
 endif
 
 ifeq ($(DEBUG),)

--- a/Scripts/Makefile.configs
+++ b/Scripts/Makefile.configs
@@ -53,6 +53,7 @@ CXXFLAGS += -Wall -std=c++14
 ifeq ($(DEBUG),1)
 CFLAGS += -gdwarf-2 -g3
 CXXFLAGS += -gdwarf-2 -g3
+ASFLAGS += -gdwarf-2 -g3
 CFLAGS += -DDEBUG
 ASFLAGS += -DDEBUG
 endif


### PR DESCRIPTION
This is based on https://github.com/oscarlab/graphene/pull/1864, so I'm marking it as draft until the other PR is merged.

SGX backtraces should now work, i.e. it's possible to break in an ocall, and see the backtrace up to the code inside enclave. Unfortunately, the backtrace doesn't go any further (to program startup outside the enclave).

There is also a simple regression test for GDB that checks if:
* breakpoints work (which should catch problems with symbol loading),
* backtraces look sane (`_start`, no `??`).

## How to test this PR? <!-- (if applicable) -->

See https://github.com/oscarlab/graphene/pull/1864 but should work also in Linux-SGX.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1868)
<!-- Reviewable:end -->
