### PR TITLE
[LibOS,Pal] Fix debug information for perf

### DIFF
--- a/LibOS/shim/src/Makefile
+++ b/LibOS/shim/src/Makefile
@@ -142,12 +142,12 @@ endif
 $(files_to_install): $(RUNTIME_DIR)/%: %
 	$(call cmd,ln_sfr)
 
-LDFLAGS-libsysdb.so += --version-script shim.map -T shim-$(ARCH).lds
+LDFLAGS-libsysdb.so += --version-script shim.map -T shim-$(ARCH).lds --eh-frame-hdr
 libsysdb.so: $(objs) $(filter %.map %.lds,$(LDFLAGS-$@)) \
 	     $(graphene_lib) $(pal_lib) shim.map shim-$(ARCH).lds
 	$(call cmd,ld_so_o)
 
-LDFLAGS-libsysdb_debug.so += --version-script shim-debug.map -T shim-$(ARCH).lds
+LDFLAGS-libsysdb_debug.so += --version-script shim-debug.map -T shim-$(ARCH).lds --eh-frame-hdr
 libsysdb_debug.so: $(filter-out syscallas-$(ARCH).o,$(objs)) \
 		   $(filter %.map %.lds,$(LDFLAGS-$@)) \
 		   $(graphene_lib) $(pal_lib) shim-debug.map shim-$(ARCH).lds

--- a/Pal/src/host/Linux-SGX/Makefile.am
+++ b/Pal/src/host/Linux-SGX/Makefile.am
@@ -9,6 +9,7 @@ ASFLAGS += -DPIC -DSHARED -fPIC -DASSEMBLER -Wa,--noexecstack \
 	  -x assembler-with-cpp
 LDFLAGS += -shared -nostdlib -z combreloc -z defs \
 	  --version-script $(HOST_DIR)/pal.map -T $(HOST_DIR)/enclave.lds \
+	  --eh-frame-hdr \
 	  --hash-style=gnu -z relro -z now
 
 CRYPTO_PROVIDER = mbedtls

--- a/Pal/src/host/Linux/Makefile.am
+++ b/Pal/src/host/Linux/Makefile.am
@@ -10,6 +10,7 @@ ASFLAGS += -DPIC -DSHARED -fPIC -DASSEMBLER -Wa,--noexecstack \
 	  -x assembler-with-cpp
 LDFLAGS += -shared -nostdlib -z combreloc -z defs \
 	  --version-script $(HOST_DIR)/pal.map -T $(HOST_DIR)/pal-$(ARCH).lds \
+	  --eh-frame-hdr \
 	  -z relro -z now
 
 pal_loader = $(HOST_DIR)/libpal.so

--- a/Pal/src/host/Skeleton/Makefile.am
+++ b/Pal/src/host/Skeleton/Makefile.am
@@ -8,7 +8,8 @@ CFLAGS += -Wextra -Wno-unused-parameter -Wno-sign-compare $(call cc-option,-Wnul
 ASFLAGS += -DPIC -DSHARED -fPIC -DASSEMBLER -Wa,--noexecstack \
 	  -x assembler-with-cpp
 LDFLAGS += -shared -nostdlib -z combreloc -z defs \
-	  --version-script $(HOST_DIR)/pal.map -T $(HOST_DIR)/pal-$(ARCH).lds
+	  --version-script $(HOST_DIR)/pal.map -T $(HOST_DIR)/pal-$(ARCH).lds \
+	  --eh-frame-hdr
 
 pal_loader =
 pal_sec =


### PR DESCRIPTION
This fixes call graphs reported by 'perf report' involving PAL
and LibOS. When using custom linker scripts, the .eh_frame_hdr
section was missing from the .so files (despite being mentioned
in linker script). Adding '--eh-frame-hdr' to ld invocation
restores it.

## How to test this PR? <!-- (if applicable) -->

1. `perf record --call-graph dwarf ./pal_loader ...`
2. `perf report`
3. This should display call chains for Graphene (press `e` to expand in terminal UI).

See https://graphene.readthedocs.io/en/latest/devel/performance.html for more information about `perf`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2026)
<!-- Reviewable:end -->
