### PR TITLE
[Pal] Add SGX profiling support

### DIFF
--- a/.ci/ubuntu18.04.dockerfile
+++ b/.ci/ubuntu18.04.dockerfile
@@ -46,6 +46,7 @@ RUN apt-get update && env DEBIAN_FRONTEND=noninteractive apt-get install -y \
     python3-numpy \
     python3-pip \
     python3-protobuf \
+    python3-pyelftools \
     python3-pytest \
     python3-scipy \
     r-base-core \

--- a/Documentation/devel/performance.rst
+++ b/Documentation/devel/performance.rst
@@ -513,7 +513,7 @@ SGX profiling
 There is some experimental support for profiling the code inside the SGX
 enclave. Here is how to use it:
 
-#. Compile Graphene with ``SGX=1 SGX_PROFILE=1 DEBUG=1``.
+#. Compile Graphene with ``SGX=1 DEBUG=1``.
 
 #. Make sure to install Python package ``pyelftools`` (e.g. ``sudo apt-get
    install python-pyelftools``).

--- a/Documentation/devel/performance.rst
+++ b/Documentation/devel/performance.rst
@@ -489,7 +489,7 @@ Some useful options for recording (``perf record``):
 * ``-e cpu-clock``: sample the ``cpu-clock`` event, which will be triggered also
   inside enclave (as opposed to the default ``cpu-cycles`` event). Unfortunately
   such events will be counted towards ``async_exit_pointer`` instead of
-  functions executing inside enclave.
+  functions executing inside enclave (but see also :ref:`sgx-profile`).
 
 Some useful options for displaying the report (``perf report``):
 
@@ -504,6 +504,37 @@ Further reading
 * `Linux perf examples - Brendan Gregg
   <http://www.brendangregg.com/perf.html>`__
 * Man pages: ``man perf record``, ``man perf report`` etc.
+
+.. _sgx-profile:
+
+SGX profiling
+-------------
+
+There is some experimental support for profiling the code inside the SGX
+enclave. Here is how to use it:
+
+#. Compile Graphene with ``SGX=1 SGX_PROFILE=1 DEBUG=1``.
+
+#. Make sure to install Python package ``pyelftools`` (e.g. ``sudo apt-get
+   install python-pyelftools``).
+
+#. Add ``sgx.profile = "root"`` to manifest (to collect data for the main
+   process), or ``sgx.profile = "all"`` (to collect data for all processes).
+
+#. Run your application. It should say something like ``writing profile data to
+   sgx-profile.data`` on process exit (in case of ``sgx.profile = "all"``,
+   multiple files will be written).
+
+#. Run ``profile-report``
+   (``Pal/src/host/Linux-SGX/tools/profile-report/profile-report``) with the
+   data file as parameter. It should display a table of functions (or raw
+   addresses, if symbol information is not available)
+
+*Note*: The accuracy of this tool is unclear. The SGX profiling works by
+measuring the value of instruction pointer on each asynchronous enclave exit
+(AEX), which happen on Linux scheduler interrupts as well as other such as page
+faults. While we attempt to measure time (and not only count occurences), the
+results might be inaccurate.
 
 Other useful tools for profiling
 --------------------------------

--- a/Documentation/devel/performance.rst
+++ b/Documentation/devel/performance.rst
@@ -518,7 +518,7 @@ enclave. Here is how to use it:
 #. Make sure to install Python package ``pyelftools`` (e.g. ``sudo apt-get
    install python-pyelftools``).
 
-#. Add ``sgx.profile = "root"`` to manifest (to collect data for the main
+#. Add ``sgx.profile = "main"`` to manifest (to collect data for the main
    process), or ``sgx.profile = "all"`` (to collect data for all processes).
 
 #. Run your application. It should say something like ``writing profile data to
@@ -528,13 +528,13 @@ enclave. Here is how to use it:
 #. Run ``profile-report``
    (``Pal/src/host/Linux-SGX/tools/profile-report/profile-report``) with the
    data file as parameter. It should display a table of functions (or raw
-   addresses, if symbol information is not available)
+   addresses, if symbol information is not available).
 
 *Note*: The accuracy of this tool is unclear. The SGX profiling works by
 measuring the value of instruction pointer on each asynchronous enclave exit
-(AEX), which happen on Linux scheduler interrupts as well as other such as page
-faults. While we attempt to measure time (and not only count occurences), the
-results might be inaccurate.
+(AEX), which happen on Linux scheduler interrupts, as well as other events such
+as page faults. While we attempt to measure time (and not only count
+occurences), the results might be inaccurate.
 
 Other useful tools for profiling
 --------------------------------

--- a/Documentation/manifest-syntax.rst
+++ b/Documentation/manifest-syntax.rst
@@ -458,3 +458,28 @@ This syntax specifies whether to enable SGX enclave-specific statistics:
 *Note:* this option is insecure and cannot be used with production enclaves
 (``sgx.debug = 0``). If the production enclave is started with this option set,
 Graphene will fail initialization of the enclave.
+
+SGX profiling
+^^^^^^^^^^^^^
+
+::
+
+    sgx.profile = ["none"|"root"|"all"]
+    (Default: "none")
+
+This syntax specifies whether to enable SGX profiling. Graphene must be compiled
+with ``DEBUG=1`` and ``SGX_PROFILE=1`` for this option to work.
+
+If this option is set to ``root``, the root process will collect IP samples and
+save them as ``profile-sgx.data``. If it's to ``all``, all processes will
+collect samples and save them to ``profile-sgx-<PID>.data``.
+
+The saved files can be used to generate a report with ``profile-report`` tool,
+located in ``Pal/src/host/Linux-SGX/tools/profile-report/`` directory. It
+requires ``pyelftools`` Python package to be installed.
+
+See :doc:`devel/performance` for more information.
+
+*Note:* this option is insecure and cannot be used with production enclaves
+(``sgx.debug = 0``). If the production enclave is started with this option set,
+Graphene will fail initialization of the enclave.

