### PR TITLE
Misc PAL fixes (removing unused code + fixing error explanation printing)

### DIFF
--- a/Documentation/pal/porting.rst
+++ b/Documentation/pal/porting.rst
@@ -62,7 +62,6 @@ directory:
      used by PAL internally.
    + ``_DkGetProcessId`` (required): Return a unique process ID for each
      process.
-   + ``_DkGetHostId`` (optional): Return a unique host ID for each host.
    + ``_DkGetCPUInfo`` (optional): Retrieve CPU information, such as vendor ID,
      model name.
 

--- a/Pal/include/pal/pal.h
+++ b/Pal/include/pal/pal.h
@@ -127,7 +127,6 @@ typedef struct PAL_MEM_INFO_ {
 typedef struct PAL_CONTROL_ {
     PAL_STR host_type;
     PAL_NUM process_id; /*!< An identifier of current picoprocess */
-    PAL_NUM host_id;
 
     /*
      * Handles and executables

--- a/Pal/include/pal/pal_error.h
+++ b/Pal/include/pal/pal_error.h
@@ -62,6 +62,7 @@ typedef enum _pal_error_t {
 #define PAL_ERROR_CRYPTO_END PAL_ERROR_CRYPTO_INVALID_DH_STATE
 } pal_error_t;
 
+/* err - positive value of error code */
 const char* pal_strerror(int err);
 
 #endif

--- a/Pal/regression/Bootstrap.c
+++ b/Pal/regression/Bootstrap.c
@@ -25,9 +25,6 @@ int main(int argc, char** argv, char** envp) {
     /* unique process ID */
     pal_printf("Process ID: %016lx\n", pal_control.process_id);
 
-    /* unique host ID */
-    pal_printf("Host ID: %016lx\n", pal_control.host_id);
-
     /* parent process */
     pal_printf("Parent Process: %p\n", pal_control.parent_process);
 

--- a/Pal/regression/normalize_path.c
+++ b/Pal/regression/normalize_path.c
@@ -57,7 +57,7 @@ static int run_test(void) {
         int ret = func_to_test(cases[i][0], buf, &size);
 
         if (ret < 0) {
-            print_err(func_name, i, "failed with error: %s\n", pal_strerror(ret));
+            print_err(func_name, i, "failed with error: %s\n", pal_strerror(-ret));
             return 1;
         }
 

--- a/Pal/src/db_main.c
+++ b/Pal/src/db_main.c
@@ -427,7 +427,6 @@ noreturn void pal_main(PAL_NUM instance_id,        /* current instance id */
 
     g_pal_control.host_type       = XSTRINGIFY(HOST_TYPE);
     g_pal_control.process_id      = _DkGetProcessId();
-    g_pal_control.host_id         = _DkGetHostId();
     g_pal_control.manifest_root   = g_pal_state.manifest_root;
     g_pal_control.executable      = exec_uri;
     g_pal_control.parent_process  = parent_process;

--- a/Pal/src/db_main.c
+++ b/Pal/src/db_main.c
@@ -421,7 +421,7 @@ noreturn void pal_main(PAL_NUM instance_id,        /* current instance id */
         ret = load_elf_object_by_handle(exec_handle, OBJECT_EXEC);
     }
     if (ret < 0)
-        INIT_FAIL(-ret, pal_strerror(ret));
+        INIT_FAIL(-ret, pal_strerror(-ret));
 
     set_debug_type();
 

--- a/Pal/src/db_rtld.c
+++ b/Pal/src/db_rtld.c
@@ -121,7 +121,7 @@ static struct link_map* map_elf_object_by_handle(PAL_HANDLE handle, enum object_
     int ret;
 
     if (handle == NULL) {
-        print_error("cannot stat shared object", -PAL_ERROR_INVAL);
+        print_error("cannot stat shared object", PAL_ERROR_INVAL);
         return NULL;
     }
 
@@ -143,7 +143,7 @@ static struct link_map* map_elf_object_by_handle(PAL_HANDLE handle, enum object_
         phdr = (ElfW(Phdr)*)malloc(maplength);
 
         if ((ret = _DkStreamRead(handle, header->e_phoff, maplength, phdr, NULL, 0)) < 0) {
-            print_error("cannot read file data", ret);
+            print_error("cannot read file data", -ret);
             return NULL;
         }
     }
@@ -186,13 +186,13 @@ static struct link_map* map_elf_object_by_handle(PAL_HANDLE handle, enum object_
                 /* A load command tells us to map in part of the file.
                    We record the load commands and process them all later.  */
                 if (!IS_ALLOC_ALIGNED(ph->p_align)) {
-                    print_error("ELF load command alignment not aligned", -PAL_ERROR_NOMEM);
+                    print_error("ELF load command alignment not aligned", PAL_ERROR_NOMEM);
                     return NULL;
                 }
 
                 if (!IS_ALIGNED_POW2(ph->p_vaddr - ph->p_offset, ph->p_align)) {
                     print_error("ELF load command address/offset not properly aligned",
-                                -PAL_ERROR_NOMEM);
+                                PAL_ERROR_NOMEM);
                     return NULL;
                 }
 
@@ -237,7 +237,7 @@ static struct link_map* map_elf_object_by_handle(PAL_HANDLE handle, enum object_
         /* This only happens for a bogus object that will be caught with
            another error below.  But we don't want to go through the
            calculations below using NLOADCMDS - 1.  */
-        print_error("object file has no loadable segments", -PAL_ERROR_INVAL);
+        print_error("object file has no loadable segments", PAL_ERROR_INVAL);
         return NULL;
     }
 
@@ -261,7 +261,7 @@ static struct link_map* map_elf_object_by_handle(PAL_HANDLE handle, enum object_
         ret = _DkStreamMap(handle, (void**)&mapaddr, APPEND_WRITECOPY(c->prot), c->mapoff,
                            maplength);
         if (ret < 0) {
-            print_error("failed to map dynamic segment from shared object", ret);
+            print_error("failed to map dynamic segment from shared object", -ret);
             return NULL;
         }
 
@@ -292,7 +292,7 @@ static struct link_map* map_elf_object_by_handle(PAL_HANDLE handle, enum object_
 
             if ((ret = _DkStreamMap(handle, &mapaddr, APPEND_WRITECOPY(c->prot), c->mapoff,
                                     c->mapend - c->mapstart)) < 0) {
-                print_error("failed to map segment from shared object", ret);
+                print_error("failed to map segment from shared object", -ret);
                 return NULL;
             }
         }
@@ -327,7 +327,7 @@ static struct link_map* map_elf_object_by_handle(PAL_HANDLE handle, enum object_
                         _DkVirtualMemoryProtect((void*)ALLOC_ALIGN_DOWN(zero),
                                                 g_pal_state.alloc_align, c->prot | PAL_PROT_WRITE);
                     if (ret < 0) {
-                        print_error("cannot change memory protections", ret);
+                        print_error("cannot change memory protections", -ret);
                         return NULL;
                     }
                 }
@@ -342,7 +342,7 @@ static struct link_map* map_elf_object_by_handle(PAL_HANDLE handle, enum object_
                 void* mapat = (void*)zerosec;
                 ret = _DkVirtualMemoryAlloc(&mapat, zeroend - zerosec, 0, c->prot);
                 if (ret < 0) {
-                    print_error("cannot map zero-fill allocation", ret);
+                    print_error("cannot map zero-fill allocation", -ret);
                     return NULL;
                 }
             }
@@ -353,7 +353,7 @@ static struct link_map* map_elf_object_by_handle(PAL_HANDLE handle, enum object_
 
     if (l->l_ld == 0) {
         if (e_type == ET_DYN) {
-            print_error("object file has no dynamic section", -PAL_ERROR_INVAL);
+            print_error("object file has no dynamic section", PAL_ERROR_INVAL);
             return NULL;
         }
     } else {
@@ -371,7 +371,7 @@ static struct link_map* map_elf_object_by_handle(PAL_HANDLE handle, enum object_
            temporary place.  */
         ElfW(Phdr)* newp = (ElfW(Phdr)*)malloc(header->e_phnum * sizeof(ElfW(Phdr)));
         if (!newp) {
-            print_error("cannot allocate memory for program header", -PAL_ERROR_NOMEM);
+            print_error("cannot allocate memory for program header", PAL_ERROR_NOMEM);
             return NULL;
         }
 

--- a/Pal/src/host/Linux-SGX/db_files.c
+++ b/Pal/src/host/Linux-SGX/db_files.c
@@ -42,7 +42,7 @@ static int file_open(PAL_HANDLE* handle, const char* type, const char* uri, int 
     char* path = (void*)hdl + HANDLE_SIZE(file);
     int ret;
     if ((ret = get_norm_path(uri, path, &len)) < 0) {
-        SGX_DBG(DBG_E, "Could not normalize path (%s): %s\n", uri, pal_strerror(ret));
+        SGX_DBG(DBG_E, "Could not normalize path (%s): %s\n", uri, pal_strerror(-ret));
         free(hdl);
         return ret;
     }
@@ -119,7 +119,7 @@ static int file_open(PAL_HANDLE* handle, const char* type, const char* uri, int 
         if (ret < 0) {
             SGX_DBG(DBG_E, "Accessing file:%s is denied (%s). This file is not trusted or allowed."
                     " Trusted files should be regular files (seekable).\n", hdl->file.realpath,
-                    pal_strerror(ret));
+                    pal_strerror(-ret));
             goto out;
         }
 
@@ -608,7 +608,7 @@ static int file_attrquery(const char* type, const char* uri, PAL_STREAM_ATTR* at
     size_t len = URI_MAX;
     ret = get_norm_path(uri, path, &len);
     if (ret < 0) {
-        SGX_DBG(DBG_E, "Could not normalize path (%s): %s\n", uri, pal_strerror(ret));
+        SGX_DBG(DBG_E, "Could not normalize path (%s): %s\n", uri, pal_strerror(-ret));
         goto out;
     }
 

--- a/Pal/src/host/Linux-SGX/db_main.c
+++ b/Pal/src/host/Linux-SGX/db_main.c
@@ -67,10 +67,6 @@ PAL_NUM _DkGetProcessId(void) {
     return g_linux_state.process_id;
 }
 
-PAL_NUM _DkGetHostId(void) {
-    return 0;
-}
-
 #include "dynamic_link.h"
 #include "elf-x86_64.h"
 

--- a/Pal/src/host/Linux-SGX/enclave_framework.c
+++ b/Pal/src/host/Linux-SGX/enclave_framework.c
@@ -305,7 +305,7 @@ int load_trusted_file(PAL_HANDLE file, sgx_stub_t** stubptr, uint64_t* sizeptr, 
     ret = get_norm_path(uri + URI_PREFIX_FILE_LEN, normpath + URI_PREFIX_FILE_LEN, &len);
     if (ret < 0) {
         SGX_DBG(DBG_E, "Path (%s) normalization failed: %s\n", uri + URI_PREFIX_FILE_LEN,
-                pal_strerror(ret));
+                pal_strerror(-ret));
         return ret;
     }
     len += URI_PREFIX_FILE_LEN;
@@ -729,7 +729,7 @@ static int init_trusted_file(const char* key, const char* uri) {
     ret = get_norm_path(uri + URI_PREFIX_FILE_LEN, normpath + URI_PREFIX_FILE_LEN, &len);
     if (ret < 0) {
         SGX_DBG(DBG_E, "Path (%s) normalization failed: %s\n", uri + URI_PREFIX_FILE_LEN,
-                pal_strerror(ret));
+                pal_strerror(-ret));
         goto out;
     }
 
@@ -863,7 +863,7 @@ no_trusted:
 
         if (ret < 0) {
             SGX_DBG(DBG_E, "Path (%s) normalization failed: %s\n",
-                    toml_allowed_file_str + URI_PREFIX_FILE_LEN, pal_strerror(ret));
+                    toml_allowed_file_str + URI_PREFIX_FILE_LEN, pal_strerror(-ret));
             return ret;
         }
 

--- a/Pal/src/host/Linux-SGX/enclave_pf.c
+++ b/Pal/src/host/Linux-SGX/enclave_pf.c
@@ -334,7 +334,7 @@ static int register_protected_path(const char* path, struct protected_file** new
     size_t len = URI_MAX;
     ret = get_norm_path(path, normpath, &len);
     if (ret < 0) {
-        SGX_DBG(DBG_E, "Couldn't normalize path (%s): %s\n", path, pal_strerror(ret));
+        SGX_DBG(DBG_E, "Couldn't normalize path (%s): %s\n", path, pal_strerror(-ret));
         goto out;
     }
 

--- a/Pal/src/host/Linux/db_main.c
+++ b/Pal/src/host/Linux/db_main.c
@@ -130,10 +130,6 @@ PAL_NUM _DkGetProcessId(void) {
     return g_linux_state.process_id;
 }
 
-PAL_NUM _DkGetHostId(void) {
-    return 0;
-}
-
 #include "dynamic_link.h"
 
 #if USE_VDSO_GETTIME == 1

--- a/Pal/src/host/Skeleton/db_main.c
+++ b/Pal/src/host/Skeleton/db_main.c
@@ -28,10 +28,6 @@ PAL_NUM _DkGetProcessId(void) {
     return 0;
 }
 
-PAL_NUM _DkGetHostId(void) {
-    return 0;
-}
-
 int _DkGetCPUInfo(PAL_CPU_INFO* ci) {
     /* needs to be implemented */
     return 0;

--- a/Pal/src/pal_error.c
+++ b/Pal/src/pal_error.c
@@ -3,6 +3,8 @@
 
 #include "pal_error.h"
 
+#include "assert.h"
+
 struct pal_error_description {
     int error;
     const char* description;
@@ -58,6 +60,7 @@ static const struct pal_error_description g_pal_error_list[] = {
 #define PAL_ERROR_COUNT (sizeof(g_pal_error_list) / sizeof(g_pal_error_list[0]))
 
 const char* pal_strerror(int err) {
+    assert(err >= 0);
     for (size_t i = 0; i < PAL_ERROR_COUNT; i++)
         if (g_pal_error_list[i].error == err)
             return g_pal_error_list[i].description;

--- a/Pal/src/pal_internal.h
+++ b/Pal/src/pal_internal.h
@@ -341,9 +341,9 @@ void _DkPrintConsole(const void* buf, int size);
 int printf(const char* fmt, ...) __attribute__((format(printf, 1, 2)));
 int vprintf(const char* fmt, va_list ap) __attribute__((format(printf, 1, 0)));
 
-/* errval is negative value, see pal_strerror */
-static inline void print_error(const char* errstring, int errval) {
-    printf("%s (%s)\n", errstring, pal_strerror(errval));
+/* err - positive value of error code */
+static inline void print_error(const char* msg, int err) {
+    printf("%s (%s)\n", msg, pal_strerror(err));
 }
 
 #endif

--- a/Pal/src/pal_internal.h
+++ b/Pal/src/pal_internal.h
@@ -199,7 +199,6 @@ unsigned long _DkGetAllocationAlignment(void);
 void _DkGetAvailableUserAddressRange(PAL_PTR* start, PAL_PTR* end);
 bool _DkCheckMemoryMappable(const void* addr, size_t size);
 PAL_NUM _DkGetProcessId(void);
-PAL_NUM _DkGetHostId(void);
 unsigned long _DkMemoryQuota(void);
 unsigned long _DkMemoryAvailableQuota(void);
 // Returns 0 on success, negative PAL code on failure


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Two small things I noticed when implementing the next iteration of loader rework, which can be merged separately:
* Removal of unused and not implemented `DkGetHostId()`
* Fixing error explanation printing in `print_error()` and `pal_strerror()` callsites (see commit message for more details).

## How to test this PR? <!-- (if applicable) -->

Trigger an error in PAL and enjoy an explanation instead of "Unknown error" message :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2018)
<!-- Reviewable:end -->
