### PR TITLE
[Pal/{Linux,Linux-SGX}] Allow communication with host devices

### DIFF
--- a/LibOS/shim/src/fs/chroot/fs.c
+++ b/LibOS/shim/src/fs/chroot/fs.c
@@ -711,12 +711,15 @@ static off_t chroot_seek(struct shim_handle* hdl, off_t offset, int wence) {
     struct shim_file_handle* file = &hdl->info.file;
     lock(&hdl->lock);
 
+    /* TODO: this function emulates lseek() completely inside the LibOS, but some device files
+     *       may report size == 0 during fstat() and may provide device-specific lseek() logic;
+     *       this emulation breaks for such device-specific cases */
     off_t marker = file->marker;
     off_t size = file->size;
 
     if (check_version(hdl)) {
         struct shim_file_data* data = FILE_HANDLE_DATA(hdl);
-        if (data->type != FILE_REGULAR) {
+        if (data->type != FILE_REGULAR && data->type != FILE_DEV) {
             ret = -ESPIPE;
             goto out;
         }

--- a/LibOS/shim/test/regression/.gitignore
+++ b/LibOS/shim/test/regression/.gitignore
@@ -20,6 +20,7 @@
 /debug_log_inline
 /debug_regs-x86_64
 /dev
+/device
 /env_from_file
 /env_from_host
 /epoll_wait_timeout

--- a/LibOS/shim/test/regression/Makefile
+++ b/LibOS/shim/test/regression/Makefile
@@ -15,6 +15,7 @@ c_executables = \
 	bootstrap_static \
 	debug \
 	dev \
+	device \
 	epoll_wait_timeout \
 	eventfd \
 	exec \

--- a/LibOS/shim/test/regression/device.c
+++ b/LibOS/shim/test/regression/device.c
@@ -1,0 +1,51 @@
+#include <err.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+int main(int argc, char* arvg[]) {
+    int devfd = open("/dev/kmsg", O_RDONLY);
+    if (devfd < 0)
+        err(1, "/dev/kmsg open");
+
+    off_t offset;
+#if 0
+    /* FIXME: doesn't work in Graphene because lseek() is fully emulated in LibOS and therefore
+     *        lseek() is not aware of device-specific semantics */
+    offset = lseek(devfd, 0, SEEK_CUR);
+    if (offset != -1 || errno != EINVAL) {
+        errx(1, "/dev/kmsg lseek(0, SEEK_CUR) didn't return -EINVAL (returned: %ld, errno=%d)",
+             offset, errno);
+    }
+
+    offset = lseek(devfd, 1, SEEK_CUR);
+    if (offset != -1 || errno != ESPIPE) {
+        errx(1, "/dev/kmsg lseek(1, SEEK_CUR) didn't return -ESPIPE (returned: %ld, errno=%d)",
+             offset, errno);
+    }
+#endif
+
+    offset = lseek(devfd, /*offset=*/0, SEEK_SET);
+    if (offset < 0)
+        err(1, "/dev/kmsg lseek(0, SEEK_SET)");
+    if (offset > 0)
+        errx(1, "/dev/kmsg lseek(0, SEEK_SET) didn't return 0 (returned: %ld)", offset);
+
+    char buf[1024];
+    ssize_t bytes = read(devfd, buf, sizeof(buf) - 1);
+    if (bytes < 0)
+        err(1, "/dev/kmsg read");
+
+    buf[bytes] = '\0';
+    printf("First line of /dev/kmsg: %s", buf);
+
+    int ret = close(devfd);
+    if (ret < 0)
+        err(1, "/dev/kmsg close");
+
+    puts("TEST OK");
+    return 0;
+}

--- a/LibOS/shim/test/regression/manifest.template
+++ b/LibOS/shim/test/regression/manifest.template
@@ -19,6 +19,10 @@ fs.mount.bin.type = "chroot"
 fs.mount.bin.path = "/bin"
 fs.mount.bin.uri = "file:/bin"
 
+fs.mount.devkmsg.type = "chroot"
+fs.mount.devkmsg.path = "/dev/kmsg"
+fs.mount.devkmsg.uri = "dev:/dev/kmsg"
+
 sgx.trusted_files.ld = "file:../../../../Runtime/ld-linux-x86-64.so.2"
 sgx.trusted_files.libc = "file:../../../../Runtime/libc.so.6"
 sgx.trusted_files.libdl = "file:../../../../Runtime/libdl.so.2"

--- a/LibOS/shim/test/regression/test_libos.py
+++ b/LibOS/shim/test/regression/test_libos.py
@@ -584,6 +584,10 @@ class TC_40_FileSystem(RegressionTestCase):
         self.assertIn('/dev/stderr', stdout)
         self.assertIn('Four bytes from /dev/urandom', stdout)
 
+    def test_002_device(self):
+        stdout, _ = self.run_binary(['device'])
+        self.assertIn('TEST OK', stdout)
+
     def test_010_path(self):
         stdout, _ = self.run_binary(['proc_path'])
         self.assertIn('proc path test success', stdout)

--- a/Pal/src/host/Linux-SGX/db_devices.c
+++ b/Pal/src/host/Linux-SGX/db_devices.c
@@ -1,29 +1,31 @@
 /* SPDX-License-Identifier: LGPL-3.0-or-later */
 /* Copyright (C) 2014 Stony Brook University */
+/* Copyright (C) 2020 Intel Labs */
 
 /*
- * Operations to handle devices (currently only "dev:tty" which is stdin/stdout).
+ * Operations to handle devices (with special case of "dev:tty" which is stdin/stdout).
+ *
+ * TODO: Some devices allow lseek() but typically with device-specific semantics. Graphene currently
+ *       emulates lseek() completely in LibOS layer, thus seeking at PAL layer cannot be correctly
+ *       implemented (without device-specific changes to LibOS layer).
  */
 
 #include "api.h"
 #include "pal.h"
 #include "pal_error.h"
+#include "pal_flags_conv.h"
 #include "pal_internal.h"
 #include "pal_linux.h"
 #include "pal_linux_error.h"
 
 static int dev_open(PAL_HANDLE* handle, const char* type, const char* uri, int access, int share,
                     int create, int options) {
+    int ret;
     __UNUSED(share);
     __UNUSED(create);
     __UNUSED(options);
 
-    /* currently support only "dev:tty" device which is the standard input + standard output */
-    if (strcmp(type, URI_TYPE_DEV) || strcmp(uri, "tty"))
-        return -PAL_ERROR_INVAL;
-
-    /* "dev:tty" device can only be opened either for read (stdin) or for write (stdout) */
-    if (access & PAL_ACCESS_RDWR)
+    if (strcmp(type, URI_TYPE_DEV))
         return -PAL_ERROR_INVAL;
 
     assert(WITHIN_MASK(access,  PAL_ACCESS_MASK));
@@ -37,16 +39,48 @@ static int dev_open(PAL_HANDLE* handle, const char* type, const char* uri, int a
 
     SET_HANDLE_TYPE(hdl, dev);
 
-    if (access & PAL_ACCESS_WRONLY) {
-        HANDLE_HDR(hdl)->flags |= WFD(0);
-        hdl->dev.fd = 1; /* host stdout */
+    if (!strcmp(uri, "tty")) {
+        /* special case of "dev:tty" device which is the standard input + standard output */
+        hdl->dev.nonblocking = PAL_FALSE;
+
+        if (access & PAL_ACCESS_RDWR) {
+            ret = -PAL_ERROR_INVAL;
+            goto fail;
+        } else if (access & PAL_ACCESS_WRONLY) {
+            HANDLE_HDR(hdl)->flags |= WFD(0);
+            hdl->dev.fd = 1; /* host stdout */
+        } else {
+            HANDLE_HDR(hdl)->flags |= RFD(0);
+            hdl->dev.fd = 0; /* host stdin */
+        }
     } else {
-        HANDLE_HDR(hdl)->flags |= RFD(0);
-        hdl->dev.fd = 0; /* host stdin */
+        /* other devices must be opened through the host */
+        hdl->dev.nonblocking = (options & PAL_OPTION_NONBLOCK) ? PAL_TRUE : PAL_FALSE;
+
+        ret = ocall_open(uri, PAL_ACCESS_TO_LINUX_OPEN(access)  |
+                              PAL_CREATE_TO_LINUX_OPEN(create)  |
+                              PAL_OPTION_TO_LINUX_OPEN(options),
+                         share);
+        if (IS_ERR(ret)) {
+            ret = unix_to_pal_error(ERRNO(ret));
+            goto fail;
+        }
+        hdl->dev.fd = ret;
+
+        if (access & PAL_ACCESS_RDWR) {
+            HANDLE_HDR(hdl)->flags |= RFD(0) | WFD(0);
+        } else if (access & PAL_ACCESS_WRONLY) {
+            HANDLE_HDR(hdl)->flags |= WFD(0);
+        } else {
+            HANDLE_HDR(hdl)->flags |= RFD(0);
+        }
     }
 
     *handle = hdl;
     return 0;
+fail:
+    free(hdl);
+    return ret;
 }
 
 static int64_t dev_read(PAL_HANDLE handle, uint64_t offset, uint64_t size, void* buffer) {
@@ -81,9 +115,13 @@ static int dev_close(PAL_HANDLE handle) {
     if (!IS_HANDLE_TYPE(handle, dev))
         return -PAL_ERROR_INVAL;
 
-    /* Currently we just assign `0` or `1` without duplicating, so close is a no-op. */
+    /* currently we just assign `0`/`1` FDs without duplicating, so close is a no-op for them */
+    int ret = 0;
+    if (handle->dev.fd != PAL_IDX_POISON && handle->dev.fd != 0 && handle->dev.fd != 1) {
+        ret = ocall_close(handle->dev.fd);
+    }
     handle->dev.fd = PAL_IDX_POISON;
-    return 0;
+    return IS_ERR(ret) ? unix_to_pal_error(ERRNO(ret)) : 0;
 }
 
 static int dev_flush(PAL_HANDLE handle) {
@@ -101,15 +139,40 @@ static int dev_flush(PAL_HANDLE handle) {
 static int dev_attrquery(const char* type, const char* uri, PAL_STREAM_ATTR* attr) {
     __UNUSED(uri);
 
-    /* currently support only "dev:tty" device which is the standard input + standard output */
-    if (strcmp(type, URI_TYPE_DEV) || strcmp(uri, "tty"))
+    if (strcmp(type, URI_TYPE_DEV))
         return -PAL_ERROR_INVAL;
 
+    if (!strcmp(uri, "tty")) {
+        /* special case of "dev:tty" device which is the standard input + standard output */
+        attr->readable     = PAL_TRUE; /* we don't know if it's stdin/stdout so simply return true */
+        attr->writable     = PAL_TRUE; /* we don't know if it's stdin/stdout so simply return true */
+        attr->runnable     = PAL_FALSE;
+        attr->share_flags  = 0;
+        attr->pending_size = 0;
+    } else {
+        /* other devices must query the host */
+        int fd = ocall_open(uri, 0, 0);
+        if (IS_ERR(fd))
+            return unix_to_pal_error(ERRNO(fd));
+
+        struct stat stat_buf;
+        int ret = ocall_fstat(fd, &stat_buf);
+        if (IS_ERR(ret)) {
+            ocall_close(fd);
+            return unix_to_pal_error(ERRNO(ret));
+        }
+
+        attr->readable     = stataccess(&stat_buf, ACCESS_R);
+        attr->writable     = stataccess(&stat_buf, ACCESS_W);
+        attr->runnable     = stataccess(&stat_buf, ACCESS_X);
+        attr->share_flags  = stat_buf.st_mode;
+        attr->pending_size = stat_buf.st_size;
+
+        ocall_close(fd);
+    }
+
     attr->handle_type  = pal_type_dev;
-    attr->readable     = PAL_TRUE; /* we don't know if it's stdin/stdout so simply return true */
-    attr->writable     = PAL_TRUE; /* we don't know if it's stdin/stdout so simply return true */
-    attr->runnable     = PAL_FALSE;
-    attr->pending_size = 0;
+    attr->nonblocking  = PAL_FALSE;
     return 0;
 }
 
@@ -117,11 +180,29 @@ static int dev_attrquerybyhdl(PAL_HANDLE handle, PAL_STREAM_ATTR* attr) {
     if (!IS_HANDLE_TYPE(handle, dev))
         return -PAL_ERROR_INVAL;
 
+    if (handle->dev.fd == 0 || handle->dev.fd == 1) {
+        /* special case of "dev:tty" device which is the standard input + standard output */
+        attr->readable     = HANDLE_HDR(handle)->flags & RFD(0);
+        attr->writable     = HANDLE_HDR(handle)->flags & WFD(0);
+        attr->runnable     = PAL_FALSE;
+        attr->share_flags  = 0;
+        attr->pending_size = 0;
+    } else {
+        /* other devices must query the host */
+        struct stat stat_buf;
+        int ret = ocall_fstat(handle->dev.fd, &stat_buf);
+        if (IS_ERR(ret))
+            return unix_to_pal_error(ERRNO(ret));
+
+        attr->readable     = stataccess(&stat_buf, ACCESS_R);
+        attr->writable     = stataccess(&stat_buf, ACCESS_W);
+        attr->runnable     = stataccess(&stat_buf, ACCESS_X);
+        attr->share_flags  = stat_buf.st_mode;
+        attr->pending_size = stat_buf.st_size;
+    }
+
     attr->handle_type  = pal_type_dev;
-    attr->readable     = HANDLE_HDR(handle)->flags & RFD(0);
-    attr->writable     = HANDLE_HDR(handle)->flags & WFD(0);
-    attr->runnable     = PAL_FALSE;
-    attr->pending_size = 0;
+    attr->nonblocking  = handle->dev.nonblocking;
     return 0;
 }
 

--- a/Pal/src/host/Linux-SGX/pal_host.h
+++ b/Pal/src/host/Linux-SGX/pal_host.h
@@ -109,6 +109,7 @@ typedef struct pal_handle {
 
         struct {
             PAL_IDX fd;
+            PAL_BOL nonblocking;
         } dev;
 
         struct {

--- a/Pal/src/host/Linux/db_devices.c
+++ b/Pal/src/host/Linux/db_devices.c
@@ -1,28 +1,30 @@
 /* SPDX-License-Identifier: LGPL-3.0-or-later */
 /* Copyright (C) 2014 Stony Brook University */
+/* Copyright (C) 2020 Intel Labs */
 
 /*
- * Operations to handle devices (currently only "dev:tty" which is stdin/stdout).
+ * Operations to handle devices (with special case of "dev:tty" which is stdin/stdout).
+ *
+ * TODO: Some devices allow lseek() but typically with device-specific semantics. Graphene currently
+ *       emulates lseek() completely in LibOS layer, thus seeking at PAL layer cannot be correctly
+ *       implemented (without device-specific changes to LibOS layer).
  */
 
 #include "api.h"
 #include "pal.h"
 #include "pal_error.h"
+#include "pal_flags_conv.h"
 #include "pal_internal.h"
 #include "pal_linux.h"
 
 static int dev_open(PAL_HANDLE* handle, const char* type, const char* uri, int access, int share,
                     int create, int options) {
+    int ret;
     __UNUSED(share);
     __UNUSED(create);
     __UNUSED(options);
 
-    /* currently support only "dev:tty" device which is the standard input + standard output */
-    if (strcmp(type, URI_TYPE_DEV) || strcmp(uri, "tty"))
-        return -PAL_ERROR_INVAL;
-
-    /* "dev:tty" device can only be opened either for read (stdin) or for write (stdout) */
-    if (access & PAL_ACCESS_RDWR)
+    if (strcmp(type, URI_TYPE_DEV))
         return -PAL_ERROR_INVAL;
 
     assert(WITHIN_MASK(access,  PAL_ACCESS_MASK));
@@ -36,16 +38,48 @@ static int dev_open(PAL_HANDLE* handle, const char* type, const char* uri, int a
 
     SET_HANDLE_TYPE(hdl, dev);
 
-    if (access & PAL_ACCESS_WRONLY) {
-        HANDLE_HDR(hdl)->flags |= WFD(0);
-        hdl->dev.fd = 1; /* host stdout */
+    if (!strcmp(uri, "tty")) {
+        /* special case of "dev:tty" device which is the standard input + standard output */
+        hdl->dev.nonblocking = PAL_FALSE;
+
+        if (access & PAL_ACCESS_RDWR) {
+            ret = -PAL_ERROR_INVAL;
+            goto fail;
+        } else if (access & PAL_ACCESS_WRONLY) {
+            HANDLE_HDR(hdl)->flags |= WFD(0);
+            hdl->dev.fd = 1; /* host stdout */
+        } else {
+            HANDLE_HDR(hdl)->flags |= RFD(0);
+            hdl->dev.fd = 0; /* host stdin */
+        }
     } else {
-        HANDLE_HDR(hdl)->flags |= RFD(0);
-        hdl->dev.fd = 0; /* host stdin */
+        /* other devices must be opened through the host */
+        hdl->dev.nonblocking = (options & PAL_OPTION_NONBLOCK) ? PAL_TRUE : PAL_FALSE;
+
+        ret = INLINE_SYSCALL(open, 3, uri, PAL_ACCESS_TO_LINUX_OPEN(access)  |
+                                           PAL_CREATE_TO_LINUX_OPEN(create)  |
+                                           PAL_OPTION_TO_LINUX_OPEN(options),
+                             share);
+        if (IS_ERR(ret)) {
+            ret = unix_to_pal_error(ERRNO(ret));
+            goto fail;
+        }
+        hdl->dev.fd = ret;
+
+        if (access & PAL_ACCESS_RDWR) {
+            HANDLE_HDR(hdl)->flags |= RFD(0) | WFD(0);
+        } else if (access & PAL_ACCESS_WRONLY) {
+            HANDLE_HDR(hdl)->flags |= WFD(0);
+        } else {
+            HANDLE_HDR(hdl)->flags |= RFD(0);
+        }
     }
 
     *handle = hdl;
     return 0;
+fail:
+    free(hdl);
+    return ret;
 }
 
 static int64_t dev_read(PAL_HANDLE handle, uint64_t offset, uint64_t size, void* buffer) {
@@ -80,9 +114,13 @@ static int dev_close(PAL_HANDLE handle) {
     if (!IS_HANDLE_TYPE(handle, dev))
         return -PAL_ERROR_INVAL;
 
-    /* Currently we just assign `0` or `1` without duplicating, so close is a no-op. */
+    /* currently we just assign `0`/`1` FDs without duplicating, so close is a no-op for them */
+    int ret = 0;
+    if (handle->dev.fd != PAL_IDX_POISON && handle->dev.fd != 0 && handle->dev.fd != 1) {
+        ret = INLINE_SYSCALL(close, 1, handle->dev.fd);
+    }
     handle->dev.fd = PAL_IDX_POISON;
-    return 0;
+    return IS_ERR(ret) ? unix_to_pal_error(ERRNO(ret)) : 0;
 }
 
 static int dev_flush(PAL_HANDLE handle) {
@@ -100,15 +138,32 @@ static int dev_flush(PAL_HANDLE handle) {
 static int dev_attrquery(const char* type, const char* uri, PAL_STREAM_ATTR* attr) {
     __UNUSED(uri);
 
-    /* currently support only "dev:tty" device which is the standard input + standard output */
-    if (strcmp(type, URI_TYPE_DEV) || strcmp(uri, "tty"))
+    if (strcmp(type, URI_TYPE_DEV))
         return -PAL_ERROR_INVAL;
 
+    if (!strcmp(uri, "tty")) {
+        /* special case of "dev:tty" device which is the standard input + standard output */
+        attr->readable     = PAL_TRUE; /* we don't know if it's stdin/stdout so simply return true */
+        attr->writable     = PAL_TRUE; /* we don't know if it's stdin/stdout so simply return true */
+        attr->runnable     = PAL_FALSE;
+        attr->share_flags  = 0;
+        attr->pending_size = 0;
+    } else {
+        /* other devices must query the host */
+        struct stat stat_buf;
+        int ret = INLINE_SYSCALL(stat, 2, uri, &stat_buf);
+        if (IS_ERR(ret))
+            return unix_to_pal_error(ERRNO(ret));
+
+        attr->readable     = stataccess(&stat_buf, ACCESS_R);
+        attr->writable     = stataccess(&stat_buf, ACCESS_W);
+        attr->runnable     = stataccess(&stat_buf, ACCESS_X);
+        attr->share_flags  = stat_buf.st_mode;
+        attr->pending_size = stat_buf.st_size;
+    }
+
     attr->handle_type  = pal_type_dev;
-    attr->readable     = PAL_TRUE; /* we don't know if it's stdin/stdout so simply return true */
-    attr->writable     = PAL_TRUE; /* we don't know if it's stdin/stdout so simply return true */
-    attr->runnable     = PAL_FALSE;
-    attr->pending_size = 0;
+    attr->nonblocking  = PAL_FALSE;
     return 0;
 }
 
@@ -116,11 +171,29 @@ static int dev_attrquerybyhdl(PAL_HANDLE handle, PAL_STREAM_ATTR* attr) {
     if (!IS_HANDLE_TYPE(handle, dev))
         return -PAL_ERROR_INVAL;
 
+    if (handle->dev.fd == 0 || handle->dev.fd == 1) {
+        /* special case of "dev:tty" device which is the standard input + standard output */
+        attr->readable     = HANDLE_HDR(handle)->flags & RFD(0);
+        attr->writable     = HANDLE_HDR(handle)->flags & WFD(0);
+        attr->runnable     = PAL_FALSE;
+        attr->share_flags  = 0;
+        attr->pending_size = 0;
+    } else {
+        /* other devices must query the host */
+        struct stat stat_buf;
+        int ret = INLINE_SYSCALL(fstat, 2, handle->dev.fd, &stat_buf);
+        if (IS_ERR(ret))
+            return unix_to_pal_error(ERRNO(ret));
+
+        attr->readable     = stataccess(&stat_buf, ACCESS_R);
+        attr->writable     = stataccess(&stat_buf, ACCESS_W);
+        attr->runnable     = stataccess(&stat_buf, ACCESS_X);
+        attr->share_flags  = stat_buf.st_mode;
+        attr->pending_size = stat_buf.st_size;
+    }
+
     attr->handle_type  = pal_type_dev;
-    attr->readable     = HANDLE_HDR(handle)->flags & RFD(0);
-    attr->writable     = HANDLE_HDR(handle)->flags & WFD(0);
-    attr->runnable     = PAL_FALSE;
-    attr->pending_size = 0;
+    attr->nonblocking  = handle->dev.nonblocking;
     return 0;
 }
 

--- a/Pal/src/host/Linux/pal_host.h
+++ b/Pal/src/host/Linux/pal_host.h
@@ -97,6 +97,7 @@ typedef struct pal_handle {
 
         struct {
             PAL_IDX fd;
+            PAL_BOL nonblocking;
         } dev;
 
         struct {


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Previously, Graphene supported only `/dev/tty` (stdin/stdout terminal) device. This PR introduces support for other, arbitrary host devices. The devices must be explicitly allowed in the manifest via a mount point like this:
```
      fs.mount.devkmsg.type = chroot
      fs.mount.devkmsg.path = /dev/kmsg
      fs.mount.devkmsg.uri  = dev:/dev/kmsg
```

Currently only `open/read/write/close/fstat` are supported. Support for IOCTLs and mmaps will be introduced in future PRs.

~~Needs to be rebased on top of #1951.~~

## How to test this PR? <!-- (if applicable) -->

A simple test that opens `/dev/kmsg` and reads from it is added to LibOS regression tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1959)
<!-- Reviewable:end -->