--- a/Documentation/manifest-syntax.rst
+++ b/Documentation/manifest-syntax.rst
@@ -468,7 +468,7 @@ SGX profiling
     (Default: "none")
 
 This syntax specifies whether to enable SGX profiling. Graphene must be compiled
-with ``DEBUG=1`` and ``SGX_PROFILE=1`` for this option to work.
+with ``DEBUG=1`` for this option to work.
 
 If this option is set to ``main``, the main process will collect IP samples and
 save them as ``sgx-profile.data``. If it is set to ``all``, all processes will

--- a/Documentation/manifest-syntax.rst
+++ b/Documentation/manifest-syntax.rst
@@ -464,15 +464,15 @@ SGX profiling
 
 ::
 
-    sgx.profile = ["none"|"root"|"all"]
+    sgx.profile = ["none"|"main"|"all"]
     (Default: "none")
 
 This syntax specifies whether to enable SGX profiling. Graphene must be compiled
 with ``DEBUG=1`` and ``SGX_PROFILE=1`` for this option to work.
 
-If this option is set to ``root``, the root process will collect IP samples and
-save them as ``profile-sgx.data``. If it's to ``all``, all processes will
-collect samples and save them to ``profile-sgx-<PID>.data``.
+If this option is set to ``main``, the main process will collect IP samples and
+save them as ``sgx-profile.data``. If it is set to ``all``, all processes will
+collect samples and save them to ``sgx-profile-<PID>.data``.
 
 The saved files can be used to generate a report with ``profile-report`` tool,
 located in ``Pal/src/host/Linux-SGX/tools/profile-report/`` directory. It

--- a/Pal/include/pal/pal_debug.h
+++ b/Pal/include/pal/pal_debug.h
@@ -11,6 +11,7 @@
 #include "pal.h"
 
 int pal_printf(const char* fmt, ...) __attribute__((format(printf, 1, 2)));
+int pal_fdprintf(int fd, const char* fmt, ...) __attribute__((format(printf, 2, 3)));
 void warn(const char* format, ...);
 
 void DkDebugAttachBinary(PAL_STR uri, PAL_PTR start_addr);

--- a/Pal/src/host/Linux-SGX/Makefile
+++ b/Pal/src/host/Linux-SGX/Makefile
@@ -70,6 +70,7 @@ enclave-asm-objs = enclave_entry.o
 
 urts-objs = \
 	clone-x86_64.o \
+	sgx_profile.o \
 	sgx_enclave.o \
 	sgx_exception.o \
 	sgx_framework.o \

--- a/Pal/src/host/Linux-SGX/Makefile
+++ b/Pal/src/host/Linux-SGX/Makefile
@@ -70,7 +70,6 @@ enclave-asm-objs = enclave_entry.o
 
 urts-objs = \
 	clone-x86_64.o \
-	sgx_profile.o \
 	sgx_enclave.o \
 	sgx_exception.o \
 	sgx_framework.o \
@@ -78,6 +77,7 @@ urts-objs = \
 	sgx_main.o \
 	sgx_platform.o \
 	sgx_process.o \
+	sgx_profile.o \
 	sgx_gdb_info.o \
 	sgx_thread.o \
 	quote/aesm.pb-c.o \

--- a/Pal/src/host/Linux-SGX/enclave_framework.c
+++ b/Pal/src/host/Linux-SGX/enclave_framework.c
@@ -38,14 +38,14 @@ bool sgx_is_completely_outside_enclave(const void* addr, size_t size) {
 }
 
 /*
- * When SGX_PROFILE is enabled, we run some code on asynchronous enclave exit (AEX) that uses the
- * stack. Make sure to update URSP so that the AEX handler does not overwrite the part of the stack
- * that we just allocated.
+ * When DEBUG is enabled, we run sgx_profile_sample() during asynchronous enclave exit (AEX), which
+ * uses the stack. Make sure to update URSP so that the AEX handler does not overwrite the part of
+ * the stack that we just allocated.
  *
  * (Recall that URSP is an outside stack pointer, saved by EENTER and restored on AEX by the SGX
  * hardware itself.)
  */
