### PR TITLE
[LibOS] Remove unused flush_handle() and flush_handle_map()

### DIFF
--- a/LibOS/shim/include/shim_handle.h
+++ b/LibOS/shim/include/shim_handle.h
@@ -354,7 +354,6 @@ struct shim_handle {
 
 /* allocating / manage handle */
 struct shim_handle* get_new_handle(void);
-void flush_handle(struct shim_handle* hdl);
 void get_handle(struct shim_handle* hdl);
 void put_handle(struct shim_handle* hdl);
 
@@ -410,7 +409,6 @@ struct shim_handle* detach_fd_handle(FDTYPE fd, int* flags, struct shim_handle_m
 
 /* manage handle mapping */
 int dup_handle_map(struct shim_handle_map** new_map, struct shim_handle_map* old_map);
-int flush_handle_map(struct shim_handle_map* map);
 void get_handle_map(struct shim_handle_map* map);
 void put_handle_map(struct shim_handle_map* map);
 int walk_handle_map(int (*callback)(struct shim_fd_handle*, struct shim_handle_map*),

--- a/LibOS/shim/src/sys/shim_open.c
+++ b/LibOS/shim/src/sys/shim_open.c
@@ -560,7 +560,6 @@ int shim_do_truncate(const char* path, loff_t length) {
         goto out_handle;
 
     ret = fs->fs_ops->truncate(hdl, length);
-    flush_handle(hdl);
 out_handle:
     put_handle(hdl);
 out:


### PR DESCRIPTION

## Description of the changes <!-- (reasons and measures) -->

Functions `flush_handle()` and `flush_handle_map()` are not used. The function `flush_handle()` was used in the `truncate()` syscall emulation for no good reason.

## How to test this PR? <!-- (if applicable) -->

All tests must pass.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2005)
<!-- Reviewable:end -->
