### PR TITLE
[Pal/lib] Add spinlocks to mbedTLS-specific SSL recv/send

### DIFF
--- a/LibOS/shim/test/regression/.gitignore
+++ b/LibOS/shim/test/regression/.gitignore
@@ -65,6 +65,7 @@
 /multi_pthread_exitless
 /openmp
 /pipe
+/pipe_multithread
 /pipe_nonblocking
 /pipe_ocloexec
 /poll

--- a/LibOS/shim/test/regression/Makefile
+++ b/LibOS/shim/test/regression/Makefile
@@ -53,6 +53,7 @@ c_executables = \
 	multi_pthread \
 	openmp \
 	pipe \
+	pipe_multithread \
 	pipe_nonblocking \
 	pipe_ocloexec \
 	poll \
@@ -151,26 +152,27 @@ extra_rules = \
 include ../../../../Scripts/Makefile.manifest
 include ../../../../Scripts/Makefile.Test
 
-CFLAGS-bootstrap_static = -static
+CFLAGS-abort_multithread = -pthread
 CFLAGS-bootstrap_pie = -fPIC -pie
+CFLAGS-bootstrap_static = -static
 CFLAGS-debug = -g3
 CFLAGS-debug_regs-x86_64 = -g3
-CFLAGS-exec_same = -pthread
-CFLAGS-shared_object = -fPIC -pie
-CFLAGS-syscall += -I$(PALDIR)/../include -I$(PALDIR)/host/$(PAL_HOST) -I$(PALDIR)/../include/arch/$(ARCH)/Linux
-CFLAGS-openmp = -fopenmp
-CFLAGS-multi_pthread = -pthread
-CFLAGS-exit_group = -pthread
-CFLAGS-abort_multithread = -pthread
 CFLAGS-eventfd = -pthread
+CFLAGS-exec_same = -pthread
+CFLAGS-exit_group = -pthread
 CFLAGS-futex_bitset = -pthread
 CFLAGS-futex_requeue = -pthread
 CFLAGS-futex_wake_op = -pthread
+CFLAGS-multi_pthread = -pthread
+CFLAGS-openmp = -fopenmp
+CFLAGS-pipe_multithread = -pthread
 CFLAGS-proc_common = -pthread
-CFLAGS-spinlock += -I$(PALDIR)/../include/lib -I$(PALDIR)/../include/arch/$(ARCH) -pthread
+CFLAGS-pthread_set_get_affinity += -pthread
+CFLAGS-shared_object = -fPIC -pie
 CFLAGS-sigaction_per_process += -pthread
 CFLAGS-signal_multithread += -pthread
-CFLAGS-pthread_set_get_affinity += -pthread
+CFLAGS-spinlock += -I$(PALDIR)/../include/lib -I$(PALDIR)/../include/arch/$(ARCH) -pthread
+CFLAGS-syscall += -I$(PALDIR)/../include -I$(PALDIR)/host/$(PAL_HOST) -I$(PALDIR)/../include/arch/$(ARCH)/Linux
 
 CFLAGS-attestation += -I$(PALDIR)/../lib/crypto/mbedtls/crypto/include \
                       -I$(PALDIR)/host/Linux-SGX \

--- a/LibOS/shim/test/regression/pipe_multithread.c
+++ b/LibOS/shim/test/regression/pipe_multithread.c
@@ -1,0 +1,81 @@
+/* test creates two threads simulteneously writing on the same pipe */
+
+#include <err.h>
+#include <errno.h>
+#include <pthread.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+
+#define ITERATIONS 100000
+
+int fds[2];
+
+static void* thread_run(void* arg) {
+    char c = (char)(uintptr_t)arg;
+    for (int i = 0; i < ITERATIONS; i++) {
+        ssize_t bytes = 0;
+        while (bytes < sizeof(c)) {
+            bytes = send(fds[1], &c, sizeof(c), /*flags=*/0);
+            if (bytes < 0) {
+                if (errno == EAGAIN || errno == EINTR)
+                    continue;
+                err(1, "send");
+            }
+        }
+    }
+    return NULL;
+}
+
+int main(int argc, char** argv) {
+    int ret;
+    pthread_t threads[2];
+    char thread_ids[2]   = {42, 24};
+    int thread_bytes[2]  = {0, 0};
+
+    ret = socketpair(AF_UNIX, SOCK_STREAM, 0, fds);
+    if (ret) {
+        err(1, "socketpair");
+    }
+
+    ret = pthread_create(&threads[0], NULL, &thread_run, (void*)(uintptr_t)thread_ids[0]);
+    if (ret) {
+        errno = ret;
+        err(1, "pthread_create");
+    }
+
+    ret = pthread_create(&threads[1], NULL, &thread_run, (void*)(uintptr_t)thread_ids[1]);
+    if (ret) {
+        errno = ret;
+        err(1, "pthread_create");
+    }
+
+    for (int i = 0; i < 2 * ITERATIONS; i++) {
+        char c = 0;
+        ssize_t bytes = 0;
+        while (bytes < sizeof(c)) {
+            bytes = recv(fds[0], &c, sizeof(c), /*flags=*/0);
+            if (bytes < 0) {
+                if (errno == EAGAIN || errno == EINTR)
+                    continue;
+                err(1, "recv");
+            }
+        }
+
+        if (c == thread_ids[0])
+            thread_bytes[0] += bytes;
+        else if (c == thread_ids[1])
+            thread_bytes[1] += bytes;
+        else
+            errx(1, "received unrecognized thread ID");
+    }
+
+    printf("received total bytes from threads: %d and %d\n", thread_bytes[0], thread_bytes[1]);
+
+    if (thread_bytes[0] != ITERATIONS || thread_bytes[1] != ITERATIONS)
+        errx(1, "received wrong number of bytes from threads");
+
+    puts("TEST OK");
+    return 0;
+}

