### PR TITLE
SGX profiling based on perf

### DIFF
--- a/Documentation/devel/performance.rst
+++ b/Documentation/devel/performance.rst
@@ -489,7 +489,7 @@ Some useful options for recording (``perf record``):
 * ``-e cpu-clock``: sample the ``cpu-clock`` event, which will be triggered also
   inside enclave (as opposed to the default ``cpu-cycles`` event). Unfortunately
   such events will be counted towards ``async_exit_pointer`` instead of
-  functions executing inside enclave.
+  functions executing inside enclave (but see also :ref:`sgx-profile`).
 
 Some useful options for displaying the report (``perf report``):
 
@@ -504,6 +504,34 @@ Further reading
 * `Linux perf examples - Brendan Gregg
   <http://www.brendangregg.com/perf.html>`__
 * Man pages: ``man perf record``, ``man perf report`` etc.
+
+.. _sgx-profile:
+
+SGX profiling
+-------------
+
+There is some experimental support for profiling the code inside the SGX
+enclave. Here is how to use it:
+
+#. Compile Graphene with ``SGX=1 DEBUG=1``.
+
+#. Add ``sgx.profile.enable = "main"`` to manifest (to collect data for the main
+   process), or ``sgx.profile.enable = "all"`` (to collect data for all
+   processes).
+
+#. (Add ``sgx.profile.with_stack = 1`` for call chain information.)
+
+#. Run your application. It should say something like ``Profile data written to
+   sgx-perf.data`` on process exit (in case of ``sgx.profile.enable = "all"``,
+   multiple files will be written).
+
+#. Run ``perf report -i <data file>`` (see :ref:`perf` above).
+
+*Note*: The accuracy of this tool is unclear. The SGX profiling works by
+measuring the value of instruction pointer on each asynchronous enclave exit
+(AEX), which happen on Linux scheduler interrupts, as well as other events such
+as page faults. While we attempt to measure time (and not only count
+occurences), the results might be inaccurate.
 
 Other useful tools for profiling
 --------------------------------

--- a/Documentation/manifest-syntax.rst
+++ b/Documentation/manifest-syntax.rst
@@ -458,3 +458,48 @@ This syntax specifies whether to enable SGX enclave-specific statistics:
 *Note:* this option is insecure and cannot be used with production enclaves
 (``sgx.debug = 0``). If the production enclave is started with this option set,
 Graphene will fail initialization of the enclave.
+
+SGX profiling
+^^^^^^^^^^^^^
+
+::
+
+    sgx.profile.enable = ["none"|"main"|"all"]
+    (Default: "none")
+
+This syntax specifies whether to enable SGX profiling. Graphene must be compiled
+with ``DEBUG=1`` for this option to work.
+
+If this option is set to ``main``, the main process will collect IP samples and
+save them as ``sgx-perf.data``. If it is set to ``all``, all processes will
+collect samples and save them to ``sgx-perf-<PID>.data``.
+
+The saved files can be viewed with the ``perf`` tool, e.g. ``perf report -i
+sgx-perf.data``.
+
+See :doc:`devel/performance` for more information.
+
+*Note:* this option is insecure and cannot be used with production enclaves
+(``sgx.debug = 0``). If the production enclave is started with this option set,
+Graphene will fail initialization of the enclave.
+
+::
+
+    sgx.profile.with_stack = [1|0]
+    (Default: 0)
+
+This syntax specifies whether to include stack information with the profiling
+data. This will enable ``perf report`` to show call chains. However, it will
+make the output file much bigger, and slow down the process.
+
+::
+
+    sgx.profile.frequency = [INTEGER]
+    (Default: 50)
+
+This syntax specifies approximate frequency at which profiling samples are taken
+(in samples per second). Lower values will mean less accurate results, but also
+lower overhead.
+
+Note that the accuracy is limited by how often the process is interrupted by
+Linux scheduler: the effective maximum is 250 samples per second.

--- a/LibOS/shim/src/Makefile
+++ b/LibOS/shim/src/Makefile
@@ -142,7 +142,7 @@ endif
 $(files_to_install): $(RUNTIME_DIR)/%: %
 	$(call cmd,ln_sfr)
 
-LDFLAGS-libsysdb.so += --version-script shim.map -T shim-$(ARCH).lds
+LDFLAGS-libsysdb.so += --version-script shim.map -T shim-$(ARCH).lds --eh-frame-hdr
 libsysdb.so: $(objs) $(filter %.map %.lds,$(LDFLAGS-$@)) \
 	     $(graphene_lib) $(pal_lib) shim.map shim-$(ARCH).lds
 	$(call cmd,ld_so_o)

--- a/Pal/include/pal/pal_debug.h
+++ b/Pal/include/pal/pal_debug.h
@@ -11,6 +11,7 @@
 #include "pal.h"
 
 int pal_printf(const char* fmt, ...) __attribute__((format(printf, 1, 2)));
+int pal_fdprintf(int fd, const char* fmt, ...) __attribute__((format(printf, 2, 3)));
 void warn(const char* format, ...);
 
 void DkDebugAttachBinary(PAL_STR uri, PAL_PTR start_addr);

--- a/Pal/src/host/Linux-SGX/Makefile
+++ b/Pal/src/host/Linux-SGX/Makefile
@@ -78,6 +78,7 @@ urts-objs = \
 	sgx_perf_data.o \
 	sgx_platform.o \
 	sgx_process.o \
+	sgx_profile.o \
 	sgx_gdb_info.o \
 	sgx_thread.o \
 	quote/aesm.pb-c.o \

--- a/Pal/src/host/Linux-SGX/Makefile
+++ b/Pal/src/host/Linux-SGX/Makefile
@@ -75,6 +75,7 @@ urts-objs = \
 	sgx_framework.o \
 	sgx_graphene.o \
 	sgx_main.o \
+	sgx_perf_data.o \
 	sgx_platform.o \
 	sgx_process.o \
 	sgx_gdb_info.o \

--- a/Pal/src/host/Linux-SGX/Makefile.am
+++ b/Pal/src/host/Linux-SGX/Makefile.am
@@ -9,6 +9,7 @@ ASFLAGS += -DPIC -DSHARED -fPIC -DASSEMBLER -Wa,--noexecstack \
 	  -x assembler-with-cpp
 LDFLAGS += -shared -nostdlib -z combreloc -z defs \
 	  --version-script $(HOST_DIR)/pal.map -T $(HOST_DIR)/enclave.lds \
+	  --eh-frame-hdr \
 	  --hash-style=gnu -z relro -z now
 
 CRYPTO_PROVIDER = mbedtls

--- a/Pal/src/host/Linux-SGX/db_rtld.c
+++ b/Pal/src/host/Linux-SGX/db_rtld.c
@@ -198,6 +198,14 @@ void _DkDebugAddMap(struct link_map* map) {
     }
 
     debug_map_add(debug_map);
