### PR TITLE
[Pal/Linux-SGX] Enable ENCLAVE_ADD_PAGES on SGX drivers than cap to 1MB

### DIFF
--- a/Pal/src/host/Linux-SGX/sgx_internal.h
+++ b/Pal/src/host/Linux-SGX/sgx_internal.h
@@ -154,6 +154,10 @@ int block_async_signals(bool block);
 
 void update_debugger(void);
 
+/* some versions of the Intel SGX driver have a 1MB (256 pages) cap implicitly (and erroneously)
+ * enforced on ioctl(SGX_IOC_ENCLAVE_ADD_PAGES); we let Graphene support these subpar versions */
+#define SGX_DRIVER_MAX_ADDPAGES_SIZE (256UL * 4096)
+
 #ifdef DEBUG
 /* SGX profiling (sgx_profile.c) */
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Some versions of the Intel SGX driver have a 1MB (256 pages) cap implicitly (and erroneously) enforced on `ioctl(SGX_IOC_ENCLAVE_ADD_PAGES)`. This PR lets Graphene support these subpar versions by always
requesting no more than 1MB of enclave pages to be added at a time.

Two arguments against this PR:
1. This is a fix for basically "broken temporary" SGX driver versions (I don't even know the exact versions/commits, somewhere around v40-v41). One day everyone will migrate to the stable version and this will be over...
2. This fix slightly regresses all Graphene enclave startups: previously, one `ioctl(ADD_PAGES)` could add the whole 8GB enclave, now you'll need a bunch of such ioctls. On the other hand, the overhead of 1MB-capped ioctl is negligible anyway. The real bottleneck is adding the pages themselves at the kernel/HW level.

One argument for this PR:
1. We won't be asked why Graphene fails with error `EADD returned -16` on seemingly good systems.


## How to test this PR? <!-- (if applicable) -->

All tests must pass. For fun, try all intermediate versions of the in-kernel Intel SGX driver and verify they all work with Graphene.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2049)
<!-- Reviewable:end -->
