### PR TITLE
Fix exit_group test

### DIFF
--- a/LibOS/shim/test/regression/exit_group.c
+++ b/LibOS/shim/test/regression/exit_group.c
@@ -1,34 +1,80 @@
 #define _XOPEN_SOURCE 700
-#include <linux/unistd.h>
 #include <pthread.h>
-#include <stdatomic.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <sys/wait.h>
 #include <unistd.h>
+
+/*
+ * Test the process exit logic. Make Nth thread run exit_group(), which should override exit code of
+ * the process.
+ *
+ * The above is done in a forked process, so that we also check if the right exit code propagates
+ * through wait().
+ */
 
 #define THREAD_NUM 4
 
-atomic_int counter = 1;
-
+int exit_codes[THREAD_NUM];
 pthread_barrier_t barrier;
 
-/* Test the process exit logic in Graphene. Multiple threads race to execute exit()/exit_group().
- * Expected return code is 0 .. 4, depending on which thread wins. */
-
-static void* inc(void* arg) {
-    int a = counter++;
+static void* run(void* arg) {
     pthread_barrier_wait(&barrier);
-    exit(a);
+
+    int* code = arg;
+    if (*code != 0)
+        exit(*code);
+
+    // Wait on the barrier again - one of the processes will exit, so we shouldn't ever finish
+    pthread_barrier_wait(&barrier);
+    return NULL;
 }
 
 int main(int argc, char** argv) {
-    pthread_t thread[THREAD_NUM];
-    pthread_barrier_init(&barrier, NULL, THREAD_NUM + 1);
-
-    for (int j = 0; j < THREAD_NUM; j++) {
-        pthread_create(&thread[j], NULL, inc, NULL);
+    if (argc != 3) {
+        fprintf(stderr, "Usage: %s thread_idx exit_code\n", argv[0]);
+        exit(255);
     }
 
-    pthread_barrier_wait(&barrier);
-    return 0;
+    int thread_idx = atoi(argv[1]);
+    int exit_code = atoi(argv[2]);
+
+    if (!(0 <= thread_idx && thread_idx < THREAD_NUM)) {
+        fprintf(stderr, "thread_idx should be between 0 and %d exclusive\n", THREAD_NUM);
+        exit(255);
+    }
+
+    if (exit_code == 0) {
+        fprintf(stderr, "exit_code should not be 0\n");
+        exit(255);
+    }
+
+    pid_t pid = fork();
+    if (pid < 0) {
+        perror("fork");
+        exit(255);
+    } else if (pid > 0) {
+        int status;
+        if (wait(&status) < 0) {
+            perror("wait");
+            exit(255);
+        }
+        if (!WIFEXITED(status)) {
+            fprintf(stderr, "wrong wait() status: %d\n", status);
+            exit(255);
+        }
+        exit(WEXITSTATUS(status));
+    }
+
+    exit_codes[thread_idx] = exit_code;
+
+    pthread_t thread[THREAD_NUM];
+    pthread_barrier_init(&barrier, NULL, THREAD_NUM);
+
+    for (int j = 1; j < THREAD_NUM; j++) {
+        pthread_create(&thread[j], NULL, run, &exit_codes[j]);
+    }
+
+    run(&exit_codes[0]);
+    return 0; // should not be reached
 }

--- a/LibOS/shim/test/regression/exit_group.manifest.template
+++ b/LibOS/shim/test/regression/exit_group.manifest.template
@@ -2,6 +2,7 @@ loader.preload = "file:../../src/libsysdb.so"
 loader.env.LD_LIBRARY_PATH = "/lib"
 loader.debug_type = "none"
 loader.argv0_override = "exit_group"
+loader.insecure__use_cmdline_argv = 1
 
 fs.mount.lib.type = "chroot"
 fs.mount.lib.path = "/lib"

--- a/LibOS/shim/test/regression/test_libos.py
+++ b/LibOS/shim/test/regression/test_libos.py
@@ -168,10 +168,13 @@ class TC_01_Bootstrap(RegressionTestCase):
             self.run_binary(['exit'])
 
     def test_401_exit_group(self):
-        try:
-            self.run_binary(['exit_group'])
-        except subprocess.CalledProcessError as e:
-            self.assertTrue(1 <= e.returncode <= 4)
+        for thread_idx in range(4):
+            exit_code = 100 + thread_idx
+            try:
+                self.run_binary(['exit_group', str(thread_idx), str(exit_code)])
+                self.fail('exit_group returned 0 instead of {}'.format(exit_code))
+            except subprocess.CalledProcessError as e:
+                self.assertEqual(e.returncode, exit_code)
 
     def test_402_signalexit(self):
         with self.expect_returncode(134):


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

~This fixes #1937, but more importantly, makes sure that any thread calling `exit()` will cause the correct exit code to be reported.~

The issue has been fixed by threads rework in #1949, this adds a test for `exit()` from a thread.

## How to test this PR? <!-- (if applicable) -->

The `exit_group` test is a test for this scenario:

```sh
cd LibOS/shim/test/regression
make exit_group exit_group.manifest

# run the test:
../../../../Scripts/run-pytest -k test_401_exit_group -v

# trigger the binary manually:
./exit_group 3 100; echo $?
./pal_loader exit_group 3 100; echo $?
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1943)
<!-- Reviewable:end -->
