### PR TITLE
[LibOS] Remove bogus "signal delayed (2)" message

### DIFF
--- a/LibOS/shim/src/bookkeep/shim_signal.c
+++ b/LibOS/shim/src/bookkeep/shim_signal.c
@@ -821,13 +821,13 @@ void handle_signals(void) {
     shim_tcb_t* tcb = shim_get_tcb();
     assert(tcb);
 
-    int64_t preempt = __disable_preempt(tcb);
-
-    if (preempt > 1)
-        debug("signal delayed (%ld)\n", preempt);
-    else
+    int64_t preempt_level = __disable_preempt(tcb);
+    if (preempt_level == 1) {
+        /* upon entering this function, preempt level was 0 and thus we can handle signals now
+         * (otherwise preempt level was 1+, indicating that we are in signal handler; we don't
+         * support nested sighandling so we defer such signals until preempt level is 0 again) */
         __handle_signals(tcb);
-
+    }
     __enable_preempt(tcb);
 }
 


### PR DESCRIPTION


<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://graphene.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

This message appeared even if there were no pending signals, and its "(2)" part was confusing (it showed incremented-preempt-level and not the more intuitive pending-signal number).

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->

Check e.g. Nginx with `loader.debug_type = "inline"`. Without this PR, it shows a lot of bogus `signal delayed (2)` messages upon Ctrl-C.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2029)
<!-- Reviewable:end -->
