### PR TITLE
[Pal] Fix semantics of DkSegmentRegister

### DIFF
--- a/Documentation/pal/host-abi.rst
+++ b/Documentation/pal/host-abi.rst
@@ -371,7 +371,10 @@ and to obtain an attestation report and quote.
 .. doxygenfunction:: DkRandomBitsRead
    :project: pal
 
-.. doxygenfunction:: DkSegmentRegister
+.. doxygenfunction:: DkSegmentRegisterGet
+   :project: pal
+
+.. doxygenfunction:: DkSegmentRegisterSet
    :project: pal
 
 .. doxygenenum:: PAL_SEGMENT

--- a/LibOS/shim/include/arch/x86_64/shim_tcb-arch.h
+++ b/LibOS/shim/include/arch/x86_64/shim_tcb-arch.h
@@ -187,7 +187,7 @@ static inline void shim_regs_set_syscallnr(struct shim_regs* sr, uint64_t sc_num
     } while (0)
 
 static inline void shim_arch_update_fs_base(unsigned long fs_base) {
-    DkSegmentRegister(PAL_SEGMENT_FS, (PAL_PTR)fs_base);
+    DkSegmentRegisterSet(PAL_SEGMENT_FS, (PAL_PTR)fs_base);
 }
 
 /* On x86_64 the fs_base is the same as the tls parameter to 'clone' */

--- a/LibOS/shim/src/shim_syscalls.c
+++ b/LibOS/shim/src/shim_syscalls.c
@@ -505,7 +505,7 @@ void* shim_do_arch_prctl(int code, void* addr) {
             return NULL;
 
         case ARCH_GET_FS:
-            return (void*)DkSegmentRegister(PAL_SEGMENT_FS, NULL) ?: (void*)-PAL_ERRNO();
+            return DkSegmentRegisterGet(PAL_SEGMENT_FS, addr) ? NULL : (void*)-PAL_ERRNO();
     }
 
     return (void*)-ENOSYS;

--- a/Pal/include/pal/pal.h
+++ b/Pal/include/pal/pal.h
@@ -715,20 +715,29 @@ PAL_NUM DkRandomBitsRead(PAL_PTR buffer, PAL_NUM size);
 PAL_BOL DkInstructionCacheFlush(PAL_PTR addr, PAL_NUM size);
 
 enum PAL_SEGMENT {
-    PAL_SEGMENT_FS = 0x1,
-    PAL_SEGMENT_GS = 0x2,
+    PAL_SEGMENT_FS = 1,
+    PAL_SEGMENT_GS,
 };
+
+/*!
+ * \brief Get segment register
+ *
+ * \param reg the register to get (#PAL_SEGMENT)
+ * \param addr the address where result will be stored
+ *
+ * \return true on success, false on error
+ */
+PAL_BOL DkSegmentRegisterGet(PAL_FLG reg, PAL_PTR* addr);
 
 /*!
  * \brief Set segment register
  *
  * \param reg the register to be set (#PAL_SEGMENT)
- * \param addr the address to be set; if `NULL`, return the current value of the
- *  segment register.
+ * \param addr the address to be set
  *
- * \todo Please note that this API is broken and doesn't allow setting segment base to 0.
+ * \return true on success, false on error
  */
