### PR TITLE
Introduce human-readable file permission helpers

### DIFF
--- a/Documentation/devel/coding-style.rst
+++ b/Documentation/devel/coding-style.rst
@@ -113,7 +113,7 @@ Code formatting
       bool asdf = true;
       file->size      = 123;
       file->full_path = "/asdf/ghjkl";
-      file->perms     = 0644;
+      file->perms     = PERM_rw_r__r__;
 
 Conventions and high-level style
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/LibOS/shim/include/shim_fs.h
+++ b/LibOS/shim/include/shim_fs.h
@@ -8,8 +8,6 @@
 #ifndef _SHIM_FS_H_
 #define _SHIM_FS_H_
 
-#define __KERNEL__
-#include <linux/stat.h>
 #include <stdbool.h>
 
 #include "list.h"
@@ -18,6 +16,7 @@
 #include "shim_handle.h"
 #include "shim_types.h"
 #include "shim_utils.h"
+#include "stat.h"
 
 struct shim_handle;
 

--- a/LibOS/shim/include/shim_fs.h
+++ b/LibOS/shim/include/shim_fs.h
@@ -9,6 +9,7 @@
 #define _SHIM_FS_H_
 
 #include <stdbool.h>
+#include <asm/stat.h>
 
 #include "list.h"
 #include "pal.h"
@@ -16,7 +17,6 @@
 #include "shim_handle.h"
 #include "shim_types.h"
 #include "shim_utils.h"
-#include "stat.h"
 
 struct shim_handle;
 

--- a/LibOS/shim/include/shim_types.h
+++ b/LibOS/shim/include/shim_types.h
@@ -5,8 +5,6 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#define __KERNEL__
-
 #include <asm/poll.h>
 #include <asm/posix_types.h>
 #include <asm/siginfo.h>

--- a/LibOS/shim/src/fs/chroot/fs.c
+++ b/LibOS/shim/src/fs/chroot/fs.c
@@ -5,6 +5,12 @@
  * This file contains code for implementation of 'chroot' filesystem.
  */
 
+#include <asm/fcntl.h>
+#include <asm/mman.h>
+#include <asm/unistd.h>
+#include <errno.h>
+#include <linux/fcntl.h>
+
 #include "pal.h"
 #include "pal_error.h"
 #include "shim_flags_conv.h"
@@ -15,12 +21,7 @@
 #include "shim_thread.h"
 #include "shim_utils.h"
 #include "shim_vma.h"
-
-#include <asm/fcntl.h>
-#include <asm/mman.h>
-#include <asm/unistd.h>
-#include <errno.h>
-#include <linux/fcntl.h>
+#include "stat.h"
 
 #define URI_MAX_SIZE STR_SIZE
 

--- a/LibOS/shim/src/fs/chroot/fs.c
+++ b/LibOS/shim/src/fs/chroot/fs.c
@@ -5,7 +5,6 @@
  * This file contains code for implementation of 'chroot' filesystem.
  */
 
-// FIXME: Sorting these includes causes a bunch of "error: ‘S_IFREG’ undeclared" errors.
 #include "pal.h"
 #include "pal_error.h"
 #include "shim_flags_conv.h"
@@ -22,7 +21,6 @@
 #include <asm/unistd.h>
 #include <errno.h>
 #include <linux/fcntl.h>
-#include <linux/stat.h>
 
 #define URI_MAX_SIZE STR_SIZE
 

--- a/LibOS/shim/src/fs/dev/attestation.c
+++ b/LibOS/shim/src/fs/dev/attestation.c
@@ -16,6 +16,7 @@
  */
 
 #include "shim_fs.h"
+#include "stat.h"
 
 /* user_report_data, target_info and quote are opaque blobs of predefined maximum sizes. Currently
  * these sizes are overapproximations of SGX requirements (report_data is 64B, target_info is

--- a/LibOS/shim/src/fs/dev/null.c
+++ b/LibOS/shim/src/fs/dev/null.c
@@ -8,6 +8,7 @@
  */
 
 #include "shim_fs.h"
