### PR TITLE
[Pal/{Linux,Linux-SGX}] Refactor "device" PAL handles

### DIFF
--- a/LibOS/shim/test/regression/debug.gdb
+++ b/LibOS/shim/test/regression/debug.gdb
@@ -11,7 +11,7 @@ commands
 
   # Check if we can break inside PAL and get a full backtrace (across glibc).
 
-  tbreak char_write
+  tbreak dev_write
   commands
     echo \n<backtrace 2 start>\n
     backtrace

--- a/LibOS/shim/test/regression/test_libos.py
+++ b/LibOS/shim/test/regression/test_libos.py
@@ -627,7 +627,7 @@ class TC_50_GDB(RegressionTestCase):
         self.assertNotIn('??', backtrace_1)
 
         backtrace_2 = self.find('backtrace 2', stdout)
-        self.assertIn(' char_write (', backtrace_2)
+        self.assertIn(' dev_write (', backtrace_2)
         self.assertIn(' func () at debug.c', backtrace_2)
         self.assertIn(' main () at debug.c', backtrace_2)
         self.assertIn(' _start ()', backtrace_2)
@@ -636,7 +636,7 @@ class TC_50_GDB(RegressionTestCase):
         if HAS_SGX:
             backtrace_3 = self.find('backtrace 3', stdout)
             self.assertIn(' sgx_ocall_write (', backtrace_3)
-            self.assertIn(' char_write (', backtrace_3)
+            self.assertIn(' dev_write (', backtrace_3)
             self.assertIn(' func () at debug.c', backtrace_3)
             self.assertIn(' main () at debug.c', backtrace_3)
             self.assertIn(' _start ()', backtrace_3)

