### PR TITLE
[Pal/Linux-SGX] Support in-kernel SGX driver v39

### DIFF
--- a/Jenkinsfiles/Linux-SGX-18.04
+++ b/Jenkinsfiles/Linux-SGX-18.04
@@ -34,11 +34,11 @@ pipeline {
                            cd /opt/intel
                            git clone https://github.com/intel/SGXDataCenterAttestationPrimitives.git
                            cd SGXDataCenterAttestationPrimitives
-                           git checkout DCAP_1.5
+                           git checkout DCAP_1.6
                            # no need to build, we only need the SGX header file (sgx_oot.h)
                         '''
                         sh '''
-                            # test the build with the DCAP driver v1.5 and clean up afterwards
+                            # test the build with the DCAP driver v1.6 and clean up afterwards
                             cd Pal/src/host/Linux-SGX/sgx-driver
                             ISGX_DRIVER_PATH=/opt/intel/SGXDataCenterAttestationPrimitives/driver/linux make
                             cd ../../../../../

--- a/Pal/src/host/Linux-SGX/sgx_framework.c
+++ b/Pal/src/host/Linux-SGX/sgx_framework.c
@@ -263,6 +263,7 @@ int add_pages_to_enclave(sgx_arch_secs_t* secs, void* addr, void* user_addr, uns
 #ifdef SGX_DCAP_16_OR_LATER
     if (!user_addr && g_zero_pages_size < size) {
         /* not enough contigious zero pages to back up enclave pages, allocate more */
+        /* TODO: this logic can be removed if we introduce a size cap in ENCLAVE_ADD_PAGES ioctl */
         ret = INLINE_SYSCALL(munmap, 2, g_zero_pages, g_zero_pages_size);
         if (IS_ERR(ret)) {
             SGX_DBG(DBG_I, "Cannot unmap zero pages %d\n", ret);
@@ -288,15 +289,29 @@ int add_pages_to_enclave(sgx_arch_secs_t* secs, void* addr, void* user_addr, uns
         .count   = 0, /* output parameter, will be checked after IOCTL */
     };
 
-    ret = INLINE_SYSCALL(ioctl, 3, g_isgx_device, SGX_IOC_ENCLAVE_ADD_PAGES, &param);
-    if (IS_ERR(ret)) {
-        SGX_DBG(DBG_I, "Enclave EADD returned %d\n", ret);
-        return -ERRNO(ret);
-    }
-    if (param.count != param.length) {
-        SGX_DBG(DBG_I, "Enclave EADD didn't add all pages: added %lluB but expected %lluB\n",
-                param.count, param.length);
-        return -ERRNO(ret);
+    /* NOTE: SGX driver v39 removes `count` field and returns "number of bytes added" as return
+     * value directly in `ret`. It also caps the maximum number of bytes to be added as 1MB, or 256
+     * enclave pages. Thus, the below code must loop on the ADD_PAGES ioctl until all pages are
+     * added; the code must first check `ret > 0` and only then check `count` field to support all
+     * versions of the SGX driver. Note that even though `count` is removed in v39, it is the last
+     * field of struct and thus may stay redundant (and unused by driver v39). We hope that this
+     * contrived logic won't be needed when the SGX driver stabilizes its ioctl interface.
+     * (https://git.kernel.org/pub/scm/linux/kernel/git/jarkko/linux-sgx.git/tag/?h=v39) */
+    while (param.length > 0) {
+        ret = INLINE_SYSCALL(ioctl, 3, g_isgx_device, SGX_IOC_ENCLAVE_ADD_PAGES, &param);
+        if (IS_ERR(ret)) {
+            if (ret == -EINTR)
+                continue;
+            SGX_DBG(DBG_I, "Enclave EADD returned %d\n", ret);
+            return -ERRNO(ret);
+        }
+
+        uint64_t added_size = ret > 0 ? (uint64_t)ret : param.count;
+
+        param.offset += added_size;
+        if (param.src != (uint64_t)g_zero_pages)
+            param.src += added_size;
+        param.length -= added_size;
     }
 
     /* ask Intel SGX driver to actually mmap the added enclave pages */
@@ -319,6 +334,8 @@ int add_pages_to_enclave(sgx_arch_secs_t* secs, void* addr, void* user_addr, uns
     while (added_size < size) {
         ret = INLINE_SYSCALL(ioctl, 3, g_isgx_device, SGX_IOC_ENCLAVE_ADD_PAGE, &param);
         if (IS_ERR(ret)) {
+            if (ret == -EINTR)
+                continue;
             SGX_DBG(DBG_I, "Enclave EADD returned %d\n", ret);
             return -ERRNO(ret);
         }


### PR DESCRIPTION

## Description of the changes <!-- (reasons and measures) -->

SGX driver v39 removes `count` field and returns "number of bytes added" as return value of the SGX_IOC_ENCLAVE_ADD_PAGES ioctl. It also caps the maximum number of bytes to be added as 1MB, or 256 pages. Thus, we must loop on the ADD_PAGES ioctl until all pages are added and first check `ret > 0` and only then check `count` field (to support all versions of the SGX driver).

For additional details, see:
- https://lore.kernel.org/linux-sgx/20200908190042.24895-1-jarkko.sakkinen@linux.intel.com/#r
- https://git.kernel.org/pub/scm/linux/kernel/git/jarkko/linux-sgx.git/tree/arch/x86/kernel/cpu/sgx/ioctl.c?h=v39
- https://git.kernel.org/pub/scm/linux/kernel/git/jarkko/linux-sgx.git/tree/arch/x86/include/uapi/asm/sgx.h?h=v39

## How to test this PR? <!-- (if applicable) -->

I only tested on older (v33 and v36) out-of-kernel DCAP SGX drivers. Note that as of this writing, https://github.com/intel/SGXDataCenterAttestationPrimitives/tree/master/driver/linux only tracks v36 as the latest version, so impossible to test using the out-of-kernel driver.

**TODO**: Could someone test this on in-kernel v39?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1916)
<!-- Reviewable:end -->
