### PR TITLE
[Pal/Linux-SGX] Add value checking of external events

### DIFF
--- a/Pal/src/host/Linux-SGX/db_exception.c
+++ b/Pal/src/host/Linux-SGX/db_exception.c
@@ -283,7 +283,7 @@ void _DkExceptionReturn(void* event) {
 
 noreturn void _DkHandleExternalEvent(PAL_NUM event, sgx_cpu_context_t* uc,
                                      PAL_XREGS_STATE* xregs_state) {
-    assert(event);
+    assert(event > 0 && event < PAL_EVENT_NUM_BOUND);
     assert(IS_ALIGNED_PTR(xregs_state, PAL_XSTATE_ALIGN));
 
     /* we only end up in _DkHandleExternalEvent() if interrupted during host syscall; inform LibOS

--- a/Pal/src/host/Linux-SGX/enclave_entry.S
+++ b/Pal/src/host/Linux-SGX/enclave_entry.S
@@ -700,7 +700,10 @@ __morestack:
 
 	# Check if there was a signal
 	cmpq $0, %rsi
-	jne .Lexternal_event
+	je .Lno_external_event
+	cmpq $PAL_EVENT_NUM_BOUND, %rsi
+	jb .Lexternal_event
+.Lno_external_event:
 	movq %rsp, %rdi # %rdi = sgx_cpu_context_t* uc
 	movq %rsp, %rsi
 	addq $SGX_CPU_CONTEXT_SIZE, %rsi # %rsi = PAL_XREGS_STATE* xregs_state

--- a/Pal/src/host/Linux-SGX/generated-offsets.c
+++ b/Pal/src/host/Linux-SGX/generated-offsets.c
@@ -155,6 +155,9 @@ __attribute__((__used__)) static void dummy(void) {
     /* pal_linux.h */
     DEFINE(PAGESIZE, PRESET_PAGESIZE);
 
+    /* pal.h */
+    DEFINE(PAL_EVENT_NUM_BOUND, PAL_EVENT_NUM_BOUND);
+
     /* errno */
     DEFINE(EINTR, EINTR);
 


### PR DESCRIPTION

<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://graphene.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->
`event` was passed to `_DkHandleExternalEvent` without sanitization and later used as an array index.

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->
Apply the following patch and run any application.
```
diff --git a/Pal/src/host/Linux-SGX/sgx_entry.S b/Pal/src/host/Linux-SGX/sgx_entry.S
index eeb15535..0588caa6 100644
--- a/Pal/src/host/Linux-SGX/sgx_entry.S
+++ b/Pal/src/host/Linux-SGX/sgx_entry.S
@@ -150,6 +150,7 @@ sgx_raise:
        movq %rax, %rdi
        # Not interrupted
        xorq %rsi, %rsi
+       movq $0x1337, %rsi

        .global sgx_entry_return
        .type sgx_entry_return, @function
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2053)
<!-- Reviewable:end -->
