### PR TITLE
Improve the TOML source file patching

### DIFF
--- a/Pal/lib/.gitignore
+++ b/Pal/lib/.gitignore
@@ -1,3 +1,2 @@
-/toml.c
-/toml.h
-/toml.patched
+/toml.c*
+/toml.h*

--- a/Pal/lib/Makefile
+++ b/Pal/lib/Makefile
@@ -160,13 +160,15 @@ TOML_H_CHECKSUM ?= e79d6d272576561e1b46ee001b0dd6b554330843e6fc7c658a548c659f282
 TOML_C_URI ?= https://raw.githubusercontent.com/cktan/tomlc99/5be06807ad5f2230cad99e15380c4f4076c9dd83/toml.c
 TOML_C_CHECKSUM ?= c21a546ab767a7e40d4f65df179d70357059c15e4439e1980d791625655fbbc6
 
-toml.h:
+toml.h.$(TOML_H_CHECKSUM):
 	../../Scripts/download --output $@ --url $(TOML_H_URI) --sha256 $(TOML_H_CHECKSUM)
 
-toml.c:
+toml.c.$(TOML_C_CHECKSUM):
 	../../Scripts/download --output $@ --url $(TOML_C_URI) --sha256 $(TOML_C_CHECKSUM)
 
-toml.patched: toml.h toml.c
+toml.patched: toml.h.$(TOML_H_CHECKSUM) toml.c.$(TOML_C_CHECKSUM)
+	cp toml.h.$(TOML_H_CHECKSUM) toml.h
+	cp toml.c.$(TOML_C_CHECKSUM) toml.c
 	patch -p1 -l < toml.patch || exit 255
 	cp toml.h ../include/lib/toml.h
 	touch $@
@@ -179,4 +181,5 @@ clean:
 distclean: clean
 	$(RM) -r crypto/$(MBEDTLS_SRC) crypto/$(MBEDCRYPTO_SRC) crypto/mbedtls
 	$(RM) ../include/lib/uthash.h
-	$(RM) ../include/lib/toml.h toml.h toml.c toml.patched
+	$(RM) ../include/lib/toml.h toml.h toml.c toml.patched \
+              toml.h.$(TOML_H_CHECKSUM) toml.c.$(TOML_C_CHECKSUM)

--- a/Pal/lib/Makefile
+++ b/Pal/lib/Makefile
@@ -141,7 +141,7 @@ $(target)graphene-lib.a: $(addprefix $(target),$(objs))
 	@mkdir -p $(dir $@)
 	$(call cmd,ar_a_o)
 
-$(target)%.o: %.c toml.patched
+$(target)%.o: %.c toml.h
 	@mkdir -p $(dir $@)
 	$(call cmd,cc_o_c)
 
@@ -166,12 +166,14 @@ toml.h.$(TOML_H_CHECKSUM):
 toml.c.$(TOML_C_CHECKSUM):
 	../../Scripts/download --output $@ --url $(TOML_C_URI) --sha256 $(TOML_C_CHECKSUM)
 
-toml.patched: toml.h.$(TOML_H_CHECKSUM) toml.c.$(TOML_C_CHECKSUM)
+toml.c toml.h: .toml_sentinel
+	@:
+
+.toml_sentinel: toml.h.$(TOML_H_CHECKSUM) toml.c.$(TOML_C_CHECKSUM)
 	cp toml.h.$(TOML_H_CHECKSUM) toml.h
 	cp toml.c.$(TOML_C_CHECKSUM) toml.c
 	patch -p1 -l < toml.patch || exit 255
 	cp toml.h ../include/lib/toml.h
-	touch $@
 
 .PHONY: clean
 clean:
@@ -181,4 +183,4 @@ clean:
 distclean: clean
 	$(RM) -r crypto/$(MBEDTLS_SRC) crypto/$(MBEDCRYPTO_SRC) crypto/mbedtls
 	$(RM) ../include/lib/uthash.h
-	$(RM) ../include/lib/toml.h toml.h* toml.c* toml.patched
+	$(RM) ../include/lib/toml.h toml.h* toml.c*

--- a/Pal/lib/Makefile
+++ b/Pal/lib/Makefile
@@ -166,8 +166,8 @@ toml.h.$(TOML_H_CHECKSUM):
 toml.c.$(TOML_C_CHECKSUM):
 	../../Scripts/download --output $@ --url $(TOML_C_URI) --sha256 $(TOML_C_CHECKSUM)
 
-toml.c toml.h: .toml_sentinel
-	@:
+.PHONY: .toml_sentinel
+toml.c toml.h: .toml_sentinel ;
 
 .toml_sentinel: toml.h.$(TOML_H_CHECKSUM) toml.c.$(TOML_C_CHECKSUM)
 	cp toml.h.$(TOML_H_CHECKSUM) toml.h

--- a/Pal/lib/Makefile
+++ b/Pal/lib/Makefile
@@ -181,5 +181,4 @@ clean:
 distclean: clean
 	$(RM) -r crypto/$(MBEDTLS_SRC) crypto/$(MBEDCRYPTO_SRC) crypto/mbedtls
 	$(RM) ../include/lib/uthash.h
-	$(RM) ../include/lib/toml.h toml.h toml.c toml.patched \
-              toml.h.$(TOML_H_CHECKSUM) toml.c.$(TOML_C_CHECKSUM)
+	$(RM) ../include/lib/toml.h toml.h* toml.c* toml.patched


### PR DESCRIPTION
## Description of the changes
The user doesn't need to do distclean if TOML source files got
updated and separated the original files from patched ones.

Fixes #1981

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1982)
<!-- Reviewable:end -->