-PAL_PTR DkSegmentRegister(PAL_FLG reg, PAL_PTR addr);
+PAL_BOL DkSegmentRegisterSet(PAL_FLG reg, PAL_PTR addr);
 
 /*!
  * \brief Return the amount of currently available memory for LibOS/application

--- a/Pal/regression/Segment.c
+++ b/Pal/regression/Segment.c
@@ -4,9 +4,19 @@
 void* dummy = &dummy;
 
 int main(int argc, char** argv, char** envp) {
-    DkSegmentRegister(PAL_SEGMENT_FS, dummy);
-    void* ptr;
+    if (!DkSegmentRegisterSet(PAL_SEGMENT_FS, dummy)) {
+        pal_printf("Error setting FS\n");
+        return 1;
+    }
+
+    void** ptr;
     __asm__ volatile("mov %%fs:0, %0" : "=r"(ptr)::"memory");
-    pal_printf("TLS = %p\n", ptr);
+
+    if (ptr != &dummy) {
+        pal_printf("Wrong FS set: %p\n", ptr);
+        return 1;
+    }
+
+    pal_printf("Test OK\n");
     return 0;
 }

--- a/Pal/regression/Symbols.c
+++ b/Pal/regression/Symbols.c
@@ -59,7 +59,8 @@ int main(int argc, char** argv, char** envp) {
     PRINT_SYMBOL(DkRandomBitsRead);
     PRINT_SYMBOL(DkInstructionCacheFlush);
 #if defined(__x86_64__)
-    PRINT_SYMBOL(DkSegmentRegister);
+    PRINT_SYMBOL(DkSegmentRegisterGet);
+    PRINT_SYMBOL(DkSegmentRegisterSet);
 #endif
     PRINT_SYMBOL(DkMemoryAvailableQuota);
 

--- a/Pal/regression/Thread.c
+++ b/Pal/regression/Thread.c
@@ -20,7 +20,11 @@ static void callback(void* args) {
 
     pal_printf("Threads Run in Parallel OK\n");
 
-    DkSegmentRegister(PAL_SEGMENT_FS, &private2);
+    if (!DkSegmentRegisterSet(PAL_SEGMENT_FS, &private2)) {
+        pal_printf("Failed to set FS\n");
+        DkThreadExit(/*clear_child_tid=*/NULL);
+    }
+
     const char* ptr2;
     __asm__ volatile("mov %%fs:0, %0" : "=r"(ptr2)::"memory");
     pal_printf("Private Message (FS Segment) 2: %s\n", ptr2);
@@ -31,7 +35,10 @@ static void callback(void* args) {
 }
 
 int main() {
-    DkSegmentRegister(PAL_SEGMENT_FS, &private1);
+    if (!DkSegmentRegisterSet(PAL_SEGMENT_FS, &private1)) {
+        pal_printf("Failed to set FS\n");
+        return 1;
+    }
     const char* ptr1;
     __asm__ volatile("mov %%fs:0, %0" : "=r"(ptr1)::"memory");
     pal_printf("Private Message (FS Segment) 1: %s\n", ptr1);

--- a/Pal/regression/test_pal.py
+++ b/Pal/regression/test_pal.py
@@ -80,7 +80,7 @@ class TC_00_BasicSet2(RegressionTestCase):
     @unittest.skipUnless(ON_X86, "x86-specific")
     def test_Segment(self):
         _, stderr = self.run_binary(['Segment'])
-        self.assertIn('TLS = 0x', stderr)
+        self.assertIn('Test OK', stderr)
 
     def test_Select(self):
         _, stderr = self.run_binary(['Select'])
@@ -258,7 +258,8 @@ class TC_02_Symbols(RegressionTestCase):
         'DkMemoryAvailableQuota',
     ]
     if ON_X86:
-        ALL_SYMBOLS.append('DkSegmentRegister')
+        ALL_SYMBOLS.append('DkSegmentRegisterGet')
+        ALL_SYMBOLS.append('DkSegmentRegisterSet')
 
     def test_000_symbols(self):
         _, stderr = self.run_binary(['Symbols'])

--- a/Pal/src/db_misc.c
+++ b/Pal/src/db_misc.c
@@ -32,23 +32,30 @@ PAL_NUM DkRandomBitsRead(PAL_PTR buffer, PAL_NUM size) {
 }
 
 #if defined(__x86_64__)
