### PR TITLE
[LibOS,Pal] Use GCC's stack protector in LibOS and PAL functions

### DIFF
--- a/LibOS/shim/src/Makefile
+++ b/LibOS/shim/src/Makefile
@@ -6,7 +6,7 @@ CFLAGS += -fPIC -Winline -Wwrite-strings \
 	  -fmerge-all-constants -Wstrict-prototypes $(call cc-option,-Wtrampolines) \
 	  -Werror=implicit-function-declaration \
 	  $(cc-option, -Wnull-dereference) \
-	  -fno-stack-protector -fno-builtin -Wno-inline \
+	  -fno-builtin -Wno-inline \
 	  -I../include \
 	  -I../include/arch/$(ARCH) \
 	  -I../../../Pal/include \
@@ -17,6 +17,16 @@ CFLAGS += -fPIC -Winline -Wwrite-strings \
 	  -I../../../Pal/include/pal
 
 CFLAGS += -Wextra
+
+# use TLS-based stack protector of GCC (we rely on the fact that LibOS reuses the same TCB as its
+# underlying PAL which must have a canary in its PAL_TCB at offset 0x8, so no additional enabling
+# is required in the LibOS code);
+# not all compilers support mstack-protector-guard, so use stack protector only if supported
+CFLAGS += -fno-stack-protector
+ifeq ($(ARCH),x86_64)
+CFLAGS += $(call cc-option, -fstack-protector-strong -mstack-protector-guard=tls \
+	                        -mstack-protector-guard-reg=%gs -mstack-protector-guard-offset=8)
+endif
 
 # Some of the code uses alignof on expressions, which is a GNU extension.
 # Silence Clang - it complains but does support it.

--- a/LibOS/shim/src/shim_init.c
+++ b/LibOS/shim/src/shim_init.c
@@ -58,6 +58,13 @@ noreturn void __abort(void) {
     DkProcessExit(1);
 }
 
