### PR TITLE
[Pal/Linux-SGX] Do not downgrade IPC plaintext after checkpoint

### DIFF
--- a/LibOS/shim/src/shim_checkpoint.c
+++ b/LibOS/shim/src/shim_checkpoint.c
@@ -685,20 +685,6 @@ int create_process_and_send_checkpoint(migrate_func_t migrate_func, struct shim_
         goto out;
     }
 
-    /* FIXME: We shouldn't downgrade communication */
-    /* Downgrade communication with child to non-secure (only checkpoint send is secure).
-     * Currently only relevant to SGX PAL, other PALs ignore this. */
-    PAL_STREAM_ATTR attr;
-    if (!DkStreamAttributesQueryByHandle(pal_process, &attr)) {
-        ret = -PAL_ERRNO();
-        goto out;
-    }
-    attr.secure = PAL_FALSE;
-    if (!DkStreamAttributesSetByHandle(pal_process, &attr)) {
-        ret = -PAL_ERRNO();
-        goto out;
-    }
-
     if (exec) {
         /* execve case: child process "replaces" this current process: no need to notify the leader
          * or establish IPC, the only thing to do is revert self/parent PAL handles' pointers */

--- a/LibOS/shim/src/shim_init.c
+++ b/LibOS/shim/src/shim_init.c
@@ -519,16 +519,6 @@ noreturn void* shim_init(int argc, void* args) {
                                     NULL);
         if (ret == PAL_STREAM_ERROR || ret != sizeof(child_vmid))
             shim_do_exit(-PAL_ERRNO());
-
-        /* FIXME: We shouldn't downgrade communication */
-        /* Downgrade communication with parent to non-secure (only checkpoint recv is secure).
-         * Currently only relevant to SGX PAL, other PALs ignore this. */
-        PAL_STREAM_ATTR attr;
-        if (!DkStreamAttributesQueryByHandle(PAL_CB(parent_process), &attr))
-            shim_do_exit(-PAL_ERRNO());
-        attr.secure = PAL_FALSE;
-        if (!DkStreamAttributesSetByHandle(PAL_CB(parent_process), &attr))
-            shim_do_exit(-PAL_ERRNO());
     }
 
     debug("shim process initialized\n");

--- a/Pal/include/pal/pal.h
+++ b/Pal/include/pal/pal.h
@@ -426,7 +426,6 @@ typedef struct _PAL_STREAM_ATTR {
     PAL_BOL disconnected;
     PAL_BOL nonblocking;
     PAL_BOL readable, writable, runnable;
-    PAL_BOL secure;
     PAL_FLG share_flags;
     PAL_NUM pending_size;
     PAL_IDX no_of_fds;

--- a/Pal/src/host/Linux-SGX/pal_host.h
+++ b/Pal/src/host/Linux-SGX/pal_host.h
@@ -142,6 +142,7 @@ typedef struct pal_handle {
             PAL_IDX stream;
             PAL_IDX pid;
             PAL_BOL nonblocking;
+            PAL_BOL is_server;
             PAL_SESSION_KEY session_key;
             void* ssl_ctx;
         } process;


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://graphene.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

Previously, process communication (channel between parent and newly created child) was protected via TLS only during send/receive of the checkpoint; after that the channel was downgraded from TLS to plaintext. The reason for this downgrade is historical (IPC was complicated, and we wanted to have at least some TLS at the time).
This PR fixes this issue: Graphene now always uses TLS on IPC.

For more context see https://github.com/oscarlab/graphene/issues/1235.

## How to test this PR? <!-- (if applicable) -->

All tests must pass. One can manually check that messages between parent and child (including forked-execed child) are encrypted: `SGX=1 strace -ff graphene/Runtime/pal_loader ./vfork_and_exec`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1940)
<!-- Reviewable:end -->
