### PR TITLE
[LibOS] Fill si_code field in siginfo_t struct in kill/tkill/tgkill

### DIFF
--- a/LibOS/shim/src/sys/shim_exit.c
+++ b/LibOS/shim/src/sys/shim_exit.c
@@ -65,6 +65,7 @@ int thread_destroy(struct shim_thread* thread, bool send_ipc) {
             info.si_pid    = thread->tid;
             info.si_uid    = thread->uid;
             info.si_status = (exit_code & 0xff) << 8;
+            info.si_code   = (exit_code & 0xff) >= 128 ? CLD_KILLED : CLD_EXITED;
 
             if (append_signal(parent, &info) >= 0) {
                 thread_wakeup(parent);

--- a/LibOS/shim/src/sys/shim_sigaction.c
+++ b/LibOS/shim/src/sys/shim_sigaction.c
@@ -257,6 +257,7 @@ static int _signal_one_thread(struct shim_thread* thread, void* _arg) {
         siginfo_t info = {
             .si_signo = arg->sig,
             .si_pid   = arg->sender,
+            .si_code  = SI_USER
         };
         ret = append_signal(NULL, &info);
         if (ret < 0) {
@@ -411,6 +412,7 @@ int do_kill_thread(IDTYPE sender, IDTYPE tgid, IDTYPE tid, int sig, bool use_ipc
                 siginfo_t info = {
                     .si_signo = sig,
                     .si_pid   = sender,
+                    .si_code  = SI_TKILL
                 };
                 ret = append_signal(thread, &info);
                 if (ret >= 0) {
@@ -445,7 +447,8 @@ int shim_do_tkill(pid_t tid, int sig) {
             siginfo_t info;
             memset(&info, 0, sizeof(siginfo_t));
             info.si_signo = sig;
-            info.si_pid   = cur->tid;
+            info.si_pid   = cur->tgid;
+            info.si_code  = SI_TKILL;
             deliver_signal(&info, NULL);
         }
         return 0;
@@ -468,7 +471,8 @@ int shim_do_tgkill(pid_t tgid, pid_t tid, int sig) {
             siginfo_t info;
             memset(&info, 0, sizeof(siginfo_t));
             info.si_signo = sig;
-            info.si_pid   = cur->tid;
+            info.si_pid   = cur->tgid;
+            info.si_code  = SI_TKILL;
             deliver_signal(&info, NULL);
         }
         return 0;


### PR DESCRIPTION


<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://graphene.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

When a signal arrives, it must have a meaningful value in its `siginfo_t::si_code` field. Previously, Graphene set this value correctly for SIGFPE, SIGILL, SIGSEGV, SIGBUS, and for SIGCHLD during `waitid()`. However, it was not set during `kill()`, `tkill()`, `tgkill()`, and when parent thread/process was notified about the child's termination on `thread_destroy()`. This commit adds these last two scenarios; this is required for correct Glibc's pthread
cancellation via `sigcancel_handler()`.

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->

All tests must pass. Didn't add a new test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1870)
<!-- Reviewable:end -->