+/* we use GCC's stack protector; when it detects corrupted stack, it calls __stack_chk_fail() */
+noreturn void __stack_chk_fail(void); /* to suppress GCC's warning "no previous prototype" */
+noreturn void __stack_chk_fail(void) {
+    debug("Stack protector: Graphene LibOS internal stack corruption detected\n");
+    __abort();
+}
+
 static int pal_errno_to_unix_errno[PAL_ERROR_NATIVE_COUNT + 1] = {
     [PAL_ERROR_SUCCESS]         = 0,
     [PAL_ERROR_NOTIMPLEMENTED]  = ENOSYS,

--- a/Pal/include/arch/x86_64/Linux/pal_host-arch.h
+++ b/Pal/include/arch/x86_64/Linux/pal_host-arch.h
@@ -17,7 +17,9 @@
 
 #include "sysdep-arch.h"
 
-static inline int pal_set_tcb(PAL_TCB* tcb) {
+/* Graphene uses GCC's stack protector that looks for canary at gs:[0x8], but this function changes
+ * the GS register value, so we disable stack protector here (even though it is mostly inlined) */
+__attribute__((__optimize__("-fno-stack-protector"))) static inline int pal_set_tcb(PAL_TCB* tcb) {
     return INLINE_SYSCALL(arch_prctl, 2, ARCH_SET_GS, tcb);
 }
 

--- a/Pal/include/arch/x86_64/pal-arch.h
+++ b/Pal/include/arch/x86_64/pal-arch.h
@@ -13,6 +13,7 @@
 #ifndef PAL_ARCH_H
 #define PAL_ARCH_H
 
+#include <assert.h>
 #include <stdint.h>
 
 #include "cpu.h"
@@ -25,12 +26,20 @@ typedef struct pal_tcb PAL_TCB;
 
 #define PAL_LIBOS_TCB_SIZE 256
 
+#define STACK_PROTECTOR_CANARY_DEFAULT  0xbadbadbadbadUL
+
 typedef struct pal_tcb {
     struct pal_tcb* self;
+    /* random per-thread canary used by GCC's stack protector; must be at %gs:[0x8]
+     * because we specify `-mstack-protector-guard-reg=%gs -mstack-protector-guard-offset=8` */
+    uint64_t stack_protector_canary;
     /* uint64_t for alignment */
     uint64_t libos_tcb[(PAL_LIBOS_TCB_SIZE + sizeof(uint64_t) - 1) / sizeof(uint64_t)];
     /* data private to PAL implementation follows this struct. */
 } PAL_TCB;
+
+static_assert(offsetof(PAL_TCB, stack_protector_canary) == 0x8,
+              "unexpected offset of stack_protector_canary in PAL_TCB struct");
 
 #include "pal_host-arch.h"
 

--- a/Pal/include/host/Linux-common/linux_utils.h
+++ b/Pal/include/host/Linux-common/linux_utils.h
@@ -8,5 +8,8 @@ char* get_main_exec_path(void);
 
 int read_text_file_to_cstr(const char* path, char** out);
 
+/* called only from GCC-emitted code; declare here to suppress GCC warn "no previous prototype" */
+noreturn void __stack_chk_fail(void);
+
 #endif // _LINUX_UTILS_H
 

--- a/Pal/lib/Makefile
+++ b/Pal/lib/Makefile
@@ -2,6 +2,11 @@ include ../../Scripts/Makefile.configs
 include ../../Scripts/Makefile.rules
 include ../src/host/$(PAL_HOST)/Makefile.am
 
+# FIXME: currently disable GCC's stack protector in the common libs because they are linked with
+#        different libraries/executables including those that do not provide __stack_chk_fail(),
+#        e.g. PAL regression tests (in particular, avl_tree_test.c)
+CFLAGS += -fno-stack-protector
+
 CFLAGS += \
 	-I../include \
 	-I../include/arch/$(ARCH) \

--- a/Pal/regression/Makefile
+++ b/Pal/regression/Makefile
@@ -1,7 +1,7 @@
 include ../../Scripts/Makefile.configs
 include ../../Scripts/Makefile.rules
 
-CFLAGS	+= -Wp,-U_FORTIFY_SOURCE -fno-builtin -nostdlib \
+CFLAGS	+= -Wp,-U_FORTIFY_SOURCE -fno-stack-protector -fno-builtin -nostdlib \
 	  -I../src \
 	  -I../include \
 	  -I../include/pal \

--- a/Pal/src/Makefile
+++ b/Pal/src/Makefile
@@ -28,6 +28,14 @@ CFLAGS += \
 	-I../include/arch/$(ARCH)/$(PAL_HOST) \
 	-I../include/lib
 
+# use TLS-based stack protector of GCC (all PALs must have a canary in its PAL_TCB at offset 0x8);
+# not all compilers support mstack-protector-guard, so use stack protector only if supported
+CFLAGS += -fno-stack-protector
+ifeq ($(ARCH),x86_64)
+CFLAGS += $(call cc-option, -fstack-protector-strong -mstack-protector-guard=tls \
+	                        -mstack-protector-guard-reg=%gs -mstack-protector-guard-offset=8)
+endif
+
 PAL_HOST_MACRO = $(shell echo $(PAL_HOST) | tr '[:lower:]' '[:upper:]' | tr '-' '_')
 
 # Build Targets:

--- a/Pal/src/host/Linux-SGX/Makefile
+++ b/Pal/src/host/Linux-SGX/Makefile
@@ -31,7 +31,7 @@ defs	= -DIN_PAL
 CFLAGS += $(defs)
 ASFLAGS += $(defs)
 
-commons_objs_encl = bogomips.o
+commons_objs_encl = bogomips.o stack_protector.o
 commons_objs_urts = file_utils.o main_exec_path.o
 
 enclave-objs = \
@@ -85,6 +85,16 @@ urts-objs = \
 urts-asm-objs = sgx_entry.o
 
 graphene_lib = .lib/graphene-lib.a
+
+# use TLS-based stack protector of GCC (trusted PAL must have a canary in its PAL_TCB at offset
+# 0x8, untrusted PAL uses the default GCC scheme)
+# not all compilers support mstack-protector-guard, so use stack protector only if supported
+CFLAGS += -fno-stack-protector
+ifeq ($(ARCH),x86_64)
+$(enclave-objs): CFLAGS += $(call cc-option, -fstack-protector-strong -mstack-protector-guard=tls \
+                             -mstack-protector-guard-reg=%gs -mstack-protector-guard-offset=8)
+$(urts-objs): CFLAGS += $(call cc-option, -fstack-protector-strong)
+endif
 
 .PHONY: all
 all: gsgx.h $(host_files) tools

--- a/Pal/src/host/Linux-SGX/Makefile.am
+++ b/Pal/src/host/Linux-SGX/Makefile.am
@@ -1,7 +1,6 @@
 # Add host-specific compilation rules here
 
-CFLAGS += -fPIC -maes -Wp,-U_FORTIFY_SOURCE \
-	  -fno-stack-protector -fno-builtin $(call cc-option,-Wtrampolines)
+CFLAGS += -fPIC -maes -Wp,-U_FORTIFY_SOURCE -fno-builtin $(call cc-option,-Wtrampolines)
 
 CFLAGS += -Wextra $(call cc-option,-Wnull-dereference)
 

--- a/Pal/src/host/Linux-SGX/db_main.c
+++ b/Pal/src/host/Linux-SGX/db_main.c
@@ -172,6 +172,9 @@ fail:
 extern void* g_enclave_base;
 extern void* g_enclave_top;
 
+/* Graphene uses GCC's stack protector that looks for a canary at gs:[0x8], but this function starts
+ * with a default canary and then updates it to a random one, so we disable stack protector here */
+__attribute__((__optimize__("-fno-stack-protector")))
 noreturn void pal_linux_main(char* uptr_libpal_uri, size_t libpal_uri_len, char* uptr_args,
                              size_t args_size, char* uptr_env, size_t env_size,
                              struct pal_sec* uptr_sec_info) {
@@ -423,6 +426,14 @@ noreturn void pal_linux_main(char* uptr_libpal_uri, size_t libpal_uri_len, char*
     first_thread->thread.tid = 1;
     g_pal_control.first_thread = first_thread;
     SET_ENCLAVE_TLS(thread, &first_thread->thread);
+
+    uint64_t stack_protector_canary;
+    ret = _DkRandomBitsRead(&stack_protector_canary, sizeof(stack_protector_canary));
+    if (ret < 0) {
+        SGX_DBG(DBG_E, "_DkRandomBitsRead failed: %d\n", ret);
+        ocall_exit(1, /*is_exitgroup=*/true);
+    }
+    pal_set_tcb_stack_canary(stack_protector_canary);
 
     /* call main function */
     pal_main(g_pal_sec.instance_id, exec, g_pal_sec.exec_addr, parent, first_thread, arguments,

--- a/Pal/src/host/Linux-SGX/db_threading.c
+++ b/Pal/src/host/Linux-SGX/db_threading.c
@@ -50,7 +50,11 @@ static PAL_IDX pal_assign_tid(void) {
     return __atomic_add_fetch(&tid.counter, 1, __ATOMIC_SEQ_CST);
 }
 
-void pal_start_thread(void) {
+/* Initialization wrapper of a newly-created thread. This function finds a newly-created thread in
+ * g_thread_list, initializes its TCB/TLS, and jumps into the callback-to-run. Graphene uses GCC's
+ * stack protector that looks for a canary at gs:[0x8], but this function starts with a default
+ * canary and then updates it to a random one, so we disable stack protector here. */
+__attribute__((__optimize__("-fno-stack-protector"))) void pal_start_thread(void) {
     struct pal_handle_thread *new_thread = NULL, *tmp;
 
     _DkInternalLock(&g_thread_list_lock);
@@ -72,8 +76,14 @@ void pal_start_thread(void) {
     const void* param = thread_param->param;
     free(thread_param);
     new_thread->param = NULL;
+
     SET_ENCLAVE_TLS(thread, new_thread);
     SET_ENCLAVE_TLS(ready_for_exceptions, 1UL);
+
+    /* each newly-created thread (including the first thread) has its own random stack canary */
+    uint64_t stack_protector_canary;
+    _DkRandomBitsRead(&stack_protector_canary, sizeof(stack_protector_canary));
+    pal_set_tcb_stack_canary(stack_protector_canary);
     PAL_TCB* pal_tcb = pal_get_tcb();
     memset(&pal_tcb->libos_tcb, 0, sizeof(pal_tcb->libos_tcb));
     callback((void*)param);

--- a/Pal/src/host/Linux-SGX/generated-offsets.c
+++ b/Pal/src/host/Linux-SGX/generated-offsets.c
@@ -24,6 +24,9 @@ __attribute__((__used__)) static void dummy(void) {
     DEFINE(SGX_MISCSELECT_EXINFO, SGX_MISCSELECT_EXINFO);
     DEFINE(SE_KEY_SIZE, SE_KEY_SIZE);
 
+    /* defines in pal-arch.h */
+    DEFINE(STACK_PROTECTOR_CANARY_DEFAULT, STACK_PROTECTOR_CANARY_DEFAULT);
+
     /* sgx_measurement_t */
     DEFINE(SGX_HASH_SIZE, sizeof(sgx_measurement_t));
 
@@ -73,6 +76,7 @@ __attribute__((__used__)) static void dummy(void) {
 
     /* struct enclave_tls */
     OFFSET(SGX_COMMON_SELF, enclave_tls, common.self);
+    OFFSET(SGX_COMMON_STACK_PROTECTOR_CANARY, enclave_tls, common.stack_protector_canary);
     OFFSET(SGX_ENCLAVE_SIZE, enclave_tls, enclave_size);
     OFFSET(SGX_TCS_OFFSET, enclave_tls, tcs_offset);
     OFFSET(SGX_INITIAL_STACK_OFFSET, enclave_tls, initial_stack_offset);

--- a/Pal/src/host/Linux-SGX/sgx_main.c
+++ b/Pal/src/host/Linux-SGX/sgx_main.c
@@ -489,6 +489,7 @@ static int initialize_enclave(struct pal_enclave* enclave, const char* manifest_
                 memset(gs, 0, g_page_size);
                 assert(sizeof(*gs) <= g_page_size);
                 gs->common.self = (PAL_TCB*)(tls_area->addr + g_page_size * t + enclave_secs.base);
+                gs->common.stack_protector_canary = STACK_PROTECTOR_CANARY_DEFAULT;
                 gs->enclave_size = enclave->size;
                 gs->tcs_offset = tcs_area->addr + g_page_size * t;
                 gs->initial_stack_offset = stack_areas[t].addr + ENCLAVE_STACK_SIZE;

--- a/Pal/src/host/Linux-common/stack_protector.c
+++ b/Pal/src/host/Linux-common/stack_protector.c
@@ -1,0 +1,12 @@
+/* SPDX-License-Identifier: LGPL-3.0-or-later */
+/* Copyright (C) 2020 Intel Corporation */
+
+#include "api.h"
+#include "linux_utils.h"
+#include "pal_internal.h"
+
+/* we use GCC's stack protector; when it detects corrupted stack, it calls __stack_chk_fail() */
+noreturn void __stack_chk_fail(void) {
+    printf("Stack protector: Graphene PAL internal stack corruption detected\n");
+    _DkProcessExit(1);
+}

--- a/Pal/src/host/Linux/Makefile
+++ b/Pal/src/host/Linux/Makefile
@@ -1,7 +1,7 @@
 include ../../../../Scripts/Makefile.configs
 include Makefile.am
 
-CFLAGS	+= \
+CFLAGS += \
 	-I. \
 	-Iinclude \
 	-I../.. \
@@ -12,6 +12,14 @@ CFLAGS	+= \
 	-I../../../include/host/Linux \
 	-I../../../include/host/Linux-common \
 	-I../../../include/lib
+
+# use TLS-based stack protector of GCC (Linux PAL must have a canary in its PAL_TCB at offset 0x8);
+# not all compilers support mstack-protector-guard, so use stack protector only if supported
+CFLAGS += -fno-stack-protector
+ifeq ($(ARCH),x86_64)
+CFLAGS += $(call cc-option, -fstack-protector-strong -mstack-protector-guard=tls \
+	                        -mstack-protector-guard-reg=%gs -mstack-protector-guard-offset=8)
+endif
 
 ASFLAGS += \
 	-I. \
@@ -29,7 +37,8 @@ ASFLAGS += $(defs)
 commons_objs = \
 	bogomips.o \
 	file_utils.o \
-	main_exec_path.o
+	main_exec_path.o \
+	stack_protector.o
 
 objs = \
 	clone-$(ARCH).o \

--- a/Pal/src/host/Linux/Makefile.am
+++ b/Pal/src/host/Linux/Makefile.am
@@ -1,8 +1,7 @@
 # Add host-specific compilation rules here
 SEC_DIR = security/$(PAL_HOST)
 
-CFLAGS += -fPIC -Wp,-U_FORTIFY_SOURCE \
-	  -fno-stack-protector -fno-builtin $(call cc-option,-Wtrampolines)
+CFLAGS += -fPIC -Wp,-U_FORTIFY_SOURCE -fno-builtin $(call cc-option,-Wtrampolines)
 
 CFLAGS += -Wextra $(call cc-option,-Wnull-dereference)
 

--- a/Pal/src/host/Linux/db_main.c
+++ b/Pal/src/host/Linux/db_main.c
@@ -142,15 +142,26 @@ noreturn static void print_usage_and_exit(const char* argv_0) {
     _DkProcessExit(1);
 }
 
+/* Graphene uses GCC's stack protector that looks for a canary at gs:[0x8], but this function starts
+ * with no TCB in the GS register, so we disable stack protector here */
+__attribute__((__optimize__("-fno-stack-protector")))
 noreturn void pal_linux_main(void* initial_rsp, void* fini_callback) {
     __UNUSED(fini_callback);  // TODO: We should call `fini_callback` at the end.
     int ret;
+
+    /* we don't yet have a TCB in the GS register, but GCC's stack protector will look for a canary
+     * at gs:[0x8] in functions called below, so let's install a dummy TCB with a default canary */
+    PAL_TCB_LINUX dummy_tcb_for_stack_protector = { 0 };
+    dummy_tcb_for_stack_protector.common.self = &dummy_tcb_for_stack_protector.common;
+    pal_set_tcb_stack_canary(&dummy_tcb_for_stack_protector, STACK_PROTECTOR_CANARY_DEFAULT);
+    ret = pal_set_tcb(&dummy_tcb_for_stack_protector.common);
+    if (ret < 0)
+        INIT_FAIL(unix_to_pal_error(-ret), "pal_set_tcb() failed");
 
     uint64_t start_time;
     ret = _DkSystemTimeQuery(&start_time);
     if (ret < 0)
         INIT_FAIL(unix_to_pal_error(-ret), "_DkSystemTimeQuery() failed");
-
 
     /* Initialize alloc_align as early as possible, a lot of PAL APIs depend on this being set. */
     g_pal_state.alloc_align = _DkGetAllocationAlignment();

--- a/Pal/src/host/Linux/pal_linux.h
+++ b/Pal/src/host/Linux/pal_linux.h
@@ -160,4 +160,14 @@ static inline PAL_TCB_LINUX* get_tcb_linux(void) {
     return (PAL_TCB_LINUX*)pal_get_tcb();
 }
 
+__attribute__((__optimize__("-fno-stack-protector")))
+static inline void pal_set_tcb_stack_canary(PAL_TCB_LINUX* tcbptr, uint64_t canary) {
+    ((char*)&canary)[0] = 0; /* prevent C-string-based stack leaks from exposing the cookie */
+#ifdef __x86_64__
+    tcbptr->common.stack_protector_canary = canary;
+#else
+#error "unsupported architecture"
+#endif
+}
+
 #endif /* PAL_LINUX_H */

--- a/python/graphenelibos/sgx_sign.py
+++ b/python/graphenelibos/sgx_sign.py
@@ -464,6 +464,8 @@ def gen_area_content(attr, areas, enclave_base_addr, enclave_heap_min):
 
         set_tls_field(t, offs.SGX_COMMON_SELF,
                       tls_area.addr + offs.PAGESIZE * t + enclave_base_addr)
+        set_tls_field(t, offs.SGX_COMMON_STACK_PROTECTOR_CANARY,
+                      offs.STACK_PROTECTOR_CANARY_DEFAULT)
         set_tls_field(t, offs.SGX_ENCLAVE_SIZE, attr['enclave_size'])
         set_tls_field(t, offs.SGX_TCS_OFFSET, tcs_area.addr + offs.TCS_SIZE * t)
         set_tls_field(t, offs.SGX_INITIAL_STACK_OFFSET,


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

GCC (and other compilers, e.g. Clang) provide a **stack protector** feature to detect stack corruptions. This is achieved by storing a 64-bit canary value on the stack frame on function entry and verifying this value on function exit.

Previously, Graphene disabled stack protector completely. This PR enables it in LibOS and PAL code (only if `-mstack-protector` feature is supported by compiler).

The stack protector uses a random per-thread canary stored in the TLS/TCB of each thread. Each PAL implementation must follow the rule that TLS/TCB is accessed via the GS register and that the offset of canary in TLS/TCB is 0x8. Since LibOS re-uses TLS/TCB of the PAL, there is no need for additional enabling at the LibOS layer.

Since `-mstack-protector` feature is architecture-specific, it is currently enabled only for x86-64.

Co-authored-by: Isaku Yamahata <isaku.yamahata@gmail.com>

Recreation (and simplification) of #774. Closes #774.

**NOTE:** The `-mstack-protector` options were introduced in GCC8 (the default GCC of Ubuntu 18.04 is GCC7, so update to GCC8 to build with stack protector).

Useful links:
- https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html (see `no_stack_protector`)
- https://gcc.gnu.org/onlinedocs/gcc/Instrumentation-Options.html (see `-fstack-protector`)
- https://gcc.gnu.org/onlinedocs/gcc/x86-Options.html#x86-Options (see `-mstack-protector-guard`)
- https://gcc.gnu.org/bugzilla/show_bug.cgi?id=29838
- https://gcc.gnu.org/bugzilla/show_bug.cgi?id=94722
- https://embeddedartistry.com/blog/2020/05/18/implementing-stack-smashing-protection-for-microcontrollers-and-embedded-artistrys-libc/


## How to test this PR? <!-- (if applicable) -->

All tests must pass. You can manually verify that LibOS and PAL binaries now have stack checks:
```
cd graphene/Runtime
objdump -D libsysdb.so | grep __stack_chk_fail
objdump -D pal-Linux | grep __stack_chk_fail
objdump -D libpal-Linux-SGX.so | grep __stack_chk_fail

# as a bonus, verify that the untrusted part of Linux-SGX PAL doesn't have stack protector
objdump -D pal-Linux-SGX | grep __stack_chk_fail
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2038)
<!-- Reviewable:end -->
