### PR TITLE
[LibOS] Gracefully exit with message on duplicate mounts in manifest

### DIFF
--- a/Documentation/manifest-syntax.rst
+++ b/Documentation/manifest-syntax.rst
@@ -189,6 +189,19 @@ This specifies whether to allow system calls `eventfd()` and `eventfd2()`. Since
 eventfd emulation currently relies on the host, these system calls are
 disallowed by default due to security concerns.
 
+Root FS mount point
+^^^^^^^^^^^^^^^^^^^
+
+::
+
+    fs.root.[identifier].type = "[chroot|...]"
+    fs.root.[identifier].path = "[PATH]"
+    fs.root.[identifier].uri  = "[URI]"
+
+This syntax specifies the root file system to be mounted inside the library OS.
+If not specified, then Graphene mounts the current working directory as the
+root. There can be only one root FS mount point specified in the manifest.
+
 FS mount points
 ^^^^^^^^^^^^^^^
 
@@ -201,6 +214,16 @@ FS mount points
 This syntax specifies how file systems are mounted inside the library OS. For
 dynamically linked binaries, usually at least one mount point is required in the
 manifest (the mount point of the Glibc library).
+
+Start (current working) directory
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+::
+
+    fs.start_dir = "[URI]"
+
+This syntax specifies the start (current working) directory. If not specified,
+then Graphene sets the root directory as the start directory (see ``fs.root``).
 
 
 SGX syntax

--- a/LibOS/shim/src/fs/shim_fs.c
+++ b/LibOS/shim/src/fs/shim_fs.c
@@ -108,13 +108,13 @@ static int __mount_root(struct shim_dentry** root) {
     }
 
     if (fs_root_type && fs_root_uri) {
-        debug("Mounting root filesystem: %s from %s\n", fs_root_type, fs_root_uri);
+        debug("Mounting root as %s filesystem: from %s to /\n", fs_root_type, fs_root_uri);
         if ((ret = mount_fs(fs_root_type, fs_root_uri, "/", NULL, root, 0)) < 0) {
             debug("Mounting root filesystem failed (%d)\n", ret);
             goto out;
         }
     } else {
-        debug("Mounting default root filesystem\n");
+        debug("Mounting root as chroot filesystem: from file:. to /\n");
         if ((ret = mount_fs("chroot", URI_PREFIX_FILE, "/", NULL, root, 0)) < 0) {
             debug("Mounting root filesystem failed (%d)\n", ret);
             goto out;
@@ -131,25 +131,22 @@ out:
 static int __mount_sys(struct shim_dentry* root) {
     int ret;
 
-    debug("Mounting as proc filesystem: /proc\n");
-
+    debug("Mounting special proc filesystem: /proc\n");
     if ((ret = mount_fs("proc", NULL, "/proc", root, NULL, 0)) < 0) {
-        debug("Mounting proc filesystem failed (%d)\n", ret);
+        debug("Mounting /proc filesystem failed (%d)\n", ret);
         return ret;
     }
 
-    debug("Mounting as dev filesystem: /dev\n");
-
+    debug("Mounting special dev filesystem: /dev\n");
     struct shim_dentry* dev_dent = NULL;
     if ((ret = mount_fs("dev", NULL, "/dev", root, &dev_dent, 0)) < 0) {
         debug("Mounting dev filesystem failed (%d)\n", ret);
         return ret;
     }
 
-    debug("Mounting as chroot filesystem: from dev:tty to /dev\n");
-
+    debug("Mounting terminal device /dev/tty under /dev\n");
     if ((ret = mount_fs("chroot", URI_PREFIX_DEV "tty", "/dev/tty", dev_dent, NULL, 0)) < 0) {
-        debug("Mounting terminal device failed (%d)\n", ret);
+        debug("Mounting terminal device /dev/tty failed (%d)\n", ret);
         return ret;
     }
 
@@ -206,6 +203,14 @@ static int __mount_one_other(toml_table_t* mount) {
     }
 
     debug("Mounting as %s filesystem: from %s to %s\n", mount_type, mount_uri, mount_path);
+
+    if (!strcmp(mount_path, "/")) {
+        debug("Root mount / already exists, verify that there are no duplicate mounts in manifest\n"
+              "(note that root / is automatically mounted in Graphene and can be changed via "
+              "\'fs.root\' manifest entry).\n");
+        ret = -EEXIST;
+        goto out;
+    }
 
     if ((ret = mount_fs(mount_type, mount_uri, mount_path, NULL, NULL, 1)) < 0) {
         debug("Mounting %s on %s (type=%s) failed (%d)\n", mount_uri, mount_path, mount_type,
@@ -480,7 +485,12 @@ int mount_fs(const char* type, const char* uri, const char* mount_point, struct 
         }
     }
 
-    assert(dent == dentry_root || !(dent->state & DENTRY_VALID));
+    if (dent != dentry_root && dent->state & DENTRY_VALID) {
+        debug("Mount %s already exists, verify that there are no duplicate mounts in manifest\n"
+              "(note that /proc and /dev are automatically mounted in Graphene).\n", mount_point);
+        ret = -EEXIST;
+        goto out_with_unlock;
+    }
 
     // We need to fix up the relative path to this mount, but only for
     // directories.


### PR DESCRIPTION

<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://graphene.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

Sometimes users may try to add `/dev` or root (`/`) mounts to the manifest file, but these paths are already automatically mounted by Graphene on startup. Previously, Graphene failed on assert in such cases, now it prints a meaningful error message.

## How to test this PR? <!-- (if applicable) -->

Didn't want to introduce a negative test case for this. But try manually by simply adding these lines to `LibOS/shim/test/regression/manifest.template`:
```
fs.mount.dev.type = chroot
fs.mount.dev.path = /dev
fs.mount.dev.uri = file:/dev
```

Without this PR, Graphene mysteriously fails on assert (rebuild and run any LibOS test). With this PR, Graphene says something reasonable:
```
[P15650:T1:spinlock] Mount /dev already exists, verify that there are no duplicate mounts in manifest
[P15650:T1:spinlock] (note that /proc and /dev are automatically mounted in Graphene).
[P15650:T1:spinlock] Mounting file:/dev on /dev (type=chroot) failed (17)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1956)
<!-- Reviewable:end -->
