### PR TITLE
[test] allow skipping LTP tests by fnmatch

### DIFF
--- a/LibOS/shim/test/ltp/ltp-sgx.cfg
+++ b/LibOS/shim/test/ltp/ltp-sgx.cfg
@@ -441,55 +441,12 @@ skip = yes
 timeout = 80
 skip = yes
 
-[fallocate01]
+# fallocate() not implemented
+[fallocate*]
 skip = yes
 
-[fallocate02]
-skip = yes
-
-[fallocate03]
-skip = yes
-
-[fallocate04]
-skip = yes
-
-[fallocate05]
-skip = yes
-
-[fanotify01]
-skip = yes
-
-[fanotify02]
-skip = yes
-
-[fanotify03]
-skip = yes
-
-[fanotify04]
-skip = yes
-
-[fanotify05]
-skip = yes
-
-[fanotify06]
-skip = yes
-
-[fanotify07]
-skip = yes
-
-[fanotify08]
-skip = yes
-
-[fanotify09]
-skip = yes
-
-[fanotify10]
-skip = yes
-
-[fanotify11]
-skip = yes
-
-[fanotify12]
+# fanotify() not implemented
+[fanotify*]
 skip = yes
 
 [fchdir01]

--- a/LibOS/shim/test/ltp/ltp.cfg
+++ b/LibOS/shim/test/ltp/ltp.cfg
@@ -307,55 +307,12 @@ must-pass =
 [faccessat01]
 timeout = 80
 
-[fallocate01]
+# fallocate() not implemented
+[fallocate*]
 skip = yes
 
-[fallocate02]
-skip = yes
-
-[fallocate03]
-skip = yes
-
-[fallocate04]
-skip = yes
-
-[fallocate05]
-skip = yes
-
-[fanotify01]
-skip = yes
-
-[fanotify02]
-skip = yes
-
-[fanotify03]
-skip = yes
-
-[fanotify04]
-skip = yes
-
-[fanotify05]
-skip = yes
-
-[fanotify06]
-skip = yes
-
-[fanotify07]
-skip = yes
-
-[fanotify08]
-skip = yes
-
-[fanotify09]
-skip = yes
-
-[fanotify10]
-skip = yes
-
-[fanotify11]
-skip = yes
-
-[fanotify12]
+# fanotify() not implemented
+[fanotify*]
 skip = yes
 
 [fchdir02]

--- a/LibOS/shim/test/ltp/runltp_xml.py
+++ b/LibOS/shim/test/ltp/runltp_xml.py
@@ -6,6 +6,7 @@ import abc
 import argparse
 import asyncio
 import configparser
+import fnmatch
 import logging
 import os
 import pathlib
@@ -211,6 +212,10 @@ class TestRunner:
 
         if self.cfgsection.getboolean('skip', fallback=False):
             raise Skip('skipped via config', loglevel=logging.INFO)
+
+        for name, section in self.suite.match_sections(self.tag):
+            if section.getboolean('skip', fallback=False):
+                raise Skip('skipped via fnmatch section {}'.format(name), loglevel=logging.INFO)
 
         if any(c in self.cmd for c in ';|&'):
             # This is a shell command which would spawn multiple processes.
@@ -432,6 +437,10 @@ class TestSuite:
     '''
     def __init__(self, config):
         self.config = config
+        self.fnmatch_names = [
+            name for name in config
+            if is_fnmatch_pattern(name)
+        ]
         self.sgx = self.config.getboolean(config.default_section, 'sgx')
 
         self.loader = [
@@ -455,6 +464,15 @@ class TestSuite:
         self.queue = []
         self.xml = etree.Element('testsuite')
         self.time = 0
+
+    def match_sections(self, name):
+        '''
+        Find all fnmatch (wildcard) sections that match a given name.
+        '''
+
+        for fnmatch_name in self.fnmatch_names:
+            if fnmatch.fnmatch(name, fnmatch_name):
+                yield fnmatch_name, self.config[fnmatch_name]
 
     def add_test(self, tag, cmd):
         '''Instantiate appropriate :py:class:`TestRunner` and add it to the
@@ -554,7 +572,22 @@ def load_config(files):
         with file:
             config.read_file(file)
 
+    for name, proxy in config.items():
+        if is_fnmatch_pattern(name):
+            for key in proxy:
+                if key != 'skip' and proxy[key] != config.defaults().get(key):
+                    raise ValueError(
+                        'fnmatch sections like {!r} can only contain "skip", not {!r}'.format(
+                            name, key))
+
     return config
+
+def is_fnmatch_pattern(name):
+    '''
+    Check if a name is a fnmatch pattern.
+    '''
+
+    return bool(set(name) & set('*?[]!'))
 
 def main(args=None):
     logging.basicConfig(


### PR DESCRIPTION
From now you can write * into section names in ltp.cfg, but such
sections can only contain "skip".

This is in order to make the configuration file more usable: in
many cases, we want to skip a whole class of tests, because a given
feature/syscall is not supported by Graphene.

Two such groups are "collapsed" as a proof of concept. A more thorough cleanup of LTP configuration will follow later.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1886)
<!-- Reviewable:end -->
