### PR TITLE
New logging system

### DIFF
--- a/Documentation/devel/performance.rst
+++ b/Documentation/devel/performance.rst
@@ -370,7 +370,7 @@ particular, build Graphene in non-debug configuration (simple ``make SGX=1``
 defaults to non-debug configuration). Also build the application itself in
 non-debug configuration (again, typically simple ``make SGX=1`` is sufficient).
 Finally, disable the debug log of Graphene by specifying the manifest option
-``loader.debug_type = "none"``.
+``loader.log_level = "none"``.
 
 If your application periodically fails and complains about seemingly irrelevant
 things, it may be due to insufficient enclave memory. Please try to increase

--- a/Documentation/manifest-syntax.rst
+++ b/Documentation/manifest-syntax.rst
@@ -23,21 +23,21 @@ Comments can be inlined in a |~| manifest by starting them with a |~| hash sign
 Common syntax
 -------------
 
-Debug type
-^^^^^^^^^^
+Log level
+^^^^^^^^^
 
 ::
 
-    loader.debug_type = "[none|inline|file]"
-    (Default: "none")
+    loader.log_level = "[none|error|info|debug|trace|all]"
+    (Default: "error")
 
-    loader.debug_file = "[PATH]"
+    loader.log_file = "[PATH]"
 
-This specifies the debug option while running the library OS. If the debug type
-is ``none``, no debug output will be printed to standard output. If the debug
-type is ``inline``, a dmesg-like debug output will be printed inline with
-standard output. If the debug type is ``file``, debug output will be written to
-the file specified in ``loader.debug_file``.
+This configures Graphene's debug log. The ``log_level`` option specifies what
+messages to enable (e.g. ``loader.log_level = "debug"`` will enable all messages
+of type ``error``, ``info`` and ``debug``). By default, the messages are printed
+to the standard output. If ``log_file`` is specified, the messages will be
+appended to that file.
 
 Preloaded libraries
 ^^^^^^^^^^^^^^^^^^^

--- a/Examples/apache/Makefile
+++ b/Examples/apache/Makefile
@@ -32,9 +32,9 @@ GRAPHENEDIR ?= $(THIS_DIR)../..
 SGX_SIGNER_KEY ?= $(GRAPHENEDIR)/Pal/src/host/Linux-SGX/signer/enclave-key.pem
 
 ifeq ($(DEBUG),1)
-GRAPHENEDEBUG = inline
+GRAPHENE_LOG_LEVEL = debug
 else
-GRAPHENEDEBUG = none
+GRAPHENE_LOG_LEVEL = error
 endif
 
 .PHONY: all
@@ -116,7 +116,7 @@ httpd-trusted-libs: httpd-deps httpd-modules $(INSTALL_DIR)/bin/httpd
 
 httpd.manifest: httpd.manifest.template httpd-trusted-mods httpd-trusted-libs
 	sed -e 's|$$(GRAPHENEDIR)|'"$(GRAPHENEDIR)"'|g' \
-	    -e 's|$$(GRAPHENEDEBUG)|'"$(GRAPHENEDEBUG)"'|g' \
+	    -e 's|$$(GRAPHENE_LOG_LEVEL)|'"$(GRAPHENE_LOG_LEVEL)"'|g' \
 	    -e 's|$$(INSTALL_DIR)|'"$(INSTALL_DIR)"'|g' \
 	    -e 's|$$(INSTALL_DIR_ABSPATH)|'"$(abspath $(INSTALL_DIR))"'|g' \
 	    -e 's|$$(HTTPD_TRUSTED_MODS)|'"`cat httpd-trusted-mods`"'|g' \

--- a/Examples/apache/httpd.manifest.template
+++ b/Examples/apache/httpd.manifest.template
@@ -9,7 +9,7 @@ loader.argv0_override = "httpd"
 # Read application arguments directly from the command line. Don't use this on production!
 loader.insecure__use_cmdline_argv = 1
 
-loader.debug_type = "$(GRAPHENEDEBUG)"
+loader.log_level = "$(GRAPHENE_LOG_LEVEL)"
 
 # Environment variables
 loader.env.LD_LIBRARY_PATH = "/lib:$(ARCH_LIBDIR):/usr/lib:/usr/$(ARCH_LIBDIR)"

--- a/Examples/bash/Makefile
+++ b/Examples/bash/Makefile
@@ -12,9 +12,9 @@ GRAPHENEDIR ?= ../..
 SGX_SIGNER_KEY ?= $(GRAPHENEDIR)/Pal/src/host/Linux-SGX/signer/enclave-key.pem
 
 ifeq ($(DEBUG),1)
-GRAPHENEDEBUG = inline
+GRAPHENE_LOG_LEVEL = debug
 else
-GRAPHENEDEBUG = none
+GRAPHENE_LOG_LEVEL = error
 endif
 
 .PHONY: all
