### PR TITLE
[Pal/Linux-SGX] Fix type cast issue during async signal handling and also retry OCALLs on EINTR

### DIFF
--- a/Pal/include/arch/x86_64/Linux/ucontext.h
+++ b/Pal/include/arch/x86_64/Linux/ucontext.h
@@ -157,21 +157,15 @@ static inline uint64_t pal_ucontext_get_ip(ucontext_t* uc) {
     return uc->uc_mcontext.gregs[REG_RIP];
 }
 
-static inline void pal_ucontext_set_function_parameters(ucontext_t* uc, void* func, size_t count,
-                                                        ...) {
+static inline void pal_ucontext_set_function_parameters(ucontext_t* uc, void* func,
+                                                        size_t func_args_num, greg_t* func_args) {
     const unsigned int param_regs[] = {REG_RDI, REG_RSI, REG_RDX, REG_RCX};
-    va_list ap;
 
-    assert(count <= ARRAY_SIZE(param_regs));
+    assert(func_args_num <= ARRAY_SIZE(param_regs));
 
     uc->uc_mcontext.gregs[REG_RIP] = (greg_t)func;
-
-    va_start(ap, count);
-
-    for (size_t i = 0; i < count; i++)
-        uc->uc_mcontext.gregs[param_regs[i]] = va_arg(ap, greg_t);
-
-    va_end(ap);
+    for (size_t i = 0; i < func_args_num; i++)
+        uc->uc_mcontext.gregs[param_regs[i]] = func_args[i];
 }
 
 #else /* __WORDSIZE == 32 */

--- a/Pal/src/host/Linux-SGX/enclave_ocalls.c
+++ b/Pal/src/host/Linux-SGX/enclave_ocalls.c
@@ -1,5 +1,21 @@
 /*
  * This is for enclave to make ocalls to untrusted runtime.
+ *
+ * Most ocall implementations retry the host-level operations on -EINTR, except for a few ocalls
+ * that are expected to be able to return -EINTR (read, write, recv, send, accept, connect, sleep,
+ * futex). The -EINTR error happens when an async signal arrives from the host OS, with two
+ * sub-cases: (a) signal arrives during a slow host-level syscall or (b) signal arrives during other
+ * untrusted-PAL code execution. In both cases, the untrusted-PAL signal handler injects -EINTR and
+ * forces an ocall return. To prevent ocalls from returning -EINTR to unsuspecting LibOS/user app,
+ * here we retry a host-level syscall. In some cases, this may lead to FD leaks or incorrect
+ * semantics (e.g., a retried open() syscall may have succeeded the first time, but a signal arrived
+ * right-after this syscall and forced -EINTR, thus leaving an FD from the first try open and
+ * leaking). See also `man 7 signal` and `sgx_exception.c: handle_async_signal()`.
+ *
+ * FIXME: Ideally, the untrusted-PAL signal handler must inspect the interrupted RIP and unwind/fix
+ *        the untrusted state and decide whether to inject -EINTR or report success (e.g., if a
+ *        signal arrives right-after an open() syscall, the signal handler must update ocall return
+ *        values and report success instead of injecting -EINTR).
  */
 
 #include "enclave_ocalls.h"
@@ -158,7 +174,9 @@ int ocall_mmap_untrusted(int fd, uint64_t offset, size_t size, unsigned short pr
     WRITE_ONCE(ms->ms_size, size);
     WRITE_ONCE(ms->ms_prot, prot);
 
-    retval = sgx_exitless_ocall(OCALL_MMAP_UNTRUSTED, ms);
+    do {
+        retval = sgx_exitless_ocall(OCALL_MMAP_UNTRUSTED, ms);
+    } while (retval == -EINTR);
 
     if (!retval) {
         if (!sgx_copy_ptr_to_enclave(mem, READ_ONCE(ms->ms_mem), size)) {
@@ -190,7 +208,9 @@ int ocall_munmap_untrusted(const void* mem, size_t size) {
     WRITE_ONCE(ms->ms_mem, mem);
     WRITE_ONCE(ms->ms_size, size);
 
-    retval = sgx_exitless_ocall(OCALL_MUNMAP_UNTRUSTED, ms);
+    do {
+        retval = sgx_exitless_ocall(OCALL_MUNMAP_UNTRUSTED, ms);
+    } while (retval == -EINTR);
 
     sgx_reset_ustack(old_ustack);
     return retval;
@@ -282,7 +302,9 @@ int ocall_cpuid(unsigned int leaf, unsigned int subleaf, unsigned int values[4])
     WRITE_ONCE(ms->ms_leaf, leaf);
     WRITE_ONCE(ms->ms_subleaf, subleaf);
 
-    retval = bypass_exitless ? sgx_ocall(OCALL_CPUID, ms) : sgx_exitless_ocall(OCALL_CPUID, ms);
+    do {
+        retval = bypass_exitless ? sgx_ocall(OCALL_CPUID, ms) : sgx_exitless_ocall(OCALL_CPUID, ms);
+    } while (retval == -EINTR);
 
     if (!retval) {
         values[0] = READ_ONCE(ms->ms_values[0]);
@@ -316,7 +338,9 @@ int ocall_open(const char* pathname, int flags, unsigned short mode) {
     }
     WRITE_ONCE(ms->ms_pathname, untrusted_pathname);
 
-    retval = sgx_exitless_ocall(OCALL_OPEN, ms);
+    do {
+        retval = sgx_exitless_ocall(OCALL_OPEN, ms);
+    } while (retval == -EINTR);
 
     sgx_reset_ustack(old_ustack);
     return retval;
@@ -335,6 +359,7 @@ int ocall_close(int fd) {
 
     WRITE_ONCE(ms->ms_fd, fd);
 
+    /* note that close() must not be retried on -EINTR, see e.g. https://lwn.net/Articles/576478 */
     retval = sgx_exitless_ocall(OCALL_CLOSE, ms);
 
     sgx_reset_ustack(old_ustack);
@@ -577,7 +602,9 @@ int ocall_fstat(int fd, struct stat* buf) {
 
     WRITE_ONCE(ms->ms_fd, fd);
 
-    retval = sgx_exitless_ocall(OCALL_FSTAT, ms);
+    do {
+        retval = sgx_exitless_ocall(OCALL_FSTAT, ms);
+    } while (retval == -EINTR);
 
     if (!retval) {
         memcpy(buf, &ms->ms_stat, sizeof(struct stat));
@@ -600,7 +627,9 @@ int ocall_fionread(int fd) {
 
     WRITE_ONCE(ms->ms_fd, fd);
 
-    retval = sgx_exitless_ocall(OCALL_FIONREAD, ms);
+    do {
+        retval = sgx_exitless_ocall(OCALL_FIONREAD, ms);
+    } while (retval == -EINTR);
 
     sgx_reset_ustack(old_ustack);
     return retval;
@@ -620,7 +649,9 @@ int ocall_fsetnonblock(int fd, int nonblocking) {
     WRITE_ONCE(ms->ms_fd, fd);
     WRITE_ONCE(ms->ms_nonblocking, nonblocking);
 
-    retval = sgx_exitless_ocall(OCALL_FSETNONBLOCK, ms);
+    do {
+        retval = sgx_exitless_ocall(OCALL_FSETNONBLOCK, ms);
+    } while (retval == -EINTR);
 
     sgx_reset_ustack(old_ustack);
     return retval;
@@ -640,7 +671,9 @@ int ocall_fchmod(int fd, unsigned short mode) {
     WRITE_ONCE(ms->ms_fd, fd);
     WRITE_ONCE(ms->ms_mode, mode);
 
-    retval = sgx_exitless_ocall(OCALL_FCHMOD, ms);
+    do {
+        retval = sgx_exitless_ocall(OCALL_FCHMOD, ms);
+    } while (retval == -EINTR);
 
     sgx_reset_ustack(old_ustack);
     return retval;
@@ -659,7 +692,9 @@ int ocall_fsync(int fd) {
 
     WRITE_ONCE(ms->ms_fd, fd);
 
-    retval = sgx_exitless_ocall(OCALL_FSYNC, ms);
+    do {
+        retval = sgx_exitless_ocall(OCALL_FSYNC, ms);
+    } while (retval == -EINTR);
 
     sgx_reset_ustack(old_ustack);
     return retval;
@@ -679,7 +714,9 @@ int ocall_ftruncate(int fd, uint64_t length) {
     WRITE_ONCE(ms->ms_fd, fd);
     WRITE_ONCE(ms->ms_length, length);
 
-    retval = sgx_exitless_ocall(OCALL_FTRUNCATE, ms);
+    do {
+        retval = sgx_exitless_ocall(OCALL_FTRUNCATE, ms);
+    } while (retval == -EINTR);
 
     sgx_reset_ustack(old_ustack);
     return retval;
@@ -705,7 +742,9 @@ int ocall_mkdir(const char* pathname, unsigned short mode) {
     }
     WRITE_ONCE(ms->ms_pathname, untrusted_pathname);
 
-    retval = sgx_exitless_ocall(OCALL_MKDIR, ms);
+    do {
+        retval = sgx_exitless_ocall(OCALL_MKDIR, ms);
+    } while (retval == -EINTR);
 
     sgx_reset_ustack(old_ustack);
     return retval;
@@ -731,7 +770,9 @@ int ocall_getdents(int fd, struct linux_dirent64* dirp, size_t dirp_size) {
     }
     WRITE_ONCE(ms->ms_dirp, untrusted_dirp);
 
-    retval = sgx_exitless_ocall(OCALL_GETDENTS, ms);
+    do {
+        retval = sgx_exitless_ocall(OCALL_GETDENTS, ms);
+    } while (retval == -EINTR);
 
     if (retval > 0) {
         size_t size = (size_t)retval;
@@ -767,12 +808,21 @@ out:
 }
 
 int ocall_resume_thread(void* tcs) {
-    return sgx_exitless_ocall(OCALL_RESUME_THREAD, tcs);
+    int retval = 0;
+    do {
+        retval = sgx_exitless_ocall(OCALL_RESUME_THREAD, tcs);
+    } while (retval == -EINTR);
+    return retval;
 }
 
 int ocall_clone_thread(void) {
+    int retval = 0;
     void* dummy = NULL;
-    return sgx_exitless_ocall(OCALL_CLONE_THREAD, dummy);
+    do {
+        /* FIXME: if there was an EINTR, there may be an untrusted thread left over */
+        retval = sgx_exitless_ocall(OCALL_CLONE_THREAD, dummy);
+    } while (retval == -EINTR);
+    return retval;
 }
 
 int ocall_create_process(const char* uri, size_t nargs, const char** args, int* stream_fd,
@@ -807,7 +857,10 @@ int ocall_create_process(const char* uri, size_t nargs, const char** args, int* 
         WRITE_ONCE(ms->ms_args[i], unstrusted_arg);
     }
 
-    retval = sgx_exitless_ocall(OCALL_CREATE_PROCESS, ms);
+    do {
+        /* FIXME: if there was an EINTR, there may be an untrusted process left over */
+        retval = sgx_exitless_ocall(OCALL_CREATE_PROCESS, ms);
+    } while (retval == -EINTR);
 
     if (!retval) {
         if (pid)
@@ -861,7 +914,9 @@ int ocall_socketpair(int domain, int type, int protocol, int sockfds[2]) {
     WRITE_ONCE(ms->ms_type, type);
     WRITE_ONCE(ms->ms_protocol, protocol);
 
-    retval = sgx_exitless_ocall(OCALL_SOCKETPAIR, ms);
+    do {
+        retval = sgx_exitless_ocall(OCALL_SOCKETPAIR, ms);
+    } while (retval == -EINTR);
 
     if (!retval) {
         sockfds[0] = READ_ONCE(ms->ms_sockfds[0]);
@@ -897,7 +952,9 @@ int ocall_listen(int domain, int type, int protocol, int ipv6_v6only, struct soc
     }
     WRITE_ONCE(ms->ms_addr, untrusted_addr);
 
-    retval = sgx_exitless_ocall(OCALL_LISTEN, ms);
+    do {
+        retval = sgx_exitless_ocall(OCALL_LISTEN, ms);
+    } while (retval == -EINTR);
 
     if (retval >= 0) {
         if (addr && len) {
@@ -1192,7 +1249,9 @@ int ocall_setsockopt(int sockfd, int level, int optname, const void* optval, siz
         WRITE_ONCE(ms->ms_optval, untrusted_optval);
     }
 
-    retval = sgx_exitless_ocall(OCALL_SETSOCKOPT, ms);
+    do {
+        retval = sgx_exitless_ocall(OCALL_SETSOCKOPT, ms);
+    } while (retval == -EINTR);
 
     sgx_reset_ustack(old_ustack);
     return retval;
@@ -1212,7 +1271,9 @@ int ocall_shutdown(int sockfd, int how) {
     WRITE_ONCE(ms->ms_sockfd, sockfd);
     WRITE_ONCE(ms->ms_how, how);
 
-    retval = sgx_exitless_ocall(OCALL_SHUTDOWN, ms);
+    do {
+        retval = sgx_exitless_ocall(OCALL_SHUTDOWN, ms);
+    } while (retval == -EINTR);
 
     sgx_reset_ustack(old_ustack);
     return retval;
@@ -1332,7 +1393,9 @@ int ocall_rename(const char* oldpath, const char* newpath) {
     WRITE_ONCE(ms->ms_oldpath, untrusted_oldpath);
     WRITE_ONCE(ms->ms_newpath, untrusted_newpath);
 
-    retval = sgx_exitless_ocall(OCALL_RENAME, ms);
+    do {
+        retval = sgx_exitless_ocall(OCALL_RENAME, ms);
+    } while (retval == -EINTR);
 
     sgx_reset_ustack(old_ustack);
     return retval;
@@ -1357,7 +1420,9 @@ int ocall_delete(const char* pathname) {
     }
     WRITE_ONCE(ms->ms_pathname, untrusted_pathname);
 
-    retval = sgx_exitless_ocall(OCALL_DELETE, ms);
+    do {
+        retval = sgx_exitless_ocall(OCALL_DELETE, ms);
+    } while (retval == -EINTR);
 
     sgx_reset_ustack(old_ustack);
     return retval;
@@ -1375,7 +1440,10 @@ int ocall_update_debugger(struct debug_map* _Atomic* debug_map) {
     }
 
     WRITE_ONCE(ms->ms_debug_map, debug_map);
-    retval = sgx_exitless_ocall(OCALL_UPDATE_DEBUGGER, ms);
+
+    do {
+        retval = sgx_exitless_ocall(OCALL_UPDATE_DEBUGGER, ms);
+    } while (retval == -EINTR);
 
     sgx_reset_ustack(old_ustack);
     return retval;
@@ -1423,7 +1491,9 @@ int ocall_eventfd(unsigned int initval, int flags) {
     WRITE_ONCE(ms->ms_initval, initval);
     WRITE_ONCE(ms->ms_flags, flags);
 
-    retval = sgx_exitless_ocall(OCALL_EVENTFD, ms);
+    do {
+        retval = sgx_exitless_ocall(OCALL_EVENTFD, ms);
+    } while (retval == -EINTR);
 
     sgx_reset_ustack(old_ustack);
     return retval;
@@ -1454,7 +1524,9 @@ int ocall_get_quote(const sgx_spid_t* spid, bool linkable, const sgx_report_t* r
     memcpy(&ms->ms_nonce, nonce, sizeof(*nonce));
     WRITE_ONCE(ms->ms_linkable, linkable);
 
-    retval = sgx_exitless_ocall(OCALL_GET_QUOTE, ms);
+    do {
+        retval = sgx_exitless_ocall(OCALL_GET_QUOTE, ms);
+    } while (retval == -EINTR);
 
     if (!IS_ERR(retval)) {
         ms_ocall_get_quote_t ms_copied;
@@ -1519,7 +1591,10 @@ int ocall_sched_setaffinity(void* tcs, size_t cpumask_size, void* cpu_mask) {
     }
     WRITE_ONCE(ms->ms_cpu_mask, untrusted_cpu_mask);
 
-    retval = sgx_exitless_ocall(OCALL_SCHED_SETAFFINITY, ms);
+    do {
+        retval = sgx_exitless_ocall(OCALL_SCHED_SETAFFINITY, ms);
+    } while (retval == -EINTR);
+
     if (IS_ERR(retval) && !IS_UNIX_ERR(retval))
         retval = -EPERM;
 
@@ -1565,7 +1640,10 @@ int ocall_sched_getaffinity(void* tcs, size_t cpumask_size, void* cpu_mask) {
     }
     WRITE_ONCE(ms->ms_cpu_mask, untrusted_cpu_mask);
 
-    retval = sgx_exitless_ocall(OCALL_SCHED_GETAFFINITY, ms);
+    do {
+        retval = sgx_exitless_ocall(OCALL_SCHED_GETAFFINITY, ms);
+    } while (retval == -EINTR);
+
     if (IS_ERR(retval) && !IS_UNIX_ERR(retval))
         retval = -EPERM;
 

--- a/Pal/src/host/Linux-SGX/sgx_exception.c
+++ b/Pal/src/host/Linux-SGX/sgx_exception.c
@@ -174,10 +174,11 @@ static void handle_async_signal(int signum, siginfo_t* info, struct ucontext* uc
     }
 
     /* signal arrived while in untrusted PAL code (during syscall handling), emulate as if syscall
-     * was interrupted */
+     * was interrupted by calling sgx_entry_return(syscall_return_value=-EINTR, event) */
     /* TODO: we abandon PAL state here (possibly still holding some locks, etc) and return to
      *       enclave; ideally we must unwind/fix the state and only then jump into enclave */
-    pal_ucontext_set_function_parameters(uc, sgx_entry_return, 2, -EINTR, event);
+    greg_t func_args[2] = {-EINTR, event};
+    pal_ucontext_set_function_parameters(uc, sgx_entry_return, /*func_args_num=*/2, func_args);
 }
 
 static void handle_dummy_signal(int signum, siginfo_t* info, struct ucontext* uc) {


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://graphene.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

Untrusted Linux-SGX PAL handles host-level asynchronous signals by emulating the interrupt (-EINTR) of the pending OCALL. Unfortunately, there was a type cast issue such that int32_t -EINTR (`-4`) was casted to a positive uint64_t and then OCALL consumed this positive number instead of erroring out on -EINTR. This PR adds explicit type casting to fix this bug.

After the above was fixed (in the first commit of this PR), I debugged a small data race and fixed it. It goes like this. Graphene internal logic as well as application logic relies on most OCALLs being "uninterruptible", e.g., `recv()` OCALL is assumed to be interruptible but `mmap()` OCALL is assumed to be uninterruptible. At the same time, Linux-SGX PAL always injects `-EINTR` in OCALLs when an async signal arrives from host OS, no matter what OCALL. This led to spontaneous failures with debug message "ocall returned -4". The second commit of this PR adds retrying on all "uninterruptible" OCALLs.

## How to test this PR? <!-- (if applicable) -->

All tests must pass. This bug was found on a large workload that spawned several child processes. Sometimes it so happened that one child process finished and sent SIGCHLD signal to the main (parent) process, and the main process simultaneously was sending a checkpoint to another spawned child. This resulted in `ocall_read()` being interrupted and then returning a ridiculous big number instead of `-EINTR`, and the whole application crashed.


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2020)
<!-- Reviewable:end -->
