### PR TITLE
Loader rework part 3: Disallow starting without an executable

### DIFF
--- a/Documentation/manifest-syntax.rst
+++ b/Documentation/manifest-syntax.rst
@@ -43,8 +43,7 @@ Preloaded libraries
 
 This syntax specifies the libraries to be preloaded before loading the
 executable. The URIs of the libraries must be separated by commas. The libraries
-must be ELF binaries. This syntax currently always contains the LibOS library
-``libsysdb.so``.
+must be ELF binaries. This usually contains the LibOS library ``libsysdb.so``.
 
 Command-line arguments
 ^^^^^^^^^^^^^^^^^^^^^^

--- a/Documentation/pal/host-abi.rst
+++ b/Documentation/pal/host-abi.rst
@@ -33,7 +33,7 @@ To run a program in Graphene properly, the PAL loader generally requires both a
 manifest and an executable, although it is possible to load with only one of
 them. The user shall specify either the manifest or the executable to load in
 the command line, and the PAL loader will try to locate the other based on the
-file name or content.
+file name.
 
 Precisely, the loading rules for the manifest and executable are as follows:
 
@@ -47,8 +47,6 @@ Precisely, the loading rules for the manifest and executable are as follows:
    to infer the executable. The potential executable file has the same file name
    as the manifest file except it doesn't have the `.manifest` or
    `.manifest.sgx` extension.
-#. If a manifest is given to the command line, and no executable file can be
-   found, then no executable is used for the execution.
 
 
 Data types and variables

--- a/Pal/regression/Bootstrap5.manifest.template
+++ b/Pal/regression/Bootstrap5.manifest.template
@@ -1,4 +1,0 @@
-loader.debug_type = inline
-loader.preload = file:Preload1.so,file:Preload2.so
-# This example doesn't use any binary, this line is only to stop argv protection from complaining.
-loader.argv0_override = Bootstrap

--- a/Pal/regression/Makefile
+++ b/Pal/regression/Makefile
@@ -63,7 +63,6 @@ manifests = \
 	Bootstrap2.manifest \
 	Bootstrap3.manifest \
 	Bootstrap4.manifest \
-	Bootstrap5.manifest \
 	Bootstrap6.manifest \
 	Bootstrap7.manifest \
 	File.manifest \
@@ -132,13 +131,6 @@ Thread2_exitless: Thread2
 
 ifeq ($(filter %clean,$(MAKECMDGOALS)),)
 include $(wildcard *.d)
-ifeq ($(SGX), 1)
-# Bootstrap5.manifest doesn't have main executable, but only preloaded
-# libraries. Static pattern rule is needed to override the implicit pattern
-# rule defined in Pal/src/host/Linux-SGX/Makefile.Test.
-Bootstrap5.manifest.sgx.d: %.manifest.sgx.d: %.manifest
-	$(call cmd,sgx_sign_depend)
-endif
 endif
 
 $(graphene_lib):

--- a/Pal/regression/test_pal.py
+++ b/Pal/regression/test_pal.py
@@ -213,12 +213,6 @@ class TC_01_Bootstrap(RegressionTestCase):
         self.assertIn('Preloaded Function 1 Called', stderr)
         self.assertIn('Preloaded Function 2 Called', stderr)
 
-    def test_111_preload_libraries(self):
-        # Bootstrap without Executable but Preload Libraries
-        _, stderr = self.run_binary([self.get_manifest('Bootstrap5')])
-        self.assertIn('Binary 1 Preloaded', stderr)
-        self.assertIn('Binary 2 Preloaded', stderr)
-
     @unittest.skipUnless(HAS_SGX, 'this test requires SGX')
     def test_120_8gb_enclave(self):
         manifest = self.get_manifest('Bootstrap6')

--- a/Pal/src/db_main.c
+++ b/Pal/src/db_main.c
@@ -344,13 +344,8 @@ noreturn void pal_main(PAL_NUM instance_id,        /* current instance id */
             if (!exec_uri)
                 INIT_FAIL(PAL_ERROR_NOMEM, "Cannot allocate URI buf");
             ret = _DkStreamOpen(&exec_handle, exec_uri, PAL_ACCESS_RDONLY, 0, 0, 0);
-            // DEP 3/20/17: There are cases where we want to let
-            // the PAL start up without a main executable.  Don't
-            // die here, just free the exec_uri buffer.
-            if (ret < 0) {
-                free(exec_uri);
-                exec_uri = NULL;
-            }
+            if (ret < 0)
+                INIT_FAIL(PAL_ERROR_INVAL, "Cannot open the executable");
         }
     }
 

--- a/Pal/src/host/Linux-SGX/Makefile.manifest
+++ b/Pal/src/host/Linux-SGX/Makefile.manifest
@@ -33,14 +33,7 @@ $(SGX_SIGNER_KEY):
 	$(call cmd,sgx_sign_depend_exec)
 
 %.manifest.sgx.d: manifest
-	$(call cmd,sgx_sign_depend)
-
-# It is possible to have an SGX manifest without main executable: manifest may have only preloaded
-# libraries. There is no good way to distinguish this rule from the above rule. Since manifests
-# without main executables are very rare, these cases use static pattern rules in the corresponding
-# Makefiles (e.g., in Pal/regression).
-# %.manifest.sgx.d: %.manifest
-# 	$(call cmd,sgx_sign_depend)
+	$(call cmd,sgx_sign_depend_exec)
 
 ifeq ($(filter %clean,$(MAKECMDGOALS)),)
 ifeq ($(target),)
