### PR TITLE
[LibOS] Fix dangling pointer `dent` on connect(AF_UNIX)

### DIFF
--- a/LibOS/shim/src/fs/shim_namei.c
+++ b/LibOS/shim/src/fs/shim_namei.c
@@ -229,6 +229,12 @@ out:
  * manifest.
  *
  * If the file isn't found, returns -ENOENT.
+ * FIXME: path_lookupat() abuses -ENOENT for two cases:
+ *        - actual failure: one of the subdirs was not found, i.e., the file
+ *          cannot be created at all (and then dent is set to NULL);
+ *        - benign failure: all subdirs are found but the file doesn't exist,
+ *          i.e., the file can be created (and then dent is set to object).
+ *        This is terrible semantics and must be fixed when FS is re-worked.
  *
  * If the LOOKUP_DIRECTORY flag is set, and the found file isn't a directory,
  *  returns -ENOTDIR.

--- a/LibOS/shim/src/sys/shim_socket.c
+++ b/LibOS/shim/src/sys/shim_socket.c
@@ -476,9 +476,9 @@ int shim_do_bind(int sockfd, struct sockaddr* addr, int _addrlen) {
         struct shim_dentry* dent  = NULL;
 
         if ((ret = path_lookupat(NULL, spath, LOOKUP_CREATE, &dent, NULL)) < 0) {
-            // DEP 7/3/17: We actually want either 0 or -ENOENT, as the
-            // expected case is that the name is free (and we get the dent to
-            // populate the name)
+            /* We want either 0 or -ENOENT (dent is a valid object in both cases), as the expected
+             * case is that the name is free (and we use dent with the name already populated).
+             * FIXME: This is terrible semantics; path_lookupat() must be re-worked. */
             if (ret != -ENOENT || !dent)
                 goto out;
         }
@@ -744,7 +744,7 @@ int shim_do_connect(int sockfd, struct sockaddr* addr, int _addrlen) {
 
         struct sockaddr_un* saddr = (struct sockaddr_un*)addr;
         char* spath               = saddr->sun_path;
-        struct shim_dentry* dent;
+        struct shim_dentry* dent  = NULL;
 
         if ((ret = path_lookupat(NULL, spath, LOOKUP_CREATE, &dent, NULL)) < 0) {
             // DEP 7/3/17: We actually want either 0 or -ENOENT, as the

--- a/LibOS/shim/src/sys/shim_stat.c
+++ b/LibOS/shim/src/sys/shim_stat.c
@@ -223,7 +223,7 @@ int shim_do_newfstatat(int dirfd, const char* pathname, struct stat* statbuf, in
             return ret;
     }
 
-    struct shim_dentry* dent;
+    struct shim_dentry* dent = NULL;
     int ret = path_lookupat(dir, pathname, lookup_flags, &dent, NULL);
     if (ret >= 0) {
         struct shim_d_ops* d_ops = dent->fs->d_ops;


### PR DESCRIPTION

## Description of the changes <!-- (reasons and measures) -->

When connecting on a named UNIX domain socket, the `connect()` syscall checks if the socket path exists via `path_lookupat(&dent)`. However, `path_lookupat()` may return error and *not* update `dent` allocated on stack. In this case, `dent` contains garbage, and Graphene fails.

This PR fixes this via explicit `dent = NULL`.

## How to test this PR? <!-- (if applicable) -->

A `unix` LibOS test is updated to test this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1913)
<!-- Reviewable:end -->
