### PR TITLE
[LibOS] Do not call test_user_memory on LibOS allocated memory

### DIFF
--- a/LibOS/shim/test/ltp/ltp.cfg
+++ b/LibOS/shim/test/ltp/ltp.cfg
@@ -2055,8 +2055,6 @@ skip = yes
 skip = yes
 
 # EINVAL from native sendmsg()
-# also, shim_sendmmsg() has wrong vlen handling?
-# issue: https://github.com/oscarlab/graphene/issues/1931
 [sendmmsg01]
 skip = yes
 


### PR DESCRIPTION

<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://graphene.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->
This commit additionally fixes bugs in shim_do_sendmmsg and
shim_do_recvmmsg - `vlen` argument is the number of items in the array,
not size (in bytes) of it, as previous code assumed.

This change is important in a follow up PR, which causes LibOS to use internally allocated stack.

Fixes #1931
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2061)
<!-- Reviewable:end -->
