### PR TITLE
[GSC] Fix test makefile to correctly use configuration files and build base images

### DIFF
--- a/Jenkinsfiles/Linux-SGX-gsc
+++ b/Jenkinsfiles/Linux-SGX-gsc
@@ -11,8 +11,8 @@ pipeline {
                             # merged)
                             export COMMIT=`git log --pretty="%H %P" -n 1 | awk '{if(!$3) \
                                                                 {print $1} else {print $3}}'`
-                            make TESTCASES='python3 python3-trusted-args' \
-                                 DISTRIBUTIONS="ubuntu18.04" \
+                            make TESTCASES='python3 python3-trusted-args base-python3' \
+                                 DISTRIBUTIONS='ubuntu18.04' \
                                  IMAGE_SUFFIX=-${COMMIT} GRAPHENE_BRANCH=${COMMIT}
                         '''
                     }
@@ -28,13 +28,13 @@ pipeline {
                                                                 {print $1} else {print $3}}'`
                             # Test Linux Pal
                             make test ENV_VARS='GSC_PAL=Linux' MAXTESTNUM=2 TESTCASES=python3 \
-                                      DISTRIBUTIONS="ubuntu18.04" IMAGE_SUFFIX=-${COMMIT}
+                                      DISTRIBUTIONS='ubuntu18.04' IMAGE_SUFFIX=-${COMMIT}
                             # Test Linux-SGX PAL
                             make test MAXTESTNUM=3 TESTCASES='python3 python3-trusted-args' \
-                                      DISTRIBUTIONS="ubuntu18.04" IMAGE_SUFFIX=-${COMMIT}
+                                      DISTRIBUTIONS='ubuntu18.04' IMAGE_SUFFIX=-${COMMIT}
                             # Test use of base Graphene Image
                             make test MAXTESTNUM=2 TESTCASES='python3' \
-                                      DISTRIBUTIONS="ubuntu18.04" IMAGE_SUFFIX=-base-${COMMIT}
+                                      DISTRIBUTIONS='ubuntu18.04-base' IMAGE_SUFFIX=-${COMMIT}
                         '''
                     }
                 }
