### PR TITLE
[Pal] regression: reenable test_140_missing_executable_and_manifest

### DIFF
--- a/Pal/regression/test_pal.py
+++ b/Pal/regression/test_pal.py
@@ -225,14 +225,13 @@ class TC_01_Bootstrap(RegressionTestCase):
         self.assertIn('key1000=na', stderr)
         self.assertIn('key1=na', stderr)
 
-    @unittest.skip('this is broken on non-SGX, see #860')
     def test_140_missing_executable_and_manifest(self):
         try:
             _, stderr = self.run_binary(['fakenews'])
             self.fail(
                 'expected non-zero returncode, stderr: {!r}'.format(stderr))
         except subprocess.CalledProcessError as e:
-            self.assertIn('USAGE: ', e.stderr.decode())
+            pass
 
 class TC_02_Symbols(RegressionTestCase):
     ALL_SYMBOLS = [


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

This test started to work correctly some time ago, probably after we began to fix the loader (most likely after #1915).
FYI: I removed matching of the stderr, because on Linux PAL we have a totally different message logged and it's hard to match both.

Fixes #860.

## How to test this PR? <!-- (if applicable) -->

CI.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1946)
<!-- Reviewable:end -->
