### PR TITLE
[Pal,LibOS] Fix loader.debug_type = file

### DIFF
--- a/Documentation/manifest-syntax.rst
+++ b/Documentation/manifest-syntax.rst
@@ -28,13 +28,16 @@ Debug type
 
 ::
 
-    loader.debug_type = "[none|inline]"
+    loader.debug_type = "[none|inline|file]"
     (Default: "none")
+
+    loader.debug_file = "[PATH]"
 
 This specifies the debug option while running the library OS. If the debug type
 is ``none``, no debug output will be printed to standard output. If the debug
 type is ``inline``, a dmesg-like debug output will be printed inline with
-standard output.
+standard output. If the debug type is ``file``, debug output will be written to
+the file specified in ``loader.debug_file``.
 
 Preloaded libraries
 ^^^^^^^^^^^^^^^^^^^

--- a/Documentation/pal/host-abi.rst
+++ b/Documentation/pal/host-abi.rst
@@ -370,6 +370,9 @@ cryptographically-strong random bits, flush portions of instruction caches,
 increment and decrement the reference counts on objects shared between threads,
 and to obtain an attestation report and quote.
 
+.. doxygenfunction:: DkDebugLog
+   :project: pal
+
 .. doxygenfunction:: DkSystemTimeQuery
    :project: pal
 

