### PR TITLE
[LibOS] Enhance /dev/null stat

### DIFF
--- a/LibOS/shim/include/shim_fs.h
+++ b/LibOS/shim/include/shim_fs.h
@@ -494,6 +494,15 @@ struct pseudo_name_ops {
     int (*list_name)(const char* name, struct shim_dirent** buf, int count);
 };
 
+static inline dev_t makedev(unsigned int major, unsigned int minor) {
+    dev_t dev;
+    dev  = (((dev_t)(major & 0x00000fffu)) <<  8);
+    dev |= (((dev_t)(major & 0xfffff000u)) << 32);
+    dev |= (((dev_t)(minor & 0x000000ffu)) <<  0);
+    dev |= (((dev_t)(minor & 0xffffff00u)) << 12);
+    return dev;
+}
+
 struct pseudo_fs_ops {
     int (*open)(struct shim_handle* hdl, const char* name, int flags);
     int (*mode)(const char* name, mode_t* mode);

--- a/LibOS/shim/src/fs/dev/null.c
+++ b/LibOS/shim/src/fs/dev/null.c
@@ -35,11 +35,17 @@ static int dev_null_mode(const char* name, mode_t* mode) {
     return 0;
 }
 
+/* st_rdev field in struct stat of /dev/null is (1,3).
+ * https://elixir.bootlin.com/linux/v5.9/source/drivers/char/mem.c#L950
+ */
+#define DEV_NULL_MAJOR 1
+#define DEV_NULL_MINOR 3
 static int dev_null_stat(const char* name, struct stat* buf) {
     __UNUSED(name);
     memset(buf, 0, sizeof(*buf));
 
     buf->st_mode = FILE_RW_MODE | S_IFCHR;
+    buf->st_rdev = makedev(DEV_NULL_MAJOR, DEV_NULL_MINOR);
     return 0;
 }
 
@@ -69,9 +75,37 @@ struct pseudo_fs_ops dev_null_fs_ops = {
     .stat = &dev_null_stat,
 };
 
-/* /dev/tty is exactly the same as /dev/null in Graphene, so it has the same operations */
+static int dev_tty_stat(const char* name, struct stat* buf) {
+    __UNUSED(name);
+    memset(buf, 0, sizeof(*buf));
+
+    buf->st_mode = FILE_RW_MODE | S_IFCHR;
+    return 0;
+}
+
+static int dev_tty_hstat(struct shim_handle* hdl, struct stat* buf) {
+    __UNUSED(hdl);
+    return dev_tty_stat(/*name=*/NULL, buf);
+}
+
+static int dev_tty_open(struct shim_handle* hdl, const char* name, int flags) {
+    __UNUSED(name);
+    __UNUSED(flags);
+
+    struct shim_dev_ops ops = {.read     = &dev_null_read,
+                               .write    = &dev_null_write,
+                               .truncate = &dev_null_truncate,
+                               .mode     = &dev_null_mode,
+                               .stat     = &dev_tty_stat,
+                               .hstat    = &dev_tty_hstat};
+
+    memcpy(&hdl->info.dev.dev_ops, &ops, sizeof(ops));
+    return 0;
+}
+
+/* /dev/tty differs from /dev/null only in its st_rdev field (and thus in stat/hstat/open) */
 struct pseudo_fs_ops dev_tty_fs_ops = {
-    .open = &dev_null_open,
+    .open = &dev_tty_open,
     .mode = &dev_null_mode,
-    .stat = &dev_null_stat,
+    .stat = &dev_tty_stat,
 };


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->
Glibc function daemon() checks `st_rdev` field in struct stat of `/dev/null`. However current  pseudo dev_null_fs doesn't fill  `st_rdev` field. This PR updates `dev_null_stat` to fill `st_rdev` field with hard code value and leaves `dev_tty_fs_ops` unchanged.
Fixes #1891

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1911)
<!-- Reviewable:end -->
