### PR TITLE
Add first meson.build for installing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+/build
+
 # No editor backup files.
 *.sw*
 *.backup

--- a/Runtime/meson.build
+++ b/Runtime/meson.build
@@ -1,0 +1,44 @@
+install_data('../Pal/src/host/Linux/libpal.so',
+    install_dir: pkglibexecdir / 'linux')
+install_subdir('../Pal/src/host/Linux/gdb_integration',
+    install_dir: pkglibexecdir / 'linux')
+
+install_data(
+    '../Pal/src/host/Linux-SGX/pal-sgx',
+    '../Pal/src/host/Linux-SGX/libpal.so',
+    install_dir: pkglibexecdir / 'linux-sgx')
+install_subdir('../Pal/src/host/Linux-SGX/gdb_integration',
+    install_dir: pkglibexecdir / 'linux-sgx')
+
+conf = configuration_data()
+conf.set_quoted('IN_GIT', '')
+
+hostpalpath_linux = prefix / pkglibexecdir / 'linux'
+conf_graphene = configuration_data()
+conf_graphene.merge_from(conf)
+conf_graphene.set('SGX', 0)
+conf_graphene.set_quoted('HOST_PAL_PATH', hostpalpath_linux)
+conf_graphene.set_quoted('LIBPAL_PATH', hostpalpath_linux / 'libpal.so')
+conf_graphene.set_quoted('PAL_CMD', hostpalpath_linux / 'libpal.so')
+
+configure_file(
+    input: 'pal_loader',
+    output: 'graphene',
+    configuration: conf_graphene,
+    install_dir: get_option('bindir'),
+)
+
+hostpalpath_linux_sgx = prefix / pkglibexecdir / 'linux-sgx'
+conf_graphene_sgx = configuration_data()
+conf_graphene_sgx.merge_from(conf)
+conf_graphene_sgx.set('SGX', 1)
+conf_graphene_sgx.set_quoted('HOST_PAL_PATH', hostpalpath_linux_sgx)
+conf_graphene_sgx.set_quoted('LIBPAL_PATH', hostpalpath_linux_sgx / 'libpal.so')
+conf_graphene_sgx.set_quoted('PAL_CMD', hostpalpath_linux_sgx / 'pal-sgx')
+
+configure_file(
+    input: 'pal_loader',
+    output: 'graphene-sgx',
+    configuration: conf_graphene_sgx,
+    install_dir: get_option('bindir'),
+)

--- a/Runtime/pal_loader
+++ b/Runtime/pal_loader
@@ -4,61 +4,79 @@
 # Copyright (C) 2019 Invisible Things Lab
 # Copyright (C) 2020 Intel Corporation
 #                    Michał Kowalczyk <mkow@invisiblethingslab.com>
+#                    Wojtek Porczyk <woju@invisiblethingslab.com>
 
-while :
-do
-	case "$1" in
-		"SGX")
-			SGX=1
-			export SGX
-			;;
-		"GDB")
-			GDB=1
-			;;
-		*)
-			break
-			;;
-	esac
-	shift
-done
 