--- a/LibOS/shim/include/shim_internal.h
+++ b/LibOS/shim/include/shim_internal.h
@@ -36,7 +36,7 @@ struct debug_buf {
 #include "pal_debug.h"
 #include "pal_error.h"
 
-extern PAL_HANDLE debug_handle;
+extern bool g_debug_log_enabled;
 
 #include <stdarg.h>
 
@@ -47,7 +47,7 @@ void debug_vprintf(const char* fmt, va_list ap) __attribute__((format(printf, 1,
 
 #define debug(fmt, ...)                       \
     do {                                      \
-        if (debug_handle)                     \
+        if (g_debug_log_enabled)              \
             debug_printf(fmt, ##__VA_ARGS__); \
     } while (0)
 
@@ -120,11 +120,11 @@ static inline int64_t get_cur_preempt(void) {
     r func(PROTO_ARGS_##n(args));
 
 #define PARSE_SYSCALL1(name, ...) \
-    if (debug_handle)             \
+    if (g_debug_log_enabled)      \
         parse_syscall_before(__NR_##name, #name, ##__VA_ARGS__);
 
 #define PARSE_SYSCALL2(name, ...) \
-    if (debug_handle)             \
+    if (g_debug_log_enabled)      \
         parse_syscall_after(__NR_##name, #name, ##__VA_ARGS__);
 
 void parse_syscall_before(int sysno, const char* name, int nr, ...);

--- a/LibOS/shim/include/shim_thread.h
+++ b/LibOS/shim/include/shim_thread.h
@@ -137,7 +137,7 @@ void debug_setprefix(shim_tcb_t* tcb);
 
 static inline void debug_setbuf(shim_tcb_t* tcb,
                                 struct debug_buf* debug_buf) {
-    if (!debug_handle)
+    if (!g_debug_log_enabled)
         return;
 
     tcb->debug_buf = debug_buf ? debug_buf : malloc(sizeof(struct debug_buf));

--- a/LibOS/shim/include/shim_utils.h
+++ b/LibOS/shim/include/shim_utils.h
@@ -13,8 +13,6 @@
 
 struct shim_handle;
 
-void sysparser_printf(const char* fmt, ...);
-
 /* quick hash function based on Robert Jenkins' hash algorithm */
 static inline uint64_t hash64(uint64_t key) {
     key = (~key) + (key << 21);

--- a/LibOS/shim/src/shim_init.c
+++ b/LibOS/shim/src/shim_init.c
@@ -421,7 +421,7 @@ fail:
 extern PAL_HANDLE thread_start_event;
 
 noreturn void* shim_init(int argc, void* args) {
-    debug_handle = PAL_CB(debug_stream);
+    g_debug_log_enabled = PAL_CB(enable_debug_log);
     g_process_ipc_info.vmid = (IDTYPE)PAL_CB(process_id);
 
     /* create the initial TCB, shim can not be run without a tcb */

--- a/LibOS/shim/src/shim_parser.c
+++ b/LibOS/shim/src/shim_parser.c
@@ -482,10 +482,6 @@ static inline int is_pointer_or_long(const char* type) {
     do {                 \
         debug_putch(ch); \
     } while (0)
-#define VPRINTF(fmt, ap)        \
-    do {                        \
-        debug_vprintf(fmt, ap); \
-    } while (0)
 
 struct flag_table {
     const char *name;
@@ -556,15 +552,8 @@ static inline void skip_syscall_args(va_list* ap) {
         va_arg(*ap, int);
 }
 
-void sysparser_printf(const char* fmt, ...) {
-    va_list ap;
-    va_start(ap, fmt);
-    VPRINTF(fmt, ap);
-    va_end(ap);
-}
-
 void parse_syscall_before(int sysno, const char* name, int nr, ...) {
-    if (!debug_handle)
+    if (!g_debug_log_enabled)
         return;
 
     struct parser_table* parser = &syscall_parser_table[sysno];
@@ -600,7 +589,7 @@ dotdotdot:
 }
 
 void parse_syscall_after(int sysno, const char* name, int nr, ...) {
-    if (!debug_handle)
+    if (!g_debug_log_enabled)
         return;
 
     struct parser_table* parser = &syscall_parser_table[sysno];

--- a/LibOS/shim/src/sys/shim_exit.c
+++ b/LibOS/shim/src/sys/shim_exit.c
@@ -214,8 +214,7 @@ noreturn int shim_do_exit_group(int error_code) {
 
     error_code &= 0xFF;
 
-    if (debug_handle)
-        sysparser_printf("---- shim_exit_group (returning %d)\n", error_code);
+    debug("---- shim_exit_group (returning %d)\n", error_code);
 
     process_exit(error_code, 0);
 }
@@ -225,8 +224,7 @@ noreturn int shim_do_exit(int error_code) {
 
     error_code &= 0xFF;
 
-    if (debug_handle)
-        sysparser_printf("---- shim_exit (returning %d)\n", error_code);
+    debug("---- shim_exit (returning %d)\n", error_code);
 
     thread_exit(error_code, 0);
 }

--- a/LibOS/shim/src/utils/printf.c
+++ b/LibOS/shim/src/utils/printf.c
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: LGPL-3.0-or-later */
 /* Copyright (C) 2014 Stony Brook University */
 
+#include <assert.h>
 #include <stdarg.h>
 #include <stdint.h>
 
@@ -10,13 +11,25 @@
 #include "shim_internal.h"
 #include "shim_ipc.h"
 
-PAL_HANDLE debug_handle = NULL;
+bool g_debug_log_enabled = false;
 
-static inline int debug_fputs(const char* buf, int len) {
-    if (DkStreamWrite(debug_handle, 0, len, (void*)buf, NULL) == (PAL_NUM)len)
-        return 0;
-    else
-        return -1;
+static inline int debug_fputs(const char* buf, size_t size) {
+    size_t bytes = 0;
+
+    while (bytes < size) {
+        PAL_NUM x = DkDebugLog((void*)(buf + bytes), size - bytes);
+        if (x == PAL_STREAM_ERROR) {
+            int err = PAL_ERRNO();
+            if (err == EINTR || err == EAGAIN || err == EWOULDBLOCK) {
+                continue;
+            }
+            return -err;
+        }
+
+        bytes += x;
+    }
+
+    return 0;
 }
 
 static int debug_fputch(void* f, int ch, void* b) {
@@ -98,7 +111,7 @@ void debug_printf(const char* fmt, ...) {
 }
 
 void debug_setprefix(shim_tcb_t* tcb) {
-    if (!debug_handle)
+    if (!g_debug_log_enabled)
         return;
 
     struct debug_buf* buf = tcb->debug_buf;

--- a/LibOS/shim/test/regression/.gitignore
+++ b/LibOS/shim/test/regression/.gitignore
@@ -16,6 +16,8 @@
 /bootstrap_static
 /cpuid
 /debug
+/debug_log_file
+/debug_log_inline
 /debug_regs-x86_64
 /dev
 /env_from_file

--- a/LibOS/shim/test/regression/Makefile
+++ b/LibOS/shim/test/regression/Makefile
@@ -91,6 +91,8 @@ manifests = \
 	manifest \
 	argv_from_file.manifest \
 	attestation.manifest \
+	debug_log_file.manifest \
+	debug_log_inline.manifest \
 	env_from_file.manifest \
 	env_from_host.manifest \
 	eventfd.manifest \
@@ -117,6 +119,8 @@ exec_target = \
 	$(c_executables) \
 	$(cxx_executables) \
 	argv_from_file.manifest \
+	debug_log_file.manifest \
+	debug_log_inline.manifest \
 	env_from_file.manifest \
 	env_from_host.manifest \
 	file_check_policy_allow_all_but_log.manifest \
@@ -126,6 +130,8 @@ exec_target = \
 
 target = \
 	argv_from_file \
+	debug_log_file \
+	debug_log_inline \
 	env_from_host \
 	env_from_file \
 	file_check_policy_allow_all_but_log \
@@ -177,6 +183,9 @@ LDLIBS-fp_multithread += -lm
 # correspondence).
 
 argv_from_file env_from_host env_from_file: bootstrap
+	$(call cmd,ln_sfr)
+
+debug_log_file debug_log_inline: bootstrap
 	$(call cmd,ln_sfr)
 
 file_check_policy_allow_all_but_log file_check_policy_strict: file_check_policy

--- a/LibOS/shim/test/regression/debug_log_file.manifest.template
+++ b/LibOS/shim/test/regression/debug_log_file.manifest.template
@@ -1,0 +1,15 @@
+loader.argv0_override = "bootstrap"
+
+loader.preload = "file:../../src/libsysdb.so"
+loader.env.LD_LIBRARY_PATH = "/lib"
+loader.debug_type = "file"
+loader.debug_file = "tmp/debug_log_file.log"
+
+fs.mount.lib.type = "chroot"
+fs.mount.lib.path = "/lib"
+fs.mount.lib.uri = "file:../../../../Runtime"
+
+sgx.trusted_files.ld = "file:../../../../Runtime/ld-linux-x86-64.so.2"
+sgx.trusted_files.libc = "file:../../../../Runtime/libc.so.6"
+
+sgx.static_address = 1

--- a/LibOS/shim/test/regression/debug_log_inline.manifest.template
+++ b/LibOS/shim/test/regression/debug_log_inline.manifest.template
@@ -1,0 +1,14 @@
+loader.argv0_override = "bootstrap"
+
+loader.preload = "file:../../src/libsysdb.so"
+loader.env.LD_LIBRARY_PATH = "/lib"
+loader.debug_type = "inline"
+
+fs.mount.lib.type = "chroot"
+fs.mount.lib.path = "/lib"
+fs.mount.lib.uri = "file:../../../../Runtime"
+
+sgx.trusted_files.ld = "file:../../../../Runtime/ld-linux-x86-64.so.2"
+sgx.trusted_files.libc = "file:../../../../Runtime/libc.so.6"
+
+sgx.static_address = 1

--- a/LibOS/shim/test/regression/test_libos.py
+++ b/LibOS/shim/test/regression/test_libos.py
@@ -47,8 +47,7 @@ class TC_01_Bootstrap(RegressionTestCase):
         with open('argv_test_input', 'wb') as f:
             f.write(result.stdout)
         try:
-            manifest = self.get_manifest('argv_from_file')
-            stdout, _ = self.run_binary([manifest, 'WRONG', 'ARGUMENTS'])
+            stdout, _ = self.run_binary(['argv_from_file', 'WRONG', 'ARGUMENTS'])
             self.assertIn('# of arguments: %d\n' % len(args), stdout)
             for i, arg in enumerate(args):
                 self.assertIn('argv[%d] = %s\n' % (i, arg), stdout)
@@ -62,8 +61,7 @@ class TC_01_Bootstrap(RegressionTestCase):
             'some weir:d\nvar_name': ' even we\nirder\tvalue',
         }
         manifest_envs = {'LD_LIBRARY_PATH': '/lib'}
-        manifest = self.get_manifest('env_from_host')
-        stdout, _ = self.run_binary([manifest], env=host_envs)
+        stdout, _ = self.run_binary(['env_from_host'], env=host_envs)
         self.assertIn('# of envs: %d\n' % (len(host_envs) + len(manifest_envs)), stdout)
         for _, (key, val) in enumerate({**host_envs, **manifest_envs}.items()):
             # We don't enforce any specific order of envs, so we skip checking the index.
@@ -78,8 +76,7 @@ class TC_01_Bootstrap(RegressionTestCase):
         with open('env_test_input', 'wb') as f:
             f.write(result.stdout)
         try:
-            manifest = self.get_manifest('env_from_file')
-            stdout, _ = self.run_binary([manifest], env=host_envs)
+            stdout, _ = self.run_binary(['env_from_file'], env=host_envs)
             self.assertIn('# of envs: %d\n' % (len(envs) + len(manifest_envs)), stdout)
             for _, arg in enumerate(envs + manifest_envs):
                 # We don't enforce any specific order of envs, so we skip checking the index.
@@ -199,8 +196,7 @@ class TC_01_Bootstrap(RegressionTestCase):
     @unittest.skipUnless(HAS_SGX, 'This test relies on SGX-specific manifest options.')
     def test_501_init_fail2(self):
         try:
-            manifest = self.get_manifest('init_fail2')
-            self.run_binary([manifest], timeout=60)
+            self.run_binary(['init_fail2'], timeout=60)
             self.fail('expected to return nonzero (and != 42)')
         except subprocess.CalledProcessError as e:
             self.assertNotEqual(e.returncode, 42, 'expected returncode != 42')
@@ -213,8 +209,7 @@ class TC_01_Bootstrap(RegressionTestCase):
 
     @unittest.skipUnless(HAS_SGX, 'This test is only meaningful on SGX PAL')
     def test_601_multi_pthread_exitless(self):
-        manifest = self.get_manifest('multi_pthread_exitless')
-        stdout, _ = self.run_binary([manifest], timeout=60)
+        stdout, _ = self.run_binary(['multi_pthread_exitless'], timeout=60)
 
         # Multiple thread creation
         self.assertIn('128 Threads Created', stdout)
@@ -231,8 +226,7 @@ class TC_01_Bootstrap(RegressionTestCase):
         self.assertIn('FE_TOWARDZERO parent: 42.5 = 42.0, -42.5 = -42.0', stdout)
 
     def test_700_debug_log_inline(self):
-        manifest = self.get_manifest('debug_log_inline')
-        stdout, _ = self.run_binary([manifest])
+        stdout, _ = self.run_binary(['debug_log_inline'])
         self._verify_debug_log(stdout)
 
     def test_701_debug_log_file(self):
@@ -240,8 +234,7 @@ class TC_01_Bootstrap(RegressionTestCase):
         if os.path.exists(log_path):
             os.remove(log_path)
 
-        manifest = self.get_manifest('debug_log_file')
-        self.run_binary([manifest])
+        self.run_binary(['debug_log_file'])
 
         with open(log_path) as log_file:
             log = log_file.read()
@@ -270,27 +263,25 @@ class TC_02_OpenMP(RegressionTestCase):
     'only relevant to SGX.')
 class TC_03_FileCheckPolicy(RegressionTestCase):
     def test_000_strict_success(self):
-        manifest = self.get_manifest('file_check_policy_strict')
-        stdout, _ = self.run_binary([manifest, 'trusted_testfile'])
+        stdout, _ = self.run_binary(['file_check_policy_strict', 'trusted_testfile'])
 
         self.assertIn('file_check_policy succeeded', stdout)
 
     def test_001_strict_fail(self):
-        manifest = self.get_manifest('file_check_policy_strict')
         with self.expect_returncode(2):
-            self.run_binary([manifest, 'unknown_testfile'])
+            self.run_binary(['file_check_policy_strict', 'unknown_testfile'])
 
     def test_002_allow_all_but_log_success(self):
-        manifest = self.get_manifest('file_check_policy_allow_all_but_log')
-        stdout, stderr = self.run_binary([manifest, 'unknown_testfile'])
+        stdout, stderr = self.run_binary(['file_check_policy_allow_all_but_log',
+                                          'unknown_testfile'])
 
         self.assertIn('Allowing access to an unknown file due to file_check_policy settings: '
                       'file:unknown_testfile', stderr)
         self.assertIn('file_check_policy succeeded', stdout)
 
     def test_003_allow_all_but_log_fail(self):
-        manifest = self.get_manifest('file_check_policy_allow_all_but_log')
-        stdout, stderr = self.run_binary([manifest, 'trusted_testfile'])
+        stdout, stderr = self.run_binary(['file_check_policy_allow_all_but_log',
+                                          'trusted_testfile'])
 
         self.assertNotIn('Allowing access to an unknown file due to file_check_policy settings: '
                          'file:trusted_testfile', stderr)

--- a/LibOS/shim/test/regression/test_libos.py
+++ b/LibOS/shim/test/regression/test_libos.py
@@ -230,6 +230,30 @@ class TC_01_Bootstrap(RegressionTestCase):
         self.assertIn('FE_TOWARDZERO  child: 42.5 = 42.0, -42.5 = -42.0', stdout)
         self.assertIn('FE_TOWARDZERO parent: 42.5 = 42.0, -42.5 = -42.0', stdout)
 
+    def test_700_debug_log_inline(self):
+        manifest = self.get_manifest('debug_log_inline')
+        stdout, _ = self.run_binary([manifest])
+        self._verify_debug_log(stdout)
+
+    def test_701_debug_log_file(self):
+        log_path = 'tmp/debug_log_file.log'
+        if os.path.exists(log_path):
+            os.remove(log_path)
+
+        manifest = self.get_manifest('debug_log_file')
+        self.run_binary([manifest])
+
+        with open(log_path) as log_file:
+            log = log_file.read()
+
+        self._verify_debug_log(log)
+
+    def _verify_debug_log(self, log: str):
+        self.assertIn('Host:', log)
+        self.assertIn('Shim process initialized', log)
+        self.assertIn('--- shim_exit_group', log)
+
+
 @unittest.skipUnless(HAS_SGX,
     'This test is only meaningful on SGX PAL because only SGX catches raw '
     'syscalls and redirects to Graphene\'s LibOS. If we will add seccomp to '

--- a/Pal/include/pal/pal.h
+++ b/Pal/include/pal/pal.h
@@ -134,7 +134,7 @@ typedef struct PAL_CONTROL_ {
     PAL_STR executable;         /*!< executable name */
     PAL_HANDLE parent_process;  /*!< handle of parent process */
     PAL_HANDLE first_thread;    /*!< handle of first thread */
-    PAL_HANDLE debug_stream;    /*!< debug stream */
+    PAL_BOL enable_debug_log;   /*!< enable debug log calls */
 
     /*
      * Memory layout
@@ -361,6 +361,9 @@ PAL_NUM DkStreamRead(PAL_HANDLE handle, PAL_NUM offset, PAL_NUM count, PAL_PTR b
  *
  * If the handle is a file, `offset` must be specified at each call of DkStreamWrite. `dest` can be
  * used to specify the remote socket address if the handle is a UDP socket.
+ *
+ * \return number of bytes written if succeeded, PAL_STREAM_ERROR on failure (in which case
+ *  PAL_ERRNO() is set)
  */
 PAL_NUM DkStreamWrite(PAL_HANDLE handle, PAL_NUM offset, PAL_NUM count, PAL_PTR buffer,
                       PAL_STR dest);
@@ -677,6 +680,17 @@ void DkObjectClose(PAL_HANDLE objectHandle);
 /*
  * MISC
  */
+
+/*!
+ * \brief Output a message to the debug stream.
+ *
+ * Works only if the debug stream has been initialized, which can be checked by looking at
+ * `g_pal_control.enable_debug_log`.
+ *
+ * \return number of bytes written if succeeded, PAL_STREAM_ERROR on failure (in which case
+ *  PAL_ERRNO() is set)
+ */
+PAL_NUM DkDebugLog(PAL_PTR buffer, PAL_NUM size);
 
 /*!
  * \brief Get the current time

--- a/Pal/regression/Bootstrap.c
+++ b/Pal/regression/Bootstrap.c
@@ -38,7 +38,7 @@ int main(int argc, char** argv, char** envp) {
 
     /* test debug stream */
     char* msg = "Written to Debug Stream\n";
-    DkStreamWrite(pal_control.debug_stream, 0, strlen(msg), msg, NULL);
+    DkDebugLog(msg, strlen(msg));
 
     /* Allocation Alignment */
     pal_printf("Allocation Alignment: %ld\n", pal_control.alloc_align);

--- a/Pal/regression/test_pal.py
+++ b/Pal/regression/test_pal.py
@@ -190,13 +190,13 @@ class TC_01_Bootstrap(RegressionTestCase):
 
     def test_104_manifest_as_executable_name(self):
         manifest = self.get_manifest('Bootstrap2')
-        _, stderr = self.run_binary([manifest])
+        _, stderr = self.run_binary(['Bootstrap2'])
         self.assertIn('User Program Started', stderr)
         self.assertIn('Loaded Manifest: file:' + manifest, stderr)
 
     def test_105_manifest_as_argument(self):
         manifest = self.get_manifest('Bootstrap4')
-        _, stderr = self.run_binary([manifest])
+        _, stderr = self.run_binary(['Bootstrap4'])
         self.assertIn('Loaded Manifest: file:' + manifest, stderr)
         self.assertIn('Loaded Executable: file:Bootstrap', stderr)
 
@@ -210,12 +210,12 @@ class TC_01_Bootstrap(RegressionTestCase):
     @unittest.skipUnless(HAS_SGX, 'this test requires SGX')
     def test_120_8gb_enclave(self):
         manifest = self.get_manifest('Bootstrap6')
-        _, stderr = self.run_binary([manifest], timeout=360)
+        _, stderr = self.run_binary(['Bootstrap6'], timeout=360)
         self.assertIn('Loaded Manifest: file:' + manifest, stderr)
         self.assertIn('Executable Range OK', stderr)
 
     def test_130_large_number_of_items_in_manifest(self):
-        _, stderr = self.run_binary([self.get_manifest('Bootstrap7')])
+        _, stderr = self.run_binary(['Bootstrap7'])
         self.assertIn('key1000=na', stderr)
         self.assertIn('key1=na', stderr)
 
@@ -566,8 +566,7 @@ class TC_20_SingleProcess(RegressionTestCase):
 
     @unittest.skipUnless(HAS_SGX, 'This test is only meaningful on SGX PAL')
     def test_511_thread2_exitless(self):
-        manifest = self.get_manifest('Thread2_exitless')
-        _, stderr = self.run_binary([manifest], timeout=60)
+        _, stderr = self.run_binary(['Thread2_exitless'], timeout=60)
 
         # Thread Cleanup: Exit by return.
         self.assertIn('Thread 2 ok.', stderr)

--- a/Pal/src/db_streams.c
+++ b/Pal/src/db_streams.c
@@ -751,3 +751,15 @@ const char* _DkStreamRealpath(PAL_HANDLE hdl) {
 
     return ops->getrealpath(hdl);
 }
+
+PAL_NUM DkDebugLog(PAL_PTR buffer, PAL_NUM size) {
+    ENTER_PAL_CALL(DkDebugLog);
+
+    ssize_t ret = _DkDebugLog(buffer, size);
+    if (ret < 0) {
+        _DkRaiseFailure(-ret);
+        ret = PAL_STREAM_ERROR;
+    }
+
+    LEAVE_PAL_CALL_RETURN(ret);
+}

--- a/Pal/src/host/Linux-SGX/db_streams.c
+++ b/Pal/src/host/Linux-SGX/db_streams.c
@@ -33,6 +33,8 @@ typedef __kernel_pid_t pid_t;
 #define DUMMYPAYLOAD     "dummypayload"
 #define DUMMYPAYLOADSIZE (sizeof(DUMMYPAYLOAD))
 
+static int g_debug_fd = -1;
+
 struct hdl_header {
     uint8_t fds;       /* bitmask of host file descriptors corresponding to PAL handle */
     size_t  data_size; /* total size of serialized PAL handle */
@@ -396,4 +398,30 @@ int _DkReceiveHandle(PAL_HANDLE hdl, PAL_HANDLE* cargo) {
 
     *cargo = handle;
     return 0;
+}
+
+int _DkInitDebugStream(const char* path) {
+    int ret;
+
+    if (g_debug_fd >= 0) {
+        ret = ocall_close(g_debug_fd);
+        g_debug_fd = -1;
+        if (ret < 0)
+            return unix_to_pal_error(ERRNO(ret));
+    }
+
+    ret = ocall_open(path, O_WRONLY | O_APPEND | O_CREAT, 0600);
+    if (ret < 0)
+        return unix_to_pal_error(ERRNO(ret));
+    g_debug_fd = ret;
+    return 0;
+}
+
+ssize_t _DkDebugLog(const void* buf, size_t size) {
+    if (g_debug_fd < 0)
+        return -PAL_ERROR_BADHANDLE;
+
+    ssize_t ret = ocall_write(g_debug_fd, buf, size);
+    ret = IS_ERR(ret) ? unix_to_pal_error(ERRNO(ret)) : ret;
+    return ret;
 }

--- a/Pal/src/host/Skeleton/db_streams.c
+++ b/Pal/src/host/Skeleton/db_streams.c
@@ -33,3 +33,11 @@ int _DkSendHandle(PAL_HANDLE hdl, PAL_HANDLE cargo) {
 int _DkReceiveHandle(PAL_HANDLE hdl, PAL_HANDLE* cargo) {
     return -PAL_ERROR_NOTIMPLEMENTED;
 }
+
+int _DkInitDebugStream(const char* path) {
+    return -PAL_ERROR_NOTIMPLEMENTED;
+}
+
+ssize_t _DkDebugLog(const void* buf, size_t size) {
+    return -PAL_ERROR_NOTIMPLEMENTED;
+}

--- a/Pal/src/pal-symbols
+++ b/Pal/src/pal-symbols
@@ -48,6 +48,7 @@ DkDebugDetachBinary
 DkAttestationReport
 DkAttestationQuote
 DkSetProtectedFilesKey
+DkDebugLog
 pal_printf
 pal_control_addr
 pal_strerror

--- a/Pal/src/pal_internal.h
+++ b/Pal/src/pal_internal.h
@@ -337,6 +337,8 @@ void free(void* mem);
 #define EXTERN_ALIAS(name)
 #endif
 
+int _DkInitDebugStream(const char* path);
+ssize_t _DkDebugLog(const void* buf, size_t size);
 void _DkPrintConsole(const void* buf, int size);
 int printf(const char* fmt, ...) __attribute__((format(printf, 1, 2)));
 int vprintf(const char* fmt, va_list ap) __attribute__((format(printf, 1, 0)));


### PR DESCRIPTION
See https://github.com/oscarlab/graphene/issues/1947.

## Description of the changes <!-- (reasons and measures) -->

This makes `loader.debug_type = "file"` usable again by introducing a new `DkDebugLog` call.

## How to test this PR? <!-- (if applicable) -->

Run a program with:

```toml
loader.debug_type = "file"
loader.debug_file = "graphene.log"
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1965)
<!-- Reviewable:end -->
