### PR TITLE
[LibOS] Preserve type checking when copying equivalent structures

### DIFF
--- a/LibOS/shim/src/bookkeep/shim_handle.c
+++ b/LibOS/shim/src/bookkeep/shim_handle.c
@@ -811,7 +811,7 @@ BEGIN_CP_FUNC(fd_handle) {
 
     size_t off = ADD_CP_OFFSET(sizeof(struct shim_fd_handle));
     new_fdhdl = (struct shim_fd_handle*)(base + off);
-    memcpy(new_fdhdl, fdhdl, sizeof(struct shim_fd_handle));
+    *new_fdhdl = *fdhdl;
     DO_CP(handle, fdhdl->handle, &new_fdhdl->handle);
     ADD_CP_FUNC_ENTRY(off);
 
@@ -840,7 +840,7 @@ BEGIN_CP_FUNC(handle_map) {
         off            = ADD_CP_OFFSET(size);
         new_handle_map = (struct shim_handle_map*)(base + off);
 
-        memcpy(new_handle_map, handle_map, sizeof(struct shim_handle_map));
+        *new_handle_map = *handle_map;
 
         ptr_array = (void*)new_handle_map + sizeof(struct shim_handle_map);
 

--- a/LibOS/shim/src/bookkeep/shim_vma.c
+++ b/LibOS/shim/src/bookkeep/shim_vma.c
@@ -1229,7 +1229,7 @@ BEGIN_CP_FUNC(vma) {
         ADD_TO_CP_MAP(obj, off);
 
         new_vma = (struct shim_vma_info*)(base + off);
-        memcpy(new_vma, vma, sizeof(*vma));
+        *new_vma = *vma;
 
         if (vma->file)
             DO_CP(handle, vma->file, &new_vma->file);

--- a/LibOS/shim/src/fs/dev/null.c
+++ b/LibOS/shim/src/fs/dev/null.c
@@ -65,7 +65,7 @@ static int dev_null_open(struct shim_handle* hdl, const char* name, int flags) {
                                .stat     = &dev_null_stat,
                                .hstat    = &dev_null_hstat};
 
-    memcpy(&hdl->info.dev.dev_ops, &ops, sizeof(ops));
+    hdl->info.dev.dev_ops = ops;
     return 0;
 }
 
@@ -99,7 +99,7 @@ static int dev_tty_open(struct shim_handle* hdl, const char* name, int flags) {
                                .stat     = &dev_tty_stat,
                                .hstat    = &dev_tty_hstat};
 
-    memcpy(&hdl->info.dev.dev_ops, &ops, sizeof(ops));
+    hdl->info.dev.dev_ops = ops;
     return 0;
 }
 

--- a/LibOS/shim/src/fs/dev/random.c
+++ b/LibOS/shim/src/fs/dev/random.c
@@ -55,7 +55,7 @@ static int dev_random_open(struct shim_handle* hdl, const char* name, int flags)
                                .stat  = &dev_random_stat,
                                .hstat = &dev_random_hstat};
 
-    memcpy(&hdl->info.dev.dev_ops, &ops, sizeof(ops));
+    hdl->info.dev.dev_ops = ops;
     return 0;
 }
 

--- a/LibOS/shim/src/fs/dev/zero.c
+++ b/LibOS/shim/src/fs/dev/zero.c
@@ -58,7 +58,7 @@ static int dev_zero_open(struct shim_handle* hdl, const char* name, int flags) {
                                .stat     = &dev_zero_stat,
                                .hstat    = &dev_zero_hstat};
 
-    memcpy(&hdl->info.dev.dev_ops, &ops, sizeof(ops));
+    hdl->info.dev.dev_ops = ops;
     return 0;
 }
 