+#include "stat.h"
 
 static ssize_t dev_null_read(struct shim_handle* hdl, void* buf, size_t count) {
     __UNUSED(hdl);

--- a/LibOS/shim/src/fs/dev/random.c
+++ b/LibOS/shim/src/fs/dev/random.c
@@ -8,6 +8,7 @@
  */
 
 #include "shim_fs.h"
+#include "stat.h"
 
 static ssize_t dev_random_read(struct shim_handle* hdl, void* buf, size_t count) {
     __UNUSED(hdl);

--- a/LibOS/shim/src/fs/dev/std.c
+++ b/LibOS/shim/src/fs/dev/std.c
@@ -8,6 +8,7 @@
  */
 
 #include "shim_fs.h"
+#include "stat.h"
 
 static int dev_std_mode(const char* name, mode_t* mode) {
     __UNUSED(name);

--- a/LibOS/shim/src/fs/dev/zero.c
+++ b/LibOS/shim/src/fs/dev/zero.c
@@ -8,6 +8,7 @@
  */
 
 #include "shim_fs.h"
+#include "stat.h"
 
 static ssize_t dev_zero_read(struct shim_handle* hdl, void* buf, size_t count) {
     __UNUSED(hdl);

--- a/LibOS/shim/src/fs/eventfd/fs.c
+++ b/LibOS/shim/src/fs/eventfd/fs.c
@@ -9,7 +9,6 @@
 #include <asm/unistd.h>
 #include <errno.h>
 #include <linux/fcntl.h>
-#include <linux/stat.h>
 
 #include "pal.h"
 #include "shim_fs.h"

--- a/LibOS/shim/src/fs/pipe/fs.c
+++ b/LibOS/shim/src/fs/pipe/fs.c
@@ -5,8 +5,6 @@
  * This file contains code for implementation of 'pipe' filesystem.
  */
 
-#define __KERNEL__
-
 #include <asm/fcntl.h>
 #include <asm/mman.h>
 #include <asm/unistd.h>
@@ -16,11 +14,13 @@
 #include "pal.h"
 #include "pal_debug.h"
 #include "pal_error.h"
+#include "perm.h"
 #include "shim_fs.h"
 #include "shim_handle.h"
 #include "shim_internal.h"
 #include "shim_lock.h"
 #include "shim_thread.h"
+#include "stat.h"
 
 static ssize_t pipe_read(struct shim_handle* hdl, void* buf, size_t count) {
     if (!hdl->info.pipe.ready_for_ops)

--- a/LibOS/shim/src/fs/pipe/fs.c
+++ b/LibOS/shim/src/fs/pipe/fs.c
@@ -12,7 +12,6 @@
 #include <asm/unistd.h>
 #include <errno.h>
 #include <linux/fcntl.h>
-#include <linux/stat.h>
 
 #include "pal.h"
 #include "pal_debug.h"

--- a/LibOS/shim/src/fs/pipe/fs.c
+++ b/LibOS/shim/src/fs/pipe/fs.c
@@ -76,7 +76,7 @@ static int pipe_hstat(struct shim_handle* hdl, struct stat* stat) {
     stat->st_atime   = (time_t)0;          /* access time */
     stat->st_mtime   = (time_t)0;          /* last modification */
     stat->st_ctime   = (time_t)0;          /* last status change */
-    stat->st_mode    = S_IRUSR | S_IWUSR | S_IFIFO;
+    stat->st_mode    = PERM_rw_______ | S_IFIFO;
 
     return 0;
 }

--- a/LibOS/shim/src/fs/proc/info.c
+++ b/LibOS/shim/src/fs/proc/info.c
@@ -8,6 +8,7 @@
  */
 
 #include "shim_fs.h"
+#include "stat.h"
 
 static int proc_info_mode(const char* name, mode_t* mode) {
     __UNUSED(name);

--- a/LibOS/shim/src/fs/proc/ipc-thread.c
+++ b/LibOS/shim/src/fs/proc/ipc-thread.c
@@ -5,7 +5,6 @@
 #include <asm/unistd.h>
 #include <errno.h>
 #include <linux/fcntl.h>
-#include <linux/stat.h>
 
 #include "pal.h"
 #include "pal_error.h"

--- a/LibOS/shim/src/fs/proc/ipc-thread.c
+++ b/LibOS/shim/src/fs/proc/ipc-thread.c
@@ -1,5 +1,3 @@
-#define __KERNEL__
-
 #include <asm/fcntl.h>
 #include <asm/mman.h>
 #include <asm/unistd.h>
@@ -8,6 +6,7 @@
 
 #include "pal.h"
 #include "pal_error.h"
+#include "perm.h"
 #include "shim_fs.h"
 #include "shim_handle.h"
 #include "shim_internal.h"
@@ -16,6 +15,7 @@
 #include "shim_table.h"
 #include "shim_thread.h"
 #include "shim_utils.h"
+#include "stat.h"
 
 static int parse_ipc_thread_name(const char* name, IDTYPE* pidptr, const char** next,
                                  size_t* next_len, const char** nextnext) {

--- a/LibOS/shim/src/fs/proc/ipc-thread.c
+++ b/LibOS/shim/src/fs/proc/ipc-thread.c
@@ -224,7 +224,7 @@ static int proc_ipc_thread_dir_mode(const char* name, mode_t* mode) {
         for (size_t i = 0; i < pid_status_cache->nstatus; i++)
             if (pid_status_cache->status[i].pid == pid) {
                 unlock(&status_lock);
-                *mode = 0500;
+                *mode = PERM_r_x______;
                 return 0;
             }
 
@@ -250,7 +250,7 @@ static int proc_ipc_thread_dir_stat(const char* name, struct stat* buf) {
             if (pid_status_cache->status[i].pid == pid) {
                 memset(buf, 0, sizeof(struct stat));
                 buf->st_dev = buf->st_ino = 1;
-                buf->st_mode              = 0500 | S_IFDIR;
+                buf->st_mode              = PERM_r_x______ | S_IFDIR;
                 buf->st_uid               = 0; /* XXX */
                 buf->st_gid               = 0; /* XXX */
                 buf->st_size              = 4096;

--- a/LibOS/shim/src/fs/proc/thread.c
+++ b/LibOS/shim/src/fs/proc/thread.c
@@ -576,7 +576,7 @@ err:
 static int proc_thread_maps_mode(const char* name, mode_t* mode) {
     // Only used by one file
     __UNUSED(name);
-    *mode = 0400;
+    *mode = PERM_r________;
     return 0;
 }
 
@@ -586,7 +586,7 @@ static int proc_thread_maps_stat(const char* name, struct stat* buf) {
     memset(buf, 0, sizeof(struct stat));
 
     buf->st_dev = buf->st_ino = 1;
-    buf->st_mode              = 0400 | S_IFREG;
+    buf->st_mode              = PERM_r________ | S_IFREG;
     buf->st_uid               = 0;
     buf->st_gid               = 0;
     buf->st_size              = 0;
@@ -621,7 +621,7 @@ static int proc_thread_dir_mode(const char* name, mode_t* mode) {
     if (ret < 0)
         return ret;
 
-    *mode = 0500;
+    *mode = PERM_r_x______;
     return 0;
 }
 
@@ -640,7 +640,7 @@ static int proc_thread_dir_stat(const char* name, struct stat* buf) {
 
     memset(buf, 0, sizeof(struct stat));
     buf->st_dev = buf->st_ino = 1;
-    buf->st_mode              = 0500 | S_IFDIR;
+    buf->st_mode              = PERM_r_x______ | S_IFDIR;
     lock(&thread->lock);
     buf->st_uid = thread->uid;
     buf->st_gid = thread->gid;

--- a/LibOS/shim/src/fs/proc/thread.c
+++ b/LibOS/shim/src/fs/proc/thread.c
@@ -5,7 +5,6 @@
 #include <asm/unistd.h>
 #include <errno.h>
 #include <linux/fcntl.h>
-#include <linux/stat.h>
 
 #include "pal.h"
 #include "pal_error.h"

--- a/LibOS/shim/src/fs/proc/thread.c
+++ b/LibOS/shim/src/fs/proc/thread.c
@@ -1,5 +1,3 @@
-#define __KERNEL__
-
 #include <asm/fcntl.h>
 #include <asm/mman.h>
 #include <asm/unistd.h>
@@ -8,6 +6,7 @@
 
 #include "pal.h"
 #include "pal_error.h"
+#include "perm.h"
 #include "shim_fs.h"
 #include "shim_handle.h"
 #include "shim_internal.h"
@@ -15,6 +14,7 @@
 #include "shim_table.h"
 #include "shim_thread.h"
 #include "shim_utils.h"
+#include "stat.h"
 
 static int parse_thread_name(const char* name, IDTYPE* pidptr, const char** next, size_t* next_len,
                              const char** nextnext) {

--- a/LibOS/shim/src/fs/shim_fs_pseudo.c
+++ b/LibOS/shim/src/fs/shim_fs_pseudo.c
@@ -10,6 +10,7 @@
  */
 
 #include "shim_fs.h"
+#include "stat.h"
 
 /*!
  * \brief Find entry corresponding to path, starting from \p root_ent.

--- a/LibOS/shim/src/fs/shim_namei.c
+++ b/LibOS/shim/src/fs/shim_namei.c
@@ -16,6 +16,7 @@
 #include "shim_lock.h"
 #include "shim_thread.h"
 #include "shim_utils.h"
+#include "stat.h"
 
 /* Advances a char pointer (string) past any repeated slashes and returns the result.
  * Must be a null-terminated string. */

--- a/LibOS/shim/src/fs/shim_namei.c
+++ b/LibOS/shim/src/fs/shim_namei.c
@@ -7,7 +7,6 @@
 
 #include <asm/fcntl.h>
 #include <linux/fcntl.h>
-#include <linux/stat.h>
 #include <stdbool.h>
 
 #include "pal.h"

--- a/LibOS/shim/src/fs/socket/fs.c
+++ b/LibOS/shim/src/fs/socket/fs.c
@@ -5,8 +5,6 @@
  * This file contains code for implementation of 'socket' filesystem.
  */
 
-#define __KERNEL__
-
 #include <asm/fcntl.h>
 #include <asm/mman.h>
 #include <asm/unistd.h>
@@ -19,6 +17,7 @@
 #include "shim_internal.h"
 #include "shim_lock.h"
 #include "shim_thread.h"
+#include "stat.h"
 
 static int socket_close(struct shim_handle* hdl) {
     /* XXX: Shouldn't this do something? */

--- a/LibOS/shim/src/fs/socket/fs.c
+++ b/LibOS/shim/src/fs/socket/fs.c
@@ -12,7 +12,6 @@
 #include <asm/unistd.h>
 #include <errno.h>
 #include <linux/fcntl.h>
-#include <linux/stat.h>
 
 #include "pal.h"
 #include "pal_error.h"

--- a/LibOS/shim/src/fs/str/fs.c
+++ b/LibOS/shim/src/fs/str/fs.c
@@ -10,7 +10,6 @@
 #include <asm/unistd.h>
 #include <errno.h>
 #include <linux/fcntl.h>
-#include <linux/stat.h>
 
 #include "pal.h"
 #include "pal_error.h"

--- a/LibOS/shim/src/shim_parser.c
+++ b/LibOS/shim/src/shim_parser.c
@@ -15,7 +15,6 @@
 #include <linux/in.h>
 #include <linux/in6.h>
 #include <linux/sched.h>
-#include <linux/stat.h>
 #include <linux/un.h>
 #include <linux/wait.h>
 
@@ -28,6 +27,7 @@
 #include "shim_tcb.h"
 #include "shim_thread.h"
 #include "shim_utils.h"
+#include "stat.h"
 
 static void parse_open_flags(va_list*);
 static void parse_open_mode(va_list*);

--- a/LibOS/shim/src/sys/shim_exec.c
+++ b/LibOS/shim/src/sys/shim_exec.c
@@ -19,6 +19,7 @@
 #include "shim_lock.h"
 #include "shim_table.h"
 #include "shim_thread.h"
+#include "stat.h"
 
 /* returns 0 if normalized URIs are the same; assumes file URIs */
 static int normalize_and_cmp_uris(const char* uri1, const char* uri2) {

--- a/LibOS/shim/src/sys/shim_fs.c
+++ b/LibOS/shim/src/sys/shim_fs.c
@@ -6,8 +6,6 @@
  * "chmod", "fchmod", "fchmodat", "rename", "renameat" and "sendfile".
  */
 
-#define __KERNEL__
-
 #include <asm/mman.h>
 #include <errno.h>
 #include <linux/fcntl.h>
@@ -21,6 +19,7 @@
 #include "shim_table.h"
 #include "shim_thread.h"
 #include "shim_utils.h"
+#include "stat.h"
 
 /* The kernel would look up the parent directory, and remove the child from the inode. But we are
  * working with the PAL, so we open the file, truncate and close it. */

--- a/LibOS/shim/src/sys/shim_fs.c
+++ b/LibOS/shim/src/sys/shim_fs.c
@@ -11,7 +11,6 @@
 #include <asm/mman.h>
 #include <errno.h>
 #include <linux/fcntl.h>
-#include <linux/stat.h>
 
 #include "pal.h"
 #include "pal_error.h"

--- a/LibOS/shim/src/sys/shim_msgget.c
+++ b/LibOS/shim/src/sys/shim_msgget.c
@@ -22,6 +22,7 @@
 #include "shim_table.h"
 #include "shim_types.h"
 #include "shim_utils.h"
+#include "stat.h"
 
 #define MSGQ_HASH_LEN  8
 #define MSGQ_HASH_NUM  (1 << MSGQ_HASH_LEN)
@@ -683,7 +684,7 @@ static int __store_msg_persist(struct shim_msg_handle* msgq) {
     char fileuri[20];
     snprintf(fileuri, 20, URI_PREFIX_FILE "msgq.%08x", msgq->msqid);
 
-    PAL_HANDLE file = DkStreamOpen(fileuri, PAL_ACCESS_RDWR, 0600, PAL_CREATE_TRY, 0);
+    PAL_HANDLE file = DkStreamOpen(fileuri, PAL_ACCESS_RDWR, PERM_rw_______, PAL_CREATE_TRY, 0);
     if (!file) {
         ret = -PAL_ERRNO();
         goto out;

--- a/LibOS/shim/src/sys/shim_msgget.c
+++ b/LibOS/shim/src/sys/shim_msgget.c
@@ -14,6 +14,7 @@
 #include "list.h"
 #include "pal.h"
 #include "pal_error.h"
+#include "perm.h"
 #include "shim_handle.h"
 #include "shim_internal.h"
 #include "shim_ipc.h"

--- a/LibOS/shim/src/sys/shim_open.c
+++ b/LibOS/shim/src/sys/shim_open.c
@@ -20,7 +20,6 @@
 
 #include <errno.h>
 #include <dirent.h>
-#include <linux/stat.h>
 #include <linux/fcntl.h>
 
 int do_handle_read(struct shim_handle* hdl, void* buf, int count) {

--- a/LibOS/shim/src/sys/shim_open.c
+++ b/LibOS/shim/src/sys/shim_open.c
@@ -6,7 +6,12 @@
  * "pread64", "pwrite64", "getdents", "getdents64", "fsync", "truncate" and "ftruncate".
  */
 
-// FIXME: Moving Linux includes first causes a bunch of "error: ‘S_IFLNK’ undeclared" errors.
+#include <dirent.h>
+#include <errno.h>
+#include <linux/fcntl.h>
+
+#include "pal.h"
+#include "pal_error.h"
 #include "shim_fs.h"
 #include "shim_handle.h"
 #include "shim_internal.h"
@@ -14,13 +19,7 @@
 #include "shim_table.h"
 #include "shim_thread.h"
 #include "shim_utils.h"
-
-#include "pal.h"
-#include "pal_error.h"
-
-#include <errno.h>
-#include <dirent.h>
-#include <linux/fcntl.h>
+#include "stat.h"
 
 int do_handle_read(struct shim_handle* hdl, void* buf, int count) {
     if (!(hdl->acc_mode & MAY_READ))

--- a/LibOS/shim/src/sys/shim_pipe.c
+++ b/LibOS/shim/src/sys/shim_pipe.c
@@ -249,7 +249,7 @@ int shim_do_mknodat(int dirfd, const char* pathname, mode_t mode, dev_t dev) {
         /* FIXME: Graphene assumes that file is at least readable by owner, in particular, see
          *        unlink() emulation that uses DkStreamOpen(). We change empty mode to readable
          *        by user here to allow a consequent unlink. Was detected on LTP mknod tests. */
-        int fd = shim_do_openat(dirfd, pathname, O_CREAT | O_EXCL, mode ?: S_IRUSR);
+        int fd = shim_do_openat(dirfd, pathname, O_CREAT | O_EXCL, mode ?: PERM_r________);
         if (fd < 0)
             return fd;
         return shim_do_close(fd);

--- a/LibOS/shim/src/sys/shim_pipe.c
+++ b/LibOS/shim/src/sys/shim_pipe.c
@@ -10,6 +10,7 @@
 
 #include "pal.h"
 #include "pal_error.h"
+#include "perm.h"
 #include "shim_flags_conv.h"
 #include "shim_fs.h"
 #include "shim_handle.h"
@@ -17,6 +18,7 @@
 #include "shim_table.h"
 #include "shim_types.h"
 #include "shim_utils.h"
+#include "stat.h"
 
 static int create_pipes(struct shim_handle* srv, struct shim_handle* cli, int flags, char* name,
                         struct shim_qstr* qstr) {

--- a/Pal/include/host/Linux-common/pal_flags_conv.h
+++ b/Pal/include/host/Linux-common/pal_flags_conv.h
@@ -15,7 +15,6 @@
 #undef __GLIBC__
 #include <asm/fcntl.h>
 #include <linux/mman.h>
-#include <linux/stat.h>
 #include <sys/types.h>
 
 #include "assert.h"

--- a/Pal/include/host/Linux-common/pal_flags_conv.h
+++ b/Pal/include/host/Linux-common/pal_flags_conv.h
@@ -12,7 +12,6 @@
 #ifndef PAL_FLAGS_CONV_H
 #define PAL_FLAGS_CONV_H
 
-#undef __GLIBC__
 #include <asm/fcntl.h>
 #include <linux/mman.h>
 #include <sys/types.h>

--- a/Pal/include/lib/perm.h
+++ b/Pal/include/lib/perm.h
@@ -1,0 +1,34 @@
+/* SPDX-License-Identifier: LGPL-3.0-or-later */
+/* Copyright (C) 2020 Intel Corporation
+ *                    Paweł Marczewski <pawel@invisiblethingslab.com>
+ */
+
+/*
+ * Human-readable macros for common file permissions.
+ * Inspired by Linux patch by Ingo Molnar (https://lwn.net/Articles/696231/).
+ */
+
+#ifndef PERM_H
+#define PERM_H
+
+#define PERM_r________  0400
+#define PERM_r__r_____  0440
+#define PERM_r__r__r__  0444
+
+#define PERM_rw_______  0600
+#define PERM_rw_r_____  0640
+#define PERM_rw_r__r__  0644
+#define PERM_rw_rw_r__  0664
+#define PERM_rw_rw_rw_  0666
+
+#define PERM_r_x______  0500
+#define PERM_r_xr_x___  0550
+#define PERM_r_xr_xr_x  0555
+
+#define PERM_rwx______  0700
+#define PERM_rwxr_x___  0750
+#define PERM_rwxr_xr_x  0755
+#define PERM_rwxrwxr_x  0775
+#define PERM_rwxrwxrwx  0777
+
+#endif /* PERM_H */

--- a/Pal/include/lib/stat.h
+++ b/Pal/include/lib/stat.h
@@ -1,0 +1,52 @@
+/* SPDX-License-Identifier: LGPL-3.0-or-later */
+/* Copyright (C) 2020 Intel Corporation
+ *                    Paweł Marczewski <pawel@invisiblethingslab.com>
+ */
+
+/*
+ * Linux file type permission macros.
+ */
+
+#ifndef STAT_H
+#define STAT_H
+
+#ifdef S_IFREG
+#error "Do not include <linux/stat.h> or <sys/stat.h> together with this file."
+#endif
+
+#define S_IFMT  00170000
+#define S_IFSOCK 0140000
+#define S_IFLNK  0120000
+#define S_IFREG  0100000
+#define S_IFBLK  0060000
+#define S_IFDIR  0040000
+#define S_IFCHR  0020000
+#define S_IFIFO  0010000
+#define S_ISUID  0004000
+#define S_ISGID  0002000
+#define S_ISVTX  0001000
+
+#define S_ISLNK(m)      (((m) & S_IFMT) == S_IFLNK)
+#define S_ISREG(m)      (((m) & S_IFMT) == S_IFREG)
+#define S_ISDIR(m)      (((m) & S_IFMT) == S_IFDIR)
+#define S_ISCHR(m)      (((m) & S_IFMT) == S_IFCHR)
+#define S_ISBLK(m)      (((m) & S_IFMT) == S_IFBLK)
+#define S_ISFIFO(m)     (((m) & S_IFMT) == S_IFIFO)
+#define S_ISSOCK(m)     (((m) & S_IFMT) == S_IFSOCK)
+
+#define S_IRWXU 00700
+#define S_IRUSR 00400
+#define S_IWUSR 00200
+#define S_IXUSR 00100
+
+#define S_IRWXG 00070
+#define S_IRGRP 00040
+#define S_IWGRP 00020
+#define S_IXGRP 00010
+
+#define S_IRWXO 00007
+#define S_IROTH 00004
+#define S_IWOTH 00002
+#define S_IXOTH 00001
+
+#endif /* STAT_H */

--- a/Pal/include/lib/stat.h
+++ b/Pal/include/lib/stat.h
@@ -14,9 +14,6 @@
 #error "Do not include <linux/stat.h> or <sys/stat.h> together with this file."
 #endif
 
-/* Include PERM_* helpers for convenience. */
-#include "perm.h"
-
 #define S_IFMT  00170000
 #define S_IFSOCK 0140000
 #define S_IFLNK  0120000

--- a/Pal/include/lib/stat.h
+++ b/Pal/include/lib/stat.h
@@ -14,6 +14,9 @@
 #error "Do not include <linux/stat.h> or <sys/stat.h> together with this file."
 #endif
 
+/* Include PERM_* helpers for convenience. */
+#include "perm.h"
+
 #define S_IFMT  00170000
 #define S_IFSOCK 0140000
 #define S_IFLNK  0120000

--- a/Pal/src/host/Linux-SGX/db_files.c
+++ b/Pal/src/host/Linux-SGX/db_files.c
@@ -670,7 +670,7 @@ static int file_attrquerybyhdl(PAL_HANDLE handle, PAL_STREAM_ATTR* attr) {
 
 static int file_attrsetbyhdl(PAL_HANDLE handle, PAL_STREAM_ATTR* attr) {
     int fd  = handle->file.fd;
-    int ret = ocall_fchmod(fd, attr->share_flags | 0600);
+    int ret = ocall_fchmod(fd, attr->share_flags | PERM_rw_______);
     if (IS_ERR(ret))
         return unix_to_pal_error(ERRNO(ret));
 

--- a/Pal/src/host/Linux-SGX/db_files.c
+++ b/Pal/src/host/Linux-SGX/db_files.c
@@ -5,6 +5,11 @@
  * This file contains operands to handle streams with URIs that start with "file:" or "dir:".
  */
 
+#include <asm/fcntl.h>
+#include <asm/stat.h>
+#include <linux/fs.h>
+#include <linux/types.h>
+
 #include "api.h"
 #include "pal.h"
 #include "pal_debug.h"
@@ -15,13 +20,8 @@
 #include "pal_linux.h"
 #include "pal_linux_defs.h"
 #include "pal_linux_error.h"
+#include "perm.h"
 #include "stat.h"
-typedef __kernel_pid_t pid_t;
-#undef __GLIBC__
-#include <asm/fcntl.h>
-#include <asm/stat.h>
-#include <linux/fs.h>
-#include <linux/types.h>
 
 #include "enclave_pages.h"
 

--- a/Pal/src/host/Linux-SGX/db_files.c
+++ b/Pal/src/host/Linux-SGX/db_files.c
@@ -15,12 +15,12 @@
 #include "pal_linux.h"
 #include "pal_linux_defs.h"
 #include "pal_linux_error.h"
+#include "stat.h"
 typedef __kernel_pid_t pid_t;
 #undef __GLIBC__
 #include <asm/fcntl.h>
 #include <asm/stat.h>
 #include <linux/fs.h>
-#include <linux/stat.h>
 #include <linux/types.h>
 
 #include "enclave_pages.h"

--- a/Pal/src/host/Linux-SGX/db_pipes.c
+++ b/Pal/src/host/Linux-SGX/db_pipes.c
@@ -5,6 +5,11 @@
  * This file contains operands to handle streams with URIs that start with "pipe:" or "pipe.srv:".
  */
 
+#include <asm/fcntl.h>
+#include <asm/poll.h>
+#include <linux/types.h>
+#include <linux/un.h>
+
 #include "api.h"
 #include "cpu.h"
 #include "pal.h"
@@ -18,11 +23,6 @@
 #include "pal_linux_error.h"
 #include "pal_security.h"
 
-typedef __kernel_pid_t pid_t;
-#include <asm/fcntl.h>
-#include <asm/poll.h>
-#include <linux/types.h>
-#include <linux/un.h>
 
 static int pipe_addr(const char* name, struct sockaddr_un* addr) {
     /* use abstract UNIX sockets for pipes, with name format "@/graphene/<pipename>" */

--- a/Pal/src/host/Linux-SGX/db_process.c
+++ b/Pal/src/host/Linux-SGX/db_process.c
@@ -9,6 +9,7 @@
  * creation.
  */
 
+#include <asm/fcntl.h>
 #include <linux/fs.h>
 #include <linux/sched.h>
 #include <linux/types.h>
@@ -26,8 +27,6 @@
 #include "pal_security.h"
 #include "protected-files/protected_files.h"
 #include "spinlock.h"
-typedef __kernel_pid_t pid_t;
-#include <asm/fcntl.h>
 
 DEFINE_LIST(trusted_child);
 struct trusted_child {

--- a/Pal/src/host/Linux-SGX/db_sockets.c
+++ b/Pal/src/host/Linux-SGX/db_sockets.c
@@ -6,6 +6,8 @@
  * "udp.srv:".
  */
 
+#include <asm-generic/socket.h>
+#include <asm/fcntl.h>
 #include <linux/in.h>
 #include <linux/in6.h>
 #include <linux/poll.h>
@@ -21,9 +23,6 @@
 #include "pal_linux_defs.h"
 #include "pal_linux_error.h"
 #include "pal_security.h"
-typedef __kernel_pid_t pid_t;
-#include <asm-generic/socket.h>
-#include <asm/fcntl.h>
 
 #ifndef SOL_TCP
 #define SOL_TCP 6

--- a/Pal/src/host/Linux-SGX/db_streams.c
+++ b/Pal/src/host/Linux-SGX/db_streams.c
@@ -410,7 +410,7 @@ int _DkInitDebugStream(const char* path) {
             return unix_to_pal_error(ERRNO(ret));
     }
 
-    ret = ocall_open(path, O_WRONLY | O_APPEND | O_CREAT, 0600);
+    ret = ocall_open(path, O_WRONLY | O_APPEND | O_CREAT, PERM_rw_______);
     if (ret < 0)
         return unix_to_pal_error(ERRNO(ret));
     g_debug_fd = ret;

--- a/Pal/src/host/Linux-SGX/db_streams.c
+++ b/Pal/src/host/Linux-SGX/db_streams.c
@@ -5,6 +5,17 @@
  * This file contains APIs to open, read, write and get attribute of streams.
  */
 
+#include <asm/fcntl.h>
+#include <asm/poll.h>
+#include <asm/socket.h>
+#include <asm/stat.h>
+#include <linux/in.h>
+#include <linux/in6.h>
+#include <linux/msg.h>
+#include <linux/socket.h>
+#include <linux/types.h>
+#include <linux/wait.h>
+
 #include "api.h"
 #include "enclave_pages.h"
 #include "pal.h"
@@ -16,19 +27,9 @@
 #include "pal_linux.h"
 #include "pal_linux_defs.h"
 #include "pal_linux_error.h"
+#include "perm.h"
 #include "stat.h"
 
-typedef __kernel_pid_t pid_t;
-#include <asm/fcntl.h>
-#include <asm/poll.h>
-#include <asm/socket.h>
-#include <asm/stat.h>
-#include <linux/in.h>
-#include <linux/in6.h>
-#include <linux/msg.h>
-#include <linux/socket.h>
-#include <linux/types.h>
-#include <linux/wait.h>
 
 #define DUMMYPAYLOAD     "dummypayload"
 #define DUMMYPAYLOADSIZE (sizeof(DUMMYPAYLOAD))

--- a/Pal/src/host/Linux-SGX/db_streams.c
+++ b/Pal/src/host/Linux-SGX/db_streams.c
@@ -16,6 +16,7 @@
 #include "pal_linux.h"
 #include "pal_linux_defs.h"
 #include "pal_linux_error.h"
+#include "stat.h"
 
 typedef __kernel_pid_t pid_t;
 #include <asm/fcntl.h>
@@ -26,7 +27,6 @@ typedef __kernel_pid_t pid_t;
 #include <linux/in6.h>
 #include <linux/msg.h>
 #include <linux/socket.h>
-#include <linux/stat.h>
 #include <linux/types.h>
 #include <linux/wait.h>
 

--- a/Pal/src/host/Linux-SGX/tools/common/pf_util.c
+++ b/Pal/src/host/Linux-SGX/tools/common/pf_util.c
@@ -21,6 +21,7 @@
 #include <unistd.h>
 
 #include "api.h"
+#include "perm.h"
 #include "util.h"
 
 /* High-level protected files helper functions. */
@@ -263,7 +264,7 @@ int pf_encrypt_file(const char* input_path, const char* output_path, const pf_ke
         goto out;
     }
 
-    output = open(output_path, O_RDWR | O_CREAT, 0664);
+    output = open(output_path, O_RDWR | O_CREAT, PERM_rw_rw_r__);
     if (output < 0) {
         ERROR("Failed to create output file '%s': %s\n", output_path, strerror(errno));
         goto out;
@@ -347,7 +348,7 @@ int pf_decrypt_file(const char* input_path, const char* output_path, bool verify
         goto out;
     }
 
-    output = open(output_path, O_RDWR | O_CREAT, 0664);
+    output = open(output_path, O_RDWR | O_CREAT, PERM_rw_rw_r__);
     if (output < 0) {
         ERROR("Failed to create output file '%s': %s\n", output_path, strerror(errno));
         goto out;
@@ -468,7 +469,7 @@ static int process_files(const char* input_dir, const char* output_dir, const ch
             return pf_decrypt_file(input_dir, output_dir, verify_path, &wrap_key);
     }
 
-    ret = mkdir(output_dir, S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
+    ret = mkdir(output_dir, PERM_rwxrwxr_x);
     if (ret != 0 && errno != EEXIST) {
         ERROR("Failed to create directory %s: %s\n", output_dir, strerror(errno));
         goto out;

--- a/Pal/src/host/Linux/db_files.c
+++ b/Pal/src/host/Linux/db_files.c
@@ -17,10 +17,10 @@
 #include "pal_linux.h"
 #include "pal_linux_defs.h"
 #include "pal_linux_error.h"
+#include "stat.h"
 typedef __kernel_pid_t pid_t;
 #undef __GLIBC__
 #include <asm/errno.h>
-#include <linux/stat.h>
 
 /* 'open' operation for file streams */
 static int file_open(PAL_HANDLE* handle, const char* type, const char* uri, int access, int share,

--- a/Pal/src/host/Linux/db_files.c
+++ b/Pal/src/host/Linux/db_files.c
@@ -250,7 +250,7 @@ static int file_attrquerybyhdl(PAL_HANDLE handle, PAL_STREAM_ATTR* attr) {
 static int file_attrsetbyhdl(PAL_HANDLE handle, PAL_STREAM_ATTR* attr) {
     int fd = handle->generic.fds[0], ret;
 
-    ret = INLINE_SYSCALL(fchmod, 2, fd, attr->share_flags | 0600);
+    ret = INLINE_SYSCALL(fchmod, 2, fd, attr->share_flags | PERM_rw_______);
     if (IS_ERR(ret))
         return unix_to_pal_error(ERRNO(ret));
 

--- a/Pal/src/host/Linux/db_files.c
+++ b/Pal/src/host/Linux/db_files.c
@@ -17,10 +17,8 @@
 #include "pal_linux.h"
 #include "pal_linux_defs.h"
 #include "pal_linux_error.h"
+#include "perm.h"
 #include "stat.h"
-typedef __kernel_pid_t pid_t;
-#undef __GLIBC__
-#include <asm/errno.h>
 
 /* 'open' operation for file streams */
 static int file_open(PAL_HANDLE* handle, const char* type, const char* uri, int access, int share,

--- a/Pal/src/host/Linux/db_pipes.c
+++ b/Pal/src/host/Linux/db_pipes.c
@@ -5,6 +5,14 @@
  * This file contains operands to handle streams with URIs that start with "pipe:" or "pipe.srv:".
  */
 
+#include <asm/errno.h>
+#include <asm/fcntl.h>
+#include <asm/poll.h>
+#include <linux/time.h>
+#include <linux/types.h>
+#include <linux/un.h>
+#include <sys/socket.h>
+
 #include "api.h"
 #include "pal.h"
 #include "pal_debug.h"
@@ -14,15 +22,6 @@
 #include "pal_linux.h"
 #include "pal_linux_defs.h"
 #include "pal_security.h"
-
-typedef __kernel_pid_t pid_t;
-#include <asm/errno.h>
-#include <asm/fcntl.h>
-#include <asm/poll.h>
-#include <linux/time.h>
-#include <linux/types.h>
-#include <linux/un.h>
-#include <sys/socket.h>
 
 static int pipe_addr(const char* name, struct sockaddr_un* addr) {
     /* use abstract UNIX sockets for pipes, with name format "@/graphene/<pipename>" */

--- a/Pal/src/host/Linux/db_process.c
+++ b/Pal/src/host/Linux/db_process.c
@@ -9,6 +9,14 @@
  * creation.
  */
 
+#include <asm/errno.h>
+#include <asm/fcntl.h>
+#include <asm/poll.h>
+#include <linux/sched.h>
+#include <linux/time.h>
+#include <linux/types.h>
+#include <sys/socket.h>
+
 #include "api.h"
 #include "pal.h"
 #include "pal_debug.h"
@@ -20,14 +28,10 @@
 #include "pal_rtld.h"
 #include "pal_security.h"
 
-typedef __kernel_pid_t pid_t;
-#include <asm/errno.h>
-#include <asm/fcntl.h>
-#include <asm/poll.h>
-#include <linux/sched.h>
-#include <linux/time.h>
-#include <linux/types.h>
-#include <sys/socket.h>
+/*
+ * This needs to be included here because it conflicts with sigset.h included in pal_linux.
+ * TODO: Make sure we define WIFEXITED() etc. and remove this.
+ */
 #include <sys/wait.h>
 
 extern char* g_pal_loader_path;

--- a/Pal/src/host/Linux/db_sockets.c
+++ b/Pal/src/host/Linux/db_sockets.c
@@ -6,8 +6,15 @@
  * "udp.srv:".
  */
 
+#include <asm/errno.h>
+#include <asm/fcntl.h>
+#include <linux/in.h>
+#include <linux/in6.h>
 #include <linux/poll.h>
+#include <linux/time.h>
 #include <linux/types.h>
+#include <netinet/tcp.h>
+#include <sys/socket.h>
 
 #include "api.h"
 #include "pal.h"
@@ -18,14 +25,6 @@
 #include "pal_linux.h"
 #include "pal_linux_defs.h"
 #include "pal_security.h"
-typedef __kernel_pid_t pid_t;
-#include <asm/errno.h>
-#include <asm/fcntl.h>
-#include <linux/in.h>
-#include <linux/in6.h>
-#include <linux/time.h>
-#include <netinet/tcp.h>
-#include <sys/socket.h>
 
 #ifndef SOL_TCP
 #define SOL_TCP 6

--- a/Pal/src/host/Linux/db_streams.c
+++ b/Pal/src/host/Linux/db_streams.c
@@ -5,17 +5,6 @@
  * This file contains APIs to open, read, write and get attribute of streams.
  */
 
-#include "api.h"
-#include "pal.h"
-#include "pal_debug.h"
-#include "pal_defs.h"
-#include "pal_error.h"
-#include "pal_internal.h"
-#include "pal_linux.h"
-#include "pal_linux_defs.h"
-#include "pal_security.h"
-
-typedef __kernel_pid_t pid_t;
 #include <asm/errno.h>
 #include <asm/fcntl.h>
 #include <asm/poll.h>
@@ -25,8 +14,19 @@ typedef __kernel_pid_t pid_t;
 #include <linux/types.h>
 #include <linux/wait.h>
 #include <netinet/in.h>
-#include <sys/signal.h>
 #include <sys/socket.h>
+
+#include "api.h"
+#include "pal.h"
+#include "pal_debug.h"
+#include "pal_defs.h"
+#include "pal_error.h"
+#include "pal_internal.h"
+#include "pal_linux.h"
+#include "pal_linux_defs.h"
+#include "pal_security.h"
+#include "perm.h"
+#include "stat.h"
 
 static int g_debug_fd = -1;
 

--- a/Pal/src/host/Linux/db_streams.c
+++ b/Pal/src/host/Linux/db_streams.c
@@ -376,7 +376,7 @@ int _DkInitDebugStream(const char* path) {
             return unix_to_pal_error(ERRNO(ret));
     }
 
-    ret = INLINE_SYSCALL(open, 3, path, O_WRONLY | O_APPEND | O_CREAT, 0600);
+    ret = INLINE_SYSCALL(open, 3, path, O_WRONLY | O_APPEND | O_CREAT, PERM_rw_______);
     if (ret < 0)
         return unix_to_pal_error(ERRNO(ret));
     g_debug_fd = ret;

--- a/Pal/src/host/Linux/pal_linux.h
+++ b/Pal/src/host/Linux/pal_linux.h
@@ -5,9 +5,9 @@
 #define PAL_LINUX_H
 
 #include <asm/fcntl.h>
+#include <asm/stat.h>
 #include <linux/mman.h>
 #include <sigset.h>
-#include <sys/stat.h>
 #include <sys/syscall.h>
 #include <sys/types.h>
 #include <unistd.h>
@@ -18,6 +18,7 @@
 #include "pal_internal.h"
 #include "pal_linux_defs.h"
 #include "pal_linux_error.h"
+#include "stat.h"
 #include "sysdep-arch.h"
 
 #define IS_ERR   INTERNAL_SYSCALL_ERROR


### PR DESCRIPTION
This first creates our own `stat.h` (to avoid the dance with `#define __KERNEL__` + `#include <linux/stat.h>` etc.), and then introduces human-readable macros such as `PERM_rwxrwxr_x` from this patch: https://lwn.net/Articles/696231/

This is a follow-up to the discussion in https://github.com/oscarlab/graphene/pull/1965

The macros do look nice, but stuff like `PERM_r________` is going to be hard to write in an editor without autocomplete.

CC @boryspoplawski @mkow

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1978)
<!-- Reviewable:end -->
