### PR TITLE
[LibOS] Add XSAVE area handling and save/restore it on child thread creation

### DIFF
--- a/LibOS/shim/include/arch/x86_64/shim_tcb-arch.h
+++ b/LibOS/shim/include/arch/x86_64/shim_tcb-arch.h
@@ -26,6 +26,85 @@ struct shim_regs {
     uint64_t rip;
 };
 
+/* adopt Linux x86-64 structs for FP layout: self-contained definition is needed for LibOS, so
+ * define the exact same layout with `shim_` prefix; taken from
+ * https://elixir.bootlin.com/linux/v5.9/source/arch/x86/include/uapi/asm/sigcontext.h */
+#define SHIM_FP_XSTATE_MAGIC1      0x46505853U
+#define SHIM_FP_XSTATE_MAGIC2      0x46505845U
+#define SHIM_FP_XSTATE_MAGIC2_SIZE (sizeof(SHIM_FP_XSTATE_MAGIC2))
+
+#define SHIM_XSTATE_ALIGN 64
+
+enum SHIM_XFEATURE {
+    SHIM_XFEATURE_FP,
+    SHIM_XFEATURE_SSE,
+    SHIM_XFEATURE_YMM,
+    SHIM_XFEATURE_BNDREGS,
+    SHIM_XFEATURE_BNDCSR,
+    SHIM_XFEATURE_OPMASK,
+    SHIM_XFEATURE_ZMM_Hi256,
+    SHIM_XFEATURE_Hi16_ZMM,
+    SHIM_XFEATURE_PT,
+    SHIM_XFEATURE_PKRU,
+};
+
+#define SHIM_XFEATURE_MASK_FP        (1UL << SHIM_XFEATURE_FP)
+#define SHIM_XFEATURE_MASK_SSE       (1UL << SHIM_XFEATURE_SSE)
+#define SHIM_XFEATURE_MASK_YMM       (1UL << SHIM_XFEATURE_YMM)
+#define SHIM_XFEATURE_MASK_BNDREGS   (1UL << SHIM_XFEATURE_BNDREGS)
+#define SHIM_XFEATURE_MASK_BNDCSR    (1UL << SHIM_XFEATURE_BNDCSR)
+#define SHIM_XFEATURE_MASK_OPMASK    (1UL << SHIM_XFEATURE_OPMASK)
+#define SHIM_XFEATURE_MASK_ZMM_Hi256 (1UL << SHIM_XFEATURE_ZMM_Hi256)
+#define SHIM_XFEATURE_MASK_Hi16_ZMM  (1UL << SHIM_XFEATURE_Hi16_ZMM)
+#define SHIM_XFEATURE_MASK_PT        (1UL << SHIM_XFEATURE_PT)
+#define SHIM_XFEATURE_MASK_PKRU      (1UL << SHIM_XFEATURE_PKRU)
+
+#define SHIM_XFEATURE_MASK_FPSSE     (SHIM_XFEATURE_MASK_FP | SHIM_XFEATURE_MASK_SSE)
+#define SHIM_XFEATURE_MASK_AVX512    (SHIM_XFEATURE_MASK_OPMASK | SHIM_XFEATURE_MASK_ZMM_Hi256 \
+                                      | SHIM_XFEATURE_MASK_Hi16_ZMM)
+
+/* Bytes 464..511 in the 512B layout of the FXSAVE/FXRSTOR frame are reserved for SW usage. On
+ * CPUs supporting XSAVE/XRSTOR, these bytes are used to extend the fpstate pointer in the
+ * sigcontext, which includes the extended state information along with fpstate information. */
+struct shim_fpx_sw_bytes {
+    uint32_t magic1;        /*!< SHIM_FP_XSTATE_MAGIC1 (it is an xstate context) */
+    uint32_t extended_size; /*!< g_shim_xsave_size + SHIM_FP_STATE_MAGIC2_SIZE */
+    uint64_t xfeatures;     /*!< XSAVE features (feature bit mask, including FP/SSE/extended) */
+    uint32_t xstate_size;   /*!< g_shim_xsave_size (XSAVE area size as reported by CPUID) */
+    uint32_t padding[7];    /*!< for future use */
+};
+
+/* 64-bit FPU frame (FXSAVE format, 512B total size) */
+struct shim_fpstate {
+    uint16_t cwd;
+    uint16_t swd;
+    uint16_t twd;
+    uint16_t fop;
+    uint64_t rip;
+    uint64_t rdp;
+    uint32_t mxcsr;
+    uint32_t mxcr_mask;
+    uint32_t st_space[32];  /*  8x  FP registers, 16 bytes each */
+    uint32_t xmm_space[64]; /* 16x XMM registers, 16 bytes each */
+    uint32_t reserved2[12];
+    union {
+        uint32_t reserved3[12];
+        struct shim_fpx_sw_bytes sw_reserved; /* potential extended state is encoded here */
+    };
+};
+
+struct shim_xstate_header {
+    uint64_t xfeatures;
+    uint64_t reserved1[2];
+    uint64_t reserved2[5];
+};
+
+struct shim_xstate {
+    struct shim_fpstate fpstate;          /* 512B legacy FXSAVE/FXRSTOR frame (FP and XMM regs) */
+    struct shim_xstate_header xstate_hdr; /* 64B header for newer XSAVE/XRSTOR frame */
+    /* rest is filled with extended regs (YMM, ZMM, ...) by HW + 4B of MAGIC2 value by SW */
+} __attribute__((aligned(SHIM_XSTATE_ALIGN)));
+
 static inline uint64_t shim_regs_get_sp(struct shim_regs* sr) {
     return sr->rsp;
 }

