### PR TITLE
[LibOS] Miscellaneous sigaction fixes

### DIFF
--- a/LibOS/shim/include/shim_signal.h
+++ b/LibOS/shim/include/shim_signal.h
@@ -100,6 +100,8 @@ __SIGSETFN(shim_sigdelset, ((__set->__val[__word] &= ~__mask), 0), )
 #define __sigaddset   shim_sigaddset
 #define __sigdelset   shim_sigdelset
 
+void clear_illegal_signals(__sigset_t* set);
+
 /* NB: Check shim_signal.c if this changes.  Some memset(0) elision*/
 struct shim_signal {
     siginfo_t    info;
@@ -120,8 +122,8 @@ int append_signal(struct shim_thread* thread, siginfo_t* info);
 
 void deliver_signal(siginfo_t* info, PAL_CONTEXT* context);
 
-__sigset_t* get_sig_mask(struct shim_thread* thread);
-__sigset_t* set_sig_mask(struct shim_thread* thread, const __sigset_t* new_set);
+void get_sig_mask(struct shim_thread* thread, __sigset_t* mask);
+void set_sig_mask(struct shim_thread* thread, const __sigset_t* new_set);
 
 int do_kill_thread(IDTYPE sender, IDTYPE tgid, IDTYPE tid, int sig, bool use_ipc);
 int do_kill_proc(IDTYPE sender, IDTYPE tgid, int sig, bool use_ipc);

--- a/LibOS/shim/src/bookkeep/shim_signal.c
+++ b/LibOS/shim/src/bookkeep/shim_signal.c
@@ -693,14 +693,14 @@ static __rt_sighandler_t get_sighandler(struct shim_thread* thread, int sig, boo
 #endif
 
     __rt_sighandler_t handler = (void*)sig_action->k_sa_handler;
-    if (allow_reset && sig_action->sa_flags & SA_RESETHAND) {
-        sigaction_make_defaults(sig_action);
-    }
-
     if ((void*)handler == (void*)SIG_IGN) {
         handler = NULL;
     } else if ((void*)handler == (void*)SIG_DFL) {
         handler = default_sighandler[sig - 1];
+    }
+
+    if (allow_reset && handler && sig_action->sa_flags & SA_RESETHAND) {
+        sigaction_make_defaults(sig_action);
     }
 
     unlock(&thread->signal_handles->lock);


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->
Always clear SIGSTOP and SIGKILL from signals mask.
Restore the signal action to the default when `SA_RESETHAND` is set only if a signal handler is called.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1966)
<!-- Reviewable:end -->
