### PR TITLE
[PAL] Some cleanups around pal_linux_tcb and pal_tcb structures

### DIFF
--- a/LibOS/shim/src/shim_context-x86_64.c
+++ b/LibOS/shim/src/shim_context-x86_64.c
@@ -7,7 +7,6 @@
 #include <stdnoreturn.h>
 
 #include "asm-offsets.h"
-#include "immintrin.h"
 #include "pal.h"
 #include "shim_context.h"
 #include "shim_internal.h"

--- a/Pal/include/arch/x86_64/pal-arch.h
+++ b/Pal/include/arch/x86_64/pal-arch.h
@@ -38,6 +38,11 @@ typedef struct pal_tcb {
     /* data private to PAL implementation follows this struct. */
 } PAL_TCB;
 
+__attribute__((__optimize__("-fno-stack-protector")))
+static inline void pal_tcb_arch_set_stack_canary(PAL_TCB* tcb, uint64_t canary) {
+    tcb->stack_protector_canary = canary;
+}
+
 static_assert(offsetof(PAL_TCB, stack_protector_canary) == 0x8,
               "unexpected offset of stack_protector_canary in PAL_TCB struct");
 

--- a/Pal/src/host/Linux/db_main.c
+++ b/Pal/src/host/Linux/db_main.c
@@ -153,7 +153,7 @@ noreturn void pal_linux_main(void* initial_rsp, void* fini_callback) {
      * at gs:[0x8] in functions called below, so let's install a dummy TCB with a default canary */
     PAL_TCB_LINUX dummy_tcb_for_stack_protector = { 0 };
     dummy_tcb_for_stack_protector.common.self = &dummy_tcb_for_stack_protector.common;
-    pal_set_tcb_stack_canary(&dummy_tcb_for_stack_protector, STACK_PROTECTOR_CANARY_DEFAULT);
+    pal_tcb_set_stack_canary(&dummy_tcb_for_stack_protector.common, STACK_PROTECTOR_CANARY_DEFAULT);
     ret = pal_set_tcb(&dummy_tcb_for_stack_protector.common);
     if (ret < 0)
         INIT_FAIL(unix_to_pal_error(-ret), "pal_set_tcb() failed");
@@ -211,7 +211,7 @@ noreturn void pal_linux_main(void* initial_rsp, void* fini_callback) {
 
     // Initialize TCB at the top of the alternative stack.
     PAL_TCB_LINUX* tcb = alt_stack + ALT_STACK_SIZE - sizeof(PAL_TCB_LINUX);
-    pal_tcb_linux_init(tcb, first_thread, alt_stack, NULL, NULL);
+    pal_tcb_linux_init(tcb, first_thread, alt_stack, /*callback=*/NULL, /*param=*/NULL);
     ret = pal_thread_init(tcb);
     if (ret < 0)
         INIT_FAIL(unix_to_pal_error(-ret), "pal_thread_init() failed");

--- a/Pal/src/host/Linux/db_main.c
+++ b/Pal/src/host/Linux/db_main.c
@@ -211,12 +211,7 @@ noreturn void pal_linux_main(void* initial_rsp, void* fini_callback) {
 
     // Initialize TCB at the top of the alternative stack.
     PAL_TCB_LINUX* tcb = alt_stack + ALT_STACK_SIZE - sizeof(PAL_TCB_LINUX);
-    tcb->common.self = &tcb->common;
-    tcb->handle      = first_thread;
-    tcb->alt_stack   = alt_stack; // Stack bottom
-    tcb->callback    = NULL;
-    tcb->param       = NULL;
-
+    pal_tcb_linux_init(tcb, first_thread, alt_stack, NULL, NULL);
     ret = pal_thread_init(tcb);
     if (ret < 0)
         INIT_FAIL(unix_to_pal_error(-ret), "pal_thread_init() failed");

--- a/Pal/src/host/Linux/db_threading.c
+++ b/Pal/src/host/Linux/db_threading.c
@@ -89,7 +89,7 @@ __attribute__((__optimize__("-fno-stack-protector"))) int pal_thread_init(void* 
     /* we inherited the parent's GS register which we shouldn't use in the child thread, but GCC's
      * stack protector will look for a canary at gs:[0x8] in functions called below (e.g.,
      * _DkRandomBitsRead), so let's install a default canary in the child's TCB */
-    pal_set_tcb_stack_canary(tcb, STACK_PROTECTOR_CANARY_DEFAULT);
+    pal_tcb_set_stack_canary(&tcb->common, STACK_PROTECTOR_CANARY_DEFAULT);
     ret = pal_set_tcb(&tcb->common);
     if (IS_ERR(ret))
         return -ERRNO(ret);
@@ -100,7 +100,7 @@ __attribute__((__optimize__("-fno-stack-protector"))) int pal_thread_init(void* 
     if (IS_ERR(ret))
         return -EPERM;
 
-    pal_set_tcb_stack_canary(tcb, stack_protector_canary);
+    pal_tcb_set_stack_canary(&tcb->common, stack_protector_canary);
 
     if (tcb->alt_stack) {
         stack_t ss = {
@@ -160,7 +160,7 @@ int _DkThreadCreate(PAL_HANDLE* handle, int (*callback)(void*), const void* para
 
     // Initialize TCB at the top of the alternative stack.
     PAL_TCB_LINUX* tcb = child_stack + ALT_STACK_SIZE - sizeof(PAL_TCB_LINUX);
-    pal_tcb_linux_init(tcb, hdl, child_stack, callback, (void *)param);
+    pal_tcb_linux_init(tcb, hdl, child_stack, callback, (void*)param);
 
     /* align child_stack to 16 */
     child_stack = ALIGN_DOWN_PTR(child_stack, 16);

--- a/Pal/src/host/Linux/db_threading.c
+++ b/Pal/src/host/Linux/db_threading.c
@@ -160,11 +160,7 @@ int _DkThreadCreate(PAL_HANDLE* handle, int (*callback)(void*), const void* para
 
     // Initialize TCB at the top of the alternative stack.
     PAL_TCB_LINUX* tcb = child_stack + ALT_STACK_SIZE - sizeof(PAL_TCB_LINUX);
-    tcb->common.self = &tcb->common;
-    tcb->handle      = hdl;
-    tcb->alt_stack   = child_stack; // Stack bottom
-    tcb->callback    = callback;
-    tcb->param       = (void*)param;
+    pal_tcb_linux_init(tcb, hdl, child_stack, callback, (void *)param);
 
     /* align child_stack to 16 */
     child_stack = ALIGN_DOWN_PTR(child_stack, 16);

--- a/Pal/src/host/Linux/pal_linux.h
+++ b/Pal/src/host/Linux/pal_linux.h
@@ -170,13 +170,9 @@ static inline PAL_TCB_LINUX* get_tcb_linux(void) {
 }
 
 __attribute__((__optimize__("-fno-stack-protector")))
-static inline void pal_set_tcb_stack_canary(PAL_TCB_LINUX* tcbptr, uint64_t canary) {
+static inline void pal_tcb_set_stack_canary(PAL_TCB* tcb, uint64_t canary) {
     ((char*)&canary)[0] = 0; /* prevent C-string-based stack leaks from exposing the cookie */
-#ifdef __x86_64__
-    tcbptr->common.stack_protector_canary = canary;
-#else
-#error "unsupported architecture"
-#endif
+    pal_tcb_arch_set_stack_canary(tcb, canary);
 }
 
 #endif /* PAL_LINUX_H */

--- a/Pal/src/host/Linux/pal_linux.h
+++ b/Pal/src/host/Linux/pal_linux.h
@@ -156,6 +156,15 @@ typedef struct pal_tcb_linux {
 
 int pal_thread_init(void* tcbptr);
 
+static inline void pal_tcb_linux_init(PAL_TCB_LINUX* tcb, PAL_HANDLE handle, void* alt_stack,
+                                      int (*callback)(void*), void* param) {
+    tcb->common.self = &tcb->common;
+    tcb->handle      = handle;
+    tcb->alt_stack   = alt_stack; // Stack bottom
+    tcb->callback    = callback;
+    tcb->param       = param;
+}
+
 static inline PAL_TCB_LINUX* get_tcb_linux(void) {
     return (PAL_TCB_LINUX*)pal_get_tcb();
 }


### PR DESCRIPTION
This PR creates an inline function for initializing the pal_linux_tcb structure and an architecture-specific inline function for setting the stack canary. For the latter it turned out to be sufficient to use PAL_TCB, rather than PAL_LINUX_TCB, to also set the stack canary on the ppc64 port [On ppc64 the stack canary must be at the 2nd last 64 bit entry in the PAL_TCB structure, so at offset -0x10].

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2065)
<!-- Reviewable:end -->