@@ -48,4 +41,3 @@ $(error define "target" variable for manifest.sgx dependency calculation)
 endif
 include $(addsuffix .manifest.sgx.d,$(call drop_manifest_suffix,$(target)))
 endif
-

--- a/Pal/src/host/Linux-SGX/db_main.c
+++ b/Pal/src/host/Linux-SGX/db_main.c
@@ -366,12 +366,7 @@ noreturn void pal_linux_main(char* uptr_libpal_uri, size_t libpal_uri_len, char*
     PAL_HANDLE manifest, exec = NULL;
 
     manifest = setup_dummy_file_handle(g_pal_sec.manifest_name);
-
-    if (g_pal_sec.exec_name[0] != '\0') {
-        exec = setup_dummy_file_handle(g_pal_sec.exec_name);
-    } else {
-        SGX_DBG(DBG_I, "Run without executable\n");
-    }
+    exec = setup_dummy_file_handle(g_pal_sec.exec_name);
 
     uint64_t manifest_size = GET_ENCLAVE_TLS(manifest_size);
     void* manifest_addr = g_enclave_top - ALIGN_UP_PTR_POW2(manifest_size, g_page_size);

--- a/Pal/src/host/Linux-SGX/enclave_framework.c
+++ b/Pal/src/host/Linux-SGX/enclave_framework.c
@@ -747,11 +747,9 @@ int init_trusted_files(void) {
     char* k;
     char* tmp;
 
-    if (g_pal_sec.exec_name[0] != '\0') {
-        ret = init_trusted_file("exec", g_pal_sec.exec_name);
-        if (ret < 0)
-            goto out;
-    }
+    ret = init_trusted_file("exec", g_pal_sec.exec_name);
+    if (ret < 0)
+        goto out;
 
     cfgbuf = malloc(CONFIG_MAX);
     if (!cfgbuf) {

--- a/Pal/src/host/Linux/db_main.c
+++ b/Pal/src/host/Linux/db_main.c
@@ -241,16 +241,12 @@ noreturn void pal_linux_main(void* initial_rsp, void* fini_callback) {
         g_linux_state.parent_process_id = g_linux_state.process_id;
 
     if (first_process) {
-        // We need to find a binary to run.
-        const char* exec_target = argv[3];
-        size_t size = URI_PREFIX_FILE_LEN + strlen(exec_target) + 1;
-        char* uri = malloc(size);
-        if (!uri)
+        char* exec_uri = alloc_concat(URI_PREFIX_FILE, URI_PREFIX_FILE_LEN, argv[3], -1);
+        if (!exec_uri)
             INIT_FAIL(PAL_ERROR_NOMEM, "Out of memory");
-        snprintf(uri, size, URI_PREFIX_FILE "%s", exec_target);
         PAL_HANDLE file;
-        int ret = _DkStreamOpen(&file, uri, PAL_ACCESS_RDONLY, 0, 0, PAL_OPTION_CLOEXEC);
-        free(uri);
+        int ret = _DkStreamOpen(&file, exec_uri, PAL_ACCESS_RDONLY, 0, 0, PAL_OPTION_CLOEXEC);
+        free(exec_uri);
         if (ret < 0)
             INIT_FAIL(-ret, "Failed to open file to execute");
 

--- a/README.rst
+++ b/README.rst
@@ -67,7 +67,7 @@ Graphene library OS uses the PAL (``libpal.so``) as a loader to bootstrap
 applications in the library OS. To start Graphene, PAL (``libpal.so``) will have
 to be run as an executable, with the name of the program, and a |nbsp| "manifest
 file" (per-app configuration) given from the command line. Graphene provides
-three options for specifying the programs and manifest files:
+two options for specifying the programs and manifest files:
 
 - option 1 (automatic manifest)::
 

--- a/Scripts/Makefile.rules
+++ b/Scripts/Makefile.rules
@@ -152,11 +152,6 @@ quiet_cmd_sgx_get_token = [ Token: $(basename $*) ]
 quiet_cmd_sgx_sign_depend_exec = [ $@ ]
       cmd_sgx_sign_depend_exec = $(SGX_SIGN) -depend -output $@ -exec $* -manifest $<
 
-# SGX manifest dependency without executable, but possibly with preload libraries. Use static
-# pattern rule for this recipe.
-quiet_cmd_sgx_sign_depend = [ $@ ]
-      cmd_sgx_sign_depend = $(SGX_SIGN) -depend -output $@ -manifest $<
-
 # manifest
 quiet_cmd_manifest = [ $@ ]
       cmd_manifest = \


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Previously, it was possible to use Graphene without the main executable (e.g. having only preloaded libraries). We aren't aware of anyone using this weird option, but worse, it led to a very bad UX when the user made mistakes - e.g. having a typo in the manifest or executable name could lead to Graphene starting without errors, but doing nothing.

Fixes #1905.

## How to test this PR? <!-- (if applicable) -->

See #1905 for reproduction steps for an example of a problem fixed by this change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1915)
<!-- Reviewable:end -->
