### PR TITLE
[Pal] Handle EINTR in _DkEventWaitTimeout

### DIFF
--- a/Pal/include/pal/pal.h
+++ b/Pal/include/pal/pal.h
@@ -624,11 +624,6 @@ void DkEventSet(PAL_HANDLE eventHandle);
  */
 void DkEventClear(PAL_HANDLE eventHandle);
 
-/*!
- * \brief Wait for an event.
- */
-void DkEventWait(PAL_HANDLE handle);
-
 /*! block until the handle's event is triggered */
 #define NO_TIMEOUT ((PAL_NUM)-1)
 

--- a/Pal/src/db_events.c
+++ b/Pal/src/db_events.c
@@ -57,22 +57,6 @@ void DkEventSet(PAL_HANDLE handle) {
     LEAVE_PAL_CALL();
 }
 
-void DkEventWait(PAL_HANDLE handle) {
-    ENTER_PAL_CALL(DkEventWait);
-
-    if (!handle || !IS_HANDLE_TYPE(handle, event)) {
-        _DkRaiseFailure(PAL_ERROR_INVAL);
-        LEAVE_PAL_CALL();
-    }
-
-    int ret = _DkEventWait(handle);
-
-    if (ret < 0)
-        _DkRaiseFailure(-ret);
-
-    LEAVE_PAL_CALL();
-}
-
 void DkEventClear(PAL_HANDLE handle) {
     ENTER_PAL_CALL(DkEventClear);
 

--- a/Pal/src/host/Linux-SGX/db_events.c
+++ b/Pal/src/host/Linux-SGX/db_events.c
@@ -68,8 +68,9 @@ int _DkEventSet(PAL_HANDLE event, int wakeup) {
 int _DkEventWaitTimeout(PAL_HANDLE event, int64_t timeout_us) {
     int ret = 0;
 
-    if (timeout_us < 0)
-        return _DkEventWait(event);
+    if (timeout_us < 0) {
+        timeout_us = -1;
+    }
 
     if (!event->event.isnotification || !__atomic_load_n(event->event.signaled, __ATOMIC_SEQ_CST)) {
         __atomic_add_fetch(&event->event.nwaiters.counter, 1, __ATOMIC_SEQ_CST);
@@ -77,36 +78,16 @@ int _DkEventWaitTimeout(PAL_HANDLE event, int64_t timeout_us) {
         do {
             ret = ocall_futex(event->event.signaled, FUTEX_WAIT, 0, timeout_us);
 
-            if (IS_ERR(ret)) {
-                if (ERRNO(ret) == EWOULDBLOCK) {
+            if (ret < 0) {
+                if (ret == -EWOULDBLOCK) {
                     ret = 0;
-                } else {
-                    ret = unix_to_pal_error(ERRNO(ret));
+                } else if (ret == -EINTR
+                           && (!event->event.isnotification
+                               || __atomic_load_n(&event->event.signaled, __ATOMIC_SEQ_CST))) {
+                    ret = 0;
                     break;
-                }
-            }
-        } while (event->event.isnotification &&
-                 !__atomic_load_n(event->event.signaled, __ATOMIC_SEQ_CST));
-
-        __atomic_sub_fetch(&event->event.nwaiters.counter, 1, __ATOMIC_SEQ_CST);
-    }
-
-    return ret;
-}
-
-int _DkEventWait(PAL_HANDLE event) {
-    int ret = 0;
-
-    if (!event->event.isnotification || !__atomic_load_n(event->event.signaled, __ATOMIC_SEQ_CST)) {
-        __atomic_add_fetch(&event->event.nwaiters.counter, 1, __ATOMIC_SEQ_CST);
-
-        do {
-            ret = ocall_futex(event->event.signaled, FUTEX_WAIT, 0, -1);
-            if (IS_ERR(ret)) {
-                if (ERRNO(ret) == EWOULDBLOCK) {
-                    ret = 0;
                 } else {
-                    ret = unix_to_pal_error(ERRNO(ret));
+                    ret = unix_to_pal_error(-ret);
                     break;
                 }
             }

--- a/Pal/src/host/Skeleton/db_events.c
+++ b/Pal/src/host/Skeleton/db_events.c
@@ -23,10 +23,6 @@ int _DkEventWaitTimeout(PAL_HANDLE event, int64_t timeout_us) {
     return -PAL_ERROR_NOTIMPLEMENTED;
 }
 
-int _DkEventWait(PAL_HANDLE event) {
-    return -PAL_ERROR_NOTIMPLEMENTED;
-}
-
 int _DkEventClear(PAL_HANDLE event) {
     return -PAL_ERROR_NOTIMPLEMENTED;
 }

--- a/Pal/src/pal_internal.h
+++ b/Pal/src/pal_internal.h
@@ -241,7 +241,6 @@ int _DkMutexGetCurrentCount(PAL_HANDLE sem);
 int _DkEventCreate(PAL_HANDLE* event, bool initialState, bool isnotification);
 int _DkEventSet(PAL_HANDLE event, int wakeup);
 int _DkEventWaitTimeout(PAL_HANDLE event, int64_t timeout_us);
-int _DkEventWait(PAL_HANDLE event);
 int _DkEventClear(PAL_HANDLE event);
 
 /* DkVirtualMemory calls */


### PR DESCRIPTION


<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://graphene.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->
If futex wait returns -EINTR, but the waiting condition no longer holds,
we ignore EINTR and treat that as successful wait.
This commit also removes redundant, copy-pasted code (_DkEventWait).
<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2060)
<!-- Reviewable:end -->
