### PR TITLE
[LibOS] Disallow changing permissions of unnamed UNIX domain sockets

### DIFF
--- a/LibOS/shim/src/sys/shim_fs.c
+++ b/LibOS/shim/src/sys/shim_fs.c
@@ -205,6 +205,11 @@ long shim_do_fchmod(int fd, mode_t mode) {
     struct shim_dentry* dent = hdl->dentry;
     int ret = 0;
 
+    if (!dent) {
+        ret = -EINVAL;
+        goto out;
+    }
+
     if (dent->fs && dent->fs->d_ops && dent->fs->d_ops->chmod) {
         if ((ret = dent->fs->d_ops->chmod(dent, mode)) < 0)
             goto out;


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->
This patch fixes the unprotected NULL pointer access on dentry
when calling function shim_do_fchmod trying to modify the permissions
of an unnamed domain socket. The fchmod function will return EINVAL
error code according to BSD style in case of no existed dentry
associated with a domain socket FD.

Fixes #2066

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2070)
<!-- Reviewable:end -->
