### PR TITLE
Miscelaneous inline asm fixes

### DIFF
--- a/LibOS/shim/include/arch/x86_64/shim_internal-arch.h
+++ b/LibOS/shim/include/arch/x86_64/shim_internal-arch.h
@@ -10,10 +10,13 @@
         __stack_top &= ~0xf;                                    \
         __stack_top -= 8;                                       \
         __asm__ volatile (                                      \
-            "movq %0, %%rbp\n"                                  \
             "movq %0, %%rsp\n"                                  \
-            "jmpq *%1\n"                                        \
-            ::"r"(__stack_top), "r"(func), "D"(arg): "memory"); \
+            "xorq %%rbp, %%rbp\n"                               \
+            "jmpq *%%rcx\n"                                     \
+            :                                                   \
+            : "r"(__stack_top), "c"(func), "D"(arg)             \
+            : "memory");                                        \
+        __builtin_unreachable();                                \
     } while (0)
 
 #define CALL_ELF_ENTRY(ENTRY, ARGP)      \

--- a/LibOS/shim/include/arch/x86_64/shim_tcb-arch.h
+++ b/LibOS/shim/include/arch/x86_64/shim_tcb-arch.h
@@ -135,34 +135,11 @@ static inline void shim_regs_set_syscallnr(struct shim_regs* sr, uint64_t sc_num
                       sizeof(ret) == 1,                                 \
                       "SHIM_TCB_GET can be used only for "              \
                       "8, 4, 2, or 1-byte(s) members");                 \
-        switch (sizeof(ret)) {                                          \
-        case 8:                                                         \
-            __asm__("movq %%gs:%c1, %0\n"                               \
-                    : "=r"(ret)                                         \
-                    : "i" (offsetof(PAL_TCB, libos_tcb) +               \
-                           offsetof(shim_tcb_t, member)));              \
-            break;                                                      \
-        case 4:                                                         \
-            __asm__("movl %%gs:%c1, %0\n"                               \
-                    : "=r"(ret)                                         \
-                    : "i" (offsetof(PAL_TCB, libos_tcb) +               \
-                           offsetof(shim_tcb_t, member)));              \
-            break;                                                      \
-        case 2:                                                         \
-            __asm__("movw %%gs:%c1, %0\n"                               \
-                    : "=r"(ret)                                         \
-                    : "i" (offsetof(PAL_TCB, libos_tcb) +               \
-                           offsetof(shim_tcb_t, member)));              \
-            break;                                                      \
-        case 1:                                                         \
-            __asm__("movb %%gs:%c1, %0\n"                               \
-                    : "=r"(ret)                                         \
-                    : "i" (offsetof(PAL_TCB, libos_tcb) +               \
-                           offsetof(shim_tcb_t, member)));              \
-            break;                                                      \
-        default:                                                        \
-            __abort();                                                  \
-        }                                                               \
+        __asm__("mov %%gs:%c1, %0\n"                                    \
+                : "=r"(ret)                                             \
+                : "i" (offsetof(PAL_TCB, libos_tcb) +                   \
+                       offsetof(shim_tcb_t, member))                    \
+                : "memory");                                            \
         ret;                                                            \
     })
 
@@ -180,25 +157,29 @@ static inline void shim_regs_set_syscallnr(struct shim_regs* sr, uint64_t sc_num
             __asm__("movq %0, %%gs:%c1\n"                               \
                     :: "ir"(value),                                     \
                      "i"(offsetof(PAL_TCB, libos_tcb) +                 \
-                         offsetof(shim_tcb_t, member)));                \
+                         offsetof(shim_tcb_t, member))                  \
+                    : "memory");                                        \
             break;                                                      \
         case 4:                                                         \
             __asm__("movl %0, %%gs:%c1\n"                               \
                     :: "ir"(value),                                     \
                      "i"(offsetof(PAL_TCB, libos_tcb) +                 \
-                         offsetof(shim_tcb_t, member)));                \
+                         offsetof(shim_tcb_t, member))                  \
+                    : "memory");                                        \
             break;                                                      \
         case 2:                                                         \
             __asm__("movw %0, %%gs:%c1\n"                               \
                     :: "ir"(value),                                     \
                      "i"(offsetof(PAL_TCB, libos_tcb) +                 \
-                         offsetof(shim_tcb_t, member)));                \
+                         offsetof(shim_tcb_t, member))                  \
+                    : "memory");                                        \
             break;                                                      \
         case 1:                                                         \
             __asm__("movb %0, %%gs:%c1\n"                               \
                     :: "ir"(value),                                     \
                      "i"(offsetof(PAL_TCB, libos_tcb) +                 \
-                         offsetof(shim_tcb_t, member)));                \
+                         offsetof(shim_tcb_t, member))                  \
+                    : "memory");                                        \
             break;                                                      \
         default:                                                        \
             __abort();                                                  \