-PAL_PTR DkSegmentRegister(PAL_FLG reg, PAL_PTR addr) {
-    ENTER_PAL_CALL(DkSegmentRegister);
-    void* seg_addr = (void*)addr;
-    int ret;
+PAL_BOL DkSegmentRegisterGet(PAL_FLG reg, PAL_PTR* addr) {
+    ENTER_PAL_CALL(DkSegmentRegisterGet);
 
-    if (addr) {
-        ret = _DkSegmentRegisterSet(reg, seg_addr);
-    } else {
-        ret = _DkSegmentRegisterGet(reg, &seg_addr);
-    }
+    int ret = _DkSegmentRegisterGet(reg, addr);
 
     if (ret < 0) {
         _DkRaiseFailure(-ret);
-        seg_addr = NULL;
+        LEAVE_PAL_CALL_RETURN(PAL_FALSE);
     }
 
-    LEAVE_PAL_CALL_RETURN((PAL_PTR)seg_addr);
+    LEAVE_PAL_CALL_RETURN(PAL_TRUE);
+}
+
+PAL_BOL DkSegmentRegisterSet(PAL_FLG reg, PAL_PTR addr) {
+    ENTER_PAL_CALL(DkSegmentRegisterSet);
+
+    int ret = _DkSegmentRegisterSet(reg, addr);
+
+    if (ret < 0) {
+        _DkRaiseFailure(-ret);
+        LEAVE_PAL_CALL_RETURN(PAL_FALSE);
+    }
+
+    LEAVE_PAL_CALL_RETURN(PAL_TRUE);
 }
 #endif
 

--- a/Pal/src/host/Linux-SGX/db_main-x86_64.c
+++ b/Pal/src/host/Linux-SGX/db_main-x86_64.c
@@ -219,21 +219,29 @@ size_t _DkRandomBitsRead(void* buffer, size_t size) {
     return 0;
 }
 
-int _DkSegmentRegisterSet(int reg, const void* addr) {
-    /* GS is internally used, denied any access to it */
-    if (reg != PAL_SEGMENT_FS)
-        return -PAL_ERROR_DENIED;
-
-    SET_ENCLAVE_TLS(fsbase, (void*)addr);
-    wrfsbase((uint64_t)addr);
-    return 0;
+int _DkSegmentRegisterGet(int reg, void** addr) {
+    switch (reg) {
+        case PAL_SEGMENT_FS:
+            *addr = (void*)GET_ENCLAVE_TLS(fsbase);
+            return 0;
+        case PAL_SEGMENT_GS:
+            /* GS is internally used, deny any access to it */
+            return -PAL_ERROR_DENIED;
+        default:
+            return -PAL_ERROR_INVAL;
+    }
 }
 
-int _DkSegmentRegisterGet(int reg, void** addr) {
-    /* GS is internally used, denied any access to it */
-    if (reg != PAL_SEGMENT_FS)
-        return -PAL_ERROR_DENIED;
-
-    *addr = (void*)GET_ENCLAVE_TLS(fsbase);
-    return 0;
+int _DkSegmentRegisterSet(int reg, void* addr) {
+    switch (reg) {
+        case PAL_SEGMENT_FS:
+            SET_ENCLAVE_TLS(fsbase, addr);
+            wrfsbase((uint64_t)addr);
+            return 0;
+        case PAL_SEGMENT_GS:
+            /* GS is internally used, deny any access to it */
+            return -PAL_ERROR_DENIED;
+        default:
+            return -PAL_ERROR_INVAL;
+    }
 }

--- a/Pal/src/host/Linux/db_main-x86_64.c
+++ b/Pal/src/host/Linux/db_main-x86_64.c
@@ -230,40 +230,28 @@ int _DkRandomBitsRead(void* buffer, size_t size) {
 }
 #endif
 
-int _DkSegmentRegisterSet(int reg, const void* addr) {
-    int ret = 0;
-
-    if (reg == PAL_SEGMENT_FS) {
-        ret = INLINE_SYSCALL(arch_prctl, 2, ARCH_SET_FS, addr);
-    } else if (reg == PAL_SEGMENT_GS) {
-        return -PAL_ERROR_DENIED;
-    } else {
-        return -PAL_ERROR_INVAL;
+int _DkSegmentRegisterGet(int reg, void** addr) {
+    switch (reg) {
+        case PAL_SEGMENT_FS:
+            return INLINE_SYSCALL(arch_prctl, 2, ARCH_GET_FS, addr);
+        case PAL_SEGMENT_GS:
+            // The GS segment is used for the internal TCB of PAL
+            return -PAL_ERROR_DENIED;
+        default:
+            return -PAL_ERROR_INVAL;
     }
-    if (IS_ERR(ret))
-        return -PAL_ERROR_DENIED;
-
-    return 0;
 }
 
-int _DkSegmentRegisterGet(int reg, void** addr) {
-    int ret;
-    unsigned long ret_addr;
-
-    if (reg == PAL_SEGMENT_FS) {
-        ret = INLINE_SYSCALL(arch_prctl, 2, ARCH_GET_FS, &ret_addr);
-    } else if (reg == PAL_SEGMENT_GS) {
-        // The GS segment is used for the internal TCB of PAL
-        return -PAL_ERROR_DENIED;
-    } else {
-        return -PAL_ERROR_INVAL;
+int _DkSegmentRegisterSet(int reg, void* addr) {
+    switch (reg) {
+        case PAL_SEGMENT_FS:
+            return INLINE_SYSCALL(arch_prctl, 2, ARCH_SET_FS, addr);
+        case PAL_SEGMENT_GS:
+            // The GS segment is used for the internal TCB of PAL
+            return -PAL_ERROR_DENIED;
+        default:
+            return -PAL_ERROR_INVAL;
     }
-
-    if (IS_ERR(ret))
-        return -PAL_ERROR_DENIED;
-
-    *addr = (void*)ret_addr;
-    return 0;
 }
 
 int _DkCpuIdRetrieve(unsigned int leaf, unsigned int subleaf, unsigned int values[4]) {

--- a/Pal/src/host/Skeleton/db_misc.c
+++ b/Pal/src/host/Skeleton/db_misc.c
@@ -32,11 +32,11 @@ size_t _DkRandomBitsRead(void* buffer, size_t size) {
     return -PAL_ERROR_NOTIMPLEMENTED;
 }
 
-int _DkSegmentRegisterSet(int reg, const void* addr) {
+int _DkSegmentRegisterGet(int reg, void** addr) {
     return -PAL_ERROR_NOTIMPLEMENTED;
 }
 
-int _DkSegmentRegisterGet(int reg, void** addr) {
+int _DkSegmentRegisterSet(int reg, void* addr) {
     return -PAL_ERROR_NOTIMPLEMENTED;
 }
 

--- a/Pal/src/pal-symbols
+++ b/Pal/src/pal-symbols
@@ -39,7 +39,8 @@ DkCpuIdRetrieve
 DkObjectClose
 DkSetExceptionHandler
 DkExceptionReturn
-DkSegmentRegister
+DkSegmentRegisterGet
+DkSegmentRegisterSet
 DkStreamChangeName
 DkStreamAttributesSetByHandle
 DkMemoryAvailableQuota

--- a/Pal/src/pal_internal.h
+++ b/Pal/src/pal_internal.h
@@ -277,8 +277,8 @@ int _DkSystemTimeQuery(uint64_t* out_usec);
  * 0 on success, negative on failure.
  */
 size_t _DkRandomBitsRead(void* buffer, size_t size);
-int _DkSegmentRegisterSet(int reg, const void* addr);
 int _DkSegmentRegisterGet(int reg, void** addr);
+int _DkSegmentRegisterSet(int reg, void* addr);
 int _DkInstructionCacheFlush(const void* addr, int size);
 int _DkCpuIdRetrieve(unsigned int leaf, unsigned int subleaf, unsigned int values[4]);
 int _DkAttestationReport(PAL_PTR user_report_data, PAL_NUM* user_report_data_size,


### PR DESCRIPTION


<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://graphene.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->
On x64 DkSegmentRegister had weird semantics which also disabled some
usages like `0` as fsbase. This is now fixed.
<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2032)
<!-- Reviewable:end -->
