### PR TITLE
[LibOS] Consolidate and remove unused code in thread checkpointing

### DIFF
--- a/LibOS/shim/include/shim_thread.h
+++ b/LibOS/shim/include/shim_thread.h
@@ -63,8 +63,6 @@ struct shim_thread {
 
     /* parent handle */
     struct shim_thread* parent;
-    /* thread leader */
-    struct shim_thread* leader;
     /* child handles; protected by thread->lock */
     LISTP_TYPE(shim_thread) children;
     /* nodes in child handles; protected by the parent's lock */

--- a/LibOS/shim/src/sys/shim_exec.c
+++ b/LibOS/shim/src/sys/shim_exec.c
@@ -160,7 +160,7 @@ static BEGIN_MIGRATION_DEF(execve, struct shim_thread* thread,
                            const char** argv, const char** envp) {
     DEFINE_MIGRATE(process_ipc_info, process_ipc_info, sizeof(struct shim_process_ipc_info));
     DEFINE_MIGRATE(all_mounts, NULL, 0);
-    DEFINE_MIGRATE(running_thread, thread, sizeof(struct shim_thread));
+    DEFINE_MIGRATE(thread, thread, sizeof(struct shim_thread));
     DEFINE_MIGRATE(pending_signals, NULL, 0);
     DEFINE_MIGRATE(migratable, NULL, 0);
     DEFINE_MIGRATE(arguments, argv, 0);

--- a/LibOS/shim/src/sys/shim_fork.c
+++ b/LibOS/shim/src/sys/shim_fork.c
@@ -25,7 +25,7 @@ static BEGIN_MIGRATION_DEF(fork, struct shim_thread* thread,
     DEFINE_MIGRATE(process_ipc_info, process_ipc_info, sizeof(struct shim_process_ipc_info));
     DEFINE_MIGRATE(all_mounts, NULL, 0);
     DEFINE_MIGRATE(all_vmas, NULL, 0);
-    DEFINE_MIGRATE(running_thread, thread, sizeof(struct shim_thread));
+    DEFINE_MIGRATE(thread, thread, sizeof(struct shim_thread));
     DEFINE_MIGRATE(migratable, NULL, 0);
     DEFINE_MIGRATE(brk, NULL, 0);
     DEFINE_MIGRATE(loaded_libraries, NULL, 0);


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->
This PR removes unneeded checkpointing of `running_thread` (merging necessary parts with checkpointing of `thread`). Cloning a new thread does not use checkpointing. fork and execve checkpoint only information about the new thread to be run.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1889)
<!-- Reviewable:end -->
