### PR TITLE
Create a helper script for running pytest

### DIFF
--- a/.ci/run-shellcheck
+++ b/.ci/run-shellcheck
@@ -14,5 +14,6 @@ LC_ALL=C.UTF-8 shellcheck "$@" \
     Scripts/clean-check-test-copy \
     Scripts/download \
     Scripts/gitignore-test \
+    Scripts/run-pytest \
     .ci/run-pylint \
     .ci/run-shellcheck

--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -7,5 +7,6 @@
  (asm-mode . ((indent-tabs-mode . t)))
  (shell-script-mode . ((indent-tabs-mode . t)))
  ("\.git/COMMIT_EDITMSG" . ((nil . ((fill-column . 80)))))
+ (rst-mode . ((fill-column . 80)))
  ((nil . ((truncate-lines . t)))
           (text-mode . ((eval . ((turn-on-auto-fill)))))))

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -39,7 +39,9 @@ Or you can see the archives at this google group:
 https://groups.google.com/forum/#!forum/graphene-support
 
 Please verify that your change doesn't introduce any insecure-by-default
-functionality. If an option allows users to introduce a security risk, the option should have a name prefixed with ``insecure__`` and be disabled by default.
+functionality. If an option allows users to introduce a security risk, the
+option should have a name prefixed with ``insecure__`` and be disabled by
+default.
 
 Simple bugfixes need not have advance discussion, but we welcome queries from
 newcomers.
@@ -175,8 +177,8 @@ For SGX, one needs to do the following::
 If a |nbsp| test fails unexpectedly, one can use the :makevar:`KEEP_LOG=1`
 option to get the complete output.
 
-One can run tests manually (prepend the command with ``SGX=1`` or ``PAL_HOST=Linux-SGX`` to run the
-SGX variant)::
+One can run tests manually (prepend the command with ``SGX=1`` or
+``PAL_HOST=Linux-SGX`` to run the SGX variant)::
 
    /path/to/graphene/Scripts/run-pytest -v -rs test_pal.py
    SGX=1 /path/to/graphene/Scripts/run-pytest -v -rs test_pal.py
@@ -186,8 +188,9 @@ It is also possible to run subset of tests::
    /path/to/graphene/Scripts/run-pytest -v -rs test_pal.py::TC_01_Bootstrap
    /path/to/graphene/Scripts/run-pytest -v -rs test_pal.py::TC_01_Bootstrap::test_100_basic_boostrapping
 
-The ``run-pytest`` script is a wrapper for `pytest <https://docs.pytest.org/en/stable/usage.html>`__
-and accepts the same command-line options.
+The ``run-pytest`` script is a wrapper for `pytest
+<https://docs.pytest.org/en/stable/usage.html>`__ and accepts the same
+command-line options.
 
 The shim unit tests work similarly, and are under
 :file:`LibOS/shim/test/regression`.
@@ -226,6 +229,10 @@ The current members of the management team are:
 The procedure for adding and removing maintainers
 -------------------------------------------------
 
-+ Joining: # of PRs submitted & merged + # of PRs reviewed + # of issues closed >= 20 (this means that a PR which fixes 3 issues counts as 4). Only complete and thorough reviews count.
-+ Leaving: a member may be removed if not active or notoriously breaking rules from this document.
-+ Additionally, at least 60% (rounded up) of current members have to agree to make any change to the team membership.
++ Joining: # of PRs submitted & merged + # of PRs reviewed + # of issues closed
+  >= 20 (this means that a PR which fixes 3 issues counts as 4). Only complete
+  and thorough reviews count.
++ Leaving: a member may be removed if not active or notoriously breaking rules
+  from this document.
++ Additionally, at least 60% (rounded up) of current members have to agree to
+  make any change to the team membership.

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -175,19 +175,19 @@ For SGX, one needs to do the following::
 If a |nbsp| test fails unexpectedly, one can use the :makevar:`KEEP_LOG=1`
 option to get the complete output.
 
-One can run tests manually::
+One can run tests manually (prepend the command with ``SGX=1`` or ``PAL_HOST=Linux-SGX`` to run the
+SGX variant)::
 
-   PYTHONPATH=path/to/graphene/Scripts
-   PAL_LOADER=path/to/pal-Linux
-   LIBPAL_PATH=path/to/libpal-Linux.so
-   export PYTHONPATH PAL_LOADER LIBPAL_PATH
-   python3 -m pytest -v -rs test_pal.py
+   /path/to/graphene/Scripts/run-pytest -v -rs test_pal.py
+   SGX=1 /path/to/graphene/Scripts/run-pytest -v -rs test_pal.py
 
 It is also possible to run subset of tests::
 
-   # after env export
-   python3 -m pytest -v -rs test_pal.py::TC_01_Bootstrap
-   python3 -m pytest -v -rs test_pal.py::TC_01_Bootstrap::test_100_basic_boostrapping
+   /path/to/graphene/Scripts/run-pytest -v -rs test_pal.py::TC_01_Bootstrap
+   /path/to/graphene/Scripts/run-pytest -v -rs test_pal.py::TC_01_Bootstrap::test_100_basic_boostrapping
+
+The ``run-pytest`` script is a wrapper for `pytest <https://docs.pytest.org/en/stable/usage.html>`__
+and accepts the same command-line options.
 
 The shim unit tests work similarly, and are under
 :file:`LibOS/shim/test/regression`.

