### PR TITLE
LibOS: Remove unnecessary asm from test case

### DIFF
--- a/LibOS/shim/test/regression/pthread_set_get_affinity.c
+++ b/LibOS/shim/test/regression/pthread_set_get_affinity.c
@@ -25,14 +25,10 @@ pthread_barrier_t barrier;
 
 /* Run a busy loop for some iterations, so that we can verify affinity with htop manually */
 static void* dowork(void* args) {
-    uint64_t* iterations = (uint64_t*)args;
-    __asm__ volatile (
-                      "movq %0, %%rax\n"
-                      "loop:\n"
-                      "dec %%rax\n"
-                      "cmp $0, %%rax\n"
-                      "jne loop\n"
-                      : /*no outs*/ : "m"(*iterations)  : "rax", "cc");
+    volatile uint64_t iterations = *(uint64_t*)args;
+
+    while (iterations != 0)
+        iterations--;
 
     int ret = pthread_barrier_wait(&barrier);
     if (ret != 0 && ret != PTHREAD_BARRIER_SERIAL_THREAD) {


### PR DESCRIPTION
 Remove unnecessary asm from test case

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1955)
<!-- Reviewable:end -->
