### PR TITLE
Introduce log levels, convert inner PAL to the logging system

### DIFF
--- a/LibOS/shim/include/shim_internal.h
+++ b/LibOS/shim/include/shim_internal.h
@@ -36,7 +36,7 @@ struct debug_buf {
 #include "pal_debug.h"
 #include "pal_error.h"
 
-extern bool g_debug_log_enabled;
+extern unsigned int g_debug_log_level;
 
 #include <stdarg.h>
 
@@ -45,11 +45,16 @@ void debug_puts(const char* str);
 void debug_putch(int ch);
 void debug_vprintf(const char* fmt, va_list ap) __attribute__((format(printf, 1, 0)));
 
-#define debug(fmt, ...)                       \
-    do {                                      \
-        if (g_debug_log_enabled)              \
-            debug_printf(fmt, ##__VA_ARGS__); \
-    } while (0)
+#define _debug(level, fmt...)                          \
+    do {                                               \
+        if ((level) <= g_debug_log_level)              \
+            debug_printf(fmt);                         \
+    }  while(0)
+
+#define debug_error(fmt...)    _debug(PAL_LOG_ERROR, fmt)
+#define debug_info(fmt...)     _debug(PAL_LOG_INFO, fmt)
+#define debug_trace(fmt...)    _debug(PAL_LOG_TRACE, fmt)
+#define debug(fmt...)          _debug(PAL_LOG_INFO, fmt)
 
 #if 0
 #define DEBUG_BREAK_ON_FAILURE() DEBUG_BREAK()
@@ -120,11 +125,11 @@ static inline int64_t get_cur_preempt(void) {
     r func(PROTO_ARGS_##n(args));
 
 #define PARSE_SYSCALL1(name, ...) \
-    if (g_debug_log_enabled)      \
+    if (g_debug_log_level >= PAL_LOG_TRACE)      \
         parse_syscall_before(__NR_##name, #name, ##__VA_ARGS__);
 
 #define PARSE_SYSCALL2(name, ...) \
-    if (g_debug_log_enabled)      \
+    if (g_debug_log_level >= PAL_LOG_TRACE)      \
         parse_syscall_after(__NR_##name, #name, ##__VA_ARGS__);
 
 void parse_syscall_before(int sysno, const char* name, int nr, ...);

--- a/LibOS/shim/include/shim_thread.h
+++ b/LibOS/shim/include/shim_thread.h
@@ -137,7 +137,7 @@ void debug_setprefix(shim_tcb_t* tcb);
 
 static inline void debug_setbuf(shim_tcb_t* tcb,
                                 struct debug_buf* debug_buf) {
-    if (!g_debug_log_enabled)
+    if (g_debug_log_level == PAL_LOG_NONE)
         return;
 
     tcb->debug_buf = debug_buf ? debug_buf : malloc(sizeof(struct debug_buf));

--- a/LibOS/shim/src/shim_init.c
+++ b/LibOS/shim/src/shim_init.c
@@ -421,7 +421,9 @@ fail:
 extern PAL_HANDLE thread_start_event;
 
 noreturn void* shim_init(int argc, void* args) {
-    g_debug_log_enabled = PAL_CB(enable_debug_log);
+    /* For now, assume all debug() calls are at PAL_LOG_INFO level. */
+    g_debug_log_enabled = PAL_CB(debug_log_level) >= PAL_LOG_INFO;
+
     g_process_ipc_info.vmid = (IDTYPE)PAL_CB(process_id);
 
     /* create the initial TCB, shim can not be run without a tcb */

--- a/LibOS/shim/src/shim_init.c
+++ b/LibOS/shim/src/shim_init.c
@@ -421,8 +421,7 @@ fail:
 extern PAL_HANDLE thread_start_event;
 
 noreturn void* shim_init(int argc, void* args) {
-    /* For now, assume all debug() calls are at PAL_LOG_INFO level. */
-    g_debug_log_enabled = PAL_CB(debug_log_level) >= PAL_LOG_INFO;
+    g_debug_log_level = PAL_CB(debug_log_level);
 
     g_process_ipc_info.vmid = (IDTYPE)PAL_CB(process_id);
 

--- a/LibOS/shim/src/shim_parser.c
+++ b/LibOS/shim/src/shim_parser.c
@@ -553,7 +553,7 @@ static inline void skip_syscall_args(va_list* ap) {
 }
 
 void parse_syscall_before(int sysno, const char* name, int nr, ...) {
-    if (!g_debug_log_enabled)
+    if (g_debug_log_level < PAL_LOG_TRACE)
         return;
 
     struct parser_table* parser = &syscall_parser_table[sysno];
@@ -589,7 +589,7 @@ dotdotdot:
 }
 
 void parse_syscall_after(int sysno, const char* name, int nr, ...) {
-    if (!g_debug_log_enabled)
+    if (g_debug_log_level < PAL_LOG_TRACE)
         return;
 
     struct parser_table* parser = &syscall_parser_table[sysno];

--- a/LibOS/shim/src/utils/printf.c
+++ b/LibOS/shim/src/utils/printf.c
@@ -11,7 +11,7 @@
 #include "shim_internal.h"
 #include "shim_ipc.h"
 
-bool g_debug_log_enabled = false;
+unsigned int g_debug_log_level = PAL_LOG_NONE;
 
 static inline int debug_fputs(const char* buf, size_t size) {
     size_t bytes = 0;
@@ -111,7 +111,7 @@ void debug_printf(const char* fmt, ...) {
 }
 
 void debug_setprefix(shim_tcb_t* tcb) {
-    if (!g_debug_log_enabled)
+    if (g_debug_log_level == PAL_LOG_NONE)
         return;
 
     struct debug_buf* buf = tcb->debug_buf;

--- a/Pal/include/pal/pal.h
+++ b/Pal/include/pal/pal.h
@@ -87,6 +87,15 @@ typedef union pal_handle {
 
 #include "pal-arch.h"
 
+/*! Debug log level */
+enum {
+    PAL_LOG_NONE   = 0,
+    PAL_LOG_ERROR  = 1,
+    PAL_LOG_INFO   = 2,
+    PAL_LOG_TRACE  = 3,
+    PAL_LOG_ALL    = 4,
+};
+
 /********** PAL TYPE DEFINITIONS **********/
 enum {
     pal_type_file,
@@ -134,7 +143,7 @@ typedef struct PAL_CONTROL_ {
     PAL_STR executable;         /*!< executable name */
     PAL_HANDLE parent_process;  /*!< handle of parent process */
     PAL_HANDLE first_thread;    /*!< handle of first thread */
-    PAL_BOL enable_debug_log;   /*!< enable debug log calls */
+    PAL_NUM debug_log_level;    /*!< debug log level */
 
     /*
      * Memory layout
@@ -684,8 +693,8 @@ void DkObjectClose(PAL_HANDLE objectHandle);
 /*!
  * \brief Output a message to the debug stream.
  *
- * Works only if the debug stream has been initialized, which can be checked by looking at
- * `g_pal_control.enable_debug_log`.
+ * Works only if the debug stream has been initialized, which can be checked by verifying if
+ * `g_pal_control.debug_log_level` is greater than `PAL_LOG_NONE`.
  *
  * \return number of bytes written if succeeded, PAL_STREAM_ERROR on failure (in which case
  *  PAL_ERRNO() is set)

--- a/Pal/src/host/Linux-SGX/db_main-x86_64.c
+++ b/Pal/src/host/Linux-SGX/db_main-x86_64.c
@@ -196,7 +196,7 @@ int _DkGetCPUInfo(PAL_CPU_INFO* ci) {
 
     ci->cpu_bogomips = get_bogomips();
     if (ci->cpu_bogomips == 0.0) {
-        SGX_DBG(DBG_E,
+        debug_error(
                 "Warning: bogomips could not be retrieved, passing 0.0 to the application\n");
     }
 

--- a/Pal/src/host/Linux-SGX/db_main.c
+++ b/Pal/src/host/Linux-SGX/db_main.c
@@ -58,7 +58,7 @@ void _DkGetAvailableUserAddressRange(PAL_PTR* start, PAL_PTR* end) {
     *end = SATURATED_P_SUB(*end, g_pal_internal_mem_size, *start);
 
     if (*end <= *start) {
-        SGX_DBG(DBG_E, "Not enough enclave memory, please increase enclave size!\n");
+        debug_error("Not enough enclave memory, please increase enclave size!\n");
         ocall_exit(1, /*is_exitgroup=*/true);
     }
 }
@@ -96,7 +96,7 @@ static PAL_HANDLE setup_dummy_file_handle(const char* name) {
     char* path = (void*)handle + HANDLE_SIZE(file);
     int ret = get_norm_path(name, path, &len);
     if (ret < 0) {
-        SGX_DBG(DBG_E, "Could not normalize path (%s): %s\n", name, pal_strerror(ret));
+        debug_error("Could not normalize path (%s): %s\n", name, pal_strerror(ret));
         free(handle);
         return NULL;
     }
@@ -189,13 +189,13 @@ noreturn void pal_linux_main(char* uptr_libpal_uri, size_t libpal_uri_len, char*
 
     rv = _DkSystemTimeQuery(&start_time);
     if (rv < 0) {
-        SGX_DBG(DBG_E, "_DkSystemTimeQuery() failed: %d\n", rv);
+        debug_error("_DkSystemTimeQuery() failed: %d\n", rv);
         ocall_exit(1, /*is_exitgroup=*/true);
     }
 
     struct pal_sec sec_info;
     if (!sgx_copy_to_enclave(&sec_info, sizeof(sec_info), uptr_sec_info, sizeof(*uptr_sec_info))) {
-        SGX_DBG(DBG_E, "Copying sec_info into the enclave failed\n");
+        debug_error("Copying sec_info into the enclave failed\n");
         ocall_exit(1, /*is_exitgroup=*/true);
     }
 
@@ -206,7 +206,7 @@ noreturn void pal_linux_main(char* uptr_libpal_uri, size_t libpal_uri_len, char*
 
     /* Skip URI_PREFIX_FILE. */
     if (libpal_uri_len < URI_PREFIX_FILE_LEN) {
-        SGX_DBG(DBG_E, "Invalid libpal_uri length (missing \"%s\" prefix?)\n", URI_PREFIX_FILE);
+        debug_error("Invalid libpal_uri length (missing \"%s\" prefix?)\n", URI_PREFIX_FILE);
         ocall_exit(1, /*is_exitgroup=*/true);
     }
     libpal_uri_len -= URI_PREFIX_FILE_LEN;
@@ -217,7 +217,7 @@ noreturn void pal_linux_main(char* uptr_libpal_uri, size_t libpal_uri_len, char*
     if (libpal_uri_len >= sizeof(libpal_path)
             || !sgx_copy_to_enclave(libpal_path, sizeof(libpal_path) - 1, uptr_libpal_uri,
                                     libpal_uri_len)) {
-        SGX_DBG(DBG_E, "Copying libpal_path into the enclave failed\n");
+        debug_error("Copying libpal_path into the enclave failed\n");
         ocall_exit(1, /*is_exitgroup=*/true);
     }
     libpal_path[libpal_uri_len] = '\0';
@@ -259,21 +259,21 @@ noreturn void pal_linux_main(char* uptr_libpal_uri, size_t libpal_uri_len, char*
     /* ppid should be positive when interpreted as signed. It's 0 if we don't
      * have a graphene parent process. */
     if (sec_info.ppid > INT32_MAX) {
-        SGX_DBG(DBG_E, "Invalid sec_info.ppid: %u\n", sec_info.ppid);
+        debug_error("Invalid sec_info.ppid: %u\n", sec_info.ppid);
         ocall_exit(1, /*is_exitgroup=*/true);
     }
     g_pal_sec.ppid = sec_info.ppid;
 
     /* As ppid but we always have a pid, so 0 is invalid. */
     if (sec_info.pid > INT32_MAX || sec_info.pid == 0) {
-        SGX_DBG(DBG_E, "Invalid sec_info.pid: %u\n", sec_info.pid);
+        debug_error("Invalid sec_info.pid: %u\n", sec_info.pid);
         ocall_exit(1, /*is_exitgroup=*/true);
     }
     g_pal_sec.pid = sec_info.pid;
 
     /* -1 is treated as special value for example by chown. */
     if (sec_info.uid == (PAL_IDX)-1 || sec_info.gid == (PAL_IDX)-1) {
-        SGX_DBG(DBG_E, "Invalid sec_info.gid: %u\n", sec_info.gid);
+        debug_error("Invalid sec_info.gid: %u\n", sec_info.gid);
         ocall_exit(1, /*is_exitgroup=*/true);
     }
     g_pal_sec.uid = sec_info.uid;
@@ -283,12 +283,12 @@ noreturn void pal_linux_main(char* uptr_libpal_uri, size_t libpal_uri_len, char*
     if (online_logical_cores >= 1 && online_logical_cores <= (1 << 16)) {
         g_pal_sec.online_logical_cores = online_logical_cores;
     } else {
-        SGX_DBG(DBG_E, "Invalid sec_info.online_logical_cores: %d\n", online_logical_cores);
+        debug_error("Invalid sec_info.online_logical_cores: %d\n", online_logical_cores);
         ocall_exit(1, /*is_exitgroup=*/true);
     }
 
     if (sec_info.physical_cores_per_socket <= 0) {
-        SGX_DBG(DBG_E, "Invalid sec_info.physical_cores_per_socket: %ld\n",
+        debug_error("Invalid sec_info.physical_cores_per_socket: %ld\n",
                 sec_info.physical_cores_per_socket);
         ocall_exit(1, /*is_exitgroup=*/true);
     }
@@ -312,22 +312,22 @@ noreturn void pal_linux_main(char* uptr_libpal_uri, size_t libpal_uri_len, char*
     /* initialize enclave properties */
     rv = init_enclave();
     if (rv) {
-        SGX_DBG(DBG_E, "Failed to initialize enclave properties: %d\n", rv);
+        debug_error("Failed to initialize enclave properties: %d\n", rv);
         ocall_exit(1, /*is_exitgroup=*/true);
     }
 
     if (args_size > MAX_ARGS_SIZE || env_size > MAX_ENV_SIZE) {
-        SGX_DBG(DBG_E, "Invalid args_size (%lu) or env_size (%lu)\n", args_size, env_size);
+        debug_error("Invalid args_size (%lu) or env_size (%lu)\n", args_size, env_size);
         ocall_exit(1, /*is_exitgroup=*/true);
     }
     const char** arguments = make_argv_list(uptr_args, args_size);
     if (!arguments) {
-        SGX_DBG(DBG_E, "Creating arguments failed\n");
+        debug_error("Creating arguments failed\n");
         ocall_exit(1, /*is_exitgroup=*/true);
     }
     const char** environments = make_argv_list(uptr_env, env_size);
     if (!environments) {
-        SGX_DBG(DBG_E, "Creating environments failed\n");
+        debug_error("Creating environments failed\n");
         ocall_exit(1, /*is_exitgroup=*/true);
     }
 
@@ -342,13 +342,13 @@ noreturn void pal_linux_main(char* uptr_libpal_uri, size_t libpal_uri_len, char*
     /* Allocate enclave memory to store "logical core -> socket" mappings */
     int* cpu_socket = (int*)malloc(online_logical_cores * sizeof(int));
     if (!cpu_socket) {
-        SGX_DBG(DBG_E, "Allocation for logical core -> socket mappings failed\n");
+        debug_error("Allocation for logical core -> socket mappings failed\n");
         ocall_exit(1, /*is_exitgroup=*/true);
     }
 
     if (!sgx_copy_to_enclave(cpu_socket, online_logical_cores * sizeof(int), sec_info.cpu_socket,
                              online_logical_cores * sizeof(int))) {
-        SGX_DBG(DBG_E, "Copying cpu_socket into the enclave failed\n");
+        debug_error("Copying cpu_socket into the enclave failed\n");
         ocall_exit(1, /*is_exitgroup=*/true);
     }
     g_pal_sec.cpu_socket = cpu_socket;
@@ -358,14 +358,14 @@ noreturn void pal_linux_main(char* uptr_libpal_uri, size_t libpal_uri_len, char*
      * this enclave is child */
     int ret = _DkRandomBitsRead(&g_master_key, sizeof(g_master_key));
     if (ret < 0) {
-        SGX_DBG(DBG_E, "_DkRandomBitsRead failed: %d\n", ret);
+        debug_error("_DkRandomBitsRead failed: %d\n", ret);
         ocall_exit(1, /*is_exitgroup=*/true);
     }
 
     /* if there is a parent, create parent handle */
     if (g_pal_sec.ppid) {
         if ((rv = init_child_process(&parent)) < 0) {
-            SGX_DBG(DBG_E, "Failed to initialize child process: %d\n", rv);
+            debug_error("Failed to initialize child process: %d\n", rv);
             ocall_exit(1, /*is_exitgroup=*/true);
         }
     }
@@ -394,7 +394,7 @@ noreturn void pal_linux_main(char* uptr_libpal_uri, size_t libpal_uri_len, char*
     char errbuf[256];
     toml_table_t* manifest_root = toml_parse(manifest_addr, errbuf, sizeof(errbuf));
     if (!manifest_root) {
-        SGX_DBG(DBG_E, "PAL failed at parsing the manifest: %s\n"
+        debug_error("PAL failed at parsing the manifest: %s\n"
                 "  Graphene switched to the TOML format recently, please update the manifest\n"
                 "  (in particular, string values must be put in double quotes)\n", errbuf);
         ocall_exit(1, /*is_exitgroup=*/true);
@@ -404,28 +404,28 @@ noreturn void pal_linux_main(char* uptr_libpal_uri, size_t libpal_uri_len, char*
     ret = toml_sizestring_in(g_pal_state.manifest_root, "loader.pal_internal_mem_size",
                              /*defaultval=*/0, &g_pal_internal_mem_size);
     if (ret < 0) {
-        SGX_DBG(DBG_E, "Cannot parse \'loader.pal_internal_mem_size\' "
+        debug_error("Cannot parse \'loader.pal_internal_mem_size\' "
                        "(the value must be put in double quotes!)\n");
         ocall_exit(1, true);
     }
 
     if ((rv = init_trusted_files()) < 0) {
-        SGX_DBG(DBG_E, "Failed to load the checksums of trusted files: %d\n", rv);
+        debug_error("Failed to load the checksums of trusted files: %d\n", rv);
         ocall_exit(1, true);
     }
 
     if ((rv = init_trusted_children()) < 0) {
-        SGX_DBG(DBG_E, "Failed to load the measurement of trusted child enclaves: %d\n", rv);
+        debug_error("Failed to load the measurement of trusted child enclaves: %d\n", rv);
         ocall_exit(1, true);
     }
 
     if ((rv = init_file_check_policy()) < 0) {
-        SGX_DBG(DBG_E, "Failed to load the file check policy: %d\n", rv);
+        debug_error("Failed to load the file check policy: %d\n", rv);
         ocall_exit(1, true);
     }
 
     if ((rv = init_protected_files()) < 0) {
-        SGX_DBG(DBG_E, "Failed to initialize protected files: %d\n", rv);
+        debug_error("Failed to initialize protected files: %d\n", rv);
         ocall_exit(1, true);
     }
 
@@ -433,7 +433,7 @@ noreturn void pal_linux_main(char* uptr_libpal_uri, size_t libpal_uri_len, char*
     uint64_t end_time;
     rv = _DkSystemTimeQuery(&end_time);
     if (rv < 0) {
-        SGX_DBG(DBG_E, "_DkSystemTimeQuery() failed: %d\n", rv);
+        debug_error("_DkSystemTimeQuery() failed: %d\n", rv);
         ocall_exit(1, /*is_exitgroup=*/true);
     }
     printf("                >>>>>>>> Enclave loading time =      %10ld milliseconds\n",

--- a/Pal/src/host/Linux-SGX/db_memory.c
+++ b/Pal/src/host/Linux-SGX/db_memory.c
@@ -22,7 +22,7 @@ extern size_t g_page_size;
 
 bool _DkCheckMemoryMappable(const void* addr, size_t size) {
     if (addr < DATA_END && addr + size > TEXT_START) {
-        SGX_DBG(DBG_E, "Address %p-%p is not mappable\n", addr, addr + size);
+        debug_error("Address %p-%p is not mappable\n", addr, addr + size);
         return true;
     }
 
@@ -83,7 +83,7 @@ int _DkVirtualMemoryProtect(void* addr, uint64_t size, int prot) {
     int64_t t = 0;
     if (__atomic_compare_exchange_n(&at_cnt.counter, &t, 1, /*weak=*/false, __ATOMIC_SEQ_CST,
                                     __ATOMIC_RELAXED))
-        SGX_DBG(DBG_M, "[Warning] DkVirtualMemoryProtect is unimplemented in Linux-SGX PAL");
+        debug_info("[Warning] DkVirtualMemoryProtect is unimplemented in Linux-SGX PAL");
     return 0;
 }
 

--- a/Pal/src/host/Linux-SGX/db_misc.c
+++ b/Pal/src/host/Linux-SGX/db_misc.c
@@ -293,12 +293,12 @@ static void sanity_check_cpuid(uint32_t leaf, uint32_t subleaf, uint32_t values[
             case PKRU:
                 if (extension_enabled(xfrm, subleaf)) {
                     if (values[EAX] != extension_sizes_bytes[subleaf]) {
-                        SGX_DBG(DBG_E, "Unexpected value in host CPUID. Exiting...\n");
+                        debug_error("Unexpected value in host CPUID. Exiting...\n");
                         _DkProcessExit(1);
                     }
                 } else {
                     if (values[EAX] != 0) {
-                        SGX_DBG(DBG_E, "Unexpected value in host CPUID. Exiting...\n");
+                        debug_error("Unexpected value in host CPUID. Exiting...\n");
                         _DkProcessExit(1);
                     }
                 }
@@ -403,7 +403,7 @@ int _DkAttestationQuote(const PAL_PTR user_report_data, PAL_NUM user_report_data
     char* ra_client_spid_str = NULL;
     ret = toml_string_in(g_pal_state.manifest_root, "sgx.ra_client_spid", &ra_client_spid_str);
     if (ret < 0) {
-        SGX_DBG(DBG_E, "Cannot parse \'sgx.ra_client_spid\' "
+        debug_error("Cannot parse \'sgx.ra_client_spid\' "
                        "(the value must be put in double quotes!)\n");
         return -PAL_ERROR_INVAL;
     }
@@ -419,7 +419,7 @@ int _DkAttestationQuote(const PAL_PTR user_report_data, PAL_NUM user_report_data
         is_epid = true;
 
         if (strlen(ra_client_spid_str) != sizeof(sgx_spid_t) * 2) {
-            SGX_DBG(DBG_E, "Malformed \'sgx.ra_client_spid\' value in the manifest: %s\n",
+            debug_error("Malformed \'sgx.ra_client_spid\' value in the manifest: %s\n",
                     ra_client_spid_str);
             free(ra_client_spid_str);
             return -PAL_ERROR_INVAL;
@@ -428,7 +428,7 @@ int _DkAttestationQuote(const PAL_PTR user_report_data, PAL_NUM user_report_data
         for (size_t i = 0; i < strlen(ra_client_spid_str); i++) {
             int8_t val = hex2dec(ra_client_spid_str[i]);
             if (val < 0) {
-                SGX_DBG(DBG_E, "Malformed \'sgx.ra_client_spid\' value in the manifest: %s\n",
+                debug_error("Malformed \'sgx.ra_client_spid\' value in the manifest: %s\n",
                         ra_client_spid_str);
                 free(ra_client_spid_str);
                 return -PAL_ERROR_INVAL;
@@ -441,7 +441,7 @@ int _DkAttestationQuote(const PAL_PTR user_report_data, PAL_NUM user_report_data
         ret = toml_int_in(g_pal_state.manifest_root, "sgx.ra_client_linkable",
                           /*defaultval=*/0, &linkable_int64);
         if (ret < 0 || (linkable_int64 != 0 && linkable_int64 != 1)) {
-            SGX_DBG(DBG_E, "Cannot parse \'sgx.ra_client_linkable\' (the value must be 0 or 1)\n");
+            debug_error("Cannot parse \'sgx.ra_client_linkable\' (the value must be 0 or 1)\n");
             free(ra_client_spid_str);
             return -PAL_ERROR_INVAL;
         }

--- a/Pal/src/host/Linux-SGX/db_pipes.c
+++ b/Pal/src/host/Linux-SGX/db_pipes.c
@@ -61,7 +61,7 @@ static int pipe_session_key(PAL_PIPE_NAME* name, PAL_SESSION_KEY* session_key) {
 
     return 0;
 fail:
-    SGX_DBG(DBG_E, "Failed to derive the pre-shared key for pipe %s: %d\n", name->str, ret);
+    debug_error("Failed to derive the pre-shared key for pipe %s: %d\n", name->str, ret);
     return ret;
 }
 
@@ -76,7 +76,7 @@ static int thread_handshake_func(void* param) {
     int ret = _DkStreamSecureInit(handle, handle->pipe.is_server, &handle->pipe.session_key,
                                   (LIB_SSL_CONTEXT**)&handle->pipe.ssl_ctx, NULL, 0);
     if (ret < 0) {
-        SGX_DBG(DBG_E, "Failed to initialize secure pipe %s: %d\n", handle->pipe.name.str, ret);
+        debug_error("Failed to initialize secure pipe %s: %d\n", handle->pipe.name.str, ret);
         _DkProcessExit(1);
     }
 

--- a/Pal/src/host/Linux-SGX/db_process.c
+++ b/Pal/src/host/Linux-SGX/db_process.c
@@ -98,7 +98,7 @@ int register_trusted_child(const char* uri, const char* mr_enclave_str) {
         return -PAL_ERROR_INVAL;
     }
 
-    SGX_DBG(DBG_S, "trusted: %s %s\n", mr_enclave_text, new->uri);
+    debug_trace("trusted: %s %s\n", mr_enclave_text, new->uri);
 
     spinlock_lock(&trusted_children_lock);
 
@@ -180,7 +180,7 @@ static int generate_sign_data(const PAL_SESSION_KEY* session_key, uint64_t encla
     if (ret < 0)
         return ret;
 
-    SGX_DBG(DBG_P | DBG_S, "Enclave identifier: %016lx -> %s\n", enclave_id,
+    debug_trace("Enclave identifier: %016lx -> %s\n", enclave_id,
             ALLOCA_BYTES2HEXSTR(data.eid_mac));
 
     /* Copy proc_data into sgx_sign_data_t */
@@ -208,7 +208,7 @@ static int check_child_mr_enclave(PAL_HANDLE child, sgx_measurement_t* mr_enclav
 
     /* Always accept the same mr_enclave as child process */
     if (!memcmp(mr_enclave, &g_pal_sec.mr_enclave, sizeof(sgx_measurement_t))) {
-        SGX_DBG(DBG_S, "trusted child: <forked>\n");
+        debug_trace("trusted child: <forked>\n");
         return 0;
     }
 
@@ -219,7 +219,7 @@ static int check_child_mr_enclave(PAL_HANDLE child, sgx_measurement_t* mr_enclav
     LISTP_FOR_EACH_ENTRY(tc, &trusted_children, list) {
         if (!memcmp(mr_enclave, &tc->mr_enclave, sizeof(sgx_measurement_t))) {
             spinlock_unlock(&trusted_children_lock);
-            SGX_DBG(DBG_S, "trusted child: %s\n", tc->uri);
+            debug_trace("trusted child: %s\n", tc->uri);
             return 0;
         }
     }
@@ -379,7 +379,7 @@ int init_child_process(PAL_HANDLE* parent_handle) {
 
 noreturn void _DkProcessExit(int exitcode) {
     if (exitcode)
-        SGX_DBG(DBG_I, "DkProcessExit: Returning exit code %d\n", exitcode);
+        debug_info("DkProcessExit: Returning exit code %d\n", exitcode);
     ocall_exit(exitcode, /*is_exitgroup=*/true);
     while (true) {
         /* nothing */;

--- a/Pal/src/host/Linux-SGX/db_rtld.c
+++ b/Pal/src/host/Linux-SGX/db_rtld.c
@@ -177,7 +177,7 @@ void _DkDebugAddMap(struct link_map* map) {
 
     struct debug_map* debug_map = debug_map_alloc(map->l_name, (void*)map->l_addr);
     if (!debug_map) {
-        SGX_DBG(DBG_E, "_DkDebugAddMap: error allocating new map\n");
+        debug_error("_DkDebugAddMap: error allocating new map\n");
         return;
     }
 
@@ -191,7 +191,7 @@ void _DkDebugAddMap(struct link_map* map) {
 
         if (!debug_map_add_section(debug_map, shstrtab + s->sh_name,
                                    (void*)(map->l_addr + s->sh_addr))) {
-            SGX_DBG(DBG_E, "_DkDebugAddMap: error allocating new section\n");
+            debug_error("_DkDebugAddMap: error allocating new section\n");
             debug_map_free(debug_map);
             return;
         }
@@ -225,7 +225,7 @@ void setup_pal_map(struct link_map* pal_map) {
 
     struct debug_map* debug_map = debug_map_alloc(pal_map->l_name, (void*)pal_map->l_addr);
     if (!debug_map) {
-        SGX_DBG(DBG_E, "setup_pal_map: error allocating new map\n");
+        debug_error("setup_pal_map: error allocating new map\n");
         return;
     }
 
@@ -248,6 +248,6 @@ void setup_pal_map(struct link_map* pal_map) {
     return;
 
 fail:
-    SGX_DBG(DBG_E, "setup_pal_map: error allocating new section\n");
+    debug_error("setup_pal_map: error allocating new section\n");
     debug_map_free(debug_map);
 }

--- a/Pal/src/host/Linux-SGX/enclave_pages.c
+++ b/Pal/src/host/Linux-SGX/enclave_pages.c
@@ -92,7 +92,7 @@ int init_enclave_pages(void) {
          * in case of non-PIE executables that start at a predefined address (typically 0x400000) */
         exec_vma = __alloc_vma();
         if (!exec_vma) {
-            SGX_DBG(DBG_E, "*** Cannot initialize VMA for executable ***\n");
+            debug_error("*** Cannot initialize VMA for executable ***\n");
             ret = -PAL_ERROR_NOMEM;
             goto out;
         }
@@ -108,7 +108,7 @@ int init_enclave_pages(void) {
 
     __atomic_add_fetch(&g_allocated_pages.counter, reserved_size / g_page_size, __ATOMIC_SEQ_CST);
 
-    SGX_DBG(DBG_M, "Heap size: %luM\n", (g_heap_top - g_heap_bottom - reserved_size) / 1024 / 1024);
+    debug_trace("Heap size: %luM\n", (g_heap_top - g_heap_bottom - reserved_size) / 1024 / 1024);
     ret = 0;
 
 out:
@@ -137,7 +137,7 @@ static void* __create_vma_and_merge(void* addr, size_t size, bool is_pal_interna
     struct heap_vma* check_vma_above = vma_above;
     while (check_vma_above && addr + size > check_vma_above->bottom) {
         if (check_vma_above->is_pal_internal != is_pal_internal) {
-            SGX_DBG(DBG_M, "VMA %p-%p (internal=%d) overlaps with %p-%p (internal=%d)\n", addr,
+            debug_trace("VMA %p-%p (internal=%d) overlaps with %p-%p (internal=%d)\n", addr,
                     addr + size, is_pal_internal, check_vma_above->bottom, check_vma_above->top,
                     check_vma_above->is_pal_internal);
             return NULL;
@@ -149,7 +149,7 @@ static void* __create_vma_and_merge(void* addr, size_t size, bool is_pal_interna
     struct heap_vma* check_vma_below = vma_below;
     while (check_vma_below && addr < check_vma_below->top) {
         if (check_vma_below->is_pal_internal != is_pal_internal) {
-            SGX_DBG(DBG_M, "VMA %p-%p (internal=%d) overlaps with %p-%p (internal=%d)\n", addr,
+            debug_trace("VMA %p-%p (internal=%d) overlaps with %p-%p (internal=%d)\n", addr,
                     addr + size, is_pal_internal, check_vma_below->bottom, check_vma_below->top,
                     check_vma_below->is_pal_internal);
             return NULL;
@@ -176,7 +176,7 @@ static void* __create_vma_and_merge(void* addr, size_t size, bool is_pal_interna
     while (vma_above && vma_above->bottom <= vma->top &&
            vma_above->is_pal_internal == vma->is_pal_internal) {
         /* newly created VMA grows into above VMA; expand newly created VMA and free above-VMA */
-        SGX_DBG(DBG_M, "Merge %p-%p and %p-%p\n", vma->bottom, vma->top, vma_above->bottom,
+        debug_trace("Merge %p-%p and %p-%p\n", vma->bottom, vma->top, vma_above->bottom,
                 vma_above->top);
 
         freed += vma_above->top - vma_above->bottom;
@@ -193,7 +193,7 @@ static void* __create_vma_and_merge(void* addr, size_t size, bool is_pal_interna
     while (vma_below && vma_below->top >= vma->bottom &&
            vma_below->is_pal_internal == vma->is_pal_internal) {
         /* newly created VMA grows into below VMA; expand newly create VMA and free below-VMA */
-        SGX_DBG(DBG_M, "Merge %p-%p and %p-%p\n", vma->bottom, vma->top, vma_below->bottom,
+        debug_trace("Merge %p-%p and %p-%p\n", vma->bottom, vma->top, vma_below->bottom,
                 vma_below->top);
 
         freed += vma_below->top - vma_below->bottom;
@@ -209,10 +209,10 @@ static void* __create_vma_and_merge(void* addr, size_t size, bool is_pal_interna
 
     INIT_LIST_HEAD(vma, list);
     LISTP_ADD_AFTER(vma, vma_above, &g_heap_vma_list, list);
-    SGX_DBG(DBG_M, "Created vma %p-%p\n", vma->bottom, vma->top);
+    debug_trace("Created vma %p-%p\n", vma->bottom, vma->top);
 
     if (vma->bottom >= vma->top) {
-        SGX_DBG(DBG_E, "*** Bad memory bookkeeping: %p - %p ***\n", vma->bottom, vma->top);
+        debug_error("*** Bad memory bookkeeping: %p - %p ***\n", vma->bottom, vma->top);
         ocall_exit(/*exitcode=*/1, /*is_exitgroup=*/true);
     }
 
@@ -239,7 +239,7 @@ void* get_enclave_pages(void* addr, size_t size, bool is_pal_internal) {
 
     assert(access_ok(addr, size));
 
-    SGX_DBG(DBG_M, "Allocating %lu bytes in enclave memory at %p (%s)\n", size, addr,
+    debug_trace("Allocating %lu bytes in enclave memory at %p (%s)\n", size, addr,
             is_pal_internal ? "PAL internal" : "normal");
 
     struct heap_vma* vma_above = NULL;
@@ -302,7 +302,7 @@ int free_enclave_pages(void* addr, size_t size) {
         return -PAL_ERROR_INVAL;
     }
 
-    SGX_DBG(DBG_M, "Freeing %lu bytes in enclave memory at %p\n", size, addr);
+    debug_trace("Freeing %lu bytes in enclave memory at %p\n", size, addr);
 
     _DkInternalLock(&g_heap_vma_lock);
 
@@ -329,7 +329,7 @@ int free_enclave_pages(void* addr, size_t size) {
         }
 
         if (is_pal_internal != vma->is_pal_internal) {
-            SGX_DBG(DBG_E,
+            debug_error(
                     "*** Area to free (address %p, size %lu) overlaps with both normal and "
                     "pal-internal VMAs ***\n",
                     addr, size);
@@ -343,7 +343,7 @@ int free_enclave_pages(void* addr, size_t size) {
             /* create VMA [vma->bottom, addr); this may leave VMA [addr + size, vma->top), see below */
             struct heap_vma* new = __alloc_vma();
             if (!new) {
-                SGX_DBG(DBG_E, "*** Cannot create split VMA during freeing of address %p ***\n",
+                debug_error("*** Cannot create split VMA during freeing of address %p ***\n",
                         addr);
                 ret = -PAL_ERROR_NOMEM;
                 goto out;

--- a/Pal/src/host/Linux-SGX/enclave_pf.c
+++ b/Pal/src/host/Linux-SGX/enclave_pf.c
@@ -41,14 +41,14 @@ static pf_status_t cb_read(pf_handle_t handle, void* buffer, uint64_t offset, si
             continue;
 
         if (read < 0) {
-            SGX_DBG(DBG_E, "cb_read(%d, %p, %lu, %lu): read failed: %ld\n", fd, buffer, offset,
+            debug_error("cb_read(%d, %p, %lu, %lu): read failed: %ld\n", fd, buffer, offset,
                     size, read);
             return PF_STATUS_CALLBACK_FAILED;
         }
 
         /* EOF is an error condition, we want to read exactly `size` bytes */
         if (read == 0) {
-            SGX_DBG(DBG_E, "cb_read(%d, %p, %lu, %lu): EOF\n", fd, buffer, offset, size);
+            debug_error("cb_read(%d, %p, %lu, %lu): EOF\n", fd, buffer, offset, size);
             return PF_STATUS_CALLBACK_FAILED;
         }
 
@@ -69,14 +69,14 @@ static pf_status_t cb_write(pf_handle_t handle, const void* buffer, uint64_t off
             continue;
 
         if (written < 0) {
-            SGX_DBG(DBG_E, "cb_write(%d, %p, %lu, %lu): write failed: %ld\n", fd, buffer, offset,
+            debug_error("cb_write(%d, %p, %lu, %lu): write failed: %ld\n", fd, buffer, offset,
                     size, written);
             return PF_STATUS_CALLBACK_FAILED;
         }
 
         /* EOF is an error condition, we want to write exactly `size` bytes */
         if (written == 0) {
-            SGX_DBG(DBG_E, "cb_write(%d, %p, %lu, %lu): EOF\n", fd, buffer, offset, size);
+            debug_error("cb_write(%d, %p, %lu, %lu): EOF\n", fd, buffer, offset, size);
             return PF_STATUS_CALLBACK_FAILED;
         }
 
@@ -90,7 +90,7 @@ static pf_status_t cb_truncate(pf_handle_t handle, uint64_t size) {
     int fd = *(int*)handle;
     int ret = ocall_ftruncate(fd, size);
     if (IS_ERR(ret)) {
-        SGX_DBG(DBG_E, "cb_truncate(%d, %lu): ocall failed: %d\n", fd, size, ret);
+        debug_error("cb_truncate(%d, %lu): ocall failed: %d\n", fd, size, ret);
         return PF_STATUS_CALLBACK_FAILED;
     }
     return PF_STATUS_SUCCESS;
@@ -98,7 +98,7 @@ static pf_status_t cb_truncate(pf_handle_t handle, uint64_t size) {
 
 #ifdef DEBUG
 static void cb_debug(const char* msg) {
-    SGX_DBG(DBG_D, "%s", msg);
+    debug_trace("%s", msg);
 }
 #endif
 
@@ -108,7 +108,7 @@ static pf_status_t cb_aes_gcm_encrypt(const pf_key_t* key, const pf_iv_t* iv, co
     int ret = lib_AESGCMEncrypt((const uint8_t*)key, sizeof(*key), (const uint8_t*)iv, input,
                                 input_size, aad, aad_size, output, (uint8_t*)mac, sizeof(*mac));
     if (ret != 0) {
-        SGX_DBG(DBG_E, "lib_AESGCMEncrypt failed: %d\n", ret);
+        debug_error("lib_AESGCMEncrypt failed: %d\n", ret);
         return PF_STATUS_CALLBACK_FAILED;
     }
     return PF_STATUS_SUCCESS;
@@ -121,7 +121,7 @@ static pf_status_t cb_aes_gcm_decrypt(const pf_key_t* key, const pf_iv_t* iv, co
                                 input_size, aad, aad_size, output, (const uint8_t*)mac,
                                 sizeof(*mac));
     if (ret != 0) {
-        SGX_DBG(DBG_E, "lib_AESGCMDecrypt failed: %d\n", ret);
+        debug_error("lib_AESGCMDecrypt failed: %d\n", ret);
         return PF_STATUS_CALLBACK_FAILED;
     }
     return PF_STATUS_SUCCESS;
@@ -130,7 +130,7 @@ static pf_status_t cb_aes_gcm_decrypt(const pf_key_t* key, const pf_iv_t* iv, co
 static pf_status_t cb_random(uint8_t* buffer, size_t size) {
     int ret = _DkRandomBitsRead(buffer, size);
     if (IS_ERR(ret)) {
-        SGX_DBG(DBG_E, "_DkRandomBitsRead failed: %d\n", ret);
+        debug_error("_DkRandomBitsRead failed: %d\n", ret);
         return PF_STATUS_CALLBACK_FAILED;
     }
     return PF_STATUS_SUCCESS;
@@ -212,7 +212,7 @@ struct protected_file* get_protected_file(const char* path) {
     pf = find_protected_dir(path);
     if (pf) {
         /* path not registered but matches registered dir */
-        SGX_DBG(DBG_D, "get_pf: registering new PF '%s' in dir '%s'\n", path, pf->path);
+        debug_trace("get_pf: registering new PF '%s' in dir '%s'\n", path, pf->path);
         int ret = register_protected_path(path, &pf);
         __UNUSED(ret);
         assert(ret == 0);
@@ -240,7 +240,7 @@ static int is_directory(const char* path, bool* is_dir) {
     fd = ret;
     ret = ocall_fstat(fd, &st);
     if (IS_ERR(ret)) {
-        SGX_DBG(DBG_E, "is_directory(%s): fstat failed: %d\n", path, ret);
+        debug_error("is_directory(%s): fstat failed: %d\n", path, ret);
         goto out;
     }
 
@@ -251,7 +251,7 @@ out:
     if (fd >= 0) {
         int rv = ocall_close(fd);
         if (IS_ERR(rv)) {
-            SGX_DBG(DBG_E, "is_directory(%s): close failed: %d\n", path, rv);
+            debug_error("is_directory(%s): close failed: %d\n", path, rv);
         }
     }
 
@@ -270,7 +270,7 @@ static int register_protected_dir(const char* path) {
 
     ret = ocall_open(path, O_RDONLY | O_DIRECTORY, 0);
     if (IS_ERR(ret)) {
-        SGX_DBG(DBG_E, "register_protected_dir: opening %s failed: %d\n", path, ret);
+        debug_error("register_protected_dir: opening %s failed: %d\n", path, ret);
         ret = unix_to_pal_error(ERRNO(ret));
         goto out;
     }
@@ -282,7 +282,7 @@ static int register_protected_dir(const char* path) {
         returned = ocall_getdents(fd, buf, bufsize);
         if (IS_ERR(returned)) {
             ret = unix_to_pal_error(ERRNO(returned));
-            SGX_DBG(DBG_E, "register_protected_dir: reading %s failed: %d\n", path, ret);
+            debug_error("register_protected_dir: reading %s failed: %d\n", path, ret);
             goto out;
         }
 
@@ -334,7 +334,7 @@ static int register_protected_path(const char* path, struct protected_file** new
     size_t len = URI_MAX;
     ret = get_norm_path(path, normpath, &len);
     if (ret < 0) {
-        SGX_DBG(DBG_E, "Couldn't normalize path (%s): %s\n", path, pal_strerror(ret));
+        debug_error("Couldn't normalize path (%s): %s\n", path, pal_strerror(ret));
         goto out;
     }
 
@@ -346,7 +346,7 @@ static int register_protected_path(const char* path, struct protected_file** new
 
     if (find_protected_file(path)) {
         ret = 0;
-        SGX_DBG(DBG_D, "register_protected_path: file %s already registered\n", path);
+        debug_trace("register_protected_path: file %s already registered\n", path);
         goto out;
     }
 
@@ -374,7 +374,7 @@ static int register_protected_path(const char* path, struct protected_file** new
     if (ret < 0)
         goto out;
 
-    SGX_DBG(DBG_D, "register_protected_path: [%s] %s = %p\n", is_dir ? "dir" : "file", path, new);
+    debug_trace("register_protected_path: [%s] %s = %p\n", is_dir ? "dir" : "file", path, new);
 
     if (is_dir)
         register_protected_dir(path);
@@ -430,12 +430,12 @@ static int register_protected_files(void) {
         char* toml_pf_value = NULL;
         ret = toml_rtos(toml_pf_value_raw, &toml_pf_value);
         if (ret < 0) {
-            SGX_DBG(DBG_E, "Invalid PF entry in manifest: \'%s\'\n", toml_pf_key);
+            debug_error("Invalid PF entry in manifest: \'%s\'\n", toml_pf_key);
             continue;
         }
 
         if (!strstartswith(toml_pf_value, URI_PREFIX_FILE)) {
-            SGX_DBG(DBG_E, "Invalid URI [%s]: URIs of protected files must start with \'"
+            debug_error("Invalid URI [%s]: URIs of protected files must start with \'"
                     URI_PREFIX_FILE "\'\n", toml_pf_value);
         } else {
             register_protected_path(toml_pf_value, NULL);
@@ -444,7 +444,7 @@ static int register_protected_files(void) {
     }
 
     pf_lock();
-    SGX_DBG(DBG_D, "Registered %u protected directories and %u protected files\n",
+    debug_trace("Registered %u protected directories and %u protected files\n",
             HASH_COUNT(g_protected_dirs), HASH_COUNT(g_protected_files));
     pf_unlock();
     return 0;
@@ -470,14 +470,14 @@ int init_protected_files(void) {
     ret = toml_string_in(g_pal_state.manifest_root, "sgx.protected_files_key",
                          &protected_files_key_str);
     if (ret < 0) {
-        SGX_DBG(DBG_E, "Cannot parse \'sgx.protected_files_key\' "
+        debug_error("Cannot parse \'sgx.protected_files_key\' "
                        "(the value must be put in double quotes!)\n");
         return -PAL_ERROR_INVAL;
     }
 
     if (protected_files_key_str) {
         if (strlen(protected_files_key_str) != PF_KEY_SIZE * 2) {
-            SGX_DBG(DBG_E, "Malformed \'sgx.protected_files_key\' value in the manifest\n");
+            debug_error("Malformed \'sgx.protected_files_key\' value in the manifest\n");
             free(protected_files_key_str);
             return -PAL_ERROR_INVAL;
         }
@@ -486,7 +486,7 @@ int init_protected_files(void) {
         for (size_t i = 0; i < strlen(protected_files_key_str); i++) {
             int8_t val = hex2dec(protected_files_key_str[i]);
             if (val < 0) {
-                SGX_DBG(DBG_E, "Malformed \'sgx.protected_files_key\' value in the manifest\n");
+                debug_error("Malformed \'sgx.protected_files_key\' value in the manifest\n");
                 free(protected_files_key_str);
                 return -PAL_ERROR_INVAL;
             }
@@ -498,7 +498,7 @@ int init_protected_files(void) {
     }
 
     if (register_protected_files() < 0) {
-        SGX_DBG(DBG_E, "Malformed protected files found in manifest\n");
+        debug_error("Malformed protected files found in manifest\n");
     }
 
     return 0;
@@ -508,14 +508,14 @@ int init_protected_files(void) {
 static int open_protected_file(const char* path, struct protected_file* pf, pf_handle_t handle,
                                uint64_t size, pf_file_mode_t mode, bool create) {
     if (!g_pf_wrap_key_set) {
-        SGX_DBG(DBG_E, "pf_open(%d, %s) failed: wrap key was not provided\n", *(int*)handle, path);
+        debug_error("pf_open(%d, %s) failed: wrap key was not provided\n", *(int*)handle, path);
         return -PAL_ERROR_DENIED;
     }
 
     pf_status_t pfs;
     pfs = pf_open(handle, path, size, mode, create, &g_pf_wrap_key, &pf->context);
     if (PF_FAILURE(pfs)) {
-        SGX_DBG(DBG_E, "pf_open(%d, %s) failed: %d\n", *(int*)handle, path, pfs);
+        debug_error("pf_open(%d, %s) failed: %d\n", *(int*)handle, path, pfs);
         return -PAL_ERROR_DENIED;
     }
     return 0;
@@ -527,7 +527,7 @@ static int open_protected_file(const char* path, struct protected_file* pf, pf_h
 struct protected_file* load_protected_file(const char* path, int* fd, uint64_t size,
                                            pf_file_mode_t mode, bool create,
                                            struct protected_file* pf) {
-    SGX_DBG(DBG_D, "load_protected_file: %s, fd %d, size %lu, mode %d, create %d, pf %p\n", path,
+    debug_trace("load_protected_file: %s, fd %d, size %lu, mode %d, create %d, pf %p\n", path,
             *fd, size, mode, create, pf);
 
     if (!pf)
@@ -535,12 +535,12 @@ struct protected_file* load_protected_file(const char* path, int* fd, uint64_t s
 
     if (pf) {
         if (!pf->context) {
-            SGX_DBG(DBG_D, "load_protected_file: %s, fd %d: opening new PF %p\n", path, *fd, pf);
+            debug_trace("load_protected_file: %s, fd %d: opening new PF %p\n", path, *fd, pf);
             int ret = open_protected_file(path, pf, (pf_handle_t)fd, size, mode, create);
             if (ret < 0)
                 return NULL;
         } else {
-            SGX_DBG(DBG_D, "load_protected_file: %s, fd %d: returning old PF %p\n", path, *fd, pf);
+            debug_trace("load_protected_file: %s, fd %d: returning old PF %p\n", path, *fd, pf);
         }
     }
 
@@ -558,7 +558,7 @@ int flush_pf_maps(struct protected_file* pf, void* buffer, bool remove) {
     uint64_t pf_size;
     pf_status_t pfs;
 
-    SGX_DBG(DBG_D, "flush_pf_maps: pf %p, buf %p, remove %d\n", pf, buffer, remove);
+    debug_trace("flush_pf_maps: pf %p, buf %p, remove %d\n", pf, buffer, remove);
 
     pf_lock();
     LISTP_FOR_EACH_ENTRY_SAFE(map, tmp, &g_pf_map_list, list) {
@@ -574,7 +574,7 @@ int flush_pf_maps(struct protected_file* pf, void* buffer, bool remove) {
         pfs = pf_get_size(map_pf->context, &pf_size);
         assert(PF_SUCCESS(pfs));
 
-        SGX_DBG(DBG_D, "flush_pf_maps: pf %p, buf %p, map size %lu, offset %lu\n", map_pf,
+        debug_trace("flush_pf_maps: pf %p, buf %p, map size %lu, offset %lu\n", map_pf,
                 map->buffer, map_size, map->offset);
 
         assert(pf_size >= map->offset);
@@ -584,7 +584,7 @@ int flush_pf_maps(struct protected_file* pf, void* buffer, bool remove) {
         if (map_size > 0) {
             pfs = pf_write(map_pf->context, map->offset, map_size, map->buffer);
             if (PF_FAILURE(pfs)) {
-                SGX_DBG(DBG_E, "flush_pf_maps: pf_write failed: %d\n", pfs);
+                debug_error("flush_pf_maps: pf_write failed: %d\n", pfs);
                 pf_unlock();
                 return -PAL_ERROR_INVAL;
             }
@@ -608,7 +608,7 @@ int unload_protected_file(struct protected_file* pf) {
         return ret;
     pf_status_t pfs = pf_close(pf->context);
     if (PF_FAILURE(pfs)) {
-        SGX_DBG(DBG_E, "unload_protected_file(%p) failed: %d\n", pf, pfs);
+        debug_error("unload_protected_file(%p) failed: %d\n", pf, pfs);
     }
 
     pf->context = NULL;

--- a/Pal/src/host/Linux-SGX/enclave_platform.c
+++ b/Pal/src/host/Linux-SGX/enclave_platform.c
@@ -16,13 +16,13 @@ int sgx_get_quote(const sgx_spid_t* spid, const sgx_quote_nonce_t* nonce,
 
     int ret = sgx_report(&targetinfo, &_report_data, &report);
     if (ret) {
-        SGX_DBG(DBG_E, "Failed to get enclave report\n");
+        debug_error("Failed to get enclave report\n");
         return -PAL_ERROR_DENIED;
     }
 
     ret = ocall_get_quote(spid, linkable, &report, nonce, quote, quote_len);
     if (ret < 0) {
-        SGX_DBG(DBG_E, "Failed to get quote\n");
+        debug_error("Failed to get quote\n");
         return unix_to_pal_error(ERRNO(ret));
     }
     return 0;

--- a/Pal/src/host/Linux-SGX/enclave_xstate.c
+++ b/Pal/src/host/Linux-SGX/enclave_xstate.c
@@ -83,7 +83,7 @@ void init_xsave_size(uint64_t xfrm) {
     g_xsave_features = PAL_XFEATURE_MASK_FPSSE;
     g_xsave_size = 512 + 64;
     if (!xfrm || (xfrm & SGX_XFRM_RESERVED)) {
-        SGX_DBG(DBG_M, "xsave is disabled, xfrm 0x%lx\n", xfrm);
+        debug_trace("xsave is disabled, xfrm 0x%lx\n", xfrm);
         return;
     }
 
@@ -94,5 +94,5 @@ void init_xsave_size(uint64_t xfrm) {
             g_xsave_size = xsave_size_table[i].size;
         }
     }
-    SGX_DBG(DBG_M, "xsave is enabled with g_xsave_size: %u\n", g_xsave_size);
+    debug_trace("xsave is enabled with g_xsave_size: %u\n", g_xsave_size);
 }

--- a/Pal/src/host/Linux-SGX/pal_linux.h
+++ b/Pal/src/host/Linux-SGX/pal_linux.h
@@ -312,13 +312,8 @@ int sgx_create_process(const char* uri, size_t nargs, const char** args, int* st
 #define DBG_P 0x10
 #define DBG_M 0x20
 
-#ifdef DEBUG
-#define DBG_LEVEL (DBG_E | DBG_I | DBG_D | DBG_S)
-#else
-#define DBG_LEVEL DBG_E
-#endif
-
 #ifdef IN_ENCLAVE
+
 #undef uthash_fatal
 #define uthash_fatal(msg)                \
     do {                                 \
@@ -326,23 +321,26 @@ int sgx_create_process(const char* uri, size_t nargs, const char** args, int* st
         DkProcessExit(-PAL_ERROR_NOMEM); \
     } while (0)
 
-#define SGX_DBG(class, fmt...)   \
-    do {                         \
-        if ((class) & DBG_LEVEL) \
-            printf(fmt);         \
-    } while (0)
-#else
+#else /* IN_ENCLAVE not defined */
+
 #include "pal_debug.h"
+#ifdef DEBUG
+#define DBG_LEVEL (DBG_E | DBG_I | DBG_D | DBG_S)
+#else
+#define DBG_LEVEL DBG_E
+#endif
 
 #define SGX_DBG(class, fmt...)   \
     do {                         \
         if ((class) & DBG_LEVEL) \
             pal_printf(fmt);     \
     } while (0)
+
 #endif
 
 #ifndef IN_ENCLAVE
 int clone(int (*__fn)(void* __arg), void* __child_stack, int __flags, const void* __arg, ...);
-#endif
+
+#endif /* IN_ENCLAVE */
 
 #endif /* PAL_LINUX_H */

--- a/Pal/src/pal_internal.h
+++ b/Pal/src/pal_internal.h
@@ -342,10 +342,22 @@ ssize_t _DkDebugLog(const void* buf, size_t size);
 void _DkPrintConsole(const void* buf, int size);
 int printf(const char* fmt, ...) __attribute__((format(printf, 1, 2)));
 int vprintf(const char* fmt, va_list ap) __attribute__((format(printf, 1, 0)));
+int debug_printf(const char* fmt, ...) __attribute__((format(printf, 1, 2)));
+int debug_vprintf(const char* fmt, va_list ap) __attribute__((format(printf, 1, 0)));
 
 /* errval is negative value, see pal_strerror */
 static inline void print_error(const char* errstring, int errval) {
     printf("%s (%s)\n", errstring, pal_strerror(errval));
 }
+
+#define _debug(level, fmt...)                          \
+    do {                                               \
+        if ((level) <= g_pal_control.debug_log_level)  \
+            debug_printf(fmt);                         \
+    }  while(0)
+
+#define debug_error(fmt...)    _debug(PAL_LOG_ERROR, fmt)
+#define debug_info(fmt...)     _debug(PAL_LOG_INFO, fmt)
+#define debug_trace(fmt...)    _debug(PAL_LOG_TRACE, fmt)
 
 #endif

--- a/Pal/src/printf.c
+++ b/Pal/src/printf.c
@@ -43,6 +43,17 @@ int vprintf(const char* fmt, va_list ap) {
     return b.cnt;
 }
 
+int debug_vprintf(const char* fmt, va_list ap) {
+    struct printbuf b;
+
+    b.idx = 0;
+    b.cnt = 0;
+    vfprintfmt((void*)&fputch, NULL, &b, fmt, ap);
+    _DkDebugLog(b.buf, b.idx);
+
+    return b.cnt;
+}
+
 int printf(const char* fmt, ...) {
     va_list ap;
     int cnt;
@@ -55,4 +66,14 @@ int printf(const char* fmt, ...) {
 }
 EXTERN_ALIAS(printf);
 
+int debug_printf(const char* fmt, ...) {
+    va_list ap;
+    int cnt;
+
+    va_start(ap, fmt);
+    cnt = debug_vprintf(fmt, ap);
+    va_end(ap);
+
+    return cnt;
+}
 #endif


### PR DESCRIPTION
I still want to verify this manually so I'm keeping it as draft until I do.

## Description of the changes

* Introduce log levels to PAL. The client (i.e. LibOS or Pal) is responsible for calling or not calling `DkDebugLog`, but the log level determined on startup.
* The logging level is "error" if `debug_type` is not specified (so that the messages previously output from `SGX_DBG` are still being output), and "info" / "trace" if it's specified, depending on the `DEBUG` variable.
  * Of course, later we should have an explicit `loader.debug_level` variable, but for now, I wanted to mimic the current behaviour.
* Convert `SGX_DBG()` to PAL logging system. Unfortunately this doesn't include the "outer" PAL as the logging system is initialized from inside. I don't have a good idea yet how to handle it.

## How to test this PR?

Run workloads with various combinations of `Linux / Linux-SGX`, `DEBUG`, `loader.debug_type`.

## Possible next steps

* Output to stderr, not stdout! (Didn't want to do it here because it will probably involve updating tests)
* Do something about the rest of `SGX_DBG` (not sure how exactly, yet)
* Make log level directly controllable via manifest (instead of `debug_type = inline`, there should be `debug_level = info/error/...`) - this also looks like a bigger change, and a breaking one...
* Make the log prefix (currently, process and thread numbers in LibOS) the same in LibOS and PAL

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1979)
<!-- Reviewable:end -->