--- a/LibOS/shim/src/ipc/shim_ipc.c
+++ b/LibOS/shim/src/ipc/shim_ipc.c
@@ -428,7 +428,7 @@ BEGIN_CP_FUNC(ipc_info) {
         ADD_TO_CP_MAP(obj, off);
 
         new_info = (struct shim_ipc_info*)(base + off);
-        memcpy(new_info, info, sizeof(struct shim_ipc_info));
+        *new_info = *info;
         REF_SET(new_info->ref_count, 0);
 
         /* call qstr-specific checkpointing function for new_info->uri */
@@ -468,7 +468,7 @@ BEGIN_CP_FUNC(process_ipc_info) {
         ADD_TO_CP_MAP(obj, off);
 
         new_process_ipc_info = (struct shim_process_ipc_info*)(base + off);
-        memcpy(new_process_ipc_info, process_ipc_info, sizeof(*new_process_ipc_info));
+        *new_process_ipc_info = *process_ipc_info;
 
         /* call ipc_info-specific checkpointing functions for new_process_ipc_info's self, parent
          * and ns infos */
@@ -512,7 +512,7 @@ BEGIN_RS_FUNC(process_ipc_info) {
     if (process_ipc_info->ns)
         get_ipc_info(process_ipc_info->ns);
 
-    memcpy(&g_process_ipc_info, process_ipc_info, sizeof(g_process_ipc_info));
+    g_process_ipc_info = *process_ipc_info;
     // this lock will be created in init_ipc
     clear_lock(&g_process_ipc_info.lock);
 

--- a/LibOS/shim/src/shim_debug.c
+++ b/LibOS/shim/src/shim_debug.c
@@ -124,7 +124,7 @@ BEGIN_CP_FUNC(gdb_map) {
         size_t off = ADD_CP_OFFSET(sizeof(struct gdb_link_map));
         newm       = (struct gdb_link_map*)(base + off);
 
-        memcpy(newm, m, sizeof(struct gdb_link_map));
+        *newm = *m;
         newm->l_prev = newm->l_next = NULL;
 
         size_t len   = strlen(newm->l_name);

--- a/LibOS/shim/src/sys/shim_clone.c
+++ b/LibOS/shim/src/sys/shim_clone.c
@@ -288,7 +288,7 @@ long shim_do_clone(unsigned long flags, unsigned long user_stack_addr, int* pare
         /* Preemption is disabled and we are copying our own tcb, which should be ok to do,
          * even without any locks. Note this is a shallow copy, so `shim_tcb.context.regs` will be
          * shared with the parent. */
-        memcpy(&shim_tcb, self->shim_tcb, sizeof(shim_tcb));
+        shim_tcb = *self->shim_tcb;
         __shim_tcb_init(&shim_tcb);
         shim_tcb.tp = NULL;
         thread->shim_tcb = &shim_tcb;

--- a/LibOS/shim/src/sys/shim_exec.c
+++ b/LibOS/shim/src/sys/shim_exec.c
@@ -63,8 +63,7 @@ struct execve_rtld_arg {
 };
 
 noreturn static void __shim_do_execve_rtld(struct execve_rtld_arg* __arg) {
-    struct execve_rtld_arg arg;
-    memcpy(&arg, __arg, sizeof(arg));
+    struct execve_rtld_arg arg = *__arg;
 
     struct shim_thread* cur_thread = get_cur_thread();
     int ret = 0;

--- a/LibOS/shim/src/sys/shim_sigaction.c
+++ b/LibOS/shim/src/sys/shim_sigaction.c
@@ -41,13 +41,11 @@ int shim_do_sigaction(int signum, const struct __kernel_sigaction* act,
 
     struct __kernel_sigaction* sigaction = &cur->signal_handles->actions[signum - 1];
 
-    if (oldact) {
-        memcpy(oldact, sigaction, sizeof(*oldact));
-    }
+    if (oldact)
+        *oldact = *sigaction;
 
-    if (act) {
-        memcpy(sigaction, act, sizeof(*sigaction));
-    }
+    if (act)
+        *sigaction = *act;
 
     clear_illegal_signals(&sigaction->sa_mask);
 


### PR DESCRIPTION
Get rid of a few memcpy's to preserve the type checking when copying
structures around.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>

<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://graphene.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1962)
<!-- Reviewable:end -->
