### PR TITLE
Add /sys pseudo-filesystem support

### DIFF
--- a/Examples/openvino/Makefile
+++ b/Examples/openvino/Makefile
@@ -60,8 +60,8 @@ $(OPENVINO_DIR)/README.md:
 
 $(OPENVINO_DIR)/inference-engine/bin/intel64/$(OPENVINO_BUILD)/object_detection_sample_ssd: $(OPENVINO_DIR)/README.md
 	cd $(OPENVINO_DIR)/inference-engine && mkdir -p build
-	cd $(OPENVINO_DIR)/inference-engine/build && cmake -DTHREADING=OMP -DCMAKE_BUILD_TYPE=$(OPENVINO_BUILD) ../..
-	$(MAKE) -C $(OPENVINO_DIR)/inference-engine/build
+	cd $(OPENVINO_DIR)/inference-engine/build && cmake -DCMAKE_BUILD_TYPE=$(OPENVINO_BUILD) ../..
+	$(MAKE) -C $(OPENVINO_DIR)/inference-engine/build -j8
 
 object_detection_sample_ssd.manifest: object_detection_sample_ssd.manifest.template
 	sed -e 's|$$(GRAPHENE_DIR)|'"$(GRAPHENE_DIR)"'|g' \

--- a/Examples/openvino/object_detection_sample_ssd.manifest.template
+++ b/Examples/openvino/object_detection_sample_ssd.manifest.template
@@ -13,7 +13,7 @@ loader.debug_type = "$(GRAPHENE_DEBUG)"
 loader.insecure__use_cmdline_argv = 1
 
 # Environment variables
-loader.env.LD_LIBRARY_PATH = "/lib:$(ARCH_LIBDIR):/usr/$(ARCH_LIBDIR)"
+loader.env.LD_LIBRARY_PATH = /lib:$(ARCH_LIBDIR):/usr/$(ARCH_LIBDIR):$(OPENVINO_DIR)/inference-engine/temp/tbb/lib
 
 # Mounted FSes. The following "chroot" FSes mount a part of the host FS into the
 # guest. Other parts of the host FS will not be available in the guest.
@@ -80,12 +80,14 @@ sgx.trusted_files.libnssnis = "file:$(ARCH_LIBDIR)/libnss_nis.so.2"
 sgx.trusted_files.libnsl = "file:$(ARCH_LIBDIR)/libnsl.so.1"
 
 # OpenVINO C++ dependencies
-sgx.trusted_files.libcpp = "file:/usr/$(ARCH_LIBDIR)/libstdc++.so.6"
-sgx.trusted_files.libgcc = "file:$(ARCH_LIBDIR)/libgcc_s.so.1"
-
-# OpenVINO TBB dependencies
-sgx.trusted_files.libtbbmalloc = "file:/usr/$(ARCH_LIBDIR)/libtbbmalloc.so.2"
-sgx.trusted_files.libtbb = "file:/usr/$(ARCH_LIBDIR)/libtbb.so.2"
+sgx.trusted_files.libcpp = file:/usr/$(ARCH_LIBDIR)/libstdc++.so.6
+sgx.trusted_files.libgcc = file:$(ARCH_LIBDIR)/libgcc_s.so.1
+sgx.trusted_files.libnuma    = file:/usr/$(ARCH_LIBDIR)/libnuma.so.1
+sgx.trusted_files.libxml2    = file:/usr/$(ARCH_LIBDIR)/libxml2.so.2
+sgx.trusted_files.libicuuc   = file:/usr/$(ARCH_LIBDIR)/libicuuc.so.60
+sgx.trusted_files.libz       = file:$(ARCH_LIBDIR)/libz.so.1
+sgx.trusted_files.liblzma    = file:$(ARCH_LIBDIR)/liblzma.so.5
+sgx.trusted_files.libicudata = file:/usr/$(ARCH_LIBDIR)/libicudata.so.60
 
 # OpenVINO main libraries
 sgx.trusted_files.libformatreader = "file:$(OPENVINO_DIR)/bin/intel64/$(OPENVINO_BUILD)/lib/libformat_reader.so"
@@ -108,8 +110,12 @@ sgx.trusted_files.libimgcodecs = "file:$(OPENVINO_DIR)/inference-engine/temp/ope
 sgx.trusted_files.libimgproc = "file:$(OPENVINO_DIR)/inference-engine/temp/opencv_4.3.0_ubuntu18/opencv/lib/libopencv_imgproc.so.4.3"
 sgx.trusted_files.libopencvcore = "file:$(OPENVINO_DIR)/inference-engine/temp/opencv_4.3.0_ubuntu18/opencv/lib/libopencv_core.so.4.3"
 
-# OpenVINO OMP libraries
-sgx.trusted_files.libiomp5 = "file:$(OPENVINO_DIR)/inference-engine/temp/omp/lib/libiomp5.so"
+#OpenVINO TBB dependencies
+sgx.trusted_files.libtbbmalloc = file:$(OPENVINO_DIR)/inference-engine/temp/tbb/lib/libtbbmalloc.so.2
+sgx.trusted_files.libtbb       = file:$(OPENVINO_DIR)/inference-engine/temp/tbb/lib/libtbb.so.2
+sgx.trusted_files.libtbbbind   = file:$(OPENVINO_DIR)/inference-engine/temp/tbb/lib/libtbbbind.so.2
+sgx.trusted_files.libhwloc     = file:$(OPENVINO_DIR)/inference-engine/temp/tbb/lib/libhwloc.so.5
+$(LIBTBB_DEBUG)
 
 # OpenVINO SSD300 model
 sgx.trusted_files.pluginsxml = "file:$(OPENVINO_DIR)/bin/intel64/$(OPENVINO_BUILD)/lib/plugins.xml"

--- a/LibOS/shim/include/shim_fs.h
+++ b/LibOS/shim/include/shim_fs.h
@@ -483,11 +483,16 @@ extern struct shim_mount eventfd_builtin_fs;
 #define FILE_RW_MODE 0666
 #define FILE_R_MODE  0444
 
+#define SYSFS_FILESZ    256
+
 extern struct shim_fs_ops dev_fs_ops;
 extern struct shim_d_ops dev_d_ops;
 
 extern struct shim_fs_ops proc_fs_ops;
 extern struct shim_d_ops proc_d_ops;
