### PR TITLE
[LibOS] Use correct v5.8 x86 syscall numbers

### DIFF
--- a/LibOS/shim/include/arch/x86_64/shim_syscalls.h
+++ b/LibOS/shim/include/arch/x86_64/shim_syscalls.h
@@ -38,16 +38,18 @@
 #define __NR_rseq 334
 #endif
 #ifndef __NR_pidfd_send_signal
-#define __NR_pidfd_send_signal 335
+#define __NR_pidfd_send_signal 424
 #endif
 #ifndef __NR_io_uring_setup
-#define __NR_io_uring_setup 336
+#define __NR_io_uring_setup 425
 #endif
 #ifndef __NR_io_uring_enter
-#define __NR_io_uring_enter 337
+#define __NR_io_uring_enter 426
 #endif
 #ifndef __NR_io_uring_register
-#define __NR_io_uring_register 338
+#define __NR_io_uring_register 427
 #endif
-
+#ifndef __NR_syscalls
+#define __NR_syscalls 428
+#endif
 #endif  /* SHIM_SYSCALLS_H_ */

--- a/LibOS/shim/include/shim_defs.h
+++ b/LibOS/shim/include/shim_defs.h
@@ -1,6 +1,8 @@
 #ifndef _SHIM_DEFS_H_
 #define _SHIM_DEFS_H_
 
+#include "shim_syscalls.h"
+
 #define DEFAULT_HEAP_MIN_SIZE  (256 * 1024 * 1024) /* 256MB */
 #define DEFAULT_MEM_MAX_NPAGES (1024 * 1024)       /* 4GB */
 #define DEFAULT_BRK_MAX_SIZE   (256 * 1024)        /* 256KB */
@@ -17,9 +19,6 @@
 /* ELF aux vectors  */
 #define REQUIRED_ELF_AUXV       8  /* number of LibOS-supported vectors */
 #define REQUIRED_ELF_AUXV_SPACE 16 /* extra memory space (in bytes) */
-
-#if defined(__i386__) || defined(__x86_64__)
-#define LIBOS_SYSCALL_BOUND (340 + 1)
-#endif
+#define LIBOS_SYSCALL_BOUND __NR_syscalls
 
 #endif /* _SHIM_DEFS_H_ */

--- a/LibOS/shim/src/Makefile
+++ b/LibOS/shim/src/Makefile
@@ -26,7 +26,7 @@ CFLAGS += -Wno-gnu-alignof-expression
 # member" warning in Clang and newer GCC. That code needs to be rewritten.
 CFLAGS += -Wno-address-of-packed-member
 
-ASFLAGS += -Wa,--noexecstack -x assembler-with-cpp -I../include
+ASFLAGS += -Wa,--noexecstack -x assembler-with-cpp -I../include -I../include/arch/$(ARCH)
 
 LDFLAGS += -shared -nostdlib -z combreloc -z relro -z now -z defs \
 	  -rpath-link=$(abspath $(RUNTIME_DIR))


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

When compiling against v5.8 (or later) kernel headers, we encounter
compilation errors such as:

  In file included from /usr/include/asm/unistd.h:13,
                   from shim_parser.c:11:
  shim_parser.c:408:10: error: array index in initializer exceeds array bounds
           [__NR_io_uring_setup]    = {.slow = 0, .parser = {NULL}},

The remedy is to extend "syscall_parser_table" by modyfing the
definition of LIBOS_SYSCALL_BOUND so the offending system calls fit in the table.

While at it, also fix the actual values for syscall numbers in "shim_syscalls.h"
(The numbers are not sequential, there is an intentional gap between the numers)

Fixes #1878.

## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1882)
<!-- Reviewable:end -->
