### PR TITLE
[GSC] New info-image command to retrieve SGX information from graphenized Docker image

### DIFF
--- a/.ci/gsc.jenkinsfile
+++ b/.ci/gsc.jenkinsfile
@@ -35,6 +35,8 @@ pipeline {
                     # Test use of base Graphene Image
                     make test MAXTESTNUM=2 TESTCASES='python3' \
                               DISTRIBUTIONS='ubuntu18.04-base' IMAGE_SUFFIX=-${COMMIT}
+                    # Test info image command
+                    make test-info-image-ubuntu18.04
                 '''
             }
         }

--- a/Documentation/manpages/gsc.rst
+++ b/Documentation/manpages/gsc.rst
@@ -41,13 +41,13 @@ Software packages
 -----------------
 
 Please install the ``docker.io``, ``python3``, ``python3-pip`` packages. In
-addition, install the Docker client python package via pip. GSC requires Python
-3.6 or later.
+addition, install the Docker client, Jinja2, TOML, and YAML python packages via
+pip. GSC requires Python 3.6 or later.
 
 .. code-block:: sh
 
    sudo apt install docker.io python3 python3-pip
-   pip3 install docker pyyaml jinja2
+   pip3 install docker jinja2 toml pyyaml
 
 SGX software stack
 ------------------
@@ -206,6 +206,22 @@ parameter `Graphene.Image`.
 
    Name of the resulting Graphene Docker image
 
+.. program:: gsc-info-image
+
+:command:`gsc info-image` -- retrieve information about graphenized Docker image
+--------------------------------------------------------------------------------
+
+Retrieves Intel SGX relevant information about the graphenized Docker image such
+as the ``MRENCLAVE`` and ``MRSIGNER`` measurements for each application in the
+Docker image.
+
+Synopsis:
+
+:command:`gsc info-image` <*IMAGE-NAME*>
+
+.. option:: IMAGE-NAME
+
+   Name of the graphenized Docker image
 
 Using Graphene's trusted command line arguments
 -----------------------------------------------
@@ -411,6 +427,12 @@ This example assumes that all prerequisites are installed and configured.
    .. code-block:: sh
 
       ./gsc sign-image python enclave-key.pem
+
+#. Retrieve SGX-related information from graphenized image using :command:`gsc info-image`:
+
+   .. code-block:: sh
+
+      ./gsc info-image gsc-python
 
 #. Test the graphenized Docker image (change ``--device=/dev/isgx`` to your
    version of the Intel SGX driver if needed):

--- a/Tools/gsc/gsc.py
+++ b/Tools/gsc/gsc.py
@@ -6,14 +6,17 @@
 
 import argparse
 import json
+import hashlib
 import os
 import pathlib
 import shutil
+import struct
 import sys
-
-import jinja2
+import tempfile
 
 import docker  # pylint: disable=import-error
+import jinja2
+import toml    # pylint: disable=import-error
 import yaml    # pylint: disable=import-error
 
 def gsc_image_name(original_image_name):
@@ -291,11 +294,71 @@ def gsc_sign_image(args):
           f'`{unsigned_image_name}`.')
 
 
+# Simplified version of read_sigstruct from python/graphenelibos/sgx_get_token.py
+def read_sigstruct(sig):
+    # Offsets for fields in SIGSTRUCT (defined by the SGX HW architecture, they never change)
+    SGX_ARCH_ENCLAVE_CSS_DATE = 20
+    SGX_ARCH_ENCLAVE_CSS_MODULUS = 128
+    SGX_ARCH_ENCLAVE_CSS_ENCLAVE_HASH = 960
+    SGX_ARCH_ENCLAVE_CSS_ISV_PROD_ID = 1024
+    SGX_ARCH_ENCLAVE_CSS_ISV_SVN = 1026
+    # Field format: (offset, type, value)
+    fields = {
+        'date': (SGX_ARCH_ENCLAVE_CSS_DATE, '<HBB', 'year', 'month', 'day'),
+        'modulus': (SGX_ARCH_ENCLAVE_CSS_MODULUS, '384s', 'modulus'),
+        'enclave_hash': (SGX_ARCH_ENCLAVE_CSS_ENCLAVE_HASH, '32s', 'enclave_hash'),
+        'isv_prod_id': (SGX_ARCH_ENCLAVE_CSS_ISV_PROD_ID, '<H', 'isv_prod_id'),
+        'isv_svn': (SGX_ARCH_ENCLAVE_CSS_ISV_SVN, '<H', 'isv_svn'),
+    }
+    attr = {}
+    for field in fields.values():
+        values = struct.unpack_from(field[1], sig, field[0])
+        for i, value in enumerate(values):
+            attr[field[i + 2]] = value
+
+    return attr
+
+# Retrieve information about a previously built graphenized Docker image
+def gsc_info_image(args):
+    docker_socket = docker.from_env()
+    gsc_image = get_docker_image(docker_socket, args.image)
+    if gsc_image is None:
+        print(f'Could not find graphenized Docker image {args.image}.\n'
+              'Please make sure to build the graphenized image first by using \'gsc build\''
+              ' command.')
+        sys.exit(1)
+
+    # Create temporary directory on the host for sigstruct file
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        # Copy sigstruct file from Docker container into temporary directory on the host
+        docker_socket.containers.run(args.image,
+                                 '\'cp entrypoint.sig /tmp/host/ 2>/dev/null || :\'',
+                                 entrypoint=['sh', '-c'], remove=True,
+                                 volumes={tmpdirname: {'bind': '/tmp/host', 'mode': 'rw'}})
+        sigstruct = {}
+        with open(os.path.join(tmpdirname, "entrypoint.sig"), 'rb') as sig:
+            attr = read_sigstruct(sig.read())
+            # calculate MRSIGNER as sha256 hash over RSA public key's modulus
+            mrsigner = hashlib.sha256()
+            mrsigner.update(attr['modulus'])
+            sigstruct['mr_enclave'] = attr['enclave_hash'].hex()
+            sigstruct['mr_signer'] = mrsigner.digest().hex()
+            sigstruct['isv_prod_id'] = attr['isv_prod_id']
+            sigstruct['isv_svn'] = attr['isv_svn']
+            sigstruct['date'] = '%d-%02d-%02d' % (attr['year'], attr['month'], attr['day'])
+
+        if not sigstruct:
+            print(f'Could not extract Intel SGX-related information from image {args.image}.')
+            sys.exit(1)
+
+        print(toml.dumps(sigstruct))
+
+
 argparser = argparse.ArgumentParser()
 subcommands = argparser.add_subparsers(metavar='<command>')
 subcommands.required = True
 
-sub_build = subcommands.add_parser('build', help="Build graphenized Docker image")
+sub_build = subcommands.add_parser('build', help='Build graphenized Docker image')
 sub_build.set_defaults(command=gsc_build)
 sub_build.add_argument('-d', '--debug', action='store_true',
     help='Compile Graphene with debug flags and output.')
@@ -316,7 +379,7 @@ sub_build.add_argument('image', help='Name of the application Docker image.')
 sub_build.add_argument('manifest', help='Manifest file to use.')
 
 sub_build_graphene = subcommands.add_parser('build-graphene',
-    help="Build base-Graphene Docker image")
+    help='Build base-Graphene Docker image')
 sub_build_graphene.set_defaults(command=gsc_build_graphene)
 sub_build_graphene.add_argument('-d', '--debug', action='store_true',
     help='Compile Graphene with debug flags and output.')
@@ -336,12 +399,17 @@ sub_build_graphene.add_argument('-f', '--file-only', action='store_true',
 sub_build_graphene.add_argument('image',
     help='Name of the output base-Graphene Docker image.')
 
-sub_sign = subcommands.add_parser('sign-image', help="Sign graphenized Docker image")
+sub_sign = subcommands.add_parser('sign-image', help='Sign graphenized Docker image')
 sub_sign.set_defaults(command=gsc_sign_image)
 sub_sign.add_argument('-c', '--config_file', type=argparse.FileType('r', encoding='UTF-8'),
     default='config.yaml', help='Specify configuration file.')
 sub_sign.add_argument('image', help='Name of the application (base) Docker image.')
 sub_sign.add_argument('key', help='Key to sign the Intel SGX enclaves inside the Docker image.')
+
+sub_info = subcommands.add_parser('info-image', help='Retrieve information about a graphenized '
+                                  'Docker image')
+sub_info.set_defaults(command=gsc_info_image)
+sub_info.add_argument('image', help='Name of the graphenized Docker image.')
 
 def main(args):
     args = argparser.parse_args()

--- a/Tools/gsc/test/Makefile
+++ b/Tools/gsc/test/Makefile
@@ -27,49 +27,51 @@ DEVICES_VOLUMES = --device=/dev/${INTEL_SGX_DEVICE} ${ADDITIONAL_DEVICES} ${ADDI
 .PHONY: all
 all: $(KEY_FILE)
 	for d in $(DISTRIBUTIONS); do \
-		echo "Distro: \"$${d}\"" > config-$${d}.yaml; \
-		echo "Graphene:" >> config-$${d}.yaml; \
-		echo "    Repository: \"$(GRAPHENE_REPO)\"" >> config-$${d}.yaml; \
-		echo "    Branch:     \"$(GRAPHENE_BRANCH)\"" >> config-$${d}.yaml; \
-		echo "SGXDriver:" >> config-$${d}.yaml; \
-		echo "    Repository: \"$(SGXDRIVER_REPO)\"" >> config-$${d}.yaml; \
-		echo "    Branch:     \"$(SGXDRIVER_BRANCH)\"" >> config-$${d}.yaml; \
 		$(MAKE) $(addprefix gsc-$${d}-, $(TESTCASES)) || exit 1; \
 	done
+
+config-%.yaml:
+	echo "Distro: \"$*\"" > config-$*.yaml
+	echo "Graphene:" >> config-$*.yaml
+	echo "    Repository: \"$(GRAPHENE_REPO)\"" >> config-$*.yaml
+	echo "    Branch:     \"$(GRAPHENE_BRANCH)\"" >> config-$*.yaml
+	echo "SGXDriver:" >> config-$*.yaml
+	echo "    Repository: \"$(SGXDRIVER_REPO)\"" >> config-$*.yaml
+	echo "    Branch:     \"$(SGXDRIVER_BRANCH)\"" >> config-$*.yaml;
 
 $(KEY_FILE):
 	openssl genrsa -3 -out $(KEY_FILE) 3072
 
 .PRECIOUS: gsc-%-bash
-gsc-%-bash: %-bash
+gsc-%-bash: %-bash config-%.yaml
 	echo "Building graphenized image $@..."
 	cd .. && ./gsc build -c test/config-$*.yaml -L --insecure-args $(GSC_BUILD_FLAGS) $(addsuffix $(IMAGE_SUFFIX), $*-bash) test/bash.manifest
 	cd .. && ./gsc sign-image -c test/config-$*.yaml $(addsuffix $(IMAGE_SUFFIX), $*-bash) $(notdir $(KEY_FILE))
 	touch $@
 
 .PRECIOUS: gsc-%-python3
-gsc-%-python3: %-python3 %-python3.manifest
+gsc-%-python3: %-python3 %-python3.manifest config-%.yaml
 	echo "Building graphenized image $@..."
 	cd .. && ./gsc build -c test/config-$*.yaml -L --insecure-args $(GSC_BUILD_FLAGS) $(addsuffix $(IMAGE_SUFFIX), $*-python3) test/$*-python3.manifest
 	cd .. && ./gsc sign-image -c test/config-$*.yaml $(addsuffix $(IMAGE_SUFFIX), $*-python3) $(notdir $(KEY_FILE))
 	touch $@
 
 .PRECIOUS: gsc-%-python3-trusted-args
-gsc-%-python3-trusted-args: %-python3-trusted-args %-python3.manifest
+gsc-%-python3-trusted-args: %-python3-trusted-args %-python3.manifest config-%.yaml
 	echo "Building graphenized image $@..."
 	cd .. && ./gsc build -c test/config-$*.yaml -L $(GSC_BUILD_FLAGS) $(addsuffix $(IMAGE_SUFFIX), $*-python3-trusted-args) test/$*-python3.manifest
 	cd .. && ./gsc sign-image -c test/config-$*.yaml $(addsuffix $(IMAGE_SUFFIX), $*-python3-trusted-args) $(notdir $(KEY_FILE))
 	touch $@
 
 .PRECIOUS: gsc-%-pytorch
-gsc-%-pytorch: %-pytorch %-pytorch.manifest
+gsc-%-pytorch: %-pytorch %-pytorch.manifest config-%.yaml
 	echo "Building graphenized image $@..."
 	cd .. && ./gsc build -c test/config-$*.yaml -L --insecure-args $(GSC_BUILD_FLAGS) $(addsuffix $(IMAGE_SUFFIX), $*-pytorch) test/$*-pytorch.manifest
 	cd .. && ./gsc sign-image -c test/config-$*.yaml $(addsuffix $(IMAGE_SUFFIX), $*-pytorch) $(notdir $(KEY_FILE))
 	touch $@
 
 .PRECIOUS: gsc-%-base-python3
-gsc-%-base-python3: graphene-% %-base-python3
+gsc-%-base-python3: graphene-% %-base-python3 config-%.yaml
 	printf "Distro: \"$*\"\nGraphene:\n   Image: \"graphene-$*$(IMAGE_SUFFIX)\"\n" > config-image-$*.yaml
 	echo "Building graphenized image $@..."
 	cd .. && ./gsc build -c test/config-image-$*.yaml -L --insecure-args $(GSC_BUILD_FLAGS) $(addsuffix $(IMAGE_SUFFIX), $*-base-python3) test/$*-python3.manifest
@@ -77,14 +79,14 @@ gsc-%-base-python3: graphene-% %-base-python3
 	touch $@
 
 .PRECIOUS: gsc-%
-gsc-%: %
+gsc-%: % config-%.yaml
 	echo "Building graphenized image $@..."
 	cd .. && ./gsc build -c test/config-$(firstword $(subst -, ,$*)).yaml -L --insecure-args $(GSC_BUILD_FLAGS) $(addsuffix $(IMAGE_SUFFIX), $*) test/$(*:gsc-%=%).manifest
 	cd .. && ./gsc sign-image -c test/config-$(firstword $(subst -, ,$*)).yaml $(addsuffix $(IMAGE_SUFFIX), $*) $(notdir $(KEY_FILE))
 	touch $@
 
 .PRECIOUS: graphene-%
-graphene-%:
+graphene-%: config-%.yaml
 	echo "Building Graphene image $@..."
 	cd .. && ./gsc build-graphene -c test/config-$*.yaml -L $(GSC_BUILD_FLAGS) $(addsuffix $(IMAGE_SUFFIX), $@)
 	touch $@
@@ -189,6 +191,12 @@ test-12-%: gsc-%-pytorch
 	docker run $(addprefix -e , $(ENV_VARS)) $(DEVICES_VOLUMES) -v$${PWD}/result.txt:/graphene/Examples/result.txt $(addsuffix $(IMAGE_SUFFIX), gsc-$*-pytorch) pytorchexample.py
 	grep -q "('Labrador retriever'" result.txt
 	$(RM) results.txt
+
+.PHONY: test-info-image-%
+test-info-image-%: gsc-%-python3
+	../gsc info-image $< > sig.txt
+	grep -q "mr_enclave" sig.txt
+	$(RM) sig.txt
 
 .PHONY: clean-image-%
 clean-image-%:


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://graphene.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

This PR adds a new command to GSC called `info-image`. `info-image` command retrieves the SGX related information from the Docker image. In particular, it prints the sig struct information for each application inside the Docker image. It also adds documentation, a new test case to GSC's test makefile, and a new test to GSC's Jenkins pipeline.

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->

Run GSC Jenkins pipeline or create a graphenized Docker image (via `gsc build-image` and `gsc sign-image`) and afterwards run `gsc info-image <image-name>`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1961)
<!-- Reviewable:end -->
