### PR TITLE
[Pal] Remove empty DkExceptionReturn function

### DIFF
--- a/Documentation/pal/host-abi.rst
+++ b/Documentation/pal/host-abi.rst
@@ -314,9 +314,6 @@ Exception handling
 .. doxygenfunction:: DkSetExceptionHandler
    :project: pal
 
-.. doxygenfunction:: DkExceptionReturn
-   :project: pal
-
 
 Synchronization
 ^^^^^^^^^^^^^^^

--- a/LibOS/shim/src/shim_init.c
+++ b/LibOS/shim/src/shim_init.c
@@ -43,8 +43,7 @@ toml_table_t* g_manifest_root = NULL;
 
 const unsigned int glibc_version = GLIBC_VERSION;
 
-static void handle_failure(PAL_PTR event, PAL_NUM arg, PAL_CONTEXT* context) {
-    __UNUSED(event);
+static void handle_failure(PAL_NUM arg, PAL_CONTEXT* context) {
     __UNUSED(context);
     if ((arg <= PAL_ERROR_NATIVE_COUNT) ||
             (arg >= PAL_ERROR_CRYPTO_START && arg <= PAL_ERROR_CRYPTO_END))

--- a/Pal/include/pal/pal.h
+++ b/Pal/include/pal/pal.h
@@ -568,7 +568,7 @@ enum PAL_EVENT {
     PAL_EVENT_NUM_BOUND        = 8,
 };
 
-typedef void (*PAL_EVENT_HANDLER)(PAL_PTR event, PAL_NUM arg, PAL_CONTEXT*);
+typedef void (*PAL_EVENT_HANDLER)(PAL_NUM arg, PAL_CONTEXT*);
 
 /*!
  * \brief Set the handler for the specific exception event.
@@ -576,16 +576,6 @@ typedef void (*PAL_EVENT_HANDLER)(PAL_PTR event, PAL_NUM arg, PAL_CONTEXT*);
  * \param event can be one of #PAL_EVENT values
  */
 PAL_BOL DkSetExceptionHandler(PAL_EVENT_HANDLER handler, PAL_NUM event);
-
-/*!
- * \brief Exit an exception handler and restore the context.
- */
-void DkExceptionReturn(PAL_PTR event);
-
-/* parameter: keeping int threadHandle for now (to be in sync with the paper).
- * We may want to replace it with a PAL_HANDLE. Ideally, either use PAL_HANDLE
- * or threadHandle.
- */
 
 /*
  * Synchronization

--- a/Pal/regression/Event.c
+++ b/Pal/regression/Event.c
@@ -18,15 +18,13 @@ static int thread2_run(void* args) {
     /* UNREACHABLE */
 }
 
-static void pal_failure_handler(PAL_PTR event, PAL_NUM error, PAL_CONTEXT* context) {
+static void pal_failure_handler(PAL_NUM error, PAL_CONTEXT* context) {
     pal_printf("pal_failure_handler called\n");
 
     if (error == PAL_ERROR_TRYAGAIN) {
         pal_printf("Timeout event received.\n");
         timeouts += 1;
     }
-
-    DkExceptionReturn(event);
 }
 
 int main(void) {

--- a/Pal/regression/Exception.c
+++ b/Pal/regression/Exception.c
@@ -12,38 +12,32 @@ static void* get_stack(void) {
     return stack;
 }
 
-static void handler1(PAL_PTR event, PAL_NUM arg, PAL_CONTEXT* context) {
+static void handler1(PAL_NUM arg, PAL_CONTEXT* context) {
     pal_printf("Arithmetic Exception Handler 1: 0x%08lx, rip = 0x%08lx\n", arg, context->rip);
 
     pal_printf("Stack in handler: %p\n", get_stack());
 
     while (*(unsigned char*)context->rip != 0x90)
         context->rip++;
-
-    DkExceptionReturn(event);
 }
 
-static void handler2(PAL_PTR event, PAL_NUM arg, PAL_CONTEXT* context) {
+static void handler2(PAL_NUM arg, PAL_CONTEXT* context) {
     pal_printf("Arithmetic Exception Handler 2: 0x%08lx, rip = 0x%08lx\n", arg, context->rip);
 
     while (*(unsigned char*)context->rip != 0x90)
         context->rip++;
-
-    DkExceptionReturn(event);
 }
 
-static void handler3(PAL_PTR event, PAL_NUM arg, PAL_CONTEXT* context) {
+static void handler3(PAL_NUM arg, PAL_CONTEXT* context) {
     pal_printf("Memory Fault Exception Handler: 0x%08lx, rip = 0x%08lx\n", arg, context->rip);
 
     while (*(unsigned char*)context->rip != 0x90)
         context->rip++;
-
-    DkExceptionReturn(event);
 }
 
 atomic_bool handler4_called = false;
 
-static void handler4(PAL_PTR event, PAL_NUM arg, PAL_CONTEXT* context) {
+static void handler4(PAL_NUM arg, PAL_CONTEXT* context) {
     pal_printf("Arithmetic Exception Handler 4: 0x%" PRIx64 ", rip = 0x%" PRIx64 "\n", arg,
                context->rip);
 
@@ -51,8 +45,6 @@ static void handler4(PAL_PTR event, PAL_NUM arg, PAL_CONTEXT* context) {
         context->rip++;
 
     handler4_called = true;
-
-    DkExceptionReturn(event);
 }
 
 static void red_zone_test(void) {

--- a/Pal/regression/Exception2.c
+++ b/Pal/regression/Exception2.c
@@ -4,14 +4,12 @@
 int count = 0;
 int i     = 0;
 
-static void handler(PAL_PTR event, PAL_NUM arg, PAL_CONTEXT* context) {
+static void handler(PAL_NUM arg, PAL_CONTEXT* context) {
     pal_printf("failure in the handler: 0x%08lx\n", arg);
     count++;
 
     if (count == 30)
         DkProcessExit(0);
-
-    DkExceptionReturn(event);
 }
 
 int main(void) {

--- a/Pal/regression/Failure.c
+++ b/Pal/regression/Failure.c
@@ -4,11 +4,10 @@
 
 int handled = 0;
 
-static void FailureHandler(PAL_PTR event, PAL_NUM arg, PAL_CONTEXT* context) {
+static void FailureHandler(PAL_NUM arg, PAL_CONTEXT* context) {
     pal_printf("Failure notified: %s\n", pal_strerror((unsigned long)arg));
 
     handled = 1;
-    DkExceptionReturn(event);
 }
 
 int main(int argc, char** argv, char** envp) {

--- a/Pal/regression/Memory.c
+++ b/Pal/regression/Memory.c
@@ -8,7 +8,7 @@
 
 static volatile int count = 0;
 
-static void handler(PAL_PTR event, PAL_NUM arg, PAL_CONTEXT* context) {
+static void handler(PAL_NUM arg, PAL_CONTEXT* context) {
     count++;
     pal_printf("Memory Fault %d\n", count);
 
@@ -19,8 +19,6 @@ static void handler(PAL_PTR event, PAL_NUM arg, PAL_CONTEXT* context) {
 #else
 #error Unsupported architecture
 #endif
-
-    DkExceptionReturn(event);
 }
 
 int main(int argc, char** argv, char** envp) {

--- a/Pal/regression/Symbols.c
+++ b/Pal/regression/Symbols.c
@@ -43,7 +43,6 @@ int main(int argc, char** argv, char** envp) {
     PRINT_SYMBOL(DkThreadResume);
 
     PRINT_SYMBOL(DkSetExceptionHandler);
-    PRINT_SYMBOL(DkExceptionReturn);
 
     PRINT_SYMBOL(DkMutexCreate);
     PRINT_SYMBOL(DkMutexRelease);

--- a/Pal/regression/test_pal.py
+++ b/Pal/regression/test_pal.py
@@ -242,7 +242,6 @@ class TC_02_Symbols(RegressionTestCase):
         'DkThreadExit',
         'DkThreadResume',
         'DkSetExceptionHandler',
-        'DkExceptionReturn',
         'DkMutexCreate',
         'DkMutexRelease',
         'DkNotificationEventCreate',

--- a/Pal/src/db_exception.c
+++ b/Pal/src/db_exception.c
@@ -35,10 +35,6 @@ DkSetExceptionHandler(PAL_EVENT_HANDLER handler, PAL_NUM event) {
     LEAVE_PAL_CALL_RETURN(PAL_TRUE);
 }
 
-void DkExceptionReturn(PAL_PTR event) {
-    _DkExceptionReturn(event);
-}
-
 /* This does not return */
 noreturn void __abort(void) {
     _DkProcessExit(-ENOTRECOVERABLE);

--- a/Pal/src/host/Linux-SGX/db_exception.c
+++ b/Pal/src/host/Linux-SGX/db_exception.c
@@ -264,7 +264,7 @@ void _DkExceptionHandler(unsigned int exit_info, sgx_cpu_context_t* uc,
 
     PAL_EVENT_HANDLER upcall = _DkGetExceptionHandler(event_num);
     if (upcall) {
-        (*upcall)(/*event=*/NULL, arg, &ctx);
+        (*upcall)(arg, &ctx);
     }
 
     restore_pal_context(uc, &ctx);
@@ -273,12 +273,8 @@ void _DkExceptionHandler(unsigned int exit_info, sgx_cpu_context_t* uc,
 void _DkRaiseFailure(int error) {
     PAL_EVENT_HANDLER upcall = _DkGetExceptionHandler(PAL_EVENT_FAILURE);
     if (upcall) {
-        (*upcall)(/*event=*/NULL, error, /*context=*/NULL);
+        (*upcall)(error, /*context=*/NULL);
     }
-}
-
-void _DkExceptionReturn(void* event) {
-    __UNUSED(event);
 }
 
 noreturn void _DkHandleExternalEvent(PAL_NUM event, sgx_cpu_context_t* uc,
@@ -299,7 +295,7 @@ noreturn void _DkHandleExternalEvent(PAL_NUM event, sgx_cpu_context_t* uc,
 
     PAL_EVENT_HANDLER upcall = _DkGetExceptionHandler(event);
     if (upcall) {
-        (*upcall)(/*event=*/NULL, /*arg=*/0, &ctx);
+        (*upcall)(/*arg=*/0, &ctx);
     }
 
     /* modification to PAL_CONTEXT is discarded; it is assumed that LibOS won't change context

--- a/Pal/src/host/Linux/db_exception.c
+++ b/Pal/src/host/Linux/db_exception.c
@@ -120,7 +120,7 @@ static void perform_signal_handling(int event, siginfo_t* info, ucontext_t* uc) 
 
     PAL_CONTEXT context;
     ucontext_to_pal_context(&context, uc);
-    (*upcall)(/*event=*/NULL, arg, &context);
+    (*upcall)(arg, &context);
     pal_context_to_ucontext(uc, &context);
 }
 
@@ -196,7 +196,7 @@ void __check_pending_event(void) {
     for (int i = 0; i < num; i++) {
         PAL_EVENT_HANDLER upcall = _DkGetExceptionHandler(tcb->pending_events[i]);
         if (upcall) {
-            (*upcall)(/*event=*/NULL, /*arg=*/0, /*context=*/NULL);
+            (*upcall)(/*arg=*/0, /*context=*/NULL);
         }
     }
 
@@ -206,12 +206,8 @@ void __check_pending_event(void) {
 void _DkRaiseFailure(int error) {
     PAL_EVENT_HANDLER upcall = _DkGetExceptionHandler(PAL_EVENT_FAILURE);
     if (upcall) {
-        (*upcall)(/*event=*/NULL, error, /*context=*/NULL);
+        (*upcall)(error, /*context=*/NULL);
     }
-}
-
-void _DkExceptionReturn(void* event) {
-    __UNUSED(event);
 }
 
 void signal_setup(void) {

--- a/Pal/src/host/Skeleton/db_exception.c
+++ b/Pal/src/host/Skeleton/db_exception.c
@@ -28,7 +28,3 @@ int (*_DkExceptionHandlers[PAL_EVENT_NUM_BOUND])(int, PAL_UPCALL, int) = {
 void _DkRaiseFailure(int error) {
     /* needs to be implemented */
 }
-
-void _DkExceptionReturn(void* event) {
-    /* needs to be implemented */
-}

--- a/Pal/src/pal-symbols
+++ b/Pal/src/pal-symbols
@@ -38,7 +38,6 @@ DkInstructionCacheFlush
 DkCpuIdRetrieve
 DkObjectClose
 DkSetExceptionHandler
-DkExceptionReturn
 DkSegmentRegisterGet
 DkSegmentRegisterSet
 DkStreamChangeName

--- a/Pal/src/pal_internal.h
+++ b/Pal/src/pal_internal.h
@@ -259,7 +259,6 @@ int _DkStreamsWaitEvents(size_t count, PAL_HANDLE* handle_array, PAL_FLG* events
 /* DkException calls & structures */
 PAL_EVENT_HANDLER _DkGetExceptionHandler(PAL_NUM event_num);
 void _DkRaiseFailure(int error);
-void _DkExceptionReturn(void* event);
 
 /* other DK calls */
 void _DkInternalLock(PAL_LOCK* mut);


### PR DESCRIPTION


<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://graphene.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->
This function was empty and it is responsibility of the caller (Pal
level) of specific exception handling function (LibOS level) to return
from the exception.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2054)
<!-- Reviewable:end -->