--- a/LibOS/shim/test/fs/Makefile
+++ b/LibOS/shim/test/fs/Makefile
@@ -53,10 +53,6 @@ else
 $(execs)
 endif
 
-export PAL_LOADER = $(RUNTIME)/pal-$(PAL_HOST)
-export LIBPAL_PATH = $(RUNTIME)/libpal-$(PAL_HOST).so
-export PYTHONPATH = ../../../../Scripts
-
 .PHONY: fs-test
 fs-test: $(target)
 	$(RM) fs-test.xml
@@ -68,10 +64,10 @@ test: $(target)
 	$(MAKE) pf-test.xml
 
 fs-test.xml: test_fs.py $(call expand_target_to_token,$(target))
-	python3 -m pytest --junit-xml $@ -v $<
+	$(SCRIPTS_DIR)/run-pytest --junit-xml $@ -v $<
 
 pf-test.xml: test_pf.py $(call expand_target_to_token,$(target))
-	python3 -m pytest --junit-xml $@ -v $<
+	$(SCRIPTS_DIR)/run-pytest --junit-xml $@ -v $<
 
 .PHONY: clean-tmp
 clean-tmp:

--- a/LibOS/shim/test/regression/Makefile
+++ b/LibOS/shim/test/regression/Makefile
@@ -167,18 +167,13 @@ LDLIBS-attestation += $(PALDIR)/../lib/crypto/mbedtls/install/lib/libmbedcrypto.
 %: %.cpp
 	$(call cmd,cxxsingle)
 
-export PAL_LOADER = $(RUNTIME)/pal-$(PAL_HOST)
-export LIBPAL_PATH = $(RUNTIME)/libpal-$(PAL_HOST).so
-export HOST_PAL_PATH = $(RUNTIME)/../Pal/src/host/$(PAL_HOST)
-export PYTHONPATH=../../../../Scripts
-
 .PHONY: regression
 regression: $(target)
 	$(RM) libos-regression.xml
 	$(MAKE) libos-regression.xml
 
 libos-regression.xml: test_libos.py $(call expand_target_to_token,$(target))
-	python3 -m pytest --junit-xml $@ -v $<
+	../../../../Scripts/run-pytest --junit-xml $@ -v $<
 
 .PHONY: clean-tmp
 clean-tmp:

--- a/Pal/regression/Makefile
+++ b/Pal/regression/Makefile
@@ -131,17 +131,13 @@ endif
 $(graphene_lib):
 	$(MAKE) -C ../lib target=$(abspath .lib)/
 
-export PAL_LOADER = $(RUNTIME_DIR)/pal-$(PAL_HOST)
-export LIBPAL_PATH = $(RUNTIME_DIR)/libpal-$(PAL_HOST).so
-export PYTHONPATH=../../Scripts
-
 .PHONY: regression
 regression:
 	$(RM) pal-regression.xml
 	$(MAKE) pal-regression.xml
 
 pal-regression.xml: test_pal.py $(target) $(call expand_target_to_sig,$(target)) $(call expand_target_to_sgx,$(target)) $(call expand_target_to_token,$(target))
-	python3 -m pytest --junit-xml $@ -v $<
+	../../Scripts/run-pytest --junit-xml $@ -v $<
 
 .PHONY: clean
 clean:

--- a/Scripts/run-pytest
+++ b/Scripts/run-pytest
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+set -e
+
+# A wrapper for running pytest, either manually or through a Makefile.
+# Usage:
+#    PAL_HOST=Linux .../run-pytest
+#    PAL_HOST=Linux-SGX .../run-pytest
+#    SGX=1 .../run-pytest
+
+PROJECT_ROOT=$(realpath "$(dirname "$0")/..")
+
+# Determine PAL_HOST if we're not being run from inside Makefile.
+if [[ "$PAL_HOST" == "" ]]; then
+   if [[ "$SGX" == "1" ]]; then
+       export PAL_HOST="Linux-SGX"
+   else
+       export PAL_HOST="Linux"
+   fi
+   echo "Running pytest for PAL_HOST = $PAL_HOST"
+fi
+
+# Add path to regression.py common library.
+export PYTHONPATH="$PROJECT_ROOT/Scripts:$PYTHONPATH"
+
+# Environment variables needed by regression.py
+export PAL_LOADER="$PROJECT_ROOT/Runtime/pal-$PAL_HOST"
+export LIBPAL_PATH="$PROJECT_ROOT/Runtime/libpal-$PAL_HOST.so"
+export HOST_PAL_PATH="$PROJECT_ROOT/Pal/src/host/$PAL_HOST"
+
+exec python3 -m pytest "$@"


### PR DESCRIPTION
Running a subset of regression tests, or a single test, is
currently rather annoying, as you cannot simply run 'pytest':
you need to override PYTHONPATH and specify several environment
variables.

Instead, move the whole boilerplate to a wrapper scripts that
allows running pytest with any command line options. Use it in
Makefiles as well, so that it doesn't go out of sync with CI.

## How to test this PR? <!-- (if applicable) -->

Try to follow the instructions for `run-pytest` added in `CONTRIBUTING.rst`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1881)
<!-- Reviewable:end -->