+
+extern struct shim_fs_ops sys_fs_ops;
+extern struct shim_d_ops sys_d_ops;
 
 struct pseudo_name_ops {
     int (*match_name)(const char* name);
@@ -552,5 +557,16 @@ ssize_t str_read(struct shim_handle* hdl, void* buf, size_t count);
 ssize_t str_write(struct shim_handle* hdl, const void* buf, size_t count);
 off_t str_seek(struct shim_handle* hdl, off_t offset, int whence);
 int str_flush(struct shim_handle* hdl);
+
+/* /sys fs related common APIs*/
+const char* extract_filename (const char* pathname);
+int extract_num_from_path(const char* path);
+int sys_info_mode(const char* name, mode_t* mode);
+int sys_info_stat(const char* name, struct stat* buf);
+int sys_dir_open(struct shim_handle* hdl, const char* name, int flags);
+int sys_dir_mode(const char* name, mode_t* mode);
+int sys_dir_stat(const char* name, struct stat* buf);
+int sys_match_resource_num(const char* pathname);
+int sys_list_resource_num(const char* pathname, struct shim_dirent** buf, int len);
 
 #endif /* _SHIM_FS_H_ */

--- a/LibOS/shim/src/Makefile
+++ b/LibOS/shim/src/Makefile
@@ -76,6 +76,10 @@ objs = \
 	fs/proc/thread.o \
 	fs/socket/fs.o \
 	fs/str/fs.o \
+	fs/sys/fs.o \
+	fs/sys/cpu_info.o \
+	fs/sys/cache_info.o \
+	fs/sys/node_info.o \
 	ipc/shim_ipc.o \
 	ipc/shim_ipc_child.o \
 	ipc/shim_ipc_helper.o \

--- a/LibOS/shim/src/fs/proc/info.c
+++ b/LibOS/shim/src/fs/proc/info.c
@@ -143,7 +143,7 @@ static int proc_cpuinfo_open(struct shim_handle* hdl, const char* name, int flag
         len += ret;                                                  \
     } while (0)
 
-    for (size_t n = 0; n < pal_control.cpu_info.online_logical_cores; n++) {
+    for (size_t n = 0; n < pal_control.cpu_info.num_online_logical_cores; n++) {
         /* Below strings must match exactly the strings retrieved from /proc/cpuinfo
          * (see Linux's arch/x86/kernel/cpu/proc.c) */
         ADD_INFO("processor\t: %lu\n", n);

--- a/LibOS/shim/src/fs/shim_fs.c
+++ b/LibOS/shim/src/fs/shim_fs.c
@@ -40,6 +40,11 @@ struct shim_fs mountable_fs[] = {
         .fs_ops = &dev_fs_ops,
         .d_ops  = &dev_d_ops,
     },
+    {
+        .name   = "sys",
+        .fs_ops = &sys_fs_ops,
+        .d_ops  = &sys_d_ops,
+    },
 };
 
 struct shim_mount* builtin_fs[] = {
@@ -150,6 +155,13 @@ static int __mount_sys(struct shim_dentry* root) {
 
     if ((ret = mount_fs("chroot", URI_PREFIX_DEV "tty", "/dev/tty", dev_dent, NULL, 0)) < 0) {
         debug("Mounting terminal device failed (%d)\n", ret);
+        return ret;
+    }
+
+    debug("mounting as sys filesystem: /sys\n");
+
+    if ((ret = mount_fs("sys", NULL, "/sys", root, NULL, 0)) < 0) {
+        debug("mounting sys filesystem failed (%d)\n", ret);
         return ret;
     }
 

--- a/LibOS/shim/src/fs/sys/cache_info.c
+++ b/LibOS/shim/src/fs/sys/cache_info.c
@@ -1,0 +1,142 @@
+/* SPDX-License-Identifier: LGPL-3.0-or-later */
+/* Copyright (C) 2020 Intel Corporation */
+
+/*!
+ * \file
+ *
+ * This file contains the implementation of `/sys/devices/system/cpu/cpuX/cache`
+ */
+
+#include "shim_fs.h"
+
+static int cache_info_open (struct shim_handle* hdl, const char* name, int flags) {
+    __UNUSED(hdl);
+    __UNUSED(flags);
+
+    int len;
+    char* str = malloc(SYSFS_FILESZ);
+    if (!str)
+        return -ENOMEM;
+
+    const char* filename = extract_filename(name);
+    int cpunum = extract_num_from_path(name);
+    if (cpunum < 0 )
+        return -ENOENT;
+
+    int idx = extract_num_from_path(strstr(name, "index"));
+    if (idx < 0 )
+        return -ENOENT;
+
+    if (!strcmp(filename, "shared_cpu_map")) {
+        const char* cachemap;
+        cachemap = pal_control.topo_info.core_topology[cpunum].cache[idx].shared_cpu_map;
+        len =  strlen(cachemap) + 1;
+        memcpy(str, cachemap, len);
+
+    } else if (!strcmp(filename, "level")) {
+        const char* level = pal_control.topo_info.core_topology[cpunum].cache[idx].level;
+        len =  strlen(level) + 1;
+        memcpy(str, level, len);
+
+    } else if (!strcmp(filename, "type")) {
+        const char* type = pal_control.topo_info.core_topology[cpunum].cache[idx].type;
+        len =  strlen(type) + 1;
+        memcpy(str, type, len);
+
+    } else if (!strcmp(filename, "size")) {
+        const char* size = pal_control.topo_info.core_topology[cpunum].cache[idx].size;
+        len =  strlen(size) + 1;
+        memcpy(str, size, len);
+
+    } else if (!strcmp(filename, "coherency_line_size")) {
+        const char* coherency;
+        coherency = pal_control.topo_info.core_topology[cpunum].cache[idx].coherency_line_size;
+        len =  strlen(coherency) + 1;
+        memcpy(str, coherency, len);
+
+    } else if (!strcmp(filename, "number_of_sets")) {
+        const char* sets  = pal_control.topo_info.core_topology[cpunum].cache[idx].number_of_sets;
+        len =  strlen(sets) + 1;
+        memcpy(str, sets, len);
+
+    } else if (!strcmp(filename, "physical_line_partition")) {
+        const char* partition;
+        partition = pal_control.topo_info.core_topology[cpunum].cache[idx].physical_line_partition;
+        len =  strlen(partition) + 1;
+        memcpy(str, partition, len);
+
+    } else {
+        debug("Unsupported Filepath %s\n", name);
+        return -ENOENT;
+    }
+
+    struct shim_str_data* data = malloc(sizeof(struct shim_str_data));
+    if (!data) {
+        free(str);
+        return -ENOMEM;
+    }
+
+    memset(data, 0, sizeof(struct shim_str_data));
+    data->str          = str;
+    data->len          = len;
+    hdl->type          = TYPE_STR;
+    hdl->flags         = flags & ~O_RDONLY;
+    hdl->acc_mode      = MAY_READ;
+    hdl->info.str.data = data;
+
+    return 0;
+}
+
+static const struct pseudo_fs_ops cache_idx_info = {
+    .mode = &sys_info_mode,
+    .stat = &sys_info_stat,
+    .open = &cache_info_open,
+};
+
+static const struct pseudo_dir cache_idx_dir = {
+    .size = 7,
+    .ent  = {
+              { .name   = "shared_cpu_map",
+                .fs_ops = &cache_idx_info,
+                .type   = LINUX_DT_REG },
+              { .name   = "level",
+                .fs_ops = &cache_idx_info,
+                .type   = LINUX_DT_REG },
+              { .name   = "type",
+                .fs_ops = &cache_idx_info,
+                .type   = LINUX_DT_REG },
+              { .name   = "size",
+                .fs_ops = &cache_idx_info,
+                .type   = LINUX_DT_REG },
+              { .name   = "coherency_line_size",
+                .fs_ops = &cache_idx_info,
+                .type   = LINUX_DT_REG },
+              { .name   = "number_of_sets",
+                .fs_ops = &cache_idx_info,
+                .type   = LINUX_DT_REG },
+              { .name   = "physical_line_partition",
+                .fs_ops = &cache_idx_info,
+                .type   = LINUX_DT_REG },
+            }
+};
+
+static const struct pseudo_fs_ops cache_info = {
+    .mode = &sys_dir_mode,
+    .stat = &sys_dir_stat,
+    .open = &sys_dir_open,
+};
+
+static const struct pseudo_name_ops cache_ops = {
+    .match_name = &sys_match_resource_num,
+    .list_name  = &sys_list_resource_num,
+};
+
+const struct pseudo_dir cpunum_cache_dir = {
+    .size = 1,
+    .ent  = {
+              { .name_ops = &cache_ops,
+                .fs_ops   = &cache_info,
+                .dir      = &cache_idx_dir,
+                .type     = LINUX_DT_DIR },
+            }
+};

--- a/LibOS/shim/src/fs/sys/cpu_info.c
+++ b/LibOS/shim/src/fs/sys/cpu_info.c
@@ -1,0 +1,168 @@
+/* SPDX-License-Identifier: LGPL-3.0-or-later */
+/* Copyright (C) 2020 Intel Corporation */
+
+/*!
+ * \file
+ *
+ * This file contains the implementation of `/sys/devices/system/cpu` and its sub-directories.
+ */
+
+#include "shim_fs.h"
+extern const struct pseudo_dir cpunum_cache_dir;
+
+static int cpu_info_open(struct shim_handle* hdl, const char* name, int flags) {
+    __UNUSED(hdl);
+    __UNUSED(flags);
+
+    int len;
+    char* str = malloc(SYSFS_FILESZ);
+    if (!str)
+        return -ENOMEM;
+
+    const char* filename = extract_filename(name);
+    if (!strcmp(filename, "online")) {
+        const char* online_info;
+        if (strstr(name, "cpu/cpu")) {
+            int cpunum = extract_num_from_path(name);
+            if (cpunum < 0 )
+                return -ENOENT;
+            online_info = pal_control.topo_info.core_topology[cpunum].is_logical_core_online;
+        }
+        else
+            online_info = pal_control.topo_info.online_logical_cores;
+
+        len = strlen(online_info) + 1;
+        memcpy(str, online_info, len);
+
+    } else if (!strcmp(filename, "possible")) {
+        const char* possible_info = pal_control.topo_info.possible_logical_cores;
+        len = strlen(possible_info) + 1;
+        memcpy(str, possible_info, len);
+
+    } else if (!strcmp(filename, "core_id")) {
+        int cpunum = extract_num_from_path(name);
+        if (cpunum < 0 )
+            return -ENOENT;
+
+        const char* core_id;
+        core_id = pal_control.topo_info.core_topology[cpunum].core_id;
+        len = strlen(core_id) + 1;
+        memcpy(str, core_id, len);
+
+    } else if (!strcmp(filename, "physical_package_id")) {
+        int cpunum = extract_num_from_path(name);
+        if (cpunum < 0 )
+            return -ENOENT;
+        /* we have already collected this info as part of /proc/cpuinfo. So reuse it */
+        snprintf(str, sizeof(str), "%d", pal_control.cpu_info.cpu_socket[cpunum]);
+        len = strlen(str) + 1;
+        str[len] = '\0';
+
+    } else if (!strcmp(filename, "core_siblings")) {
+        int cpunum = extract_num_from_path(name);
+        if (cpunum < 0 )
+            return -ENOENT;
+
+        const char* coresiblings_info;
+        coresiblings_info = pal_control.topo_info.core_topology[cpunum].core_siblings;
+        len = strlen(coresiblings_info) + 1;
+        memcpy(str, coresiblings_info, len);
+
+    } else if (!strcmp(filename, "thread_siblings")) {
+        int cpunum = extract_num_from_path(name);
+        if (cpunum < 0 )
+            return -ENOENT;
+
+        const char* threadsiblings_info;
+        threadsiblings_info = pal_control.topo_info.core_topology[cpunum].thread_siblings;
+        len = strlen(threadsiblings_info) + 1;
+        memcpy(str, threadsiblings_info, len);
+
+    } else {
+        debug("Unsupported Filepath %s\n", name);
+        return -ENOENT;
+    }
+
+    struct shim_str_data* data = malloc(sizeof(struct shim_str_data));
+    if (!data) {
+        free(str);
+        return -ENOMEM;
+    }
+
+    memset(data, 0, sizeof(struct shim_str_data));
+    data->str          = str;
+    data->len          = len;
+    hdl->type          = TYPE_STR;
+    hdl->flags         = flags & ~O_RDONLY;
+    hdl->acc_mode      = MAY_READ;
+    hdl->info.str.data = data;
+
+    return 0;
+}
+
+static const struct pseudo_fs_ops cpu_info = {
+    .mode = &sys_info_mode,
+    .stat = &sys_info_stat,
+    .open = &cpu_info_open,
+};
+
+static const struct pseudo_dir cpunum_topo_dir = {
+    .size = 4,
+    .ent  = {
+              { .name   = "core_id",
+                .fs_ops = &cpu_info,
+                .type   = LINUX_DT_REG },
+              { .name   = "physical_package_id",
+                .fs_ops = &cpu_info,
+                .type   = LINUX_DT_REG },
+              { .name   = "core_siblings",
+                .fs_ops = &cpu_info,
+                .type   = LINUX_DT_REG },
+              { .name   = "thread_siblings",
+                .fs_ops = &cpu_info,
+                .type   = LINUX_DT_REG },
+            }
+};
+
+static const struct pseudo_fs_ops cpunum_dirinfo = {
+    .mode = &sys_dir_mode,
+    .stat = &sys_dir_stat,
+    .open = &sys_dir_open,
+};
+
+static const struct pseudo_dir cpunum_dir = {
+    .size = 3,
+    .ent  = {
+              { .name   = "online",
+		        .fs_ops = &cpu_info,
+                .type   = LINUX_DT_REG },
+              { .name   = "topology",
+		        .fs_ops = &cpunum_dirinfo,
+                .dir    = &cpunum_topo_dir,
+                .type   = LINUX_DT_DIR },
+              { .name   = "cache",
+		        .fs_ops = &cpunum_dirinfo,
+                .dir    = &cpunum_cache_dir,
+                .type   = LINUX_DT_DIR },
+            }
+};
+
+static const struct pseudo_name_ops cpunum_ops = {
+    .match_name = &sys_match_resource_num,
+    .list_name  = &sys_list_resource_num,
+};
+
+const struct pseudo_dir sys_cpu_dir = {
+    .size = 3,
+    .ent  = {
+              { .name     = "online",
+                .fs_ops   = &cpu_info,
+                .type     = LINUX_DT_REG },
+              { .name     = "possible",
+                .fs_ops   = &cpu_info,
+                .type     = LINUX_DT_REG },
+              { .name_ops = &cpunum_ops,
+                .dir      = &cpunum_dir,
+                .type     = LINUX_DT_DIR },
+            }
+};

--- a/LibOS/shim/src/fs/sys/fs.c
+++ b/LibOS/shim/src/fs/sys/fs.c
@@ -1,0 +1,280 @@
+/* SPDX-License-Identifier: LGPL-3.0-or-later */
+/* Copyright (C) 2020 Intel Corporation */
+
+/*!
+ * \file
+ *
+ * This file contains the implementation of `/sys` pseudo-filesystem.
+ */
+
+#include "shim_fs.h"
+extern const struct pseudo_dir sys_cpu_dir;
+extern const struct pseudo_dir sys_node_dir;
+
+/* Extract name of the file from the given path*/
+const char* extract_filename (const char* pathname) {
+    const char* filename = pathname;
+     while (filename && *filename) {
+        char* slash_ptr = strchr(filename, '/');
+        if (!slash_ptr)
+            break;
+
+        filename = slash_ptr + 1; /* set it past '/' */
+    }
+
+    return filename;
+}
+
+/* This function will extract 3 from "cpu/cpu3/topology/core_siblings" */
+int extract_num_from_path(const char* pathname) {
+    const char* str = pathname;
+    int ret = -1;
+
+    while(*str) {
+        if ((*str >= '0') && (*str <= '9') ) {
+            ret = strtol(str, NULL, 10);
+            break;
+        }
+        str++;
+    }
+
+    return ret;
+}
+
+/* This function will extract cpu105 from "cpu105/cache/Index0/type". If string doesn't have "/"
+ * delimiter, original string is returned. */
+static char* extract_first_token_from_path (char* pathname) {
+    char* begin = pathname;
+    if (begin == NULL)
+        return NULL;
+
+    while(*pathname) {
+        if (*pathname == '/') {
+            *pathname = '\0';
+            break;
+        }
+        pathname++;
+    }
+
+    return begin;
+}
+
+int sys_match_resource_num(const char* pathname) {
+    int num, totalcnt;
+    int ret = 1;
+
+    char* name = strdup(pathname);
+    if (!name)
+        return 0;
+
+    char *token = extract_first_token_from_path(name);
+    if (!token) {
+        ret = 0;
+        goto out;
+    }
+
+    num = extract_num_from_path(token);
+    if (num < 0) {
+        ret = 0;
+        goto out;
+    }
+
+    if (strstr(token, "node")) {
+        totalcnt = pal_control.topo_info.num_online_nodes;
+    } else if (strstr(token, "cpu")) {
+        totalcnt = pal_control.cpu_info.num_online_logical_cores;
+    } else if (strstr(token, "index")) {
+        totalcnt = pal_control.topo_info.num_cache_index;
+    } else {
+        debug("Invalid resource %s!", token);
+        ret = 0;
+        goto out;
+    }
+
+    if (num > totalcnt) {
+        debug("Incorrect Index %d in path: %s! Max supported is %d\n", num, pathname, totalcnt);
+        ret = 0;
+        goto out;
+    }
+out:
+    free(name);
+    return ret;
+}
+
+int sys_list_resource_num(const char* pathname, struct shim_dirent** buf, int len) {
+    int totalcnt;
+    char res_name[6];
+    char ent_name[32];
+    struct shim_dirent* dirent_in_buf = *buf;
+    size_t buf_size = len;
+    size_t total_size = 0;
+
+    if (strstr(pathname, "node")) {
+        snprintf(res_name, sizeof(res_name), "node");
+        totalcnt = pal_control.topo_info.num_online_nodes;
+
+    } else if (strstr(pathname, "index")) {
+        snprintf(res_name, sizeof(res_name), "index");
+        totalcnt = pal_control.topo_info.num_cache_index;
+
+    } else if (strstr(pathname, "cpu")) {
+        snprintf(res_name, sizeof(res_name), "cpu");
+        totalcnt = pal_control.cpu_info.num_online_logical_cores;
+
+    } else {
+        debug("Invalid resource name in path: %s\n", pathname);
+        return 0;
+    }
+
+    for (int i = 0; i < totalcnt; i++) {
+        snprintf(ent_name, sizeof(ent_name), "%s%d", res_name, i);
+        size_t name_size   = strlen(ent_name) + 1;
+        size_t dirent_size = sizeof(struct shim_dirent) + name_size;
+
+        total_size += dirent_size;
+        if (total_size > buf_size)
+            return -ENOMEM;
+
+        memcpy(dirent_in_buf->name, ent_name, name_size);
+        dirent_in_buf->next = (void*)dirent_in_buf + dirent_size;
+        dirent_in_buf->ino  = 1;
+        dirent_in_buf->type = LINUX_DT_DIR;
+        dirent_in_buf  = dirent_in_buf->next;
+    }
+
+    *buf = dirent_in_buf;
+    return 1;
+}
+
+int sys_info_mode(const char* name, mode_t* mode) {
+    __UNUSED(name);
+    *mode = FILE_R_MODE | S_IFREG;
+    return 0;
+}
+
+int sys_info_stat(const char* name, struct stat* buf) {
+    __UNUSED(name);
+    memset(buf, 0, sizeof(struct stat));
+    buf->st_dev  = 1;    /* dummy ID of device containing file */
+    buf->st_ino  = 1;    /* dummy inode number */
+    buf->st_mode = FILE_R_MODE | S_IFREG;
+    return 0;
+}
+
+int sys_dir_open(struct shim_handle* hdl, const char* name, int flags) {
+    __UNUSED(hdl);
+    __UNUSED(name);
+
+    if (flags & (O_WRONLY | O_RDWR))
+        return -EISDIR;
+
+    return 0;
+}
+
+int sys_dir_mode(const char* name, mode_t* mode) {
+    __UNUSED(name);
+
+    *mode = 0500;
+    return 0;
+}
+
+int sys_dir_stat(const char* name, struct stat* buf) {
+    __UNUSED(name);
+
+    memset(buf, 0, sizeof(struct stat));
+    buf->st_mode  = 0500 | S_IFDIR;
+    buf->st_nlink = 4; //FIXME: need atleast 4 `/sys/devices/system/node/nodeX/hugepages`
+
+    return 0;
+}
+
+static const struct pseudo_fs_ops fs_sysdir = {
+    .mode = &sys_dir_mode,
+    .stat = &sys_dir_stat,
+    .open = &sys_dir_open,
+};
+
+static const struct pseudo_dir sys_sys_dir = {
+    .size = 2,
+    .ent  = {
+              { .name   = "cpu",
+                .dir    = &sys_cpu_dir,
+		        .fs_ops = &fs_sysdir,
+                .type   = LINUX_DT_DIR },
+              { .name   = "node",
+                .dir    = &sys_node_dir,
+		        .fs_ops = &fs_sysdir,
+                .type   = LINUX_DT_DIR },
+            }
+};
+
+static const struct pseudo_dir sys_dev_dir = {
+    .size = 1,
+    .ent  = {
+              { .name   = "system",
+                .dir    = &sys_sys_dir,
+                .type   = LINUX_DT_DIR },
+            }
+};
+
+static const struct pseudo_dir sys_root_dir = {
+    .size = 1,
+    .ent  = {
+              { .name   = "devices",
+                .dir    = &sys_dev_dir,
+                .type   = LINUX_DT_DIR },
+            }
+};
+
+static const struct pseudo_fs_ops sys_root_fs = {
+    .open = &pseudo_dir_open,
+    .mode = &pseudo_dir_mode,
+    .stat = &pseudo_dir_stat,
+};
+
+static const struct pseudo_ent sys_root_ent = {
+    .name   = "",
+    .fs_ops = &sys_root_fs,
+    .dir    = &sys_root_dir,
+};
+
+static int sys_mode(struct shim_dentry* dent, mode_t* mode) {
+    return pseudo_mode(dent, mode, &sys_root_ent);
+}
+
+static int sys_lookup(struct shim_dentry* dent) {
+    return pseudo_lookup(dent, &sys_root_ent);
+}
+
+static int sys_open(struct shim_handle* hdl, struct shim_dentry* dent, int flags) {
+    return pseudo_open(hdl, dent, flags, &sys_root_ent);
+}
+
+static int sys_readdir(struct shim_dentry* dent, struct shim_dirent** dirent) {
+    return pseudo_readdir(dent, dirent, &sys_root_ent);
+}
+
+static int sys_stat(struct shim_dentry* dent, struct stat* buf) {
+    return pseudo_stat(dent, buf, &sys_root_ent);
+}
+
+static int sys_hstat(struct shim_handle* hdl, struct stat* buf) {
+    return pseudo_hstat(hdl, buf, &sys_root_ent);
+}
+
+struct shim_fs_ops sys_fs_ops = {
+    .mount   = &pseudo_mount,
+    .unmount = &pseudo_unmount,
+    .close   = &str_close,
+    .read    = &str_read,
+    .seek    = &str_seek,
+    .hstat   = &sys_hstat,
+};
+
+struct shim_d_ops sys_d_ops = {
+    .open    = &sys_open,
+    .stat    = &sys_stat,
+    .mode    = &sys_mode,
+    .lookup  = &sys_lookup,
+    .readdir = &sys_readdir,
+};

--- a/LibOS/shim/src/fs/sys/node_info.c
+++ b/LibOS/shim/src/fs/sys/node_info.c
@@ -1,0 +1,152 @@
+/* SPDX-License-Identifier: LGPL-3.0-or-later */
+/* Copyright (C) 2020 Intel Corporation */
+
+/*!
+ * \file
+ *
+ * This file contains the implementation of `/sys/devices/system/node`
+ */
+
+#include "shim_fs.h"
+
+static int node_info_open(struct shim_handle* hdl, const char* name, int flags) {
+    __UNUSED(hdl);
+    __UNUSED(flags);
+
+    int len;
+    char* str = malloc(SYSFS_FILESZ);
+    if (!str)
+        return -ENOMEM;
+
+    const char* filename = extract_filename(name);
+    if (!strcmp(filename, "online")) {
+        const char* online_info = pal_control.topo_info.online_nodes;
+        len = strlen(online_info) + 1;
+        memcpy(str, online_info, len);
+
+    } else if (!strcmp(filename, "cpumap")) {
+        int nodenum = extract_num_from_path(name);
+        if (nodenum < 0 )
+            return -ENOENT;
+
+        const char* cpumap_info = pal_control.topo_info.numa_topology[nodenum].cpumap;
+        len =  strlen(cpumap_info) + 1;
+        memcpy(str, cpumap_info, len);
+
+    } else if (!strcmp(filename, "distance")) {
+        int nodenum = extract_num_from_path(name);
+        if (nodenum < 0 )
+            return -ENOENT;
+
+        const char* distance = pal_control.topo_info.numa_topology[nodenum].distance;
+        len =  strlen(distance) + 1;
+        memcpy(str, distance, len);
+
+    } else if (strstr(name, "hugepages-2048kB/nr_hugepages")) {
+        int nodenum = extract_num_from_path(name);
+        if (nodenum < 0 )
+            return -ENOENT;
+
+        const char* nr_hugepages_2M;
+        nr_hugepages_2M = pal_control.topo_info.numa_topology[nodenum].hugepages[0].nr_hugepages;
+        len =  strlen(nr_hugepages_2M) + 1;
+        memcpy(str, nr_hugepages_2M, len);
+
+    } else if (strstr(name, "hugepages-1048576kB/nr_hugepages")) {
+        int nodenum = extract_num_from_path(name);
+        if (nodenum < 0 )
+            return -ENOENT;
+
+        const char* nr_hugepages_1G;
+        nr_hugepages_1G = pal_control.topo_info.numa_topology[nodenum].hugepages[1].nr_hugepages;
+        len =  strlen(nr_hugepages_1G) + 1;
+        memcpy(str, nr_hugepages_1G, len);
+
+    } else {
+        debug("Unsupported Filepath %s\n", name);
+        return -ENOENT;
+    }
+
+    struct shim_str_data* data = malloc(sizeof(struct shim_str_data));
+    if (!data) {
+        free(str);
+        return -ENOMEM;
+    }
+
+    memset(data, 0, sizeof(struct shim_str_data));
+    data->str          = str;
+    data->len          = len;
+    hdl->type          = TYPE_STR;
+    hdl->flags         = flags & ~O_RDONLY;
+    hdl->acc_mode      = MAY_READ;
+    hdl->info.str.data = data;
+
+    return 0;
+}
+
+static const struct pseudo_fs_ops node_info = {
+    .mode = &sys_info_mode,
+    .stat = &sys_info_stat,
+    .open = &node_info_open,
+};
+static const struct pseudo_name_ops nodenum_ops = {
+    .match_name = &sys_match_resource_num,
+    .list_name  = &sys_list_resource_num,
+};
+
+static const struct pseudo_fs_ops nodenum_dirinfo = {
+    .mode = &sys_dir_mode,
+    .stat = &sys_dir_stat,
+    .open = &sys_dir_open,
+};
+
+static const struct pseudo_dir nr_hugepage_dir = {
+    .size = 1,
+    .ent  = {
+              { .name   = "nr_hugepages",
+                .fs_ops = &node_info,
+                .type   = LINUX_DT_REG },
+            }
+};
+
+static const struct pseudo_dir nodenum_hugepg_dir = {
+    .size = 2,
+    .ent  = {
+              { .name   = "hugepages-2048kB",
+                .fs_ops = &nodenum_dirinfo,
+                .dir    = &nr_hugepage_dir,
+                .type   = LINUX_DT_DIR },
+              { .name   = "hugepages-1048576kB",
+                .fs_ops = &nodenum_dirinfo,
+                .dir    = &nr_hugepage_dir,
+                .type   = LINUX_DT_DIR },
+            }
+};
+
+static const struct pseudo_dir node_num_dir = {
+    .size = 3,
+    .ent  = {
+              { .name   = "cpumap",
+                .fs_ops = &node_info,
+                .type   = LINUX_DT_REG },
+              { .name   = "distance",
+                .fs_ops = &node_info,
+                .type   = LINUX_DT_REG },
+              { .name   = "hugepages",
+                .fs_ops = &nodenum_dirinfo,
+                .dir    = &nodenum_hugepg_dir,
+                .type   = LINUX_DT_DIR },
+            }
+};
+
+const struct pseudo_dir sys_node_dir = {
+    .size = 2,
+    .ent  = {
+              { .name     = "online",
+                .fs_ops   = &node_info,
+                .type     = LINUX_DT_REG },
+              { .name_ops = &nodenum_ops,
+                .dir      = &node_num_dir,
+                .type     = LINUX_DT_DIR },
+            }
+};

--- a/LibOS/shim/src/sys/shim_sched.c
+++ b/LibOS/shim/src/sys/shim_sched.c
@@ -175,7 +175,7 @@ long shim_do_sched_setaffinity(pid_t pid, unsigned int cpumask_size, unsigned lo
 
 long shim_do_sched_getaffinity(pid_t pid, unsigned int cpumask_size, unsigned long* user_mask_ptr) {
     int ret;
-    size_t cpu_cnt = PAL_CB(cpu_info.online_logical_cores);
+    size_t cpu_cnt = PAL_CB(cpu_info.num_online_logical_cores);
 
     /* Check if user_mask_ptr is valid */
     if (test_user_memory(user_mask_ptr, cpumask_size, /*write=*/true))

--- a/LibOS/shim/test/regression/.gitignore
+++ b/LibOS/shim/test/regression/.gitignore
@@ -72,9 +72,11 @@
 /proc_cpuinfo
 /proc_path
 /pselect
+/pthread_set_get_affinity
 /rdtsc
 /readdir
 /sched
+/sched_set_get_affinity
 /select
 /shared_object
 /sigaction_per_process
@@ -88,6 +90,7 @@
 /stat_invalid_args
 /str_close_leak
 /syscall
+/sysfs_common
 /tcp_ipv6_v6only
 /tcp_msg_peek
 /testfile

--- a/LibOS/shim/test/regression/Makefile
+++ b/LibOS/shim/test/regression/Makefile
@@ -78,6 +78,7 @@ c_executables = \
 	stat_invalid_args \
 	str_close_leak \
 	syscall \
+	sysfs_common \
 	tcp_ipv6_v6only \
 	tcp_msg_peek \
 	udp \

--- a/LibOS/shim/test/regression/sysfs_common.c
+++ b/LibOS/shim/test/regression/sysfs_common.c
@@ -1,0 +1,177 @@
+#define _GNU_SOURCE
+#include <dirent.h>
+#include <err.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/sysmacros.h>
+#include <unistd.h>
+
+static int get_random_int(long maxprocs) {
+    return rand() % maxprocs;
+}
+
+static void display_file_contents(const char* path) {
+    char buf[4096];
+    int ret;
+    FILE* fd;
+
+    printf("===== Contents of %s file =====\n", path);
+    fd = fopen(path, "r");
+    if (!fd)
+         err(EXIT_FAILURE, "fopen failed for %s", path);
+
+    ret = fread(buf, 1, sizeof(buf) - 1, fd);
+    if (ferror(fd))
+         err(EXIT_FAILURE, "fread failed for %s", path);
+    buf[ret] = '\0';
+
+    printf("%s\n", buf);
+
+    ret = fclose(fd);
+    if (ret)
+        err(EXIT_FAILURE, "fclose failed for %s", path);
+}
+
+int main(int argc, char** argv) {
+    char path[256];
+    int ret, count = 0;
+    FILE* fd;
+    DIR* dir;
+    struct dirent* dirent;
+    struct dirent64* dirent64;
+    struct stat sb;
+
+    long maxprocs = sysconf(_SC_NPROCESSORS_CONF);
+    printf("Number of processors: %ld\n", maxprocs);
+
+    printf("===== faccessat of sys/devices/system/cpu =====\n");
+    ret = faccessat(-1, "/sys/devices/system/cpu", R_OK, 0);
+    if (ret)
+        err(EXIT_FAILURE, "faccessat failed for /sys/devices/system/cpu");
+
+    printf("===== fopen of sys/devices/system/node =====\n");
+    fd = fopen("/sys/devices/system/node", "r");
+    if (!fd)
+        err(EXIT_FAILURE, "fopen failed for /sys/devices/system/cpu");
+
+    ret = fclose(fd);
+    if (ret)
+        err(EXIT_FAILURE, "fclose failed for /sys/devices/system/cpu");
+
+    /* skip this test, if it is a single-core machine */
+    if (maxprocs > 0) {
+        display_file_contents("/sys/devices/system/cpu/cpu1/online");
+    }
+
+    snprintf(path, sizeof(path), "/sys/devices/system/cpu/cpu%d/topology/core_id",
+             get_random_int(maxprocs));
+    display_file_contents(path);
+
+    snprintf(path, sizeof(path), "/sys/devices/system/cpu/cpu%d/topology/core_siblings",
+             get_random_int(maxprocs));
+    display_file_contents(path);
+
+    display_file_contents("/sys/devices/system/node/node0/cpumap");
+
+    display_file_contents("/sys/devices/system/node/node0/distance");
+
+    display_file_contents("/sys/devices/system/node/node0/hugepages/hugepages-2048kB/nr_hugepages");
+
+    /* Read L1 data, L1 Instruction and L2 cache type*/
+    for (int lvl = 0; lvl < 3; lvl++) {
+        snprintf(path, sizeof(path),"/sys/devices/system/cpu/cpu%d/cache/index%d/type",
+                 get_random_int(maxprocs), lvl);
+        display_file_contents(path);
+    }
+
+    printf("===== fstatat of /sys/devices/system/node/node0/hugepages =====\n");
+    ret = fstatat(-1, "/sys/devices/system/node/node0/hugepages", &sb, 0);
+    if (ret)
+        err(EXIT_FAILURE, "fstatat failed for /sys/devices/system/node/node0/hugepages");
+
+    printf("ID of containing device:  [%lx,%lx]\n", (long)major(sb.st_dev), (long)minor(sb.st_dev));
+
+    printf("File type:                ");
+    switch (sb.st_mode & S_IFMT) {
+        case S_IFBLK:  printf("block device\n");            break;
+        case S_IFCHR:  printf("character device\n");        break;
+        case S_IFDIR:  printf("directory\n");               break;
+        case S_IFIFO:  printf("FIFO/pipe\n");               break;
+        case S_IFLNK:  printf("symlink\n");                 break;
+        case S_IFREG:  printf("regular file\n");            break;
+        case S_IFSOCK: printf("socket\n");                  break;
+        default:       printf("unknown?\n");                break;
+    }
+
+    printf("I-node number:            %ld\n", (long)sb.st_ino);
+    printf("Mode:                     %lo (octal)\n", (unsigned long)sb.st_mode);
+    printf("Link count:               %ld\n", (long) sb.st_nlink);
+    printf("Ownership:                UID=%ld   GID=%ld\n", (long)sb.st_uid, (long)sb.st_gid);
+    printf("Preferred I/O block size: %ld bytes\n", (long)sb.st_blksize);
+    printf("File size:                %lld bytes\n", (long long)sb.st_size);
+    printf("Blocks allocated:         %lld\n", (long long)sb.st_blocks);
+
+    printf("\n===== Count num of CPUs from /sys/devices/system/cpu =====\n");
+    dir = opendir("/sys/devices/system/cpu");
+    if (!dir)
+        err(EXIT_FAILURE, "opendir failed for /sys/devices/system/cpu");
+
+    errno = 0;
+    while ((dirent64 = readdir64(dir))) {
+        printf("/sys/devices/system/cpu/%s, type=%d\n", dirent64->d_name, dirent64->d_type);
+        if (dirent64->d_type == DT_DIR && strncmp (dirent64->d_name, "cpu", 3) == 0) {
+            char *endp;
+            unsigned long int nr = strtoul (dirent64->d_name + 3, &endp, 10);
+            if (nr != _SC_ULONG_MAX && endp != dirent64->d_name + 3 && *endp == '\0')
+                count++;
+        }
+    }
+
+    if (errno) {
+        perror("readdir /sys/devices/system/cpu");
+        return 1;
+    }
+    printf("Total CPU count=%d\n", count);
+
+    ret = closedir(dir);
+    if (ret < 0) {
+        perror("closedir /sys/devices/system/cpu");
+        return 1;
+    }
+
+    printf("\n===== Count num of nodes from /sys/devices/system/node =====\n");
+    count = 0;
+    dir = opendir("/sys/devices/system/node");
+    if (!dir)
+         err(EXIT_FAILURE, "opendir failed for /sys/devices/system/node");
+
+    errno = 0;
+    while ((dirent = readdir(dir))) {
+        printf("/sys/devices/system/node/%s \n", dirent->d_name);
+        if (strncmp (dirent->d_name, "node", 4) == 0) {
+            char *endp;
+            unsigned long int nr = strtoul(dirent->d_name + 4,  &endp, 10);
+            if (nr != _SC_ULONG_MAX && endp != dirent64->d_name + 4 && *endp == '\0')
+                count++;
+        }
+    }
+
+    if (errno) {
+        perror("readdir /sys/devices/system/node");
+        return 1;
+    }
+    printf("Total Node count=%d\n", count);
+
+    ret = closedir(dir);
+    if (ret < 0) {
+        perror("closedir /sys/devices/system/node");
+        return 1;
+    }
+
+    printf("TEST OK\n");
+    return 0;
+}

--- a/LibOS/shim/test/regression/test_libos.py
+++ b/LibOS/shim/test/regression/test_libos.py
@@ -597,6 +597,10 @@ class TC_40_FileSystem(RegressionTestCase):
         stdout, _ = self.run_binary(['str_close_leak'], timeout=60)
         self.assertIn("Success", stdout)
 
+    def test_050_sysfs(self):
+        stdout, _ = self.run_binary(['sysfs_common'])
+        self.assertIn('TEST OK', stdout)
+
 
 class TC_50_GDB(RegressionTestCase):
     def setUp(self):

--- a/Pal/include/arch/x86_64/pal-arch.h
+++ b/Pal/include/arch/x86_64/pal-arch.h
@@ -188,10 +188,10 @@ static inline bool pal_context_has_user_pagefault(PAL_CONTEXT* context) {
 /* PAL_CPU_INFO holds /proc/cpuinfo data */
 typedef struct PAL_CPU_INFO_ {
     /* Number of logical cores available in the host */
-    PAL_NUM online_logical_cores;
+    PAL_NUM num_online_logical_cores;
     /* Number of physical cores in a socket (physical package) */
     PAL_NUM physical_cores_per_socket;
-    /* array of "logical core -> socket" mappings; has online_logical_cores elements */
+    /* array of "logical core -> socket" mappings; has num_online_logical_cores elements */
     int* cpu_socket;
     PAL_STR cpu_vendor;
     PAL_STR cpu_brand;

--- a/Pal/include/arch/x86_64/pal-arch.h
+++ b/Pal/include/arch/x86_64/pal-arch.h
@@ -25,6 +25,10 @@ typedef struct pal_tcb PAL_TCB;
 
 #define PAL_LIBOS_TCB_SIZE 256
 
+#define PAL_SYSFS_INT_FILESZ      16
+#define PAL_SYSFS_BUF_FILESZ      64
+#define PAL_SYSFS_MAP_FILESZ      256
+
 typedef struct pal_tcb {
     struct pal_tcb* self;
     /* uint64_t for alignment */
@@ -185,10 +189,18 @@ static inline bool pal_context_has_user_pagefault(PAL_CONTEXT* context) {
     return !!(context->err & 4);
 }
 
+enum {
+    HUGEPAGES_2M = 0,
+    HUGEPAGES_1G,
+    HUGEPAGES_MAX,
+};
+
 /* PAL_CPU_INFO holds /proc/cpuinfo data */
 typedef struct PAL_CPU_INFO_ {
     /* Number of logical cores available in the host */
     PAL_NUM num_online_logical_cores;
+    /* Max number of logical cores available in the host */
+    PAL_NUM num_possible_logical_cores;
     /* Number of physical cores in a socket (physical package) */
     PAL_NUM physical_cores_per_socket;
     /* array of "logical core -> socket" mappings; has num_online_logical_cores elements */
@@ -201,5 +213,45 @@ typedef struct PAL_CPU_INFO_ {
     double  cpu_bogomips;
     PAL_STR cpu_flags;
 } PAL_CPU_INFO;
+
+typedef struct PAL_CORE_CACHE_INFO_ {
+    char shared_cpu_map[PAL_SYSFS_MAP_FILESZ];
+    char level[PAL_SYSFS_INT_FILESZ];
+    char type[PAL_SYSFS_BUF_FILESZ];
+    char size[PAL_SYSFS_BUF_FILESZ];
+    char coherency_line_size[PAL_SYSFS_INT_FILESZ];
+    char number_of_sets[PAL_SYSFS_INT_FILESZ];
+    char physical_line_partition[PAL_SYSFS_INT_FILESZ];
+} PAL_CORE_CACHE_INFO;
+
+typedef struct PAL_CORE_TOPO_INFO_ {
+    char is_logical_core_online[PAL_SYSFS_INT_FILESZ];
+    char core_id[PAL_SYSFS_INT_FILESZ];
+    char core_siblings[PAL_SYSFS_MAP_FILESZ];
+    char thread_siblings[PAL_SYSFS_MAP_FILESZ];
+    PAL_CORE_CACHE_INFO* cache;
+} PAL_CORE_TOPO_INFO;
+
+typedef struct PAL_NUMA_HUGEPAGE_INFO_ {
+    char nr_hugepages[PAL_SYSFS_INT_FILESZ];
+} PAL_NUMA_HUGEPAGE_INFO;
+
+typedef struct PAL_NUMA_TOPO_INFO_ {
+    char cpumap[PAL_SYSFS_MAP_FILESZ];
+    char distance[PAL_SYSFS_INT_FILESZ];
+    PAL_NUMA_HUGEPAGE_INFO hugepages[HUGEPAGES_MAX];
+} PAL_NUMA_TOPO_INFO;
+
+typedef struct PAL_TOPO_INFO_ {
+    char online_logical_cores[PAL_SYSFS_BUF_FILESZ];
+    char possible_logical_cores[PAL_SYSFS_BUF_FILESZ];
+    char online_nodes[PAL_SYSFS_BUF_FILESZ];
+    /* Number of nodes available in the host */
+    PAL_NUM num_online_nodes;
+    /* cache index corresponds number of cache levels(such as L2 or L3) available in the host */
+    PAL_NUM num_cache_index;
+    PAL_CORE_TOPO_INFO* core_topology; /* Array of logical core topology info */
+    PAL_NUMA_TOPO_INFO* numa_topology; /* Array of numa topology info */
+} PAL_TOPO_INFO;
 
 #endif /* PAL_ARCH_H */

--- a/Pal/include/pal/pal.h
+++ b/Pal/include/pal/pal.h
@@ -160,6 +160,7 @@ typedef struct PAL_CONTROL_ {
 
     PAL_CPU_INFO cpu_info; /*!< CPU information (only required ones) */
     PAL_MEM_INFO mem_info; /*!< memory information (only required ones) */
+    PAL_TOPO_INFO topo_info; /* Topology information (only required ones) */
 } PAL_CONTROL;
 
 #define pal_control (*pal_control_addr())

--- a/Pal/regression/Bootstrap.c
+++ b/Pal/regression/Bootstrap.c
@@ -62,7 +62,7 @@ int main(int argc, char** argv, char** envp) {
         (void*)&test_func < pal_control.executable_range.end)
         pal_printf("Executable Range OK\n");
 
-    pal_printf("CPU num: %ld\n", pal_control.cpu_info.online_logical_cores);
+    pal_printf("CPU num: %ld\n", pal_control.cpu_info.num_online_logical_cores);
     pal_printf("CPU vendor: %s\n", pal_control.cpu_info.cpu_vendor);
     pal_printf("CPU brand: %s\n", pal_control.cpu_info.cpu_brand);
     pal_printf("CPU family: %ld\n", pal_control.cpu_info.cpu_family);

--- a/Pal/src/db_main.c
+++ b/Pal/src/db_main.c
@@ -540,6 +540,10 @@ noreturn void pal_main(PAL_NUM instance_id,        /* current instance id */
     }
     g_pal_control.mem_info.mem_total = _DkMemoryQuota();
 
+    if (_DkGetTopologyInfo(&g_pal_control.topo_info) < 0) {
+        goto out_fail;
+    }
+
     /* Now we will start the execution */
     start_execution(arguments, environments);
 

--- a/Pal/src/host/Linux-SGX/db_main-x86_64.c
+++ b/Pal/src/host/Linux-SGX/db_main-x86_64.c
@@ -210,6 +210,18 @@ out_vendor_id:
     return rv;
 }
 
+int _DkGetTopologyInfo(PAL_TOPO_INFO* topo_info) {
+    topo_info->num_online_nodes = g_pal_sec.topo_info.num_online_nodes;
+    topo_info->num_cache_index  = g_pal_sec.topo_info.num_cache_index;
+    topo_info->core_topology    = g_pal_sec.topo_info.core_topology;
+    topo_info->numa_topology    = g_pal_sec.topo_info.numa_topology;
+    COPY_ARRAY(topo_info->online_logical_cores, g_pal_sec.topo_info.online_logical_cores);
+    COPY_ARRAY(topo_info->possible_logical_cores, g_pal_sec.topo_info.possible_logical_cores);
+    COPY_ARRAY(topo_info->online_nodes, g_pal_sec.topo_info.online_nodes);
+
+    return 0;
+}
+
 size_t _DkRandomBitsRead(void* buffer, size_t size) {
     uint32_t rand;
     for (size_t i = 0; i < size; i += sizeof(rand)) {

--- a/Pal/src/host/Linux-SGX/db_main-x86_64.c
+++ b/Pal/src/host/Linux-SGX/db_main-x86_64.c
@@ -150,7 +150,7 @@ int _DkGetCPUInfo(PAL_CPU_INFO* ci) {
     brand[BRAND_SIZE - 1] = '\0';
     ci->cpu_brand = brand;
 
-    ci->online_logical_cores = g_pal_sec.online_logical_cores;
+    ci->num_online_logical_cores = g_pal_sec.num_online_logical_cores;
     ci->physical_cores_per_socket = g_pal_sec.physical_cores_per_socket;
     ci->cpu_socket = g_pal_sec.cpu_socket;
 

--- a/Pal/src/host/Linux-SGX/db_main.c
+++ b/Pal/src/host/Linux-SGX/db_main.c
@@ -279,11 +279,11 @@ noreturn void pal_linux_main(char* uptr_libpal_uri, size_t libpal_uri_len, char*
     g_pal_sec.uid = sec_info.uid;
     g_pal_sec.gid = sec_info.gid;
 
-    int online_logical_cores = sec_info.online_logical_cores;
-    if (online_logical_cores >= 1 && online_logical_cores <= (1 << 16)) {
-        g_pal_sec.online_logical_cores = online_logical_cores;
+    int num_online_logical_cores = sec_info.num_online_logical_cores;
+    if (num_online_logical_cores >= 1 && num_online_logical_cores <= (1 << 16)) {
+        g_pal_sec.num_online_logical_cores = num_online_logical_cores;
     } else {
-        SGX_DBG(DBG_E, "Invalid sec_info.online_logical_cores: %d\n", online_logical_cores);
+        SGX_DBG(DBG_E, "Invalid sec_info.num_online_logical_cores: %d\n", num_online_logical_cores);
         ocall_exit(1, /*is_exitgroup=*/true);
     }
 
@@ -340,14 +340,14 @@ noreturn void pal_linux_main(char* uptr_libpal_uri, size_t libpal_uri_len, char*
     SET_ENCLAVE_TLS(ready_for_exceptions, 1UL);
 
     /* Allocate enclave memory to store "logical core -> socket" mappings */
-    int* cpu_socket = (int*)malloc(online_logical_cores * sizeof(int));
+    int* cpu_socket = (int*)malloc(num_online_logical_cores * sizeof(int));
     if (!cpu_socket) {
         SGX_DBG(DBG_E, "Allocation for logical core -> socket mappings failed\n");
         ocall_exit(1, /*is_exitgroup=*/true);
     }
 
-    if (!sgx_copy_to_enclave(cpu_socket, online_logical_cores * sizeof(int), sec_info.cpu_socket,
-                             online_logical_cores * sizeof(int))) {
+    if (!sgx_copy_to_enclave(cpu_socket, num_online_logical_cores * sizeof(int), sec_info.cpu_socket,
+                             num_online_logical_cores * sizeof(int))) {
         SGX_DBG(DBG_E, "Copying cpu_socket into the enclave failed\n");
         ocall_exit(1, /*is_exitgroup=*/true);
     }

--- a/Pal/src/host/Linux-SGX/enclave_ocalls.c
+++ b/Pal/src/host/Linux-SGX/enclave_ocalls.c
@@ -1501,7 +1501,7 @@ int ocall_sched_setaffinity(void* tcs, size_t cpumask_size, void* cpu_mask) {
 
 static bool is_cpumask_valid(void* cpu_mask, size_t cpumask_size) {
     size_t max_cpumask_bits = cpumask_size * BITS_IN_BYTE;
-    size_t valid_cpumask_bits = g_pal_control.cpu_info.online_logical_cores;
+    size_t valid_cpumask_bits = g_pal_control.cpu_info.num_online_logical_cores;
     size_t invalid_bits = max_cpumask_bits - valid_cpumask_bits;
 
     if (invalid_bits == 0)

--- a/Pal/src/host/Linux-SGX/pal_security.h
+++ b/Pal/src/host/Linux-SGX/pal_security.h
@@ -37,8 +37,10 @@ struct pal_sec {
     PAL_SEC_STR pipe_prefix;
 
     PAL_NUM num_online_logical_cores;
+    PAL_NUM num_possible_logical_cores;
     PAL_NUM physical_cores_per_socket;
     int* cpu_socket;
+    PAL_TOPO_INFO topo_info;
 
 #ifdef DEBUG
     PAL_BOL in_gdb;

--- a/Pal/src/host/Linux-SGX/pal_security.h
+++ b/Pal/src/host/Linux-SGX/pal_security.h
@@ -36,7 +36,7 @@ struct pal_sec {
     /* additional information */
     PAL_SEC_STR pipe_prefix;
 
-    PAL_NUM online_logical_cores;
+    PAL_NUM num_online_logical_cores;
     PAL_NUM physical_cores_per_socket;
     int* cpu_socket;
 

--- a/Pal/src/host/Linux/db_files.c
+++ b/Pal/src/host/Linux/db_files.c
@@ -361,26 +361,6 @@ static int dir_open(PAL_HANDLE* handle, const char* type, const char* uri, int a
     return 0;
 }
 
-struct linux_dirent64 {
-    unsigned long  d_ino;
-    unsigned long  d_off;
-    unsigned short d_reclen;
-    unsigned char  d_type;
-    char           d_name[];
-};
-
-#define DT_UNKNOWN 0
-#define DT_FIFO    1
-#define DT_CHR     2
-#define DT_DIR     4
-#define DT_BLK     6
-#define DT_REG     8
-#define DT_LNK     10
-#define DT_SOCK    12
-#define DT_WHT     14
-
-#define DIRBUF_SIZE 1024
-
 static inline bool is_dot_or_dotdot(const char* name) {
     return (name[0] == '.' && !name[1]) || (name[0] == '.' && name[1] == '.' && !name[2]);
 }

--- a/Pal/src/host/Linux/db_main.c
+++ b/Pal/src/host/Linux/db_main.c
@@ -327,11 +327,238 @@ ssize_t read_file_buffer(const char* filename, char* buf, size_t buf_size) {
     int fd;
 
     fd = INLINE_SYSCALL(open, 2, filename, O_RDONLY);
-    if (fd < 0)
-        return fd;
+    if (IS_ERR(fd))
+        return unix_to_pal_error(ERRNO(fd));
 
     ssize_t n = INLINE_SYSCALL(read, 3, fd, buf, buf_size);
     INLINE_SYSCALL(close, 1, fd);
+    if (IS_ERR(n))
+        return unix_to_pal_error(ERRNO(n));
 
     return n;
+}
+
+int get_num_cache_level(const char* path) {
+    char buf[1024];
+    int bpos;
+    int nread;
+    int num_dirs = 0;
+    struct linux_dirent64* dirent64;
+
+    int fd = INLINE_SYSCALL(open, 2, path, O_RDONLY | O_DIRECTORY);
+    if (IS_ERR(fd))
+        return unix_to_pal_error(ERRNO(fd));
+
+    while (1) {
+        nread = INLINE_SYSCALL(getdents64, 3, fd, buf, 1024);
+        if (IS_ERR(nread))
+            return unix_to_pal_error(ERRNO(nread));
+
+        if (nread == 0)
+            break;
+
+        for (bpos = 0; bpos < nread;) {
+            dirent64 = (struct linux_dirent64*)(buf + bpos);
+            if (dirent64->d_type == DT_DIR && strncmp (dirent64->d_name, "index", 5) == 0)
+                num_dirs++;
+            bpos += dirent64->d_reclen;
+        }
+    }
+
+    INLINE_SYSCALL(close, 1, fd);
+    if (num_dirs)
+        return num_dirs;
+
+    return -PAL_ERROR_STREAMNOTEXIST;;
+}
+
+/*Get Core topology related info*/
+int get_core_topo_info(PAL_TOPO_INFO* topo_info) {
+    int num_online_logical_cores = get_hw_resource("/sys/devices/system/cpu/online",
+                                                   /*count=*/true);
+    if (num_online_logical_cores < 0)
+        return num_online_logical_cores;
+
+    int ret = read_file_buffer("/sys/devices/system/cpu/online", topo_info->online_logical_cores,
+                               PAL_SYSFS_BUF_FILESZ);
+    if (ret < 0)
+        return ret;
+    topo_info->online_logical_cores[ret] = '\0';
+
+    ret = read_file_buffer("/sys/devices/system/cpu/possible", topo_info->possible_logical_cores,
+                           PAL_SYSFS_BUF_FILESZ);
+    if (ret < 0)
+        return ret;
+    topo_info->possible_logical_cores[ret] = '\0';
+
+    int num_cache_lvl = get_num_cache_level("/sys/devices/system/cpu/cpu0/cache");
+    if (num_cache_lvl < 0)
+        return num_cache_lvl;
+    topo_info->num_cache_index = num_cache_lvl;
+    PAL_CORE_CACHE_INFO* core_cache;
+
+    PAL_CORE_TOPO_INFO* core_topology = (PAL_CORE_TOPO_INFO*)malloc(num_online_logical_cores *
+                                                                    sizeof(PAL_CORE_TOPO_INFO));
+    if (!core_topology)
+        return -PAL_ERROR_NOMEM;
+
+    char filename[128];
+    for (int idx = 0; idx < num_online_logical_cores; idx++) {
+        /* cpu0 is always online and so this file is not present */
+        if (idx != 0) {
+            snprintf(filename, sizeof(filename), "/sys/devices/system/cpu/cpu%d/online", idx);
+            ret = read_file_buffer(filename, core_topology[idx].is_logical_core_online,
+                                   PAL_SYSFS_INT_FILESZ);
+            if (ret < 0)
+                goto out_topology;
+            core_topology[idx].is_logical_core_online[ret] = '\0';
+        }
+
+        snprintf(filename, sizeof(filename), "/sys/devices/system/cpu/cpu%d/topology/core_id", idx);
+        ret = read_file_buffer(filename, core_topology[idx].core_id, PAL_SYSFS_INT_FILESZ);
+        if (ret < 0)
+            goto out_topology;
+        core_topology[idx].core_id[ret] = '\0';
+
+        snprintf(filename, sizeof(filename),
+                 "/sys/devices/system/cpu/cpu%d/topology/core_siblings", idx);
+        ret = read_file_buffer(filename, core_topology[idx].core_siblings, PAL_SYSFS_MAP_FILESZ);
+        if (ret < 0)
+            goto out_topology;
+        core_topology[idx].core_siblings[ret] = '\0';
+
+        snprintf(filename, sizeof(filename),
+                 "/sys/devices/system/cpu/cpu%d/topology/thread_siblings", idx);
+        ret = read_file_buffer(filename, core_topology[idx].thread_siblings, PAL_SYSFS_MAP_FILESZ);
+        if (ret < 0)
+            goto out_topology;
+        core_topology[idx].thread_siblings[ret] = '\0';
+
+        core_cache = (PAL_CORE_CACHE_INFO*)malloc(num_cache_lvl * sizeof(PAL_CORE_CACHE_INFO));
+        if (!core_cache) {
+            ret = -PAL_ERROR_NOMEM;
+            goto out_topology;
+        }
+
+        for (int lvl = 0; lvl < num_cache_lvl; lvl++) {
+            snprintf(filename, sizeof(filename),
+                     "/sys/devices/system/cpu/cpu%d/cache/index%d/shared_cpu_map", idx, lvl);
+            ret = read_file_buffer(filename, core_cache[lvl].shared_cpu_map, PAL_SYSFS_MAP_FILESZ);
+            if (ret < 0)
+                goto out_cache;
+            core_cache[lvl].shared_cpu_map[ret] = '\0';
+
+            snprintf(filename, sizeof(filename),
+                     "/sys/devices/system/cpu/cpu%d/cache/index%d/level", idx, lvl);
+            ret = read_file_buffer(filename, core_cache[lvl].level, PAL_SYSFS_INT_FILESZ);
+            if (ret < 0)
+                goto out_cache;
+            core_cache[lvl].level[ret] = '\0';
+
+            snprintf(filename, sizeof(filename),
+                     "/sys/devices/system/cpu/cpu%d/cache/index%d/type", idx, lvl);
+            ret = read_file_buffer(filename, core_cache[lvl].type, PAL_SYSFS_BUF_FILESZ);
+            if (ret < 0)
+                goto out_cache;
+            core_cache[lvl].type[ret] = '\0';
+
+            snprintf(filename, sizeof(filename),
+                     "/sys/devices/system/cpu/cpu%d/cache/index%d/size", idx, lvl);
+            ret = read_file_buffer(filename, core_cache[lvl].size, PAL_SYSFS_BUF_FILESZ);
+            if (ret < 0)
+                goto out_cache;
+            core_cache[lvl].size[ret] = '\0';
+
+            snprintf(filename, sizeof(filename),
+                     "/sys/devices/system/cpu/cpu%d/cache/index%d/coherency_line_size", idx, lvl);
+            ret = read_file_buffer(filename, core_cache[lvl].coherency_line_size,
+                                   PAL_SYSFS_INT_FILESZ);
+            if (ret < 0)
+                goto out_cache;
+            core_cache[lvl].coherency_line_size[ret] = '\0';
+
+            snprintf(filename, sizeof(filename),
+                     "/sys/devices/system/cpu/cpu%d/cache/index%d/number_of_sets", idx, lvl);
+            ret = read_file_buffer(filename, core_cache[lvl].number_of_sets, PAL_SYSFS_INT_FILESZ);
+            if (ret < 0)
+                goto out_cache;
+            core_cache[lvl].number_of_sets[ret] = '\0';
+
+            snprintf(filename, sizeof(filename),
+                     "/sys/devices/system/cpu/cpu%d/cache/index%d/physical_line_partition", idx,
+                     lvl);
+            ret = read_file_buffer(filename, core_cache[lvl].physical_line_partition,
+                                   PAL_SYSFS_INT_FILESZ);
+            if (ret < 0)
+                goto out_cache;
+            core_cache[lvl].physical_line_partition[ret] = '\0';
+        }
+        core_topology[idx].cache = core_cache;
+    }
+    topo_info->core_topology = core_topology;
+    return 0;
+
+out_cache:
+    free(core_cache);
+out_topology:
+    free(core_topology);
+    return ret;
+}
+
+/*Get Numa topology related info*/
+int get_numa_topo_info(PAL_TOPO_INFO* topo_info) {
+    int ret = read_file_buffer("/sys/devices/system/node/online", topo_info->online_nodes,
+                               PAL_SYSFS_BUF_FILESZ);
+    if (ret < 0)
+        return ret;
+    topo_info->online_nodes[ret] = '\0';
+
+    int num_nodes = get_hw_resource("/sys/devices/system/node/online", /*count=*/true);
+    if (num_nodes < 0)
+        return num_nodes;
+    topo_info->num_online_nodes = num_nodes;
+
+    PAL_NUMA_TOPO_INFO* numa_topology = (PAL_NUMA_TOPO_INFO*)malloc(num_nodes *
+                                                                    sizeof(PAL_NUMA_TOPO_INFO));
+    if (!numa_topology)
+        return -ENOMEM;
+
+    char filename[128];
+    for (int idx = 0; idx < num_nodes; idx++) {
+        snprintf(filename, sizeof(filename), "/sys/devices/system/node/node%d/cpumap", idx);
+        ret = read_file_buffer(filename, numa_topology[idx].cpumap, PAL_SYSFS_MAP_FILESZ);
+        if (ret < 0)
+            goto out_topology;
+        numa_topology[idx].cpumap[ret] = '\0';
+
+        snprintf(filename, sizeof(filename), "/sys/devices/system/node/node%d/distance", idx);
+        ret = read_file_buffer(filename, numa_topology[idx].distance, PAL_SYSFS_INT_FILESZ);
+        if (ret < 0)
+            goto out_topology;
+        numa_topology[idx].distance[ret] = '\0';
+
+        /* Collect hugepages info*/
+        snprintf(filename, sizeof(filename),
+                 "/sys/devices/system/node/node%d/hugepages/hugepages-2048kB/nr_hugepages", idx);
+        ret = read_file_buffer(filename, numa_topology[idx].hugepages[HUGEPAGES_2M].nr_hugepages,
+                               PAL_SYSFS_INT_FILESZ);
+        if (ret < 0)
+            goto out_topology;
+        numa_topology[idx].hugepages[HUGEPAGES_2M].nr_hugepages[ret] = '\0';
+
+        snprintf(filename, sizeof(filename),
+                 "/sys/devices/system/node/node%d/hugepages/hugepages-1048576kB/nr_hugepages", idx);
+        ret = read_file_buffer(filename, numa_topology[idx].hugepages[HUGEPAGES_1G].nr_hugepages,
+                               PAL_SYSFS_INT_FILESZ);
+        if (ret < 0)
+            goto out_topology;
+        numa_topology[idx].hugepages[HUGEPAGES_1G].nr_hugepages[ret] = '\0';
+
+    }
+    topo_info->numa_topology = numa_topology;
+    return 0;
+
+out_topology:
+    free(numa_topology);
+    return ret;
 }

--- a/Pal/src/host/Linux/pal_linux.h
+++ b/Pal/src/host/Linux/pal_linux.h
@@ -128,6 +128,9 @@ void init_child_process(int parent_pipe_fd, PAL_HANDLE* parent, PAL_HANDLE* exec
 
 int get_hw_resource(const char* filename, bool count);
 ssize_t read_file_buffer(const char* filename, char* buf, size_t buf_size);
+int get_num_cache_level(const char* path);
+int get_core_topo_info(PAL_TOPO_INFO* topo_info);
+int get_numa_topo_info(PAL_TOPO_INFO* topo_info);
 
 void cpuid(unsigned int leaf, unsigned int subleaf, unsigned int words[]);
 int block_async_signals(bool block);
@@ -164,5 +167,25 @@ int pal_thread_init(void* tcbptr);
 static inline PAL_TCB_LINUX* get_tcb_linux(void) {
     return (PAL_TCB_LINUX*)pal_get_tcb();
 }
+
+struct linux_dirent64 {
+    unsigned long  d_ino;
+    unsigned long  d_off;
+    unsigned short d_reclen;
+    unsigned char  d_type;
+    char           d_name[];
+};
+
+#define DT_UNKNOWN 0
+#define DT_FIFO    1
+#define DT_CHR     2
+#define DT_DIR     4
+#define DT_BLK     6
+#define DT_REG     8
+#define DT_LNK     10
+#define DT_SOCK    12
+#define DT_WHT     14
+
+#define DIRBUF_SIZE 1024
 
 #endif /* PAL_LINUX_H */

--- a/Pal/src/pal_internal.h
+++ b/Pal/src/pal_internal.h
@@ -205,6 +205,7 @@ unsigned long _DkMemoryQuota(void);
 unsigned long _DkMemoryAvailableQuota(void);
 // Returns 0 on success, negative PAL code on failure
 int _DkGetCPUInfo(PAL_CPU_INFO* info);
+int _DkGetTopologyInfo(PAL_TOPO_INFO* topo_info);
 
 /* Internal DK calls, in case any of the internal routines needs to use them */
 /* DkStream calls */


### PR DESCRIPTION

## Description of the changes <!-- (reasons and measures) -->
This PR adds support for /sys pseudo-filesystem which in turn helps to enable open-source libraries such as "Hardware Locality" to relay underlying hardware topology-related information to applications. This is critical for ML benchmarks which seem to use topology-related info for better scheduling of threads.

 Fixes #1783 

## How to test this PR? <!-- (if applicable) -->
Please use the newly added regression test "sysfs_common.c" to test the PR. Another option would be to run openVINO benchmark which exercies lot flows introduced in this PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1970)
<!-- Reviewable:end -->
