### PR TITLE
[Pal/Linux-SGX] Print error message if buggy SGX driver is detected

### DIFF
--- a/Pal/src/host/Linux-SGX/sgx_framework.c
+++ b/Pal/src/host/Linux-SGX/sgx_framework.c
@@ -310,6 +310,11 @@ int add_pages_to_enclave(sgx_arch_secs_t* secs, void* addr, void* user_addr, uns
         }
 
         uint64_t added_size = ret > 0 ? (uint64_t)ret : param.count;
+        if (!added_size) {
+            SGX_DBG(DBG_E, "Intel SGX driver did not perform EADD. This may indicate a buggy "
+                           "driver, please update to the most recent version.\n");
+            return -EPERM;
+        }
 
         param.offset += added_size;
         if (param.src != (uint64_t)g_zero_pages)


### PR DESCRIPTION

## Description of the changes <!-- (reasons and measures) -->

Some versions of the Intel SGX driver have a 1MB (256 pages) cap enforced on `ioctl(SGX_IOC_ENCLAVE_ADD_PAGES)`. Such versions must return how many pages were actually added in `ret` or `count` fields; Graphene supports this. However, some version of the driver are buggy and do not report any error or how many pages were added, but instead silently skip all enclave pages past 1MB. This confuses Graphene (it re-tries the EADD), which leads to `-EBUSY` from the driver (it sees that Graphene wants to add already added enclave pages).

This is a bug in the driver which was introduced in some intermediate commits between v40 and v41 (and unfortunately was/is used in some systems). We simply error out with a message to update the driver when we detect this bug.

Closes #2049 . See the discussion there.

## How to test this PR? <!-- (if applicable) -->

All tests must pass.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2055)
<!-- Reviewable:end -->
