### PR TITLE
[LibOS] Remove unused IPC port types

### DIFF
--- a/LibOS/shim/include/shim_ipc.h
+++ b/LibOS/shim/include/shim_ipc.h
@@ -28,28 +28,17 @@
 #define MAX_IPC_PORT_FINI_CB 3
 
 enum {
-    IPC_LISTEN,       /* listening */
-    IPC_SERVER,       /* connect as a server */
-    IPC_KEEPALIVE,    /* keep the connetion alive */
-    IPC_DIRECTCHILD,  /* direct child */
-    IPC_DIRECTPARENT, /* direct parent */
-    IPC_CLIENT,       /* pid/sysv namespace client */
-    IPC_LEADER,       /* pid/sysv namespace leader */
-    IPC_OWNER,        /* pid/sysv namespace owner */
-    IPC_CONNECTION,   /* pid/sysv namespace connection */
+    IPC_LISTENING,    /* listening port; processes connect to it to create connection ports */
+    IPC_CONNECTION,   /* processes communicate on ports of this type */
+    IPC_DIRECTCHILD,  /* direct child: used to broadcast messages to children processes */
+    IPC_DIRECTPARENT, /* direct parent: used to broadcast messages to parent process */
 };
 
 enum {
-    IPC_PORT_LISTEN       = 1 << IPC_LISTEN,
-    IPC_PORT_SERVER       = 1 << IPC_SERVER,
-    IPC_PORT_KEEPALIVE    = 1 << IPC_KEEPALIVE,
+    IPC_PORT_LISTENING    = 1 << IPC_LISTENING,
+    IPC_PORT_CONNECTION   = 1 << IPC_CONNECTION,
     IPC_PORT_DIRECTCHILD  = 1 << IPC_DIRECTCHILD,
     IPC_PORT_DIRECTPARENT = 1 << IPC_DIRECTPARENT,
-
-    IPC_PORT_CLIENT     = 1 << IPC_CLIENT,
-    IPC_PORT_LEADER     = 1 << IPC_LEADER,
-    IPC_PORT_OWNER      = 1 << IPC_OWNER,
-    IPC_PORT_CONNECTION = 1 << IPC_CONNECTION,
 };
 
 enum {

--- a/LibOS/shim/src/ipc/shim_ipc.c
+++ b/LibOS/shim/src/ipc/shim_ipc.c
@@ -390,7 +390,7 @@ struct shim_ipc_info* create_ipc_info_and_port(bool use_vmid_as_port_name) {
         return NULL;
     }
 
-    add_ipc_port_by_id(g_process_ipc_info.vmid, info->pal_handle, IPC_PORT_SERVER, NULL,
+    add_ipc_port_by_id(g_process_ipc_info.vmid, info->pal_handle, IPC_PORT_LISTENING, NULL,
                        &info->port);
 
     return info;

--- a/LibOS/shim/src/shim_checkpoint.c
+++ b/LibOS/shim/src/shim_checkpoint.c
@@ -699,9 +699,8 @@ int create_process_and_send_checkpoint(migrate_func_t migrate_func, struct shim_
         snprintf(process_self_uri, sizeof(process_self_uri), URI_PREFIX_PIPE "%u", child_vmid);
         ipc_sublease_send(child_vmid, thread->tid, process_self_uri);
 
-        /* listen on the new IPC port to the new child process */
-        add_ipc_port_by_id(child_vmid, pal_process,
-                           IPC_PORT_DIRECTCHILD | IPC_PORT_LISTEN | IPC_PORT_KEEPALIVE,
+        /* create new IPC port to communicate over pal_process channel with the child process */
+        add_ipc_port_by_id(child_vmid, pal_process, IPC_PORT_CONNECTION | IPC_PORT_DIRECTCHILD,
                            &ipc_port_with_child_fini, NULL);
     }
 


### PR DESCRIPTION


<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://graphene.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

Previously, `IPC_PORT_SERVER` meant "listening port", and the actual communication ports had several types. Only two of these types were used for differentiation during IPC broadcast (direct-child and direct-parent types). All other types denoted who is the remote party this port connects to, but this info is superfluous. So this commit replaces all these types with a generic `IPC_PORT_CONNECTION`, and renames `IPC_PORT_SERVER` to a more familiar `IPC_PORT_LISTENING`.

## How to test this PR? <!-- (if applicable) -->

Cosmetic change, all tests must pass.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1942)
<!-- Reviewable:end -->