--- a/Pal/src/db_main.c
+++ b/Pal/src/db_main.c
@@ -173,15 +173,15 @@ static void set_debug_type(void) {
     PAL_HANDLE handle = NULL;
 
     if (!strcmp(debug_type, "inline")) {
-        ret = _DkStreamOpen(&handle, URI_PREFIX_DEV "tty", PAL_ACCESS_RDWR, 0, 0, 0);
+        ret = _DkStreamOpen(&handle, URI_PREFIX_DEV "tty", PAL_ACCESS_WRONLY, 0, 0, 0);
     } else if (!strcmp(debug_type, "file")) {
         char* debug_file = NULL;
         ret = toml_string_in(g_pal_state.manifest_root, "loader.debug_file", &debug_file);
         if (ret < 0 || !debug_file)
             INIT_FAIL_MANIFEST(PAL_ERROR_DENIED, "Cannot find/parse \'loader.debug_file\'");
 
-        ret = _DkStreamOpen(&handle, debug_file, PAL_ACCESS_RDWR,
-                            PAL_SHARE_OWNER_R | PAL_SHARE_OWNER_W, PAL_CREATE_TRY, 0);
+        ret = _DkStreamOpen(&handle, debug_file, PAL_ACCESS_WRONLY, PAL_SHARE_OWNER_W,
+                            PAL_CREATE_TRY, 0);
         free(debug_file);
     } else if (!strcmp(debug_type, "none")) {
         ret = 0;

--- a/Pal/src/host/Linux-SGX/db_devices.c
+++ b/Pal/src/host/Linux-SGX/db_devices.c
@@ -2,383 +2,137 @@
 /* Copyright (C) 2014 Stony Brook University */
 
 /*
- * This file contains operands to handle streams with URIs that start with "dev:".
+ * Operations to handle devices (currently only "dev:tty" which is stdin/stdout).
  */
-
-#include <linux/types.h>
 
 #include "api.h"
 #include "pal.h"
-#include "pal_debug.h"
-#include "pal_defs.h"
 #include "pal_error.h"
 #include "pal_internal.h"
 #include "pal_linux.h"
-#include "pal_linux_defs.h"
 #include "pal_linux_error.h"
-typedef __kernel_pid_t pid_t;
-#include <asm/fcntl.h>
-#include <asm/stat.h>
-#include <linux/stat.h>
 
-#define DEVICE_OPS(handle)                                                               \
-    ({                                                                                   \
-        int _type = (handle)->dev.dev_type;                                              \
-        (_type <= 0 || _type >= PAL_DEVICE_TYPE_BOUND) ? NULL : g_pal_device_ops[_type]; \
-    })
-
-enum {
-    device_type_none = 0,
-    device_type_term,
-    PAL_DEVICE_TYPE_BOUND,
-};
-
-static struct handle_ops g_term_ops;
-
-static const struct handle_ops* g_pal_device_ops[PAL_DEVICE_TYPE_BOUND] = {
-    NULL,
-    &g_term_ops,
-};
-
-/* parse_device_uri scans the uri, parses the prefix of the uri and searches
-   for stream handler wich will open or access the device. */
-static int parse_device_uri(const char** uri, char** type, struct handle_ops** ops) {
-    struct handle_ops* dops = NULL;
-    const char* p;
-    const char* u = *uri;
-
-    for (p = u; *p && *p != ',' && *p != '/'; p++)
-        ;
-
-    if (strstartswith(u, "tty"))
-        dops = &g_term_ops;
-
-    if (!dops)
-        return -PAL_ERROR_NOTSUPPORT;
-
-    *uri = *p ? p + 1 : p;
-    if (type) {
-        *type = alloc_substr(u, p - u);
-        if (!*type)
-            return -PAL_ERROR_NOMEM;
-    }
-    if (ops)
-        *ops = dops;
-    return 0;
-}
-
-static int64_t char_read(PAL_HANDLE handle, uint64_t offset, uint64_t count, void* buffer);
-static int64_t char_write(PAL_HANDLE handle, uint64_t offset, uint64_t count, const void* buffer);
-static int term_attrquery(const char* type, const char* uri, PAL_STREAM_ATTR* attr);
-static int term_attrquerybyhdl(PAL_HANDLE hdl, PAL_STREAM_ATTR* attr);
-
-/* Method to open standard terminal */
-static int open_standard_term(PAL_HANDLE* handle, const char* param, int access) {
-    if (param)
-        return -PAL_ERROR_NOTIMPLEMENTED;
-
-    PAL_HANDLE hdl = malloc(HANDLE_SIZE(dev));
-    SET_HANDLE_TYPE(hdl, dev);
-    hdl->dev.dev_type = device_type_term;
-
-    if (!(access & PAL_ACCESS_WRONLY)) {
-        HANDLE_HDR(hdl)->flags |= RFD(0);
-        hdl->dev.fd_in = 0;
-    }
-
-    if (access & (PAL_ACCESS_WRONLY | PAL_ACCESS_RDWR)) {
-        HANDLE_HDR(hdl)->flags |= WFD(1);
-        hdl->dev.fd_out = 1;
-    }
-
-    *handle = hdl;
-    return 0;
-}
-
-/* 'open' operation for terminal stream */
-static int term_open(PAL_HANDLE* handle, const char* type, const char* uri, int access, int share,
-                     int create, int options) {
+static int dev_open(PAL_HANDLE* handle, const char* type, const char* uri, int access, int share,
+                    int create, int options) {
     __UNUSED(share);
     __UNUSED(create);
     __UNUSED(options);
+
+    /* currently support only "dev:tty" device which is the standard input + standard output */
+    if (strcmp(type, URI_TYPE_DEV) || strcmp(uri, "tty"))
+        return -PAL_ERROR_INVAL;
+
+    /* "dev:tty" device can only be opened either for read (stdin) or for write (stdout) */
+    if (access & PAL_ACCESS_RDWR)
+        return -PAL_ERROR_INVAL;
 
     assert(WITHIN_MASK(access,  PAL_ACCESS_MASK));
     assert(WITHIN_MASK(share,   PAL_SHARE_MASK));
     assert(WITHIN_MASK(create,  PAL_CREATE_MASK));
     assert(WITHIN_MASK(options, PAL_OPTION_MASK));
 
-    if (strcmp(type, "tty"))
-        return -PAL_ERROR_INVAL;
+    PAL_HANDLE hdl = malloc(HANDLE_SIZE(dev));
+    if (!hdl)
+        return -PAL_ERROR_NOMEM;
 
-    const char* term  = NULL;
-    const char* param = NULL;
+    SET_HANDLE_TYPE(hdl, dev);
 
-    const char* tmp = uri;
-    while (*tmp) {
-        if (!term && *tmp == '/')
-            term = tmp + 1;
-        if (*tmp == ',') {
-            param = param + 1;
-            break;
-        }
-        tmp++;
+    if (access & PAL_ACCESS_WRONLY) {
+        HANDLE_HDR(hdl)->flags |= WFD(0);
+        hdl->dev.fd = 1; /* host stdout */
+    } else {
+        HANDLE_HDR(hdl)->flags |= RFD(0);
+        hdl->dev.fd = 0; /* host stdin */
     }
 
-    if (term)
-        return -PAL_ERROR_NOTIMPLEMENTED;
-
-    return open_standard_term(handle, param, access);
-}
-
-static int term_close(PAL_HANDLE handle) {
-    __UNUSED(handle);
+    *handle = hdl;
     return 0;
 }
 
-/* 'attrquery' operation for terminal stream */
-static int term_attrquery(const char* type, const char* uri, PAL_STREAM_ATTR* attr) {
+static int64_t dev_read(PAL_HANDLE handle, uint64_t offset, uint64_t size, void* buffer) {
+    if (offset || !IS_HANDLE_TYPE(handle, dev))
+        return -PAL_ERROR_INVAL;
+
+    if (!(HANDLE_HDR(handle)->flags & RFD(0)))
+        return -PAL_ERROR_DENIED;
+
+    if (handle->dev.fd == PAL_IDX_POISON)
+        return -PAL_ERROR_DENIED;
+
+    ssize_t bytes = ocall_read(handle->dev.fd, buffer, size);
+    return IS_ERR(bytes) ? unix_to_pal_error(ERRNO(bytes)) : bytes;
+}
+
+static int64_t dev_write(PAL_HANDLE handle, uint64_t offset, uint64_t size, const void* buffer) {
+    if (offset || !IS_HANDLE_TYPE(handle, dev))
+        return -PAL_ERROR_INVAL;
+
+    if (!(HANDLE_HDR(handle)->flags & WFD(0)))
+        return -PAL_ERROR_DENIED;
+
+    if (handle->dev.fd == PAL_IDX_POISON)
+        return -PAL_ERROR_DENIED;
+
+    ssize_t bytes = ocall_write(handle->dev.fd, buffer, size);
+    return IS_ERR(bytes) ? unix_to_pal_error(ERRNO(bytes)) : bytes;
+}
+
+static int dev_close(PAL_HANDLE handle) {
+    if (!IS_HANDLE_TYPE(handle, dev))
+        return -PAL_ERROR_INVAL;
+
+    int ret = 0;
+    if (handle->dev.fd != PAL_IDX_POISON) {
+        ret = ocall_close(handle->dev.fd);
+        handle->dev.fd = PAL_IDX_POISON;
+    }
+    return IS_ERR(ret) ? unix_to_pal_error(ERRNO(ret)) : 0;
+}
+
+static int dev_flush(PAL_HANDLE handle) {
+    if (!IS_HANDLE_TYPE(handle, dev))
+        return -PAL_ERROR_INVAL;
+
+    if (handle->dev.fd != PAL_IDX_POISON) {
+        int ret = ocall_fsync(handle->dev.fd);
+        if (IS_ERR(ret))
+            return unix_to_pal_error(ERRNO(ret));
+    }
+    return 0;
+}
+
+static int dev_attrquery(const char* type, const char* uri, PAL_STREAM_ATTR* attr) {
     __UNUSED(uri);
 
-    if (strcmp(type, "tty"))
+    /* currently support only "dev:tty" device which is the standard input + standard output */
+    if (strcmp(type, URI_TYPE_DEV) || strcmp(uri, "tty"))
         return -PAL_ERROR_INVAL;
 
     attr->handle_type  = pal_type_dev;
-    attr->readable     = PAL_TRUE;
-    attr->writable     = PAL_TRUE;
+    attr->readable     = PAL_TRUE; /* we don't know if it's stdin/stdout so simply return true */
+    attr->writable     = PAL_TRUE; /* we don't know if it's stdin/stdout so simply return true */
     attr->runnable     = PAL_FALSE;
     attr->pending_size = 0;
     return 0;
 }
 
-/* 'attrquery' operation for terminal stream */
-static int term_attrquerybyhdl(PAL_HANDLE hdl, PAL_STREAM_ATTR* attr) {
-    attr->handle_type  = pal_type_dev;
-    attr->readable     = (hdl->dev.fd_in != PAL_IDX_POISON);
-    attr->writable     = (hdl->dev.fd_out != PAL_IDX_POISON);
-    attr->runnable     = PAL_FALSE;
-    attr->pending_size = 0;
-    return 0;
-}
-
-static struct handle_ops g_term_ops = {
-    .open           = &term_open,
-    .close          = &term_close,
-    .read           = &char_read,
-    .write          = &char_write,
-    .attrquery      = &term_attrquery,
-    .attrquerybyhdl = &term_attrquerybyhdl,
-};
-
-/* 'read' operation for character streams. */
-static int64_t char_read(PAL_HANDLE handle, uint64_t offset, uint64_t size, void* buffer) {
-    if (offset)
-        return -PAL_ERROR_INVAL;
-
-    PAL_IDX fd = handle->dev.fd_in;
-
-    if (fd == PAL_IDX_POISON)
-        return -PAL_ERROR_DENIED;
-
-    if (size != (uint32_t)size)
-        return -PAL_ERROR_INVAL;
-
-    ssize_t bytes = ocall_read(fd, buffer, size);
-    return IS_ERR(bytes) ? unix_to_pal_error(ERRNO(bytes)) : bytes;
-}
-
-/* 'write' operation for character streams. */
-static int64_t char_write(PAL_HANDLE handle, uint64_t offset, uint64_t size, const void* buffer) {
-    if (offset)
-        return -PAL_ERROR_INVAL;
-
-    PAL_IDX fd = handle->dev.fd_out;
-
-    if (fd == PAL_IDX_POISON)
-        return -PAL_ERROR_DENIED;
-
-    if (size != (uint32_t)size)
-        return -PAL_ERROR_INVAL;
-
-    ssize_t bytes = ocall_write(fd, buffer, size);
-    return IS_ERR(bytes) ? unix_to_pal_error(ERRNO(bytes)) : bytes;
-}
-
-/* 'open' operation for device streams */
-static int dev_open(PAL_HANDLE* handle, const char* type, const char* uri, int access, int share,
-                    int create, int options) {
-    if (strcmp(type, URI_TYPE_DEV))
-        return -PAL_ERROR_INVAL;
-
-    struct handle_ops* ops = NULL;
-    char* dev_type = NULL;
-    int ret = 0;
-
-    ret = parse_device_uri(&uri, &dev_type, &ops);
-
-    if (ret < 0)
-        return ret;
-
-    if (!ops->open)
-        return -PAL_ERROR_NOTSUPPORT;
-
-    PAL_HANDLE hdl = malloc(HANDLE_SIZE(dev));
-    SET_HANDLE_TYPE(hdl, dev);
-    hdl->dev.fd_in  = PAL_IDX_POISON;
-    hdl->dev.fd_out = PAL_IDX_POISON;
-    *handle         = hdl;
-
-    ret = ops->open(handle, dev_type, uri, access, share, create, options);
-    free(dev_type);
-    return ret;
-}
-
-/* 'read' operation for device stream */
-static int64_t dev_read(PAL_HANDLE handle, uint64_t offset, uint64_t size, void* buffer) {
-    const struct handle_ops* ops = DEVICE_OPS(handle);
-
-    if (!ops || !ops->read)
-        return -PAL_ERROR_NOTSUPPORT;
-
-    return ops->read(handle, offset, size, buffer);
-}
-
-/* 'write' operation for device stream */
-static int64_t dev_write(PAL_HANDLE handle, uint64_t offset, uint64_t size, const void* buffer) {
-    const struct handle_ops* ops = DEVICE_OPS(handle);
-
-    if (!ops || !ops->write)
-        return -PAL_ERROR_NOTSUPPORT;
-
-    return ops->write(handle, offset, size, buffer);
-}
-
-/* 'close' operation for device streams */
-static int dev_close(PAL_HANDLE handle) {
-    const struct handle_ops* ops = DEVICE_OPS(handle);
-
-    if (ops && ops->close)
-        return ops->close(handle);
-
-    if (handle->dev.fd_in != PAL_IDX_POISON) {
-        int fd = handle->dev.fd_in;
-        ocall_close(fd);
-    }
-
-    if (handle->dev.fd_out != PAL_IDX_POISON) {
-        int fd = handle->dev.fd_out;
-        ocall_close(fd);
-    }
-
-    if (handle->file.realpath)
-        free((void*)handle->file.realpath);
-
-    return 0;
-}
-
-/* 'delete' operation for device streams */
-static int dev_delete(PAL_HANDLE handle, int access) {
-    const struct handle_ops* ops = DEVICE_OPS(handle);
-
-    if (!ops || !ops->delete)
-        return -PAL_ERROR_DENIED;
-
-    int ret = dev_close(handle);
-
-    if (ret < 0)
-        return ret;
-
-    return ops->delete(handle, access);
-}
-
-/* 'flush' operation for device streams */
-static int dev_flush(PAL_HANDLE handle) {
-    const struct handle_ops* ops = DEVICE_OPS(handle);
-
-    if (ops && ops->flush)
-        return ops->flush(handle);
-
-    /* try to flush input stream */
-    if (handle->dev.fd_in != PAL_IDX_POISON) {
-        int fd = handle->dev.fd_in;
-        ocall_fsync(fd);
-    }
-
-    /* if output stream exists and does not equal to input stream,
-       flush output stream as well */
-    if (handle->dev.fd_out != PAL_IDX_POISON && handle->dev.fd_out != handle->dev.fd_in) {
-        int fd = handle->dev.fd_out;
-        ocall_fsync(fd);
-    }
-
-    return 0;
-}
-
-/* 'attrquery' operation for device streams */
-static int dev_attrquery(const char* type, const char* uri, PAL_STREAM_ATTR* attr) {
-    if (strcmp(type, URI_TYPE_DEV))
-        return -PAL_ERROR_INVAL;
-
-    struct handle_ops* ops = NULL;
-    char* dev_type = NULL;
-    int ret = 0;
-
-    ret = parse_device_uri(&uri, &dev_type, &ops);
-
-    if (ret < 0)
-        return ret;
-
-    if (!ops || !ops->attrquery)
-        return -PAL_ERROR_NOTSUPPORT;
-
-    ret = ops->attrquery(dev_type, uri, attr);
-    free(dev_type);
-    return ret;
-}
-
-/* 'attrquerybyhdl' operation for device stream */
 static int dev_attrquerybyhdl(PAL_HANDLE handle, PAL_STREAM_ATTR* attr) {
-    const struct handle_ops* ops = DEVICE_OPS(handle);
+    if (!IS_HANDLE_TYPE(handle, dev))
+        return -PAL_ERROR_INVAL;
 
-    if (ops && ops->attrquerybyhdl)
-        return ops->attrquerybyhdl(handle, attr);
-
-    struct stat stat_buf;
-    struct stat* stat_in = NULL;
-    struct stat* stat_out = NULL;
-    int ret;
-
-    attr->handle_type = pal_type_dev;
-
-    if (handle->dev.fd_in != PAL_IDX_POISON) {
-        ret = ocall_fstat(handle->dev.fd_in, &stat_buf);
-        if (!IS_ERR(ret))
-            stat_in = &stat_buf;
-    }
-
-    if (handle->dev.fd_in != PAL_IDX_POISON) {
-        ret = ocall_fstat(handle->dev.fd_in, &stat_buf);
-        if (!IS_ERR(ret))
-            stat_out = &stat_buf;
-    }
-
-    attr->readable     = (stat_in && stataccess(stat_in, ACCESS_R));
-    attr->writable     = (stat_in && stataccess(stat_in, ACCESS_W));
-    attr->runnable     = (stat_out && stataccess(stat_out, ACCESS_X));
-    attr->pending_size = stat_in ? stat_in->st_size : (stat_out ? stat_out->st_size : 0);
+    attr->handle_type  = pal_type_dev;
+    attr->readable     = HANDLE_HDR(handle)->flags & RFD(0);
+    attr->writable     = HANDLE_HDR(handle)->flags & WFD(0);
+    attr->runnable     = PAL_FALSE;
+    attr->pending_size = 0;
     return 0;
-}
-
-static const char* dev_getrealpath(PAL_HANDLE handle) {
-    return handle->dev.realpath;
 }
 
 struct handle_ops g_dev_ops = {
-    .getrealpath    = &dev_getrealpath,
     .open           = &dev_open,
     .read           = &dev_read,
     .write          = &dev_write,
     .close          = &dev_close,
-    .delete         = &dev_delete,
     .flush          = &dev_flush,
     .attrquery      = &dev_attrquery,
     .attrquerybyhdl = &dev_attrquerybyhdl,

--- a/Pal/src/host/Linux-SGX/db_streams.c
+++ b/Pal/src/host/Linux-SGX/db_streams.c
@@ -114,10 +114,7 @@ static ssize_t handle_serialize(PAL_HANDLE handle, void** data) {
         case pal_type_pipeprv:
             break;
         case pal_type_dev:
-            if (handle->dev.realpath) {
-                d1   = handle->dev.realpath;
-                dsz1 = strlen(handle->dev.realpath) + 1;
-            }
+            /* devices have no fields to serialize */
             break;
         case pal_type_dir:
             if (handle->dir.realpath) {
@@ -206,7 +203,6 @@ static int handle_deserialize(PAL_HANDLE* handle, const void* data, size_t size,
         case pal_type_pipeprv:
             break;
         case pal_type_dev:
-            hdl->dev.realpath = hdl->dev.realpath ? (PAL_STR)hdl + hdlsz : NULL;
             break;
         case pal_type_dir:
             hdl->dir.realpath = hdl->dir.realpath ? (PAL_STR)hdl + hdlsz : NULL;

--- a/Pal/src/host/Linux-SGX/pal_host.h
+++ b/Pal/src/host/Linux-SGX/pal_host.h
@@ -108,10 +108,7 @@ typedef struct pal_handle {
         } eventfd;
 
         struct {
-            PAL_IDX fd_in, fd_out;
-            PAL_IDX dev_type;
-            PAL_BOL destroy;
-            PAL_STR realpath;
+            PAL_IDX fd;
         } dev;
 
         struct {

--- a/Pal/src/host/Linux/db_devices.c
+++ b/Pal/src/host/Linux/db_devices.c
@@ -2,105 +2,27 @@
 /* Copyright (C) 2014 Stony Brook University */
 
 /*
- * This file contains operands to handle streams with URIs that start with "dev:".
+ * Operations to handle devices (currently only "dev:tty" which is stdin/stdout).
  */
-
-#include <linux/types.h>
 
 #include "api.h"
 #include "pal.h"
-#include "pal_debug.h"
-#include "pal_defs.h"
 #include "pal_error.h"
 #include "pal_internal.h"
 #include "pal_linux.h"
-#include "pal_linux_defs.h"
-typedef __kernel_pid_t pid_t;
-#include <asm/errno.h>
-#include <asm/fcntl.h>
 
-#define DEVICE_OPS(handle)                                                               \
-    ({                                                                                   \
-        int _type = (handle)->dev.dev_type;                                              \
-        (_type <= 0 || _type >= PAL_DEVICE_TYPE_BOUND) ? NULL : g_pal_device_ops[_type]; \
-    })
-
-enum {
-    device_type_none = 0,
-    device_type_term,
-    PAL_DEVICE_TYPE_BOUND,
-};
-
-static struct handle_ops g_term_ops;
-
-static const struct handle_ops* g_pal_device_ops[PAL_DEVICE_TYPE_BOUND] = {
-    NULL,
-    &g_term_ops,
-};
-
-/* parse_device_uri scans the uri, parses the prefix of the uri and searches
-   for stream handler wich will open or access the device. */
-static int parse_device_uri(const char** uri, char** type, struct handle_ops** ops) {
-    struct handle_ops* dops = NULL;
-    const char* p;
-    const char* u = *uri;
-
-    for (p = u; *p && *p != ',' && *p != '/'; p++)
-        ;
-
-    if (strstartswith(u, "tty"))
-        dops = &g_term_ops;
-
-    if (!dops)
-        return -PAL_ERROR_NOTSUPPORT;
-
-    *uri = (*p) ? p + 1 : p;
-    if (type) {
-        *type = alloc_substr(u, p - u);
-        if (!*type)
-            return -PAL_ERROR_NOMEM;
-    }
-    if (ops)
-        *ops = dops;
-    return 0;
-}
-
-static int64_t char_read(PAL_HANDLE handle, uint64_t offset, uint64_t count, void* buffer);
-static int64_t char_write(PAL_HANDLE handle, uint64_t offset, uint64_t count, const void* buffer);
-static int term_attrquery(const char* type, const char* uri, PAL_STREAM_ATTR* attr);
-static int term_attrquerybyhdl(PAL_HANDLE hdl, PAL_STREAM_ATTR* attr);
-
-/* Method to open standard terminal */
-static int open_standard_term(PAL_HANDLE* handle, const char* param, int access) {
-    if (param)
-        return -PAL_ERROR_NOTIMPLEMENTED;
-
-    PAL_HANDLE hdl = malloc(HANDLE_SIZE(dev));
-    SET_HANDLE_TYPE(hdl, dev);
-    hdl->dev.dev_type = device_type_term;
-
-    if (!(access & PAL_ACCESS_WRONLY)) {
-        HANDLE_HDR(hdl)->flags |= RFD(0);
-        hdl->dev.fd_in = 0;
-    }
-
-    if (access & (PAL_ACCESS_WRONLY | PAL_ACCESS_RDWR)) {
-        HANDLE_HDR(hdl)->flags |= WFD(1);
-        hdl->dev.fd_out = 1;
-    }
-
-    *handle = hdl;
-    return 0;
-}
-
-/* 'open' operation for terminal stream */
-static int term_open(PAL_HANDLE* handle, const char* type, const char* uri, int access, int share,
-                     int create, int options) {
+static int dev_open(PAL_HANDLE* handle, const char* type, const char* uri, int access, int share,
+                    int create, int options) {
     __UNUSED(share);
     __UNUSED(create);
     __UNUSED(options);
 
-    if (strcmp(type, "tty"))
+    /* currently support only "dev:tty" device which is the standard input + standard output */
+    if (strcmp(type, URI_TYPE_DEV) || strcmp(uri, "tty"))
+        return -PAL_ERROR_INVAL;
+
+    /* "dev:tty" device can only be opened either for read (stdin) or for write (stdout) */
+    if (access & PAL_ACCESS_RDWR)
         return -PAL_ERROR_INVAL;
 
     assert(WITHIN_MASK(access,  PAL_ACCESS_MASK));
@@ -108,306 +30,108 @@ static int term_open(PAL_HANDLE* handle, const char* type, const char* uri, int 
     assert(WITHIN_MASK(create,  PAL_CREATE_MASK));
     assert(WITHIN_MASK(options, PAL_OPTION_MASK));
 
-    const char* term  = NULL;
-    const char* param = NULL;
+    PAL_HANDLE hdl = malloc(HANDLE_SIZE(dev));
+    if (!hdl)
+        return -PAL_ERROR_NOMEM;
 
-    const char* tmp = uri;
-    while (*tmp) {
-        if (!term && *tmp == '/')
-            term = tmp + 1;
-        if (*tmp == ',') {
-            param = param + 1;
-            break;
-        }
-        tmp++;
+    SET_HANDLE_TYPE(hdl, dev);
+
+    if (access & PAL_ACCESS_WRONLY) {
+        HANDLE_HDR(hdl)->flags |= WFD(0);
+        hdl->dev.fd = 1; /* host stdout */
+    } else {
+        HANDLE_HDR(hdl)->flags |= RFD(0);
+        hdl->dev.fd = 0; /* host stdin */
     }
 
-    if (term)
-        return -PAL_ERROR_NOTIMPLEMENTED;
-
-    return open_standard_term(handle, param, access);
-}
-
-static int term_close(PAL_HANDLE handle) {
-    __UNUSED(handle);
-
+    *handle = hdl;
     return 0;
 }
 
-/* 'attrquery' operation for terminal stream */
-static int term_attrquery(const char* type, const char* uri, PAL_STREAM_ATTR* attr) {
+static int64_t dev_read(PAL_HANDLE handle, uint64_t offset, uint64_t size, void* buffer) {
+    if (offset || !IS_HANDLE_TYPE(handle, dev))
+        return -PAL_ERROR_INVAL;
+
+    if (!(HANDLE_HDR(handle)->flags & RFD(0)))
+        return -PAL_ERROR_DENIED;
+
+    if (handle->dev.fd == PAL_IDX_POISON)
+        return -PAL_ERROR_DENIED;
+
+    int64_t bytes = INLINE_SYSCALL(read, 3, handle->dev.fd, buffer, size);
+    return IS_ERR(bytes) ? unix_to_pal_error(ERRNO(bytes)) : bytes;
+}
+
+static int64_t dev_write(PAL_HANDLE handle, uint64_t offset, uint64_t size, const void* buffer) {
+    if (offset || !IS_HANDLE_TYPE(handle, dev))
+        return -PAL_ERROR_INVAL;
+
+    if (!(HANDLE_HDR(handle)->flags & WFD(0)))
+        return -PAL_ERROR_DENIED;
+
+    if (handle->dev.fd == PAL_IDX_POISON)
+        return -PAL_ERROR_DENIED;
+
+    int64_t bytes = INLINE_SYSCALL(write, 3, handle->dev.fd, buffer, size);
+    return IS_ERR(bytes) ? unix_to_pal_error(ERRNO(bytes)) : bytes;
+}
+
+static int dev_close(PAL_HANDLE handle) {
+    if (!IS_HANDLE_TYPE(handle, dev))
+        return -PAL_ERROR_INVAL;
+
+    int ret = 0;
+    if (handle->dev.fd != PAL_IDX_POISON) {
+        ret = INLINE_SYSCALL(close, 1, handle->dev.fd);
+        handle->dev.fd = PAL_IDX_POISON;
+    }
+    return IS_ERR(ret) ? unix_to_pal_error(ERRNO(ret)) : 0;
+}
+
+static int dev_flush(PAL_HANDLE handle) {
+    if (!IS_HANDLE_TYPE(handle, dev))
+        return -PAL_ERROR_INVAL;
+
+    if (handle->dev.fd != PAL_IDX_POISON) {
+        int ret = INLINE_SYSCALL(fsync, 1, handle->dev.fd);
+        if (IS_ERR(ret))
+            return unix_to_pal_error(ERRNO(ret));
+    }
+    return 0;
+}
+
+static int dev_attrquery(const char* type, const char* uri, PAL_STREAM_ATTR* attr) {
     __UNUSED(uri);
 
-    if (strcmp(type, "tty"))
+    /* currently support only "dev:tty" device which is the standard input + standard output */
+    if (strcmp(type, URI_TYPE_DEV) || strcmp(uri, "tty"))
         return -PAL_ERROR_INVAL;
 
     attr->handle_type  = pal_type_dev;
-    attr->readable     = PAL_TRUE;
-    attr->writable     = PAL_TRUE;
+    attr->readable     = PAL_TRUE; /* we don't know if it's stdin/stdout so simply return true */
+    attr->writable     = PAL_TRUE; /* we don't know if it's stdin/stdout so simply return true */
     attr->runnable     = PAL_FALSE;
     attr->pending_size = 0;
     return 0;
 }
 
-/* 'attrquery' operation for terminal stream */
-static int term_attrquerybyhdl(PAL_HANDLE hdl, PAL_STREAM_ATTR* attr) {
-    attr->handle_type  = pal_type_dev;
-    attr->readable     = (hdl->dev.fd_in != PAL_IDX_POISON);
-    attr->writable     = (hdl->dev.fd_out != PAL_IDX_POISON);
-    attr->runnable     = PAL_FALSE;
-    attr->pending_size = 0;
-    return 0;
-}
-
-static struct handle_ops g_term_ops = {
-    .open           = &term_open,
-    .close          = &term_close,
-    .read           = &char_read,
-    .write          = &char_write,
-    .attrquery      = &term_attrquery,
-    .attrquerybyhdl = &term_attrquerybyhdl,
-};
-
-/* 'read' operation for character streams. */
-static int64_t char_read(PAL_HANDLE handle, uint64_t offset, uint64_t size, void* buffer) {
-    if (offset)
-        return -PAL_ERROR_INVAL;
-
-    int fd = handle->dev.fd_in;
-
-    if ((PAL_IDX)fd == PAL_IDX_POISON)
-        return -PAL_ERROR_DENIED;
-
-    int64_t bytes = INLINE_SYSCALL(read, 3, fd, buffer, size);
-
-    if (IS_ERR(bytes))
-        return unix_to_pal_error(ERRNO(bytes));
-
-    return bytes;
-}
-
-/* 'write' operation for character streams. */
-static int64_t char_write(PAL_HANDLE handle, uint64_t offset, uint64_t size, const void* buffer) {
-    if (offset)
-        return -PAL_ERROR_INVAL;
-
-    int fd = handle->dev.fd_out;
-
-    if ((PAL_IDX)fd == PAL_IDX_POISON)
-        return -PAL_ERROR_DENIED;
-
-    int64_t bytes = INLINE_SYSCALL(write, 3, fd, buffer, size);
-
-    if (IS_ERR(bytes))
-        return unix_to_pal_error(ERRNO(bytes));
-
-    return bytes;
-}
-
-/* 'open' operation for device streams */
-static int dev_open(PAL_HANDLE* handle, const char* type, const char* uri, int access, int share,
-                    int create, int options) {
-    if (strcmp(type, URI_TYPE_DEV))
-        return -PAL_ERROR_INVAL;
-
-    struct handle_ops* ops = NULL;
-    char* dev_type = NULL;
-    int ret = 0;
-
-    ret = parse_device_uri(&uri, &dev_type, &ops);
-
-    if (ret < 0)
-        return ret;
-
-    if (!ops->open)
-        return -PAL_ERROR_NOTSUPPORT;
-
-    PAL_HANDLE hdl = malloc(HANDLE_SIZE(dev));
-    SET_HANDLE_TYPE(hdl, dev);
-    hdl->dev.fd_in  = PAL_IDX_POISON;
-    hdl->dev.fd_out = PAL_IDX_POISON;
-    *handle         = hdl;
-
-    ret = ops->open(handle, dev_type, uri, access, share, create, options);
-    free(dev_type);
-    return ret;
-}
-
-/* 'read' operation for device stream */
-static int64_t dev_read(PAL_HANDLE handle, uint64_t offset, uint64_t size, void* buffer) {
-    const struct handle_ops* ops = DEVICE_OPS(handle);
-
-    if (!ops || !ops->read)
-        return -PAL_ERROR_NOTSUPPORT;
-
-    return ops->read(handle, offset, size, buffer);
-}
-
-/* 'write' operation for device stream */
-static int64_t dev_write(PAL_HANDLE handle, uint64_t offset, uint64_t size, const void* buffer) {
-    const struct handle_ops* ops = DEVICE_OPS(handle);
-
-    if (!ops || !ops->write)
-        return -PAL_ERROR_NOTSUPPORT;
-
-    return ops->write(handle, offset, size, buffer);
-}
-
-/* 'close' operation for device streams */
-static int dev_close(PAL_HANDLE handle) {
-    const struct handle_ops* ops = DEVICE_OPS(handle);
-
-    if (ops && ops->close)
-        return ops->close(handle);
-
-    if (handle->dev.fd_in != PAL_IDX_POISON) {
-        int fd = handle->dev.fd_in;
-
-        int ret = INLINE_SYSCALL(close, 1, fd);
-
-        if (IS_ERR(ret)) {
-            if (ERRNO(ret) != EBADF && ERRNO(ret) != EINVAL)
-                return unix_to_pal_error(ERRNO(ret));
-        }
-    }
-
-    if (handle->dev.fd_out != PAL_IDX_POISON) {
-        int fd = handle->dev.fd_out;
-
-        int ret = INLINE_SYSCALL(close, 1, fd);
-
-        if (IS_ERR(ret)) {
-            if (ERRNO(ret) != EBADF && ERRNO(ret) != EINVAL)
-                return unix_to_pal_error(ERRNO(ret));
-        }
-    }
-
-    if (handle->file.realpath)
-        free((void*)handle->file.realpath);
-
-    return 0;
-}
-
-/* 'delete' operation for device streams */
-static int dev_delete(PAL_HANDLE handle, int access) {
-    const struct handle_ops* ops = DEVICE_OPS(handle);
-
-    if (!ops || !ops->delete)
-        return -PAL_ERROR_DENIED;
-
-    int ret = dev_close(handle);
-
-    if (ret < 0)
-        return ret;
-
-    return ops->delete(handle, access);
-}
-
-/* 'flush' operation for device streams */
-static int dev_flush(PAL_HANDLE handle) {
-    const struct handle_ops* ops = DEVICE_OPS(handle);
-
-    if (ops && ops->flush)
-        return ops->flush(handle);
-
-    /* try to flush input stream */
-    if (handle->dev.fd_in != PAL_IDX_POISON) {
-        int fd = handle->dev.fd_in;
-
-        int ret = INLINE_SYSCALL(fsync, 1, fd);
-
-        if (IS_ERR(ret)) {
-            if (ERRNO(ret) == EBADF || ERRNO(ret) == EINVAL)
-                return -PAL_ERROR_BADHANDLE;
-            else
-                return unix_to_pal_error(ERRNO(ret));
-        }
-    }
-
-    /* if output stream exists and does not equal to input stream,
-       flush output stream as well */
-    if (handle->dev.fd_out != PAL_IDX_POISON && handle->dev.fd_out != handle->dev.fd_in) {
-        int fd = handle->dev.fd_out;
-
-        int ret = INLINE_SYSCALL(fsync, 1, fd);
-
-        if (IS_ERR(ret)) {
-            if (ERRNO(ret) == EBADF || ERRNO(ret) == EINVAL)
-                return -PAL_ERROR_BADHANDLE;
-            else
-                return unix_to_pal_error(ERRNO(ret));
-        }
-    }
-
-    return 0;
-}
-
-/* 'attrquery' operation for device streams */
-static int dev_attrquery(const char* type, const char* uri, PAL_STREAM_ATTR* attr) {
-    if (strcmp(type, URI_TYPE_DEV))
-        return -PAL_ERROR_INVAL;
-
-    struct handle_ops* ops = NULL;
-    char* dev_type = NULL;
-    int ret = 0;
-
-    ret = parse_device_uri(&uri, &dev_type, &ops);
-
-    if (ret < 0)
-        return ret;
-
-    if (!ops || !ops->attrquery)
-        return -PAL_ERROR_NOTSUPPORT;
-
-    ret = ops->attrquery(dev_type, uri, attr);
-    free(dev_type);
-    return ret;
-}
-
-/* 'attrquerybyhdl' operation for device stream */
 static int dev_attrquerybyhdl(PAL_HANDLE handle, PAL_STREAM_ATTR* attr) {
-    const struct handle_ops* ops = DEVICE_OPS(handle);
+    if (!IS_HANDLE_TYPE(handle, dev))
+        return -PAL_ERROR_INVAL;
 
-    if (ops && ops->attrquerybyhdl)
-        return ops->attrquerybyhdl(handle, attr);
-
-    struct stat stat_buf, *stat_in = NULL, *stat_out = NULL;
-    int ret;
-
-    attr->handle_type = pal_type_dev;
-
-    if (handle->dev.fd_in != PAL_IDX_POISON) {
-        ret = INLINE_SYSCALL(fstat, 2, handle->dev.fd_in, &stat_buf);
-
-        if (!IS_ERR(ret))
-            stat_in = &stat_buf;
-    }
-
-    if (handle->dev.fd_in != PAL_IDX_POISON) {
-        ret = INLINE_SYSCALL(fstat, 2, handle->dev.fd_in, &stat_buf);
-
-        if (!IS_ERR(ret))
-            stat_out = &stat_buf;
-    }
-
-    attr->readable     = (stat_in && stataccess(stat_in, ACCESS_R));
-    attr->runnable     = (stat_in && stataccess(stat_in, ACCESS_X));
-    attr->writable     = (stat_out && stataccess(stat_out, ACCESS_W));
-    attr->pending_size = stat_in ? stat_in->st_size : (stat_out ? stat_out->st_size : 0);
+    attr->handle_type  = pal_type_dev;
+    attr->readable     = HANDLE_HDR(handle)->flags & RFD(0);
+    attr->writable     = HANDLE_HDR(handle)->flags & WFD(0);
+    attr->runnable     = PAL_FALSE;
+    attr->pending_size = 0;
     return 0;
-}
-
-static const char* dev_getrealpath(PAL_HANDLE handle) {
-    return handle->dev.realpath;
 }
 
 struct handle_ops g_dev_ops = {
-    .getrealpath    = &dev_getrealpath,
     .open           = &dev_open,
     .read           = &dev_read,
     .write          = &dev_write,
     .close          = &dev_close,
-    .delete         = &dev_delete,
     .flush          = &dev_flush,
     .attrquery      = &dev_attrquery,
     .attrquerybyhdl = &dev_attrquerybyhdl,

--- a/Pal/src/host/Linux/db_streams.c
+++ b/Pal/src/host/Linux/db_streams.c
@@ -112,10 +112,7 @@ int handle_serialize(PAL_HANDLE handle, void** data) {
             /* pipes have no fields to serialize */
             break;
         case pal_type_dev:
-            if (handle->dev.realpath) {
-                d1   = handle->dev.realpath;
-                dsz1 = strlen(handle->dev.realpath) + 1;
-            }
+            /* devices have no fields to serialize */
             break;
         case pal_type_dir:
             if (handle->dir.realpath) {
@@ -178,7 +175,6 @@ int handle_deserialize(PAL_HANDLE* handle, const void* data, int size) {
         case pal_type_pipeprv:
             break;
         case pal_type_dev:
-            hdl->dev.realpath = hdl->dev.realpath ? (PAL_STR)hdl + hdlsz : NULL;
             break;
         case pal_type_dir:
             hdl->dir.realpath = hdl->dir.realpath ? (PAL_STR)hdl + hdlsz : NULL;

--- a/Pal/src/host/Linux/pal_host.h
+++ b/Pal/src/host/Linux/pal_host.h
@@ -96,10 +96,7 @@ typedef struct pal_handle {
         } eventfd;
 
         struct {
-            PAL_IDX fd_in, fd_out;
-            PAL_IDX dev_type;
-            PAL_BOL destroy;
-            PAL_STR realpath;
+            PAL_IDX fd;
         } dev;
 
         struct {

--- a/Pal/src/host/Skeleton/db_devices.c
+++ b/Pal/src/host/Skeleton/db_devices.c
@@ -2,7 +2,7 @@
 /* Copyright (C) 2014 Stony Brook University */
 
 /*
- * This file contains operands to handle streams with URIs that start with "dev:".
+ * Operations to handle devices (currently only "dev:tty" which is stdin/stdout).
  */
 
 #include "api.h"
@@ -12,197 +12,40 @@
 #include "pal_error.h"
 #include "pal_internal.h"
 
-#define DEVICE_OPS(handle)                                                               \
-    ({                                                                                   \
-        int _type = (handle)->dev.dev_type;                                              \
-        (_type <= 0 || _type >= PAL_DEVICE_TYPE_BOUND) ? NULL : g_pal_device_ops[_type]; \
-    })
-
-enum {
-    device_type_none = 0,
-    device_type_term,
-    PAL_DEVICE_TYPE_BOUND,
-};
-
-static struct handle_ops g_term_ops;
-
-static const struct handle_ops* g_pal_device_ops[PAL_DEVICE_TYPE_BOUND] = {
-    NULL,
-    &g_term_ops,
-};
-
-/* parse_device_uri scans the uri, parses the prefix of the uri and searches for stream handler
- * which will open or access the device. */
-static int parse_device_uri(const char** uri, char** type, struct handle_ops** ops) {
-    struct handle_ops* dops = NULL;
-    const char* p;
-    const char* u = *uri;
-
-    for (p = u; *p && *p != ',' && *p != '/'; p++)
-        ;
-
-    if (strstartswith(u, "tty"))
-        dops = &g_term_ops;
-
-    if (!dops)
-        return -PAL_ERROR_NOTSUPPORT;
-
-    *uri = *p ? p + 1 : p;
-    if (type) {
-        *type = alloc_substr(u, p - u);
-        if (!*type)
-            return -PAL_ERROR_NOMEM;
-    }
-    if (ops)
-        *ops = dops;
-    return 0;
-}
-
-static int64_t char_read(PAL_HANDLE handle, uint64_t offset, uint64_t count, void* buffer);
-static int64_t char_write(PAL_HANDLE handle, uint64_t offset, uint64_t count, const void* buffer);
-static int term_attrquery(const char* type, const char* uri, PAL_STREAM_ATTR* attr);
-static int term_attrquerybyhdl(PAL_HANDLE hdl, PAL_STREAM_ATTR* attr);
-
-/* 'open' operation for terminal stream */
-static int term_open(PAL_HANDLE* handle, const char* type, const char* uri, int access, int share,
-                     int create, int options) {
-    return -PAL_ERROR_NOTIMPLEMENTED;
-}
-
-static int term_close(PAL_HANDLE handle) {
-    return -PAL_ERROR_NOTIMPLEMENTED;
-}
-
-/* 'attrquery' operation for terminal stream */
-static int term_attrquery(const char* type, const char* uri, PAL_STREAM_ATTR* attr) {
-    return -PAL_ERROR_NOTIMPLEMENTED;
-}
-
-/* 'attrquery' operation for terminal stream */
-static int term_attrquerybyhdl(PAL_HANDLE hdl, PAL_STREAM_ATTR* attr) {
-    return -PAL_ERROR_NOTIMPLEMENTED;
-}
-
-static struct handle_ops g_term_ops = {
-    .open           = &term_open,
-    .close          = &term_close,
-    .read           = &char_read,
-    .write          = &char_write,
-    .attrquery      = &term_attrquery,
-    .attrquerybyhdl = &term_attrquerybyhdl,
-};
-
-/* 'read' operation for character streams. */
-static int64_t char_read(PAL_HANDLE handle, uint64_t offset, uint64_t size, void* buffer) {
-    return -PAL_ERROR_NOTIMPLEMENTED;
-}
-
-/* 'write' operation for character streams. */
-static int64_t char_write(PAL_HANDLE handle, uint64_t offset, uint64_t size, const void* buffer) {
-    return -PAL_ERROR_NOTIMPLEMENTED;
-}
-
-/* 'open' operation for device streams */
 static int dev_open(PAL_HANDLE* handle, const char* type, const char* uri, int access, int share,
                     int create, int options) {
     return -PAL_ERROR_NOTIMPLEMENTED;
 }
 
-/* 'read' operation for device stream */
 static int64_t dev_read(PAL_HANDLE handle, uint64_t offset, uint64_t size, void* buffer) {
-    const struct handle_ops* ops = DEVICE_OPS(handle);
-
-    if (!ops || !ops->read)
-        return -PAL_ERROR_NOTSUPPORT;
-
-    return ops->read(handle, offset, size, buffer);
+    return -PAL_ERROR_NOTIMPLEMENTED;
 }
 
-/* 'write' operation for device stream */
 static int64_t dev_write(PAL_HANDLE handle, uint64_t offset, uint64_t size, const void* buffer) {
-    const struct handle_ops* ops = DEVICE_OPS(handle);
-
-    if (!ops || !ops->write)
-        return -PAL_ERROR_NOTSUPPORT;
-
-    return ops->write(handle, offset, size, buffer);
+    return -PAL_ERROR_NOTIMPLEMENTED;
 }
 
-/* 'close' operation for device streams */
 static int dev_close(PAL_HANDLE handle) {
-    const struct handle_ops* ops = DEVICE_OPS(handle);
-
-    if (ops && ops->close)
-        return ops->close(handle);
-
     return -PAL_ERROR_NOTIMPLEMENTED;
 }
 
-/* 'delete' operation for device streams */
-static int dev_delete(PAL_HANDLE handle, int access) {
-    const struct handle_ops* ops = DEVICE_OPS(handle);
-
-    if (!ops || !ops->delete)
-        return -PAL_ERROR_DENIED;
-
-    int ret = dev_close(handle);
-
-    if (ret < 0)
-        return ret;
-
-    return ops->delete(handle, access);
-}
-
-/* 'flush' operation for device streams */
 static int dev_flush(PAL_HANDLE handle) {
-    const struct handle_ops* ops = DEVICE_OPS(handle);
-
-    if (ops && ops->flush)
-        return ops->flush(handle);
-
     return -PAL_ERROR_NOTIMPLEMENTED;
 }
 
-/* 'attrquery' operation for device streams */
 static int dev_attrquery(const char* type, const char* uri, PAL_STREAM_ATTR* attr) {
-    struct handle_ops* ops = NULL;
-    char* dev_type = NULL;
-    int ret = 0;
-
-    ret = parse_device_uri(&uri, &dev_type, &ops);
-
-    if (ret < 0)
-        return ret;
-
-    if (!ops || !ops->attrquery)
-        return -PAL_ERROR_NOTSUPPORT;
-
-    ret = ops->attrquery(dev_type, uri, attr);
-    free(dev_type);
-    return ret;
-}
-
-/* 'attrquerybyhdl' operation for device stream */
-static int dev_attrquerybyhdl(PAL_HANDLE handle, PAL_STREAM_ATTR* attr) {
-    const struct handle_ops* ops = DEVICE_OPS(handle);
-
-    if (ops && ops->attrquerybyhdl)
-        return ops->attrquerybyhdl(handle, attr);
-
     return -PAL_ERROR_NOTIMPLEMENTED;
 }
 
-static const char* dev_getrealpath(PAL_HANDLE handle) {
-    return NULL;
+static int dev_attrquerybyhdl(PAL_HANDLE handle, PAL_STREAM_ATTR* attr) {
+    return -PAL_ERROR_NOTIMPLEMENTED;
 }
 
 struct handle_ops g_dev_ops = {
-    .getrealpath    = &dev_getrealpath,
     .open           = &dev_open,
     .read           = &dev_read,
     .write          = &dev_write,
     .close          = &dev_close,
-    .delete         = &dev_delete,
     .flush          = &dev_flush,
     .attrquery      = &dev_attrquery,
     .attrquerybyhdl = &dev_attrquerybyhdl,

--- a/Pal/src/host/Skeleton/pal_host.h
+++ b/Pal/src/host/Skeleton/pal_host.h
@@ -57,7 +57,6 @@ typedef struct pal_handle {
 
         struct {
             PAL_IDX fd;
-            PAL_IDX dev_type;
         } dev;
 
         struct {


### PR DESCRIPTION

## Description of the changes <!-- (reasons and measures) -->

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

This PR refactors the source code of `pal_type_device` PAL handle (currently used only for `/dev/tty` STDIN/STDOUT streams). As a side effect, it also slightly refactors the corresponding code in LibOS.

## How to test this PR? <!-- (if applicable) -->

All tests must pass. Only refactoring, no change in logic.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1951)
<!-- Reviewable:end -->
