### PR TITLE
GDB: support extended registers

### DIFF
--- a/LibOS/shim/test/regression/.gitignore
+++ b/LibOS/shim/test/regression/.gitignore
@@ -15,6 +15,7 @@
 /bootstrap_static
 /cpuid
 /debug
+/debug_regs-x86_64
 /dev
 /epoll_wait_timeout
 /eventfd

--- a/LibOS/shim/test/regression/Makefile
+++ b/LibOS/shim/test/regression/Makefile
@@ -3,6 +3,7 @@ include ../../../../Scripts/Makefile.configs
 c_executables-x86_64 = \
 	attestation \
 	cpuid \
+	debug_regs-x86_64 \
 	rdtsc \
 	sighandler_divbyzero
 
@@ -140,6 +141,7 @@ include ../../../../Scripts/Makefile.Test
 CFLAGS-bootstrap_static = -static
 CFLAGS-bootstrap_pie = -fPIC -pie
 CFLAGS-debug = -g3
+CFLAGS-debug_regs-x86_64 = -g3
 CFLAGS-exec_same = -pthread
 CFLAGS-shared_object = -fPIC -pie
 CFLAGS-syscall += -I$(PALDIR)/../include -I$(PALDIR)/host/$(PAL_HOST) -I$(PALDIR)/../include/arch/$(ARCH)/Linux

--- a/LibOS/shim/test/regression/debug_regs-x86_64.c
+++ b/LibOS/shim/test/regression/debug_regs-x86_64.c
@@ -1,0 +1,25 @@
+#include <stdint.h>
+
+int main(void) {
+    volatile uint64_t val = 0;
+
+    __asm__ volatile("int3");
+
+    __asm__ volatile(
+        "movq %1, %%rdx\n"
+        "int3\n"
+        "movq %%rdx, %0\n"
+        : "=m"(val)
+        : "m"(val)
+        : "rdx");
+
+    __asm__ volatile(
+        "movhps %1, %%xmm0\n"
+        "movlps %1, %%xmm0\n"
+        "int3\n"
+        "movlps %%xmm0, %0\n"
+        : "=m"(val)
+        : "m"(val)
+        : "xmm0");
+    return 0;
+}

--- a/LibOS/shim/test/regression/debug_regs-x86_64.gdb
+++ b/LibOS/shim/test/regression/debug_regs-x86_64.gdb
@@ -1,0 +1,36 @@
+set breakpoint pending on
+set pagination off
+
+# Run until trap #1
+run
+
+# Run until trap #2, check RDX register read
+set val = 0x1000100010001000
+continue
+echo \n<RDX start>\n
+print/x $rdx
+echo <RDX end>\n\n
+
+# Check RDX register write
+set $rdx = 0x2000200020002000
+next
+echo \n<RDX result start>\n
+print/x val
+echo <RDX result end>\n\n
+
+# Run until trap #3, check XMM0 register read
+set val = 0x3000300030003000
+continue
+echo \n<XMM0 start>\n
+print/x $xmm0.uint128
+echo <XMM0 end>\n\n
+
+# Check XMM0 register write
+set $xmm0.uint128 = 0x4000400040004000
+next
+echo \n<XMM0 result start>\n
+print/x val
+echo <XMM0 result end>\n\n
+
+# Run until end
+continue

--- a/LibOS/shim/test/regression/test_libos.py
+++ b/LibOS/shim/test/regression/test_libos.py
@@ -623,6 +623,25 @@ class TC_50_GDB(RegressionTestCase):
             self.assertIn(' _start ()', backtrace_3)
             self.assertNotIn('??', backtrace_3)
 
+    @unittest.skipUnless(ON_X86, 'x86-specific')
+    def test_010_regs_x86_64(self):
+        # To run this test manually, use:
+        # GDB=1 GDB_SCRIPT=debug_regs-x86_64.gdb ./pal_loader debug_regs-x86_64
+
+        stdout, stderr = self.run_gdb(['debug_regs-x86_64'], 'debug_regs-x86_64.gdb')
+
+        rdx = self.find('RDX', stdout)
+        self.assertEqual(rdx, '$1 = 0x1000100010001000')
+
+        rdx_result = self.find('RDX result', stdout)
+        self.assertEqual(rdx_result, '$2 = 0x2000200020002000')
+
+        xmm0 = self.find('XMM0', stdout)
+        self.assertEqual(xmm0, '$3 = 0x30003000300030003000300030003000')
+
+        xmm0_result = self.find('XMM0 result', stdout)
+        self.assertEqual(xmm0_result, '$4 = 0x4000400040004000')
+
 
 class TC_80_Socket(RegressionTestCase):
     def test_000_getsockopt(self):


### PR DESCRIPTION
Issue: https://github.com/oscarlab/graphene/issues/1814

On top of https://github.com/oscarlab/graphene/pull/1868.

This allows reading/writing XMM0 etc. by passing XSAVE data when GDB requests it. There is also a test for that.

## How to test this PR? <!-- (if applicable) -->

Check if `print $xmm0` and `set $xmm0 = ...` work.

You can use the provided test program (`tdebug_regs.c`) for that. In `LibOS/shim/test/regression`:

* Run the test script: `SGX=1 GDB=1 GDB_SCRIPT=debug_regs.gdb pal_loader ./debug_regs`
* Or play with the program in GDB: `SGX=1 GDB=1 pal_loader ./debug_regs`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1874)
<!-- Reviewable:end -->
