### PR TITLE
Remove parentheses from assert argument evaluation

### DIFF
--- a/LibOS/shim/src/shim_context-x86_64.c
+++ b/LibOS/shim/src/shim_context-x86_64.c
@@ -118,7 +118,7 @@ void shim_xstate_restore(const void* xstate_extended) {
     assert(fpx_sw->magic1 == SHIM_FP_XSTATE_MAGIC1);
     assert(fpx_sw->extended_size == g_shim_xsave_size + SHIM_FP_XSTATE_MAGIC2_SIZE);
     assert(fpx_sw->xfeatures == g_shim_xsave_features);
-    assert(fpx_sw->xstate_size = g_shim_xsave_size);
+    assert(fpx_sw->xstate_size == g_shim_xsave_size);
     assert(*((__typeof__(SHIM_FP_XSTATE_MAGIC2)*)bytes_after_xstate) == SHIM_FP_XSTATE_MAGIC2);
 
     __UNUSED(bytes_after_xstate);

--- a/Pal/include/lib/assert.h
+++ b/Pal/include/lib/assert.h
@@ -21,13 +21,15 @@ noreturn void __abort(void);
  * build system.
  */
 #ifdef DEBUG
-#define assert(expr)                                                     \
-    ({                                                                   \
-        (!(expr)) ? ({                                                   \
-            warn("assert failed " __FILE__ ":%d %s\n", __LINE__, #expr); \
-            __abort();                                                   \
-        })                                                               \
-                  : (void)0;                                             \
+/* This `if` is weird intentionally - not to have parentheses around `expr` to catch `assert(x = y)`
+ * errors. */
+#define assert(expr)                                                        \
+    ({                                                                      \
+        if (expr) {} else {                                                 \
+            warn("assert failed " __FILE__ ":%d %s\n", __LINE__, #expr);    \
+            __abort();                                                      \
+        }                                                                   \
+        (void)0;                                                            \
     })
 #else
 #define assert(expr) ((void)0)


### PR DESCRIPTION


<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://graphene.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->
This helps with catching errors like `assert(x = y)`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2051)
<!-- Reviewable:end -->