-#if SGX_PROFILE
+#ifdef DEBUG
 
 #define UPDATE_USTACK(_ustack)                           \
     do {                                                 \

--- a/Pal/src/host/Linux-SGX/enclave_framework.c
+++ b/Pal/src/host/Linux-SGX/enclave_framework.c
@@ -41,6 +41,9 @@ bool sgx_is_completely_outside_enclave(const void* addr, size_t size) {
  * When SGX_PROFILE is enabled, we run some code on asynchronous enclave exit (AEX) that uses the
  * stack. Make sure to update URSP so that the AEX handler does not overwrite the part of the stack
  * that we just allocated.
+ *
+ * (Recall that URSP is an outside stack pointer, saved by EENTER and restored on AEX by the SGX
+ * hardware itself.)
  */
 #if SGX_PROFILE
 

--- a/Pal/src/host/Linux-SGX/enclave_framework.c
+++ b/Pal/src/host/Linux-SGX/enclave_framework.c
@@ -37,13 +37,32 @@ bool sgx_is_completely_outside_enclave(const void* addr, size_t size) {
     return g_enclave_base >= addr + size || g_enclave_top <= addr;
 }
 
+/*
+ * When SGX_PROFILE is enabled, we run some code on asynchronous enclave exit (AEX) that uses the
+ * stack. Make sure to update URSP so that the AEX handler does not overwrite the part of the stack
+ * that we just allocated.
+ */
+#if SGX_PROFILE
+
+#define UPDATE_USTACK(_ustack)                           \
+    do {                                                 \
+        SET_ENCLAVE_TLS(ustack, _ustack);                \
+        GET_ENCLAVE_TLS(gpr)->ursp = (uint64_t)_ustack;  \
+    } while(0)
+
+#else
+
+#define UPDATE_USTACK(_ustack) SET_ENCLAVE_TLS(ustack, _ustack)
+
+#endif
+
 void* sgx_prepare_ustack(void) {
     void* old_ustack = GET_ENCLAVE_TLS(ustack);
 
     void* ustack = old_ustack;
     if (ustack != GET_ENCLAVE_TLS(ustack_top))
         ustack -= RED_ZONE_SIZE;
-    SET_ENCLAVE_TLS(ustack, ustack);
+    UPDATE_USTACK(ustack);
 
     return old_ustack;
 }
@@ -55,7 +74,7 @@ void* sgx_alloc_on_ustack_aligned(size_t size, size_t alignment) {
     if (!sgx_is_completely_outside_enclave(ustack, size)) {
         return NULL;
     }
-    SET_ENCLAVE_TLS(ustack, ustack);
+    UPDATE_USTACK(ustack);
     return ustack;
 }
 
@@ -76,7 +95,7 @@ void* sgx_copy_to_ustack(const void* ptr, size_t size) {
 
 void sgx_reset_ustack(const void* old_ustack) {
     assert(old_ustack <= GET_ENCLAVE_TLS(ustack_top));
-    SET_ENCLAVE_TLS(ustack, old_ustack);
+    UPDATE_USTACK(old_ustack);
 }
 
 bool sgx_copy_ptr_to_enclave(void** ptr, void* uptr, size_t size) {

--- a/Pal/src/host/Linux-SGX/sgx_enclave.c
+++ b/Pal/src/host/Linux-SGX/sgx_enclave.c
@@ -64,6 +64,9 @@ static long sgx_ocall_exit(void* pms) {
     /* exit the whole process if exit_group() */
     if (ms->ms_is_exitgroup) {
         update_and_print_stats(/*process_wide=*/true);
+#ifdef SGX_PROFILE
+        sgx_profile_finish();
+#endif
         INLINE_SYSCALL(exit_group, 1, (int)ms->ms_exitcode);
     }
 
@@ -76,6 +79,9 @@ static long sgx_ocall_exit(void* pms) {
     if (!current_enclave_thread_cnt()) {
         /* no enclave threads left, kill the whole process */
         update_and_print_stats(/*process_wide=*/true);
+#ifdef SGX_PROFILE
+        sgx_profile_finish();
+#endif
         INLINE_SYSCALL(exit_group, 1, (int)ms->ms_exitcode);
     }
 

--- a/Pal/src/host/Linux-SGX/sgx_enclave.c
+++ b/Pal/src/host/Linux-SGX/sgx_enclave.c
@@ -64,7 +64,7 @@ static long sgx_ocall_exit(void* pms) {
     /* exit the whole process if exit_group() */
     if (ms->ms_is_exitgroup) {
         update_and_print_stats(/*process_wide=*/true);
-#ifdef SGX_PROFILE
+#ifdef DEBUG
         sgx_profile_finish();
 #endif
         INLINE_SYSCALL(exit_group, 1, (int)ms->ms_exitcode);
@@ -79,7 +79,7 @@ static long sgx_ocall_exit(void* pms) {
     if (!current_enclave_thread_cnt()) {
         /* no enclave threads left, kill the whole process */
         update_and_print_stats(/*process_wide=*/true);
-#ifdef SGX_PROFILE
+#ifdef DEBUG
         sgx_profile_finish();
 #endif
         INLINE_SYSCALL(exit_group, 1, (int)ms->ms_exitcode);

--- a/Pal/src/host/Linux-SGX/sgx_entry.S
+++ b/Pal/src/host/Linux-SGX/sgx_entry.S
@@ -69,7 +69,7 @@ async_exit_pointer:
 	# increment per-thread AEX counter for stats
 	lock incq %gs:PAL_TCB_URTS_AEX_CNT
 
-#ifdef SGX_PROFILE
+#ifdef DEBUG
 	# Save ERESUME parameters
 	pushq %rax
 	.cfi_adjust_cfa_offset 8

--- a/Pal/src/host/Linux-SGX/sgx_entry.S
+++ b/Pal/src/host/Linux-SGX/sgx_entry.S
@@ -78,7 +78,7 @@ async_exit_pointer:
 	pushq %rcx
 	.cfi_adjust_cfa_offset 8
 
-	# Align stack (eequired by System V AMD64 ABI)
+	# Align stack (required by System V AMD64 ABI)
 	movq %rsp, %rbp
 	andq $~0xF, %rsp
 

--- a/Pal/src/host/Linux-SGX/sgx_entry.S
+++ b/Pal/src/host/Linux-SGX/sgx_entry.S
@@ -64,8 +64,42 @@ sgx_ecall:
 	.type async_exit_pointer, @function
 
 async_exit_pointer:
+	.cfi_startproc
+
 	# increment per-thread AEX counter for stats
 	lock incq %gs:PAL_TCB_URTS_AEX_CNT
+
+#ifdef SGX_PROFILE
+	# Save ERESUME parameters
+	pushq %rax
+	.cfi_adjust_cfa_offset 8
+	pushq %rbx
+	.cfi_adjust_cfa_offset 8
+	pushq %rcx
+	.cfi_adjust_cfa_offset 8
+
+	# Align stack (eequired by System V AMD64 ABI)
+	movq %rsp, %rbp
+	andq $~0xF, %rsp
+
+	# Call sgx_profile_sample with %rdi = TCS
+	movq %rbx, %rdi
+	call sgx_profile_sample
+
+	# Restore stack
+	movq %rbp, %rsp
+
+	# Restore ERESUME parameters
+	popq %rcx
+	.cfi_adjust_cfa_offset -8
+	popq %rbx
+	.cfi_adjust_cfa_offset -8
+	popq %rax
+	.cfi_adjust_cfa_offset -8
+#endif
+
+	.cfi_endproc
+
 	# fall-through to ERESUME
 
 	.global eresume_pointer

--- a/Pal/src/host/Linux-SGX/sgx_graphene.c
+++ b/Pal/src/host/Linux-SGX/sgx_graphene.c
@@ -29,15 +29,26 @@ static int fputch(void* f, int ch, struct printbuf* b) {
     return 0;
 }
 
-static int vprintf(const char* fmt, va_list ap) {
+static int vprintf(int fd, const char* fmt, va_list ap) {
     struct printbuf b;
 
     b.idx = 0;
     b.cnt = 0;
     vfprintfmt((void*)&fputch, NULL, &b, fmt, ap);
-    INLINE_SYSCALL(write, 3, 2, b.buf, b.idx);
+    INLINE_SYSCALL(write, 3, fd, b.buf, b.idx);
 
     return b.cnt;
+}
+
+int pal_fdprintf(int fd, const char* fmt, ...) {
+    va_list ap;
+    int cnt;
+
+    va_start(ap, fmt);
+    cnt = vprintf(fd, fmt, ap);
+    va_end(ap);
+
+    return cnt;
 }
 
 int pal_printf(const char* fmt, ...) {
@@ -45,7 +56,7 @@ int pal_printf(const char* fmt, ...) {
     int cnt;
 
     va_start(ap, fmt);
-    cnt = vprintf(fmt, ap);
+    cnt = vprintf(2, fmt, ap);
     va_end(ap);
 
     return cnt;

--- a/Pal/src/host/Linux-SGX/sgx_graphene.c
+++ b/Pal/src/host/Linux-SGX/sgx_graphene.c
@@ -29,7 +29,7 @@ static int fputch(void* f, int ch, struct printbuf* b) {
     return 0;
 }
 
-static int vprintf(int fd, const char* fmt, va_list ap) {
+static int vfdprintf(int fd, const char* fmt, va_list ap) {
     struct printbuf b;
 
     b.idx = 0;
@@ -45,7 +45,7 @@ int pal_fdprintf(int fd, const char* fmt, ...) {
     int cnt;
 
     va_start(ap, fmt);
-    cnt = vprintf(fd, fmt, ap);
+    cnt = vfdprintf(fd, fmt, ap);
     va_end(ap);
 
     return cnt;
@@ -56,7 +56,7 @@ int pal_printf(const char* fmt, ...) {
     int cnt;
 
     va_start(ap, fmt);
-    cnt = vprintf(2, fmt, ap);
+    cnt = vfdprintf(2, fmt, ap);
     va_end(ap);
 
     return cnt;

--- a/Pal/src/host/Linux-SGX/sgx_internal.h
+++ b/Pal/src/host/Linux-SGX/sgx_internal.h
@@ -147,7 +147,7 @@ int block_async_signals(bool block);
 
 void update_debugger(void);
 
-#ifdef SGX_PROFILE
+#ifdef DEBUG
 int sgx_profile_init(bool all);
 void sgx_profile_finish(void);
 void sgx_profile_sample(void* tcs);

--- a/Pal/src/host/Linux-SGX/sgx_internal.h
+++ b/Pal/src/host/Linux-SGX/sgx_internal.h
@@ -147,4 +147,10 @@ int block_async_signals(bool block);
 
 void update_debugger(void);
 
+#ifdef SGX_PROFILE
+int sgx_profile_init(bool all);
+void sgx_profile_finish(void);
+void sgx_profile_sample(void* tcs);
+#endif
+
 #endif

--- a/Pal/src/host/Linux-SGX/sgx_main.c
+++ b/Pal/src/host/Linux-SGX/sgx_main.c
@@ -308,7 +308,7 @@ static int initialize_enclave(struct pal_enclave* enclave, bool first_process) {
         ret = -EINVAL;
         goto out;
     }
-#ifdef SGX_PROFILE
+#ifdef DEBUG
     if (!profile_str || !strcmp(profile_str, "none")) {
         // do not enable
     } else if (!strcmp(profile_str, "main")) {
@@ -329,7 +329,7 @@ static int initialize_enclave(struct pal_enclave* enclave, bool first_process) {
 #else
     __UNUSED(first_process);
     if (profile_str && strcmp(profile_str, "none")) {
-        SGX_DBG(DBG_E, "Cannot use \'sgx.profile\' when compiled without SGX_PROFILE\n");
+        SGX_DBG(DBG_E, "Cannot use \'sgx.profile\' when compiled without DEBUG\n");
         ret = -EINVAL;
         goto out;
     }

--- a/Pal/src/host/Linux-SGX/sgx_profile.c
+++ b/Pal/src/host/Linux-SGX/sgx_profile.c
@@ -1,0 +1,238 @@
+/* SPDX-License-Identifier: LGPL-3.0-or-later */
+/* Copyright (C) 2020 Intel Corporation
+ *                    Paweł Marczewski <pawel@invisiblethingslab.com>
+ */
+
+/*
+ * SGX profiling. This code maintains a hash map of IP locations encountered inside the enclave,
+ * storing counters with elapsed time. The map is written out on program exit, along with map of
+ * loaded objects, so that the resulting file can be converted to a report.
+ */
+
+#ifdef SGX_PROFILE
+
+#include <assert.h>
+#include <errno.h>
+#include <stddef.h>
+
+#include "cpu.h"
+#include "perm.h"
+#include "sgx_internal.h"
+#include "spinlock.h"
+
+struct counter {
+    void* ip;
+    uint64_t count;
+    UT_hash_handle hh;
+};
+
+static spinlock_t g_profile_lock = INIT_SPINLOCK_UNLOCKED;
+static struct counter* g_counters = NULL;
+static uint64_t g_last_tsc = 0;
+
+static int g_profile_enabled = false;
+static int g_profile_all = false;
+static int g_mem_fd = -1;
+static uint64_t g_max_dt = 0;
+
+/* Read memory from inside enclave (using /proc/self/mem). */
+static void debug_read(void* dest, void* addr, size_t size) {
+    int ret;
+    size_t cur_size = size;
+    void* cur_dest = dest;
+    void* cur_addr = addr;
+
+    while (cur_size > 0) {
+        ret = INLINE_SYSCALL(pread, 4, g_mem_fd, cur_dest, cur_size, (off_t)cur_addr);
+
+        if (IS_ERR(ret) && ERRNO(ret) == EINTR)
+            continue;
+
+        if (IS_ERR(ret)) {
+            SGX_DBG(DBG_E, "debug_read: error reading %lu bytes at %p: %d\n", size, addr, ERRNO(ret));
+            INLINE_SYSCALL(exit_group, 1, ERRNO(ret));
+        }
+
+        if (ret == 0) {
+            SGX_DBG(DBG_E, "debug_read: EOF reading %lu bytes at %p\n", size, addr);
+            INLINE_SYSCALL(exit_group, 1, 255);
+        }
+
+        assert(ret > 0);
+        assert((unsigned)ret <= cur_size);
+        cur_size -= ret;
+        cur_dest += ret;
+        cur_addr += ret;
+    }
+}
+
+static void* get_sgx_ip(void* tcs) {
+    uint64_t ossa;
+    uint32_t cssa;
+    debug_read(&ossa, tcs + 16, sizeof(ossa));
+    debug_read(&cssa, tcs + 24, sizeof(cssa));
+
+    void* gpr_addr = (void*)(
+        g_pal_enclave.baseaddr
+        + ossa + cssa * g_pal_enclave.ssaframesize
+        - sizeof(sgx_pal_gpr_t));
+
+    uint64_t rip;
+    debug_read(&rip, gpr_addr + offsetof(sgx_pal_gpr_t, rip), sizeof(rip));
+
+    return (void*)rip;
+}
+
+#define CPUID_LEAF_TSC_FREQ 0x15
+
+static uint64_t get_tsc_hz(void) {
+    uint32_t words[PAL_CPUID_WORD_NUM];
+    uint64_t crys_hz;
+
+    cpuid(CPUID_LEAF_TSC_FREQ, 0, words);
+    if (words[PAL_CPUID_WORD_EBX] > 0 && words[PAL_CPUID_WORD_EAX] > 0) {
+        /* nominal frequency of the core crystal clock in kHz */
+        crys_hz = words[PAL_CPUID_WORD_ECX];
+        if (crys_hz > 0) {
+            return crys_hz * words[PAL_CPUID_WORD_EBX] / words[PAL_CPUID_WORD_EAX];
+        }
+    }
+    return 0;
+}
+
+int sgx_profile_init(bool all) {
+    assert(!g_profile_enabled);
+    assert(g_mem_fd == -1);
+
+    uint64_t tsc_hz = get_tsc_hz();
+    if (tsc_hz == 0) {
+        SGX_DBG(DBG_E, "sgx_profile_init: failed to get TSC frequency\n");
+        return -ENOSYS;
+    }
+
+    // Assume Linux scheduler will normally interrupt the enclave 4 ms, or 250 times per second.
+    g_max_dt = tsc_hz / 250;
+
+    int ret = INLINE_SYSCALL(open, 3, "/proc/self/mem", O_RDONLY | O_LARGEFILE, 0);
+    if (IS_ERR(ret)) {
+        SGX_DBG(DBG_E, "sgx_profile_init: opening /proc/self/mem failed: %d\n", ERRNO(ret));
+        return ret;
+    }
+    g_mem_fd = ret;
+    g_profile_enabled = true;
+    g_profile_all = all;
+    return 0;
+}
+
+/*
+ * Shut down profiling and write out data to a file.
+
+ * The file will contain two kinds of lines:
+ * - "counter 0x<addr> <count>": counter value
+ * - "file 0x<addr> <path>": address of shared object loaded inside enclave
+ */
+void sgx_profile_finish(void) {
+    int ret;
+
+    if (!g_profile_enabled)
+        return;
+
+    char buf[64];
+    if (g_profile_all)
+        snprintf(buf, sizeof(buf), "sgx-profile-%d.data", g_pal_enclave.pal_sec.pid);
+    else
+        snprintf(buf, sizeof(buf), "sgx-profile.data");
+    SGX_DBG(DBG_I, "writing profile data to %s\n", buf);
+
+    int fd = INLINE_SYSCALL(open, 3, buf, O_WRONLY | O_TRUNC | O_CREAT, PERM_rw_______);
+    if (IS_ERR(fd)) {
+        SGX_DBG(DBG_E, "sgx_profile_finish: error opening file: %d\n", -fd);
+        goto out;
+    }
+
+    // Write out counters
+    struct counter* counter;
+    struct counter* tmp;
+    HASH_ITER(hh, g_counters, counter, tmp) {
+        pal_fdprintf(fd, "counter %p %lu\n", counter->ip, counter->count);
+        HASH_DEL(g_counters, counter);
+        free(counter);
+    }
+
+    // Write out debug_map (unfortunately we have to read it from enclave memory)
+    if (g_pal_enclave.debug_map) {
+        struct debug_map* _Atomic pmap;
+        debug_read(&pmap, g_pal_enclave.debug_map, sizeof(pmap));
+
+        while (pmap) {
+            struct debug_map map;
+            debug_read(&map, pmap, sizeof(map));
+
+            pal_fdprintf(fd, "file %p ", map.load_addr);
+
+            // Read file_name byte by byte until we encounter null terminator, and write it out
+            char* file_name = map.file_name;
+            char c;
+            do {
+                debug_read(&c, file_name, sizeof(c));
+                pal_fdprintf(fd, "%c", c ?: '\n');
+                file_name++;
+            } while (c);
+
+            pmap = map.next;
+        }
+    }
+
+    ret = INLINE_SYSCALL(close, 1, fd);
+    if (IS_ERR(ret))
+        SGX_DBG(DBG_E, "sgx_profile_finish: closing %s failed: %d\n", buf, -ret);
+
+out:
+    ret = INLINE_SYSCALL(close, 1, g_mem_fd);
+    if (IS_ERR(ret))
+        SGX_DBG(DBG_E, "sgx_profile_finish: closing /proc/self/mem failed: %d\n", -ret);
+    g_mem_fd = -1;
+    g_profile_enabled = false;
+}
+
+/*
+ * Update counters after exit from enclave.
+ *
+ * We use RDTSC to measure time since the last measurement, because in some cases the asynchronous
+ * exits happen more often (e.g. repeated page faults), and places causing these exits would be
+ * inaccurately counted if we always increased counters by 1.
+ */
+void sgx_profile_sample(void* tcs) {
+    if (!g_profile_enabled)
+        return;
+
+    void* ip = get_sgx_ip(tcs);
+    spinlock_lock(&g_profile_lock);
+
+    uint64_t tsc = get_tsc();
+    if (g_last_tsc > 0) {
+        assert(tsc >= g_last_tsc);
+        uint64_t dt = tsc - g_last_tsc;
+
+        // Increase by at most g_max_dt ticks: if the last measurement is older, it means we
+        // probably slept since then.
+        if (dt > g_max_dt)
+            dt = g_max_dt;
+
+        struct counter* counter;
+        HASH_FIND_PTR(g_counters, &ip, counter);
+        if (counter) {
+            counter->count += dt;
+        } else {
+            counter = malloc(sizeof(*counter));
+            counter->ip = ip;
+            counter->count = dt;
+            HASH_ADD_PTR(g_counters, ip, counter);
+        }
+    }
+    g_last_tsc = tsc;
+
+    spinlock_unlock(&g_profile_lock);
+}
+
+#endif /* SGX_PROFILE */

--- a/Pal/src/host/Linux-SGX/sgx_profile.c
+++ b/Pal/src/host/Linux-SGX/sgx_profile.c
@@ -245,6 +245,12 @@ void sgx_profile_sample(void* tcs) {
             counter->count += dt;
         } else {
             counter = malloc(sizeof(*counter));
+            if (!counter) {
+                SGX_DBG(DBG_E, "sgx_profile_sample: out of memory\n");
+                spinlock_unlock(&g_profile_lock);
+                return;
+            }
+
             counter->ip = ip;
             counter->count = dt;
             HASH_ADD_PTR(g_counters, ip, counter);

--- a/Pal/src/host/Linux-SGX/sgx_profile.c
+++ b/Pal/src/host/Linux-SGX/sgx_profile.c
@@ -9,7 +9,7 @@
  * loaded objects, so that the resulting file can be converted to a report.
  */
 
-#ifdef SGX_PROFILE
+#ifdef DEBUG
 
 #include <assert.h>
 #include <errno.h>
@@ -254,4 +254,4 @@ void sgx_profile_sample(void* tcs) {
     }
 }
 
-#endif /* SGX_PROFILE */
+#endif /* DEBUG */

--- a/Pal/src/host/Linux-SGX/sgx_thread.c
+++ b/Pal/src/host/Linux-SGX/sgx_thread.c
@@ -85,6 +85,8 @@ void pal_tcb_urts_init(PAL_TCB_URTS* tcb, void* stack, void* alt_stack) {
     tcb->aex_cnt          = 0;
     tcb->sync_signal_cnt  = 0;
     tcb->async_signal_cnt = 0;
+
+    tcb->profile_sample_time = 0;
 }
 
 static spinlock_t tcs_lock = INIT_SPINLOCK_UNLOCKED;

--- a/Pal/src/host/Linux-SGX/sgx_tls.h
+++ b/Pal/src/host/Linux-SGX/sgx_tls.h
@@ -93,6 +93,7 @@ typedef struct pal_tcb_urts {
     atomic_ulong aex_cnt;          /* # of AEXs, corresponds to # of interrupts/signals */
     atomic_ulong sync_signal_cnt;  /* # of sync signals, corresponds to # of SIGSEGV/SIGILL/.. */
     atomic_ulong async_signal_cnt; /* # of async signals, corresponds to # of SIGINT/SIGCONT/.. */
+    uint64_t profile_sample_time;  /* last time sgx_profile_sample() has been called */
 } PAL_TCB_URTS;
 
 extern void pal_tcb_urts_init(PAL_TCB_URTS* tcb, void* stack, void* alt_stack);

--- a/Pal/src/host/Linux-SGX/tools/profile-report/profile-report
+++ b/Pal/src/host/Linux-SGX/tools/profile-report/profile-report
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-3.0-or-later
+# Copyright (C) 2020  Intel Corporation
+#                     Paweł Marczewski <pawel@invisiblethingslab.com>
+
+# Display SGX profile report based on a file produced by Graphene (SGX_PROFILE).
+
+# TODO: Improve symbol resolution - currently we parse the ELF file, but this doesn't properly load
+# external debug info (e.g. Python binary)
+
+import argparse
+from collections import namedtuple
+import os
+import sys
+import bisect
+
+from elftools.elf.elffile import ELFFile
+
+Symbol = namedtuple('Symbol', ['name', 'obj', 'start', 'end'])
+
+def load_symbols(file_name, offset):
+    basename = os.path.basename(file_name)
+    with open(file_name, 'rb') as f:
+        elf = ELFFile(f)
+        symtab = elf.get_section_by_name('.symtab')
+        if not symtab:
+            print('No symbols for {}'.format(file_name), file=sys.stderr)
+            return
+        for symbol in symtab.iter_symbols():
+            if (symbol['st_info']['type'] == 'STT_FUNC' and
+                symbol['st_value'] > 0 and
+                symbol['st_size'] > 0):
+
+                yield Symbol(
+                    name=symbol.name,
+                    obj=basename,
+                    start=offset + symbol['st_value'],
+                    end=offset + symbol['st_value'] + symbol['st_size'],
+                )
+
+
+class Resolver:
+    def __init__(self, files):
+        self.symbols = []
+        self.files = files
+        self.files.sort()
+        for addr, file_name in self.files:
+            self.symbols.extend(load_symbols(file_name, addr))
+        self.symbols.sort(key=lambda sym: sym.start)
+        self.starts = [sym.start for sym in self.symbols]
+        self.file_starts = [addr for addr, file_name in self.files]
+
+    def resolve(self, addr):
+        idx = bisect.bisect(self.starts, addr) - 1
+        if idx < 0:
+            return self.resolve_by_file(addr)
+        sym = self.symbols[idx]
+        assert sym.start <= addr
+        if sym.end <= addr:
+            return self.resolve_by_file(addr)
+
+        return sym.name, sym.obj
+
+    def resolve_by_file(self, addr):
+        idx = bisect.bisect(self.file_starts, addr) - 1
+        if idx < 0:
+            return '({:x})'.format(addr), '?'
+
+        file_addr, file_name = self.files[idx]
+        obj = os.path.basename(file_name)
+        return '({:x})'.format(addr - file_addr), obj
+
+    def resolve_all(self, counters):
+        result = {}
+        for addr, count in counters.items():
+            location = self.resolve(addr)
+            if location in result:
+                result[location] += count
+            else:
+                result[location] = count
+
+        return result
+
+
+def load_file(file_name):
+    counters = {}
+    files = []
+    with open(file_name, 'r') as f:
+        for line in f:
+            line = line.rstrip()
+            if line.startswith('counter'):
+                _, s_addr, s_count = line.split(' ', 3)
+                addr = int(s_addr, 16)
+                count = int(s_count)
+                counters[addr] = count
+            elif line.startswith('file'):
+                _, s_addr, file_name = line.split(' ', 3)
+                addr = int(s_addr, 16)
+                files.append((addr, file_name))
+
+    return counters, files
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Display SGX profile report based on a file produced by Graphene.')
+    parser.add_argument('file_name', metavar='FILE', nargs='?', default='sgx-profile.data',
+                        help='file to load data from (default: %(default)s)')
+    parser.add_argument('-t', '--threshold', type=float, default=0.05, metavar='K',
+                        help='discard samples less frequent than K%%, default: %(default)s '
+                        '(use 0 to show everything)')
+    args = parser.parse_args()
+
+    counters, files = load_file(args.file_name)
+    resolver = Resolver(files)
+    report = resolver.resolve_all(counters)
+
+    total = sum(counters.values())
+
+    row = '{:>7}  {:20}  {:20}'
+    print(row.format('TIME', 'OBJ', 'SYMBOL'))
+    print()
+
+    for (name, obj), count in sorted(report.items(), key=lambda item: item[1], reverse=True):
+        percent = 100 * count / total
+        if percent >= args.threshold:
+            print(row.format(
+                '{:.2f}%'.format(percent),
+                obj,
+                name,
+            ))
+
+
+if __name__ == '__main__':
+    main()

--- a/Pal/src/host/Linux-SGX/tools/profile-report/profile-report
+++ b/Pal/src/host/Linux-SGX/tools/profile-report/profile-report
@@ -9,34 +9,95 @@
 # external debug info (e.g. Python binary)
 
 import argparse
+import bisect
 from collections import namedtuple
 import os
+from pathlib import Path
 import sys
-import bisect
 
 from elftools.elf.elffile import ELFFile
 
 Symbol = namedtuple('Symbol', ['name', 'obj', 'start', 'end'])
 
+
+def iter_symbols(elf, offset, basename):
+    symtab = elf.get_section_by_name('.symtab')
+    if not symtab:
+        return
+    for symbol in symtab.iter_symbols():
+        if (symbol['st_info']['type'] == 'STT_FUNC' and
+            symbol['st_value'] > 0 and
+            symbol['st_size'] > 0):
+
+            yield Symbol(
+                name=symbol.name,
+                obj=basename,
+                start=offset + symbol['st_value'],
+                end=offset + symbol['st_value'] + symbol['st_size'],
+            )
+
+
+def find_debug_binary(elf, path):
+    '''
+    Find a debug binary for a given ELF.
+
+    See: https://sourceware.org/gdb/onlinedocs/gdb/Separate-Debug-Files.html
+    '''
+
+    debug_dir = Path('/usr/lib/debug')
+
+    # Try looking up by build-id
+    section = elf.get_section_by_name('.note.gnu.build-id')
+    if section:
+        notes = list(section.iter_notes())
+        assert len(notes) == 1
+        note = notes[0]
+        assert note['n_type'] == 'NT_GNU_BUILD_ID'
+        build_id = note['n_desc']
+
+        # /usr/lib/debug/.build-id/ab/cdef1234.debug',
+        debug_path = debug_dir / '.build-id' / build_id[:2] / (build_id[2:] + '.debug')
+        if debug_path.is_file():
+            return debug_path
+
+    debug_name = path.name + '.debug'
+    for debug_path in [
+            # /usr/bin/ls.debug
+            path.with_name(debug_name),
+            # /usr/bin/.debug/ls.debug
+            path.parent / '.debug' / debug_name,
+            # /usr/lib/debug/usr/bin/ls.debug
+            debug_dir / path.with_name(debug_name)
+    ]:
+        if debug_path.is_file():
+            return debug_path
+
+    return None
+
+
 def load_symbols(file_name, offset):
-    basename = os.path.basename(file_name)
+    path = Path(file_name).resolve()
+    if not path.is_file():
+        print('File not found: {}'.format(path), file=sys.stderr)
+        return
+
     with open(file_name, 'rb') as f:
         elf = ELFFile(f)
-        symtab = elf.get_section_by_name('.symtab')
-        if not symtab:
-            print('No symbols for {}'.format(file_name), file=sys.stderr)
-            return
-        for symbol in symtab.iter_symbols():
-            if (symbol['st_info']['type'] == 'STT_FUNC' and
-                symbol['st_value'] > 0 and
-                symbol['st_size'] > 0):
 
-                yield Symbol(
-                    name=symbol.name,
-                    obj=basename,
-                    start=offset + symbol['st_value'],
-                    end=offset + symbol['st_value'] + symbol['st_size'],
-                )
+        if elf.get_section_by_name('.symtab'):
+            yield from iter_symbols(elf, offset, path.name)
+            return
+
+        debug_path = find_debug_binary(elf, path)
+        if not debug_path:
+            print('No symbols for {}, and no debug info found. '
+                  'Consider installing a *-dbg/dbgsym/debuginfo package.'
+                  .format(path), file=sys.stderr)
+            return
+
+    with open(debug_path, 'rb') as f:
+        elf = ELFFile(f)
+        yield from iter_symbols(elf, offset, path.name)
 
 
 class Resolver:

--- a/Pal/src/host/Linux-SGX/tools/profile-report/profile-report
+++ b/Pal/src/host/Linux-SGX/tools/profile-report/profile-report
@@ -3,10 +3,7 @@
 # Copyright (C) 2020  Intel Corporation
 #                     Paweł Marczewski <pawel@invisiblethingslab.com>
 
-# Display SGX profile report based on a file produced by Graphene (SGX_PROFILE).
-
-# TODO: Improve symbol resolution - currently we parse the ELF file, but this doesn't properly load
-# external debug info (e.g. Python binary)
+# Display SGX profile report based on a file produced by Graphene ('sgx.profile' manifest option).
 
 import argparse
 import bisect

--- a/Scripts/Makefile.configs
+++ b/Scripts/Makefile.configs
@@ -47,9 +47,6 @@ ARCH_LONG := $(SYS)
 DEBUG ?=
 export DEBUG
 
-SGX_PROFILE ?=
-export SGX_PROFILE
-
 CFLAGS += -Wall -std=c11 -Wmissing-prototypes
 CXXFLAGS += -Wall -std=c++14
 
@@ -60,15 +57,6 @@ ASFLAGS += -gdwarf-2 -g3
 CFLAGS += -DDEBUG
 ASFLAGS += -DDEBUG
 CXXFLAGS += -DDEBUG
-endif
-
-ifeq ($(SGX_PROFILE),1)
-ifneq ($(DEBUG),1)
-$(error SGX_PROFILE needs DEBUG)
-endif
-CFLAGS += -DSGX_PROFILE
-ASFLAGS += -DSGX_PROFILE
-CXXFLAGS += -DSGX_PROFILE
 endif
 
 ifeq ($(DEBUG),)

--- a/Scripts/Makefile.configs
+++ b/Scripts/Makefile.configs
@@ -47,6 +47,9 @@ ARCH_LONG := $(SYS)
 DEBUG ?=
 export DEBUG
 
+SGX_PROFILE ?=
+export SGX_PROFILE
+
 CFLAGS += -Wall -std=c11 -Wmissing-prototypes
 CXXFLAGS += -Wall -std=c++14
 
@@ -57,6 +60,15 @@ ASFLAGS += -gdwarf-2 -g3
 CFLAGS += -DDEBUG
 ASFLAGS += -DDEBUG
 CXXFLAGS += -DDEBUG
+endif
+
+ifeq ($(SGX_PROFILE),1)
+ifneq ($(DEBUG),1)
+$(error SGX_PROFILE needs DEBUG)
+endif
+CFLAGS += -DSGX_PROFILE
+ASFLAGS += -DSGX_PROFILE
+CXXFLAGS += -DSGX_PROFILE
 endif
 
 ifeq ($(DEBUG),)


### PR DESCRIPTION
This adds a "do it yourself" profiler that instruments AEX handler. I'm not sure how accurate it is, but the overhead seems to be pretty low (I haven't measured it though).

## Background

Background: I looked into `perf` first, and while it's pretty good for profiling non-SGX code, for SGX it only shows time spent in `async_exit_pointer` on interrupts. Unfortunately it seems pretty hard to extend, as perf events are generated in the kernel (and even if we did that, there's still the matter of resolving addresses to symbols).

First, I wrote some code on `async_exit_pointer` that reads the IP from enclave memory. This can already be dynamically instrumented by perf (using `perf probe`), but the resulting report is a list of events with `ip=0xabcd` and doesn't seem very usable. So I decided to go all the way and implement both event collection and symbol resolution in Graphene.

## Description of the changes <!-- (reasons and measures) -->

* `SGX_PROFILE` compilation flag, and `sgx.profile` manifest option
* Code in `async_exit_pointer` to measure IP and collect it in a hash table
* `profile-report` Python tool for generating a report

## How to test this PR? <!-- (if applicable) -->

Try to follow the instructions in `performance.rst`, and run some non-trivial workload.

## Possible improvements

* Make `perf` do more work somehow? Maybe we could generate synthetic `perf` events from userspace, not sure if it's ever done
* The Python program is pretty bad at symbol resolution: unlike perf and gdb, it doesn't understand that there can be external debug info. What can I use to do it better?
* Recover call graph (or at least a single caller)? I guess we could follow saved `RBP` and get something useful most of the time...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2001)
<!-- Reviewable:end -->
