### PR TITLE
[LibOS] Defer wakeup of thread until after sighandler ran

### DIFF
--- a/LibOS/shim/include/shim_thread.h
+++ b/LibOS/shim/include/shim_thread.h
@@ -84,6 +84,7 @@ struct shim_thread {
      * `process_pending_signals_cnt`. */
     uint64_t pending_signals;
     bool signal_handled;
+    bool wakeup_after_sighandler_run;
     stack_t signal_altstack;
 
     /* futex robust list */

--- a/LibOS/shim/src/bookkeep/shim_signal.c
+++ b/LibOS/shim/src/bookkeep/shim_signal.c
@@ -751,6 +751,9 @@ static void __handle_one_signal(shim_tcb_t* tcb, struct shim_signal* signal) {
 
     if (signal->pal_context)
         ucontext_to_pal_context(signal->pal_context, &signal->context);
+
+    if (thread->wakeup_after_sighandler_run) /* deferred wakeup for sigsuspend */
+        thread_wakeup(thread);
 }
 
 void __handle_signals(shim_tcb_t* tcb) {


### PR DESCRIPTION
If a thread is in sigsuspend() we need to defer the wakeup of
that thread until after the signal hander was run.

This PR addresses issue #1957.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1958)
<!-- Reviewable:end -->
