### PR TITLE
[LibOS] Save/restore FP/SSE/AVX/... control words on syscalls

### DIFF
--- a/LibOS/shim/include/shim_tcb.h
+++ b/LibOS/shim/include/shim_tcb.h
@@ -11,6 +11,8 @@
 
 struct shim_context {
     struct shim_regs* regs;
+    uint16_t          fpcw;    /* FPU Control Word (for x87) */
+    uint32_t          mxcsr;   /* MXCSR control/status register (for SSE/AVX/...) */
     uint64_t          fs_base;
     struct atomic_int preempt;
 };

--- a/LibOS/shim/src/generated-offsets.c
+++ b/LibOS/shim/src/generated-offsets.c
@@ -7,6 +7,8 @@
 __attribute__((__used__)) static void dummy(void) {
     OFFSET_T(SHIM_TCB_OFFSET, PAL_TCB, libos_tcb);
     OFFSET_T(TCB_REGS, shim_tcb_t, context.regs);
+    OFFSET_T(TCB_FPCW, shim_tcb_t, context.fpcw);
+    OFFSET_T(TCB_MXCSR, shim_tcb_t, context.mxcsr);
     OFFSET(SHIM_REGS_RSP, shim_regs, rsp);
     OFFSET(SHIM_REGS_R15, shim_regs, r15);
     OFFSET(SHIM_REGS_RIP, shim_regs, rip);

--- a/LibOS/shim/src/syscallas-x86_64.S
+++ b/LibOS/shim/src/syscallas-x86_64.S
@@ -2,9 +2,20 @@
 /* Copyright (C) 2014 Stony Brook University */
 
 /*
- * syscallas.S
+ * This file contains the entry point of system call table in library OS (the function syscalldb()
+ * and its wrapper syscall_wrapper() for cases of redirection of raw SYSCALL instructions).
  *
- * This file contains the entry point of system call table in library OS.
+ * The below entry point implementation first saves the CPU context of the current application
+ * thread on the thread's stack, then calls the corresponding LibOS syscall-emulation function, and
+ * then restores the context and passes control back to the application. The context consists of
+ * GPRs, FP control word (fpcw) and the SSE/AVX/... control word (mxcsr).
+ *
+ * Note that LibOS may clobber all FP/SSE/AVX/... (extended) state except the control words. We rely
+ * on the fact that applications do *not* assume that this extended state is preserved across system
+ * calls. Indeed, the extended state (bar control words) is explicitly described as *not* preserved
+ * by the System V ABI, and though syscall ABI is not the same as System V ABI, we assume that no
+ * sane application issues syscalls in a non-System-V compliant manner. See System V ABI docs
+ * (https://uclibc.org/docs/psABI-x86_64.pdf), "Register Usage" for more information.
  */
 
 #include "asm-offsets.h"
@@ -62,7 +73,10 @@ syscalldb:
         cmp $0, %rbx
         je isundef
 
+        # set pointer to shim_regs and save FP Control Word & MXCSR into current thread's TCB
         movq %rbp, %gs:(SHIM_TCB_OFFSET + TCB_REGS)
+        fnstcw %gs:(SHIM_TCB_OFFSET + TCB_FPCW)
+        stmxcsr %gs:(SHIM_TCB_OFFSET + TCB_MXCSR)
 
         /* Translating x86_64 kernel calling convention to user-space
          * calling convention */
@@ -70,7 +84,10 @@ syscalldb:
         andq $~0xF, %rsp  # Required by System V AMD64 ABI.
         call *%rbx
 
+        # invalidate pointer to shim_regs and restore FP Control Word & MXCSR from TCB
         movq $0, %gs:(SHIM_TCB_OFFSET + TCB_REGS)
+        fldcw %gs:(SHIM_TCB_OFFSET + TCB_FPCW)
+        ldmxcsr %gs:(SHIM_TCB_OFFSET + TCB_MXCSR)
 
 ret:
         movq %rbp, %rsp


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Previously, Graphene saved and restored only the GP registers of the CPU context on entering and leaving syscall emulation in `syscalldb()`. In reality, the CPU context must also contain FP control word (fpcw) and the SSE/AVX/... control word (mxcsr). This commit preserves these control words across app-to-Graphene context switches.

During syscall emulation, Graphene may clobber the FP/SSE/AVX/... state (except the control words). We rely on the fact that apps do *not* assume that this state is preserved across syscalls (except the control words). Thus, it is enough to save/restore only the control words on each syscall. This commit also removes previous hack of performing expensive xsave/xrstor instructions on `clone()`.

Note the performance regression: we add 4 instructions on each syscall (`fnstcw`, `stmxcsr`, `fldcw`, `ldmxcsr`). According to Agner Fog's instruction tables, each of these instructions has latency of about 5 cycles. So there is a total penalty of ~20 cycles, which sounds very reasonable.

**Why not save the whole extended state (xstate)?**

Answer: This is very expensive. We would perform `fxsave/xsave` and then `fxrstor/xrstor` on each syscall. The latency of each of these instructions is 100-300 cycles, so that would add up to 500-1200 cycles. Moreover, sane applications must not assume that FP/SSE/AVX registers are preserved across system calls -- even though the syscall ABI never explicitly mandates this, it is written in the System V ABI, and there are some discussions in the LKML: http://lkml.iu.edu/hypermail/linux/kernel/1107.3/00124.html.

Therefore, it seems reasonable to allow Graphene internal code (LibOS and PALs) to use FP/vector instructions as they please and only preserve the control words for applications on top.

For more info, see https://github.com/oscarlab/graphene/pull/301.

For some info on how Linux kernel works with FP, see https://www.halolinux.us/kernel-reference/process-switch.html.

For System-V ABI, see https://uclibc.org/docs/psABI-x86_64.pdf (especially Figure 3.4. Register Usage).

Closes #301.

## How to test this PR? <!-- (if applicable) -->

All tests must pass. We have `fp_multithread` that tests exactly this already, so this test must pass.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2036)
<!-- Reviewable:end -->
