### PR TITLE
[LibOS] Fix a type error in memory allocation for shim_handle_map

### DIFF
--- a/LibOS/shim/src/bookkeep/shim_handle.c
+++ b/LibOS/shim/src/bookkeep/shim_handle.c
@@ -488,7 +488,7 @@ static struct shim_handle_map* get_new_handle_map(FDTYPE size) {
     if (!handle_map)
         return NULL;
 
-    handle_map->map = calloc(size, sizeof(struct shim_fd_handle));
+    handle_map->map = calloc(size, sizeof(*handle_map->map));
 
     if (!handle_map->map) {
         free(handle_map);


### PR DESCRIPTION
`struct shim_handle_map` has a member field `map`, which is a pointer to an array of element of type `struct shim_fd_handle *` . 

The original code `handle_map->map = calloc(size, sizeof(struct shim_fd_handle));` has an type error and may malloc more memory than needed.

Fixes #2022

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2024)
<!-- Reviewable:end -->
