### PR TITLE
Fix ref counting bug in shim_do_poll()

### DIFF
--- a/LibOS/shim/src/sys/shim_poll.c
+++ b/LibOS/shim/src/sys/shim_poll.c
@@ -148,12 +148,12 @@ static int _shim_do_poll(struct pollfd* fds, nfds_t nfds, int timeout_ms) {
 
     PAL_BOL polled = DkStreamsWaitEvents(pal_cnt, pals, pal_events, ret_events, timeout_us);
 
-    /* update fds.revents, but only if something was actually polled */
-    if (polled) {
-        for (nfds_t i = 0; i < nfds; i++) {
-            if (!fds_mapping[i].hdl)
-                continue;
+    for (nfds_t i = 0; i < nfds; i++) {
+        if (!fds_mapping[i].hdl)
+            continue;
 
+        /* update fds.revents, but only if something was actually polled */
+        if (polled) {
             fds[i].revents = 0;
             if (ret_events[fds_mapping[i].idx] & PAL_WAIT_ERROR)
                 fds[i].revents |= POLLERR | POLLHUP;
@@ -164,9 +164,9 @@ static int _shim_do_poll(struct pollfd* fds, nfds_t nfds, int timeout_ms) {
 
             if (fds[i].revents)
                 nrevents++;
-
-            put_handle(fds_mapping[i].hdl);
         }
+
+        put_handle(fds_mapping[i].hdl);
     }
 
     free(pals);


### PR DESCRIPTION

## Description of the changes <!-- (reasons and measures) -->

During poll/select emulation, Graphene incremented refcount of polled handles, but forgot to decrement it in case poll timed out or failed.

In a particular long-running application, this led to an FD leak of pipes (the pipe FD is actually closed on the host only after `handle.refcount == 0`). This led to Linux failing to allocate new FDs at some point (`-EMFILE` on `pipe2()`).

Fixes #1960.

## How to test this PR? <!-- (if applicable) -->

No new test, since this is an FD leak that happens only in long-running apps and only in rare cases.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1980)
<!-- Reviewable:end -->
