### PR TITLE
[Pal/Linux-SGX] Remove memmove() of environ on LD_PRELOAD

### DIFF
--- a/Pal/src/host/Linux-SGX/sgx_main.c
+++ b/Pal/src/host/Linux-SGX/sgx_main.c
@@ -858,11 +858,6 @@ static int load_enclave(struct pal_enclave* enclave, char* loader_config, const 
         if (!strcmp(&env[env_i], "IN_GDB=1")) {
             SGX_DBG(DBG_I, "[ Running under GDB ]\n");
             pal_sec->in_gdb = true;
-        } else if (strstartswith(&env[env_i], "LD_PRELOAD=")) {
-            uint64_t env_i_size = strnlen(&env[env_i], env_size - env_i) + 1;
-            memmove(&env[env_i], &env[env_i + env_i_size], env_size - env_i - env_i_size);
-            env_size -= env_i_size;
-            continue;
         }
 
         env_i += strnlen(&env[env_i], env_size - env_i) + 1;


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Previously, Linux-SGX PAL's untrusted loader removed "LD_PRELOAD=..." string from environment variables via `memmove(environ)` (writing the rest of envvars over "LD_PRELOAD=..."). However, the corresponding `environ` pointers were never updated, so all pointers after "LD_PRELOAD" envvar pointed to wrong addresses. This memmove trick is actually not needed because `gdb_integration/graphene_sgx.gdb` script already resets LD_PRELOAD variable, so we simply remove it.

## How to test this PR? <!-- (if applicable) -->

This bug is only visible during GDB debugging. The bug manifested in one of the more complex workloads, and prevented me from debugging normally (the child process exited with error message). I manually looked at `env` in the parent process and then child and found out that `env` in the child got corrupted. After I removed the memmove trick (now host-level `env` is not modified at all), everything worked.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2019)
<!-- Reviewable:end -->
