### PR TITLE
[Docs] Fix reST in README.rst to work with GitHub

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -63,7 +63,7 @@ are available <https://graphene.readthedocs.io/en/latest/building.html>`__.
 How to run an application in Graphene?
 ======================================
 
-Graphene library OS uses :program:`pal_loader` utility as a loader to bootstrap
+Graphene library OS uses ``pal_loader`` utility as a loader to bootstrap
 applications in the library OS::
 
    [PATH TO Runtime]/pal_loader [EXECUTABLE] [ARGUMENTS]...


### PR DESCRIPTION
## Description of the changes

Seems that GitHub reST parser is somehow limited and as a result, #2008 broke its rendering in one place (the emitted text was literally ":program:\`pal_loader\`").

## How to test this PR? <!-- (if applicable) -->

Check rich diff on GitHub.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2012)
<!-- Reviewable:end -->
