### PR TITLE
[LibOS] Rename shim_process

### DIFF
--- a/LibOS/shim/include/shim_checkpoint.h
+++ b/LibOS/shim/include/shim_checkpoint.h
@@ -332,8 +332,8 @@ struct checkpoint_hdr {
     size_t palhdl_entries_cnt;
 };
 
-typedef int (*migrate_func_t)(struct shim_cp_store*, struct shim_thread*, struct shim_process*,
-                              va_list);
+typedef int (*migrate_func_t)(struct shim_cp_store*, struct shim_thread*,
+                              struct shim_process_ipc_info*, va_list);
 
 /*!
  * \brief Create child process and migrate current-process state to it.

--- a/LibOS/shim/include/shim_fork.h
+++ b/LibOS/shim/include/shim_fork.h
@@ -8,6 +8,6 @@
 #include "shim_checkpoint.h"
 
 int migrate_fork(struct shim_cp_store* store, struct shim_thread* thread,
-                 struct shim_process* process, va_list ap);
+                 struct shim_process_ipc_info* process, va_list ap);
 
 #endif /* _SHIM_FORK_H_ */

--- a/LibOS/shim/include/shim_ipc.h
+++ b/LibOS/shim/include/shim_ipc.h
@@ -102,7 +102,6 @@ struct shim_ipc_info {
 struct shim_process_ipc_info {
     IDTYPE vmid;
     struct shim_lock lock;
-    int exit_code;
     struct shim_ipc_info* self;
     struct shim_ipc_info* parent;
     struct shim_ipc_info* ns;

--- a/LibOS/shim/include/shim_ipc.h
+++ b/LibOS/shim/include/shim_ipc.h
@@ -99,7 +99,7 @@ struct shim_ipc_info {
     REFTYPE ref_count;
 };
 
-struct shim_process {
+struct shim_process_ipc_info {
     IDTYPE vmid;
     struct shim_lock lock;
     int exit_code;
@@ -108,7 +108,7 @@ struct shim_process {
     struct shim_ipc_info* ns;
 };
 
-extern struct shim_process cur_process;
+extern struct shim_process_ipc_info g_process_ipc_info;
 
 struct shim_ipc_msg {
     unsigned char code;
@@ -427,10 +427,10 @@ int ipc_sysv_semret_callback(struct shim_ipc_msg* msg, struct shim_ipc_port* por
 int init_ipc(void);
 int init_ipc_helper(void);
 
-struct shim_process* create_process(bool dup_cur_process);
-void free_process(struct shim_process* process);
+struct shim_process_ipc_info* create_process_ipc_info(bool is_execve);
+void free_process_ipc_info(struct shim_process_ipc_info* process);
 
-struct shim_ipc_info* create_ipc_info_cur_process(bool is_self_ipc_info);
+struct shim_ipc_info* create_ipc_info_and_port(bool use_vmid_as_port_name);
 int get_ipc_info_cur_process(struct shim_ipc_info** pinfo);
 
 void add_ipc_port_by_id(IDTYPE vmid, PAL_HANDLE hdl, IDTYPE type, port_fini fini,

--- a/LibOS/shim/src/bookkeep/shim_handle.c
+++ b/LibOS/shim/src/bookkeep/shim_handle.c
@@ -265,7 +265,7 @@ struct shim_handle* get_new_handle(void) {
         free_mem_obj_to_mgr(handle_mgr, new_handle);
         return NULL;
     }
-    new_handle->owner = cur_process.vmid;
+    new_handle->owner = g_process_ipc_info.vmid;
     INIT_LISTP(&new_handle->epolls);
     return new_handle;
 }

--- a/LibOS/shim/src/bookkeep/shim_signal.c
+++ b/LibOS/shim/src/bookkeep/shim_signal.c
@@ -299,11 +299,11 @@ static noreturn void internal_fault(const char* errstr, PAL_NUM addr, PAL_CONTEX
 
     if (context_is_internal(context))
         SYS_PRINTF("%s at 0x%08lx (IP = +0x%lx, VMID = %u, TID = %u)\n", errstr, addr,
-                   (void*)ip - (void*)&__load_address, cur_process.vmid,
+                   (void*)ip - (void*)&__load_address, g_process_ipc_info.vmid,
                    is_internal_tid(tid) ? 0 : tid);
     else
         SYS_PRINTF("%s at 0x%08lx (IP = 0x%08lx, VMID = %u, TID = %u)\n", errstr, addr,
-                   context ? ip : 0, cur_process.vmid, is_internal_tid(tid) ? 0 : tid);
+                   context ? ip : 0, g_process_ipc_info.vmid, is_internal_tid(tid) ? 0 : tid);
 
     DEBUG_BREAK_ON_FAILURE();
     DkProcessExit(1);

--- a/LibOS/shim/src/bookkeep/shim_thread.c
+++ b/LibOS/shim/src/bookkeep/shim_thread.c
@@ -238,7 +238,7 @@ struct shim_thread* get_new_thread(IDTYPE new_tid) {
         goto out_error;
     }
 
-    thread->vmid             = cur_process.vmid;
+    thread->vmid             = g_process_ipc_info.vmid;
     thread->scheduler_event  = DkNotificationEventCreate(PAL_TRUE);
     thread->exit_event       = DkNotificationEventCreate(PAL_FALSE);
     thread->child_exit_event = DkNotificationEventCreate(PAL_FALSE);
@@ -275,7 +275,7 @@ struct shim_thread* get_new_internal_thread(void) {
     if (!thread)
         return NULL;
 
-    thread->vmid  = cur_process.vmid;
+    thread->vmid  = g_process_ipc_info.vmid;
     thread->tid   = new_tid;
     thread->in_vm = thread->is_alive = true;
     if (!create_lock(&thread->lock)) {
@@ -702,7 +702,7 @@ BEGIN_RS_FUNC(running_thread) {
     struct shim_thread* cur_thread = get_cur_thread();
     thread->in_vm = true;
 
-    thread->vmid = cur_process.vmid;
+    thread->vmid = g_process_ipc_info.vmid;
 
     if (thread->shim_tcb)
         CP_REBASE(thread->shim_tcb);

--- a/LibOS/shim/src/ipc/shim_ipc.c
+++ b/LibOS/shim/src/ipc/shim_ipc.c
@@ -4,7 +4,7 @@
 /*
  * This file contains code to maintain generic bookkeeping of IPC: operations on shim_ipc_msg
  * (one-way IPC messages), shim_ipc_msg_with_ack (IPC messages with acknowledgement), shim_ipc_info
- * (IPC ports of process), shim_process.
+ * (IPC ports of process).
  */
 
 #include "list.h"
@@ -31,7 +31,7 @@ static MEM_MGR ipc_info_mgr;
 
 struct shim_lock ipc_info_lock;
 
-struct shim_process cur_process;
+struct shim_process_ipc_info g_process_ipc_info;
 
 #define CLIENT_HASH_BITLEN 6
 #define CLIENT_HASH_NUM    (1 << CLIENT_HASH_BITLEN)
@@ -44,7 +44,7 @@ int init_ipc(void) {
     int ret = 0;
 
     if (!create_lock(&ipc_info_lock)
-        || !create_lock(&cur_process.lock)
+        || !create_lock(&g_process_ipc_info.lock)
         || !create_lock(&ipc_info_mgr_lock)) {
         return -ENOMEM;
     }
@@ -186,84 +186,81 @@ struct shim_ipc_info* lookup_ipc_info(IDTYPE vmid) {
     return NULL;
 }
 
-struct shim_process* create_process(bool dup_cur_process) {
-    struct shim_process* new_process = calloc(1, sizeof(struct shim_process));
-    if (!new_process)
+struct shim_process_ipc_info* create_process_ipc_info(bool is_execve) {
+    struct shim_process_ipc_info* new_process_ipc_info = calloc(1, sizeof(*new_process_ipc_info));
+    if (!new_process_ipc_info)
         return NULL;
 
-    lock(&cur_process.lock);
+    lock(&g_process_ipc_info.lock);
 
     /* current process must have been initialized with info on its own IPC info */
-    assert(cur_process.self);
+    assert(g_process_ipc_info.self);
 
-    if (dup_cur_process) {
+    if (is_execve) {
         /* execve case, new process assumes identity of current process and thus has
          * - same vmid as current process
          * - same self IPC info as current process
          * - same parent IPC info as current process */
-        new_process->vmid = cur_process.vmid;
-        new_process->self = create_ipc_info(cur_process.self->vmid,
-                                            qstrgetstr(&cur_process.self->uri),
-                                            cur_process.self->uri.len);
-        if (!new_process->self)
+        new_process_ipc_info->vmid = g_process_ipc_info.vmid;
+        new_process_ipc_info->self = create_ipc_info(g_process_ipc_info.self->vmid,
+                                                     qstrgetstr(&g_process_ipc_info.self->uri),
+                                                     g_process_ipc_info.self->uri.len);
+        if (!new_process_ipc_info->self)
             goto fail;
 
         /* there is a corner case of execve in very first process; such process does
          * not have parent process, so cannot copy parent IPC info */
-        if (cur_process.parent) {
-            new_process->parent = create_ipc_info(cur_process.parent->vmid,
-                                                  qstrgetstr(&cur_process.parent->uri),
-                                                  cur_process.parent->uri.len);
-            if (!new_process->parent)
+        if (g_process_ipc_info.parent) {
+            new_process_ipc_info->parent =
+                create_ipc_info(g_process_ipc_info.parent->vmid,
+                                qstrgetstr(&g_process_ipc_info.parent->uri),
+                                g_process_ipc_info.parent->uri.len);
+            if (!new_process_ipc_info->parent)
                 goto fail;
         }
     } else {
         /* fork/clone case, new process has new identity but inherits parent  */
-        new_process->vmid   = 0;
-        new_process->self   = NULL;
-        new_process->parent = create_ipc_info(cur_process.self->vmid,
-                                              qstrgetstr(&cur_process.self->uri),
-                                              cur_process.self->uri.len);
-        if (!new_process->parent)
+        new_process_ipc_info->vmid   = 0;
+        new_process_ipc_info->self   = NULL;
+        new_process_ipc_info->parent = create_ipc_info(g_process_ipc_info.self->vmid,
+                                                       qstrgetstr(&g_process_ipc_info.self->uri),
+                                                       g_process_ipc_info.self->uri.len);
+        if (!new_process_ipc_info->parent)
             goto fail;
     }
 
     /* new process inherits the same namespace leader */
-    if (cur_process.ns) {
-        new_process->ns = create_ipc_info(cur_process.ns->vmid, qstrgetstr(&cur_process.ns->uri),
-                                          cur_process.ns->uri.len);
-        if (!new_process->ns)
+    if (g_process_ipc_info.ns) {
+        new_process_ipc_info->ns = create_ipc_info(g_process_ipc_info.ns->vmid,
+                                                   qstrgetstr(&g_process_ipc_info.ns->uri),
+                                                   g_process_ipc_info.ns->uri.len);
+        if (!new_process_ipc_info->ns)
             goto fail;
     }
 
-    unlock(&cur_process.lock);
-    return new_process;
+    unlock(&g_process_ipc_info.lock);
+    return new_process_ipc_info;
 
 fail:
-    unlock(&cur_process.lock);
-    if (new_process->self)
-        put_ipc_info(new_process->self);
-    if (new_process->parent)
-        put_ipc_info(new_process->parent);
-    if (new_process->ns)
-        put_ipc_info(new_process->ns);
+    unlock(&g_process_ipc_info.lock);
+    free_process_ipc_info(new_process_ipc_info);
     return NULL;
 }
 
-void free_process(struct shim_process* process) {
-    if (process->self)
-        put_ipc_info(process->self);
-    if (process->parent)
-        put_ipc_info(process->parent);
-    if (process->ns)
-        put_ipc_info(process->ns);
-    free(process);
+void free_process_ipc_info(struct shim_process_ipc_info* process_ipc_info) {
+    if (process_ipc_info->self)
+        put_ipc_info(process_ipc_info->self);
+    if (process_ipc_info->parent)
+        put_ipc_info(process_ipc_info->parent);
+    if (process_ipc_info->ns)
+        put_ipc_info(process_ipc_info->ns);
+    free(process_ipc_info);
 }
 
 void init_ipc_msg(struct shim_ipc_msg* msg, int code, size_t size, IDTYPE dest) {
     msg->code = code;
     msg->size = get_ipc_msg_size(size);
-    msg->src  = cur_process.vmid;
+    msg->src  = g_process_ipc_info.vmid;
     msg->dst  = dest;
     msg->seq  = 0;
 }
@@ -279,7 +276,7 @@ void init_ipc_msg_with_ack(struct shim_ipc_msg_with_ack* msg, int code, size_t s
 int send_ipc_message(struct shim_ipc_msg* msg, struct shim_ipc_port* port) {
     assert(msg->size >= IPC_MSG_MINIMAL_SIZE);
 
-    msg->src = cur_process.vmid;
+    msg->src = g_process_ipc_info.vmid;
     debug("Sending ipc message to port %p (handle %p)\n", port, port->pal_handle);
 
     size_t total_bytes = msg->size;
@@ -376,41 +373,43 @@ out:
     return ret;
 }
 
-struct shim_ipc_info* create_ipc_info_cur_process(bool is_self_ipc_info) {
-    assert(locked(&cur_process.lock));
+struct shim_ipc_info* create_ipc_info_and_port(bool use_vmid_as_port_name) {
+    assert(locked(&g_process_ipc_info.lock));
 
-    struct shim_ipc_info* info = create_ipc_info(cur_process.vmid, NULL, 0);
+    struct shim_ipc_info* info = create_ipc_info(g_process_ipc_info.vmid, NULL, 0);
     if (!info)
         return NULL;
 
-    /* pipe for cur_process.self is of format "pipe:<cur_process.vmid>", others with random name */
+    /* pipe for g_process_ipc_info.self is of format "pipe:<g_process_ipc_info.vmid>", others with
+     * random name */
     char uri[PIPE_URI_SIZE];
-    if (create_pipe(NULL, uri, PIPE_URI_SIZE, &info->pal_handle, &info->uri, is_self_ipc_info) <
-        0) {
+    if (create_pipe(NULL, uri, PIPE_URI_SIZE, &info->pal_handle, &info->uri,
+                    use_vmid_as_port_name) < 0) {
         put_ipc_info(info);
         return NULL;
     }
 
-    add_ipc_port_by_id(cur_process.vmid, info->pal_handle, IPC_PORT_SERVER, NULL, &info->port);
+    add_ipc_port_by_id(g_process_ipc_info.vmid, info->pal_handle, IPC_PORT_SERVER, NULL,
+                       &info->port);
 
     return info;
 }
 
 int get_ipc_info_cur_process(struct shim_ipc_info** info) {
-    lock(&cur_process.lock);
+    lock(&g_process_ipc_info.lock);
 
-    if (!cur_process.self) {
-        cur_process.self = create_ipc_info_cur_process(true);
-        if (!cur_process.self) {
-            unlock(&cur_process.lock);
+    if (!g_process_ipc_info.self) {
+        g_process_ipc_info.self = create_ipc_info_and_port(/*use_vmid_as_port_name=*/true);
+        if (!g_process_ipc_info.self) {
+            unlock(&g_process_ipc_info.lock);
             return -EACCES;
         }
     }
 
-    get_ipc_info(cur_process.self);
-    *info = cur_process.self;
+    get_ipc_info(g_process_ipc_info.self);
+    *info = g_process_ipc_info.self;
 
-    unlock(&cur_process.lock);
+    unlock(&g_process_ipc_info.lock);
     return 0;
 }
 
@@ -454,71 +453,71 @@ BEGIN_CP_FUNC(ipc_info) {
 }
 END_CP_FUNC_NO_RS(ipc_info)
 
-BEGIN_CP_FUNC(process) {
+BEGIN_CP_FUNC(process_ipc_info) {
     __UNUSED(size);
-    assert(size == sizeof(struct shim_process));
+    assert(size == sizeof(struct shim_process_ipc_info));
 
-    struct shim_process* process     = (struct shim_process*)obj;
-    struct shim_process* new_process = NULL;
+    struct shim_process_ipc_info* process_ipc_info     = (struct shim_process_ipc_info*)obj;
+    struct shim_process_ipc_info* new_process_ipc_info = NULL;
 
     size_t off = GET_FROM_CP_MAP(obj);
 
     if (!off) {
-        off = ADD_CP_OFFSET(sizeof(struct shim_process));
+        off = ADD_CP_OFFSET(sizeof(*new_process_ipc_info));
         ADD_TO_CP_MAP(obj, off);
 
-        new_process = (struct shim_process*)(base + off);
-        memcpy(new_process, process, sizeof(struct shim_process));
+        new_process_ipc_info = (struct shim_process_ipc_info*)(base + off);
+        memcpy(new_process_ipc_info, process_ipc_info, sizeof(*new_process_ipc_info));
 
-        /* call ipc_info-specific checkpointing functions
-         * for new_process's self, parent, and ns infos */
-        if (process->self)
-            DO_CP_MEMBER(ipc_info, process, new_process, self);
-        if (process->parent)
-            DO_CP_MEMBER(ipc_info, process, new_process, parent);
-        if (process->ns)
-            DO_CP_MEMBER(ipc_info, process, new_process, ns);
+        /* call ipc_info-specific checkpointing functions for new_process_ipc_info's self, parent
+         * and ns infos */
+        if (process_ipc_info->self)
+            DO_CP_MEMBER(ipc_info, process_ipc_info, new_process_ipc_info, self);
+        if (process_ipc_info->parent)
+            DO_CP_MEMBER(ipc_info, process_ipc_info, new_process_ipc_info, parent);
+        if (process_ipc_info->ns)
+            DO_CP_MEMBER(ipc_info, process_ipc_info, new_process_ipc_info, ns);
 
         ADD_CP_FUNC_ENTRY(off);
     } else {
         /* already checkpointed */
-        new_process = (struct shim_process*)(base + off);
+        new_process_ipc_info = (struct shim_process_ipc_info*)(base + off);
     }
 
     if (objp)
-        *objp = (void*)new_process;
+        *objp = (void*)new_process_ipc_info;
 }
-END_CP_FUNC(process)
+END_CP_FUNC(process_ipc_info)
 
-BEGIN_RS_FUNC(process) {
+BEGIN_RS_FUNC(process_ipc_info) {
     __UNUSED(offset);
-    struct shim_process* process = (void*)(base + GET_CP_FUNC_ENTRY());
+    struct shim_process_ipc_info* process_ipc_info = (void*)(base + GET_CP_FUNC_ENTRY());
 
-    /* process vmid  = 0: fork/clone case, forces to pick up new host-OS vmid
-     * process vmid != 0: execve case, forces to re-use vmid of parent */
-    if (!process->vmid)
-        process->vmid = cur_process.vmid;
+    /* process_ipc_info vmid  = 0: fork/clone case, forces to pick up new host-OS vmid
+     * process_ipc_info vmid != 0: execve case, forces to re-use vmid of parent */
+    if (!process_ipc_info->vmid)
+        process_ipc_info->vmid = g_process_ipc_info.vmid;
 
-    CP_REBASE(process->self);
-    CP_REBASE(process->parent);
-    CP_REBASE(process->ns);
+    CP_REBASE(process_ipc_info->self);
+    CP_REBASE(process_ipc_info->parent);
+    CP_REBASE(process_ipc_info->ns);
 
-    if (process->self) {
-        process->self->vmid = process->vmid;
-        get_ipc_info(process->self);
+    if (process_ipc_info->self) {
+        process_ipc_info->self->vmid = process_ipc_info->vmid;
+        get_ipc_info(process_ipc_info->self);
     }
-    if (process->parent)
-        get_ipc_info(process->parent);
-    if (process->ns)
-        get_ipc_info(process->ns);
+    if (process_ipc_info->parent)
+        get_ipc_info(process_ipc_info->parent);
+    if (process_ipc_info->ns)
+        get_ipc_info(process_ipc_info->ns);
 
-    memcpy(&cur_process, process, sizeof(struct shim_process));
+    memcpy(&g_process_ipc_info, process_ipc_info, sizeof(g_process_ipc_info));
     // this lock will be created in init_ipc
-    clear_lock(&cur_process.lock);
+    clear_lock(&g_process_ipc_info.lock);
 
-    DEBUG_RS("vmid=%u,uri=%s,parent=%u(%s)", process->vmid,
-             process->self ? qstrgetstr(&process->self->uri) : "",
-             process->parent ? process->parent->vmid : 0,
-             process->parent ? qstrgetstr(&process->parent->uri) : "");
+    DEBUG_RS("vmid=%u,uri=%s,parent=%u(%s)", process_ipc_info->vmid,
+             process_ipc_info->self ? qstrgetstr(&process_ipc_info->self->uri) : "",
+             process_ipc_info->parent ? process_ipc_info->parent->vmid : 0,
+             process_ipc_info->parent ? qstrgetstr(&process_ipc_info->parent->uri) : "");
 }
-END_RS_FUNC(process)
+END_RS_FUNC(process_ipc_info)

--- a/LibOS/shim/src/ipc/shim_ipc_child.c
+++ b/LibOS/shim/src/ipc/shim_ipc_child.c
@@ -69,7 +69,7 @@ void ipc_port_with_child_fini(struct shim_ipc_port* port, IDTYPE vmid, unsigned 
     struct thread_info info = {.vmid = vmid, .exitcode = exitcode, .term_signal = SIGKILL};
 
     /* message cannot come from our own threads (from ourselves as process) */
-    assert(vmid != cur_process.vmid);
+    assert(vmid != g_process_ipc_info.vmid);
 
     int ret;
     int exited_threads_cnt = 0;
@@ -124,7 +124,7 @@ int ipc_cld_exit_callback(struct shim_ipc_msg* msg, struct shim_ipc_port* port) 
           msgin->ppid, msgin->tid, msgin->exitcode, msgin->term_signal);
 
     /* message cannot come from our own threads (from ourselves as process) */
-    assert(msg->src != cur_process.vmid);
+    assert(msg->src != g_process_ipc_info.vmid);
 
     /* First try to find remote thread which sent this message among normal
      * threads. In the common case, we (as parent process) keep remote child

--- a/LibOS/shim/src/ipc/shim_ipc_helper.c
+++ b/LibOS/shim/src/ipc/shim_ipc_helper.c
@@ -73,80 +73,81 @@ static ipc_callback ipc_callbacks[] = {
 };
 
 static int init_self_ipc_port(void) {
-    lock(&cur_process.lock);
+    lock(&g_process_ipc_info.lock);
 
-    if (!cur_process.self) {
+    if (!g_process_ipc_info.self) {
         /* very first process or clone/fork case: create IPC port from scratch */
-        cur_process.self = create_ipc_info_cur_process(/*is_self_ipc_info=*/true);
-        if (!cur_process.self) {
-            unlock(&cur_process.lock);
+        g_process_ipc_info.self = create_ipc_info_and_port(/*use_vmid_as_port_name=*/true);
+        if (!g_process_ipc_info.self) {
+            unlock(&g_process_ipc_info.lock);
             return -EACCES;
         }
     } else {
         /* execve case: inherited IPC port from parent process */
-        assert(cur_process.self->pal_handle && !qstrempty(&cur_process.self->uri));
+        assert(g_process_ipc_info.self->pal_handle && !qstrempty(&g_process_ipc_info.self->uri));
 
-        add_ipc_port_by_id(cur_process.self->vmid, cur_process.self->pal_handle, IPC_PORT_SERVER,
-                           /*fini=*/NULL, &cur_process.self->port);
+        add_ipc_port_by_id(g_process_ipc_info.self->vmid, g_process_ipc_info.self->pal_handle,
+                           IPC_PORT_SERVER, /*fini=*/NULL, &g_process_ipc_info.self->port);
     }
 
-    unlock(&cur_process.lock);
+    unlock(&g_process_ipc_info.lock);
     return 0;
 }
 
 static int init_parent_ipc_port(void) {
-    if (!PAL_CB(parent_process) || !cur_process.parent) {
+    if (!PAL_CB(parent_process) || !g_process_ipc_info.parent) {
         /* no parent process, no sense in creating parent IPC port */
         return 0;
     }
 
-    lock(&cur_process.lock);
-    assert(cur_process.parent && cur_process.parent->vmid);
+    lock(&g_process_ipc_info.lock);
+    assert(g_process_ipc_info.parent && g_process_ipc_info.parent->vmid);
 
     /* for execve case, my parent is the parent of my parent (current process transparently inherits
      * the "real" parent through already opened pal_handle on "temporary" parent's
-     * cur_process.parent) */
-    if (!cur_process.parent->pal_handle) {
+     * g_process_ipc_info.parent) */
+    if (!g_process_ipc_info.parent->pal_handle) {
         /* for clone/fork case, parent is connected on parent_process */
-        cur_process.parent->pal_handle = PAL_CB(parent_process);
+        g_process_ipc_info.parent->pal_handle = PAL_CB(parent_process);
     }
 
-    add_ipc_port_by_id(cur_process.parent->vmid, cur_process.parent->pal_handle,
+    add_ipc_port_by_id(g_process_ipc_info.parent->vmid, g_process_ipc_info.parent->pal_handle,
                        IPC_PORT_DIRECTPARENT | IPC_PORT_LISTEN,
-                       /*fini=*/NULL, &cur_process.parent->port);
+                       /*fini=*/NULL, &g_process_ipc_info.parent->port);
 
-    unlock(&cur_process.lock);
+    unlock(&g_process_ipc_info.lock);
     return 0;
 }
 
 static int init_ns_ipc_port(void) {
-    if (!cur_process.ns) {
+    if (!g_process_ipc_info.ns) {
         /* no NS info from parent process, no sense in creating NS IPC port */
         return 0;
     }
 
-    if (!cur_process.ns->pal_handle && qstrempty(&cur_process.ns->uri)) {
+    if (!g_process_ipc_info.ns->pal_handle && qstrempty(&g_process_ipc_info.ns->uri)) {
         /* there is no connection to NS leader via PAL handle and there is no URI to find NS leader:
          * do not create NS IPC port now, it will be created on-demand during NS leader lookup */
         return 0;
     }
 
-    lock(&cur_process.lock);
+    lock(&g_process_ipc_info.lock);
 
-    if (!cur_process.ns->pal_handle) {
-        debug("Reconnecting IPC port %s\n", qstrgetstr(&cur_process.ns->uri));
-        cur_process.ns->pal_handle = DkStreamOpen(qstrgetstr(&cur_process.ns->uri), 0, 0, 0, 0);
-        if (!cur_process.ns->pal_handle) {
-            unlock(&cur_process.lock);
+    if (!g_process_ipc_info.ns->pal_handle) {
+        debug("Reconnecting IPC port %s\n", qstrgetstr(&g_process_ipc_info.ns->uri));
+        g_process_ipc_info.ns->pal_handle = DkStreamOpen(qstrgetstr(&g_process_ipc_info.ns->uri),
+                                                         0, 0, 0, 0);
+        if (!g_process_ipc_info.ns->pal_handle) {
+            unlock(&g_process_ipc_info.lock);
             return -PAL_ERRNO();
         }
     }
 
-    add_ipc_port_by_id(cur_process.ns->vmid, cur_process.ns->pal_handle,
+    add_ipc_port_by_id(g_process_ipc_info.ns->vmid, g_process_ipc_info.ns->pal_handle,
                        IPC_PORT_LEADER | IPC_PORT_LISTEN,
-                       /*fini=*/NULL, &cur_process.ns->port);
+                       /*fini=*/NULL, &g_process_ipc_info.ns->port);
 
-    unlock(&cur_process.lock);
+    unlock(&g_process_ipc_info.lock);
     return 0;
 }
 
@@ -587,7 +588,7 @@ static int receive_ipc_message(struct shim_ipc_port* port) {
             msg->seq);
 
         /* skip messages coming from myself (in case of broadcast) */
-        if (msg->src != cur_process.vmid) {
+        if (msg->src != g_process_ipc_info.vmid) {
             if (msg->code < IPC_MSG_CODE_BOUND && ipc_callbacks[msg->code]) {
                 /* invoke callback to this msg */
                 ret = (*ipc_callbacks[msg->code])(msg, port);

--- a/LibOS/shim/src/ipc/shim_ipc_ranges.c
+++ b/LibOS/shim/src/ipc/shim_ipc_ranges.c
@@ -217,9 +217,9 @@ static int __add_range(struct range* r, IDTYPE off, IDTYPE owner, const char* ur
                 LISTP_DEL(tmp, head, hlist);
 
                 /* Chia-Che Tsai 10/17/17: only when tmp->owner is non-NULL,
-                 * and tmp->owner->vmid == cur_process.vmid, tmp is on the
+                 * and tmp->owner->vmid == g_process_ipc_info.vmid, tmp is on the
                  * owned list, otherwise it is an offered. */
-                if (tmp->owner && tmp->owner->vmid == cur_process.vmid) {
+                if (tmp->owner && tmp->owner->vmid == g_process_ipc_info.vmid) {
                     LISTP_DEL(tmp, &owned_ranges, list);
                     nowned--;
                 } else {
@@ -242,7 +242,7 @@ static int __add_range(struct range* r, IDTYPE off, IDTYPE owner, const char* ur
     LISTP_ADD(r, head, hlist);
     INIT_LIST_HEAD(r, list);
 
-    LISTP_TYPE(range)* list = (owner == cur_process.vmid) ? &owned_ranges : &offered_ranges;
+    LISTP_TYPE(range)* list = (owner == g_process_ipc_info.vmid) ? &owned_ranges : &offered_ranges;
     struct range* prev      = LISTP_FIRST_ENTRY(list, range, list);
     struct range* tmp;
 
@@ -254,7 +254,7 @@ static int __add_range(struct range* r, IDTYPE off, IDTYPE owner, const char* ur
 
     LISTP_ADD_AFTER(r, prev, list, list);
 
-    if (owner == cur_process.vmid)
+    if (owner == g_process_ipc_info.vmid)
         nowned++;
     else
         noffered++;
@@ -463,7 +463,7 @@ static int del_ipc_range(IDTYPE idx) {
     if (ret < 0)
         goto failed;
 
-    if (r->owner->vmid == cur_process.vmid)
+    if (r->owner->vmid == g_process_ipc_info.vmid)
         nowned--;
     else
         noffered--;
@@ -477,9 +477,9 @@ static int del_ipc_range(IDTYPE idx) {
     LISTP_DEL(r, head, hlist);
 
     /* Chia-Che Tsai 10/17/17: only when r->owner is non-NULL,
-     * and r->owner->vmid == cur_process.vmid, r is on the
+     * and r->owner->vmid == g_process_ipc_info.vmid, r is on the
      * owned list, otherwise it is an offered. */
-    if (r->owner && r->owner->vmid == cur_process.vmid)
+    if (r->owner && r->owner->vmid == g_process_ipc_info.vmid)
         LISTP_DEL(r, &owned_ranges, list);
     else
         LISTP_DEL(r, &offered_ranges, list);
@@ -643,16 +643,16 @@ int init_ns_ranges(void) {
 
 static void ipc_leader_exit(struct shim_ipc_port* port, IDTYPE vmid, unsigned int exitcode) {
     __UNUSED(exitcode);  // Kept for API compatibility
-    lock(&cur_process.lock);
+    lock(&g_process_ipc_info.lock);
 
-    if (!cur_process.ns || cur_process.ns->port != port) {
-        unlock(&cur_process.lock);
+    if (!g_process_ipc_info.ns || g_process_ipc_info.ns->port != port) {
+        unlock(&g_process_ipc_info.lock);
         return;
     }
 
-    struct shim_ipc_info* info = cur_process.ns;
-    cur_process.ns = NULL;
-    unlock(&cur_process.lock);
+    struct shim_ipc_info* info = g_process_ipc_info.ns;
+    g_process_ipc_info.ns = NULL;
+    unlock(&g_process_ipc_info.lock);
 
     debug("ipc port %p of process %u closed suggests leader exits\n", port, vmid);
 
@@ -666,143 +666,147 @@ static void ipc_leader_exit(struct shim_ipc_port* port, IDTYPE vmid, unsigned in
  */
 static void __discover_ns(bool block, bool need_locate) {
     bool ipc_pending = false;
-    lock(&cur_process.lock);
+    lock(&g_process_ipc_info.lock);
 
-    if (cur_process.ns) {
-        if (cur_process.ns->vmid == cur_process.vmid) {
-            if (need_locate && qstrempty(&cur_process.ns->uri)) {
-                bool is_self_ipc_info      = false; /* not cur_process.self but cur_process.ns */
-                struct shim_ipc_info* info = create_ipc_info_cur_process(is_self_ipc_info);
+    if (g_process_ipc_info.ns) {
+        if (g_process_ipc_info.ns->vmid == g_process_ipc_info.vmid) {
+            if (need_locate && qstrempty(&g_process_ipc_info.ns->uri)) {
+                struct shim_ipc_info* info =
+                    create_ipc_info_and_port(/*use_vmid_as_port_name=*/false);
                 if (info) {
-                    put_ipc_info(cur_process.ns);
-                    cur_process.ns = info;
+                    put_ipc_info(g_process_ipc_info.ns);
+                    g_process_ipc_info.ns = info;
                     add_ipc_port(info->port, 0, IPC_PORT_CLIENT, &ipc_leader_exit);
                 }
             }
             goto out;
         }
 
-        if (!qstrempty(&cur_process.ns->uri))
+        if (!qstrempty(&g_process_ipc_info.ns->uri))
             goto out;
     }
 
     /*
      * Now we need to discover the leader through IPC. Because IPC calls can be blocking,
-     * we need to temporarily release cur_process.lock to prevent deadlocks. If the discovery
-     * succeeds, cur_process.ns will contain the IPC information of the namespace leader.
+     * we need to temporarily release g_process_ipc_info.lock to prevent deadlocks. If the discovery
+     * succeeds, g_process_ipc_info.ns will contain the IPC information of the namespace leader.
      */
 
-    unlock(&cur_process.lock);
+    unlock(&g_process_ipc_info.lock);
 
     // Send out an IPC message to find out the namespace information.
     // If the call is non-blocking, can't expect the answer when the function finishes.
     int ret = ipc_findns_send(block);
     if (!ret) {
         ipc_pending = !block;  // There is still some unfinished business with IPC
-        lock(&cur_process.lock);
-        assert(cur_process.ns);
+        lock(&g_process_ipc_info.lock);
+        assert(g_process_ipc_info.ns);
         goto out;
     }
 
-    lock(&cur_process.lock);
+    lock(&g_process_ipc_info.lock);
 
     // At this point, (1) the leader is not me, (2) I don't know leader's URI,
     // and (3) I failed to find out the leader via IPC. But I am pressed to
     // report the leader so promote myself (and remove stale leader info).
-    if (cur_process.ns)
-        put_ipc_info(cur_process.ns);
+    if (g_process_ipc_info.ns)
+        put_ipc_info(g_process_ipc_info.ns);
 
     if (!need_locate) {
-        cur_process.ns = create_ipc_info(cur_process.vmid, NULL, 0);
+        g_process_ipc_info.ns = create_ipc_info(g_process_ipc_info.vmid, NULL, 0);
         goto out;
     }
 
-    bool is_self_ipc_info = false; /* not cur_process.self but cur_process.ns */
-    if (!(cur_process.ns = create_ipc_info_cur_process(is_self_ipc_info)))
+    g_process_ipc_info.ns = create_ipc_info_and_port(/*use_vmid_as_port_name=*/false);
+    if (!g_process_ipc_info.ns)
         goto out;
 
     // Finally, set the IPC port as a leadership port
-    add_ipc_port(cur_process.ns->port, 0, IPC_PORT_CLIENT, &ipc_leader_exit);
+    add_ipc_port(g_process_ipc_info.ns->port, 0, IPC_PORT_CLIENT, &ipc_leader_exit);
 
 out:
-    if (cur_process.ns && !ipc_pending) {
+    if (g_process_ipc_info.ns && !ipc_pending) {
         // Assertions for checking the correctness of __discover_ns()
-        assert(cur_process.ns->vmid == cur_process.vmid  // The current process is the leader;
-               || cur_process.ns->port                   // Or there is a connected port
-               || !qstrempty(&cur_process.ns->uri));     // Or there is a known URI
+        assert(g_process_ipc_info.ns->vmid == g_process_ipc_info.vmid   // The current process is
+                                                                        // the leader
+               || g_process_ipc_info.ns->port                   // Or there is a connected port
+               || !qstrempty(&g_process_ipc_info.ns->uri));     // Or there is a known URI
         if (need_locate)
-            assert(!qstrempty(&cur_process.ns->uri));  // A known URI is needed
+            assert(!qstrempty(&g_process_ipc_info.ns->uri));    // A known URI is needed
     }
 
-    unlock(&cur_process.lock);
+    unlock(&g_process_ipc_info.lock);
 }
 
 int connect_ns(IDTYPE* vmid, struct shim_ipc_port** portptr) {
-    __discover_ns(true, false);  // This function cannot be called with cur_process.lock held
-    lock(&cur_process.lock);
+    __discover_ns(true, false);  // This function cannot be called with g_process_ipc_info.lock held
+    lock(&g_process_ipc_info.lock);
 
-    if (!cur_process.ns) {
-        unlock(&cur_process.lock);
+    if (!g_process_ipc_info.ns) {
+        unlock(&g_process_ipc_info.lock);
         return -ESRCH;
     }
 
-    if (cur_process.ns->vmid == cur_process.vmid) {
+    if (g_process_ipc_info.ns->vmid == g_process_ipc_info.vmid) {
         if (vmid)
-            *vmid = cur_process.ns->vmid;
-        unlock(&cur_process.lock);
+            *vmid = g_process_ipc_info.ns->vmid;
+        unlock(&g_process_ipc_info.lock);
         return 0;
     }
 
-    if (!cur_process.ns->port) {
-        if (qstrempty(&cur_process.ns->uri)) {
-            unlock(&cur_process.lock);
+    if (!g_process_ipc_info.ns->port) {
+        if (qstrempty(&g_process_ipc_info.ns->uri)) {
+            unlock(&g_process_ipc_info.lock);
             return -ESRCH;
         }
 
-        PAL_HANDLE pal_handle = DkStreamOpen(qstrgetstr(&cur_process.ns->uri), 0, 0, 0, 0);
+        PAL_HANDLE pal_handle = DkStreamOpen(qstrgetstr(&g_process_ipc_info.ns->uri), 0, 0, 0, 0);
 
         if (!pal_handle) {
-            unlock(&cur_process.lock);
+            unlock(&g_process_ipc_info.lock);
             return -PAL_ERRNO();
         }
 
-        add_ipc_port_by_id(cur_process.ns->vmid, pal_handle, IPC_PORT_LEADER | IPC_PORT_LISTEN,
-                           &ipc_leader_exit, &cur_process.ns->port);
+        add_ipc_port_by_id(g_process_ipc_info.ns->vmid, pal_handle,
+                           IPC_PORT_LEADER | IPC_PORT_LISTEN,
+                           &ipc_leader_exit, &g_process_ipc_info.ns->port);
     }
 
     if (vmid)
-        *vmid = cur_process.ns->vmid;
+        *vmid = g_process_ipc_info.ns->vmid;
     if (portptr) {
-        if (cur_process.ns->port)
-            get_ipc_port(cur_process.ns->port);
-        *portptr = cur_process.ns->port;
+        if (g_process_ipc_info.ns->port)
+            get_ipc_port(g_process_ipc_info.ns->port);
+        *portptr = g_process_ipc_info.ns->port;
     }
 
-    unlock(&cur_process.lock);
+    unlock(&g_process_ipc_info.lock);
     return 0;
 }
 
 #if 0 /* unused */
 static int disconnect_ns(struct shim_ipc_port * port)
 {
-    lock(&cur_process.lock);
-    if (cur_process.ns && cur_process.ns->port == port) {
-        cur_process.ns->port = NULL;
+    lock(&g_process_ipc_info.lock);
+    if (g_process_ipc_info.ns && g_process_ipc_info.ns->port == port) {
+        g_process_ipc_info.ns->port = NULL;
         put_ipc_port(port);
     }
-    unlock(&cur_process.lock);
+    unlock(&g_process_ipc_info.lock);
     del_ipc_port(port, IPC_PORT_LEADER);
     return 0;
 }
 #endif
 
 int prepare_ipc_leader(void) {
-    lock(&cur_process.lock);
-    bool need_discover = (!cur_process.ns || qstrempty(&cur_process.ns->uri));
-    unlock(&cur_process.lock);
+    lock(&g_process_ipc_info.lock);
+    bool need_discover = (!g_process_ipc_info.ns || qstrempty(&g_process_ipc_info.ns->uri));
+    unlock(&g_process_ipc_info.lock);
 
-    if (need_discover)
-        __discover_ns(true, true);  // This function cannot be called with cur_process.lock held
+    if (need_discover) {
+        // This function cannot be called with g_process_ipc_info.lock held
+        __discover_ns(true, true);
+    }
     return 0;
 }
 
@@ -822,7 +826,7 @@ int connect_owner(IDTYPE idx, struct shim_ipc_port** portptr, IDTYPE* owner) {
     if (ret < 0)
         goto out;
 
-    if (range.owner == cur_process.vmid) {
+    if (range.owner == g_process_ipc_info.vmid) {
         ret = -ESRCH;
         assert(!range.port);
         goto out;
@@ -871,16 +875,16 @@ out:
 int ipc_findns_send(bool block) {
     int ret = -ESRCH;
 
-    lock(&cur_process.lock);
-    if (!cur_process.parent || !cur_process.parent->port) {
-        unlock(&cur_process.lock);
+    lock(&g_process_ipc_info.lock);
+    if (!g_process_ipc_info.parent || !g_process_ipc_info.parent->port) {
+        unlock(&g_process_ipc_info.lock);
         goto out;
     }
 
-    IDTYPE dest = cur_process.parent->vmid;
-    struct shim_ipc_port* port = cur_process.parent->port;
+    IDTYPE dest = g_process_ipc_info.parent->vmid;
+    struct shim_ipc_port* port = g_process_ipc_info.parent->port;
     get_ipc_port(port);
-    unlock(&cur_process.lock);
+    unlock(&g_process_ipc_info.lock);
 
     if (block) {
         size_t total_msg_size = get_ipc_msg_with_ack_size(0);
@@ -910,12 +914,12 @@ int ipc_findns_callback(struct shim_ipc_msg* msg, struct shim_ipc_port* port) {
     debug("ipc callback from %u: IPC_MSG_FINDNS\n", msg->src);
 
     int ret = 0;
-    __discover_ns(false, true);  // This function cannot be called with cur_process.lock held
-    lock(&cur_process.lock);
+    __discover_ns(false, true);  // This function cannot be called with g_process_ipc_info.lock held
+    lock(&g_process_ipc_info.lock);
 
-    if (cur_process.ns && !qstrempty(&cur_process.ns->uri)) {
+    if (g_process_ipc_info.ns && !qstrempty(&g_process_ipc_info.ns->uri)) {
         // Got the answer! Send back the discovery now.
-        ret = ipc_tellns_send(port, msg->src, cur_process.ns, msg->seq);
+        ret = ipc_tellns_send(port, msg->src, g_process_ipc_info.ns, msg->seq);
     } else {
         // Don't know the answer yet, set up a callback for sending the discovery later.
         struct ns_query* query = malloc(sizeof(struct ns_query));
@@ -930,7 +934,7 @@ int ipc_findns_callback(struct shim_ipc_msg* msg, struct shim_ipc_port* port) {
             ret = -ENOMEM;
         }
     }
-    unlock(&cur_process.lock);
+    unlock(&g_process_ipc_info.lock);
     return ret;
 }
 
@@ -957,28 +961,28 @@ int ipc_tellns_callback(struct shim_ipc_msg* msg, struct shim_ipc_port* port) {
 
     debug("ipc callback from %u: IPC_MSG_TELLNS(%u, %s)\n", msg->src, msgin->vmid, msgin->uri);
 
-    lock(&cur_process.lock);
+    lock(&g_process_ipc_info.lock);
 
-    if (cur_process.ns) {
-        cur_process.ns->vmid = msgin->vmid;
-        qstrsetstr(&cur_process.ns->uri, msgin->uri, strlen(msgin->uri));
+    if (g_process_ipc_info.ns) {
+        g_process_ipc_info.ns->vmid = msgin->vmid;
+        qstrsetstr(&g_process_ipc_info.ns->uri, msgin->uri, strlen(msgin->uri));
     } else {
-        cur_process.ns = create_ipc_info(msgin->vmid, msgin->uri, strlen(msgin->uri));
-        if (!cur_process.ns) {
+        g_process_ipc_info.ns = create_ipc_info(msgin->vmid, msgin->uri, strlen(msgin->uri));
+        if (!g_process_ipc_info.ns) {
             ret = -ENOMEM;
             goto out;
         }
     }
 
-    assert(cur_process.ns->vmid != 0);
-    assert(!qstrempty(&cur_process.ns->uri));
+    assert(g_process_ipc_info.ns->vmid != 0);
+    assert(!qstrempty(&g_process_ipc_info.ns->uri));
 
     struct ns_query* query;
     struct ns_query* pos;
 
     LISTP_FOR_EACH_ENTRY_SAFE(query, pos, &ns_queries, list) {
         LISTP_DEL(query, &ns_queries, list);
-        ipc_tellns_send(query->port, query->dest, cur_process.ns, query->seq);
+        ipc_tellns_send(query->port, query->dest, g_process_ipc_info.ns, query->seq);
         put_ipc_port(query->port);
         free(query);
     }
@@ -988,7 +992,7 @@ int ipc_tellns_callback(struct shim_ipc_msg* msg, struct shim_ipc_port* port) {
         thread_wakeup(obj->thread);
 
 out:
-    unlock(&cur_process.lock);
+    unlock(&g_process_ipc_info.lock);
     return ret;
 }
 
@@ -1004,8 +1008,8 @@ int ipc_lease_send(LEASETYPE* lease) {
     if ((ret = get_ipc_info_cur_process(&self)) < 0)
         goto out;
 
-    if (leader == cur_process.vmid) {
-        ret = alloc_ipc_range(cur_process.vmid, qstrgetstr(&self->uri), NULL, NULL);
+    if (leader == g_process_ipc_info.vmid) {
+        ret = alloc_ipc_range(g_process_ipc_info.vmid, qstrgetstr(&self->uri), NULL, NULL);
         put_ipc_info(self);
         goto out;
     }
@@ -1075,8 +1079,8 @@ int ipc_offer_callback(struct shim_ipc_msg* msg, struct shim_ipc_port* port) {
 
     switch (msgin->size) {
         case RANGE_SIZE:
-            add_ipc_range(msgin->base, cur_process.vmid, qstrgetstr(&cur_process.self->uri),
-                          msgin->lease);
+            add_ipc_range(msgin->base, g_process_ipc_info.vmid,
+                          qstrgetstr(&g_process_ipc_info.self->uri), msgin->lease);
             LEASETYPE* priv = obj ? obj->private : NULL;
             if (priv)
                 *priv = msgin->lease;
@@ -1169,7 +1173,7 @@ int ipc_sublease_send(IDTYPE tenant, IDTYPE idx, const char* uri, LEASETYPE* lea
     if ((ret = connect_ns(&leader, &port)) < 0)
         goto out;
 
-    if (leader == cur_process.vmid) {
+    if (leader == g_process_ipc_info.vmid) {
         ret = add_ipc_subrange(idx, tenant, uri, NULL);
         goto out;
     }
@@ -1219,7 +1223,7 @@ int ipc_query_send(IDTYPE idx) {
     if ((ret = connect_ns(&leader, &port)) < 0)
         goto out;
 
-    if (cur_process.vmid == leader) {
+    if (g_process_ipc_info.vmid == leader) {
         ret = -ESRCH;
         goto out;
     }
@@ -1281,7 +1285,7 @@ int ipc_queryall_send(void) {
     if ((ret = connect_ns(&leader, &port)) < 0)
         goto out;
 
-    if (cur_process.vmid == leader)
+    if (g_process_ipc_info.vmid == leader)
         goto out;
 
     size_t total_msg_size = get_ipc_msg_with_ack_size(0);
@@ -1497,7 +1501,7 @@ retry:
             p = s->owner;
         }
 
-        if (p->vmid == cur_process.vmid) {
+        if (p->vmid == g_process_ipc_info.vmid) {
             idx++;
             goto next_sub;
         }

--- a/LibOS/shim/src/ipc/shim_ipc_sysv.c
+++ b/LibOS/shim/src/ipc/shim_ipc_sysv.c
@@ -34,7 +34,7 @@ int ipc_sysv_findkey_send(struct sysv_key* key) {
     if ((ret = connect_ns(&dest, &port)) < 0)
         goto out;
 
-    if (dest == cur_process.vmid) {
+    if (dest == g_process_ipc_info.vmid) {
         ret = -ENOENT;
         goto out;
     }
@@ -83,7 +83,7 @@ int ipc_sysv_tellkey_send(struct shim_ipc_port* port, IDTYPE dest, struct sysv_k
         if ((ret = connect_ns(&dest, &port)) < 0)
             goto out;
 
-        if (dest == cur_process.vmid)
+        if (dest == g_process_ipc_info.vmid)
             goto out;
 
         owned = false;
@@ -364,7 +364,7 @@ int ipc_sysv_msgrcv_send(IDTYPE msgid, long msgtype, int flags, void* buf, size_
     if ((ret = connect_owner(msgid, &port, &owner)) < 0)
         goto out;
 
-    if (owner == cur_process.vmid) {
+    if (owner == g_process_ipc_info.vmid) {
         ret = -EAGAIN;
         goto out;
     }
@@ -438,7 +438,7 @@ int ipc_sysv_semop_send(IDTYPE semid, struct sembuf* sops, int nsops, unsigned l
     if ((ret = connect_owner(semid, &port, &owner)) < 0)
         goto out;
 
-    if (owner == cur_process.vmid) {
+    if (owner == g_process_ipc_info.vmid) {
         ret = -EAGAIN;
         goto out;
     }

--- a/LibOS/shim/src/shim_init.c
+++ b/LibOS/shim/src/shim_init.c
@@ -794,7 +794,6 @@ noreturn void shim_clean_and_exit(int exit_code) {
         }
     }
 
-    g_process_ipc_info.exit_code = exit_code;
     store_all_msg_persist();
     del_all_ipc_ports();
 
@@ -802,16 +801,15 @@ noreturn void shim_clean_and_exit(int exit_code) {
         DkObjectClose(shim_stdio);
 
     shim_stdio = NULL;
-    debug("process %u exited with status %d\n", g_process_ipc_info.vmid & 0xFFFF,
-          g_process_ipc_info.exit_code);
+    debug("process %u exited with status %d\n", g_process_ipc_info.vmid & 0xFFFF, exit_code);
     MASTER_LOCK();
 
-    if (g_process_ipc_info.exit_code == PAL_WAIT_FOR_CHILDREN_EXIT) {
+    if (exit_code == PAL_WAIT_FOR_CHILDREN_EXIT) {
         /* user application specified magic exit code; this should be an extremely rare case */
         debug("exit status collides with Graphene-internal magic status; changed to 1\n");
-        g_process_ipc_info.exit_code = 1;
+        exit_code = 1;
     }
-    DkProcessExit(g_process_ipc_info.exit_code);
+    DkProcessExit(exit_code);
 }
 
 int message_confirm(const char* message, const char* options) {

--- a/LibOS/shim/src/sys/shim_exec.c
+++ b/LibOS/shim/src/sys/shim_exec.c
@@ -157,9 +157,10 @@ static int shim_do_execve_rtld(struct shim_handle* hdl, const char** argv, const
     return 0;
 }
 
-static BEGIN_MIGRATION_DEF(execve, struct shim_thread* thread, struct shim_process* proc,
+static BEGIN_MIGRATION_DEF(execve, struct shim_thread* thread,
+                           struct shim_process_ipc_info* process_ipc_info,
                            const char** argv, const char** envp) {
-    DEFINE_MIGRATE(process, proc, sizeof(struct shim_process));
+    DEFINE_MIGRATE(process_ipc_info, process_ipc_info, sizeof(struct shim_process_ipc_info));
     DEFINE_MIGRATE(all_mounts, NULL, 0);
     DEFINE_MIGRATE(running_thread, thread, sizeof(struct shim_thread));
     DEFINE_MIGRATE(pending_signals, NULL, 0);
@@ -173,7 +174,7 @@ END_MIGRATION_DEF(execve)
 /* thread is cur_thread stripped off stack & tcb (see below func);
  * process is new process which is forked and waits for checkpoint. */
 static int migrate_execve(struct shim_cp_store* cpstore, struct shim_thread* thread,
-                          struct shim_process* process, va_list ap) {
+                          struct shim_process_ipc_info* process_ipc_info, va_list ap) {
     struct shim_handle_map* handle_map;
     const char** argv = va_arg(ap, const char**);
     const char** envp = va_arg(ap, const char**);
@@ -189,7 +190,7 @@ static int migrate_execve(struct shim_cp_store* cpstore, struct shim_thread* thr
     if (ret < 0)
         return ret;
 
-    return START_MIGRATE(cpstore, execve, thread, process, argv, envp);
+    return START_MIGRATE(cpstore, execve, thread, process_ipc_info, argv, envp);
 }
 
 int shim_do_execve(const char* file, const char** argv, const char** envp) {
@@ -445,7 +446,7 @@ reopen:
      * its parent in turn may wait on it, e.g., `bash -c ls`) */
     debug(
         "Temporary process %u is exiting after emulating execve (by forking new process to replace"
-        " this one); will wait for forked process to exit...\n", cur_process.vmid & 0xFFFF);
+        " this one); will wait for forked process to exit...\n", g_process_ipc_info.vmid & 0xFFFF);
     MASTER_LOCK();
     DkProcessExit(PAL_WAIT_FOR_CHILDREN_EXIT);
 

--- a/LibOS/shim/src/sys/shim_fork.c
+++ b/LibOS/shim/src/sys/shim_fork.c
@@ -22,8 +22,9 @@
 #include "shim_table.h"
 #include "shim_thread.h"
 
-static BEGIN_MIGRATION_DEF(fork, struct shim_thread* thread, struct shim_process* process) {
-    DEFINE_MIGRATE(process, process, sizeof(struct shim_process));
+static BEGIN_MIGRATION_DEF(fork, struct shim_thread* thread,
+        struct shim_process_ipc_info* process_ipc_info) {
+    DEFINE_MIGRATE(process_ipc_info, process_ipc_info, sizeof(struct shim_process_ipc_info));
     DEFINE_MIGRATE(all_mounts, NULL, 0);
     DEFINE_MIGRATE(all_vmas, NULL, 0);
     DEFINE_MIGRATE(running_thread, thread, sizeof(struct shim_thread));
@@ -38,9 +39,9 @@ static BEGIN_MIGRATION_DEF(fork, struct shim_thread* thread, struct shim_process
 END_MIGRATION_DEF(fork)
 
 int migrate_fork(struct shim_cp_store* store, struct shim_thread* thread,
-                 struct shim_process* process, va_list ap) {
+                 struct shim_process_ipc_info* process_ipc_info, va_list ap) {
     __UNUSED(ap);
-    int ret = START_MIGRATE(store, fork, thread, process);
+    int ret = START_MIGRATE(store, fork, thread, process_ipc_info);
 
     thread->in_vm = false;
 

--- a/LibOS/shim/src/sys/shim_semget.c
+++ b/LibOS/shim/src/sys/shim_semget.c
@@ -635,7 +635,7 @@ int submit_sysv_sem(struct shim_sem_handle* sem, struct sembuf* sops, int nsops,
         struct sem_ops* op;
 
         LISTP_FOR_EACH_ENTRY(op, &sem->migrated, progress) {
-            if (op->client.vmid == (client ? client->vmid : cur_process.vmid) &&
+            if (op->client.vmid == (client ? client->vmid : g_process_ipc_info.vmid) &&
                 seq == op->client.seq) {
                 LISTP_DEL_INIT(op, &sem->migrated, progress);
                 sem_ops  = op;

--- a/LibOS/shim/src/utils/printf.c
+++ b/LibOS/shim/src/utils/printf.c
@@ -109,7 +109,7 @@ void debug_setprefix(shim_tcb_t* tcb) {
         if (*it == ':' || *it == '/')
             exec = it + 1;
 
-    uint32_t vmid = cur_process.vmid & 0xFFFF;
+    uint32_t vmid = g_process_ipc_info.vmid & 0xFFFF;
     if (tcb->tid && !is_internal_tid(tcb->tid)) {
         /* normal app thread: show Process ID, Thread ID, and exec name */
         fprintfmt(debug_fputch, NULL, buf, "[P%u:T%u:%s] ", vmid, tcb->tid, exec);
@@ -117,7 +117,7 @@ void debug_setprefix(shim_tcb_t* tcb) {
         /* internal LibOS thread: show Process ID, Internal-thread ID, and exec name */
         fprintfmt(debug_fputch, NULL, buf, "[P%u:i%u:%s] ", vmid, tcb->tid - INTERNAL_TID_BASE,
                   exec);
-    } else if (cur_process.vmid) {
+    } else if (g_process_ipc_info.vmid) {
         /* unknown thread (happens on process init): show Process ID and exec name */
         fprintfmt(debug_fputch, NULL, buf, "[P%u:%s] ", vmid, exec);
     } else {


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->
This PR renames `shim_process` to `shim_process_ipc_info` to better reflect it's purpose (+ I want to use `shim_process` in another PR) and removes unused `exit_code` field from it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1887)
<!-- Reviewable:end -->
