### PR TITLE
WIP Decouple downloads

### DIFF
--- a/.ci/ubuntu16.04.dockerfile
+++ b/.ci/ubuntu16.04.dockerfile
@@ -50,6 +50,7 @@ RUN apt-get update \
        r-base-core \
        shellcheck \
        texinfo \
+       uthash-dev \
        wget \
        zlib1g \
        zlib1g-dev \

--- a/.ci/ubuntu18.04.dockerfile
+++ b/.ci/ubuntu18.04.dockerfile
@@ -52,6 +52,7 @@ RUN apt-get update && env DEBIAN_FRONTEND=noninteractive apt-get install -y \
     r-base-core \
     shellcheck \
     texinfo \
+    uthash-dev \
     wget \
     zlib1g \
     zlib1g-dev

--- a/Documentation/building.rst
+++ b/Documentation/building.rst
@@ -62,8 +62,11 @@ Prerequisites
 
 Run the following commands on Ubuntu to install SGX-related dependencies::
 
-    sudo apt-get install -y libprotobuf-c-dev protobuf-c-compiler \
-       libcurl4-openssl-dev
+    sudo apt-get install -y \
+        libcurl4-openssl-dev \
+        libprotobuf-c-dev \
+        protobuf-c-compiler \
+        uthash-dev
 
     # For Ubuntu 18.04
     sudo apt-get install -y python3-protobuf

--- a/LICENSE.addendum.txt
+++ b/LICENSE.addendum.txt
@@ -10,7 +10,6 @@ MIT JOS (mix of MIT and BSD licenses):
 * Pal/lib/stdlib/printfmt.c
 
 cJSON - MIT
-uthash - BSD revised
 
 A number of files taken from other C libraries:
 * glibc - LGPL

--- a/Pal/include/lib/.gitignore
+++ b/Pal/include/lib/.gitignore
@@ -1,2 +1,1 @@
-/uthash.h
 /toml.h

--- a/Pal/lib/Makefile
+++ b/Pal/lib/Makefile
@@ -135,7 +135,7 @@ objs += crypto/adapters/mbedtls_encoding.o
 endif
 
 .PHONY: all
-all: ../include/lib/uthash.h $(target)graphene-lib.a
+all: $(target)graphene-lib.a
 
 $(target)graphene-lib.a: $(addprefix $(target),$(objs))
 	@mkdir -p $(dir $@)
@@ -148,12 +148,6 @@ $(target)%.o: %.c toml.patched
 ifeq ($(filter %clean,$(MAKECMDGOALS)),)
 -include $(patsubst %.o,%.d,$(addprefix $(target),$(objs)))
 endif
-
-UTHASH_URI ?= https://raw.githubusercontent.com/troydhanson/uthash/8b214aefcb81df86a7e5e0d4fa20e59a6c18bc02/src/uthash.h
-UTHASH_CHECKSUM ?= ba9af0e8c902108cc40be8e742ff4fcbb0e93062d91aefd6070b70d4e067c2ac
-
-../include/lib/uthash.h:
-	../../Scripts/download --output $@ --url $(UTHASH_URI) --sha256 $(UTHASH_CHECKSUM)
 
 TOML_H_URI ?= https://raw.githubusercontent.com/cktan/tomlc99/5be06807ad5f2230cad99e15380c4f4076c9dd83/toml.h
 TOML_H_CHECKSUM ?= e79d6d272576561e1b46ee001b0dd6b554330843e6fc7c658a548c659f282ac5
@@ -178,5 +172,4 @@ clean:
 .PHONY: distclean
 distclean: clean
 	$(RM) -r crypto/$(MBEDTLS_SRC) crypto/$(MBEDCRYPTO_SRC) crypto/mbedtls
-	$(RM) ../include/lib/uthash.h
 	$(RM) ../include/lib/toml.h toml.h toml.c toml.patched

--- a/Pal/src/host/Linux-SGX/pal_linux.h
+++ b/Pal/src/host/Linux-SGX/pal_linux.h
@@ -6,7 +6,6 @@
 
 #include <asm/mman.h>
 #include <linux/mman.h>
-#include <uthash.h>
 
 #include "api.h"
 #include "assert.h"
@@ -22,6 +21,7 @@
 #include "sgx_attest.h"
 #include "sgx_tls.h"
 #include "sysdep-arch.h"
+#include <uthash.h>
 
 #define IS_ERR      INTERNAL_SYSCALL_ERROR
 #define IS_ERR_P    INTERNAL_SYSCALL_ERROR_P

--- a/Pal/src/host/Linux-SGX/pal_linux.h
+++ b/Pal/src/host/Linux-SGX/pal_linux.h
@@ -6,6 +6,7 @@
 
 #include <asm/mman.h>
 #include <linux/mman.h>
+#include <uthash.h>
 
 #include "api.h"
 #include "assert.h"
@@ -21,7 +22,6 @@
 #include "sgx_attest.h"
 #include "sgx_tls.h"
 #include "sysdep-arch.h"
-#include "uthash.h"
 
 #define IS_ERR      INTERNAL_SYSCALL_ERROR
 #define IS_ERR_P    INTERNAL_SYSCALL_ERROR_P

--- a/Pal/src/host/Linux-SGX/protected-files/lru_cache.c
+++ b/Pal/src/host/Linux-SGX/protected-files/lru_cache.c
@@ -6,11 +6,12 @@
 
 /* TODO: add regression tests for this */
 
+#include <uthash.h>
+
 #include "lru_cache.h"
 
 #include "api.h"
 #include "list.h"
-#include "uthash.h"
 
 #ifdef IN_PAL
 #include "assert.h"

--- a/Pal/src/host/Linux-SGX/protected-files/lru_cache.c
+++ b/Pal/src/host/Linux-SGX/protected-files/lru_cache.c
@@ -6,12 +6,11 @@
 
 /* TODO: add regression tests for this */
 
-#include <uthash.h>
-
 #include "lru_cache.h"
 
 #include "api.h"
 #include "list.h"
+#include <uthash.h>
 
 #ifdef IN_PAL
 #include "assert.h"


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://graphene.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->
In Real Build Systems™ (obs, mock, ...) there is no way to download anything from the Internet. Instead all distfiles should be declared in `debian/`/`SPEC`/whatever the build system likes and are predownloaded (hashes checked etc.) and afterwards the chroot is configured without external access. This is by design to ensure reliable and repeatable builds.

Therefore we should decouple the download from our build harness and eventually retire `Scripts/download` altogether.

This PR will remove downloading of at least some of the things that we currently do download:
- [x] uthash
- [ ] cjson
- [ ] mbedtls
- [ ] tomlc99
- [ ] glibc

#790

## How to test this PR? <!-- (if applicable) -->
Nothing should regress in build. The Documentation should accurately reflect the correct build procedure.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2063)
<!-- Reviewable:end -->
