### PR TITLE
LibOS: Move x86-specific context registers into own struct

### DIFF
--- a/LibOS/shim/include/arch/x86_64/shim_tcb-arch.h
+++ b/LibOS/shim/include/arch/x86_64/shim_tcb-arch.h
@@ -195,4 +195,10 @@ static inline unsigned long tls_to_fs_base(unsigned long tls) {
     return tls;
 }
 
+/* extended context */
+struct shim_ext_context {
+    uint16_t  fpcw;    /* FPU Control Word (for x87) */
+    uint32_t  mxcsr;   /* MXCSR control/status register (for SSE/AVX/...) */
+};
+
 #endif /* _SHIM_TCB_ARCH_H_ */

--- a/LibOS/shim/include/shim_tcb.h
+++ b/LibOS/shim/include/shim_tcb.h
@@ -11,8 +11,7 @@
 
 struct shim_context {
     struct shim_regs* regs;
-    uint16_t          fpcw;    /* FPU Control Word (for x87) */
-    uint32_t          mxcsr;   /* MXCSR control/status register (for SSE/AVX/...) */
+    struct shim_ext_context ext_ctx;
     uint64_t          fs_base;
     struct atomic_int preempt;
 };

--- a/LibOS/shim/src/generated-offsets.c
+++ b/LibOS/shim/src/generated-offsets.c
@@ -7,8 +7,8 @@
 __attribute__((__used__)) static void dummy(void) {
     OFFSET_T(SHIM_TCB_OFFSET, PAL_TCB, libos_tcb);
     OFFSET_T(TCB_REGS, shim_tcb_t, context.regs);
-    OFFSET_T(TCB_FPCW, shim_tcb_t, context.fpcw);
-    OFFSET_T(TCB_MXCSR, shim_tcb_t, context.mxcsr);
+    OFFSET_T(TCB_FPCW, shim_tcb_t, context.ext_ctx.fpcw);
+    OFFSET_T(TCB_MXCSR, shim_tcb_t, context.ext_ctx.mxcsr);
     OFFSET(SHIM_REGS_RSP, shim_regs, rsp);
     OFFSET(SHIM_REGS_R15, shim_regs, r15);
     OFFSET(SHIM_REGS_RIP, shim_regs, rip);

--- a/LibOS/shim/src/shim_context-x86_64.c
+++ b/LibOS/shim/src/shim_context-x86_64.c
@@ -171,7 +171,7 @@ noreturn void restore_child_context_after_clone(struct shim_context* context) {
                      "movq "XSTRINGIFY(SHIM_REGS_RSP)" - "XSTRINGIFY(SHIM_REGS_RIP)"(%%rsp), %%rsp\r\n"
                      "movq $0, %%rax\r\n"
                      "jmp *-"XSTRINGIFY(RED_ZONE_SIZE)"-8(%%rsp)\r\n"
-                     :: "g"(&context->fpcw), "g"(&context->mxcsr), "g"(&regs) : "memory");
+                     :: "g"(&context->ext_ctx.fpcw), "g"(&context->ext_ctx.mxcsr), "g"(&regs) : "memory");
 
     __builtin_unreachable();
 }


### PR DESCRIPTION
Move the x86-specific registers fpcw and mxcsr into their
own structure.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>

<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://graphene.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2041)
<!-- Reviewable:end -->