--- a/LibOS/shim/include/shim_context.h
+++ b/LibOS/shim/include/shim_context.h
@@ -9,6 +9,15 @@
 
 #include "shim_tcb.h"
 
+extern bool     g_shim_xsave_enabled;
+extern uint64_t g_shim_xsave_features;
+extern uint32_t g_shim_xsave_size;
+
+void shim_xstate_init(void);
+void shim_xstate_save(void* xstate_extended);
+void shim_xstate_restore(const void* xstate_extended);
+void shim_xstate_reset(void);
+
 void restore_child_context_after_clone(struct shim_context* context);
 void fixup_child_context(struct shim_regs* regs);
 

--- a/LibOS/shim/include/shim_thread.h
+++ b/LibOS/shim/include/shim_thread.h
@@ -313,6 +313,7 @@ struct shim_clone_args {
     struct shim_thread* thread;
     void* stack;
     unsigned long fs_base;
+    void* xstate_extended;
 };
 
 void* allocate_stack(size_t size, size_t protect_size, bool user);

--- a/LibOS/shim/src/Makefile
+++ b/LibOS/shim/src/Makefile
@@ -127,6 +127,10 @@ all_objs = \
 graphene_lib = .lib/graphene-lib.a
 pal_lib = $(RUNTIME_DIR)/libpal-$(PAL_HOST).so
 
+ifeq ($(ARCH),x86_64)
+	CFLAGS += -mfxsr -mxsave
+endif
+
 ifeq ($(findstring x86_64,$(SYS))$(findstring linux,$(SYS)),x86_64linux)
 all: $(files_to_build) $(files_to_install)
 else

--- a/LibOS/shim/src/shim_context-x86_64.c
+++ b/LibOS/shim/src/shim_context-x86_64.c
@@ -1,13 +1,137 @@
 /* SPDX-License-Identifier: LGPL-3.0-or-later */
 
 /*
- * This file contains code for x86-specific CPU context manipulation.
+ * This file contains code for x86_64-specific CPU context manipulation.
  */
 
 #include "shim_context.h"
 
 #include "asm-offsets.h"
+#include "immintrin.h"
+#include "pal.h"
 #include "shim_internal.h"