+
+    for (ph = phdr; ph < &phdr[ehdr->e_phnum]; ++ph)
+        if (ph->p_type == PT_LOAD && ph->p_flags & PF_X) {
+            uint64_t mapstart = ALLOC_ALIGN_DOWN(ph->p_vaddr);
+            uint64_t mapend = ALLOC_ALIGN_UP(ph->p_vaddr + ph->p_filesz);
+            uint64_t offset = ALLOC_ALIGN_DOWN(ph->p_offset);
+            ocall_report_mmap(map->l_name, map->l_addr + mapstart, mapend - mapstart, offset);
+        }
 }
 
 void _DkDebugDelMap(struct link_map* map) {

--- a/Pal/src/host/Linux-SGX/enclave_ocalls.h
+++ b/Pal/src/host/Linux-SGX/enclave_ocalls.h
@@ -94,6 +94,8 @@ int ocall_delete(const char* pathname);
 
 int ocall_update_debugger(struct debug_map* _Atomic* debug_map);
 
+int ocall_report_mmap(const char* filename, uint64_t addr, uint64_t len, uint64_t offset);
+
 int ocall_eventfd(unsigned int initval, int flags);
 
 /*!

--- a/Pal/src/host/Linux-SGX/ocall_types.h
+++ b/Pal/src/host/Linux-SGX/ocall_types.h
@@ -61,6 +61,7 @@ enum {
     OCALL_RENAME,
     OCALL_DELETE,
     OCALL_UPDATE_DEBUGGER,
+    OCALL_REPORT_MMAP,
     OCALL_EVENTFD,
     OCALL_GET_QUOTE,
     OCALL_NR,
@@ -284,6 +285,13 @@ typedef struct {
 typedef struct {
     struct debug_map* _Atomic* ms_debug_map;
 } ms_ocall_update_debugger_t;
+
+typedef struct {
+    const char* ms_filename;
+    uint64_t ms_addr;
+    uint64_t ms_len;
+    uint64_t ms_offset;
+} ms_ocall_report_mmap_t;
 
 typedef struct {
     unsigned int ms_initval;

--- a/Pal/src/host/Linux-SGX/sgx_enclave.c
+++ b/Pal/src/host/Linux-SGX/sgx_enclave.c
@@ -700,6 +700,18 @@ static long sgx_ocall_update_debugger(void* pms) {
     return 0;
 }
 
+static long sgx_ocall_report_mmap(void* pms) {
+    ms_ocall_report_mmap_t* ms = (ms_ocall_report_mmap_t*)pms;
+    ODEBUG(OCALL_REPORT_MMAP, ms);
+
+#ifdef DEBUG
+    sgx_profile_report_mmap(ms->ms_filename, ms->ms_addr, ms->ms_len, ms->ms_offset);
+#else
+    __UNUSED(ms);
+#endif
+    return 0;
+}
+
 static long sgx_ocall_get_quote(void* pms) {
     ms_ocall_get_quote_t* ms = (ms_ocall_get_quote_t*)pms;
     ODEBUG(OCALL_GET_QUOTE, ms);
@@ -746,6 +758,7 @@ sgx_ocall_fn_t ocall_table[OCALL_NR] = {
     [OCALL_RENAME]           = sgx_ocall_rename,
     [OCALL_DELETE]           = sgx_ocall_delete,
     [OCALL_UPDATE_DEBUGGER]  = sgx_ocall_update_debugger,
+    [OCALL_REPORT_MMAP]      = sgx_ocall_report_mmap,
     [OCALL_EVENTFD]          = sgx_ocall_eventfd,
     [OCALL_GET_QUOTE]        = sgx_ocall_get_quote,
 };

--- a/Pal/src/host/Linux-SGX/sgx_enclave.c
+++ b/Pal/src/host/Linux-SGX/sgx_enclave.c
@@ -68,6 +68,9 @@ static long sgx_ocall_exit(void* pms) {
     /* exit the whole process if exit_group() */
     if (ms->ms_is_exitgroup) {
         update_and_print_stats(/*process_wide=*/true);
+#ifdef DEBUG
+        sgx_profile_finish();
+#endif
         INLINE_SYSCALL(exit_group, 1, (int)ms->ms_exitcode);
     }
 
@@ -80,6 +83,9 @@ static long sgx_ocall_exit(void* pms) {
     if (!current_enclave_thread_cnt()) {
         /* no enclave threads left, kill the whole process */
         update_and_print_stats(/*process_wide=*/true);
+#ifdef DEBUG
+        sgx_profile_finish();
+#endif
         INLINE_SYSCALL(exit_group, 1, (int)ms->ms_exitcode);
     }
 

--- a/Pal/src/host/Linux-SGX/sgx_entry.S
+++ b/Pal/src/host/Linux-SGX/sgx_entry.S
@@ -64,8 +64,45 @@ sgx_ecall:
 	.type async_exit_pointer, @function
 
 async_exit_pointer:
+	.cfi_startproc
+	.cfi_undefined %rip
+
 	# increment per-thread AEX counter for stats
 	lock incq %gs:PAL_TCB_URTS_AEX_CNT
+
+#ifdef DEBUG
+	# Save ERESUME parameters
+	pushq %rax
+	.cfi_adjust_cfa_offset 8
+	pushq %rbx
+	.cfi_adjust_cfa_offset 8
+	pushq %rcx
+	.cfi_adjust_cfa_offset 8
+
+	# Align stack (required by System V AMD64 ABI)
+	movq %rsp, %rbp
+	.cfi_def_cfa_register %rbp
+	andq $~0xF, %rsp
+
+	# Call sgx_profile_sample with %rdi = TCS
+	movq %rbx, %rdi
+	call sgx_profile_sample
+
+	# Restore stack
+	movq %rbp, %rsp
+	.cfi_def_cfa_register %rsp
+
+	# Restore ERESUME parameters
+	popq %rcx
+	.cfi_adjust_cfa_offset -8
+	popq %rbx
+	.cfi_adjust_cfa_offset -8
+	popq %rax
+	.cfi_adjust_cfa_offset -8
+#endif
+
+	.cfi_endproc
+
 	# fall-through to ERESUME
 
 	.global eresume_pointer

--- a/Pal/src/host/Linux-SGX/sgx_graphene.c
+++ b/Pal/src/host/Linux-SGX/sgx_graphene.c
@@ -29,15 +29,26 @@ static int fputch(void* f, int ch, struct printbuf* b) {
     return 0;
 }
 
-static int vprintf(const char* fmt, va_list ap) {
+static int vfdprintf(int fd, const char* fmt, va_list ap) {
     struct printbuf b;
 
     b.idx = 0;
     b.cnt = 0;
     vfprintfmt((void*)&fputch, NULL, &b, fmt, ap);
-    INLINE_SYSCALL(write, 3, 2, b.buf, b.idx);
+    INLINE_SYSCALL(write, 3, fd, b.buf, b.idx);
 
     return b.cnt;
+}
+
+int pal_fdprintf(int fd, const char* fmt, ...) {
+    va_list ap;
+    int cnt;
+
+    va_start(ap, fmt);
+    cnt = vfdprintf(fd, fmt, ap);
+    va_end(ap);
+
+    return cnt;
 }
 
 int pal_printf(const char* fmt, ...) {
@@ -45,7 +56,7 @@ int pal_printf(const char* fmt, ...) {
     int cnt;
 
     va_start(ap, fmt);
-    cnt = vprintf(fmt, ap);
+    cnt = vfdprintf(2, fmt, ap);
     va_end(ap);
 
     return cnt;

--- a/Pal/src/host/Linux-SGX/sgx_internal.h
+++ b/Pal/src/host/Linux-SGX/sgx_internal.h
@@ -73,6 +73,12 @@ extern struct pal_enclave {
     /* Pointer to information for GDB inside the enclave (see sgx_rtld.h).
      * Set up using update_debugger() ocall. */
     struct debug_map* _Atomic* debug_map;
+
+    /* profiling */
+    bool profile_enable;
+    char profile_filename[64];
+    bool profile_with_stack;
+    int profile_frequency;
 #endif
 
     /* security information */
@@ -147,6 +153,33 @@ int block_signals(bool block, const int* sigs, int nsig);
 int block_async_signals(bool block);
 
 void update_debugger(void);
+
+#ifdef DEBUG
+/* SGX profiling (sgx_profile.c) */
+
+/*
+ * Default and maximum sampling frequency. We depend on Linux scheduler to interrupt us, so it's not
+ * possible to achieve higher than 250.
+ */
+#define SGX_PROFILE_DEFAULT_FREQUENCY 50
+#define SGX_PROFILE_MAX_FREQUENCY 250
+
+/* Filenames for saved data */
+#define SGX_PROFILE_FILENAME "sgx-perf.data"
+#define SGX_PROFILE_FILENAME_WITH_PID "sgx-perf-%d.data"
+
+/* Initialize based on g_pal_enclave settings */
+int sgx_profile_init(void);
+
+/* Finalize and close file */
+void sgx_profile_finish(void);
+
+/* Record a sample */
+void sgx_profile_sample(void* tcs);
+
+/* Record a new mmap of executable region */
+void sgx_profile_report_mmap(const char* filename, uint64_t addr, uint64_t len, uint64_t offset);
+#endif
 
 /* perf.data output (sgx_perf_data.h) */
 

--- a/Pal/src/host/Linux-SGX/sgx_internal.h
+++ b/Pal/src/host/Linux-SGX/sgx_internal.h
@@ -148,4 +148,30 @@ int block_async_signals(bool block);
 
 void update_debugger(void);
 
+/* perf.data output (sgx_perf_data.h) */
+
+#define PD_STACK_SIZE 8192
+
+struct perf_data;
+
+struct perf_data* pd_open(const char* file_name, bool with_stack);
+
+/* Finalize and close; returns resulting file size */
+ssize_t pd_close(struct perf_data* pd);
+
+/* Write PERF_RECORD_COMM (report command name) */
+int pd_event_command(struct perf_data* pd, const char* command, uint32_t pid, uint32_t tid);
+
+/* Write PERF_RECORD_MMAP (report mmap of executable region) */
+int pd_event_mmap(struct perf_data* pd, const char* filename, uint32_t pid, uint64_t addr,
+                  uint64_t len, uint64_t pgoff);
+
+/* Write PERF_RECORD_SAMPLE (simple version) */
+int pd_event_sample_simple(struct perf_data* pd, uint64_t ip, uint32_t pid, uint32_t tid,
+                           uint64_t period);
+
+/* Write PERF_RECORD_SAMPLE (with stack sample, at most PD_STACK_SIZE bytes) */
+int pd_event_sample_stack(struct perf_data* pd,  uint64_t ip, uint32_t pid, uint32_t tid,
+                          uint64_t period, sgx_pal_gpr_t* gpr, void* stack, size_t stack_size);
+
 #endif

--- a/Pal/src/host/Linux-SGX/sgx_main.c
+++ b/Pal/src/host/Linux-SGX/sgx_main.c
@@ -45,17 +45,26 @@ char* g_libpal_path = NULL;
 
 struct pal_enclave g_pal_enclave;
 
+/*
+ * FIXME: the ELF-parsing functions in this file (scan_enclave_binary, report_mmaps,
+ * load_enclave_binary) assume that all the program headers will be found within first FILEBUF_SIZE
+ * bytes. This will be true for most binaries, but is not guaranteed.
+ *
+ * (Glibc also allocates such a buffer but recovers when it's too small, see elf/dl-load.c in glibc
+ * sources.)
+ */
+
 static int scan_enclave_binary(int fd, unsigned long* base, unsigned long* size,
                                unsigned long* entry) {
     int ret = 0;
 
     if (IS_ERR(ret = INLINE_SYSCALL(lseek, 3, fd, 0, SEEK_SET)))
-        return -ERRNO(ret);
+        return ret;
 
     char filebuf[FILEBUF_SIZE];
     ret = INLINE_SYSCALL(read, 3, fd, filebuf, FILEBUF_SIZE);
     if (IS_ERR(ret))
-        return -ERRNO(ret);
+        return ret;
 
     if ((size_t)ret < sizeof(ElfW(Ehdr)))
         return -ENOEXEC;
@@ -89,17 +98,48 @@ static int scan_enclave_binary(int fd, unsigned long* base, unsigned long* size,
     return 0;
 }
 
+#ifdef DEBUG
+static int report_mmaps(int fd, const char* filename, uint64_t base) {
+    int ret = 0;
+
+    if (IS_ERR(ret = INLINE_SYSCALL(lseek, 3, fd, 0, SEEK_SET)))
+        return ret;
+
+    char filebuf[FILEBUF_SIZE];
+    ret = INLINE_SYSCALL(read, 3, fd, filebuf, FILEBUF_SIZE);
+    if (IS_ERR(ret))
+        return ret;
+
+    if ((size_t)ret < sizeof(ElfW(Ehdr)))
+        return -ENOEXEC;
+
+    const ElfW(Ehdr)* header = (void*)filebuf;
+    const ElfW(Phdr)* phdr   = (void*)filebuf + header->e_phoff;
+    const ElfW(Phdr)* ph;
+
+    for (ph = phdr; ph < &phdr[header->e_phnum]; ph++)
+        if (ph->p_type == PT_LOAD && ph->p_flags & PF_X) {
+            uint64_t mapstart  = ALLOC_ALIGN_DOWN(ph->p_vaddr);
+            uint64_t mapend = ALLOC_ALIGN_UP(ph->p_vaddr + ph->p_filesz);
+            uint64_t mapoff = ALLOC_ALIGN_DOWN(ph->p_offset);
+            sgx_profile_report_mmap(filename, base + mapstart, mapend - mapstart, mapoff);
+        }
+
+    return 0;
+}
+#endif /* DEBUG */
+
 static int load_enclave_binary(sgx_arch_secs_t* secs, int fd, unsigned long base,
                                unsigned long prot) {
     int ret = 0;
 
     if (IS_ERR(ret = INLINE_SYSCALL(lseek, 3, fd, 0, SEEK_SET)))
-        return -ERRNO(ret);
+        return ret;
 
     char filebuf[FILEBUF_SIZE];
     ret = INLINE_SYSCALL(read, 3, fd, filebuf, FILEBUF_SIZE);
     if (IS_ERR(ret))
-        return -ERRNO(ret);
+        return ret;
 
     const ElfW(Ehdr)* header = (void*)filebuf;
     const ElfW(Phdr)* phdr   = (void*)filebuf + header->e_phoff;
@@ -190,7 +230,7 @@ static int initialize_enclave(struct pal_enclave* enclave, const char* manifest_
     enclave_image = INLINE_SYSCALL(open, 3, enclave->libpal_uri + URI_PREFIX_FILE_LEN, O_RDONLY, 0);
     if (IS_ERR(enclave_image)) {
         SGX_DBG(DBG_E, "Cannot find enclave image: %s\n", enclave->libpal_uri);
-        ret = -ERRNO(enclave_image);
+        ret = enclave_image;
         goto out;
     }
 
@@ -555,6 +595,26 @@ static int initialize_enclave(struct pal_enclave* enclave, const char* manifest_
         }
     }
 
+#ifdef DEBUG
+    if (enclave->profile_enable) {
+        /*
+         * Report libpal map. All subsequent files will be reported via DkDebugAddMap(), but this
+         * one has to be handled separately.
+         *
+         * We report it here, before enclave start (as opposed to setup_pal_map()), because we want
+         * the mmap to appear in profiling data before the samples from libpal code, so that the
+         * addresses for these samples can be resolved to symbols.
+         *
+         * TODO: Also report the map to GDB before enclave start (and not in setup_pal_map()), so
+         * that libpal symbols are known to gdb immediately after enclave start.
+         */
+        ret = report_mmaps(enclave_image, enclave->libpal_uri + URI_PREFIX_FILE_LEN,
+                           pal_area->addr);
+        if (IS_ERR(ret))
+            goto out;
+    }
+#endif
+
     ret = 0;
 
 out:
@@ -806,13 +866,13 @@ out:
 static int get_hw_resource(const char* filename, bool count) {
     int fd = INLINE_SYSCALL(open, 3, filename, O_RDONLY | O_CLOEXEC, 0);
     if (IS_ERR(fd))
-        return -ERRNO(fd);
+        return fd;
 
     char buf[64];
     int ret = INLINE_SYSCALL(read, 3, fd, buf, sizeof(buf) - 1);
     INLINE_SYSCALL(close, 1, fd);
     if (IS_ERR(ret))
-        return -ERRNO(ret);
+        return ret;
 
     buf[ret] = '\0'; /* ensure null-terminated buf even in partial read */
 

--- a/Pal/src/host/Linux-SGX/sgx_perf_data.c
+++ b/Pal/src/host/Linux-SGX/sgx_perf_data.c
@@ -1,0 +1,447 @@
+/* SPDX-License-Identifier: LGPL-3.0-or-later */
+/* Copyright (C) 2020 Intel Corporation
+ *                    Paweł Marczewski <pawel@invisiblethingslab.com>
+ */
+
+/*
+ * A library for dumping synthetic perf.data events, for consumption by 'perf report' tool.
+ *
+ * For more information on the format, see Linux sources:
+ *
+ * - tools/perf/Documentation/perf.data-file-format.txt
+ * - include/uapi/linux/perf_event.h
+ * - tools/perf/util/header.h
+ *
+ * Unfortunately, the format contains a header with data offsets and sizes, as well as additional
+ * headers at the end of files. To simplify processing, we write all of these on closing (pd_close).
+ *
+ * (There is also a simpler "pipe-mode data" format, which does not require seeking, but it's less
+ * convenient to use because perf userspace tools recognize it only when reading from stdin. This
+ * has been fixed in Linux 5.8: https://lkml.org/lkml/2020/5/7/294)
+ *
+ * To view the report, use 'perf report -i <filename>'.
+ *
+ * For debugging the output, you can use:
+ *
+ * - perf script -D -i <filename>: show a partial parse of the file
+ * - perf script -v -i <filename>: show more errors if the file doesn't parse
+ */
+
+#include <asm/errno.h>
+#include <asm/perf_regs.h>
+#include <assert.h>
+#include <linux/perf_event.h>
+
+#include "perm.h"
+#include "sgx_internal.h"
+
+#ifndef __x86_64__
+#error "Unsupported architecture"
+#endif
+
+#define PROLOGUE_SIZE (sizeof(struct perf_file_header) + sizeof(struct perf_file_attr))
+
+/* Buffer size for pending perf data. Choose a big enough size (32 MB) so that we don't need to
+ * flush to a file too often. */
+#define BUF_SIZE (32 * 1024 * 1024)
+
+/* Registers to sample - see arch/x86/include/uapi/asm/perf_regs.h */
+#define NUM_SAMPLE_REGS 18
+#define SAMPLE_REGS ((1 << PERF_REG_X86_AX)    | \
+                     (1 << PERF_REG_X86_BX)    | \
+                     (1 << PERF_REG_X86_CX)    | \
+                     (1 << PERF_REG_X86_DX)    | \
+                     (1 << PERF_REG_X86_SI)    | \
+                     (1 << PERF_REG_X86_DI)    | \
+                     (1 << PERF_REG_X86_BP)    | \
+                     (1 << PERF_REG_X86_SP)    | \
+                     (1 << PERF_REG_X86_IP)    | \
+                     (1 << PERF_REG_X86_FLAGS) | \
+                     (1 << PERF_REG_X86_R8)    | \
+                     (1 << PERF_REG_X86_R9)    | \
+                     (1 << PERF_REG_X86_R10)   | \
+                     (1 << PERF_REG_X86_R11)   | \
+                     (1 << PERF_REG_X86_R12)   | \
+                     (1 << PERF_REG_X86_R13)   | \
+                     (1 << PERF_REG_X86_R14)   | \
+                     (1 << PERF_REG_X86_R15))
+
+/* Internal perf.data file definitions - see linux/tools/perf/util/header.h */
+
+#define PERF_MAGIC 0x32454c4946524550ULL  // "PERFILE2"
+#define HEADER_ARCH 6
+
+struct perf_file_section {
+    uint64_t offset;
+    uint64_t size;
+};
+
+struct perf_file_header {
+    uint64_t magic;
+    uint64_t size;
+    uint64_t attr_size;
+    struct perf_file_section attrs;
+    struct perf_file_section data;
+    struct perf_file_section event_types;
+    uint64_t flags[4];
+};
+
+struct perf_file_attr {
+    struct perf_event_attr attr;
+    struct perf_file_section ids;
+};
+
+struct perf_data {
+    int fd;
+    // Data to be flushed to a file
+    size_t buf_count;
+    uint8_t buf[BUF_SIZE];
+
+    bool with_stack;
+};
+
+static ssize_t write_all(int fd, const void* buf, size_t count) {
+    while (count > 0) {
+        ssize_t ret = INLINE_SYSCALL(write, 3, fd, buf, count);
+        if (ret == -EINTR)
+            continue;
+        if (ret < 0)
+            return ret;
+        count -= ret;
+        buf += ret;
+    }
+    return 0;
+}
+
+static int pd_flush(struct perf_data* pd) {
+    if (pd->buf_count == 0)
+        return 0;
+
+    ssize_t ret = write_all(pd->fd, pd->buf, pd->buf_count);
+    if (ret < 0)
+        return ret;
+    pd->buf_count = 0;
+    return 0;
+}
+
+// Add data to buffer; flush first if necessary
+static int pd_write(struct perf_data* pd, const void* data, size_t size) {
+    if (pd->buf_count + size > sizeof(pd->buf)) {
+        int ret = pd_flush(pd);
+        if (ret < 0)
+            return ret;
+    }
+
+    assert(pd->buf_count + size <= sizeof(pd->buf));
+    memcpy(pd->buf + pd->buf_count, data, size);
+    pd->buf_count += size;
+    return 0;
+}
+
+struct perf_data* pd_open(const char* file_name, bool with_stack) {
+    int ret;
+
+    int fd = INLINE_SYSCALL(open, 3, file_name, O_WRONLY | O_TRUNC | O_CREAT, PERM_rw_r__r__);
+    if (fd < 0) {
+        SGX_DBG(DBG_E, "pd_open: cannot open %s for writing: %d\n", file_name, fd);
+        return NULL;
+    }
+
+    /*
+     * Start writing to file from PROLOGUE_SIZE position. The beginning will be overwritten in
+     * write_prologue_epilogue().
+     */
+
+    ret = INLINE_SYSCALL(ftruncate, 2, fd, PROLOGUE_SIZE);
+    if (ret < 0)
+        goto fail;
+
+    ret = INLINE_SYSCALL(lseek, 3, fd, PROLOGUE_SIZE, SEEK_SET);
+    if (ret < 0)
+        goto fail;
+
+    struct perf_data* pd = malloc(sizeof(*pd));
+    if (!pd) {
+        SGX_DBG(DBG_E, "pd_open: out of memory\n");
+        goto fail;
+    }
+
+    pd->fd = fd;
+    pd->buf_count = 0;
+    pd->with_stack = with_stack;
+    return pd;
+
+fail:
+    ret = INLINE_SYSCALL(close, 1, fd);
+    if (ret < 0)
+        SGX_DBG(DBG_E, "pd_open: close failed: %d\n", ret);
+    return NULL;
+};
+
+static int write_prologue_epilogue(struct perf_data* pd) {
+    int ret;
+
+    assert(pd->buf_count == 0); // all data flushed
+    ssize_t data_end = INLINE_SYSCALL(lseek, 3, pd->fd, 0, SEEK_CUR);
+    if (data_end < 0)
+        return data_end;
+
+    /*
+     * Prologue, at beginning of file:
+     * - struct perf_file_header: description of other file sections
+     * - struct perf_file_attr: event configuration
+     */
+
+    ret = INLINE_SYSCALL(lseek, 3, pd->fd, 0, SEEK_SET);
+    if (ret < 0)
+        return ret;
+
+    // Determines the set of data in PERF_RECORD_SAMPLE
+    uint64_t sample_type = PERF_SAMPLE_IP | PERF_SAMPLE_TID | PERF_SAMPLE_PERIOD;
+    if (pd->with_stack)
+        sample_type |= PERF_SAMPLE_CALLCHAIN | PERF_SAMPLE_REGS_USER | PERF_SAMPLE_STACK_USER;
+
+    struct perf_file_attr attr = {
+        .attr = {
+            .type = PERF_TYPE_SOFTWARE,
+            .size = sizeof(attr.attr),
+            .sample_type = sample_type,
+            .sample_regs_user = SAMPLE_REGS,
+        },
+        .ids = {0},
+    };
+    struct perf_file_header header = {
+        .magic = PERF_MAGIC,
+        .size = sizeof(header),
+        .attr_size = sizeof(attr.attr),
+        .attrs = {
+            .offset = sizeof(header),
+            .size = sizeof(attr),
+        },
+        .data = {
+            .offset = PROLOGUE_SIZE,
+            .size = data_end - PROLOGUE_SIZE,
+        },
+        .event_types = {0},
+        .flags = {0},
+    };
+    // Signifies that a HEADER_ARCH section will be included after data section
+    header.flags[0] |= 1 << HEADER_ARCH;
+
+    ret = write_all(pd->fd, &header, sizeof(header));
+    if (ret < 0)
+        return ret;
+    ret = write_all(pd->fd, &attr, sizeof(attr));
+    if (ret < 0)
+        return ret;
+
+    /*
+     * Epilogue, after the data section. Contains header sections, as specified by header.flags.
+     * We include a HEADER_ARCH section. While it's documented as optional, 'perf script' crashes
+     * without it.
+     */
+
+    ret = INLINE_SYSCALL(lseek, 3, pd->fd, data_end, SEEK_SET);
+    if (ret < 0)
+        return ret;
+
+    const char* arch = "x86_64";
+    uint32_t arch_size = strlen(arch) + 1;
+    struct perf_file_section arch_section = {
+        .offset = data_end + sizeof(arch_section),
+        .size = sizeof(arch_size) + arch_size,
+    };
+    ret = write_all(pd->fd, &arch_section, sizeof(arch_section));
+    if (ret < 0)
+        return ret;
+    ret = write_all(pd->fd, &arch_size, sizeof(arch_size));
+    if (ret < 0)
+        return ret;
+    ret = write_all(pd->fd, arch, arch_size);
+    if (ret < 0)
+        return ret;
+
+    return 0;
+}
+
+ssize_t pd_close(struct perf_data* pd) {
+    ssize_t ret = 0;
+    int close_ret;
+
+    ret = pd_flush(pd);
+    if (ret < 0)
+        goto out;
+
+    ret = write_prologue_epilogue(pd);
+    if (ret < 0)
+        goto out;
+
+    ret = INLINE_SYSCALL(lseek, 3, pd->fd, 0, SEEK_CUR);
+    if (ret < 0)
+        goto out;
+
+out:
+    close_ret = INLINE_SYSCALL(close, 1, pd->fd);
+    if (close_ret < 0)
+        SGX_DBG(DBG_E, "pd_close: close failed: %d\n", close_ret);
+
+    free(pd);
+    return ret;
+}
+
+int pd_event_command(struct perf_data* pd, const char* command, uint32_t pid, uint32_t tid) {
+    size_t command_size = strlen(command) + 1;
+    struct {
+        struct perf_event_header header;
+
+        uint32_t pid, tid;
+    } event = {
+        .header = {
+            .type = PERF_RECORD_COMM,
+            .misc = 0,
+            .size = sizeof(event) + command_size,
+        },
+
+        .pid = pid,
+        .tid = tid,
+    };
+    int ret;
+    ret = pd_write(pd, &event, sizeof(event));
+    if (ret < 0)
+        return ret;
+    ret = pd_write(pd, command, command_size);
+    if (ret < 0)
+        return ret;
+    return 0;
+}
+
+int pd_event_mmap(struct perf_data* pd, const char* filename, uint32_t pid, uint64_t addr,
+                  uint64_t len, uint64_t pgoff) {
+    size_t filename_size = strlen(filename) + 1;
+    struct {
+        struct perf_event_header header;
+
+        uint32_t pid, tid;
+        uint64_t addr, len, pgoff;
+    } event = {
+        .header = {
+            .type = PERF_RECORD_MMAP,
+            .misc = 0,
+            .size = sizeof(event) + filename_size,
+        },
+
+        .pid = pid,
+        .tid = pid,
+        .addr = addr,
+        .len = len,
+        .pgoff = pgoff,
+    };
+    int ret;
+    ret = pd_write(pd, &event, sizeof(event));
+    if (ret < 0)
+        return ret;
+    ret = pd_write(pd, filename, filename_size);
+    if (ret < 0)
+        return ret;
+    return 0;
+}
+
+static int pd_event_sample(struct perf_data* pd, uint64_t ip, uint32_t pid, uint32_t tid,
+                         uint64_t period, size_t extra_size) {
+    struct {
+        struct perf_event_header header;
+
+        uint64_t ip;
+        uint32_t pid, tid;
+        uint64_t period;
+    } event = {
+        .header = {
+            .type = PERF_RECORD_SAMPLE,
+            .misc = PERF_RECORD_MISC_USER, // user/kernel/hypervisor
+            .size = sizeof(event) + extra_size,
+        },
+
+        .ip = ip,
+        .pid = pid,
+        .tid = tid,
+        .period = period,
+    };
+
+    return pd_write(pd, &event, sizeof(event));
+}
+
+int pd_event_sample_simple(struct perf_data* pd, uint64_t ip, uint32_t pid, uint32_t tid,
+                           uint64_t period) {
+    assert(!pd->with_stack);
+    return pd_event_sample(pd, ip, pid, tid, period, /*extra_size=*/0);
+}
+
+int pd_event_sample_stack(struct perf_data* pd, uint64_t ip, uint32_t pid, uint32_t tid,
+                          uint64_t period, sgx_pal_gpr_t* gpr, void* stack, size_t stack_size) {
+    assert(pd->with_stack);
+    struct {
+        // Empty callchain section - needed so that perf will attempt to recover call chain
+        struct {
+            uint64_t nr;
+        } callchain;
+
+        struct {
+            uint64_t abi;
+            uint64_t regs[NUM_SAMPLE_REGS];
+        } regs;
+    } extra = {
+        .callchain = {
+            .nr = 0,
+        },
+
+        .regs = {
+            .abi = PERF_SAMPLE_REGS_ABI_64,
+            .regs = {
+                gpr->rax,
+                gpr->rbx,
+                gpr->rcx,
+                gpr->rdx,
+                gpr->rsi,
+                gpr->rdi,
+                gpr->rbp,
+                gpr->rsp,
+                gpr->rip,
+                gpr->rflags,
+                gpr->r8,
+                gpr->r9,
+                gpr->r10,
+                gpr->r11,
+                gpr->r12,
+                gpr->r13,
+                gpr->r14,
+                gpr->r15,
+            },
+        },
+    };
+    size_t extra_size = sizeof(extra) + stack_size + 2 * sizeof(uint64_t);
+    int ret;
+
+    // Common section
+    ret = pd_event_sample(pd, ip, pid, tid, period, extra_size);
+    if (ret < 0)
+        return ret;
+
+    // Callchain and regs sections
+    ret = pd_write(pd, &extra, sizeof(extra));
+    if (ret < 0)
+        return ret;
+
+    // Stack section (variable length)
+    uint64_t size_field = stack_size;
+    ret = pd_write(pd, &size_field, sizeof(size_field));  // uint64_t size
+    if (ret < 0)
+        return ret;
+    ret = pd_write(pd, stack, stack_size);
+    if (ret < 0)
+        return ret;
+    ret = pd_write(pd, &size_field, sizeof(size_field));  // uint64_t dyn_size = size
+    if (ret < 0)
+        return ret;
+
+    return 0;
+}

--- a/Pal/src/host/Linux-SGX/sgx_profile.c
+++ b/Pal/src/host/Linux-SGX/sgx_profile.c
@@ -1,0 +1,289 @@
+/* SPDX-License-Identifier: LGPL-3.0-or-later */
+/* Copyright (C) 2020 Intel Corporation
+ *                    Paweł Marczewski <pawel@invisiblethingslab.com>
+ */
+
+/*
+ * SGX profiling. This code takes samples of running code and writes them out to a perf.data file
+ * (see also sgx_perf_data.c).
+ */
+
+#ifdef DEBUG
+
+#include <assert.h>
+#include <errno.h>
+#include <linux/limits.h>
+#include <stddef.h>
+
+#include "cpu.h"
+#include "sgx_internal.h"
+#include "sgx_tls.h"
+#include "spinlock.h"
+#include "string.h"
+
+// FIXME: this is glibc realpath, declared here because the headers will conflict with PAL
+char* realpath(const char* path, char* resolved_path);
+
+#define NSEC_IN_SEC 1000000000
+
+static spinlock_t g_perf_data_lock = INIT_SPINLOCK_UNLOCKED;
+static struct perf_data* g_perf_data = NULL;
+
+static bool g_profile_enabled = false;
+static uint64_t g_profile_period;
+static int g_mem_fd = -1;
+
+/* Read memory from inside enclave (using /proc/self/mem). */
+static ssize_t debug_read(void* dest, void* addr, size_t size) {
+    ssize_t ret;
+    size_t total = 0;
+
+    while (total < size) {
+        ret = INLINE_SYSCALL(pread, 4, g_mem_fd, (uint8_t*)dest + total, size - total,
+                             (off_t)addr + total);
+
+        if (IS_ERR(ret) && ERRNO(ret) == EINTR)
+            continue;
+
+        if (IS_ERR(ret))
+            return ret;
+
+        if (ret == 0)
+            break;
+
+        assert(ret > 0);
+        assert((size_t)ret + total <= size);
+        total += ret;
+    }
+    return total;
+}
+
+static int debug_read_all(void* dest, void* addr, size_t size) {
+    ssize_t ret = debug_read(dest, addr, size);
+    if (IS_ERR(ret))
+        return ret;
+    if ((size_t)ret < size)
+        return -EINVAL;
+    return 0;
+}
+
+static int get_sgx_gpr(sgx_pal_gpr_t* gpr, void* tcs) {
+    int ret;
+    uint64_t ossa;
+    uint32_t cssa;
+    ret = debug_read_all(&ossa, tcs + 16, sizeof(ossa));
+    if (ret < 0)
+        return ret;
+    ret = debug_read_all(&cssa, tcs + 24, sizeof(cssa));
+    if (ret < 0)
+        return ret;
+
+    void* gpr_addr = (void*)(
+        g_pal_enclave.baseaddr
+        + ossa + cssa * g_pal_enclave.ssaframesize
+        - sizeof(*gpr));
+
+    ret = debug_read_all(gpr, gpr_addr, sizeof(*gpr));
+    if (ret < 0)
+        return ret;
+
+    return 0;
+}
+
+int sgx_profile_init(void) {
+    int ret;
+
+    assert(!g_profile_enabled);
+    assert(g_mem_fd == -1);
+    assert(!g_perf_data);
+
+    g_profile_period = NSEC_IN_SEC / g_pal_enclave.profile_frequency;
+
+    ret = INLINE_SYSCALL(open, 3, "/proc/self/mem", O_RDONLY | O_LARGEFILE, 0);
+    if (IS_ERR(ret)) {
+        SGX_DBG(DBG_E, "sgx_profile_init: opening /proc/self/mem failed: %d\n", ret);
+        goto out;
+    }
+    g_mem_fd = ret;
+
+    struct perf_data* pd = pd_open(g_pal_enclave.profile_filename, g_pal_enclave.profile_with_stack);
+    if (!pd) {
+        SGX_DBG(DBG_E, "sgx_profile_init: pd_open failed\n");
+        ret = -EINVAL;
+        goto out;
+    }
+    g_perf_data = pd;
+
+    pid_t pid = g_pal_enclave.pal_sec.pid;
+    ret = pd_event_command(pd, "pal-sgx", pid, /*tid=*/pid);
+    if (!pd) {
+        SGX_DBG(DBG_E, "sgx_profile_init: reporting command failed: %d\n", ret);
+        goto out;
+    }
+
+    g_profile_enabled = true;
+    return 0;
+
+out:
+    if (g_mem_fd > 0) {
+        int close_ret = INLINE_SYSCALL(close, 1, g_mem_fd);
+        if (IS_ERR(close_ret))
+            SGX_DBG(DBG_E, "sgx_profile_init: closing /proc/self/mem failed: %d\n",
+                    ERRNO(close_ret));
+        g_mem_fd = -1;
+    }
+
+    if (g_perf_data) {
+        ssize_t close_ret = pd_close(g_perf_data);
+        if (IS_ERR(close_ret))
+            SGX_DBG(DBG_E, "sgx_profile_init: pd_close failed: %ld\n", close_ret);
+            g_perf_data = NULL;
+    }
+    return ret;
+}
+
+void sgx_profile_finish(void) {
+    int ret;
+    ssize_t size;
+
+    if (!g_profile_enabled)
+        return;
+
+    spinlock_lock(&g_perf_data_lock);
+
+    size = pd_close(g_perf_data);
+    if (IS_ERR(size))
+        SGX_DBG(DBG_E, "sgx_profile_finish: pd_close failed: %ld\n", size);
+    g_perf_data = NULL;
+
+    spinlock_unlock(&g_perf_data_lock);
+
+    ret = INLINE_SYSCALL(close, 1, g_mem_fd);
+    if (IS_ERR(ret))
+        SGX_DBG(DBG_E, "sgx_profile_finish: closing /proc/self/mem failed: %d\n", ret);
+    g_mem_fd = -1;
+
+    SGX_DBG(DBG_I, "Profile data written to %s (%lu bytes)\n", g_pal_enclave.profile_filename,
+            size);
+
+    g_profile_enabled = false;
+}
+
+static void sample_simple(void* tcs, pid_t pid, pid_t tid) {
+    int ret;
+    sgx_pal_gpr_t gpr;
+
+    ret = get_sgx_gpr(&gpr, tcs);
+    if (IS_ERR(ret)) {
+        SGX_DBG(DBG_E, "error reading GPR: %d\n", ret);
+        return;
+    }
+
+    spinlock_lock(&g_perf_data_lock);
+    ret = pd_event_sample_simple(g_perf_data, gpr.rip, pid, tid, g_profile_period);
+    spinlock_unlock(&g_perf_data_lock);
+
+    if (IS_ERR(ret)) {
+        SGX_DBG(DBG_E, "error recording sample: %d\n", ret);
+    }
+}
+
+static void sample_stack(void* tcs, pid_t pid, pid_t tid) {
+    int ret;
+    sgx_pal_gpr_t gpr;
+
+    ret = get_sgx_gpr(&gpr, tcs);
+    if (IS_ERR(ret)) {
+        SGX_DBG(DBG_E, "error reading GPR: %d\n", ret);
+        return;
+    }
+
+    uint8_t stack[PD_STACK_SIZE];
+    size_t stack_size;
+    ret = debug_read(stack, (void*)gpr.rsp, sizeof(stack));
+    if (IS_ERR(ret)) {
+        SGX_DBG(DBG_E, "error reading stack: %d\n", ret);
+        return;
+    }
+    stack_size = ret;
+
+    spinlock_lock(&g_perf_data_lock);
+    ret = pd_event_sample_stack(g_perf_data, gpr.rip, pid, tid, g_profile_period,
+                                &gpr, stack, stack_size);
+    spinlock_unlock(&g_perf_data_lock);
+
+    if (IS_ERR(ret)) {
+        SGX_DBG(DBG_E, "error recording sample: %d\n", ret);
+    }
+}
+
+/*
+ * Take a sample after an exit from enclave.
+ *
+ * Use CPU time to record a sample approximately every 'g_profile_period' nanoseconds. Note that we
+ * rely on Linux scheduler to generate an AEX event 250 times per second (although other events may
+ * cause an AEX to happen more often), so sampling frequency greater than 250 cannot be reliably
+ * achieved.
+ */
+void sgx_profile_sample(void* tcs) {
+    int ret;
+
+    if (!g_profile_enabled)
+        return;
+
+    // Check current CPU time
+    struct timespec ts;
+    ret = INLINE_SYSCALL(clock_gettime, 2, CLOCK_THREAD_CPUTIME_ID, &ts);
+    if (IS_ERR(ret)) {
+        SGX_DBG(DBG_E, "sgx_profile_sample: clock_gettime failed: %d\n", ret);
+        return;
+    }
+    uint64_t sample_time = ts.tv_sec * NSEC_IN_SEC + ts.tv_nsec;
+
+    // Compare and update last recorded time per thread
+    PAL_TCB_URTS* tcb = get_tcb_urts();
+    if (tcb->profile_sample_time == 0) {
+        tcb->profile_sample_time = sample_time;
+        return;
+    }
+
+    assert(sample_time >= tcb->profile_sample_time);
+    // Report a sample, if necessary
+    if (sample_time - tcb->profile_sample_time >= g_profile_period) {
+        tcb->profile_sample_time = sample_time;
+
+        // Report all events as the same PID so that they are grouped in report.
+        pid_t pid = g_pal_enclave.pal_sec.pid;
+        pid_t tid = pid;
+
+        if (g_pal_enclave.profile_with_stack) {
+            sample_stack(tcs, pid, tid);
+        } else {
+            sample_simple(tcs, pid, tid);
+        }
+    }
+}
+
+void sgx_profile_report_mmap(const char* filename, uint64_t addr, uint64_t len, uint64_t offset) {
+    if (!g_profile_enabled)
+        return;
+
+    // Convert filename to absolute path - some tools (e.g. libunwind in 'perf report') refuse to
+    // process relative paths.
+    char buf[PATH_MAX];
+    char* path = realpath(filename, buf);
+    if (!path) {
+        SGX_DBG(DBG_E, "sgx_profile_report_mmap: realpath(%s) failed\n", filename);
+        return;
+    }
+
+    pid_t pid = g_pal_enclave.pal_sec.pid;
+
+    spinlock_lock(&g_perf_data_lock);
+    int ret = pd_event_mmap(g_perf_data, path, pid, addr, len, offset);
+    spinlock_unlock(&g_perf_data_lock);
+    if (IS_ERR(ret))
+        SGX_DBG(DBG_E, "sgx_profile_report_mmap: pd_event_mmap failed: %d\n", ret);
+}
+
+#endif /* DEBUG */

--- a/Pal/src/host/Linux-SGX/sgx_thread.c
+++ b/Pal/src/host/Linux-SGX/sgx_thread.c
@@ -85,6 +85,8 @@ void pal_tcb_urts_init(PAL_TCB_URTS* tcb, void* stack, void* alt_stack) {
     tcb->aex_cnt          = 0;
     tcb->sync_signal_cnt  = 0;
     tcb->async_signal_cnt = 0;
+
+    tcb->profile_sample_time = 0;
 }
 
 static spinlock_t tcs_lock = INIT_SPINLOCK_UNLOCKED;

--- a/Pal/src/host/Linux-SGX/sgx_tls.h
+++ b/Pal/src/host/Linux-SGX/sgx_tls.h
@@ -93,6 +93,7 @@ typedef struct pal_tcb_urts {
     atomic_ulong aex_cnt;          /* # of AEXs, corresponds to # of interrupts/signals */
     atomic_ulong sync_signal_cnt;  /* # of sync signals, corresponds to # of SIGSEGV/SIGILL/.. */
     atomic_ulong async_signal_cnt; /* # of async signals, corresponds to # of SIGINT/SIGCONT/.. */
+    uint64_t profile_sample_time;  /* last time sgx_profile_sample() recorded a sample */
 } PAL_TCB_URTS;
 
 extern void pal_tcb_urts_init(PAL_TCB_URTS* tcb, void* stack, void* alt_stack);

--- a/Pal/src/host/Linux/Makefile.am
+++ b/Pal/src/host/Linux/Makefile.am
@@ -10,6 +10,7 @@ ASFLAGS += -DPIC -DSHARED -fPIC -DASSEMBLER -Wa,--noexecstack \
 	  -x assembler-with-cpp
 LDFLAGS += -shared -nostdlib -z combreloc -z defs \
 	  --version-script $(HOST_DIR)/pal.map -T $(HOST_DIR)/pal-$(ARCH).lds \
+	  --eh-frame-hdr \
 	  -z relro -z now
 
 pal_loader = $(HOST_DIR)/libpal.so

--- a/Pal/src/host/Skeleton/Makefile.am
+++ b/Pal/src/host/Skeleton/Makefile.am
@@ -8,7 +8,8 @@ CFLAGS += -Wextra -Wno-unused-parameter -Wno-sign-compare $(call cc-option,-Wnul
 ASFLAGS += -DPIC -DSHARED -fPIC -DASSEMBLER -Wa,--noexecstack \
 	  -x assembler-with-cpp
 LDFLAGS += -shared -nostdlib -z combreloc -z defs \
-	  --version-script $(HOST_DIR)/pal.map -T $(HOST_DIR)/pal-$(ARCH).lds
+	  --version-script $(HOST_DIR)/pal.map -T $(HOST_DIR)/pal-$(ARCH).lds \
+	  --eh-frame-hdr
 
 pal_loader =
 pal_sec =


### PR DESCRIPTION
New version of https://github.com/oscarlab/graphene/pull/2001 (closes #2001).

Includes `eh_frame_hdr` fix (#2026, can be merged faster) (closes #2026).

## Description of the changes:

This generates a file with samples readable by `perf`. After recording, you can view a report with `perf record`. The samples can include stack: a snapshot of up to 8192 bytes is recorded, and `perf record` will try to walk it based on DWARF info.

Basically, this replaces the kernel part of `perf` for SGX.

![image](https://user-images.githubusercontent.com/468495/102214471-9b0b5000-3ed8-11eb-999e-f1ba73ab40c2.png)

## Alternate approaches I have considered

- **Hand-rolled statistics/report** (as in #2001): I got stuck trying to add stack traces. You can follow frame pointers (`RBP`) quite easily, but that works more or less only in Graphene code, as even glibc is compiled without frame pointers nowadays.

- **Parsing the stack ourselves**: I tried to use `libunwind` (not very flexible) and `libdwfl` (better, but complex), and it worked, but then started crashing on more complicated (and multithreaded) programs, I'm not sure why...

   Anyway, I decided I'm not comfortable introducing a complicated library to outer PAL, and invoking it during AEX. Besides, with `perf` I can lean on existing tool.

- **VTune**: Haven't looked into that, according to @dimakuv it might be a matter of [adding module maps](https://scc.ustc.edu.cn/zlsc/tc4600/intel/2017.0.098/vtune_amplifier_xe/help/GUID-B55461C0-94A2-48DA-A2DA-4B7A6A2976B7.html). Sounds promising, but regardless of that, I think it's good to have perf support because of availability (free software, present in Ubuntu, works in terminal, etc.)

- **Kernel patch for SGX perf**: Might be worth doing someday? I can imagine Linux kernel reporting the samples from enclave. Still, memory maps would have to be reported somehow.

## Limitations

- ~~I can't see symbols from `python3.6` in perf. Oddly, the same happens without Graphene. I might debug this later.~~
  - Good news: that was a local setup issue, removing `~/.debug/.build-id` cache helped.
- I'm not 100% sure the mmap reporting is correct, because the ELF linking code is pretty bad. I'd be interested in redoing it soon (CC @mkow).
- Soon LibOS syscalls will use a separate stack (@boryspoplawski is working on that). That means with this approach we will not see the transition between application and LibOS. But I think that can be worked around, by doing basically the same thing `perf` does when showing split stack traces between userland and kernel (record call chain for kernel stack, and dump for user stack).
- JITted languages won't work too well. It might be worth looking into the workarounds for normal perf (there is some support for Java).

## How to test this PR?

1. Compile with `DEBUG=1`
2. `sgx.profile.enable = "main"`, `sgx.profile.with_stack = 1`
3. Run application
4. `perf report -i sgx-perf.data`
5. To view the raw dump: `perf script -Di sgx-perf.data`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2027)
<!-- Reviewable:end -->
