### PR TITLE
[Pal/Linux-SGX] Get rid of sgx driver submodule

### DIFF
--- a/.ci/lib/stage-build-sgx.jenkinsfile
+++ b/.ci/lib/stage-build-sgx.jenkinsfile
@@ -18,19 +18,12 @@ stage('build') {
         # test the build with the DCAP driver v1.6 and clean up afterwards
 
         cd "$WORKSPACE"
-
-        ISGX_DRIVER_PATH=/opt/intel/SGXDataCenterAttestationPrimitives/driver/linux \
-            make ${MAKEOPTS} -C Pal/src/host/Linux-SGX/sgx-driver
-        make ${MAKEOPTS}
-
+        make ${MAKEOPTS} ISGX_DRIVER_PATH=/opt/intel/SGXDataCenterAttestationPrimitives/driver/linux
         make ${MAKEOPTS} clean
-        make ${MAKEOPTS} -C Pal/src/host/Linux-SGX/sgx-driver distclean
     '''
 
     sh '''
-        ISGX_DRIVER_PATH=/opt/intel/linux-sgx-driver \
-            make ${MAKEOPTS} -C Pal/src/host/Linux-SGX/sgx-driver
-        make ${MAKEOPTS}
+        make ${MAKEOPTS} ISGX_DRIVER_PATH=/opt/intel/linux-sgx-driver
     '''
 
     try {

--- a/.ci/run-pylint
+++ b/.ci/run-pylint
@@ -18,7 +18,6 @@ find . -name \*.py \
     -and -not -path ./LibOS/shim/test/ltp/build/\* \
     -and -not -path ./LibOS/shim/test/ltp/install/\* \
     -and -not -path ./Examples/pytorch/\* \
-    -and -not -path ./Pal/src/host/Linux-SGX/sgx-driver/\* \
 | sed 's/./\\&/g' \
 | xargs "${PYLINT}" "$@" \
     Pal/src/host/Linux-SGX/signer/pal-sgx-get-token \

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "Pal/src/host/Linux-SGX/sgx-driver"]
-	path = Pal/src/host/Linux-SGX/sgx-driver
-	url = https://github.com/oscarlab/graphene-sgx-driver.git
 [submodule "LibOS/shim/test/ltp/src"]
 	path = LibOS/shim/test/ltp/src
 	url = https://github.com/linux-test-project/ltp.git

--- a/Documentation/cloud-deployment.rst
+++ b/Documentation/cloud-deployment.rst
@@ -40,7 +40,6 @@ Building
 
        git clone https://github.com/oscarlab/graphene.git
        cd graphene
-       git submodule update --init -- Pal/src/host/Linux-SGX/sgx-driver/
 
 #. Prepare the signing keys::
 

--- a/Documentation/quickstart.rst
+++ b/Documentation/quickstart.rst
@@ -55,7 +55,6 @@ second command should list the process status of :command:`aesm_service`.
 
       git clone https://github.com/oscarlab/graphene.git
       cd graphene
-      git submodule update --init -- Pal/src/host/Linux-SGX/sgx-driver/
       export GRAPHENE_DIR=$PWD
 
 #. Prepare a signing key::

--- a/LICENSE.addendum.txt
+++ b/LICENSE.addendum.txt
@@ -1,9 +1,5 @@
 Graphene itself is licensed under the LGPL-3.0-or-later.
 
-Graphene on an SGX host requires a kernel driver (in
-Pal/src/host/Linux-SGX/sgx-driver), which is separately licensed under
-the GPL.
-
 Graphene also includes the following third party sources (and licenses):
 
 mbedtls crypto libraries - Apache 2.0

--- a/Pal/Makefile
+++ b/Pal/Makefile
@@ -33,7 +33,6 @@ format:
 	                               -path ./src/host/Linux-SGX/tools/common/cJSON.h -prune -o \
 	                               -path ./src/host/Linux-SGX/tools/common/cJSON-*/cJSON.c -prune -o \
 	                               -path ./src/host/Linux-SGX/tools/common/cJSON-*/cJSON.h -prune -o \
-	                               -path ./src/host/Linux-SGX/sgx-driver -prune -o \
 	                               \( -name '*.h' -o -name '*.c' \) -print)
 
 .PHONY: distclean

--- a/Pal/src/host/Linux-SGX/.gitignore
+++ b/Pal/src/host/Linux-SGX/.gitignore
@@ -1,6 +1,7 @@
 /asm-offsets.h
 /generated-offsets.s
 /generated_offsets.py
+/gsgx.h
 /pal-sgx
 /quote/aesm.pb-c.c
 /quote/aesm.pb-c.h

--- a/Pal/src/host/Linux-SGX/Makefile
+++ b/Pal/src/host/Linux-SGX/Makefile
@@ -14,8 +14,7 @@ CFLAGS += \
 	-I../../../include/lib \
 	-I../../../lib/crypto/mbedtls/include \
 	-I../../../lib/crypto/mbedtls/crypto/include \
-	-Iprotected-files \
-	-Isgx-driver
+	-Iprotected-files
 
 # Some of the code uses alignof on expressions, which is a GNU extension.
 # Silence Clang - it complains but does support it.
@@ -89,7 +88,7 @@ urts-asm-objs = sgx_entry.o
 graphene_lib = .lib/graphene-lib.a
 
 .PHONY: all
-all: sgx-driver/sgx.h $(host_files) tools
+all: gsgx.h $(host_files) tools
 
 libpal-Linux-SGX.a: $(enclave-objs) $(enclave-asm-objs)
 	$(call cmd,ar_a_o)
@@ -138,8 +137,8 @@ gdb_integration/sgx_gdb.so: gdb_integration/sgx_gdb.c
 
 enclave_entry.o sgx_entry.o: asm-offsets.h
 
-sgx-driver/sgx.h:
-	$(MAKE) -C sgx-driver $(notdir $@)
+gsgx.h: gsgx.h.in
+	./link-intel-driver.py < $< > $@
 
 ifeq ($(filter %clean,$(MAKECMDGOALS)),)
 include $(wildcard *.d) $(wildcard gdb_integration/*.d)
@@ -154,6 +153,7 @@ tools:
 CLEAN_FILES += $(notdir $(pal_static) $(pal_lib) $(pal_loader))
 CLEAN_FILES += gdb_integration/sgx_gdb.so
 CLEAN_FILES += quote/aesm.pb-c.c quote/aesm.pb-c.h quote/aesm.pb-c.d quote/aesm.pb-c.o
+CLEAN_FILES += gsgx.h
 
 .PHONY: clean_
 clean_:

--- a/Pal/src/host/Linux-SGX/Makefile
+++ b/Pal/src/host/Linux-SGX/Makefile
@@ -163,12 +163,10 @@ clean_:
 
 .PHONY: clean
 clean: clean_
-	$(MAKE) -C sgx-driver $@
 	$(MAKE) -C tools $@
 
 .PHONY: distclean
 distclean: clean_
-	$(MAKE) -C sgx-driver $@
 	$(MAKE) -C tools $@
 
 .PHONY: test

--- a/Pal/src/host/Linux-SGX/db_misc.c
+++ b/Pal/src/host/Linux-SGX/db_misc.c
@@ -18,12 +18,7 @@
 #include "pal_linux.h"
 #include "pal_linux_defs.h"
 #include "pal_security.h"
-/* sgx.h is required to define SGX_DCAP,
- * and doesn't have a definition for __packed */
-#ifndef __packed
-#define __packed __attribute__((packed))
-#endif
-#include "sgx.h"
+#include "gsgx.h"
 #include "sgx_api.h"
 #include "sgx_attest.h"
 #include "toml.h"

--- a/Pal/src/host/Linux-SGX/generated-offsets.c
+++ b/Pal/src/host/Linux-SGX/generated-offsets.c
@@ -175,7 +175,4 @@ __attribute__((__used__)) static void dummy(void) {
 #ifdef SGX_DCAP
     DEFINE(SGX_DCAP, SGX_DCAP);
 #endif
-#ifdef SGX_DCAP_16_OR_LATER
-    DEFINE(SGX_DCAP_16_OR_LATER, SGX_DCAP_16_OR_LATER);
-#endif
 }

--- a/Pal/src/host/Linux-SGX/generated-offsets.c
+++ b/Pal/src/host/Linux-SGX/generated-offsets.c
@@ -11,12 +11,7 @@
 #include "sgx_arch.h"
 #include "sgx_tls.h"
 
-/* sgx.h header from the Intel SGX driver assumes that `__packed` macro was defined */
-#ifndef __packed
-#define __packed __attribute__((packed))
-#endif
-#include "sgx.h"
-#undef __packed
+#include "gsgx.h"
 
 __attribute__((__used__)) static void dummy(void) {
     /* defines in sgx_arch.h */

--- a/Pal/src/host/Linux-SGX/gsgx.h
+++ b/Pal/src/host/Linux-SGX/gsgx.h
@@ -1,0 +1,52 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+/* (C) Copyright 2020 Intel Corporation
+ *                    Dmitrii Kuvaiskii <dmitrii.kuvaiskii@intel.com>
+ */
+
+#ifndef __ARCH_GSGX_H__
+#define __ARCH_GSGX_H__
+
+#ifndef __packed
+#define __packed __attribute__((packed))
+#endif
+
+#include <linux/stddef.h>
+#include <linux/types.h>
+
+#include "sgx.h"
+
+#define GSGX_FILE  "/dev/gsgx"
+#define GSGX_MINOR MISC_DYNAMIC_MINOR
+
+/* Graphene needs the below subset of SGX instructions' return values */
+#ifndef SGX_INVALID_SIG_STRUCT
+#define SGX_INVALID_SIG_STRUCT  1
+#endif
+
+#ifndef SGX_INVALID_ATTRIBUTE
+#define SGX_INVALID_ATTRIBUTE   2
+#endif
+
+#ifndef SGX_INVALID_MEASUREMENT
+#define SGX_INVALID_MEASUREMENT 4
+#endif
+
+#ifndef SGX_INVALID_SIGNATURE
+#define SGX_INVALID_SIGNATURE   8
+#endif
+
+#ifndef SGX_INVALID_EINITTOKEN
+#define SGX_INVALID_EINITTOKEN  16
+#endif
+
+#ifndef SGX_INVALID_CPUSVN
+#define SGX_INVALID_CPUSVN      32
+#endif
+
+/* SGX_INVALID_LICENSE was renamed to SGX_INVALID_EINITTOKEN in SGX driver 2.1:
+ *   https://github.com/intel/linux-sgx-driver/commit/a7997dafe184d7d527683d8d46c4066db205758d */
+#ifndef SGX_INVALID_LICENSE
+#define SGX_INVALID_LICENSE     SGX_INVALID_EINITTOKEN
+#endif
+
+#endif /* __ARCH_GSGX_H__ */

--- a/Pal/src/host/Linux-SGX/gsgx.h
+++ b/Pal/src/host/Linux-SGX/gsgx.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: GPL-2.0-only */
+/* SPDX-License-Identifier: LGPL-3.0-or-later */
 /* (C) Copyright 2020 Intel Corporation
  *                    Dmitrii Kuvaiskii <dmitrii.kuvaiskii@intel.com>
  */

--- a/Pal/src/host/Linux-SGX/gsgx.h.in
+++ b/Pal/src/host/Linux-SGX/gsgx.h.in
@@ -13,10 +13,9 @@
 #include <linux/stddef.h>
 #include <linux/types.h>
 
-#include "sgx.h"
+#include "@DRIVER_SGX_H@"
 
 #define GSGX_FILE  "/dev/gsgx"
-#define GSGX_MINOR MISC_DYNAMIC_MINOR
 
 /* Graphene needs the below subset of SGX instructions' return values */
 #ifndef SGX_INVALID_SIG_STRUCT
@@ -47,6 +46,14 @@
  *   https://github.com/intel/linux-sgx-driver/commit/a7997dafe184d7d527683d8d46c4066db205758d */
 #ifndef SGX_INVALID_LICENSE
 #define SGX_INVALID_LICENSE     SGX_INVALID_EINITTOKEN
+#endif
+
+#define ISGX_FILE "@ISGX_FILE@"
+
+@DEFINE_DCAP@
+
+#ifdef SGX_DCAP
+# define SGX_DCAP_16_OR_LATER 1
 #endif
 
 #endif /* __ARCH_GSGX_H__ */

--- a/Pal/src/host/Linux-SGX/gsgx.h.in
+++ b/Pal/src/host/Linux-SGX/gsgx.h.in
@@ -52,8 +52,4 @@
 
 @DEFINE_DCAP@
 
-#ifdef SGX_DCAP
-# define SGX_DCAP_16_OR_LATER 1
-#endif
-
 #endif /* __ARCH_GSGX_H__ */

--- a/Pal/src/host/Linux-SGX/link-intel-driver.py
+++ b/Pal/src/host/Linux-SGX/link-intel-driver.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+
+import sys, os, shutil
+
+DRIVER_VERSIONS = {
+        'sgx_user.h':                 '/dev/isgx',
+        'include/uapi/asm/sgx_oot.h': '/dev/sgx/enclave',
+        'include/uapi/asm/sgx.h':     '/dev/sgx/enclave',
+        'sgx_in_kernel.h':            '/dev/sgx/enclave',
+}
+
+def find_intel_sgx_driver():
+    """
+    Graphene only needs one header from the Intel SGX Driver:
+      - sgx_user.h for non-DCAP, older version of the driver
+        (https://github.com/intel/linux-sgx-driver)
+      - include/uapi/asm/sgx_oot.h for DCAP 1.6+ version of the driver
+        (https://github.com/intel/SGXDataCenterAttestationPrimitives)
+      - include/uapi/asm/sgx.h for in-kernel 20+ version of the driver
+        (https://lore.kernel.org/linux-sgx/20190417103938.7762-1-jarkko.sakkinen@linux.intel.com/)
+      - default sgx_in_kernel.h for in-kernel 32+ version of the driver
+        (https://lore.kernel.org/linux-sgx/20200716135303.276442-1-jarkko.sakkinen@linux.intel.com)
+
+    This function returns the required header from the SGX driver.
+    """
+    isgx_driver_path = os.getenv("ISGX_DRIVER_PATH")
+    if not isgx_driver_path:
+        msg = 'Enter the Intel SGX driver dir with C headers (or press ENTER for in-kernel driver): '
+        isgx_driver_path = os.path.expanduser(input(msg))
+
+    if not isgx_driver_path or isgx_driver_path.strip() == '':
+        # user did not specify any driver path, use default in-kernel driver's C header
+        isgx_driver_path = os.path.dirname(os.path.abspath(__file__))
+
+    for header_path, dev_path in DRIVER_VERSIONS.items():
+        abs_header_path = os.path.abspath(os.path.join(isgx_driver_path, header_path))
+        if os.path.exists(abs_header_path):
+            return abs_header_path, dev_path
+
+    raise Exception("Could not find the header from the Intel SGX Driver")
+
+
+def main():
+    """ Find and copy header/device paths from Intel SGX Driver"""
+    header_path, dev_path = find_intel_sgx_driver()
+
+    this_header_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'sgx.h')
+    shutil.copyfile(header_path, this_header_path)
+
+    with open(this_header_path, 'a') as f:
+        f.write('\n\n#ifndef ISGX_FILE\n#define ISGX_FILE "%s"\n#endif\n' % dev_path)
+        if dev_path == '/dev/sgx' or dev_path == '/dev/sgx/enclave':
+            f.write('\n\n#ifndef SGX_DCAP\n#define SGX_DCAP 1\n#endif\n')
+        if dev_path == '/dev/sgx/enclave':
+            f.write('\n\n#ifndef SGX_DCAP_16_OR_LATER\n#define SGX_DCAP_16_OR_LATER 1\n#endif\n')
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/Pal/src/host/Linux-SGX/link-intel-driver.py
+++ b/Pal/src/host/Linux-SGX/link-intel-driver.py
@@ -7,7 +7,6 @@ import sys
 DRIVER_VERSIONS = {
         'sgx_user.h':                 '/dev/isgx',
         'include/uapi/asm/sgx_oot.h': '/dev/sgx/enclave',
-        'include/uapi/asm/sgx.h':     '/dev/sgx/enclave',
         'sgx_in_kernel.h':            '/dev/sgx/enclave',
 }
 
@@ -18,8 +17,6 @@ def find_intel_sgx_driver(isgx_driver_path):
         (https://github.com/intel/linux-sgx-driver)
       - include/uapi/asm/sgx_oot.h for DCAP 1.6+ version of the driver
         (https://github.com/intel/SGXDataCenterAttestationPrimitives)
-      - include/uapi/asm/sgx.h for in-kernel 20+ version of the driver
-        (https://lore.kernel.org/linux-sgx/20190417103938.7762-1-jarkko.sakkinen@linux.intel.com/)
       - default sgx_in_kernel.h for in-kernel 32+ version of the driver
         (https://lore.kernel.org/linux-sgx/20200716135303.276442-1-jarkko.sakkinen@linux.intel.com)
 

--- a/Pal/src/host/Linux-SGX/sgx_framework.c
+++ b/Pal/src/host/Linux-SGX/sgx_framework.c
@@ -146,7 +146,7 @@ int create_enclave(sgx_arch_secs_t* secs, sgx_arch_token_t* token) {
     uint64_t request_mmap_addr = secs->base;
     uint64_t request_mmap_size = secs->size;
 
-#ifdef SGX_DCAP_16_OR_LATER
+#ifdef SGX_DCAP
     /* newer DCAP/in-kernel SGX drivers allow starting enclave address space with non-zero;
      * the below trick to start from DEFAULT_HEAP_MIN is to avoid vm.mmap_min_addr==0 issue */
     if (request_mmap_addr < DEFAULT_HEAP_MIN) {
@@ -157,7 +157,7 @@ int create_enclave(sgx_arch_secs_t* secs, sgx_arch_token_t* token) {
 
     uint64_t addr = INLINE_SYSCALL(mmap, 6, request_mmap_addr, request_mmap_size,
                                    PROT_NONE, /* newer DCAP driver requires such initial mmap */
-#ifdef SGX_DCAP_16_OR_LATER
+#ifdef SGX_DCAP
                                    MAP_FIXED | MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
 #else
                                    MAP_FIXED | MAP_SHARED, g_isgx_device, 0);
@@ -260,7 +260,7 @@ int add_pages_to_enclave(sgx_arch_secs_t* secs, void* addr, void* user_addr, uns
         SGX_DBG(DBG_I, "adding pages to enclave: %p-%p [%s:%s] (%s)%s\n", addr, addr + size, t, p,
                 comment, m);
 
-#ifdef SGX_DCAP_16_OR_LATER
+#ifdef SGX_DCAP
     if (!user_addr && g_zero_pages_size < size) {
         /* not enough contigious zero pages to back up enclave pages, allocate more */
         /* TODO: this logic can be removed if we introduce a size cap in ENCLAVE_ADD_PAGES ioctl */
@@ -355,7 +355,7 @@ int add_pages_to_enclave(sgx_arch_secs_t* secs, void* addr, void* user_addr, uns
         SGX_DBG(DBG_I, "Changing protections of EADDed pages returned %d\n", ret);
         return -ERRNO(ret);
     }
-#endif /* SGX_DCAP_16_OR_LATER */
+#endif /* SGX_DCAP */
 
     return 0;
 }
@@ -372,7 +372,7 @@ int init_enclave(sgx_arch_secs_t* secs, sgx_arch_enclave_css_t* sigstruct,
     SGX_DBG(DBG_I, "    mr_enclave:   %s\n", ALLOCA_BYTES2HEXSTR(sigstruct->body.enclave_hash.m));
 
     struct sgx_enclave_init param = {
-#ifndef SGX_DCAP_16_OR_LATER
+#ifndef SGX_DCAP
         .addr = enclave_valid_addr,
 #endif
         .sigstruct = (uint64_t)sigstruct,

--- a/Pal/src/host/Linux-SGX/sgx_in_kernel.h
+++ b/Pal/src/host/Linux-SGX/sgx_in_kernel.h
@@ -1,0 +1,121 @@
+/* SPDX-License-Identifier: (GPL-2.0 OR BSD-3-Clause) WITH Linux-syscall-note */
+/*
+ * Copyright(c) 2016-19 Intel Corporation.
+ */
+
+/* TODO: Graphene must remove this file after Intel SGX driver is upstreamed
+ *       and this header is distributed with the system. This header was tested
+ *       with driver versions 32 and 36, it *may* be out of sync with newer
+ *       versions. If possible, use the header found on the system instead of
+ *       this one. */
+
+#ifndef _UAPI_ASM_X86_SGX_H
+#define _UAPI_ASM_X86_SGX_H
+
+#include <linux/types.h>
+#include <linux/ioctl.h>
+
+/**
+ * enum sgx_epage_flags - page control flags
+ * %SGX_PAGE_MEASURE:	Measure the page contents with a sequence of
+ *			ENCLS[EEXTEND] operations.
+ */
+enum sgx_page_flags {
+	SGX_PAGE_MEASURE	= 0x01,
+};
+
+#define SGX_MAGIC 0xA4
+
+#define SGX_IOC_ENCLAVE_CREATE \
+	_IOW(SGX_MAGIC, 0x00, struct sgx_enclave_create)
+#define SGX_IOC_ENCLAVE_ADD_PAGES \
+	_IOWR(SGX_MAGIC, 0x01, struct sgx_enclave_add_pages)
+#define SGX_IOC_ENCLAVE_INIT \
+	_IOW(SGX_MAGIC, 0x02, struct sgx_enclave_init)
+#define SGX_IOC_ENCLAVE_SET_ATTRIBUTE \
+	_IOW(SGX_MAGIC, 0x03, struct sgx_enclave_set_attribute)
+
+/**
+ * struct sgx_enclave_create - parameter structure for the
+ *                             %SGX_IOC_ENCLAVE_CREATE ioctl
+ * @src:	address for the SECS page data
+ */
+struct sgx_enclave_create  {
+	__u64	src;
+};
+
+/**
+ * struct sgx_enclave_add_pages - parameter structure for the
+ *                                %SGX_IOC_ENCLAVE_ADD_PAGE ioctl
+ * @src:	start address for the page data
+ * @offset:	starting page offset
+ * @length:	length of the data (multiple of the page size)
+ * @secinfo:	address for the SECINFO data
+ * @flags:	page control flags
+ * @count:	number of bytes added (multiple of the page size)
+ */
+struct sgx_enclave_add_pages {
+	__u64	src;
+	__u64	offset;
+	__u64	length;
+	__u64	secinfo;
+	__u64	flags;
+	__u64	count;
+};
+
+/**
+ * struct sgx_enclave_init - parameter structure for the
+ *                           %SGX_IOC_ENCLAVE_INIT ioctl
+ * @sigstruct:	address for the SIGSTRUCT data
+ */
+struct sgx_enclave_init {
+	__u64 sigstruct;
+};
+
+/**
+ * struct sgx_enclave_set_attribute - parameter structure for the
+ *				      %SGX_IOC_ENCLAVE_SET_ATTRIBUTE ioctl
+ * @attribute_fd:	file handle of the attribute file in the securityfs
+ */
+struct sgx_enclave_set_attribute {
+	__u64 attribute_fd;
+};
+
+/**
+ * struct sgx_enclave_exception - structure to report exceptions encountered in
+ *				  __vdso_sgx_enter_enclave()
+ *
+ * @leaf:	ENCLU leaf from \%eax at time of exception
+ * @trapnr:	exception trap number, a.k.a. fault vector
+ * @error_code:	exception error code
+ * @address:	exception address, e.g. CR2 on a #PF
+ * @reserved:	reserved for future use
+ */
+struct sgx_enclave_exception {
+	__u32 leaf;
+	__u16 trapnr;
+	__u16 error_code;
+	__u64 address;
+	__u64 reserved[2];
+};
+
+/**
+ * typedef sgx_enclave_exit_handler_t - Exit handler function accepted by
+ *					__vdso_sgx_enter_enclave()
+ *
+ * @rdi:	RDI at the time of enclave exit
+ * @rsi:	RSI at the time of enclave exit
+ * @rdx:	RDX at the time of enclave exit
+ * @ursp:	RSP at the time of enclave exit (untrusted stack)
+ * @r8:		R8 at the time of enclave exit
+ * @r9:		R9 at the time of enclave exit
+ * @tcs:	Thread Control Structure used to enter enclave
+ * @ret:	0 on success (EEXIT), -EFAULT on an exception
+ * @e:		Pointer to struct sgx_enclave_exception (as provided by caller)
+ */
+typedef int (*sgx_enclave_exit_handler_t)(long rdi, long rsi, long rdx,
+					  long ursp, long r8, long r9,
+					  void *tcs, int ret,
+					  struct sgx_enclave_exception *e);
+
+#endif /* _UAPI_ASM_X86_SGX_H */

--- a/Tools/gsc/images/graphene_aks.latest.dockerfile
+++ b/Tools/gsc/images/graphene_aks.latest.dockerfile
@@ -21,19 +21,18 @@ RUN git clone https://github.com/oscarlab/graphene.git /graphene
 # Init submodules
 RUN cd /graphene \
     && git fetch origin master \
-    && git checkout master \
-    && git submodule update --init -- Pal/src/host/Linux-SGX/sgx-driver/
+    && git checkout master
 
 # Create SGX driver for header files
-RUN cd /graphene/Pal/src/host/Linux-SGX/sgx-driver \
+RUN cd /graphene/Pal/src/host/Linux-SGX \
     && git clone https://github.com/intel/SGXDataCenterAttestationPrimitives.git linux-sgx-driver \
     && cd linux-sgx-driver \
     && git checkout DCAP_1.7 && cp -r driver/linux/* .
 
 # Build Graphene-SGX
-RUN cd /graphene && ISGX_DRIVER_PATH=/graphene/Pal/src/host/Linux-SGX/sgx-driver/linux-sgx-driver \
+RUN cd /graphene && ISGX_DRIVER_PATH=/graphene/Pal/src/host/Linux-SGX/linux-sgx-driver \
     make -s -j4 SGX=1 WERROR=1 \
-     && true
+    && true
 
 # Translate runtime symlinks to files
 RUN for f in $(find /graphene/Runtime -type l); do cp --remove-destination $(realpath $f) $f; done

--- a/Tools/gsc/templates/Dockerfile.ubuntu18.04.compile.template
+++ b/Tools/gsc/templates/Dockerfile.ubuntu18.04.compile.template
@@ -21,20 +21,18 @@ RUN git clone {{Graphene.Repository}} /graphene
 # Init submodules
 RUN cd /graphene \
     && git fetch origin {{Graphene.Branch}} \
-    && git checkout {{Graphene.Branch}} \
-    && git submodule update --init -- Pal/src/host/Linux-SGX/sgx-driver/
+    && git checkout {{Graphene.Branch}}
 
 # Create SGX driver for header files
-RUN cd /graphene/Pal/src/host/Linux-SGX/sgx-driver \
+RUN cd /graphene/Pal/src/host/Linux-SGX \
     && git clone {{SGXDriver.Repository}} linux-sgx-driver \
     && cd linux-sgx-driver \
     && git checkout {{SGXDriver.Branch}}
 
 # Build Graphene-SGX
-RUN cd /graphene && ISGX_DRIVER_PATH=/graphene/Pal/src/host/Linux-SGX/sgx-driver/linux-sgx-driver \
+RUN cd /graphene && ISGX_DRIVER_PATH=/graphene/Pal/src/host/Linux-SGX/linux-sgx-driver \
     make -s -j4 SGX=1 {% if debug %} DEBUG=1 {% endif %}WERROR=1 \
     {% if linux %} && make -s -j4 WERROR=1{% if debug %} DEBUG=1{% endif %}{% else %} && true{%endif %}
 
 # Translate runtime symlinks to files
 RUN for f in $(find /graphene/Runtime -type l); do cp --remove-destination $(realpath $f) $f; done
-


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://graphene.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

- `link-intel-driver.py` is imported from oscarlab/graphene-sgx-driver and the submodule is removed.
- Interactive `input()` is removed, because it is unwieldy in build system.
- There are some changes in includes and include dirs, to include only the new file.

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->

Jenkins, as usual.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/1997)
<!-- Reviewable:end -->