+
+/* 512 for legacy regs, 64 for xsave header */
+#define XSTATE_RESET_SIZE (512 + 64)
+
+bool     g_shim_xsave_enabled  = false;
+uint64_t g_shim_xsave_features = 0;
+uint32_t g_shim_xsave_size     = 0;
+
+const uint32_t g_shim_xstate_reset_state[XSTATE_RESET_SIZE / sizeof(uint32_t)]
+__attribute__((aligned(SHIM_XSTATE_ALIGN))) = {
+    0x037F, 0, 0, 0, 0, 0, 0x1F80,     0xFFFF, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0,      0, 0, 0, 0, 0, 0,          0,      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0,      0, 0, 0, 0, 0, 0,          0,      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0,      0, 0, 0, 0, 0, 0,          0,      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0,      0, 0, 0, 0, 0, 0,          0,      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0,      0, 0, 0, 0, 0, 0x80000000, 0,      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    // XCOMP_BV[63] = 1, compaction mode
+};
+
+#define CPUID_FEATURE_XSAVE   (1UL << 26)
+#define CPUID_FEATURE_OSXSAVE (1UL << 27)
+
+#define CPUID_LEAF_PROCINFO 0x00000001
+#define CPUID_LEAF_XSAVE 0x0000000d
+
+void shim_xstate_init(void) {
+    /* by default, fall back to old-style FXSAVE (if cannot deduce from CPUID below) */
+    g_shim_xsave_enabled  = false;
+    g_shim_xsave_features = SHIM_XFEATURE_MASK_FPSSE;
+    g_shim_xsave_size     = XSTATE_RESET_SIZE;
+
+    unsigned int value[4];
+    if (!DkCpuIdRetrieve(CPUID_LEAF_PROCINFO, 0, value))
+        goto out;
+
+    if (!(value[PAL_CPUID_WORD_ECX] & CPUID_FEATURE_XSAVE) ||
+        !(value[PAL_CPUID_WORD_ECX] & CPUID_FEATURE_OSXSAVE))
+        goto out;
+
+    if (!DkCpuIdRetrieve(CPUID_LEAF_XSAVE, 0, value))
+        goto out;
+
+    uint32_t xsavesize = value[PAL_CPUID_WORD_ECX];
+    uint64_t xfeatures = value[PAL_CPUID_WORD_EAX] |
+                         ((uint64_t)value[PAL_CPUID_WORD_EDX] << 32);
+    if (!xsavesize || !xfeatures) {
+        /* could not read xfeatures; fall back to old-style FXSAVE */
+        goto out;
+    }
+
+    if (xfeatures & ~SHIM_XFEATURE_MASK_FPSSE) {
+        /* support more than just FP and SSE, can use XSAVE (it was introduced with AVX) */
+        g_shim_xsave_enabled = true;
+    }
+
+    g_shim_xsave_features  = xfeatures;
+    g_shim_xsave_size      = xsavesize;
+
+out:
+    debug("LibOS xsave_enabled %d, xsave_size 0x%x(%u), xsave_features 0x%lx\n",
+          g_shim_xsave_enabled, g_shim_xsave_size, g_shim_xsave_size, g_shim_xsave_features);
+}
+
+void shim_xstate_save(void* xstate_extended) {
+    assert(IS_ALIGNED_PTR(xstate_extended, SHIM_XSTATE_ALIGN));
+
+    struct shim_xstate* xstate = (struct shim_xstate*)xstate_extended;
+    char* bytes_after_xstate   = (char*)xstate_extended + g_shim_xsave_size;
+
+    if (g_shim_xsave_enabled) {
+        memset(&xstate->xstate_hdr, 0, sizeof(xstate->xstate_hdr));
+        __builtin_ia32_xsave64(xstate, /*mask=*/-1LL);
+    } else {
+        __builtin_ia32_fxsave64(xstate);
+    }
+
+    /* Emulate software format for bytes 464..511 in the 512-byte layout of the FXSAVE/FXRSTOR
+     * frame that Linux uses for x86-64:
+     *   https://elixir.bootlin.com/linux/v5.9/source/arch/x86/kernel/fpu/signal.c#L86
+     *   https://elixir.bootlin.com/linux/v5.9/source/arch/x86/kernel/fpu/signal.c#L517
+     *
+     * This format is assumed by Glibc; this will also be useful if we implement checks in LibOS
+     * similar to Linux's check_for_xstate(). Note that we don't care about CPUs older than
+     * FXSAVE-enabled (so-called "legacy frames"), therefore we always use MAGIC1 and MAGIC2. */
+    struct shim_fpx_sw_bytes* fpx_sw = &xstate->fpstate.sw_reserved;
+    fpx_sw->magic1        = SHIM_FP_XSTATE_MAGIC1;
+    fpx_sw->extended_size = g_shim_xsave_size + SHIM_FP_XSTATE_MAGIC2_SIZE;
+    fpx_sw->xfeatures     = g_shim_xsave_features;
+    fpx_sw->xstate_size   = g_shim_xsave_size;
+    memset(&fpx_sw->padding, 0, sizeof(fpx_sw->padding));
+
+    /* the last 32-bit word of the extended FXSAVE/XSAVE area (at the xstate + extended_size
+     * - FP_XSTATE_MAGIC2_SIZE address) is set to FP_XSTATE_MAGIC2 so that app/Graphene can sanity
+     * check FXSAVE/XSAVE size calculations */
+    *((__typeof__(SHIM_FP_XSTATE_MAGIC2)*)bytes_after_xstate) = SHIM_FP_XSTATE_MAGIC2;
+}
+
+void shim_xstate_restore(const void* xstate_extended) {
+    assert(IS_ALIGNED_PTR(xstate_extended, SHIM_XSTATE_ALIGN));
+
+    struct shim_xstate* xstate = (struct shim_xstate*)xstate_extended;
+    char* bytes_after_xstate   = (char*)xstate_extended + g_shim_xsave_size;
+
+    struct shim_fpx_sw_bytes* fpx_sw = &xstate->fpstate.sw_reserved;
+    assert(fpx_sw->magic1 == SHIM_FP_XSTATE_MAGIC1);
+    assert(fpx_sw->extended_size == g_shim_xsave_size + SHIM_FP_XSTATE_MAGIC2_SIZE);
+    assert(fpx_sw->xfeatures == g_shim_xsave_features);
+    assert(fpx_sw->xstate_size = g_shim_xsave_size);
+    assert(*((__typeof__(SHIM_FP_XSTATE_MAGIC2)*)bytes_after_xstate) == SHIM_FP_XSTATE_MAGIC2);
+
+    __UNUSED(bytes_after_xstate);
+    __UNUSED(fpx_sw);
+
+    if (g_shim_xsave_enabled)
+        __builtin_ia32_xrstor64(xstate, /*mask=*/-1LL);
+    else
+        __builtin_ia32_fxrstor64(xstate);
+}
+
+void shim_xstate_reset(void) {
+    shim_xstate_restore(g_shim_xstate_reset_state);
+}
 
 void restore_child_context_after_clone(struct shim_context* context) {
     assert(context->regs);

--- a/LibOS/shim/src/shim_init.c
+++ b/LibOS/shim/src/shim_init.c
@@ -459,6 +459,8 @@ noreturn void* shim_init(int argc, void* args) {
         shim_clean_and_exit(-EINVAL);
     }
 
+    shim_xstate_init();
+
     if (!create_lock(&__master_lock)) {
         debug("shim_init(): error: failed to allocate __master_lock\n");
         shim_clean_and_exit(-ENOMEM);

--- a/LibOS/shim/test/regression/.gitignore
+++ b/LibOS/shim/test/regression/.gitignore
@@ -36,6 +36,7 @@
 /file_size
 /fopen_cornercases
 /fork_and_exec
+/fp_multithread
 /fstat_cwd
 /futex
 /futex_bitset

--- a/LibOS/shim/test/regression/Makefile
+++ b/LibOS/shim/test/regression/Makefile
@@ -29,6 +29,7 @@ c_executables = \
 	file_size \
 	fopen_cornercases \
 	fork_and_exec \
+	fp_multithread \
 	fstat_cwd \
 	futex_bitset \
 	futex_requeue \
@@ -165,6 +166,9 @@ CFLAGS-attestation += -I$(PALDIR)/../lib/crypto/mbedtls/crypto/include \
                       -I$(PALDIR)/host/Linux-SGX \
                       -I$(PALDIR)/../include/pal
 LDLIBS-attestation += $(PALDIR)/../lib/crypto/mbedtls/install/lib/libmbedcrypto.a
+
+CFLAGS-fp_multithread += -pthread -fno-builtin  # see comment in the test's source
+LDLIBS-fp_multithread += -lm
 
 # Handle multiple tests which share one binary (Graphene requires 1-1 manifest-executable
 # correspondence).

--- a/LibOS/shim/test/regression/fp_multithread.c
+++ b/LibOS/shim/test/regression/fp_multithread.c
@@ -1,0 +1,52 @@
+/* use `-fno-builtin` compiler option to prevent nearbyint and fesetround being optimized out */
+
+#include <err.h>
+#include <fenv.h>
+#include <math.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+static int rounding_modes[] = {FE_TONEAREST, FE_UPWARD, FE_DOWNWARD, FE_TOWARDZERO};
+
+static char* get_rounding_mode(int mode) {
+    switch (mode) {
+        case FE_TONEAREST:  return "FE_TONEAREST ";
+        case FE_UPWARD:     return "FE_UPWARD    ";
+        case FE_DOWNWARD:   return "FE_DOWNWARD  ";
+        case FE_TOWARDZERO: return "FE_TOWARDZERO";
+    }
+    return "UNKNOWN";
+}
+
+static void* thread_fp(void* arg) {
+    int mode = fegetround();
+    printf("%s  child: 42.5 = %.1f, -42.5 = %.1f\n", get_rounding_mode(mode),
+           nearbyint(42.5), nearbyint(-42.5));
+    return arg;
+}
+
+int main(int argc, char* argv[]) {
+    int ret;
+
+    for (int i = 0; i < sizeof(rounding_modes)/sizeof(rounding_modes[0]); i++) {
+        int mode = rounding_modes[i];
+        ret = fesetround(mode);
+        if (ret)
+            err(EXIT_FAILURE, "fesetround failed");
+
+        pthread_t thread;
+        ret = pthread_create(&thread, NULL, thread_fp, NULL);
+        if (ret)
+            err(EXIT_FAILURE, "pthread_create failed");
+
+        ret = pthread_join(thread, NULL);
+        if (ret)
+            err(EXIT_FAILURE, "pthread_join failed");
+
+        printf("%s parent: 42.5 = %.1f, -42.5 = %.1f\n", get_rounding_mode(mode),
+               nearbyint(42.5), nearbyint(-42.5));
+    }
+
+    return 0;
+}

--- a/LibOS/shim/test/regression/test_libos.py
+++ b/LibOS/shim/test/regression/test_libos.py
@@ -234,6 +234,17 @@ class TC_01_Bootstrap(RegressionTestCase):
         # Multiple thread creation
         self.assertIn('128 Threads Created', stdout)
 
+    def test_602_fp_multithread(self):
+        stdout, _ = self.run_binary(['fp_multithread'])
+        self.assertIn('FE_TONEAREST   child: 42.5 = 42.0, -42.5 = -42.0', stdout)
+        self.assertIn('FE_TONEAREST  parent: 42.5 = 42.0, -42.5 = -42.0', stdout)
+        self.assertIn('FE_UPWARD      child: 42.5 = 43.0, -42.5 = -42.0', stdout)
+        self.assertIn('FE_UPWARD     parent: 42.5 = 43.0, -42.5 = -42.0', stdout)
+        self.assertIn('FE_DOWNWARD    child: 42.5 = 42.0, -42.5 = -43.0', stdout)
+        self.assertIn('FE_DOWNWARD   parent: 42.5 = 42.0, -42.5 = -43.0', stdout)
+        self.assertIn('FE_TOWARDZERO  child: 42.5 = 42.0, -42.5 = -42.0', stdout)
+        self.assertIn('FE_TOWARDZERO parent: 42.5 = 42.0, -42.5 = -42.0', stdout)
+
 @unittest.skipUnless(HAS_SGX,
     'This test is only meaningful on SGX PAL because only SGX catches raw '
     'syscalls and redirects to Graphene\'s LibOS. If we will add seccomp to '


### PR DESCRIPTION

<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://graphene.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

Previously, LibOS (shim) layer of Graphene didn't support XSAVE area.

The XSAVE area stores FP, XMM, YMM, ZMM, etc. registers and control states and is handled via FXSAVE/XSAVE and FXRSTOR/XRSTOR x86-64 instructions.

This PR is the first step towards adding full-fledged XSAVE support to LibOS. It adds XSAVE related structs and functions to LibOS code, and propagates XSAVE regs/states from parent to child on thread creation via `clone()`.

This PR is a partial recreation of #1218. My PR borrows the XSAVE structs and functions (but renames them for uniformity) from #1218. But XSAVE on signal-handling is not yet implemented; this is for the future.

Future commits will add XSAVE handling on syscall transitions and arriving signals.

## How to test this PR? <!-- (if applicable) -->

New test `fp_multithread` is added to LibOS regression suite.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1875)
<!-- Reviewable:end -->
