### PR TITLE
[Pal/Linux-SGX] Remove too noisy deprecation warning from signing tools

### DIFF
--- a/Pal/src/host/Linux-SGX/signer/pal-sgx-get-token
+++ b/Pal/src/host/Linux-SGX/signer/pal-sgx-get-token
@@ -4,7 +4,6 @@
 import sys
 import os
 import pathlib
-import warnings
 
 try:
     fspath = os.fspath
@@ -17,7 +16,4 @@ sys.path.insert(0, fspath(pathlib.Path(__file__).parent.parent))
 sys.path.insert(0, fspath((pathlib.Path(__file__) / '../../../../../../python').resolve()))
 from graphenelibos.sgx_get_token import main
 
-warnings.warn(
-    'pal-sgx-get-token is deprecated, please install graphene and use graphene-sgx-get-token',
-    DeprecationWarning)
 sys.exit(main())

--- a/Pal/src/host/Linux-SGX/signer/pal-sgx-sign
+++ b/Pal/src/host/Linux-SGX/signer/pal-sgx-sign
@@ -4,7 +4,6 @@
 import sys
 import os
 import pathlib
-import warnings
 
 try:
     fspath = os.fspath
@@ -17,7 +16,4 @@ sys.path.insert(0, fspath(pathlib.Path(__file__).parent.parent))
 sys.path.insert(0, fspath((pathlib.Path(__file__) / '../../../../../../python').resolve()))
 from graphenelibos.sgx_sign import main
 
-warnings.warn(
-    'pal-sgx-sign is deprecated, please install graphene and use graphene-sgx-sign',
-    DeprecationWarning)
 sys.exit(main())


### PR DESCRIPTION
## Description of the changes

Unfortunately this warning was triggered too often (including when building tests) and it's not terribly important, so let's just drop it.

## How to test this PR? <!-- (if applicable) -->

Build regression tests and look at the cleaner logs :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2011)
<!-- Reviewable:end -->