-RUNTIME_DIR=$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")
-if [ -z "$PAL_HOST" ]; then
-    if ! command -v make >/dev/null; then
-        libpal="$RUNTIME_DIR/libpal-*.so"
-        libpal="$(echo -n "$libpal")"
-        libpal="${libpal//$RUNTIME_DIR\//}"
-        if [ "$libpal" = 'libpal-*.so' ]; then
-            echo "Unable to detect PAL_HOST. Please install the make program."
-            exit 1
+# This is how we detect whether we're installed or running from inside git repo.
+# If unchanged (i.e., if this reads IN_GIT between "at" characters), this is an
+# ordinary string and test -n "$IN_GIT" is true. But when installing, this is
+# rewritten using meson's configure_file() function to an empty string and the
+# else branch is taken. See also: ./meson.build and
+# https://mesonbuild.com/Reference-manual.html#configure_file.
+IN_GIT=@IN_GIT@
+
+if test -n "$IN_GIT"
+then
+    while :
+    do
+        case "$1" in
+            "SGX")
+                SGX=1
+                export SGX
+                ;;
+            "GDB")
+                GDB=1
+                ;;
+            *)
+                break
+                ;;
+        esac
+        shift
+    done
+
+    RUNTIME_DIR=$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")
+    if [ -z "$PAL_HOST" ]; then
+        if ! command -v make >/dev/null; then
+            libpal="$RUNTIME_DIR/libpal-*.so"
+            libpal="$(echo -n "$libpal")"
+            libpal="${libpal//$RUNTIME_DIR\//}"
+            if [ "$libpal" = 'libpal-*.so' ]; then
+                echo "Unable to detect PAL_HOST. Please install the make program."
+                exit 1
+            fi
+
+            array=("$libpal")
+            if [ ${#array[@]} -ne 1 ]; then
+                echo "Multiple libpal detected ($libpal). Please explicitly set the environment variable PAL_HOST."
+                exit 1
+            fi
+
+            PAL_HOST="${libpal%.so}"
+            PAL_HOST="${PAL_HOST#libpal-}"
+        else
+            PAL_HOST=$(make --no-print-directory --quiet -f "$RUNTIME_DIR/../Scripts/Makefile.configs" print_host 2>&1)
         fi
-
-        array=("$libpal")
-        if [ ${#array[@]} -ne 1 ]; then
-            echo "Multiple libpal detected ($libpal). Please explicitly set the environment variable PAL_HOST."
-            exit 1
-        fi
-
-        PAL_HOST="${libpal%.so}"
-        PAL_HOST="${PAL_HOST#libpal-}"
-    else
-        PAL_HOST=$(make --no-print-directory --quiet -f "$RUNTIME_DIR/../Scripts/Makefile.configs" print_host 2>&1)
     fi
+    PAL_CMD="$RUNTIME_DIR/pal-$PAL_HOST"
+    LIBPAL_PATH=$(realpath "$RUNTIME_DIR/libpal-$PAL_HOST.so")
+    HOST_PAL_PATH=$(realpath "$RUNTIME_DIR/../Pal/src/host/$PAL_HOST")
+else
+    PAL_CMD=@PAL_CMD@
+    LIBPAL_PATH=@LIBPAL_PATH@
+    HOST_PAL_PATH=@HOST_PAL_PATH@
+    SGX=@SGX@
 fi
 
 MANIFEST=
 ENVS=()
 PREFIX=()
-PAL_CMD="$RUNTIME_DIR/pal-$PAL_HOST"
-LIBPAL_PATH=$(realpath "$RUNTIME_DIR/libpal-$PAL_HOST.so")
-HOST_PAL_PATH=$(realpath "$RUNTIME_DIR/../Pal/src/host/$PAL_HOST")
 
 if [ "$GDB" == "1" ]; then
 	PREFIX=("gdb" "-q")
 	if [ -n "$INSIDE_EMACS" ]; then
 		PREFIX+=("-i=mi")
 	fi
-	if [ -v SGX ]; then
+	if [ 0"$SGX" -gt 0 ]; then
 		PREFIX+=("-x" "$HOST_PAL_PATH/gdb_integration/graphene_sgx_gdb.py")
 		ENVS+=("LD_PRELOAD=$HOST_PAL_PATH/gdb_integration/sgx_gdb.so:$LD_PRELOAD")
 	else
@@ -92,7 +110,7 @@ if [ "$MANIFEST" == "" ]; then
 fi
 
 if [ ! -f "$PAL_CMD" ]; then
-	echo "$PAL_CMD is not built"
+	echo "$PAL_CMD not found"
 	exit 1
 fi
 

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,11 @@
+project(
+    'graphene', 'c',
+    version: '1.0',
+    license: 'LGPLv3+',
+)
+
+prefix = get_option('prefix')
+pkglibexecdir = get_option('libexecdir') / meson.project_name()
+pkgdatadir = get_option('datadir') / meson.project_name()
+
+subdir('Runtime')


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://graphene.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

This adds a possibility to actually install graphene in the system, and make packages for distributions.

This also might be a beginning of switching build system to meson. See #760 for a discussion of alternative build system, which I hope to revive.

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->

Compile as usual with and without SGX (this is important that both variants are built together). Prepare some `helloworld` executable with manifest, signatures etc.

After that:
```sh
sudo apt install ninja-build

# can be replaced with `sudo apt install meson` on Debian since buster,
# but not on Ubuntu 18.04, where meson is too old
python3 -m pip install meson

# pick some suitable directory; if --prefix <path> is omitted,
# will install to /usr/local
meson setup build --prefix "$HOME"/tmp

ninja -C build # currently no-op, this is where any compilation would happen
ninja -C build install

export PATH="$HOME"/tmp/bin:"$PATH"  # or wherever you chose the prefix

cd "$HOME"/my-example-programs # with manifests and signatures and tokens already prepared
graphene ./helloworld.manifest
graphene-sgx ./helloworld.manifest.sgx
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1879)
<!-- Reviewable:end -->
