### PR TITLE
[LibOS] Compile glibc on x86_64 with stack protector

### DIFF
--- a/LibOS/Makefile
+++ b/LibOS/Makefile
@@ -45,7 +45,7 @@ endif
 GLIBC_TARGET = $(addprefix $(BUILD_DIR)/, $(GLIBC_LIBS))
 GLIBC_RUNTIME = $(addprefix $(RUNTIME_DIR)/, $(notdir $(GLIBC_TARGET)))
 
-GLIBC_CFLAGS = -O2 -Wp,-U_FORTIFY_SOURCE -fno-stack-protector -Wno-unused-value
+GLIBC_CFLAGS = -O2 -Wp,-U_FORTIFY_SOURCE -Wno-unused-value
 ifeq ($(DEBUG),1)
 	GLIBC_CFLAGS += -g
 endif


### PR DESCRIPTION
This patch compiles glibc in x86_64 with the stack protector.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2073)
<!-- Reviewable:end -->