@@ -35,7 +35,7 @@ trusted-libs: ../common_tools/get_deps.sh
 
 bash.manifest: manifest.template trusted-libs
 	(sed -e 's|$$(GRAPHENEDIR)|'"$(GRAPHENEDIR)"'|g' \
-	     -e 's|$$(GRAPHENEDEBUG)|'"$(GRAPHENEDEBUG)"'|g' \
+	     -e 's|$$(GRAPHENE_LOG_LEVEL)|'"$(GRAPHENE_LOG_LEVEL)"'|g' \
 	     -e 's|$$(EXECDIR)|'"$(shell dirname $(shell which bash))"'|g' \
 	     -e 's|$$(ARCH_LIBDIR)|'"$(ARCH_LIBDIR)"'|g' \
 	     $<; \

--- a/Examples/bash/manifest.template
+++ b/Examples/bash/manifest.template
@@ -8,7 +8,7 @@ libos.entrypoint = "file:$(EXECDIR)/bash"
 # Read application arguments directly from the command line. Don't use this on production!
 loader.insecure__use_cmdline_argv = 1
 
-loader.debug_type = "$(GRAPHENEDEBUG)"
+loader.log_level = "$(GRAPHENE_LOG_LEVEL)"
 
 # Environment variables
 loader.env.LD_LIBRARY_PATH = "/lib:$(ARCH_LIBDIR):/usr$(ARCH_LIBDIR)"

--- a/Examples/blender/Makefile
+++ b/Examples/blender/Makefile
@@ -22,9 +22,9 @@ $(error This example requires Ubuntu 16.04, 18.04 or 20.04)
 endif
 
 ifeq ($(DEBUG),1)
-GRAPHENE_DEBUG = inline
+GRAPHENE_LOG_LEVEL = debug
 else
-GRAPHENE_DEBUG = none
+GRAPHENE_LOG_LEVEL = error
 endif
 
 
@@ -51,7 +51,7 @@ trusted-libs: ../common_tools/get_deps.sh $(BLENDER_DIR)/blender
 
 blender.manifest: blender.manifest.template trusted-libs | $(RUN_DIR)
 	(sed -e 's|$$(GRAPHENE_DIR)|'"$(GRAPHENE_DIR)"'|g' \
-	     -e 's|$$(GRAPHENE_DEBUG)|'"$(GRAPHENE_DEBUG)"'|g' \
+	     -e 's|$$(GRAPHENE_LOG_LEVEL)|'"$(GRAPHENE_LOG_LEVEL)"'|g' \
 	     -e 's|$$(DATA_DIR)|'"$(DATA_DIR)"'|g' \
 	     -e 's|$$(BLENDER_DIR)|'"$(BLENDER_DIR)"'|g' \
 	     -e 's|$$(BLENDER_VER)|'"$(BLENDER_VER)"'|g' \

--- a/Examples/blender/blender.manifest.template
+++ b/Examples/blender/blender.manifest.template
@@ -17,7 +17,7 @@ libos.entrypoint = "file:$(BLENDER_DIR)/blender"
 loader.insecure__use_cmdline_argv = 1
 
 loader.preload = "file:$(GRAPHENE_DIR)/Runtime/libsysdb.so"
-loader.debug_type = "$(GRAPHENE_DEBUG)"
+loader.log_level = "$(GRAPHENE_LOG_LEVEL)"
 
 loader.env.LD_LIBRARY_PATH = "/graphene_lib:/blender_lib:/usr/$(ARCH_LIBDIR):$(ARCH_LIBDIR)"
 loader.env.HOME = "/home/user"

--- a/Examples/busybox/Makefile
+++ b/Examples/busybox/Makefile
@@ -21,9 +21,9 @@ BUSYBOX_URL ?= https://busybox.net/downloads/busybox-1.32.0.tar.bz2
 BUSYBOX_SHA256 ?= c35d87f1d04b2b153d33c275c2632e40d388a88f19a9e71727e0bbbff51fe689
 
 ifeq ($(DEBUG),1)
-GRAPHENEDEBUG = inline
+GRAPHENE_LOG_LEVEL = debug
 else
-GRAPHENEDEBUG = none
+GRAPHENE_LOG_LEVEL = error
 endif
 
 
@@ -69,7 +69,7 @@ $(SRCDIR)/busybox: $(SRCDIR)/.config
 
 busybox.manifest: busybox.manifest.template
 	sed -e 's|$$(GRAPHENEDIR)|'"$(GRAPHENEDIR)"'|g' \
-		-e 's|$$(GRAPHENEDEBUG)|'"$(GRAPHENEDEBUG)"'|g' \
+		-e 's|$$(GRAPHENE_LOG_LEVEL)|'"$(GRAPHENE_LOG_LEVEL)"'|g' \
 		-e 's|$$(ARCH_LIBDIR)|'"$(ARCH_LIBDIR)"'|g' \
 		$< > $@
 

--- a/Examples/busybox/busybox.manifest.template
+++ b/Examples/busybox/busybox.manifest.template
@@ -16,10 +16,11 @@ loader.insecure__use_cmdline_argv = 1
 # build process.
 loader.preload = "file:$(GRAPHENEDIR)/Runtime/libsysdb.so"
 
-# Show/hide debug log of Graphene ('inline' or 'none' respectively). Note that
-# GRAPHENEDEBUG macro is expanded to inline/none in the Makefile as part of the
-# build process.
-loader.debug_type = "$(GRAPHENEDEBUG)"
+# Verbosity of Graphene debug log (none/error/info/debug/trace/all). Note that
+# GRAPHENE_LOG_LEVEL macro is expanded in the Makefile as part of the building
+# process: the default is "error" for non-debug builds, and "debug" for debug
+# builds.
+loader.log_level = "$(GRAPHENE_LOG_LEVEL)"
 
 ################################# ENV VARS  ###################################
 

--- a/Examples/capnproto/Makefile
+++ b/Examples/capnproto/Makefile
@@ -25,9 +25,9 @@ ADDRESSBOOK_CAP_URL    ?= $(CAPNPROTO_SRC_URL)/c%2B%2B/samples/addressbook.capnp
 ADDRESSBOOK_CAP_SHA256 ?= cf309b8b277881c95aaa785f4d0154f46f82575fdb9dea49fb10ee072b7c3ae6
 
 ifeq ($(DEBUG),1)
-GRAPHENEDEBUG = inline
+GRAPHENE_LOG_LEVEL = debug
 else
-GRAPHENEDEBUG = none
+GRAPHENE_LOG_LEVEL = error
 endif
 
 .PHONY: all
@@ -63,7 +63,7 @@ trusted-libs: ../common_tools/get_deps.sh $(SRCDIR)/addressbook
 
 addressbook.manifest: addressbook.manifest.template trusted-libs
 	(sed -e 's|$$(GRAPHENEDIR)|'"$(GRAPHENEDIR)"'|g' \
-		-e 's|$$(GRAPHENEDEBUG)|'"$(GRAPHENEDEBUG)"'|g' \
+		-e 's|$$(GRAPHENE_LOG_LEVEL)|'"$(GRAPHENE_LOG_LEVEL)"'|g' \
 		-e 's|$$(ARCH_LIBDIR)|'"$(ARCH_LIBDIR)"'|g' \
 		$<; \
 	cat trusted-libs) > $@

--- a/Examples/capnproto/addressbook.manifest.template
+++ b/Examples/capnproto/addressbook.manifest.template
@@ -8,8 +8,8 @@ libos.entrypoint = "file:addressbook"
 # LibOS layer library of Graphene (currently only one implementation, libsysdb)
 loader.preload = "file:$(GRAPHENEDIR)/Runtime/libsysdb.so"
 
-# Show/hide debug log of Graphene ('inline' or 'none' respectively)
-loader.debug_type = "$(GRAPHENEDEBUG)"
+# Graphene log level
+loader.log_level = "$(GRAPHENE_LOG_LEVEL)"
 
 # Read application arguments directly from the command line. Don't use this on production!
 loader.insecure__use_cmdline_argv = 1

--- a/Examples/curl/Makefile
+++ b/Examples/curl/Makefile
@@ -15,9 +15,9 @@ GRAPHENEDIR ?= ../..
 SGX_SIGNER_KEY ?= $(GRAPHENEDIR)/Pal/src/host/Linux-SGX/signer/enclave-key.pem
 
 ifeq ($(DEBUG),1)
-GRAPHENEDEBUG = inline
+GRAPHENE_LOG_LEVEL = debug
 else
-GRAPHENEDEBUG = none
+GRAPHENE_LOG_LEVEL = error
 endif
 
 .PHONY: all
@@ -37,7 +37,7 @@ trusted-libs: ../common_tools/get_deps.sh
 
 curl.manifest: curl.manifest.template trusted-libs
 	(sed -e 's|$$(GRAPHENEDIR)|'"$(GRAPHENEDIR)"'|g' \
-	     -e 's|$$(GRAPHENEDEBUG)|'"$(GRAPHENEDEBUG)"'|g' \
+	     -e 's|$$(GRAPHENE_LOG_LEVEL)|'"$(GRAPHENE_LOG_LEVEL)"'|g' \
 	     -e 's|$$(CURL_DIR)|'"$(CURL_DIR)"'|g' \
 	     -e 's|$$(ARCH_LIBDIR)|'"$(ARCH_LIBDIR)"'|g' \
 	     $<; \

--- a/Examples/curl/curl.manifest.template
+++ b/Examples/curl/curl.manifest.template
@@ -9,8 +9,8 @@ loader.argv0_override = "curl"
 # so it is always set to libsysdb.so. 
 loader.preload = "file:$(GRAPHENEDIR)/Runtime/libsysdb.so"
 
-# Show/hide debug log of Graphene ('inline' or 'none' respectively).
-loader.debug_type = "$(GRAPHENEDEBUG)"
+# Graphene log level
+loader.log_level = "$(GRAPHENE_LOG_LEVEL)"
 
 # Read application arguments directly from the command line. Don't use this on production!
 loader.insecure__use_cmdline_argv = 1

--- a/Examples/gcc/Makefile
+++ b/Examples/gcc/Makefile
@@ -11,9 +11,9 @@ GZIP_MIRRORS ?= https://people.csail.mit.edu/smcc/projects/single-file-programs/
 GZIP_HASH ?= 7ec7d87822e6497648580064756f64e47dbd085727910ebbc52a7c240a88dc27
 
 ifeq ($(DEBUG),1)
-GRAPHENEDEBUG = inline
+GRAPHENE_LOG_LEVEL = debug
 else
-GRAPHENEDEBUG = none
+GRAPHENE_LOG_LEVEL = error
 endif
 
 include ../../Scripts/Makefile.configs
@@ -43,7 +43,7 @@ trusted-libs: ../common_tools/get_deps.sh
 
 %.manifest: %.manifest.template trusted-libs
 	(sed -e 's|$$(GRAPHENEDIR)|'"$(GRAPHENEDIR)"'|g' \
-		-e 's|$$(GRAPHENEDEBUG)|'"$(GRAPHENEDEBUG)"'|g' \
+		-e 's|$$(GRAPHENE_LOG_LEVEL)|'"$(GRAPHENE_LOG_LEVEL)"'|g' \
 		-e 's|$$(BINUTILS_VERSION)|'"$(BINUTILS_VERSION)"'|g' \
 		-e 's|$$(GCC_MAJOR_VERSION)|'"$(GCC_MAJOR_VERSION)"'|g' \
 		-e 's|$$(GCC_LIB_PATH)|'"$(GCC_LIB_PATH)"'|g' \

--- a/Examples/gcc/gcc.manifest.template
+++ b/Examples/gcc/gcc.manifest.template
@@ -1,7 +1,7 @@
 loader.preload = "file:$(GRAPHENEDIR)/Runtime/libsysdb.so"
 loader.env.LD_LIBRARY_PATH = "/lib:$(ARCH_LIBDIR):/usr/lib:/usr/$(ARCH_LIBDIR)"
 loader.env.PATH = "/bin:/usr/bin"
-loader.debug_type = "$(GRAPHENEDEBUG)"
+loader.log_level = "$(GRAPHENE_LOG_LEVEL)"
 libos.entrypoint = "file:/usr/bin/gcc"
 
 # Read application arguments directly from the command line. Don't use this on production!

--- a/Examples/lighttpd/Makefile
+++ b/Examples/lighttpd/Makefile
@@ -17,9 +17,9 @@ GRAPHENEDIR ?= $(THIS_DIR)../..
 SGX_SIGNER_KEY ?= $(GRAPHENEDIR)/Pal/src/host/Linux-SGX/signer/enclave-key.pem
 
 ifeq ($(DEBUG),1)
-GRAPHENEDEBUG = inline
+GRAPHENE_LOG_LEVEL = debug
 else
-GRAPHENEDEBUG = none
+GRAPHENE_LOG_LEVEL = error
 endif
 
 CONF_FILES = lighttpd-server.conf lighttpd.conf
@@ -62,7 +62,7 @@ trusted-libs: ../common_tools/get_deps.sh $(INSTALL_DIR)/sbin/lighttpd
 
 lighttpd.manifest: lighttpd.manifest.template trusted-libs
 	(sed -e 's|$$(GRAPHENEDIR)|'"$(GRAPHENEDIR)"'|g' \
-	     -e 's|$$(GRAPHENEDEBUG)|'"$(GRAPHENEDEBUG)"'|g' \
+	     -e 's|$$(GRAPHENE_LOG_LEVEL)|'"$(GRAPHENE_LOG_LEVEL)"'|g' \
 	     -e 's|$$(INSTALL_DIR)|'"$(INSTALL_DIR)"'|g' \
 	     -e 's|$$(INSTALL_DIR_ABSPATH)|'"$(abspath $(INSTALL_DIR))"'|g' \
 	     -e 's|$$(ARCH_LIBDIR)|'"$(ARCH_LIBDIR)"'|g' \

--- a/Examples/lighttpd/lighttpd.manifest.template
+++ b/Examples/lighttpd/lighttpd.manifest.template
@@ -8,10 +8,11 @@
 
 libos.entrypoint = "file:$(INSTALL_DIR)/sbin/lighttpd"
 
-# Graphene environment, including the path of the library OS and the debug
-# option (inline/none).
+# Path to the library OS
 loader.preload = "file:$(GRAPHENEDIR)/Runtime/libsysdb.so"
-loader.debug_type = "$(GRAPHENEDEBUG)"
+
+# Graphene log level
+loader.log_level = "$(GRAPHENE_LOG_LEVEL)"
 
 # Read application arguments directly from the command line. Don't use this on production!
 loader.insecure__use_cmdline_argv = 1

--- a/Examples/memcached/Makefile
+++ b/Examples/memcached/Makefile
@@ -28,9 +28,9 @@ $(error This example requires Ubuntu 16.04 or 18.04)
 endif
 
 ifeq ($(DEBUG),1)
-GRAPHENEDEBUG = inline
+GRAPHENE_LOG_LEVEL = debug
 else
-GRAPHENEDEBUG = none
+GRAPHENE_LOG_LEVEL = error
 endif
 
 .PHONY: all
@@ -65,7 +65,7 @@ $(SRCDIR)/memcached: $(SRCDIR)/configure
 
 memcached.manifest: memcached.manifest.template
 	sed -e 's|$$(GRAPHENEDIR)|'"$(GRAPHENEDIR)"'|g' \
-		-e 's|$$(GRAPHENEDEBUG)|'"$(GRAPHENEDEBUG)"'|g' \
+		-e 's|$$(GRAPHENE_LOG_LEVEL)|'"$(GRAPHENE_LOG_LEVEL)"'|g' \
 		-e 's|$$(ARCH_LIBDIR)|'"$(ARCH_LIBDIR)"'|g' \
 		-e 's|# \['"$(UBUNTU_VER)"'\] ||g' \
 		$< > $@

--- a/Examples/memcached/memcached.manifest.template
+++ b/Examples/memcached/memcached.manifest.template
@@ -26,10 +26,11 @@ loader.preload = "file:$(GRAPHENEDIR)/Runtime/libsysdb.so"
 # Binary to run.
 libos.entrypoint = "file:memcached"
 
-# Show/hide debug log of Graphene ("inline" or "none" respectively). Note that
-# GRAPHENEDEBUG macro is expanded to inline/none in the Makefile as part of the
-# build process.
-loader.debug_type = "$(GRAPHENEDEBUG)"
+# Verbosity of Graphene debug log (none/error/info/debug/trace/all). Note that
+# GRAPHENE_LOG_LEVEL macro is expanded in the Makefile as part of the building
+# process: the default is "error" for non-debug builds, and "debug" for debug
+# builds.
+loader.log_level = "$(GRAPHENE_LOG_LEVEL)"
 
 ################################# ARGUMENTS ###################################
 

--- a/Examples/nginx/Makefile
+++ b/Examples/nginx/Makefile
@@ -30,9 +30,9 @@ GRAPHENEDIR ?= $(THIS_DIR)../..
 SGX_SIGNER_KEY ?= $(GRAPHENEDIR)/Pal/src/host/Linux-SGX/signer/enclave-key.pem
 
 ifeq ($(DEBUG),1)
-GRAPHENEDEBUG = inline
+GRAPHENE_LOG_LEVEL = debug
 else
-GRAPHENEDEBUG = none
+GRAPHENE_LOG_LEVEL = error
 endif
 
 .PHONY: all
@@ -72,7 +72,7 @@ trusted-libs: ../common_tools/get_deps.sh $(INSTALL_DIR)/sbin/nginx
 
 nginx.manifest: nginx.manifest.template trusted-libs
 	(sed -e 's|$$(GRAPHENEDIR)|'"$(GRAPHENEDIR)"'|g' \
-	     -e 's|$$(GRAPHENEDEBUG)|'"$(GRAPHENEDEBUG)"'|g' \
+	     -e 's|$$(GRAPHENE_LOG_LEVEL)|'"$(GRAPHENE_LOG_LEVEL)"'|g' \
 	     -e 's|$$(INSTALL_DIR)|'"$(INSTALL_DIR)"'|g' \
 	     -e 's|$$(INSTALL_DIR_ABSPATH)|'"$(abspath $(INSTALL_DIR))"'|g' \
 	     -e 's|$$(ARCH_LIBDIR)|'"$(ARCH_LIBDIR)"'|g' \

--- a/Examples/nginx/nginx.manifest.template
+++ b/Examples/nginx/nginx.manifest.template
@@ -4,10 +4,11 @@
 
 libos.entrypoint = "file:$(INSTALL_DIR)/sbin/nginx"
 
-# Graphene environment, including the path to the library OS and the debug
-# option (inline/none).
+# Path to the library OS
 loader.preload = "file:$(GRAPHENEDIR)/Runtime/libsysdb.so"
-loader.debug_type = "$(GRAPHENEDEBUG)"
+
+# Graphene log level
+loader.log_level = "$(GRAPHENE_LOG_LEVEL)"
 
 # Read application arguments directly from the command line. Don't use this on production!
 loader.insecure__use_cmdline_argv = 1

--- a/Examples/nodejs-express-server/Makefile
+++ b/Examples/nodejs-express-server/Makefile
@@ -15,9 +15,9 @@ GRAPHENEDIR ?= ../..
 SGX_SIGNER_KEY ?= $(GRAPHENEDIR)/Pal/src/host/Linux-SGX/signer/enclave-key.pem
 
 ifeq ($(DEBUG),1)
-GRAPHENEDEBUG = inline
+GRAPHENE_LOG_LEVEL = debug
 else
-GRAPHENEDEBUG = none
+GRAPHENE_LOG_LEVEL = error
 endif
 
 .PHONY: all
@@ -37,7 +37,7 @@ trusted-libs: ../common_tools/get_deps.sh
 
 nodejs.manifest: nodejs.manifest.template trusted-libs
 	(sed -e 's|$$(GRAPHENEDIR)|'"$(GRAPHENEDIR)"'|g' \
-	     -e 's|$$(GRAPHENEDEBUG)|'"$(GRAPHENEDEBUG)"'|g' \
+	     -e 's|$$(GRAPHENE_LOG_LEVEL)|'"$(GRAPHENE_LOG_LEVEL)"'|g' \
 	     -e 's|$$(NODEJS_DIR)|'"$(NODEJS_DIR)"'|g' \
 	     -e 's|$$(ARCH_LIBDIR)|'"$(ARCH_LIBDIR)"'|g' \
 	     $<; \

--- a/Examples/nodejs-express-server/nodejs.manifest.template
+++ b/Examples/nodejs-express-server/nodejs.manifest.template
@@ -8,8 +8,8 @@ libos.entrypoint = "file:$(NODEJS_DIR)/nodejs"
 # to libsysdb.so.
 loader.preload = "file:$(GRAPHENEDIR)/Runtime/libsysdb.so"
 
-# Show/hide debug log of Graphene ('inline' or 'none' respectively).
-loader.debug_type = "$(GRAPHENEDEBUG)"
+# Graphene log level
+loader.log_level = "$(GRAPHENE_LOG_LEVEL)"
 
 # Read application arguments directly from the command line. Don't use this on production!
 loader.insecure__use_cmdline_argv = 1

--- a/Examples/nodejs/Makefile
+++ b/Examples/nodejs/Makefile
@@ -15,9 +15,9 @@ GRAPHENEDIR ?= ../..
 SGX_SIGNER_KEY ?= $(GRAPHENEDIR)/Pal/src/host/Linux-SGX/signer/enclave-key.pem
 
 ifeq ($(DEBUG),1)
-GRAPHENEDEBUG = inline
+GRAPHENE_LOG_LEVEL = debug
 else
-GRAPHENEDEBUG = none
+GRAPHENE_LOG_LEVEL = error
 endif
 
 .PHONY: all
@@ -37,7 +37,7 @@ trusted-libs: ../common_tools/get_deps.sh
 
 nodejs.manifest: nodejs.manifest.template trusted-libs
 	(sed -e 's|$$(GRAPHENEDIR)|'"$(GRAPHENEDIR)"'|g' \
-	     -e 's|$$(GRAPHENEDEBUG)|'"$(GRAPHENEDEBUG)"'|g' \
+	     -e 's|$$(GRAPHENE_LOG_LEVEL)|'"$(GRAPHENE_LOG_LEVEL)"'|g' \
 	     -e 's|$$(NODEJS_DIR)|'"$(NODEJS_DIR)"'|g' \
 	     -e 's|$$(ARCH_LIBDIR)|'"$(ARCH_LIBDIR)"'|g' \
 	     $<; \

--- a/Examples/nodejs/nodejs.manifest.template
+++ b/Examples/nodejs/nodejs.manifest.template
@@ -8,8 +8,8 @@ libos.entrypoint = "file:$(NODEJS_DIR)/nodejs"
 # so it is always set to libsysdb.so.
 loader.preload = "file:$(GRAPHENEDIR)/Runtime/libsysdb.so"
 
-# Show/hide debug log of Graphene ('inline' or 'none' respectively).
-loader.debug_type = "$(GRAPHENEDEBUG)"
+# Graphene log level
+loader.log_level = "$(GRAPHENE_LOG_LEVEL)"
 
 # Read application arguments directly from the command line. Don't use this on production!
 loader.insecure__use_cmdline_argv = 1

--- a/Examples/openvino/Makefile
+++ b/Examples/openvino/Makefile
@@ -23,10 +23,10 @@ GRAPHENE_DIR ?= ../..
 SGX_SIGNER_KEY ?= $(GRAPHENE_DIR)/Pal/src/host/Linux-SGX/signer/enclave-key.pem
 
 ifeq ($(DEBUG),1)
-GRAPHENE_DEBUG = inline
+GRAPHENE_LOG_LEVEL = debug
 OPENVINO_BUILD = Debug
 else
-GRAPHENE_DEBUG = none
+GRAPHENE_LOG_LEVEL = error
 OPENVINO_BUILD = Release
 endif
 
@@ -64,7 +64,7 @@ $(OPENVINO_DIR)/inference-engine/bin/intel64/$(OPENVINO_BUILD)/object_detection_
 
 object_detection_sample_ssd.manifest: object_detection_sample_ssd.manifest.template
 	sed -e 's|$$(GRAPHENE_DIR)|'"$(GRAPHENE_DIR)"'|g' \
-	    -e 's|$$(GRAPHENE_DEBUG)|'"$(GRAPHENE_DEBUG)"'|g' \
+	    -e 's|$$(GRAPHENE_LOG_LEVEL)|'"$(GRAPHENE_LOG_LEVEL)"'|g' \
 	    -e 's|$$(OPENVINO_DIR)|'"$(OPENVINO_DIR)"'|g' \
 	    -e 's|$$(OPENVINO_DIR_ABSPATH)|'"$(abspath $(OPENVINO_DIR))"'|g' \
 	    -e 's|$$(MODEL_DIR)|'"$(MODEL_DIR)"'|g' \

--- a/Examples/openvino/object_detection_sample_ssd.manifest.template
+++ b/Examples/openvino/object_detection_sample_ssd.manifest.template
@@ -4,10 +4,11 @@
 
 libos.entrypoint = "file:$(OPENVINO_DIR)/bin/intel64/$(OPENVINO_BUILD)/object_detection_sample_ssd"
 
-# Graphene environment, including the path to the library OS and the debug
-# option (inline/none).
+# Path to the library OS
 loader.preload = "file:$(GRAPHENE_DIR)/Runtime/libsysdb.so"
-loader.debug_type = "$(GRAPHENE_DEBUG)"
+
+# Graphene log level
+loader.log_level = "$(GRAPHENE_LOG_LEVEL)"
 
 # Read application arguments directly from the command line. Don't use this on production!
 loader.insecure__use_cmdline_argv = 1

--- a/Examples/python-scipy-insecure/Makefile
+++ b/Examples/python-scipy-insecure/Makefile
@@ -17,9 +17,9 @@ GRAPHENEDIR ?= ../..
 SGX_SIGNER_KEY ?= $(GRAPHENEDIR)/Pal/src/host/Linux-SGX/signer/enclave-key.pem
 
 ifeq ($(DEBUG),1)
-GRAPHENEDEBUG = inline
+GRAPHENE_LOG_LEVEL = debug
 else
-GRAPHENEDEBUG = none
+GRAPHENE_LOG_LEVEL = error
 endif
 
 UBUNTU_VER = $(shell lsb_release --short --id)$(shell lsb_release --short --release)
@@ -47,7 +47,7 @@ trusted-libs: ../common_tools/get_deps.sh
 
 python.manifest: python.manifest.template trusted-libs
 	(sed -e 's|$$(GRAPHENEDIR)|'"$(GRAPHENEDIR)"'|g' \
-	     -e 's|$$(GRAPHENEDEBUG)|'"$(GRAPHENEDEBUG)"'|g' \
+	     -e 's|$$(GRAPHENE_LOG_LEVEL)|'"$(GRAPHENE_LOG_LEVEL)"'|g' \
 	     -e 's|$$(PYTHONDISTHOME)|'"$(PYTHONDISTHOME)"'|g' \
 	     -e 's|$$(PYTHONHOME)|'"$(PYTHONHOME)"'|g' \
 	     -e 's|$$(PYTHONEXEC)|'"$(PYTHONEXEC)"'|g' \

--- a/Examples/python-scipy-insecure/python.manifest.template
+++ b/Examples/python-scipy-insecure/python.manifest.template
@@ -4,10 +4,11 @@
 
 libos.entrypoint = "file:$(PYTHONEXEC)"
 
-# Graphene environment, including the path of the library OS and the debug
-# option (inline/none).
+# Path to the library OS
 loader.preload = "file:$(GRAPHENEDIR)/Runtime/libsysdb.so"
-loader.debug_type = "$(GRAPHENEDEBUG)"
+
+# Graphene log level
+loader.log_level = "$(GRAPHENE_LOG_LEVEL)"
 
 # Read application arguments directly from the command line. Don't use this on production!
 loader.insecure__use_cmdline_argv = 1

--- a/Examples/python-simple/Makefile
+++ b/Examples/python-simple/Makefile
@@ -17,9 +17,9 @@ GRAPHENEDIR ?= ../..
 SGX_SIGNER_KEY ?= $(GRAPHENEDIR)/Pal/src/host/Linux-SGX/signer/enclave-key.pem
 
 ifeq ($(DEBUG),1)
-GRAPHENEDEBUG = inline
+GRAPHENE_LOG_LEVEL = debug
 else
-GRAPHENEDEBUG = none
+GRAPHENE_LOG_LEVEL = error
 endif
 
 UBUNTU_VER = $(shell lsb_release --short --id)$(shell lsb_release --short --release)
@@ -59,7 +59,7 @@ trusted-libs: ../common_tools/get_deps.sh
 
 python.manifest: python.manifest.template trusted-libs
 	(sed -e 's|$$(GRAPHENEDIR)|'"$(GRAPHENEDIR)"'|g' \
-	     -e 's|$$(GRAPHENEDEBUG)|'"$(GRAPHENEDEBUG)"'|g' \
+	     -e 's|$$(GRAPHENE_LOG_LEVEL)|'"$(GRAPHENE_LOG_LEVEL)"'|g' \
 	     -e 's|$$(PYTHONDISTHOME)|'"$(PYTHONDISTHOME)"'|g' \
 	     -e 's|$$(PYTHONHOME)|'"$(PYTHONHOME)"'|g' \
 	     -e 's|$$(PYTHONEXEC)|'"$(PYTHONEXEC)"'|g' \

--- a/Examples/python-simple/python.manifest.template
+++ b/Examples/python-simple/python.manifest.template
@@ -3,11 +3,13 @@
 # This manifest was prepared and tested on Ubuntu 16.04/18.04 and tested with
 # Python 3.5 and 3.6.
 
-# Graphene environment, including the path of the library OS and the debug
-# option (inline/none).
-loader.preload = "file:$(GRAPHENEDIR)/Runtime/libsysdb.so"
 libos.entrypoint = "file:$(PYTHONEXEC)"
-loader.debug_type = "$(GRAPHENEDEBUG)"
+
+# Path to the library OS
+loader.preload = "file:$(GRAPHENEDIR)/Runtime/libsysdb.so"
+
+# Graphene log level
+loader.log_level = "$(GRAPHENE_LOG_LEVEL)"
 
 # Read application arguments directly from the command line. Don't use this on production!
 loader.insecure__use_cmdline_argv = 1

--- a/Examples/pytorch/Makefile
+++ b/Examples/pytorch/Makefile
@@ -14,9 +14,9 @@ SGX_SIGNER_KEY ?= $(GRAPHENEDIR)/Pal/src/host/Linux-SGX/signer/enclave-key.pem
 PYTHON3 ?= /usr/bin/python3
 
 ifeq ($(DEBUG),1)
-GRAPHENEDEBUG = inline
+GRAPHENE_LOG_LEVEL = debug
 else
-GRAPHENEDEBUG = none
+GRAPHENE_LOG_LEVEL = error
 endif
 
 DISTRIB_ID ?= $(shell lsb_release --short --id)
@@ -42,7 +42,7 @@ include ../../Scripts/Makefile.configs
 # those lines based on the Ubuntu version detected.
 %.manifest: %.manifest.template
 	sed -e 's|$$(GRAPHENEDIR)|'"$(GRAPHENEDIR)"'|g' \
-		-e 's|$$(GRAPHENEDEBUG)|'"$(GRAPHENEDEBUG)"'|g' \
+		-e 's|$$(GRAPHENE_LOG_LEVEL)|'"$(GRAPHENE_LOG_LEVEL)"'|g' \
 		-e 's|$$(HOME)|'"$(HOME)"'|g' \
 		-e 's|$$(PYTHON3)|'"$(PYTHON3)"'|g' \
 		-e 's|# '"$(UBUNTU_VERSION)"' ||g' \

--- a/Examples/pytorch/pytorch.manifest.template
+++ b/Examples/pytorch/pytorch.manifest.template
@@ -2,11 +2,13 @@
 #
 # This manifest was tested on Ubuntu 16.04 and 18.04.
 
-# Graphene environment, including the path to the library OS and the debug
-# option (inline/none)
-loader.preload = "file:$(GRAPHENEDIR)/Runtime/libsysdb.so"
 libos.entrypoint = "file:$(PYTHON3)"
-loader.debug_type = "$(GRAPHENEDEBUG)"
+
+# Path to the library OS
+loader.preload = "file:$(GRAPHENEDIR)/Runtime/libsysdb.so"
+
+# Graphene log level
+loader.log_level = "$(GRAPHENE_LOG_LEVEL)"
 
 # Read application arguments directly from the command line. Don't use this on production!
 loader.insecure__use_cmdline_argv = 1

--- a/Examples/r/Makefile
+++ b/Examples/r/Makefile
@@ -18,9 +18,9 @@ GRAPHENEDIR ?= ../..
 SGX_SIGNER_KEY ?= $(GRAPHENEDIR)/Pal/src/host/Linux-SGX/signer/enclave-key.pem
 
 ifeq ($(DEBUG),1)
-GRAPHENEDEBUG = inline
+GRAPHENE_LOG_LEVEL = debug
 else
-GRAPHENEDEBUG = none
+GRAPHENE_LOG_LEVEL = error
 endif
 
 LD_LIBRARY_PATH := $(LD_LIBRARY_PATH):$(R_HOME)/lib
@@ -44,7 +44,7 @@ trusted-libs: ../common_tools/get_deps.sh
 
 R.manifest: R.manifest.template trusted-libs
 	(sed -e 's|$$(GRAPHENEDIR)|'"$(GRAPHENEDIR)"'|g' \
-	     -e 's|$$(GRAPHENEDEBUG)|'"$(GRAPHENEDEBUG)"'|g' \
+	     -e 's|$$(GRAPHENE_LOG_LEVEL)|'"$(GRAPHENE_LOG_LEVEL)"'|g' \
 	     -e 's|$$(R_HOME)|'"$(R_HOME)"'|g' \
 	     -e 's|$$(R_EXEC)|'"$(R_EXEC)"'|g' \
 	     -e 's|$$(ARCH_LIBDIR)|'"$(ARCH_LIBDIR)"'|g' \

--- a/Examples/r/R.manifest.template
+++ b/Examples/r/R.manifest.template
@@ -2,10 +2,13 @@
 #
 # This manifest was prepared and tested on Ubuntu 16.04.
 
-# Graphene environment, including the path of the library OS and the debug option (inline/none).
-loader.preload = "file:$(GRAPHENEDIR)/Runtime/libsysdb.so"
 libos.entrypoint = "file:$(R_EXEC)"
-loader.debug_type = "$(GRAPHENEDEBUG)"
+
+# Path to the library OS
+loader.preload = "file:$(GRAPHENEDIR)/Runtime/libsysdb.so"
+
+# Graphene log level
+loader.log_level = "$(GRAPHENE_LOG_LEVEL)"
 
 # Read application arguments directly from the command line. Don't use this on production!
 loader.insecure__use_cmdline_argv = 1

--- a/Examples/ra-tls-mbedtls/Makefile
+++ b/Examples/ra-tls-mbedtls/Makefile
@@ -22,10 +22,10 @@ RA_CLIENT_SPID ?=
 RA_CLIENT_LINKABLE ?= 0
 
 ifeq ($(DEBUG),1)
-GRAPHENEDEBUG=inline
+GRAPHENE_LOG_LEVEL = debug
 CFLAGS += -O0 -ggdb3
 else
-GRAPHENEDEBUG=none
+GRAPHENE_LOG_LEVEL = error
 CFLAGS += -O2
 endif
 
@@ -127,7 +127,7 @@ libra_tls_verify_dcap_graphene.so: libmbedcrypto.so libmbedx509.so libsgx_util.s
 
 server.manifest: server.manifest.template
 	sed -e 's|$$(GRAPHENEDIR)|'"$(GRAPHENEDIR)"'|g' \
-		-e 's|$$(GRAPHENEDEBUG)|'"$(GRAPHENEDEBUG)"'|g' \
+		-e 's|$$(GRAPHENE_LOG_LEVEL)|'"$(GRAPHENE_LOG_LEVEL)"'|g' \
 		-e 's|$$(RA_CLIENT_SPID)|'"$(RA_CLIENT_SPID)"'|g' \
 		-e 's|$$(RA_CLIENT_LINKABLE)|'"$(RA_CLIENT_LINKABLE)"'|g' \
 		$< > $@
@@ -155,7 +155,7 @@ client-dcap-trusted-libs: ../common_tools/get_deps.sh client libra_tls_verify_dc
 
 client_dcap.manifest: client.manifest.template client-dcap-trusted-libs
 	(sed -e 's|$$(GRAPHENEDIR)|'"$(GRAPHENEDIR)"'|g' \
-	    -e 's|$$(GRAPHENEDEBUG)|'"$(GRAPHENEDEBUG)"'|g' \
+	    -e 's|$$(GRAPHENE_LOG_LEVEL)|'"$(GRAPHENE_LOG_LEVEL)"'|g' \
 	    -e 's|$$(ARCH_LIBDIR)|'"$(ARCH_LIBDIR)"'|g' \
 	    $<; \
 	cat client-dcap-trusted-libs) > $@
@@ -184,7 +184,7 @@ client-epid-trusted-libs: ../common_tools/get_deps.sh $(CLIENT_EPID_LIBS)
 
 client_epid.manifest: client.manifest.template client-epid-trusted-libs
 	(sed -e 's|$$(GRAPHENEDIR)|'"$(GRAPHENEDIR)"'|g' \
-	     -e 's|$$(GRAPHENEDEBUG)|'"$(GRAPHENEDEBUG)"'|g' \
+	     -e 's|$$(GRAPHENE_LOG_LEVEL)|'"$(GRAPHENE_LOG_LEVEL)"'|g' \
 	     -e 's|$$(RA_TLS_VERIFY_LIB)|'"libra_tls_verify_epid.so"'|g' \
 	     -e 's|$$(ARCH_LIBDIR)|'"$(ARCH_LIBDIR)"'|g' \
 	     $<; \

--- a/Examples/ra-tls-mbedtls/client.manifest.template
+++ b/Examples/ra-tls-mbedtls/client.manifest.template
@@ -8,8 +8,8 @@ libos.entrypoint = "file:client"
 # so it is always set to libsysdb.so.
 loader.preload = "file:$(GRAPHENEDIR)/Runtime/libsysdb.so"
 
-# Show/hide debug log of Graphene ('inline' or 'none' respectively).
-loader.debug_type = "$(GRAPHENEDEBUG)"
+# Graphene log level
+loader.log_level = "$(GRAPHENE_LOG_LEVEL)"
 
 # Read application arguments directly from the command line. Don't use this on production!
 loader.insecure__use_cmdline_argv = 1

--- a/Examples/ra-tls-mbedtls/server.manifest.template
+++ b/Examples/ra-tls-mbedtls/server.manifest.template
@@ -4,7 +4,7 @@
 
 loader.preload = "file:$(GRAPHENEDIR)/Runtime/libsysdb.so"
 libos.entrypoint = "file:server"
-loader.debug_type = "$(GRAPHENEDEBUG)"
+loader.log_level = "$(GRAPHENE_LOG_LEVEL)"
 
 loader.env.LD_LIBRARY_PATH = "/lib:/lib/x86_64-linux-gnu"
 

--- a/Examples/ra-tls-secret-prov/Makefile
+++ b/Examples/ra-tls-secret-prov/Makefile
@@ -20,10 +20,10 @@ RA_CLIENT_SPID ?=
 RA_CLIENT_LINKABLE ?= 0
 
 ifeq ($(DEBUG),1)
-GRAPHENEDEBUG=inline
+GRAPHENE_LOG_LEVEL = debug
 CFLAGS += -O0 -ggdb3
 else
-GRAPHENEDEBUG=none
+GRAPHENE_LOG_LEVEL = error
 CFLAGS += -O2
 endif
 
@@ -141,7 +141,7 @@ libsecret_prov_verify_dcap.so: libmbedcrypto.so libmbedx509.so libmbedtls.so lib
 
 secret_prov_client.manifest: secret_prov_client.manifest.template
 	sed -e 's|$$(GRAPHENEDIR)|'"$(GRAPHENEDIR)"'|g' \
-		-e 's|$$(GRAPHENEDEBUG)|'"$(GRAPHENEDEBUG)"'|g' \
+		-e 's|$$(GRAPHENE_LOG_LEVEL)|'"$(GRAPHENE_LOG_LEVEL)"'|g' \
 		-e 's|$$(RA_CLIENT_SPID)|'"$(RA_CLIENT_SPID)"'|g' \
 		-e 's|$$(RA_CLIENT_LINKABLE)|'"$(RA_CLIENT_LINKABLE)"'|g' \
 		$< > $@
@@ -161,7 +161,7 @@ secret_prov_client.token: secret_prov_client.sig
 
 secret_prov_min_client.manifest: secret_prov_min_client.manifest.template
 	sed -e 's|$$(GRAPHENEDIR)|'"$(GRAPHENEDIR)"'|g' \
-		-e 's|$$(GRAPHENEDEBUG)|'"$(GRAPHENEDEBUG)"'|g' \
+		-e 's|$$(GRAPHENE_LOG_LEVEL)|'"$(GRAPHENE_LOG_LEVEL)"'|g' \
 		-e 's|$$(RA_CLIENT_SPID)|'"$(RA_CLIENT_SPID)"'|g' \
 		-e 's|$$(RA_CLIENT_LINKABLE)|'"$(RA_CLIENT_LINKABLE)"'|g' \
 		$< > $@
@@ -186,7 +186,7 @@ files/input.txt: files/wrap-key files/plain.txt pf_crypt
 
 secret_prov_pf_client.manifest: secret_prov_pf_client.manifest.template
 	sed -e 's|$$(GRAPHENEDIR)|'"$(GRAPHENEDIR)"'|g' \
-		-e 's|$$(GRAPHENEDEBUG)|'"$(GRAPHENEDEBUG)"'|g' \
+		-e 's|$$(GRAPHENE_LOG_LEVEL)|'"$(GRAPHENE_LOG_LEVEL)"'|g' \
 		-e 's|$$(RA_CLIENT_SPID)|'"$(RA_CLIENT_SPID)"'|g' \
 		-e 's|$$(RA_CLIENT_LINKABLE)|'"$(RA_CLIENT_LINKABLE)"'|g' \
 		$< > $@

--- a/Examples/ra-tls-secret-prov/secret_prov_client.manifest.template
+++ b/Examples/ra-tls-secret-prov/secret_prov_client.manifest.template
@@ -4,7 +4,7 @@
 
 loader.preload = "file:$(GRAPHENEDIR)/Runtime/libsysdb.so"
 libos.entrypoint = "file:secret_prov_client"
-loader.debug_type = "$(GRAPHENEDEBUG)"
+loader.log_level = "$(GRAPHENE_LOG_LEVEL)"
 
 loader.env.LD_LIBRARY_PATH = "/lib:/lib/x86_64-linux-gnu"
 

--- a/Examples/ra-tls-secret-prov/secret_prov_min_client.manifest.template
+++ b/Examples/ra-tls-secret-prov/secret_prov_min_client.manifest.template
@@ -4,7 +4,7 @@
 
 loader.preload = "file:$(GRAPHENEDIR)/Runtime/libsysdb.so"
 libos.entrypoint = "file:secret_prov_min_client"
-loader.debug_type = "$(GRAPHENEDEBUG)"
+loader.log_level = "$(GRAPHENE_LOG_LEVEL)"
 
 loader.env.LD_LIBRARY_PATH = "/lib:/lib/x86_64-linux-gnu"
 

--- a/Examples/ra-tls-secret-prov/secret_prov_pf_client.manifest.template
+++ b/Examples/ra-tls-secret-prov/secret_prov_pf_client.manifest.template
@@ -4,7 +4,7 @@
 
 loader.preload = "file:$(GRAPHENEDIR)/Runtime/libsysdb.so"
 libos.entrypoint = "file:secret_prov_pf_client"
-loader.debug_type = "$(GRAPHENEDEBUG)"
+loader.log_level = "$(GRAPHENE_LOG_LEVEL)"
 
 loader.env.LD_LIBRARY_PATH = "/lib:/lib/x86_64-linux-gnu"
 

--- a/Examples/redis/Makefile
+++ b/Examples/redis/Makefile
@@ -25,9 +25,9 @@ COMMIT = 6.0.5
 TAR_SHA256 = f7ded6c27d48c20bc78e797046c79b6bc411121f0c2d7eead9fea50d6b0b6290
 
 ifeq ($(DEBUG),1)
-GRAPHENEDEBUG = inline
+GRAPHENE_LOG_LEVEL = debug
 else
-GRAPHENEDEBUG = none
+GRAPHENE_LOG_LEVEL = error
 endif
 
 .PHONY: all
@@ -69,7 +69,7 @@ endif
 
 redis-server.manifest: redis-server.manifest.template
 	sed -e 's|$$(GRAPHENEDIR)|'"$(GRAPHENEDIR)"'|g' \
-		-e 's|$$(GRAPHENEDEBUG)|'"$(GRAPHENEDEBUG)"'|g' \
+		-e 's|$$(GRAPHENE_LOG_LEVEL)|'"$(GRAPHENE_LOG_LEVEL)"'|g' \
 		-e 's|$$(ARCH_LIBDIR)|'"$(ARCH_LIBDIR)"'|g' \
 		$< > $@
 

--- a/Examples/redis/redis-server.manifest.template
+++ b/Examples/redis/redis-server.manifest.template
@@ -11,10 +11,11 @@
 loader.preload = "file:$(GRAPHENEDIR)/Runtime/libsysdb.so"
 libos.entrypoint = "file:redis-server"
 
-# Show/hide debug log of Graphene ('inline' or 'none' respectively). Note that
-# GRAPHENEDEBUG macro is expanded to inline/none in the Makefile as part of the
-# build process.
-loader.debug_type = "$(GRAPHENEDEBUG)"
+# Verbosity of Graphene debug log (none/error/info/debug/trace/all). Note that
+# GRAPHENE_LOG_LEVEL macro is expanded in the Makefile as part of the building
+# process: the default is "error" for non-debug builds, and "debug" for debug
+# builds.
+loader.log_level = "$(GRAPHENE_LOG_LEVEL)"
 
 ################################# ARGUMENTS ###################################
 

--- a/Examples/tensorflow-lite/Makefile
+++ b/Examples/tensorflow-lite/Makefile
@@ -55,7 +55,7 @@ label_image.manifest: libtensorflow_framework.so label_image inception_v3.tflite
 label_image.manifest: $(GRAPHENEDIR)/Runtime/libgcc_s.so.1 $(GRAPHENEDIR)/Runtime/libstdc++.so.6
 label_image.manifest: label_image.manifest.template
 	sed -e 's|$$(GRAPHENEDIR)|'"$(GRAPHENEDIR)"'|g' \
-		-e 's|$$(GRAPHENEDEBUG)|'"$(GRAPHENEDEBUG)"'|g' \
+		-e 's|$$(GRAPHENE_LOG_LEVEL)|'"$(GRAPHENE_LOG_LEVEL)"'|g' \
 		$< > $@
 
 label_image.manifest.sgx: label_image.manifest inception_v3.tflite labels.txt

--- a/Examples/tensorflow-lite/label_image.manifest.template
+++ b/Examples/tensorflow-lite/label_image.manifest.template
@@ -2,10 +2,11 @@ loader.preload = "file:$(GRAPHENEDIR)/Runtime/libsysdb.so"
 libos.entrypoint = "file:label_image"
 loader.env.LD_LIBRARY_PATH = "/lib:."
 loader.env.PATH = "/bin:/usr/bin"
-loader.debug_type = "none"
 
 # Read application arguments directly from the command line. Don't use this on production!
 loader.insecure__use_cmdline_argv = 1
+
+loader.log_level = "$(GRAPHENE_LOG_LEVEL)"
 
 fs.mount.lib1.type = "chroot"
 fs.mount.lib1.path = "/lib"

--- a/LibOS/shim/include/shim_internal.h
+++ b/LibOS/shim/include/shim_internal.h
@@ -36,7 +36,7 @@ struct debug_buf {
 #include "pal_debug.h"
 #include "pal_error.h"
 
-extern bool g_debug_log_enabled;
+extern int g_log_level;
 
 #include <stdarg.h>
 
@@ -45,11 +45,19 @@ void debug_puts(const char* str);
 void debug_putch(int ch);
 void debug_vprintf(const char* fmt, va_list ap) __attribute__((format(printf, 1, 0)));
 
-#define debug(fmt, ...)                       \
-    do {                                      \
-        if (g_debug_log_enabled)              \
-            debug_printf(fmt, ##__VA_ARGS__); \
+#define _log(level, fmt...)                          \
+    do {                                             \
+        if ((level) <= g_log_level)                  \
+            debug_printf(fmt);                       \
     } while (0)
+
+#define log_error(fmt...)    _log(PAL_LOG_ERROR, fmt)
+#define log_info(fmt...)     _log(PAL_LOG_INFO, fmt)
+#define log_debug(fmt...)    _log(PAL_LOG_DEBUG, fmt)
+#define log_trace(fmt...)    _log(PAL_LOG_TRACE, fmt)
+
+/* TODO: Replace debug() calls with log_*() at the appropriate levels, and remove this macro. */
+#define debug(fmt...)        _log(PAL_LOG_INFO, fmt)
 
 #if 0
 #define DEBUG_BREAK_ON_FAILURE() DEBUG_BREAK()

--- a/LibOS/shim/include/shim_thread.h
+++ b/LibOS/shim/include/shim_thread.h
@@ -146,7 +146,7 @@ void debug_setprefix(shim_tcb_t* tcb);
 /* Set `debug_buf` for `tcb`. If `debug_buf` is `NULL`, then new one is allocated. If `debug_buf`
  * is not NULL, this function cannot fail. */
 static inline int debug_setbuf(shim_tcb_t* tcb, struct debug_buf* debug_buf) {
-    if (!g_debug_log_enabled)
+    if (g_log_level <= PAL_LOG_NONE)
         return 0;
 
     tcb->debug_buf = debug_buf ? debug_buf : malloc(sizeof(struct debug_buf));

--- a/LibOS/shim/src/shim_init.c
+++ b/LibOS/shim/src/shim_init.c
@@ -369,7 +369,7 @@ static int read_environs(const char** envp) {
     } while (0)
 
 noreturn void* shim_init(int argc, void* args) {
-    g_debug_log_enabled = PAL_CB(enable_debug_log);
+    g_log_level = PAL_CB(log_level);
     g_process_ipc_info.vmid = (IDTYPE)PAL_CB(process_id);
 
     /* create the initial TCB, shim can not be run without a tcb */

--- a/LibOS/shim/src/shim_parser.c
+++ b/LibOS/shim/src/shim_parser.c
@@ -1541,7 +1541,7 @@ static void print_syscall_name(const char* name, int sysno) {
 }
 
 void debug_print_syscall_before(int sysno, ...) {
-    if (!g_debug_log_enabled)
+    if (g_log_level < PAL_LOG_INFO)
         return;
 
     struct parser_table* parser = &syscall_parser_table[sysno];
@@ -1573,7 +1573,7 @@ void debug_print_syscall_before(int sysno, ...) {
 }
 
 void debug_print_syscall_after(int sysno, ...) {
-    if (!g_debug_log_enabled)
+    if (g_log_level < PAL_LOG_INFO)
         return;
 
     struct parser_table* parser = &syscall_parser_table[sysno];

--- a/LibOS/shim/src/utils/printf.c
+++ b/LibOS/shim/src/utils/printf.c
@@ -11,7 +11,7 @@
 #include "shim_internal.h"
 #include "shim_ipc.h"
 
-bool g_debug_log_enabled = false;
+int g_log_level = PAL_LOG_NONE;
 
 static inline int debug_fputs(const char* buf, size_t size) {
     size_t bytes = 0;
@@ -111,7 +111,7 @@ void debug_printf(const char* fmt, ...) {
 }
 
 void debug_setprefix(shim_tcb_t* tcb) {
-    if (!g_debug_log_enabled)
+    if (g_log_level <= PAL_LOG_NONE)
         return;
 
     struct debug_buf* buf = tcb->debug_buf;

--- a/LibOS/shim/test/fs/manifest.template
+++ b/LibOS/shim/test/fs/manifest.template
@@ -1,7 +1,6 @@
 loader.preload = "file:../../src/libsysdb.so"
 libos.entrypoint = "file:$(ENTRYPOINT)"
 loader.env.LD_LIBRARY_PATH = "/lib:$(ARCH_LIBDIR):/usr/$(ARCH_LIBDIR)"
-loader.debug_type = "none"
 loader.insecure__use_cmdline_argv = 1
 
 fs.mount.graphene_lib.type = "chroot"

--- a/LibOS/shim/test/ltp/README.rst
+++ b/LibOS/shim/test/ltp/README.rst
@@ -16,7 +16,7 @@ In this way, one can debug one particular syscall testcase.
 To get more information, you can:
 
 - Enable debugging output: edit ``/install/testcases/bin/manifest`` to set
-  ``loader.debug_type = "inline"``. Note that you will need to revert this
+  ``loader.log_level = "trace"``. Note that you will need to revert this
   change for ``make regression`` to work correctly. This will also not work when
   running under SGX, because the manifest needs to be re-signed afterwards.
 

--- a/LibOS/shim/test/ltp/manifest.template
+++ b/LibOS/shim/test/ltp/manifest.template
@@ -4,7 +4,6 @@ loader.env.LD_LIBRARY_PATH = "/lib:$(ARCH_LIBDIR):/usr/lib:/usr/lib64"
 loader.env.PATH = "/bin:/usr/bin:."
 loader.env.LD_PRELOAD = "$(COREUTILS_LIBDIR)/libstdbuf.so"
 loader.env._STDBUF_O = "L"
-loader.debug_type = "none"
 loader.insecure__use_cmdline_argv = 1
 
 fs.mount.shm.type = "chroot"

--- a/LibOS/shim/test/regression/argv_from_file.manifest
+++ b/LibOS/shim/test/regression/argv_from_file.manifest
@@ -3,7 +3,6 @@ libos.entrypoint = "file:bootstrap"
 loader.argv0_override = "bootstrap"
 
 loader.env.LD_LIBRARY_PATH = "/lib"
-loader.debug_type = "none"
 loader.argv_src_file = "file:argv_test_input"
 
 fs.mount.lib.type = "chroot"

--- a/LibOS/shim/test/regression/attestation.manifest.template
+++ b/LibOS/shim/test/regression/attestation.manifest.template
@@ -3,7 +3,6 @@ libos.entrypoint = "file:attestation"
 loader.argv0_override = "attestation"
 
 loader.env.LD_LIBRARY_PATH = "/lib"
-loader.debug_type = "none"
 loader.insecure__use_cmdline_argv = 1
 
 fs.mount.lib.type = "chroot"

--- a/LibOS/shim/test/regression/debug_log_file.manifest
+++ b/LibOS/shim/test/regression/debug_log_file.manifest
@@ -3,8 +3,8 @@ libos.entrypoint = "file:bootstrap"
 loader.argv0_override = "bootstrap"
 
 loader.env.LD_LIBRARY_PATH = "/lib"
-loader.debug_type = "file"
-loader.debug_file = "tmp/debug_log_file.log"
+loader.log_level = "debug"
+loader.log_file = "tmp/debug_log_file.log"
 
 fs.mount.lib.type = "chroot"
 fs.mount.lib.path = "/lib"

--- a/LibOS/shim/test/regression/debug_log_inline.manifest
+++ b/LibOS/shim/test/regression/debug_log_inline.manifest
@@ -3,7 +3,7 @@ libos.entrypoint = "file:bootstrap"
 loader.argv0_override = "bootstrap"
 
 loader.env.LD_LIBRARY_PATH = "/lib"
-loader.debug_type = "inline"
+loader.log_level = "debug"
 
 fs.mount.lib.type = "chroot"
 fs.mount.lib.path = "/lib"

--- a/LibOS/shim/test/regression/env_from_file.manifest
+++ b/LibOS/shim/test/regression/env_from_file.manifest
@@ -2,7 +2,6 @@ loader.preload = "file:../../src/libsysdb.so"
 libos.entrypoint = "file:bootstrap"
 loader.argv0_override = "bootstrap"
 loader.env.LD_LIBRARY_PATH = "/lib"
-loader.debug_type = "none"
 loader.env_src_file = "file:env_test_input"
 
 fs.mount.lib.type = "chroot"

--- a/LibOS/shim/test/regression/env_from_host.manifest
+++ b/LibOS/shim/test/regression/env_from_host.manifest
@@ -3,7 +3,6 @@ loader.argv0_override = "bootstrap"
 libos.entrypoint = "file:bootstrap"
 
 loader.env.LD_LIBRARY_PATH = "/lib"
-loader.debug_type = "none"
 loader.insecure__use_host_env = 1
 
 fs.mount.lib.type = "chroot"

--- a/LibOS/shim/test/regression/file_check_policy_allow_all_but_log.manifest
+++ b/LibOS/shim/test/regression/file_check_policy_allow_all_but_log.manifest
@@ -3,7 +3,6 @@ libos.entrypoint = "file:file_check_policy"
 loader.argv0_override = "file_check_policy"
 
 loader.env.LD_LIBRARY_PATH = "/lib"
-loader.debug_type = "none"
 loader.insecure__use_cmdline_argv = 1
 
 fs.mount.lib.type = "chroot"

--- a/LibOS/shim/test/regression/file_check_policy_strict.manifest
+++ b/LibOS/shim/test/regression/file_check_policy_strict.manifest
@@ -3,7 +3,6 @@ libos.entrypoint = "file:file_check_policy"
 loader.argv0_override = "file_check_policy"
 
 loader.env.LD_LIBRARY_PATH = "/lib"
-loader.debug_type = "none"
 loader.insecure__use_cmdline_argv = 1
 
 fs.mount.lib.type = "chroot"

--- a/LibOS/shim/test/regression/host_root_fs.manifest
+++ b/LibOS/shim/test/regression/host_root_fs.manifest
@@ -3,7 +3,6 @@ libos.entrypoint = "file:host_root_fs"
 loader.argv0_override = "host_root_fs"
 
 loader.env.LD_LIBRARY_PATH = "/lib"
-loader.debug_type = "none"
 
 fs.root.type = "chroot"
 fs.root.path = "/"

--- a/LibOS/shim/test/regression/init_fail.manifest
+++ b/LibOS/shim/test/regression/init_fail.manifest
@@ -3,7 +3,6 @@ libos.entrypoint = "file:init_fail"
 loader.argv0_override = "init_fail"
 
 loader.env.LD_LIBRARY_PATH = "/lib"
-loader.debug_type = "none"
 
 fs.mount.lib.type = "chroot"
 fs.mount.lib.path = "/lib"

--- a/LibOS/shim/test/regression/init_fail2.manifest
+++ b/LibOS/shim/test/regression/init_fail2.manifest
@@ -3,7 +3,6 @@ libos.entrypoint = "file:init_fail"
 loader.argv0_override = "init_fail"
 
 loader.env.LD_LIBRARY_PATH = "/lib"
-loader.debug_type = "none"
 
 fs.mount.lib.type = "chroot"
 fs.mount.lib.path = "/lib"

--- a/LibOS/shim/test/regression/large_mmap.manifest
+++ b/LibOS/shim/test/regression/large_mmap.manifest
@@ -3,7 +3,6 @@ libos.entrypoint = "file:large_mmap"
 loader.argv0_override = "large_mmap"
 
 loader.env.LD_LIBRARY_PATH = "/lib"
-loader.debug_type = "none"
 
 # application allocates 2GB and 4GB memory regions which may occasionally fail
 # in an SGX enclave restricted to 8GB of virtual space if ASLR is enabled

--- a/LibOS/shim/test/regression/manifest.template
+++ b/LibOS/shim/test/regression/manifest.template
@@ -1,7 +1,6 @@
 loader.preload = "file:../../src/libsysdb.so"
 libos.entrypoint = "file:$(ENTRYPOINT)"
 loader.env.LD_LIBRARY_PATH = "/lib:$(ARCH_LIBDIR):/usr/$(ARCH_LIBDIR)"
-loader.debug_type = "none"
 loader.insecure__use_cmdline_argv = 1
 
 # for eventfd test

--- a/LibOS/shim/test/regression/multi_pthread.manifest
+++ b/LibOS/shim/test/regression/multi_pthread.manifest
@@ -1,6 +1,5 @@
 loader.preload = "file:../../src/libsysdb.so"
 loader.env.LD_LIBRARY_PATH = "/lib"
-loader.debug_type = "none"
 loader.argv0_override = "multi_pthread"
 libos.entrypoint = "file:multi_pthread"
 

--- a/LibOS/shim/test/regression/multi_pthread_exitless.manifest
+++ b/LibOS/shim/test/regression/multi_pthread_exitless.manifest
@@ -1,6 +1,5 @@
 loader.preload = "file:../../src/libsysdb.so"
 loader.env.LD_LIBRARY_PATH = "/lib"
-loader.debug_type = "none"
 libos.entrypoint = "file:multi_pthread"
 loader.argv0_override = "multi_pthread"
 

--- a/LibOS/shim/test/regression/openmp.manifest.template
+++ b/LibOS/shim/test/regression/openmp.manifest.template
@@ -3,7 +3,6 @@ libos.entrypoint = "file:openmp"
 loader.argv0_override = "openmp"
 
 loader.env.LD_LIBRARY_PATH = "/lib:/usrlib"
-loader.debug_type = "none"
 
 fs.mount.lib.type = "chroot"
 fs.mount.lib.path = "/lib"

--- a/Pal/include/pal/pal.h
+++ b/Pal/include/pal/pal.h
@@ -89,6 +89,16 @@ typedef union pal_handle {
 
 #include "pal-arch.h"
 
+/*! Log level */
+enum {
+    PAL_LOG_NONE   = 0,
+    PAL_LOG_ERROR  = 1,
+    PAL_LOG_INFO   = 2,
+    PAL_LOG_DEBUG  = 3,
+    PAL_LOG_TRACE  = 4,
+    PAL_LOG_ALL    = 5,
+};
+
 /********** PAL TYPE DEFINITIONS **********/
 enum {
     pal_type_file,
@@ -136,7 +146,7 @@ typedef struct PAL_CONTROL_ {
     PAL_STR executable;          /*!< initial executable name. TODO: remove from PAL */
     PAL_HANDLE parent_process;   /*!< handle of parent process */
     PAL_HANDLE first_thread;     /*!< handle of first thread */
-    PAL_BOL enable_debug_log;    /*!< enable debug log calls */
+    PAL_NUM log_level;           /*!< what log messsages to enable */
 
     /*
      * Memory layout
@@ -659,9 +669,6 @@ void DkObjectClose(PAL_HANDLE objectHandle);
 
 /*!
  * \brief Output a message to the debug stream.
- *
- * Works only if the debug stream has been initialized, which can be checked by looking at
- * `g_pal_control.enable_debug_log`.
  *
  * \return number of bytes written if succeeded, PAL_STREAM_ERROR on failure (in which case
  *  PAL_ERRNO() is set)

--- a/Pal/regression/Bootstrap3.manifest
+++ b/Pal/regression/Bootstrap3.manifest
@@ -1,5 +1,5 @@
 pal.entrypoint = "file:Bootstrap3"
-loader.debug_type = "inline"
+loader.log_level = "debug"
 loader.preload = "file:Preload1.so,file:Preload2.so"
 loader.argv0_override = "Bootstrap3"
 

--- a/Pal/regression/Bootstrap6.manifest
+++ b/Pal/regression/Bootstrap6.manifest
@@ -1,5 +1,5 @@
 pal.entrypoint = "file:Bootstrap"
-loader.debug_type = "inline"
+loader.log_level = "debug"
 loader.preload = "file:Preload1.so,file:Preload2.so"
 loader.argv0_override = "Bootstrap"
 

--- a/Pal/regression/File.manifest
+++ b/Pal/regression/File.manifest
@@ -1,6 +1,6 @@
 pal.entrypoint = "file:File"
 loader.argv0_override = "File"
-loader.debug_type = "inline"
+loader.log_level = "debug"
 
 fs.mount.root.uri = "file:"
 

--- a/Pal/regression/Process3.manifest
+++ b/Pal/regression/Process3.manifest
@@ -1,5 +1,5 @@
 pal.entrypoint = "file:Process3"
-loader.debug_type = "inline"
+loader.log_level = "debug"
 loader.preload = "file:Preload1.so,file:Preload2.so"
 loader.insecure__use_cmdline_argv = 1
 

--- a/Pal/regression/manifest.template
+++ b/Pal/regression/manifest.template
@@ -1,5 +1,5 @@
 pal.entrypoint = "file:$(ENTRYPOINT)"
-loader.debug_type = "inline"
+loader.log_level = "debug"
 loader.insecure__use_cmdline_argv = 1
 
 fs.mount.root.uri = "file:"

--- a/Pal/src/db_main.c
+++ b/Pal/src/db_main.c
@@ -152,43 +152,56 @@ static int insert_envs_from_manifest(const char*** envpp) {
 
 static void set_debug_type(void) {
     int ret = 0;
+    int log_level = PAL_LOG_DEFAULT_LEVEL;
 
     char* debug_type = NULL;
     ret = toml_string_in(g_pal_state.manifest_root, "loader.debug_type", &debug_type);
     if (ret < 0)
         INIT_FAIL_MANIFEST(PAL_ERROR_DENIED, "Cannot parse 'loader.debug_type'");
-
-    if (!debug_type)
-        return;
-
-    bool enable_debug_log = false;
-
-    if (!strcmp(debug_type, "inline")) {
-        // TODO: use /dev/stderr instead?
-        ret = _DkInitDebugStream("/dev/stdout");
-        enable_debug_log = true;
-    } else if (!strcmp(debug_type, "file")) {
-        char* debug_file = NULL;
-        ret = toml_string_in(g_pal_state.manifest_root, "loader.debug_file", &debug_file);
-        if (ret < 0 || !debug_file)
-            INIT_FAIL_MANIFEST(PAL_ERROR_DENIED, "Cannot find/parse 'loader.debug_file'");
-
-        ret = _DkInitDebugStream(debug_file);
-        free(debug_file);
-        enable_debug_log = true;
-    } else if (!strcmp(debug_type, "none")) {
-        ret = 0;
-    } else {
-        INIT_FAIL_MANIFEST(PAL_ERROR_INVAL, "Unknown 'loader.debug_type' "
-                           "(allowed: `inline`, `file`, `none`)");
+    if (debug_type) {
+        free(debug_type);
+        INIT_FAIL_MANIFEST(PAL_ERROR_DENIED,
+            "'loader.debug_type' has been replaced by 'loader.log_level' and 'loader.log_file'");
     }
 
-    free(debug_type);
-
+    char* log_level_str = NULL;
+    ret = toml_string_in(g_pal_state.manifest_root, "loader.log_level", &log_level_str);
     if (ret < 0)
-        INIT_FAIL(-ret, "Cannot open debug stream");
+        INIT_FAIL_MANIFEST(PAL_ERROR_DENIED, "Cannot parse 'loader.log_level'");
 
-    g_pal_control.enable_debug_log = enable_debug_log;
+    if (log_level_str) {
+        if (!strcmp(log_level_str, "none")) {
+            log_level = PAL_LOG_NONE;
+        } else if (!strcmp(log_level_str, "error")) {
+            log_level = PAL_LOG_ERROR;
+        } else if (!strcmp(log_level_str, "info")) {
+            log_level = PAL_LOG_INFO;
+        } else if (!strcmp(log_level_str, "debug")) {
+            log_level = PAL_LOG_DEBUG;
+        } else if (!strcmp(log_level_str, "trace")) {
+            log_level = PAL_LOG_TRACE;
+        } else if (!strcmp(log_level_str, "all")) {
+            log_level = PAL_LOG_ALL;
+        } else {
+            INIT_FAIL_MANIFEST(PAL_ERROR_DENIED, "Unknown 'loader.log_level'");
+        }
+    }
+    free(log_level_str);
+
+    char* log_file = NULL;
+    ret = toml_string_in(g_pal_state.manifest_root, "loader.log_file", &log_file);
+    if (ret < 0)
+        INIT_FAIL_MANIFEST(PAL_ERROR_DENIED, "Cannot parse 'loader.log_file'");
+
+    if (log_file && log_level > PAL_LOG_NONE) {
+        ret = _DkInitDebugStream(log_file);
+
+        if (ret < 0)
+            INIT_FAIL(-ret, "Cannot open log file");
+    }
+    free(log_file);
+
+    g_pal_control.log_level = log_level;
 }
 
 /* Loads a file containing a concatenation of C-strings. The resulting array of pointers is

--- a/Pal/src/host/Linux-SGX/Makefile
+++ b/Pal/src/host/Linux-SGX/Makefile
@@ -72,6 +72,7 @@ urts-objs = \
 	sgx_exception.o \
 	sgx_framework.o \
 	sgx_graphene.o \
+	sgx_log.o \
 	sgx_main.o \
 	sgx_perf_data.o \
 	sgx_platform.o \

--- a/Pal/src/host/Linux-SGX/db_streams.c
+++ b/Pal/src/host/Linux-SGX/db_streams.c
@@ -34,7 +34,7 @@
 #define DUMMYPAYLOAD     "dummypayload"
 #define DUMMYPAYLOADSIZE (sizeof(DUMMYPAYLOAD))
 
-static int g_debug_fd = -1;
+static int g_log_fd = PAL_LOG_DEFAULT_FD;
 
 struct hdl_header {
     uint8_t fds;       /* bitmask of host file descriptors corresponding to PAL handle */
@@ -404,9 +404,9 @@ int _DkReceiveHandle(PAL_HANDLE hdl, PAL_HANDLE* cargo) {
 int _DkInitDebugStream(const char* path) {
     int ret;
 
-    if (g_debug_fd >= 0) {
-        ret = ocall_close(g_debug_fd);
-        g_debug_fd = -1;
+    if (g_log_fd != PAL_LOG_DEFAULT_FD) {
+        ret = ocall_close(g_log_fd);
+        g_log_fd = PAL_LOG_DEFAULT_FD;
         if (ret < 0)
             return unix_to_pal_error(ERRNO(ret));
     }
@@ -414,15 +414,15 @@ int _DkInitDebugStream(const char* path) {
     ret = ocall_open(path, O_WRONLY | O_APPEND | O_CREAT, PERM_rw_______);
     if (ret < 0)
         return unix_to_pal_error(ERRNO(ret));
-    g_debug_fd = ret;
+    g_log_fd = ret;
     return 0;
 }
 
 ssize_t _DkDebugLog(const void* buf, size_t size) {
-    if (g_debug_fd < 0)
+    if (g_log_fd < 0)
         return -PAL_ERROR_BADHANDLE;
 
-    ssize_t ret = ocall_write(g_debug_fd, buf, size);
+    ssize_t ret = ocall_write(g_log_fd, buf, size);
     ret = IS_ERR(ret) ? unix_to_pal_error(ERRNO(ret)) : ret;
     return ret;
 }

--- a/Pal/src/host/Linux-SGX/pal_linux.h
+++ b/Pal/src/host/Linux-SGX/pal_linux.h
@@ -305,18 +305,19 @@ int sgx_create_process(const char* uri, size_t nargs, const char** args, int* st
 
 #endif /* IN_ENCLAVE */
 
-#define DBG_E 0x01
-#define DBG_I 0x02
-#define DBG_D 0x04
-#define DBG_S 0x08
-#define DBG_P 0x10
-#define DBG_M 0x20
+/*
+ * Legacy logging system (SGX_DBG).
+ *
+ * TODO: replace all SGX_DBG invocations with log_* functions (in enclave) and urts_log_* (outside
+ * of enclave), remove SGX_DBG from here.
+ */
 
-#ifdef DEBUG
-#define DBG_LEVEL (DBG_E | DBG_I | DBG_D | DBG_S)
-#else
-#define DBG_LEVEL DBG_E
-#endif
+#define DBG_E PAL_LOG_ERROR
+#define DBG_I PAL_LOG_INFO
+#define DBG_D PAL_LOG_DEBUG
+#define DBG_S PAL_LOG_DEBUG
+#define DBG_P PAL_LOG_DEBUG
+#define DBG_M PAL_LOG_DEBUG
 
 #ifdef IN_ENCLAVE
 #undef uthash_fatal
@@ -326,19 +327,14 @@ int sgx_create_process(const char* uri, size_t nargs, const char** args, int* st
         DkProcessExit(PAL_ERROR_NOMEM); \
     } while (0)
 
-#define SGX_DBG(class, fmt...)   \
-    do {                         \
-        if ((class) & DBG_LEVEL) \
-            printf(fmt);         \
-    } while (0)
-#else
-#include "pal_debug.h"
+#define SGX_DBG(class, fmt...) _log(class, fmt)
 
-#define SGX_DBG(class, fmt...)   \
-    do {                         \
-        if ((class) & DBG_LEVEL) \
-            pal_printf(fmt);     \
-    } while (0)
+#else
+
+#include "pal_debug.h"
+#include "sgx_log.h"
+#define SGX_DBG(class, fmt...) _urts_log(class, fmt)
+
 #endif
 
 #ifndef IN_ENCLAVE

--- a/Pal/src/host/Linux-SGX/sgx_log.c
+++ b/Pal/src/host/Linux-SGX/sgx_log.c
@@ -1,0 +1,32 @@
+/* SPDX-License-Identifier: LGPL-3.0-or-later */
+/* Copyright (C) 2020 Intel Corporation
+ *                    Paweł Marczewski <pawel@invisiblethingslab.com>
+ */
+
+#include <assert.h>
+
+#include "pal_debug.h"
+#include "pal_internal.h"
+#include "pal_linux.h"
+#include "perm.h"
+#include "sgx_log.h"
+
+int g_urts_log_level = PAL_LOG_DEFAULT_LEVEL;
+int g_urts_log_fd = PAL_LOG_DEFAULT_FD;
+
+int urts_log_init(const char* path) {
+    int ret;
+
+    if (g_urts_log_fd != PAL_LOG_DEFAULT_FD) {
+        ret = INLINE_SYSCALL(close, 1, g_urts_log_fd);
+        g_urts_log_fd = PAL_LOG_DEFAULT_FD;
+        if (ret < 0)
+            return ret;
+    }
+
+    ret = INLINE_SYSCALL(open, 3, path, O_WRONLY | O_APPEND | O_CREAT, PERM_rw_______);
+    if (ret < 0)
+        return ret;
+    g_urts_log_fd = ret;
+    return 0;
+}

--- a/Pal/src/host/Linux-SGX/sgx_log.h
+++ b/Pal/src/host/Linux-SGX/sgx_log.h
@@ -1,0 +1,34 @@
+/* SPDX-License-Identifier: LGPL-3.0-or-later */
+/* Copyright (C) 2020 Intel Corporation
+ *                    Paweł Marczewski <pawel@invisiblethingslab.com>
+ */
+
+/*
+ * Outer PAL logging interface. This is initialized separately to inner PAL, but (once it's
+ * initialized) should output at the level and to the file specified in manifest.
+ */
+
+#ifndef SGX_LOG_H_
+#define SGX_LOG_H_
+
+#include "pal.h"
+#include "pal_debug.h"
+
+extern int g_urts_log_level;
+extern int g_urts_log_fd;
+
+int urts_log_init(const char* path);
+int urts_log_printf(const char* fmt, ...) __attribute__((format(printf, 1, 2)));
+
+#define _urts_log(level, fmt...)                          \
+    do {                                                 \
+        if ((level) <= g_urts_log_level)                  \
+            pal_fdprintf(g_urts_log_fd, fmt);             \
+    }  while(0)
+
+#define urts_log_error(fmt...)    _urts_log(PAL_LOG_ERROR, fmt)
+#define urts_log_info(fmt...)     _urts_log(PAL_LOG_INFO, fmt)
+#define urts_log_debug(fmt...)    _urts_log(PAL_LOG_DEBUG, fmt)
+#define urts_log_trace(fmt...)    _urts_log(PAL_LOG_TRACE, fmt)
+
+#endif /* SGX_LOG_H_ */

--- a/Pal/src/pal_internal.h
+++ b/Pal/src/pal_internal.h
@@ -328,10 +328,26 @@ ssize_t _DkDebugLog(const void* buf, size_t size);
 void _DkPrintConsole(const void* buf, int size);
 int printf(const char* fmt, ...) __attribute__((format(printf, 1, 2)));
 int vprintf(const char* fmt, va_list ap) __attribute__((format(printf, 1, 0)));
+int log_printf(const char* fmt, ...) __attribute__((format(printf, 1, 2)));
+int log_vprintf(const char* fmt, va_list ap) __attribute__((format(printf, 1, 0)));
 
 /* err - positive value of error code */
 static inline void print_error(const char* msg, int err) {
     printf("%s (%s)\n", msg, pal_strerror(err));
 }
+
+#define PAL_LOG_DEFAULT_LEVEL  PAL_LOG_ERROR
+#define PAL_LOG_DEFAULT_FD     1
+
+#define _log(level, fmt...)                          \
+    do {                                             \
+        if ((level) <= g_pal_control.log_level)      \
+            log_printf(fmt);                         \
+    }  while(0)
+
+#define log_error(fmt...)    _log(PAL_LOG_ERROR, fmt)
+#define log_info(fmt...)     _log(PAL_LOG_INFO, fmt)
+#define log_debug(fmt...)    _log(PAL_LOG_DEBUG, fmt)
+#define log_trace(fmt...)    _log(PAL_LOG_TRACE, fmt)
 
 #endif

--- a/Tools/gsc/templates/manifest.template
+++ b/Tools/gsc/templates/manifest.template
@@ -6,7 +6,7 @@ loader.arg0_override = "{{binary}}"
 libos.entrypoint = "file:{{binary}}"
 loader.env.LD_LIBRARY_PATH = "/graphene/Runtime:{{"{{library_paths}}"}}"
 loader.env.PATH = "{{"{{env_path}}"}}"
-loader.debug_type = {% if debug %} "inline" {% else %} "none" {% endif %}
+loader.log_level = {% if debug %} "debug" {% else %} "error" {% endif %}
 
 fs.root.type = "chroot"
 fs.root.path = "/"

--- a/tests/benchmarks/basic.manifest.template
+++ b/tests/benchmarks/basic.manifest.template
@@ -2,7 +2,6 @@
 
 loader.preload = file:@GRAPHENEDIR@/Runtime/libsysdb.so
 loader.env.LD_LIBRARY_PATH = /lib
-loader.debug_type = none
 loader.syscall_symbol = syscalldb
 loader.insecure__use_cmdline_argv = 1
 

--- a/tests/benchmarks/redis-server.manifest.template
+++ b/tests/benchmarks/redis-server.manifest.template
@@ -1,5 +1,4 @@
 loader.preload = file:@GRAPHENEDIR@/Runtime/libsysdb.so
-loader.debug_type = none
 
 loader.insecure__use_cmdline_argv = 1
 


### PR DESCRIPTION
New version of #1979 (closes #1979). The breaking change is `loader.log_level`.

See also issue #1947 (Allow redirecting debug logs to a file).

## Description of the changes <!-- (reasons and measures) -->

Instead of 'loader.debug_type', introduce 'loader.log_level'
and 'loader.log_file', along with a set of definitions for
logging at a chosen level.

For now, the call sites keep using the legacy macros (SGX_DBG and
debug()), because converting them all will conflict with other
big changes in the code base. The existing LibOS calls are
assumed to be at 'info' level.

## Planned follow-up

* Change default stream to stderr (will need adjusting some tests)
* Convert call sites (maybe not while there are big changes in pipeline)
* Adjust levels (for example, system calls probably belong at "debug" or "trace")
* Make PAL use the same prefix for logs (thread number etc.)

## How to test this PR? <!-- (if applicable) -->

Existing tests should be enough, I expect Jenkins will put up a fight.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2075)
<!-- Reviewable:end -->