--- a/Pal/include/lib/pal_crypto.h
+++ b/Pal/include/lib/pal_crypto.h
@@ -15,6 +15,8 @@
 #include <stdint.h>
 #include <unistd.h>
 
+#include "spinlock.h"
+
 #define SHA256_DIGEST_LEN 32
 
 #ifdef CRYPTO_USE_MBEDTLS
@@ -51,6 +53,7 @@ typedef struct {
     ssize_t (*pal_recv_cb)(int fd, void* buf, size_t buf_size);
     ssize_t (*pal_send_cb)(int fd, const void* buf, size_t buf_size);
     int stream_fd;
+    spinlock_t lock;
 } LIB_SSL_CONTEXT;
 
 #endif /* CRYPTO_USE_MBEDTLS */

--- a/Pal/include/lib/spinlock.h
+++ b/Pal/include/lib/spinlock.h
@@ -7,7 +7,9 @@
 #ifndef _SPINLOCK_H
 #define _SPINLOCK_H
 
-#include "api.h"
+#include <stdbool.h>
+
+#include "assert.h"
 #include "cpu.h"
 
 #ifdef DEBUG
@@ -60,11 +62,11 @@ static inline void debug_spinlock_giveup_ownership(spinlock_t* lock) {
 }
 #else
 static inline void debug_spinlock_take_ownership(spinlock_t* lock) {
-    __UNUSED(lock);
+    (void)lock;
 }
 
 static inline void debug_spinlock_giveup_ownership(spinlock_t* lock) {
-    __UNUSED(lock);
+    (void)lock;
 }
 #endif // DEBUG_SPINLOCKS_SHIM
 
@@ -158,7 +160,8 @@ out_success:
  * returned.
  */
 static inline int spinlock_cmpxchg(spinlock_t* lock, int* expected, int desired) {
-    static_assert(SAME_TYPE(&lock->lock, expected), "spinlock is not implemented as int*");
+    static_assert(__builtin_types_compatible_p(__typeof__(&lock->lock), __typeof__(expected)),
+                  "spinlock is not implemented as int*");
     return __atomic_compare_exchange_n(&lock->lock, expected, desired, /*weak=*/false,
                                        __ATOMIC_ACQUIRE, __ATOMIC_RELAXED);
 }

--- a/Pal/src/host/Linux-SGX/tools/common/Makefile
+++ b/Pal/src/host/Linux-SGX/tools/common/Makefile
@@ -5,6 +5,8 @@ include ../../../../../../Scripts/Makefile.rules
 CFLAGS := $(filter-out -DIN_PAL, $(CFLAGS))
 CFLAGS += -I../.. \
           -I../../../../../include/lib \
+          -I../../../../../include/arch/$(ARCH) \
+          -I../../../../../include/arch/$(ARCH)/Linux \
           -I../../../../../lib/crypto/mbedtls/install/include \
           -I../../../../../lib/crypto/mbedtls/crypto/include \
           -I../../protected-files \

--- a/Pal/src/pal_internal.h
+++ b/Pal/src/pal_internal.h
@@ -9,6 +9,7 @@
 #define PAL_INTERNAL_H
 
 #include <stdarg.h>
+#include <sys/types.h>
 
 #include "pal.h"
 #include "pal_defs.h"


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Linux-SGX PAL wraps all pipe/UNIX domain socket communication in TLS sessions. Previously, Graphene assumed that only one thread at a time accesses one TLS session (i.e., no multi-threading support). This commit adds spinlocks to `lib_SSL*` functions to support such (rare) multi-threading scenarios.

Note that we cannot rely on pthreads and/or mutexes so we use simple spinlocks. Because this is in the "common library" used by PAL and LibOS, with no "complex" dependencies allowed.

Also, there is a prerequisite (first) commit in this PR: remove `api.h` from `spinlock.h`. See commit messages for explanations.

## How to test this PR? <!-- (if applicable) -->

This PR adds a corresponding LibOS test `pipe_multithread` (kudos to @lejunzhu for the initial version of this test and debugging this).