### PR TITLE
[Pal/Linux-SGX] Add enclave loading time if sgx.enable_stats = 1

### DIFF
--- a/Documentation/manifest-syntax.rst
+++ b/Documentation/manifest-syntax.rst
@@ -455,6 +455,10 @@ This syntax specifies whether to enable SGX enclave-specific statistics:
    AEXs (corresponds to interrupts/exceptions/signals during enclave
    execution). Prints per-thread and per-process stats.
 
+#. Printing the SGX enclave loading time at startup. The enclave loading time
+   includes creating the enclave, adding enclave pages, measuring them and
+   initializing the enclave.
+
 *Note:* this option is insecure and cannot be used with production enclaves
 (``sgx.debug = 0``). If the production enclave is started with this option set,
 Graphene will fail initialization of the enclave.

--- a/Pal/src/host/Linux-SGX/pal_linux_defs.h
+++ b/Pal/src/host/Linux-SGX/pal_linux_defs.h
@@ -22,10 +22,6 @@
 
 #define TRUSTED_STUB_SIZE (PRESET_PAGESIZE * 4UL)
 
-//#define USE_AES_NI          1
-
-#define PRINT_ENCLAVE_STAT 0
-
 #define MAX_ARGS_SIZE 10000000
 #define MAX_ENV_SIZE  10000000
 

--- a/Pal/src/host/Linux-SGX/pal_security.h
+++ b/Pal/src/host/Linux-SGX/pal_security.h
@@ -41,10 +41,6 @@ struct pal_sec {
 #ifdef DEBUG
     PAL_BOL in_gdb;
 #endif
-
-#if PRINT_ENCLAVE_STAT == 1
-    PAL_NUM start_time;
-#endif
 };
 
 #ifdef IN_ENCLAVE

--- a/Pal/src/host/Linux-SGX/sgx_main.c
+++ b/Pal/src/host/Linux-SGX/sgx_main.c
@@ -919,15 +919,15 @@ static int get_hw_resource(const char* filename, bool count) {
  * exits after this function's failure. */
 static int load_enclave(struct pal_enclave* enclave, char* loader_config, const char* exec_path,
                         char* args, size_t args_size, char* env, size_t env_size, bool need_gsgx) {
-    struct pal_sec* pal_sec = &enclave->pal_sec;
     int ret;
+    struct timeval tv;
+
+    struct pal_sec* pal_sec = &enclave->pal_sec;
     size_t exec_path_len = strlen(exec_path);
 
-#if PRINT_ENCLAVE_STAT == 1
-    struct timeval tv;
+    uint64_t start_time;
     INLINE_SYSCALL(gettimeofday, 2, &tv, NULL);
-    pal_sec->start_time = tv.tv_sec * 1000000UL + tv.tv_usec;
-#endif
+    start_time = tv.tv_sec * 1000000UL + tv.tv_usec;
 
     ret = open_sgx_driver(need_gsgx);
     if (ret < 0)
@@ -1090,6 +1090,17 @@ static int load_enclave(struct pal_enclave* enclave, char* loader_config, const 
     ret = pal_thread_init(tcb);
     if (ret < 0)
         return ret;
+
+    uint64_t end_time;
+    INLINE_SYSCALL(gettimeofday, 2, &tv, NULL);
+    end_time = tv.tv_sec * 1000000UL + tv.tv_usec;
+
+    if (g_sgx_enable_stats) {
+        /* this shows the time for Graphene + the Intel SGX driver to initialize the untrusted
+         * PAL and config and create the SGX enclave, add enclave pages, measure and init it */
+        pal_printf("----- SGX enclave loading time = %10lu microseconds -----\n",
+                   end_time - start_time);
+    }
 
     /* start running trusted PAL */
     ecall_enclave_start(enclave->libpal_uri, args, args_size, env, env_size);

--- a/Pal/src/host/Linux/db_main.c
+++ b/Pal/src/host/Linux/db_main.c
@@ -154,7 +154,6 @@ noreturn void pal_linux_main(void* initial_rsp, void* fini_callback) {
     __UNUSED(fini_callback);  // TODO: We should call `fini_callback` at the end.
     int ret;
     uint64_t start_time = _DkSystemTimeQueryEarly();
-    g_pal_state.start_time = start_time;
 
     /* Initialize alloc_align as early as possible, a lot of PAL APIs depend on this being set. */
     g_pal_state.alloc_align = _DkGetAllocationAlignment();

--- a/Pal/src/pal_internal.h
+++ b/Pal/src/pal_internal.h
@@ -154,13 +154,8 @@ extern struct pal_internal_state {
 
     PAL_HANDLE      exec_handle;
 
-    /* May not be the same as page size, see e.g. SYSTEM_INFO::dwAllocationGranularity on Windows.
-     */
+    /* May not be the same as page size, e.g. SYSTEM_INFO::dwAllocationGranularity on Windows */
     size_t          alloc_align;
-
-    PAL_HANDLE      console;
-
-    uint64_t        start_time;
 } g_pal_state;
 
 extern PAL_CONTROL g_pal_control;


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Adds enclave loading time if `sgx.enable_stats = 1`. This PR also removes the macro PRINT_ENCLAVE_STAT (now user must use `sgx.enable_stats = 1`) and moves all logic to untrusted PAL.

Fixes #2034.

## How to test this PR? <!-- (if applicable) -->

All tests must pass. We have PAL regression test `Thread2` is enabled stats, run it manually to see the statistics. Something like this:
```
~/graphene/Pal/regression$ SGX=1 ~/graphene/Runtime/pal_loader ./Thread2
Manifest file: ./Thread2.manifest.sgx
...
enclave initializing:
    enclave id:   0x000000000ffff000
    mr_enclave:   a635aa1e681bf5910716a1f01b1231a6ff9955ea6628dd304dc622667be8a1c9
----- SGX enclave loading time =     991851 microseconds -----
...
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2035)
<!-- Reviewable:end -->