@@ -62,8 +62,8 @@ pipeline {
                         # commit in below git-log output if merged or first commit if not merged)
                         export COMMIT=`git log --pretty="%H %P" -n 1 | awk '{if(!$3) \
                                                             {print $1} else {print $3}}'`
-                        make clean TESTCASES='python3 python3-trusted-args' \
-                                   DISTRIBUTIONS="ubuntu18.04" IMAGE_SUFFIX=-${COMMIT}
+                        make clean TESTCASES='python3 python3-trusted-args base-python3' \
+                                   DISTRIBUTIONS='ubuntu18.04' IMAGE_SUFFIX=-${COMMIT}
                         docker image prune -f
                     '''
                 }

--- a/Tools/gsc/test/Makefile
+++ b/Tools/gsc/test/Makefile
@@ -1,4 +1,4 @@
-TESTCASES ?= python3 python3-trusted-args hello-world nodejs bash numpy pytorch
+TESTCASES ?= python3 python3-trusted-args base-python3 hello-world nodejs bash numpy pytorch
 DISTRIBUTIONS ?= ubuntu18.04
 GRAPHENE_BRANCH ?= master
 DOCKER_BUILD_FLAGS ?= --rm --no-cache
@@ -16,23 +16,16 @@ ENV_VARS ?=
 IMAGE_SUFFIX ?=
 
 .PHONY: all
-all: $(KEY_FILE) $(TESTS)
+all: $(KEY_FILE)
 	for d in $(DISTRIBUTIONS); do \
 		sed -e 's/Distro: \".*\"/Distro: \"'$${d}'\"/' \
 		    -e 's/Branch: \"master\"/Branch: \"'$(GRAPHENE_BRANCH)'\"/' \
 			../config.yaml.template > config-$${d}.yaml; \
 		$(MAKE) $(addprefix gsc-$${d}-, $(TESTCASES)) || exit 1; \
-		$(MAKE) $(addprefix gsc-$${d}-, python3-base) || exit 1; \
 	done
 
 $(KEY_FILE):
 	openssl genrsa -3 -out $(KEY_FILE) 3072
-
-.PRECIOUS: %: %.dockerfile
-%: %.dockerfile
-	echo "Building base image $@.dockerfile..."
-	docker build $(DOCKER_BUILD_FLAGS) -t $(addsuffix $(IMAGE_SUFFIX), $@) -f $@.dockerfile ../../../Examples
-	touch $@
 
 .PRECIOUS: gsc-%-bash
 gsc-%-bash: %-bash
@@ -62,11 +55,19 @@ gsc-%-pytorch: %-pytorch %-pytorch.manifest
 	cd .. && ./gsc sign-image -c test/config-$*.yaml $(addsuffix $(IMAGE_SUFFIX), $*-pytorch) $(notdir $(KEY_FILE))
 	touch $@
 
+.PRECIOUS: gsc-%-base-python3
+gsc-%-base-python3: graphene-% %-base-python3
+	printf "Distro: \"$*\"\nGraphene:\n   Image: \"graphene-$*$(IMAGE_SUFFIX)\"\n" > config-image-$*.yaml
+	echo "Building graphenized image $@..."
+	cd .. && ./gsc build -c test/config-image-$*.yaml -L --insecure-args $(GSC_BUILD_FLAGS) $(addsuffix $(IMAGE_SUFFIX), $*-base-python3) $(addprefix test/, $*-python3.manifest sh.manifest ls.manifest)
+	cd .. && ./gsc sign-image -c test/config-image-$*.yaml $(addsuffix $(IMAGE_SUFFIX), $*-base-python3) $(notdir $(KEY_FILE))
+	touch $@
+
 .PRECIOUS: gsc-%
 gsc-%: %
 	echo "Building graphenized image $@..."
-	cd .. && ./gsc build -c test/config-$*.yaml -L --insecure-args $(GSC_BUILD_FLAGS) $(addsuffix $(IMAGE_SUFFIX), $*) test/$(*:gsc-%=%).manifest
-	cd .. && ./gsc sign-image -c test/config-$*.yaml $(addsuffix $(IMAGE_SUFFIX), $*) $(notdir $(KEY_FILE))
+	cd .. && ./gsc build -c test/config-$(firstword $(subst -, ,$*)).yaml -L --insecure-args $(GSC_BUILD_FLAGS) $(addsuffix $(IMAGE_SUFFIX), $*) test/$(*:gsc-%=%).manifest
+	cd .. && ./gsc sign-image -c test/config-$(firstword $(subst -, ,$*)).yaml $(addsuffix $(IMAGE_SUFFIX), $*) $(notdir $(KEY_FILE))
 	touch $@
 
 .PRECIOUS: graphene-%
@@ -75,13 +76,15 @@ graphene-%:
 	cd .. && ./gsc build-graphene -c test/config-$*.yaml -L $(GSC_BUILD_FLAGS) $(addsuffix $(IMAGE_SUFFIX), $@)
 	touch $@
 
-.PRECIOUS: gsc-%-python3-base
-gsc-%-python3-base: %-python3 graphene-%
-	docker tag $(addsuffix $(IMAGE_SUFFIX), $*-python3) $(addsuffix $(IMAGE_SUFFIX), $*-python3-base)
-	printf "Distro: \"$*\"\nGraphene:\n   Image: \"graphene-$*$(IMAGE_SUFFIX)\"\n" > config-image-$*.yaml
-	echo "Building graphenized image $@..."
-	cd .. && ./gsc build -c test/config-image-$*.yaml -L --insecure-args $(GSC_BUILD_FLAGS) $(addsuffix $(IMAGE_SUFFIX), $*-python3-base) $(addprefix test/, $*-python3.manifest sh.manifest ls.manifest)
-	cd .. && ./gsc sign-image -c test/config-image-$*.yaml $(addsuffix $(IMAGE_SUFFIX), $*-python3-base) $(notdir $(KEY_FILE))
+.PRECIOUS: ubuntu18.04-base-%
+ubuntu18.04-base-%: ubuntu18.04-%
+	docker tag $(addsuffix $(IMAGE_SUFFIX), $^) $(addsuffix $(IMAGE_SUFFIX), $@)
+	touch $@
+
+.PRECIOUS: ubuntu18.04-%
+ubuntu18.04-%: ubuntu18.04-%.dockerfile
+	echo "Building base image $@.dockerfile..."
+	docker build $(DOCKER_BUILD_FLAGS) -t $(addsuffix $(IMAGE_SUFFIX), $@) -f $@.dockerfile ../../../Examples
 	touch $@
 
 .PHONY: test


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://graphene.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

This PR fixes issues in the test Makefile of GSC. 

1) One issue was introduced when the Makefile switched to using dedicated configuration files per distribution. As a result some Makefile targets include the test case in the configuration file name which should not be the case.

2) The second issue was around building the `python3` example based on a Graphene base image. This test case is called `base-python3` and previously had issues when building multiple times in a row.

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->

Use a test case that does not have a specific Makefile target like `hello-world` and then run the respective test for this test case. In addition, Jenkins can be used to run the regular GSC pipeline.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1920)
<!-- Reviewable:end -->
