### PR TITLE
[Pal/LibOS] Add `physical id` and fix `cpu cores` in `/proc/cpuinfo`

### DIFF
--- a/LibOS/shim/src/fs/proc/info.c
+++ b/LibOS/shim/src/fs/proc/info.c
@@ -143,7 +143,7 @@ static int proc_cpuinfo_open(struct shim_handle* hdl, const char* name, int flag
         len += ret;                                                  \
     } while (0)
 
-    for (size_t n = 0; n < pal_control.cpu_info.cpu_num; n++) {
+    for (size_t n = 0; n < pal_control.cpu_info.online_logical_cores; n++) {
         /* Below strings must match exactly the strings retrieved from /proc/cpuinfo
          * (see Linux's arch/x86/kernel/cpu/proc.c) */
         ADD_INFO("processor\t: %lu\n", n);
@@ -152,8 +152,9 @@ static int proc_cpuinfo_open(struct shim_handle* hdl, const char* name, int flag
         ADD_INFO("model\t\t: %lu\n", pal_control.cpu_info.cpu_model);
         ADD_INFO("model name\t: %s\n", pal_control.cpu_info.cpu_brand);
         ADD_INFO("stepping\t: %lu\n", pal_control.cpu_info.cpu_stepping);
+        ADD_INFO("physical id\t: %d\n", pal_control.cpu_info.cpu_socket[n]);
         ADD_INFO("core id\t\t: %lu\n", n);
-        ADD_INFO("cpu cores\t: %lu\n", pal_control.cpu_info.cpu_num);
+        ADD_INFO("cpu cores\t: %lu\n", pal_control.cpu_info.physical_cores_per_socket);
         double bogomips = pal_control.cpu_info.cpu_bogomips;
         // Apparently graphene snprintf cannot into floats.
         ADD_INFO("bogomips\t: %lu.%02lu\n", (unsigned long)bogomips,

--- a/LibOS/shim/src/sys/shim_sched.c
+++ b/LibOS/shim/src/sys/shim_sched.c
@@ -160,7 +160,7 @@ static int check_affinity_params(int ncpus, size_t len, __kernel_cpu_set_t* user
 /* dummy implementation: ignore user-supplied mask and return success */
 int shim_do_sched_setaffinity(pid_t pid, size_t len, __kernel_cpu_set_t* user_mask_ptr) {
     __UNUSED(pid);
-    int ncpus = PAL_CB(cpu_info.cpu_num);
+    int ncpus = PAL_CB(cpu_info.online_logical_cores);
 
     int bitmask_size_in_bytes = check_affinity_params(ncpus, len, user_mask_ptr);
     if (bitmask_size_in_bytes < 0)
@@ -172,7 +172,7 @@ int shim_do_sched_setaffinity(pid_t pid, size_t len, __kernel_cpu_set_t* user_ma
 /* dummy implementation: always return all-ones (as many as there are host CPUs)  */
 int shim_do_sched_getaffinity(pid_t pid, size_t len, __kernel_cpu_set_t* user_mask_ptr) {
     __UNUSED(pid);
-    int ncpus = PAL_CB(cpu_info.cpu_num);
+    int ncpus = PAL_CB(cpu_info.online_logical_cores);
 
     int bitmask_size_in_bytes = check_affinity_params(ncpus, len, user_mask_ptr);
     if (bitmask_size_in_bytes < 0)

--- a/Pal/include/arch/x86_64/pal-arch.h
+++ b/Pal/include/arch/x86_64/pal-arch.h
@@ -187,7 +187,12 @@ static inline bool pal_context_has_user_pagefault(PAL_CONTEXT* context) {
 
 /* PAL_CPU_INFO holds /proc/cpuinfo data */
 typedef struct PAL_CPU_INFO_ {
-    PAL_NUM cpu_num;
+    /* Number of logical cores available in the host */
+    PAL_NUM online_logical_cores;
+    /* Number of physical cores in a socket (physical package) */
+    PAL_NUM physical_cores_per_socket;
+    /* array of "logical core -> socket" mappings; has online_logical_cores elements */
+    int* cpu_socket;
     PAL_STR cpu_vendor;
     PAL_STR cpu_brand;
     PAL_NUM cpu_family;

--- a/Pal/regression/Bootstrap.c
+++ b/Pal/regression/Bootstrap.c
@@ -62,7 +62,7 @@ int main(int argc, char** argv, char** envp) {
         (void*)&test_func < pal_control.executable_range.end)
         pal_printf("Executable Range OK\n");
 
-    pal_printf("CPU num: %ld\n", pal_control.cpu_info.cpu_num);
+    pal_printf("CPU num: %ld\n", pal_control.cpu_info.online_logical_cores);
     pal_printf("CPU vendor: %s\n", pal_control.cpu_info.cpu_vendor);
     pal_printf("CPU brand: %s\n", pal_control.cpu_info.cpu_brand);
     pal_printf("CPU family: %ld\n", pal_control.cpu_info.cpu_family);

--- a/Pal/src/host/Linux-SGX/db_main.c
+++ b/Pal/src/host/Linux-SGX/db_main.c
@@ -284,13 +284,20 @@ noreturn void pal_linux_main(char* uptr_libpal_uri, size_t libpal_uri_len, char*
     g_pal_sec.uid = sec_info.uid;
     g_pal_sec.gid = sec_info.gid;
 
-    int num_cpus = sec_info.num_cpus;
-    if (num_cpus >= 1 && num_cpus <= (1 << 16)) {
-        g_pal_sec.num_cpus = num_cpus;
+    int online_logical_cores = sec_info.online_logical_cores;
+    if (online_logical_cores >= 1 && online_logical_cores <= (1 << 16)) {
+        g_pal_sec.online_logical_cores = online_logical_cores;
     } else {
-        SGX_DBG(DBG_E, "Invalid sec_info.num_cpus: %d\n", num_cpus);
+        SGX_DBG(DBG_E, "Invalid sec_info.online_logical_cores: %d\n", online_logical_cores);
         ocall_exit(1, /*is_exitgroup=*/true);
     }
+
+    if (sec_info.physical_cores_per_socket <= 0) {
+        SGX_DBG(DBG_E, "Invalid sec_info.physical_cores_per_socket: %ld\n",
+                sec_info.physical_cores_per_socket);
+        ocall_exit(1, /*is_exitgroup=*/true);
+    }
+    g_pal_sec.physical_cores_per_socket = sec_info.physical_cores_per_socket;
 
     /* set up page allocator and slab manager */
     init_slab_mgr(g_page_size);
@@ -336,6 +343,20 @@ noreturn void pal_linux_main(char* uptr_libpal_uri, size_t libpal_uri_len, char*
     g_linux_state.process_id = (start_time & (~0xffff)) | g_pal_sec.pid;
 
     SET_ENCLAVE_TLS(ready_for_exceptions, 1UL);
+
+    /* Allocate enclave memory to store "logical core -> socket" mappings */
+    int* cpu_socket = (int*)malloc(online_logical_cores * sizeof(int));
+    if (!cpu_socket) {
+        SGX_DBG(DBG_E, "Allocation for logical core -> socket mappings failed\n");
+        ocall_exit(1, /*is_exitgroup=*/true);
+    }
+
+    if (!sgx_copy_to_enclave(cpu_socket, online_logical_cores * sizeof(int), sec_info.cpu_socket,
+                             online_logical_cores * sizeof(int))) {
+        SGX_DBG(DBG_E, "Copying cpu_socket into the enclave failed\n");
+        ocall_exit(1, /*is_exitgroup=*/true);
+    }
+    g_pal_sec.cpu_socket = cpu_socket;
 
     /* initialize master key (used for pipes' encryption for all enclaves of an application); it
      * will be overwritten below in init_child_process() with inherited-from-parent master key if

--- a/Pal/src/host/Linux-SGX/pal_security.h
+++ b/Pal/src/host/Linux-SGX/pal_security.h
@@ -36,8 +36,9 @@ struct pal_sec {
     /* additional information */
     PAL_SEC_STR pipe_prefix;
 
-    /* Need to pass in the number of cores */
-    PAL_NUM num_cpus;
+    PAL_NUM online_logical_cores;
+    PAL_NUM physical_cores_per_socket;
+    int* cpu_socket;
 
 #ifdef DEBUG
     PAL_BOL in_gdb;

--- a/Pal/src/host/Linux/db_main.c
+++ b/Pal/src/host/Linux/db_main.c
@@ -264,27 +264,30 @@ noreturn void pal_linux_main(void* initial_rsp, void* fini_callback) {
              first_process ? argv + 3 : argv + 4, envp);
 }
 
-/*
- * Returns the number of online CPUs read from /sys/devices/system/cpu/online, -errno on failure.
- * Understands complex formats like "1,3-5,6".
+/* Opens a pseudo-file describing HW resources such as online CPUs and counts the number of
+ * HW resources present in the file (if count == true) or simply reads the integer stored in the
+ * file (if count == false). For example on a single-core machine, calling this function on
+ * `/sys/devices/system/cpu/online` with count == true will return 1 and 0 with count == false.
+ * Returns PAL error code on failure.
+ * N.B: Understands complex formats like "1,3-5,6" when called with count == true.
  */
-int get_cpu_count(void) {
-    int fd = INLINE_SYSCALL(open, 3, "/sys/devices/system/cpu/online", O_RDONLY | O_CLOEXEC, 0);
-    if (fd < 0)
+int get_hw_resource(const char* filename, bool count) {
+    int fd = INLINE_SYSCALL(open, 3, filename, O_RDONLY | O_CLOEXEC, 0);
+    if (IS_ERR(fd))
         return unix_to_pal_error(ERRNO(fd));
 
     char buf[64];
     int ret = INLINE_SYSCALL(read, 3, fd, buf, sizeof(buf) - 1);
     INLINE_SYSCALL(close, 1, fd);
-    if (ret < 0) {
+    if (IS_ERR(ret))
         return unix_to_pal_error(ERRNO(ret));
-    }
 
     buf[ret] = '\0'; /* ensure null-terminated buf even in partial read */
 
     char* end;
     char* ptr = buf;
-    int cpu_count = 0;
+    int resource_cnt = 0;
+    int retval = -PAL_ERROR_STREAMNOTEXIST;
     while (*ptr) {
         while (*ptr == ' ' || *ptr == '\t' || *ptr == ',')
             ptr++;
@@ -293,22 +296,31 @@ int get_cpu_count(void) {
         if (ptr == end)
             break;
 
+        /* caller wants to read an int stored in the file */
+        if (!count) {
+            if (*end == '\n' || *end == '\0')
+                retval = firstint;
+            return retval;
+        }
+
+        /* caller wants to count the number of HW resources */
         if (*end == '\0' || *end == ',' || *end == '\n') {
-            /* single CPU index, count as one more CPU */
-            cpu_count++;
+            /* single HW resource index, count as one more */
+            resource_cnt++;
         } else if (*end == '-') {
-            /* CPU range, count how many CPUs in range */
+            /* HW resource range, count how many HW resources are in range */
             ptr = end + 1;
             int secondint = (int)strtol(ptr, &end, 10);
             if (secondint > firstint)
-                cpu_count += secondint - firstint + 1; // inclusive (e.g., 0-7, or 8-16)
+                resource_cnt += secondint - firstint + 1; // inclusive (e.g., 0-7, or 8-16)
         }
         ptr = end;
     }
 
-    if (cpu_count == 0)
-        return -PAL_ERROR_STREAMNOTEXIST;
-    return cpu_count;
+    if (count && resource_cnt > 0)
+        retval = resource_cnt;
+
+    return retval;
 }
 
 ssize_t read_file_buffer(const char* filename, char* buf, size_t buf_size) {

--- a/Pal/src/host/Linux/pal_linux.h
+++ b/Pal/src/host/Linux/pal_linux.h
@@ -126,7 +126,7 @@ bool stataccess(struct stat* stats, int acc);
 void init_child_process(int parent_pipe_fd, PAL_HANDLE* parent, PAL_HANDLE* exec,
                         PAL_HANDLE* manifest);
 
-int get_cpu_count(void);
+int get_hw_resource(const char* filename, bool count);
 ssize_t read_file_buffer(const char* filename, char* buf, size_t buf_size);
 
 void cpuid(unsigned int leaf, unsigned int subleaf, unsigned int words[]);


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Applications tend to use `/proc/cpuinfo` to get the `cpu cores` and `physical id` for computing the number of physical cores in a
socket. Currently `cpu cores` field is incorrectly implemented as it is set to the number of logical processors online and `physical id` isn't implemented. This patch addresses both of these issues.

For example, openVINO these fields in the following way to decide how many threads it should use for its inference engine.
https://github.com/openvinotoolkit/openvino/blob/master/inference-engine/src/inference_engine/os/lin/lin_system_conf.cpp#L24

## How to test this PR? <!-- (if applicable) -->
We have `proc_common.c` regression test which already covers `/proc/cpuinfo`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1910)
<!-- Reviewable:end -->