--- a/LibOS/shim/src/bookkeep/shim_signal.c
+++ b/LibOS/shim/src/bookkeep/shim_signal.c
@@ -451,7 +451,7 @@ bool test_user_memory(void* addr, size_t size, bool write) {
     tcb->test_range.start     = addr;
     tcb->test_range.end       = addr + size - 1;
     /* enforce compiler to store tcb->test_range into memory */
-    __asm__ volatile("" ::: "memory");
+    COMPILER_BARRIER();
 
     /* Try to read or write into one byte inside each page */
     void* tmp = addr;
@@ -466,7 +466,7 @@ bool test_user_memory(void* addr, size_t size, bool write) {
 
 ret_fault:
     /* enforce compiler to load tcb->test_range.has_fault below */
-    __asm__ volatile("" : "=m"(tcb->test_range.has_fault));
+    COMPILER_BARRIER();
 
     /* If any read or write into the target region causes an exception,
      * the control flow will immediately jump to here. */
@@ -517,7 +517,7 @@ bool test_user_string(const char* addr) {
     tcb->test_range.has_fault = false;
     tcb->test_range.cont_addr = &&ret_fault;
     /* enforce compiler to store tcb->test_range into memory */
-    __asm__ volatile("" ::: "memory");
+    COMPILER_BARRIER();
 
     do {
         /* Add the memory region to the watch list. This is not racy because
@@ -538,7 +538,7 @@ bool test_user_string(const char* addr) {
 
 ret_fault:
     /* enforce compiler to load tcb->test_range.has_fault below */
-    __asm__ volatile("" : "=m"(tcb->test_range.has_fault));
+    COMPILER_BARRIER();
 
     /* If any read or write into the target region causes an exception,
      * the control flow will immediately jump to here. */

--- a/LibOS/shim/src/bookkeep/shim_thread.c
+++ b/LibOS/shim/src/bookkeep/shim_thread.c
@@ -474,7 +474,7 @@ void cleanup_thread(IDTYPE caller, void* arg) {
 
     /* wait on clear_child_tid_pal; this signals that PAL layer exited child thread */
     while (__atomic_load_n(&thread->clear_child_tid_pal, __ATOMIC_RELAXED) != 0)
-        cpu_pause();
+        CPU_RELAX();
 
     /* notify parent if any */
     release_clear_child_tid(thread->clear_child_tid);

--- a/LibOS/shim/src/ipc/shim_ipc_helper.c
+++ b/LibOS/shim/src/ipc/shim_ipc_helper.c
@@ -851,6 +851,7 @@ static void shim_ipc_helper_prepare(void* arg) {
     self->stack_top = stack + IPC_HELPER_STACK_SIZE;
     self->stack     = stack;
     __SWITCH_STACK(self->stack_top, shim_ipc_helper, NULL);
+    /* UNREACHABLE */
 }
 
 /* this should be called with the ipc_helper_lock held */

--- a/LibOS/shim/src/sys/shim_exec.c
+++ b/LibOS/shim/src/sys/shim_exec.c
@@ -152,7 +152,7 @@ static int shim_do_execve_rtld(struct shim_handle* hdl, const char** argv, const
         .new_auxv = new_auxv
     };
     __SWITCH_STACK(new_argp, &__shim_do_execve_rtld, &arg);
-    return 0;
+    /* UNREACHABLE */
 }
 
 static BEGIN_MIGRATION_DEF(execve, struct shim_thread* thread,

--- a/Pal/include/arch/x86_64/cpu.h
+++ b/Pal/include/arch/x86_64/cpu.h
@@ -5,10 +5,6 @@
 
 #include <stdint.h>
 
-static inline void cpu_pause(void) {
-    __asm__ volatile("pause");
-}
-
 enum PAL_CPUID_WORD {
     PAL_CPUID_WORD_EAX = 0,
     PAL_CPUID_WORD_EBX = 1,
@@ -35,7 +31,7 @@ static inline uint64_t get_tsc(void) {
     return lo | ((uint64_t)hi << 32);
 }
 
-#define CPU_RELAX() __asm__ __volatile__("rep; nop" ::: "memory")
+#define CPU_RELAX() __asm__ volatile("pause")
 
 /* some non-Intel clones support out of order store; WMB() ceases to be a nop for these */
 #define MB()  __asm__ __volatile__("mfence" ::: "memory")

--- a/Pal/include/arch/x86_64/pal-arch.h
+++ b/Pal/include/arch/x86_64/pal-arch.h
@@ -36,7 +36,7 @@ typedef struct pal_tcb {
 
 static inline PAL_TCB* pal_get_tcb(void) {
     PAL_TCB* tcb;
-    __asm__("movq %%gs:%c1,%q0" : "=r"(tcb) : "i"(offsetof(struct pal_tcb, self)));
+    __asm__("movq %%gs:%c1, %0" : "=r"(tcb) : "i"(offsetof(struct pal_tcb, self)) : "memory");
     return tcb;
 }
 

--- a/Pal/include/arch/x86_64/pal_internal-arch.h
+++ b/Pal/include/arch/x86_64/pal_internal-arch.h
@@ -1,0 +1,25 @@
+/* SPDX-License-Identifier: LGPL-3.0-or-later */
+/* Copyright (C) 2020 Intel Corporation
+ *                    Borys Popławski <borysp@invisiblethingslab.com>
+ */
+
+#ifndef PAL_INTERNAL_ARCH_H_
+#define PAL_INTERNAL_ARCH_H_
+
+#include "assert.h"
+
+#define ARCH_PROBE_STACK(size, page_size)           \
+    assert(size / page_size > 0);                   \
+    __asm__ volatile(                               \
+        "mov %%rsp, %%rdx\n"                        \
+        "1:\n"                                      \
+        "sub %0, %%rsp\n"                           \
+        "orq $0, (%%rsp)\n"                         \
+        "loop 1b\n"                                 \
+        "mov %%rdx, %%rsp\n"                        \
+        :                                           \
+        : "ri"(page_size), "c"(size / page_size)    \
+        : "memory", "cc", "rdx"                     \
+    )
+
+#endif // PAL_INTERNAL_ARCH_H_

--- a/Pal/include/lib/spinlock.h
+++ b/Pal/include/lib/spinlock.h
@@ -104,7 +104,7 @@ static inline void spinlock_lock(spinlock_t* lock) {
     do {
         /* This check imposes no inter-thread ordering, thus does not slow other threads. */
         while (__atomic_load_n(&lock->lock, __ATOMIC_RELAXED) != SPINLOCK_UNLOCKED)
-            cpu_pause();
+            CPU_RELAX();
         /* Seen lock as free, check if it still is, this time with acquire semantics (but only
          * if we really take it). */
         val = SPINLOCK_UNLOCKED;
@@ -136,7 +136,7 @@ static inline int spinlock_lock_timeout(spinlock_t* lock, unsigned long iteratio
                 return 1;
             }
             iterations--;
-            cpu_pause();
+            CPU_RELAX();
         }
         /* Seen lock as free, check if it still is, this time with acquire semantics (but only
          * if we really take it). */

--- a/Pal/lib/string/memcpy.c
+++ b/Pal/lib/string/memcpy.c
@@ -15,7 +15,7 @@ void* memcpy(void* restrict dest, const void* restrict src, size_t count) {
      * memcpy() is heavily used in Linux-SGX PAL to copy data in/out of SGX enclave. Experiments
      * with Redis 5.0 show perf improvement of using "rep movsb" at 3-5% for 4KB payloads over
      * previous implementation taken from Glibc 2.23. */
-    __asm__ volatile("rep movsb" : "+&D"(d), "+&c"(count) : "S"(src) : "cc", "memory");
+    __asm__ volatile("rep movsb" : "+D"(d), "+c"(count), "+S"(src) :: "cc", "memory");
 #else
     const char* s = src;
     while (count--)

--- a/Pal/lib/string/memset.c
+++ b/Pal/lib/string/memset.c
@@ -15,7 +15,7 @@ void* memset(void* dest, int ch, size_t count) {
      * operations for software in common situations like memory copy and set operations"
      * Intel 64 and IA-32 Architectures Optimization Reference Manual
      */
-    __asm__ volatile("rep stosb" : "+&D"(d), "+&c"(count) : "a"((uint8_t)ch) : "cc", "memory");
+    __asm__ volatile("rep stosb" : "+D"(d), "+c"(count) : "a"((uint8_t)ch) : "cc", "memory");
 #else
     while (count--)
         *d++ = ch;

--- a/Pal/regression/Memory.c
+++ b/Pal/regression/Memory.c
@@ -1,3 +1,5 @@
+/* XXX: What on earth is this supposed to be, an attempt to fit most UBs in one file? */
+
 #include "api.h"
 #include "pal.h"
 #include "pal_debug.h"

--- a/Pal/src/db_rtld.c
+++ b/Pal/src/db_rtld.c
@@ -956,6 +956,8 @@ void DkDebugDetachBinary(PAL_PTR start_addr) {
 #ifdef __x86_64__
 void* stack_before_call __attribute_unused = NULL;
 
+/* TODO: Why on earth do we call loaded libraries entry points?!?
+ * I won't bother fixing this asm, it needs to be purged. */
 #define CALL_ENTRY(l, cookies)                                                       \
     ({                                                                               \
         long ret;                                                                    \

--- a/Pal/src/host/Linux-SGX/db_pipes.c
+++ b/Pal/src/host/Linux-SGX/db_pipes.c
@@ -386,7 +386,7 @@ static int64_t pipe_read(PAL_HANDLE handle, uint64_t offset, uint64_t len, void*
     } else {
         /* normal pipe, use a secure session (should be already initialized) */
         while (!__atomic_load_n(&handle->pipe.handshake_done, __ATOMIC_ACQUIRE))
-            cpu_pause();
+            CPU_RELAX();
 
         if (!handle->pipe.ssl_ctx)
             return -PAL_ERROR_NOTCONNECTION;
@@ -426,7 +426,7 @@ static int64_t pipe_write(PAL_HANDLE handle, uint64_t offset, uint64_t len, cons
     } else {
         /* normal pipe, use a secure session (should be already initialized) */
         while (!__atomic_load_n(&handle->pipe.handshake_done, __ATOMIC_ACQUIRE))
-            cpu_pause();
+            CPU_RELAX();
 
         if (!handle->pipe.ssl_ctx)
             return -PAL_ERROR_NOTCONNECTION;
@@ -455,7 +455,7 @@ static int pipe_close(PAL_HANDLE handle) {
         }
     } else if (handle->pipe.fd != PAL_IDX_POISON) {
         while (!__atomic_load_n(&handle->pipe.handshake_done, __ATOMIC_ACQUIRE))
-            cpu_pause();
+            CPU_RELAX();
 
         if (handle->pipe.ssl_ctx) {
             _DkStreamSecureFree((LIB_SSL_CONTEXT*)handle->pipe.ssl_ctx);

--- a/Pal/src/host/Linux-SGX/sgx_enclave.c
+++ b/Pal/src/host/Linux-SGX/sgx_enclave.c
@@ -730,7 +730,7 @@ static int rpc_thread_loop(void* arg) {
                 (void)INLINE_SYSCALL(nanosleep, 2, &tv, /*rem=*/NULL);
             } else {
                 spin_attempts++;
-                cpu_pause();
+                CPU_RELAX();
             }
             continue;
         }

--- a/Pal/src/host/Linux-SGX/sgx_exception.c
+++ b/Pal/src/host/Linux-SGX/sgx_exception.c
@@ -33,18 +33,14 @@
 
 #if defined(__x86_64__)
 /* in x86_64 kernels, sigaction is required to have a user-defined restorer */
-#define DEFINE_RESTORE_RT(syscall) DEFINE_RESTORE_RT2(syscall)
-#define DEFINE_RESTORE_RT2(syscall)          \
-    __asm__(                                 \
-        "    nop\n"                          \
-        ".align 16\n"                        \
-        ".LSTART_restore_rt:\n"              \
-        "    .type __restore_rt,@function\n" \
-        "__restore_rt:\n"                    \
-        "    movq $" #syscall                \
-        ", %rax\n"                           \
-        "    syscall\n");
-DEFINE_RESTORE_RT(__NR_rt_sigreturn)
+__asm__(
+".align 16\n"
+".LSTART_restore_rt:\n"
+".type __restore_rt,@function\n"
+"__restore_rt:\n"
+"movq $" XSTRINGIFY(__NR_rt_sigreturn) ", %rax\n"
+"syscall\n"
+);
 
 /* workaround for an old GAS (2.27) bug that incorrectly omits relocations when referencing this
  * symbol */

--- a/Pal/src/host/Linux-SGX/sgx_main.c
+++ b/Pal/src/host/Linux-SGX/sgx_main.c
@@ -10,6 +10,7 @@
  *   #define ElfW(type)       _ElfW(Elf, __ELF_NATIVE_CLASS, type)"
  * errors.
  */
+#include "pal_internal-arch.h"
 #include "pal_linux.h"
 #include "pal_linux_error.h"
 #include "pal_rtld.h"
@@ -892,21 +893,12 @@ static int load_enclave(struct pal_enclave* enclave, int manifest_fd, char* mani
     return 0;
 }
 
-/* Grow stack of main thread to THREAD_STACK_SIZE by allocating a large dummy array and probing
- * each stack page (Linux dynamically grows the stack of the main thread but gets confused with
+/* Grow the stack of the main thread to THREAD_STACK_SIZE by probing each stack page above current
+ * stack pointer (Linux dynamically grows the stack of the main thread but gets confused with
  * huge-jump stack accesses coming from within the enclave). Note that other, non-main threads
  * are created manually via clone(.., THREAD_STACK_SIZE, ..) and thus do not need this hack. */
-static void __attribute__((noinline)) force_linux_to_grow_stack(void) {
-    char dummy[THREAD_STACK_SIZE];
-    for (uint64_t i = 0; i < sizeof(dummy); i += PRESET_PAGESIZE) {
-        /* touch each page on the stack just to make it is not optimized away */
-        __asm__ volatile(
-            "movq %0, %%rbx\r\n"
-            "movq (%%rbx), %%rbx\r\n"
-            :
-            : "r"(&dummy[i])
-            : "%rbx");
-    }
+static void force_linux_to_grow_stack(void) {
+    ARCH_PROBE_STACK(THREAD_STACK_SIZE, PRESET_PAGESIZE);
 }
 
 int main(int argc, char* argv[], char* envp[]) {

--- a/Pal/src/host/Linux-SGX/sgx_thread.c
+++ b/Pal/src/host/Linux-SGX/sgx_thread.c
@@ -222,22 +222,21 @@ noreturn void thread_exit(int status) {
 
     /* free the thread stack (via munmap) and exit; note that exit() needs a "status" arg
      * but it could be allocated on a stack, so we must put it in register and do asm */
-    __asm__ volatile("cmpq $0, %%rdi \n\t"     /* check if tcb->stack != NULL */
-                     "je 1f \n\t"
-                     "syscall \n\t"            /* all args are already prepared, call munmap */
-                     "1: \n\t"
-                     "movq %%rdx, %%rax \n\t"  /* prepare for exit: rax = __NR_exit */
-                     "movq %%rbx, %%rdi \n\t"  /* prepare for exit: rdi = status    */
-                     "syscall \n\t"            /* all args are prepared, call exit  */
-                     : /* no output regs since we don't return from exit */
-                     : "a"(__NR_munmap), "D"(tcb->stack), "S"(THREAD_STACK_SIZE + ALT_STACK_SIZE),
-                       "d"(__NR_exit), "b"(status)
-                     : "cc", "rcx", "r11", "memory"  /* syscall instr clobbers cc, rcx, and r11 */
+    __asm__ volatile("cmpq $0, %%rdi \n"        /* check if tcb->stack != NULL */
+                     "je 1f \n"
+                     "syscall \n"               /* all args are already prepared, call munmap */
+                     "1: \n"
+                     "mov %[nr_exit], %%rax \n"
+                     "mov %[exit_code], %%edi \n"
+                     "syscall \n"               /* all args are prepared, call exit  */
+                     "ud2 \n"
+                     "jmp 1b \n"
+                     :
+                     : "a" (__NR_munmap), "D" (tcb->stack), "S" (THREAD_STACK_SIZE + ALT_STACK_SIZE),
+                       [nr_exit] "i" (__NR_exit), [exit_code] "r" (status)
+                     : "memory", "rcx", "r11"
     );
-
-    while (true) {
-        /* nothing */
-    }
+    __builtin_unreachable();
 }
 
 int clone_thread(void) {

--- a/Pal/src/host/Linux-SGX/sgx_tls.h
+++ b/Pal/src/host/Linux-SGX/sgx_tls.h
@@ -65,7 +65,10 @@ static inline struct enclave_tls* get_tcb_trts(void) {
         struct enclave_tls* tmp;                                                               \
         uint64_t val;                                                                          \
         static_assert(sizeof(tmp->member) == 8, "sgx_tls member should have 8-byte type");     \
-        __asm__("movq %%gs:%c1, %q0" : "=r"(val) : "i"(offsetof(struct enclave_tls, member))); \
+        __asm__("movq %%gs:%c1, %0"                                                            \
+                : "=r"(val)                                                                    \
+                : "i"(offsetof(struct enclave_tls, member))                                    \
+                : "memory");                                                                   \
         (__typeof(tmp->member))val;                                                            \
     })
 #define SET_ENCLAVE_TLS(member, value)                                                         \
@@ -73,7 +76,10 @@ static inline struct enclave_tls* get_tcb_trts(void) {
         struct enclave_tls* tmp;                                                               \
         static_assert(sizeof(tmp->member) == 8, "sgx_tls member should have 8-byte type");     \
         static_assert(sizeof(value) == 8, "only 8-byte type can be set to sgx_tls");           \
-        __asm__("movq %q0, %%gs:%c1" ::"r"(value), "i"(offsetof(struct enclave_tls, member))); \
+        __asm__("movq %0, %%gs:%c1"                                                            \
+                :                                                                              \
+                : "ir"(value), "i"(offsetof(struct enclave_tls, member))                       \
+                : "memory");                                                                   \
     } while (0)
 #else
 /* private to untrusted Linux PAL, unique to each untrusted thread */
@@ -93,9 +99,10 @@ extern void pal_tcb_urts_init(PAL_TCB_URTS* tcb, void* stack, void* alt_stack);
 
 static inline PAL_TCB_URTS* get_tcb_urts(void) {
     PAL_TCB_URTS* tcb;
-    __asm__("movq %%gs:%c1, %q0\n"
-            : "=r" (tcb)
-            : "i" (offsetof(PAL_TCB_URTS, self)));
+    __asm__("movq %%gs:%c1, %0\n"
+            : "=r"(tcb)
+            : "i"(offsetof(PAL_TCB_URTS, self))
+            : "memory");
     return tcb;
 }
 

--- a/Pal/src/host/Linux/db_exception.c
+++ b/Pal/src/host/Linux/db_exception.c
@@ -27,17 +27,14 @@
 
 #if defined(__x86_64__)
 /* in x86_64 kernels, sigaction is required to have a user-defined restorer */
-#define DEFINE_RESTORE_RT(syscall) DEFINE_RESTORE_RT2(syscall)
-#define DEFINE_RESTORE_RT2(syscall)          \
-    __asm__(                                 \
-        "    nop\n"                          \
-        ".align 16\n"                        \
-        ".LSTART_restore_rt:\n"              \
-        "    .type __restore_rt,@function\n" \
-        "__restore_rt:\n"                    \
-        "    movq $" #syscall ", %rax\n"     \
-        "    syscall\n");
-DEFINE_RESTORE_RT(__NR_rt_sigreturn)
+__asm__(
+".align 16\n"
+".LSTART_restore_rt:\n"
+".type __restore_rt,@function\n"
+"__restore_rt:\n"
+"movq $" XSTRINGIFY(__NR_rt_sigreturn) ", %rax\n"
+"syscall\n"
+);
 
 /* workaround for an old GAS (2.27) bug that incorrectly omits relocations when referencing this
  * symbol */


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Mostly adds missing "memory" clobber which caused some nasty bugs - gcc
optimized those inline asms and assumed values returned by them never
change.

Don't ask me how long it took me to debug this ...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1938)
<!-- Reviewable:end -->
