### PR TITLE
[Pal/Linux-SGX] Convert UNIX error code to PAL on ocall_create_process() fail

### DIFF
--- a/Pal/src/host/Linux-SGX/db_process.c
+++ b/Pal/src/host/Linux-SGX/db_process.c
@@ -241,8 +241,8 @@ int _DkProcessCreate(PAL_HANDLE* handle, const char* uri, const char** args) {
             nargs++;
 
     ret = ocall_create_process(uri, nargs, args, &stream_fd, &child_pid);
-    if (ret < 0)
-        return ret;
+    if (IS_ERR(ret))
+        return unix_to_pal_error(ERRNO(ret));
 
     PAL_HANDLE child = malloc(HANDLE_SIZE(process));
     SET_HANDLE_TYPE(child, process);


### PR DESCRIPTION

## Description of the changes <!-- (reasons and measures) -->

OCALLs in Linux-SGX PAL return UNIX error codes on failure. These error codes must be converted to PAL error codes.

This conversion was done almost everywhere in Linux-SGX PAL, except `ocall_create_process()`. I fixed this in this PR. From my manual audit, this seems to be the only instance of non-conversion.

Fixes #1977.

## How to test this PR? <!-- (if applicable) -->

All tests must pass. One can manually fail the creation of a child process and notice the incorrect error code returned to the application (for me it was `-99 == EADDRNOTAVAIL`).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1985)
<!-- Reviewable:end -->
