### PR TITLE
[LibOS] Rename fs_base to tls_base to be more generic

### DIFF
--- a/LibOS/shim/include/arch/x86_64/shim_tcb-arch.h
+++ b/LibOS/shim/include/arch/x86_64/shim_tcb-arch.h
@@ -186,12 +186,12 @@ static inline void shim_regs_set_syscallnr(struct shim_regs* sr, uint64_t sc_num
         }                                                               \
     } while (0)
 
-static inline void shim_arch_update_fs_base(unsigned long fs_base) {
-    DkSegmentRegisterSet(PAL_SEGMENT_FS, (PAL_PTR)fs_base);
+static inline void shim_arch_update_tls_base(unsigned long tls_base) {
+    DkSegmentRegisterSet(PAL_SEGMENT_FS, (PAL_PTR)tls_base);
 }
 
-/* On x86_64 the fs_base is the same as the tls parameter to 'clone' */
-static inline unsigned long tls_to_fs_base(unsigned long tls) {
+/* On x86_64 the tls_base (fs register) is the same as the tls parameter to 'clone' */
+static inline unsigned long tls_to_tls_base(unsigned long tls) {
     return tls;
 }
 

--- a/LibOS/shim/include/shim_tcb.h
+++ b/LibOS/shim/include/shim_tcb.h
@@ -12,7 +12,7 @@
 struct shim_context {
     struct shim_regs* regs;
     struct shim_ext_context ext_ctx;
-    uint64_t          fs_base;
+    uint64_t          tls_base;
     struct atomic_int preempt;
 };
 
@@ -77,10 +77,10 @@ static inline bool shim_tcb_check_canary(void) {
     return SHIM_TCB_GET(canary) == SHIM_TCB_CANARY;
 }
 
-static inline void update_fs_base(unsigned long fs_base) {
+static inline void update_tls_base(unsigned long tls_base) {
     shim_tcb_t* shim_tcb = shim_get_tcb();
-    shim_tcb->context.fs_base = fs_base;
-    shim_arch_update_fs_base(fs_base);
+    shim_tcb->context.tls_base = tls_base;
+    shim_arch_update_tls_base(tls_base);
     assert(shim_tcb_check_canary());
 }
 

--- a/LibOS/shim/src/bookkeep/shim_thread.c
+++ b/LibOS/shim/src/bookkeep/shim_thread.c
@@ -561,7 +561,7 @@ BEGIN_RS_FUNC(thread) {
         __shim_tcb_init(tcb);
 
         assert(tcb->context.regs && shim_context_get_sp(&tcb->context));
-        update_fs_base(tcb->context.fs_base);
+        update_tls_base(tcb->context.tls_base);
         /* Temporarily disable preemption until the thread resumes. */
         __disable_preempt(tcb);
     } else {

--- a/LibOS/shim/src/ipc/shim_ipc_helper.c
+++ b/LibOS/shim/src/ipc/shim_ipc_helper.c
@@ -885,7 +885,7 @@ static void shim_ipc_helper_prepare(void* arg) {
 
     shim_tcb_init();
     set_cur_thread(self);
-    update_fs_base(0);
+    update_tls_base(0);
 
     struct debug_buf debug_buf;
     (void)debug_setbuf(shim_get_tcb(), &debug_buf);

--- a/LibOS/shim/src/shim_async.c
+++ b/LibOS/shim/src/shim_async.c
@@ -145,7 +145,7 @@ static void shim_async_helper(void* arg) {
 
     shim_tcb_init();
     set_cur_thread(self);
-    update_fs_base(0);
+    update_tls_base(0);
 
     struct debug_buf debug_buf;
     (void)debug_setbuf(shim_get_tcb(), &debug_buf);

--- a/LibOS/shim/src/shim_init.c
+++ b/LibOS/shim/src/shim_init.c
@@ -369,7 +369,7 @@ noreturn void* shim_init(int argc, void* args) {
 
     /* create the initial TCB, shim can not be run without a tcb */
     shim_tcb_init();
-    update_fs_base(0);
+    update_tls_base(0);
     __disable_preempt(shim_get_tcb()); // Temporarily disable preemption for delaying any signal
                                        // that arrives during initialization
 

--- a/LibOS/shim/src/shim_syscalls.c
+++ b/LibOS/shim/src/shim_syscalls.c
@@ -500,7 +500,7 @@ void* shim_do_arch_prctl(int code, void* addr) {
             if (!addr)
                 return (void*)-EINVAL;
 
-            update_fs_base((unsigned long)addr);
+            update_tls_base((unsigned long)addr);
             debug("set fs_base to 0x%lx\n", (unsigned long)addr);
             return NULL;
 

--- a/LibOS/shim/src/sys/shim_exec.c
+++ b/LibOS/shim/src/sys/shim_exec.c
@@ -71,9 +71,9 @@ noreturn static void __shim_do_execve_rtld(struct execve_rtld_arg* __arg) {
     struct shim_thread* cur_thread = get_cur_thread();
     int ret = 0;
 
-    unsigned long fs_base = 0;
-    update_fs_base(fs_base);
-    debug("set fs_base to 0x%lx\n", fs_base);
+    unsigned long tls_base = 0;
+    update_tls_base(tls_base);
+    debug("set tls_base to 0x%lx\n", tls_base);
 
     thread_sigaction_reset_on_execve(cur_thread);
 


### PR DESCRIPTION
This PR now renames fs_base to tls_base to be more generic.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2045)
<!-- Reviewable:end -->
