### PR TITLE
[LibOS] Remove types from syscalls debug printing

### DIFF
--- a/LibOS/shim/include/shim_internal.h
+++ b/LibOS/shim/include/shim_internal.h
@@ -121,30 +121,28 @@ static inline int64_t get_cur_preempt(void) {
     r func(PROTO_ARGS_##n(args));
 
 #define PARSE_SYSCALL1(name, ...) \
-    if (g_debug_log_enabled)      \
-        parse_syscall_before(__NR_##name, #name, ##__VA_ARGS__);
+    debug_print_syscall_before(__NR_##name, ##__VA_ARGS__);
 
-#define PARSE_SYSCALL2(name, ...) \
-    if (g_debug_log_enabled)      \
-        parse_syscall_after(__NR_##name, #name, ##__VA_ARGS__);
+#define PARSE_SYSCALL2(name, ret_val, ...) \
+    debug_print_syscall_after(__NR_##name, ret_val, ##__VA_ARGS__);
 
-void parse_syscall_before(int sysno, const char* name, int nr, ...);
-void parse_syscall_after(int sysno, const char* name, int nr, ...);
+void debug_print_syscall_before(int sysno, ...);
+void debug_print_syscall_after(int sysno, ...);
 
 #define SHIM_SYSCALL_0(name, func, r)       \
     BEGIN_SHIM(name, void)                  \
-        PARSE_SYSCALL1(name, 0);            \
+        PARSE_SYSCALL1(name);               \
         r __ret = (func)();                 \
-        PARSE_SYSCALL2(name, 0, #r, __ret); \
+        PARSE_SYSCALL2(name, __ret);        \
         ret = (SHIM_ARG_TYPE)__ret;         \
     END_SHIM(name)
 
 #define SHIM_SYSCALL_1(name, func, r, t1, a1)        \
     BEGIN_SHIM(name, SHIM_ARG_TYPE __arg1)           \
         t1 a1 = (t1)__arg1;                          \
-        PARSE_SYSCALL1(name, 1, #t1, a1);            \
+        PARSE_SYSCALL1(name, a1);                    \
         r __ret = (func)(a1);                        \
-        PARSE_SYSCALL2(name, 1, #r, __ret, #t1, a1); \
+        PARSE_SYSCALL2(name, __ret, a1);             \
         ret = (SHIM_ARG_TYPE)__ret;                  \
     END_SHIM(name)
 
@@ -152,9 +150,9 @@ void parse_syscall_after(int sysno, const char* name, int nr, ...);
     BEGIN_SHIM(name, SHIM_ARG_TYPE __arg1, SHIM_ARG_TYPE __arg2)     \
         t1 a1 = (t1)__arg1;                                          \
         t2 a2 = (t2)__arg2;                                          \
-        PARSE_SYSCALL1(name, 2, #t1, a1, #t2, a2);                   \
+        PARSE_SYSCALL1(name, a1, a2);                                \
         r __ret = (func)(a1, a2);                                    \
-        PARSE_SYSCALL2(name, 2, #r, __ret, #t1, a1, #t2, a2);        \
+        PARSE_SYSCALL2(name, __ret, a1, a2);                         \
         ret = (SHIM_ARG_TYPE)__ret;                                  \
     END_SHIM(name)
 
@@ -163,9 +161,9 @@ void parse_syscall_after(int sysno, const char* name, int nr, ...);
         t1 a1 = (t1)__arg1;                                                                \
         t2 a2 = (t2)__arg2;                                                                \
         t3 a3 = (t3)__arg3;                                                                \
-        PARSE_SYSCALL1(name, 3, #t1, a1, #t2, a2, #t3, a3);                                \
+        PARSE_SYSCALL1(name, a1, a2, a3);                                                  \
         r __ret = (func)(a1, a2, a3);                                                      \
-        PARSE_SYSCALL2(name, 3, #r, __ret, #t1, a1, #t2, a2, #t3, a3);                     \
+        PARSE_SYSCALL2(name, __ret, a1, a2, a3);                                           \
         ret = (SHIM_ARG_TYPE)__ret;                                                        \
     END_SHIM(name)
 
@@ -176,9 +174,9 @@ void parse_syscall_after(int sysno, const char* name, int nr, ...);
         t2 a2 = (t2)__arg2;                                                                \
         t3 a3 = (t3)__arg3;                                                                \
         t4 a4 = (t4)__arg4;                                                                \
-        PARSE_SYSCALL1(name, 4, #t1, a1, #t2, a2, #t3, a3, #t4, a4);                       \
+        PARSE_SYSCALL1(name, a1, a2, a3, a4);                                              \
         r __ret = (func)(a1, a2, a3, a4);                                                  \
-        PARSE_SYSCALL2(name, 4, #r, __ret, #t1, a1, #t2, a2, #t3, a3, #t4, a4);            \
+        PARSE_SYSCALL2(name, __ret, a1, a2, a3, a4);                                       \
         ret = (SHIM_ARG_TYPE)__ret;                                                        \
     END_SHIM(name)
 
@@ -190,9 +188,9 @@ void parse_syscall_after(int sysno, const char* name, int nr, ...);
         t3 a3 = (t3)__arg3;                                                                \
         t4 a4 = (t4)__arg4;                                                                \
         t5 a5 = (t5)__arg5;                                                                \
-        PARSE_SYSCALL1(name, 5, #t1, a1, #t2, a2, #t3, a3, #t4, a4, #t5, a5);              \
+        PARSE_SYSCALL1(name, a1, a2, a3, a4, a5);                                          \
         r __ret = (func)(a1, a2, a3, a4, a5);                                              \
-        PARSE_SYSCALL2(name, 5, #r, __ret, #t1, a1, #t2, a2, #t3, a3, #t4, a4, #t5, a5);   \
+        PARSE_SYSCALL2(name, __ret, a1, a2, a3, a4, a5);                                   \
         ret = (SHIM_ARG_TYPE)__ret;                                                        \
     END_SHIM(name)
 
@@ -205,9 +203,9 @@ void parse_syscall_after(int sysno, const char* name, int nr, ...);
         t4 a4 = (t4)__arg4;                                                                       \
         t5 a5 = (t5)__arg5;                                                                       \
         t6 a6 = (t6)__arg6;                                                                       \
-        PARSE_SYSCALL1(name, 6, #t1, a1, #t2, a2, #t3, a3, #t4, a4, #t5, a5, #t6, a6);            \
+        PARSE_SYSCALL1(name, a1, a2, a3, a4, a5, a6);                                             \
         r __ret = (func)(a1, a2, a3, a4, a5, a6);                                                 \
-        PARSE_SYSCALL2(name, 6, #r, __ret, #t1, a1, #t2, a2, #t3, a3, #t4, a4, #t5, a5, #t6, a6); \
+        PARSE_SYSCALL2(name, __ret, a1, a2, a3, a4, a5, a6);                                      \
         ret = (SHIM_ARG_TYPE)__ret;                                                               \
     END_SHIM(name)
 

--- a/LibOS/shim/include/shim_table.h
+++ b/LibOS/shim/include/shim_table.h
@@ -384,7 +384,7 @@ long shim_do_select(int nfds, fd_set* readfds, fd_set* writefds, fd_set* errorfd
                     struct __kernel_timeval* timeout);
 long shim_do_sched_yield(void);
 void* shim_do_mremap(void* addr, size_t old_len, size_t new_len, int flags, void* new_addr);
-int shim_do_msync(void* start, size_t len, int flags);
+long shim_do_msync(void* start, size_t len, int flags);
 long shim_do_mincore(void* start, size_t len, unsigned char* vec);
 long shim_do_madvise(unsigned long start, size_t len_in, int behavior);
 long shim_do_dup(unsigned int fd);

--- a/LibOS/shim/src/shim_syscalls.c
+++ b/LibOS/shim/src/shim_syscalls.c
@@ -27,190 +27,189 @@
  * system call */
 
 /* read: sys/shim_open.c */
-DEFINE_SHIM_SYSCALL(read, 3, shim_do_read, size_t, int, fd, void*, buf, size_t, count)
+DEFINE_SHIM_SYSCALL(read, 3, shim_do_read, long, int, fd, void*, buf, size_t, count)
 
 /* write: sys/shim_open.c */
-DEFINE_SHIM_SYSCALL(write, 3, shim_do_write, size_t, int, fd, const void*, buf, size_t, count)
+DEFINE_SHIM_SYSCALL(write, 3, shim_do_write, long, int, fd, const void*, buf, size_t, count)
 
 /* open: sys/shim_open.c */
-DEFINE_SHIM_SYSCALL(open, 3, shim_do_open, int, const char*, file, int, flags, mode_t, mode)
+DEFINE_SHIM_SYSCALL(open, 3, shim_do_open, long, const char*, file, int, flags, mode_t, mode)
 
 /* close: sys/shim_open.c */
-DEFINE_SHIM_SYSCALL(close, 1, shim_do_close, int, int, fd)
+DEFINE_SHIM_SYSCALL(close, 1, shim_do_close, long, int, fd)
 
 /* stat: sys/shim_stat.c */
-DEFINE_SHIM_SYSCALL(stat, 2, shim_do_stat, int, const char*, file, struct stat*, statbuf)
+DEFINE_SHIM_SYSCALL(stat, 2, shim_do_stat, long, const char*, file, struct stat*, statbuf)
 
 /* fstat: sys/shim_stat.c */
-DEFINE_SHIM_SYSCALL(fstat, 2, shim_do_fstat, int, int, fd, struct stat*, statbuf)
+DEFINE_SHIM_SYSCALL(fstat, 2, shim_do_fstat, long, int, fd, struct stat*, statbuf)
 
 /* lstat: sys/shim_lstat.c */
 /* for now we don't support symbolic links, so lstat will work exactly the same as stat. */
-DEFINE_SHIM_SYSCALL(lstat, 2, shim_do_lstat, int, const char*, file, struct stat*, statbuf)
+DEFINE_SHIM_SYSCALL(lstat, 2, shim_do_lstat, long, const char*, file, struct stat*, statbuf)
 
 /* poll: sys/shim_poll.c */
-DEFINE_SHIM_SYSCALL(poll, 3, shim_do_poll, int, struct pollfd*, fds, nfds_t, nfds, int, timeout)
+DEFINE_SHIM_SYSCALL(poll, 3, shim_do_poll, long, struct pollfd*, fds, nfds_t, nfds, int, timeout)
 
 /* lseek: sys/shim_open.c */
-DEFINE_SHIM_SYSCALL(lseek, 3, shim_do_lseek, off_t, int, fd, off_t, offset, int, origin)
+DEFINE_SHIM_SYSCALL(lseek, 3, shim_do_lseek, long, int, fd, off_t, offset, int, origin)
 
 /* mmap: sys/shim_mmap.c */
 DEFINE_SHIM_SYSCALL(mmap, 6, shim_do_mmap, void*, void*, addr, size_t, length, int, prot, int,
                     flags, int, fd, off_t, offset)
 
 /* mprotect: sys/shim_mmap.c */
-DEFINE_SHIM_SYSCALL(mprotect, 3, shim_do_mprotect, int, void*, addr, size_t, len, int, prot)
+DEFINE_SHIM_SYSCALL(mprotect, 3, shim_do_mprotect, long, void*, addr, size_t, len, int, prot)
 
 /* munmap: sys/shim_mmap.c */
-DEFINE_SHIM_SYSCALL(munmap, 2, shim_do_munmap, int, void*, addr, size_t, len)
+DEFINE_SHIM_SYSCALL(munmap, 2, shim_do_munmap, long, void*, addr, size_t, len)
 
 DEFINE_SHIM_SYSCALL(brk, 1, shim_do_brk, void*, void*, brk)
 
 /* rt_sigaction: sys/shim_sigaction.c */
-DEFINE_SHIM_SYSCALL(rt_sigaction, 4, shim_do_sigaction, int, int, signum,
+DEFINE_SHIM_SYSCALL(rt_sigaction, 4, shim_do_sigaction, long, int, signum,
                     const struct __kernel_sigaction*, act, struct __kernel_sigaction*, oldact,
                     size_t, sigsetsize)
 
 /* rt_sigprocmask: sys/shim_sigaction.c */
-DEFINE_SHIM_SYSCALL(rt_sigprocmask, 3, shim_do_sigprocmask, int, int, how, const __sigset_t*, set,
+DEFINE_SHIM_SYSCALL(rt_sigprocmask, 3, shim_do_sigprocmask, long, int, how, const __sigset_t*, set,
                     __sigset_t*, oldset)
 
 /* rt_sigreturn: sys/shim_sigaction.c */
-DEFINE_SHIM_SYSCALL(rt_sigreturn, 1, shim_do_sigreturn, int, int, __unused)
+DEFINE_SHIM_SYSCALL(rt_sigreturn, 1, shim_do_sigreturn, long, int, __unused)
 
 /* ioctl: sys/shim_ioctl.c */
 DEFINE_SHIM_SYSCALL(ioctl, 3, shim_do_ioctl, long, unsigned int, fd, unsigned int, cmd, unsigned
                     long, arg)
 
 /* pread64: sys/shim_open.c */
-DEFINE_SHIM_SYSCALL(pread64, 4, shim_do_pread64, size_t, int, fd, char*, buf, size_t, count, loff_t,
+DEFINE_SHIM_SYSCALL(pread64, 4, shim_do_pread64, long, int, fd, char*, buf, size_t, count, loff_t,
                     pos)
 
 /* pwrite64: sys/shim_open.c */
-DEFINE_SHIM_SYSCALL(pwrite64, 4, shim_do_pwrite64, size_t, int, fd, char*, buf, size_t, count,
-                    loff_t, pos)
+DEFINE_SHIM_SYSCALL(pwrite64, 4, shim_do_pwrite64, long, int, fd, char*, buf, size_t, count, loff_t,
+                    pos)
 
 /* readv: sys/shim_wrappers.c */
-DEFINE_SHIM_SYSCALL(readv, 3, shim_do_readv, ssize_t, int, fd, const struct iovec*, vec, int, vlen)
+DEFINE_SHIM_SYSCALL(readv, 3, shim_do_readv, long, int, fd, const struct iovec*, vec, int, vlen)
 
 /* writev: sys/shim_wrappers.c */
-DEFINE_SHIM_SYSCALL(writev, 3, shim_do_writev, ssize_t, int, fd, const struct iovec*, vec, int,
-                    vlen)
+DEFINE_SHIM_SYSCALL(writev, 3, shim_do_writev, long, int, fd, const struct iovec*, vec, int, vlen)
 
 /* access: sys/shim_access.c */
-DEFINE_SHIM_SYSCALL(access, 2, shim_do_access, int, const char*, file, mode_t, mode)
+DEFINE_SHIM_SYSCALL(access, 2, shim_do_access, long, const char*, file, mode_t, mode)
 
 /* pipe: sys/shim_pipe.c */
-DEFINE_SHIM_SYSCALL(pipe, 1, shim_do_pipe, int, int*, fildes)
+DEFINE_SHIM_SYSCALL(pipe, 1, shim_do_pipe, long, int*, fildes)
 
 /* select: sys/shim_poll.c*/
-DEFINE_SHIM_SYSCALL(select, 5, shim_do_select, int, int, nfds, fd_set*, readfds, fd_set*, writefds,
+DEFINE_SHIM_SYSCALL(select, 5, shim_do_select, long, int, nfds, fd_set*, readfds, fd_set*, writefds,
                     fd_set*, errorfds, struct __kernel_timeval*, timeout)
 
 /* sched_yield: sys/shim_sched.c */
-DEFINE_SHIM_SYSCALL(sched_yield, 0, shim_do_sched_yield, int)
+DEFINE_SHIM_SYSCALL(sched_yield, 0, shim_do_sched_yield, long)
 
 SHIM_SYSCALL_RETURN_ENOSYS(mremap, 5, void*, void*, addr, size_t, old_len, size_t, new_len, int,
                            flags, void*, new_addr)
 
-SHIM_SYSCALL_RETURN_ENOSYS(msync, 3, int, void*, start, size_t, len, int, flags)
+SHIM_SYSCALL_RETURN_ENOSYS(msync, 3, long, void*, start, size_t, len, int, flags)
 
 /* mincore: sys/shim_mmap.c */
-DEFINE_SHIM_SYSCALL(mincore, 3, shim_do_mincore, int, void*, start, size_t, len, unsigned char*,
+DEFINE_SHIM_SYSCALL(mincore, 3, shim_do_mincore, long, void*, start, size_t, len, unsigned char*,
                     vec)
 
 /* sys/shim_mmap.c */
 DEFINE_SHIM_SYSCALL(madvise, 3, shim_do_madvise, long, unsigned long, start, size_t, len_in,
                     int, behavior)
 
-SHIM_SYSCALL_RETURN_ENOSYS(shmget, 3, int, key_t, key, size_t, size, int, shmflg)
+SHIM_SYSCALL_RETURN_ENOSYS(shmget, 3, long, key_t, key, size_t, size, int, shmflg)
 
 SHIM_SYSCALL_RETURN_ENOSYS(shmat, 3, void*, int, shmid, const void*, shmaddr, int, shmflg)
 
-SHIM_SYSCALL_RETURN_ENOSYS(shmctl, 3, int, int, shmid, int, cmd, struct shmid_ds*, buf)
+SHIM_SYSCALL_RETURN_ENOSYS(shmctl, 3, long, int, shmid, int, cmd, struct shmid_ds*, buf)
 
 /* dup: sys/shim_dup.c */
-DEFINE_SHIM_SYSCALL(dup, 1, shim_do_dup, int, unsigned int, fd)
+DEFINE_SHIM_SYSCALL(dup, 1, shim_do_dup, long, unsigned int, fd)
 
 /* dup2: sys/shim_dup.c */
-DEFINE_SHIM_SYSCALL(dup2, 2, shim_do_dup2, int, unsigned int, oldfd, unsigned int, newfd)
+DEFINE_SHIM_SYSCALL(dup2, 2, shim_do_dup2, long, unsigned int, oldfd, unsigned int, newfd)
 
 /* pause: sys/shim_sleep.c */
-DEFINE_SHIM_SYSCALL(pause, 0, shim_do_pause, int)
+DEFINE_SHIM_SYSCALL(pause, 0, shim_do_pause, long)
 
 /* nanosleep: sys/shim_sleep.c */
-DEFINE_SHIM_SYSCALL(nanosleep, 2, shim_do_nanosleep, int, const struct __kernel_timespec*, rqtp,
+DEFINE_SHIM_SYSCALL(nanosleep, 2, shim_do_nanosleep, long, const struct __kernel_timespec*, rqtp,
                     struct __kernel_timespec*, rmtp)
 
 /* getitimer: sys/shim_alarm.c */
-DEFINE_SHIM_SYSCALL(getitimer, 2, shim_do_getitimer, int, int, which, struct __kernel_itimerval*,
+DEFINE_SHIM_SYSCALL(getitimer, 2, shim_do_getitimer, long, int, which, struct __kernel_itimerval*,
                     value)
 
 /* alarm: sys/shim_alarm.c */
-DEFINE_SHIM_SYSCALL(alarm, 1, shim_do_alarm, int, unsigned int, seconds)
+DEFINE_SHIM_SYSCALL(alarm, 1, shim_do_alarm, long, unsigned int, seconds)
 
 /* setitimer: sys/shim_alarm.c */
-DEFINE_SHIM_SYSCALL(setitimer, 3, shim_do_setitimer, int, int, which, struct __kernel_itimerval*,
+DEFINE_SHIM_SYSCALL(setitimer, 3, shim_do_setitimer, long, int, which, struct __kernel_itimerval*,
                     value, struct __kernel_itimerval*, ovalue)
 
 /* getpid: sys/shim_getpid.c */
-DEFINE_SHIM_SYSCALL(getpid, 0, shim_do_getpid, pid_t)
+DEFINE_SHIM_SYSCALL(getpid, 0, shim_do_getpid, long)
 
 /* sendfile: sys/shim_fs.c */
-DEFINE_SHIM_SYSCALL(sendfile, 4, shim_do_sendfile, ssize_t, int, out_fd, int, in_fd, off_t*, offset,
+DEFINE_SHIM_SYSCALL(sendfile, 4, shim_do_sendfile, long, int, out_fd, int, in_fd, off_t*, offset,
                     size_t, count)
 
 /* socket: sys/shim_socket.c */
-DEFINE_SHIM_SYSCALL(socket, 3, shim_do_socket, int, int, family, int, type, int, protocol)
+DEFINE_SHIM_SYSCALL(socket, 3, shim_do_socket, long, int, family, int, type, int, protocol)
 
 /* connect: sys/shim_socket.c */
-DEFINE_SHIM_SYSCALL(connect, 3, shim_do_connect, int, int, sockfd, struct sockaddr*, addr, int,
+DEFINE_SHIM_SYSCALL(connect, 3, shim_do_connect, long, int, sockfd, struct sockaddr*, addr, int,
                     addrlen)
 
 /* accept: sys/shim_socket.c */
-DEFINE_SHIM_SYSCALL(accept, 3, shim_do_accept, int, int, fd, struct sockaddr*, addr, int*, addrlen)
+DEFINE_SHIM_SYSCALL(accept, 3, shim_do_accept, long, int, fd, struct sockaddr*, addr, int*, addrlen)
 
 /* sendto: sys/shim_socket.c */
-DEFINE_SHIM_SYSCALL(sendto, 6, shim_do_sendto, ssize_t, int, fd, const void*, buf, size_t, len, int,
+DEFINE_SHIM_SYSCALL(sendto, 6, shim_do_sendto, long, int, fd, const void*, buf, size_t, len, int,
                     flags, const struct sockaddr*, dest_addr, int, addrlen)
 
 /* recvfrom: sys/shim_socket.c */
-DEFINE_SHIM_SYSCALL(recvfrom, 6, shim_do_recvfrom, ssize_t, int, fd, void*, buf, size_t, len, int,
+DEFINE_SHIM_SYSCALL(recvfrom, 6, shim_do_recvfrom, long, int, fd, void*, buf, size_t, len, int,
                     flags, struct sockaddr*, addr, int*, addrlen)
 
 /* bind: sys/shim_socket.c */
-DEFINE_SHIM_SYSCALL(bind, 3, shim_do_bind, int, int, sockfd, struct sockaddr*, addr, int, addrlen)
+DEFINE_SHIM_SYSCALL(bind, 3, shim_do_bind, long, int, sockfd, struct sockaddr*, addr, int, addrlen)
 
 /* listen: sys/shim_socket.c */
-DEFINE_SHIM_SYSCALL(listen, 2, shim_do_listen, int, int, sockfd, int, backlog)
+DEFINE_SHIM_SYSCALL(listen, 2, shim_do_listen, long, int, sockfd, int, backlog)
 
 /* sendmsg: sys/shim_socket.c */
-DEFINE_SHIM_SYSCALL(sendmsg, 3, shim_do_sendmsg, ssize_t, int, fd, struct msghdr*, msg, int, flags)
+DEFINE_SHIM_SYSCALL(sendmsg, 3, shim_do_sendmsg, long, int, fd, struct msghdr*, msg, int, flags)
 
 /* recvmsg: sys/shim_socket.c */
-DEFINE_SHIM_SYSCALL(recvmsg, 3, shim_do_recvmsg, ssize_t, int, fd, struct msghdr*, msg, int, flags)
+DEFINE_SHIM_SYSCALL(recvmsg, 3, shim_do_recvmsg, long, int, fd, struct msghdr*, msg, int, flags)
 
 /* shutdown: sys/shim_socket.c */
-DEFINE_SHIM_SYSCALL(shutdown, 2, shim_do_shutdown, int, int, sockfd, int, how)
+DEFINE_SHIM_SYSCALL(shutdown, 2, shim_do_shutdown, long, int, sockfd, int, how)
 
 /* getsockname: sys/shim_socket.c */
-DEFINE_SHIM_SYSCALL(getsockname, 3, shim_do_getsockname, int, int, sockfd, struct sockaddr*, addr,
+DEFINE_SHIM_SYSCALL(getsockname, 3, shim_do_getsockname, long, int, sockfd, struct sockaddr*, addr,
                     int*, addrlen)
 
 /* getpeername: sys/shim_socket.c */
-DEFINE_SHIM_SYSCALL(getpeername, 3, shim_do_getpeername, int, int, sockfd, struct sockaddr*, addr,
+DEFINE_SHIM_SYSCALL(getpeername, 3, shim_do_getpeername, long, int, sockfd, struct sockaddr*, addr,
                     int*, addrlen)
 
 /* socketpair: sys/shim_pipe.c */
-DEFINE_SHIM_SYSCALL(socketpair, 4, shim_do_socketpair, int, int, domain, int, type, int, protocol,
+DEFINE_SHIM_SYSCALL(socketpair, 4, shim_do_socketpair, long, int, domain, int, type, int, protocol,
                     int*, sv)
 
 /* setsockopt: sys/shim_socket.c */
-DEFINE_SHIM_SYSCALL(setsockopt, 5, shim_do_setsockopt, int, int, fd, int, level, int, optname,
+DEFINE_SHIM_SYSCALL(setsockopt, 5, shim_do_setsockopt, long, int, fd, int, level, int, optname,
                     char*, optval, int, optlen)
 
 /* getsockopt: sys/shim_socket.c */
-DEFINE_SHIM_SYSCALL(getsockopt, 5, shim_do_getsockopt, int, int, fd, int, level, int, optname,
+DEFINE_SHIM_SYSCALL(getsockopt, 5, shim_do_getsockopt, long, int, fd, int, level, int, optname,
                     char*, optval, int*, optlen)
 
 /* clone: sys/shim_clone.c */
@@ -224,11 +223,11 @@ DEFINE_SHIM_SYSCALL(fork, 0, shim_do_fork, long)
 DEFINE_SHIM_SYSCALL(vfork, 0, shim_do_vfork, long)
 
 /* execve: sys/shim_exec.c */
-DEFINE_SHIM_SYSCALL(execve, 3, shim_do_execve, int, const char*, file, const char**, argv,
+DEFINE_SHIM_SYSCALL(execve, 3, shim_do_execve, long, const char*, file, const char**, argv,
                     const char**, envp)
 
 /* exit: sys/shim_exit.c */
-DEFINE_SHIM_SYSCALL(exit, 1, shim_do_exit, int, int, error_code)
+DEFINE_SHIM_SYSCALL(exit, 1, shim_do_exit, long, int, error_code)
 
 /* waitid: sys/shim_wait.c */
 DEFINE_SHIM_SYSCALL(waitid, 5, shim_do_waitid, long, int, which, pid_t, id, siginfo_t*, infop,
@@ -239,107 +238,107 @@ DEFINE_SHIM_SYSCALL(wait4, 4, shim_do_wait4, long, pid_t, pid, int*, stat_addr, 
                     struct __kernel_rusage*, ru)
 
 /* kill: sys/shim_sigaction.c */
-DEFINE_SHIM_SYSCALL(kill, 2, shim_do_kill, int, pid_t, pid, int, sig)
+DEFINE_SHIM_SYSCALL(kill, 2, shim_do_kill, long, pid_t, pid, int, sig)
 
 /* uname: sys/shim_uname.c */
-DEFINE_SHIM_SYSCALL(uname, 1, shim_do_uname, int, struct new_utsname*, buf)
+DEFINE_SHIM_SYSCALL(uname, 1, shim_do_uname, long, struct new_utsname*, buf)
 
 /* semget: sys/shim_semget.c */
-DEFINE_SHIM_SYSCALL(semget, 3, shim_do_semget, int, key_t, key, int, nsems, int, semflg)
+DEFINE_SHIM_SYSCALL(semget, 3, shim_do_semget, long, key_t, key, int, nsems, int, semflg)
 
 /* semop: sys/shim_semget.c */
-DEFINE_SHIM_SYSCALL(semop, 3, shim_do_semop, int, int, semid, struct sembuf*, sops, unsigned int,
+DEFINE_SHIM_SYSCALL(semop, 3, shim_do_semop, long, int, semid, struct sembuf*, sops, unsigned int,
                     nsops)
 
 /* semctl: sys/shim_semctl.c */
-DEFINE_SHIM_SYSCALL(semctl, 4, shim_do_semctl, int, int, semid, int, semnum, int, cmd,
+DEFINE_SHIM_SYSCALL(semctl, 4, shim_do_semctl, long, int, semid, int, semnum, int, cmd,
                     unsigned long, arg)
 
-SHIM_SYSCALL_RETURN_ENOSYS(shmdt, 1, int, const void*, shmaddr)
+SHIM_SYSCALL_RETURN_ENOSYS(shmdt, 1, long, const void*, shmaddr)
 
 /* msgget: sys/shim_msgget.c */
-DEFINE_SHIM_SYSCALL(msgget, 2, shim_do_msgget, int, key_t, key, int, msgflg)
+DEFINE_SHIM_SYSCALL(msgget, 2, shim_do_msgget, long, key_t, key, int, msgflg)
 
 /* msgsnd: sys/shim_msgget.c */
-DEFINE_SHIM_SYSCALL(msgsnd, 4, shim_do_msgsnd, int, int, msqid, const void*, msgp, size_t, msgsz,
+DEFINE_SHIM_SYSCALL(msgsnd, 4, shim_do_msgsnd, long, int, msqid, const void*, msgp, size_t, msgsz,
                     int, msgflg)
 
 /* msgrcv: sys/shim_msgget.c */
-DEFINE_SHIM_SYSCALL(msgrcv, 5, shim_do_msgrcv, int, int, msqid, void*, msgp, size_t, msgsz, long,
+DEFINE_SHIM_SYSCALL(msgrcv, 5, shim_do_msgrcv, long, int, msqid, void*, msgp, size_t, msgsz, long,
                     msgtyp, int, msgflg)
 
 /* msgctl: sys/shim_msgget.c */
-DEFINE_SHIM_SYSCALL(msgctl, 3, shim_do_msgctl, int, int, msqid, int, cmd, struct msqid_ds*, buf)
+DEFINE_SHIM_SYSCALL(msgctl, 3, shim_do_msgctl, long, int, msqid, int, cmd, struct msqid_ds*, buf)
 
 /* fcntl: sys/shim_fcntl.c */
-DEFINE_SHIM_SYSCALL(fcntl, 3, shim_do_fcntl, int, int, fd, int, cmd, unsigned long, arg)
+DEFINE_SHIM_SYSCALL(fcntl, 3, shim_do_fcntl, long, int, fd, int, cmd, unsigned long, arg)
 
-SHIM_SYSCALL_RETURN_ENOSYS(flock, 2, int, int, fd, int, cmd)
+SHIM_SYSCALL_RETURN_ENOSYS(flock, 2, long, int, fd, int, cmd)
 
 /* fsync: sys/shim_open.c */
-DEFINE_SHIM_SYSCALL(fsync, 1, shim_do_fsync, int, int, fd)
+DEFINE_SHIM_SYSCALL(fsync, 1, shim_do_fsync, long, int, fd)
 
 /* fdatasync: sys/shim_open.c */
-DEFINE_SHIM_SYSCALL(fdatasync, 1, shim_do_fdatasync, int, int, fd)
+DEFINE_SHIM_SYSCALL(fdatasync, 1, shim_do_fdatasync, long, int, fd)
 
 /* truncate: sys/shim_open.c */
-DEFINE_SHIM_SYSCALL(truncate, 2, shim_do_truncate, int, const char*, path, loff_t, length)
+DEFINE_SHIM_SYSCALL(truncate, 2, shim_do_truncate, long, const char*, path, loff_t, length)
 
 /* ftruncate: sys/shim_open.c */
-DEFINE_SHIM_SYSCALL(ftruncate, 2, shim_do_ftruncate, int, int, fd, loff_t, length)
+DEFINE_SHIM_SYSCALL(ftruncate, 2, shim_do_ftruncate, long, int, fd, loff_t, length)
 
 /* getdents: sys/shim_open.c */
-DEFINE_SHIM_SYSCALL(getdents, 3, shim_do_getdents, size_t, int, fd, struct linux_dirent*, buf,
+DEFINE_SHIM_SYSCALL(getdents, 3, shim_do_getdents, long, int, fd, struct linux_dirent*, buf,
                     size_t, count)
 
 /* getcwd: sys/shim_getcwd.c */
-DEFINE_SHIM_SYSCALL(getcwd, 2, shim_do_getcwd, int, char*, buf, size_t, size)
+DEFINE_SHIM_SYSCALL(getcwd, 2, shim_do_getcwd, long, char*, buf, size_t, size)
 
 /* chdir: sys/shim_getcwd.c */
-DEFINE_SHIM_SYSCALL(chdir, 1, shim_do_chdir, int, const char*, filename)
+DEFINE_SHIM_SYSCALL(chdir, 1, shim_do_chdir, long, const char*, filename)
 
 /* fchdir: sys/shim_getcwd.c */
-DEFINE_SHIM_SYSCALL(fchdir, 1, shim_do_fchdir, int, int, fd)
+DEFINE_SHIM_SYSCALL(fchdir, 1, shim_do_fchdir, long, int, fd)
 
 /* rename: sys/shim_fs.c */
-DEFINE_SHIM_SYSCALL(rename, 2, shim_do_rename, int, const char*, oldname, const char*, newname)
+DEFINE_SHIM_SYSCALL(rename, 2, shim_do_rename, long, const char*, oldname, const char*, newname)
 
 /* mkdir: sys/shim_fs.c */
-DEFINE_SHIM_SYSCALL(mkdir, 2, shim_do_mkdir, int, const char*, pathname, int, mode)
+DEFINE_SHIM_SYSCALL(mkdir, 2, shim_do_mkdir, long, const char*, pathname, int, mode)
 
 /* rmdir: sys/shim_fs.c */
-DEFINE_SHIM_SYSCALL(rmdir, 1, shim_do_rmdir, int, const char*, pathname)
+DEFINE_SHIM_SYSCALL(rmdir, 1, shim_do_rmdir, long, const char*, pathname)
 
-DEFINE_SHIM_SYSCALL(creat, 2, shim_do_creat, int, const char*, path, mode_t, mode)
+DEFINE_SHIM_SYSCALL(creat, 2, shim_do_creat, long, const char*, path, mode_t, mode)
 
-SHIM_SYSCALL_RETURN_ENOSYS(link, 2, int, const char*, oldname, const char*, newname)
+SHIM_SYSCALL_RETURN_ENOSYS(link, 2, long, const char*, oldname, const char*, newname)
 
 /* unlink: sys/shim_fs.c */
-DEFINE_SHIM_SYSCALL(unlink, 1, shim_do_unlink, int, const char*, file)
+DEFINE_SHIM_SYSCALL(unlink, 1, shim_do_unlink, long, const char*, file)
 
-SHIM_SYSCALL_RETURN_ENOSYS(symlink, 2, int, const char*, old, const char*, new)
+SHIM_SYSCALL_RETURN_ENOSYS(symlink, 2, long, const char*, old, const char*, new)
 
 /* readlink: sys/shim_stat.c */
-DEFINE_SHIM_SYSCALL(readlink, 3, shim_do_readlink, int, const char*, path, char*, buf, int,
+DEFINE_SHIM_SYSCALL(readlink, 3, shim_do_readlink, long, const char*, path, char*, buf, int,
                     bufsize)
 
-DEFINE_SHIM_SYSCALL(chmod, 2, shim_do_chmod, int, const char*, filename, mode_t, mode)
+DEFINE_SHIM_SYSCALL(chmod, 2, shim_do_chmod, long, const char*, filename, mode_t, mode)
 
-DEFINE_SHIM_SYSCALL(fchmod, 2, shim_do_fchmod, int, int, fd, mode_t, mode)
+DEFINE_SHIM_SYSCALL(fchmod, 2, shim_do_fchmod, long, int, fd, mode_t, mode)
 
-DEFINE_SHIM_SYSCALL(chown, 3, shim_do_chown, int, const char*, filename, uid_t, user, gid_t, group)
+DEFINE_SHIM_SYSCALL(chown, 3, shim_do_chown, long, const char*, filename, uid_t, user, gid_t, group)
 
-DEFINE_SHIM_SYSCALL(fchown, 3, shim_do_fchown, int, int, fd, uid_t, user, gid_t, group)
+DEFINE_SHIM_SYSCALL(fchown, 3, shim_do_fchown, long, int, fd, uid_t, user, gid_t, group)
 
-SHIM_SYSCALL_RETURN_ENOSYS(lchown, 3, int, const char*, filename, uid_t, user, gid_t, group)
+SHIM_SYSCALL_RETURN_ENOSYS(lchown, 3, long, const char*, filename, uid_t, user, gid_t, group)
 
-DEFINE_SHIM_SYSCALL(umask, 1, shim_do_umask, mode_t, mode_t, mask)
+DEFINE_SHIM_SYSCALL(umask, 1, shim_do_umask, long, mode_t, mask)
 
-DEFINE_SHIM_SYSCALL(gettimeofday, 2, shim_do_gettimeofday, int, struct __kernel_timeval*, tv,
+DEFINE_SHIM_SYSCALL(gettimeofday, 2, shim_do_gettimeofday, long, struct __kernel_timeval*, tv,
                     struct __kernel_timezone*, tz)
 
 /* getrlimit: sys/shim_getrlimit.c */
-DEFINE_SHIM_SYSCALL(getrlimit, 2, shim_do_getrlimit, int, int, resource, struct __kernel_rlimit*,
+DEFINE_SHIM_SYSCALL(getrlimit, 2, shim_do_getrlimit, long, int, resource, struct __kernel_rlimit*,
                     rlim)
 
 long shim_do_getrusage(int who, struct __kernel_rusage* ru) {
@@ -348,142 +347,143 @@ long shim_do_getrusage(int who, struct __kernel_rusage* ru) {
     return -ENOSYS;
 }
 
-DEFINE_SHIM_SYSCALL(getrusage, 2, shim_do_getrusage, int, int, who, struct __kernel_rusage*, ru)
+DEFINE_SHIM_SYSCALL(getrusage, 2, shim_do_getrusage, long, int, who, struct __kernel_rusage*, ru)
 
-SHIM_SYSCALL_RETURN_ENOSYS(sysinfo, 1, int, struct sysinfo*, info)
+SHIM_SYSCALL_RETURN_ENOSYS(sysinfo, 1, long, struct sysinfo*, info)
 
-SHIM_SYSCALL_RETURN_ENOSYS(times, 1, int, struct tms*, tbuf)
+SHIM_SYSCALL_RETURN_ENOSYS(times, 1, long, struct tms*, tbuf)
 
-SHIM_SYSCALL_RETURN_ENOSYS(ptrace, 4, int, long, request, pid_t, pid, void*, addr, void*, data)
+SHIM_SYSCALL_RETURN_ENOSYS(ptrace, 4, long, long, request, pid_t, pid, void*, addr, void*, data)
 
 /* getuid: sys/shim_getuid.c */
-DEFINE_SHIM_SYSCALL(getuid, 0, shim_do_getuid, uid_t)
+DEFINE_SHIM_SYSCALL(getuid, 0, shim_do_getuid, long)
 
-SHIM_SYSCALL_RETURN_ENOSYS(syslog, 3, int, int, type, char*, buf, int, len)
+SHIM_SYSCALL_RETURN_ENOSYS(syslog, 3, long, int, type, char*, buf, int, len)
 
 /* getgid: sys/shim_getuid.c */
-DEFINE_SHIM_SYSCALL(getgid, 0, shim_do_getgid, gid_t)
+DEFINE_SHIM_SYSCALL(getgid, 0, shim_do_getgid, long)
 
 /* setuid: sys/shim_getuid.c */
-DEFINE_SHIM_SYSCALL(setuid, 1, shim_do_setuid, int, uid_t, uid)
+DEFINE_SHIM_SYSCALL(setuid, 1, shim_do_setuid, long, uid_t, uid)
 
 /* setgid: sys/shim_getuid.c */
-DEFINE_SHIM_SYSCALL(setgid, 1, shim_do_setgid, int, gid_t, gid)
+DEFINE_SHIM_SYSCALL(setgid, 1, shim_do_setgid, long, gid_t, gid)
 
 /* setgroups: sys/shim_getuid.c */
-DEFINE_SHIM_SYSCALL(setgroups, 2, shim_do_setgroups, int, int, gidsetsize, gid_t*, grouplist)
+DEFINE_SHIM_SYSCALL(setgroups, 2, shim_do_setgroups, long, int, gidsetsize, gid_t*, grouplist)
 
 /* getgroups: sys/shim_getuid.c */
-DEFINE_SHIM_SYSCALL(getgroups, 2, shim_do_getgroups, int, int, gidsetsize, gid_t*, grouplist)
+DEFINE_SHIM_SYSCALL(getgroups, 2, shim_do_getgroups, long, int, gidsetsize, gid_t*, grouplist)
 
 /* geteuid: sys/shim_getuid.c */
-DEFINE_SHIM_SYSCALL(geteuid, 0, shim_do_geteuid, uid_t)
+DEFINE_SHIM_SYSCALL(geteuid, 0, shim_do_geteuid, long)
 
 /* getegid: sys/shim_getuid.c */
-DEFINE_SHIM_SYSCALL(getegid, 0, shim_do_getegid, gid_t)
+DEFINE_SHIM_SYSCALL(getegid, 0, shim_do_getegid, long)
 
 /* getpgid: sys/shim_getpid.c */
-DEFINE_SHIM_SYSCALL(setpgid, 2, shim_do_setpgid, int, pid_t, pid, pid_t, pgid)
+DEFINE_SHIM_SYSCALL(setpgid, 2, shim_do_setpgid, long, pid_t, pid, pid_t, pgid)
 
 /* getppid: sys/shim_getpid.c */
-DEFINE_SHIM_SYSCALL(getppid, 0, shim_do_getppid, pid_t)
+DEFINE_SHIM_SYSCALL(getppid, 0, shim_do_getppid, long)
 
 /* getpgrp: sys/shim_getpid.c */
-DEFINE_SHIM_SYSCALL(getpgrp, 0, shim_do_getpgrp, pid_t)
+DEFINE_SHIM_SYSCALL(getpgrp, 0, shim_do_getpgrp, long)
 
 /* setsid: sys/shim_getpid.c */
-DEFINE_SHIM_SYSCALL(setsid, 0, shim_do_setsid, int)
+DEFINE_SHIM_SYSCALL(setsid, 0, shim_do_setsid, long)
 
-SHIM_SYSCALL_RETURN_ENOSYS(setreuid, 2, int, uid_t, ruid, uid_t, euid)
+SHIM_SYSCALL_RETURN_ENOSYS(setreuid, 2, long, uid_t, ruid, uid_t, euid)
 
-SHIM_SYSCALL_RETURN_ENOSYS(setregid, 2, int, gid_t, rgid, gid_t, egid)
+SHIM_SYSCALL_RETURN_ENOSYS(setregid, 2, long, gid_t, rgid, gid_t, egid)
 
-SHIM_SYSCALL_RETURN_ENOSYS(setresuid, 3, int, uid_t, ruid, uid_t, euid, uid_t, suid)
+SHIM_SYSCALL_RETURN_ENOSYS(setresuid, 3, long, uid_t, ruid, uid_t, euid, uid_t, suid)
 
-SHIM_SYSCALL_RETURN_ENOSYS(getresuid, 3, int, uid_t*, ruid, uid_t*, euid, uid_t*, suid)
+SHIM_SYSCALL_RETURN_ENOSYS(getresuid, 3, long, uid_t*, ruid, uid_t*, euid, uid_t*, suid)
 
-SHIM_SYSCALL_RETURN_ENOSYS(setresgid, 3, int, gid_t, rgid, gid_t, egid, gid_t, sgid)
+SHIM_SYSCALL_RETURN_ENOSYS(setresgid, 3, long, gid_t, rgid, gid_t, egid, gid_t, sgid)
 
-SHIM_SYSCALL_RETURN_ENOSYS(getresgid, 3, int, gid_t*, rgid, gid_t*, egid, gid_t*, sgid)
+SHIM_SYSCALL_RETURN_ENOSYS(getresgid, 3, long, gid_t*, rgid, gid_t*, egid, gid_t*, sgid)
 
-DEFINE_SHIM_SYSCALL(getpgid, 1, shim_do_getpgid, int, pid_t, pid)
+DEFINE_SHIM_SYSCALL(getpgid, 1, shim_do_getpgid, long, pid_t, pid)
 
-SHIM_SYSCALL_RETURN_ENOSYS(setfsuid, 1, int, uid_t, uid)
+SHIM_SYSCALL_RETURN_ENOSYS(setfsuid, 1, long, uid_t, uid)
 
-SHIM_SYSCALL_RETURN_ENOSYS(setfsgid, 1, int, gid_t, gid)
+SHIM_SYSCALL_RETURN_ENOSYS(setfsgid, 1, long, gid_t, gid)
 
-DEFINE_SHIM_SYSCALL(getsid, 1, shim_do_getsid, int, pid_t, pid)
+DEFINE_SHIM_SYSCALL(getsid, 1, shim_do_getsid, long, pid_t, pid)
 
-SHIM_SYSCALL_RETURN_ENOSYS(capget, 2, int, cap_user_header_t, header, cap_user_data_t, dataptr)
+SHIM_SYSCALL_RETURN_ENOSYS(capget, 2, long, cap_user_header_t, header, cap_user_data_t, dataptr)
 
-SHIM_SYSCALL_RETURN_ENOSYS(capset, 2, int, cap_user_header_t, header, const cap_user_data_t, data)
+SHIM_SYSCALL_RETURN_ENOSYS(capset, 2, long, cap_user_header_t, header, const cap_user_data_t, data)
 
-DEFINE_SHIM_SYSCALL(rt_sigpending, 2, shim_do_sigpending, int, __sigset_t*, set, size_t, sigsetsize)
+DEFINE_SHIM_SYSCALL(rt_sigpending, 2, shim_do_sigpending, long, __sigset_t*, set, size_t,
+                    sigsetsize)
 
-SHIM_SYSCALL_RETURN_ENOSYS(rt_sigtimedwait, 4, int, const __sigset_t*, uthese, siginfo_t*, uinfo,
+SHIM_SYSCALL_RETURN_ENOSYS(rt_sigtimedwait, 4, long, const __sigset_t*, uthese, siginfo_t*, uinfo,
                            const struct timespec*, uts, size_t, sigsetsize)
 
-SHIM_SYSCALL_RETURN_ENOSYS(rt_sigqueueinfo, 3, int, int, pid, int, sig, siginfo_t*, uinfo)
+SHIM_SYSCALL_RETURN_ENOSYS(rt_sigqueueinfo, 3, long, int, pid, int, sig, siginfo_t*, uinfo)
 
-DEFINE_SHIM_SYSCALL(rt_sigsuspend, 1, shim_do_sigsuspend, int, const __sigset_t*, mask)
+DEFINE_SHIM_SYSCALL(rt_sigsuspend, 1, shim_do_sigsuspend, long, const __sigset_t*, mask)
 
-DEFINE_SHIM_SYSCALL(sigaltstack, 2, shim_do_sigaltstack, int, const stack_t*, ss, stack_t*, oss)
+DEFINE_SHIM_SYSCALL(sigaltstack, 2, shim_do_sigaltstack, long, const stack_t*, ss, stack_t*, oss)
 
-SHIM_SYSCALL_RETURN_ENOSYS(utime, 2, int, char*, filename, struct utimbuf*, times)
+SHIM_SYSCALL_RETURN_ENOSYS(utime, 2, long, char*, filename, struct utimbuf*, times)
 
-DEFINE_SHIM_SYSCALL(mknod, 3, shim_do_mknod, int, const char*, filename, int, mode, unsigned, dev)
+DEFINE_SHIM_SYSCALL(mknod, 3, shim_do_mknod, long, const char*, filename, int, mode, unsigned, dev)
 
-SHIM_SYSCALL_RETURN_ENOSYS(uselib, 1, int, const char*, library)
+SHIM_SYSCALL_RETURN_ENOSYS(uselib, 1, long, const char*, library)
 
-SHIM_SYSCALL_RETURN_ENOSYS(personality, 1, int, unsigned int, personality)
+SHIM_SYSCALL_RETURN_ENOSYS(personality, 1, long, unsigned int, personality)
 
-SHIM_SYSCALL_RETURN_ENOSYS(ustat, 2, int, unsigned, dev, struct __kernel_ustat*, ubuf)
+SHIM_SYSCALL_RETURN_ENOSYS(ustat, 2, long, unsigned, dev, struct __kernel_ustat*, ubuf)
 
-SHIM_SYSCALL_RETURN_ENOSYS(statfs, 2, int, const char*, path, struct statfs*, buf)
+SHIM_SYSCALL_RETURN_ENOSYS(statfs, 2, long, const char*, path, struct statfs*, buf)
 
-SHIM_SYSCALL_RETURN_ENOSYS(fstatfs, 2, int, int, fd, struct statfs*, buf)
+SHIM_SYSCALL_RETURN_ENOSYS(fstatfs, 2, long, int, fd, struct statfs*, buf)
 
-SHIM_SYSCALL_RETURN_ENOSYS(sysfs, 3, int, int, option, unsigned long, arg1, unsigned long, arg2)
+SHIM_SYSCALL_RETURN_ENOSYS(sysfs, 3, long, int, option, unsigned long, arg1, unsigned long, arg2)
 
-DEFINE_SHIM_SYSCALL(setpriority, 3, shim_do_setpriority, int, int, which, int, who, int, niceval)
+DEFINE_SHIM_SYSCALL(setpriority, 3, shim_do_setpriority, long, int, which, int, who, int, niceval)
 
-DEFINE_SHIM_SYSCALL(getpriority, 2, shim_do_getpriority, int, int, which, int, who)
+DEFINE_SHIM_SYSCALL(getpriority, 2, shim_do_getpriority, long, int, which, int, who)
 
-DEFINE_SHIM_SYSCALL(sched_setparam, 2, shim_do_sched_setparam, int, pid_t, pid,
+DEFINE_SHIM_SYSCALL(sched_setparam, 2, shim_do_sched_setparam, long, pid_t, pid,
                     struct __kernel_sched_param*, param)
 
-DEFINE_SHIM_SYSCALL(sched_getparam, 2, shim_do_sched_getparam, int, pid_t, pid,
+DEFINE_SHIM_SYSCALL(sched_getparam, 2, shim_do_sched_getparam, long, pid_t, pid,
                     struct __kernel_sched_param*, param)
 
-DEFINE_SHIM_SYSCALL(sched_setscheduler, 3, shim_do_sched_setscheduler, int, pid_t, pid, int, policy,
-                    struct __kernel_sched_param*, param)
+DEFINE_SHIM_SYSCALL(sched_setscheduler, 3, shim_do_sched_setscheduler, long, pid_t, pid, int,
+                    policy, struct __kernel_sched_param*, param)
 
-DEFINE_SHIM_SYSCALL(sched_getscheduler, 1, shim_do_sched_getscheduler, int, pid_t, pid)
+DEFINE_SHIM_SYSCALL(sched_getscheduler, 1, shim_do_sched_getscheduler, long, pid_t, pid)
 
-DEFINE_SHIM_SYSCALL(sched_get_priority_max, 1, shim_do_sched_get_priority_max, int, int, policy)
+DEFINE_SHIM_SYSCALL(sched_get_priority_max, 1, shim_do_sched_get_priority_max, long, int, policy)
 
-DEFINE_SHIM_SYSCALL(sched_get_priority_min, 1, shim_do_sched_get_priority_min, int, int, policy)
+DEFINE_SHIM_SYSCALL(sched_get_priority_min, 1, shim_do_sched_get_priority_min, long, int, policy)
 
-DEFINE_SHIM_SYSCALL(sched_rr_get_interval, 2, shim_do_sched_rr_get_interval, int, pid_t, pid,
+DEFINE_SHIM_SYSCALL(sched_rr_get_interval, 2, shim_do_sched_rr_get_interval, long, pid_t, pid,
                     struct timespec*, interval)
 
-SHIM_SYSCALL_RETURN_ENOSYS(mlock, 2, int, void*, start, size_t, len)
+SHIM_SYSCALL_RETURN_ENOSYS(mlock, 2, long, void*, start, size_t, len)
 
-SHIM_SYSCALL_RETURN_ENOSYS(munlock, 2, int, void*, start, size_t, len)
+SHIM_SYSCALL_RETURN_ENOSYS(munlock, 2, long, void*, start, size_t, len)
 
-SHIM_SYSCALL_RETURN_ENOSYS(mlockall, 1, int, int, flags)
+SHIM_SYSCALL_RETURN_ENOSYS(mlockall, 1, long, int, flags)
 
-SHIM_SYSCALL_RETURN_ENOSYS(munlockall, 0, int)
+SHIM_SYSCALL_RETURN_ENOSYS(munlockall, 0, long)
 
-SHIM_SYSCALL_RETURN_ENOSYS(vhangup, 0, int)
+SHIM_SYSCALL_RETURN_ENOSYS(vhangup, 0, long)
 
-SHIM_SYSCALL_RETURN_ENOSYS(modify_ldt, 3, int, int, func, void*, ptr, unsigned long, bytecount)
+SHIM_SYSCALL_RETURN_ENOSYS(modify_ldt, 3, long, int, func, void*, ptr, unsigned long, bytecount)
 
-SHIM_SYSCALL_RETURN_ENOSYS(pivot_root, 2, int, const char*, new_root, const char*, put_old)
+SHIM_SYSCALL_RETURN_ENOSYS(pivot_root, 2, long, const char*, new_root, const char*, put_old)
 
-SHIM_SYSCALL_RETURN_ENOSYS(_sysctl, 1, int, struct __kernel_sysctl_args*, args)
+SHIM_SYSCALL_RETURN_ENOSYS(_sysctl, 1, long, struct __kernel_sysctl_args*, args)
 
-SHIM_SYSCALL_RETURN_ENOSYS(prctl, 5, int, int, option, unsigned long, arg2, unsigned long, arg3,
+SHIM_SYSCALL_RETURN_ENOSYS(prctl, 5, long, int, option, unsigned long, arg2, unsigned long, arg3,
                            unsigned long, arg4, unsigned long, arg5)
 
 #if defined(__i386__) || defined(__x86_64__)
@@ -512,388 +512,392 @@ long shim_do_arch_prctl(int code, void* addr) {
 }
 #endif
 
-SHIM_SYSCALL_RETURN_ENOSYS(adjtimex, 1, int, struct ____kernel_timex*, txc_p)
+SHIM_SYSCALL_RETURN_ENOSYS(adjtimex, 1, long, struct ____kernel_timex*, txc_p)
 
 /* setrlimit: sys/shim_getrlimit.c */
-DEFINE_SHIM_SYSCALL(setrlimit, 2, shim_do_setrlimit, int, int, resource, struct __kernel_rlimit*,
+DEFINE_SHIM_SYSCALL(setrlimit, 2, shim_do_setrlimit, long, int, resource, struct __kernel_rlimit*,
                     rlim)
 
 /* chroot: sys/shim_isolate.c */
-DEFINE_SHIM_SYSCALL(chroot, 1, shim_do_chroot, int, const char*, filename)
+DEFINE_SHIM_SYSCALL(chroot, 1, shim_do_chroot, long, const char*, filename)
 
-SHIM_SYSCALL_RETURN_ENOSYS(sync, 0, int)
+SHIM_SYSCALL_RETURN_ENOSYS(sync, 0, long)
 
-SHIM_SYSCALL_RETURN_ENOSYS(acct, 1, int, const char*, name)
+SHIM_SYSCALL_RETURN_ENOSYS(acct, 1, long, const char*, name)
 
-SHIM_SYSCALL_RETURN_ENOSYS(settimeofday, 2, int, struct timeval*, tv, struct __kernel_timezone*, tz)
+SHIM_SYSCALL_RETURN_ENOSYS(settimeofday, 2, long, struct timeval*, tv, struct __kernel_timezone*,
+                           tz)
 
-SHIM_SYSCALL_RETURN_ENOSYS(mount, 5, int, char*, dev_name, char*, dir_name, char*, type,
+SHIM_SYSCALL_RETURN_ENOSYS(mount, 5, long, char*, dev_name, char*, dir_name, char*, type,
                            unsigned long, flags, void*, data)
 
-SHIM_SYSCALL_RETURN_ENOSYS(umount2, 2, int, const char*, target, int, flags)
+SHIM_SYSCALL_RETURN_ENOSYS(umount2, 2, long, const char*, target, int, flags)
 
-SHIM_SYSCALL_RETURN_ENOSYS(swapon, 2, int, const char*, specialfile, int, swap_flags)
+SHIM_SYSCALL_RETURN_ENOSYS(swapon, 2, long, const char*, specialfile, int, swap_flags)
 
-SHIM_SYSCALL_RETURN_ENOSYS(swapoff, 1, int, const char*, specialfile)
+SHIM_SYSCALL_RETURN_ENOSYS(swapoff, 1, long, const char*, specialfile)
 
-SHIM_SYSCALL_RETURN_ENOSYS(reboot, 4, int, int, magic1, int, magic2, int, cmd, void*, arg)
+SHIM_SYSCALL_RETURN_ENOSYS(reboot, 4, long, int, magic1, int, magic2, int, cmd, void*, arg)
 
 DEFINE_SHIM_SYSCALL(sethostname, 2, shim_do_sethostname, long, char*, name, int, len)
 
 DEFINE_SHIM_SYSCALL(setdomainname, 2, shim_do_setdomainname, long, char*, name, int, len)
 
 #if defined(__i386__) || defined(__x86_64__)
-SHIM_SYSCALL_RETURN_ENOSYS(iopl, 1, int, int, level)
+SHIM_SYSCALL_RETURN_ENOSYS(iopl, 1, long, int, level)
 
-SHIM_SYSCALL_RETURN_ENOSYS(ioperm, 3, int, unsigned long, from, unsigned long, num, int, on)
+SHIM_SYSCALL_RETURN_ENOSYS(ioperm, 3, long, unsigned long, from, unsigned long, num, int, on)
 #endif
 
-SHIM_SYSCALL_RETURN_ENOSYS(create_module, 2, int, const char*, name, size_t, size)
+SHIM_SYSCALL_RETURN_ENOSYS(create_module, 2, long, const char*, name, size_t, size)
 
-SHIM_SYSCALL_RETURN_ENOSYS(init_module, 3, int, void*, umod, unsigned long, len, const char*, uargs)
+SHIM_SYSCALL_RETURN_ENOSYS(init_module, 3, long, void*, umod, unsigned long, len, const char*,
+                           uargs)
 
-SHIM_SYSCALL_RETURN_ENOSYS(delete_module, 2, int, const char*, name_user, unsigned int, flags)
+SHIM_SYSCALL_RETURN_ENOSYS(delete_module, 2, long, const char*, name_user, unsigned int, flags)
 
-SHIM_SYSCALL_RETURN_ENOSYS(query_module, 5, int, const char*, name, int, which, void*, buf, size_t,
+SHIM_SYSCALL_RETURN_ENOSYS(query_module, 5, long, const char*, name, int, which, void*, buf, size_t,
                            bufsize, size_t*, retsize)
 
-SHIM_SYSCALL_RETURN_ENOSYS(quotactl, 4, int, int, cmd, const char*, special, qid_t, id, void*, addr)
+SHIM_SYSCALL_RETURN_ENOSYS(quotactl, 4, long, int, cmd, const char*, special, qid_t, id, void*,
+                           addr)
 
 /* gettid: sys/shim_getpid.c */
-DEFINE_SHIM_SYSCALL(gettid, 0, shim_do_gettid, pid_t)
+DEFINE_SHIM_SYSCALL(gettid, 0, shim_do_gettid, long)
 
-SHIM_SYSCALL_RETURN_ENOSYS(readahead, 3, int, int, fd, loff_t, offset, size_t, count)
+SHIM_SYSCALL_RETURN_ENOSYS(readahead, 3, long, int, fd, loff_t, offset, size_t, count)
 
-SHIM_SYSCALL_RETURN_ENOSYS(setxattr, 5, int, const char*, path, const char*, name, const void*,
+SHIM_SYSCALL_RETURN_ENOSYS(setxattr, 5, long, const char*, path, const char*, name, const void*,
                            value, size_t, size, int, flags)
 
-SHIM_SYSCALL_RETURN_ENOSYS(lsetxattr, 5, int, const char*, path, const char*, name, const void*,
+SHIM_SYSCALL_RETURN_ENOSYS(lsetxattr, 5, long, const char*, path, const char*, name, const void*,
                            value, size_t, size, int, flags)
 
-SHIM_SYSCALL_RETURN_ENOSYS(fsetxattr, 5, int, int, fd, const char*, name, const void*, value,
+SHIM_SYSCALL_RETURN_ENOSYS(fsetxattr, 5, long, int, fd, const char*, name, const void*, value,
                            size_t, size, int, flags)
 
-SHIM_SYSCALL_RETURN_ENOSYS(getxattr, 4, int, const char*, path, const char*, name, void*, value,
+SHIM_SYSCALL_RETURN_ENOSYS(getxattr, 4, long, const char*, path, const char*, name, void*, value,
                            size_t, size)
 
-SHIM_SYSCALL_RETURN_ENOSYS(lgetxattr, 4, int, const char*, path, const char*, name, void*, value,
+SHIM_SYSCALL_RETURN_ENOSYS(lgetxattr, 4, long, const char*, path, const char*, name, void*, value,
                            size_t, size)
 
-SHIM_SYSCALL_RETURN_ENOSYS(fgetxattr, 4, int, int, fd, const char*, name, void*, value, size_t,
+SHIM_SYSCALL_RETURN_ENOSYS(fgetxattr, 4, long, int, fd, const char*, name, void*, value, size_t,
                            size)
 
-SHIM_SYSCALL_RETURN_ENOSYS(listxattr, 3, int, const char*, path, char*, list, size_t, size)
+SHIM_SYSCALL_RETURN_ENOSYS(listxattr, 3, long, const char*, path, char*, list, size_t, size)
 
-SHIM_SYSCALL_RETURN_ENOSYS(llistxattr, 3, int, const char*, path, char*, list, size_t, size)
+SHIM_SYSCALL_RETURN_ENOSYS(llistxattr, 3, long, const char*, path, char*, list, size_t, size)
 
-SHIM_SYSCALL_RETURN_ENOSYS(flistxattr, 3, int, int, fd, char*, list, size_t, size)
+SHIM_SYSCALL_RETURN_ENOSYS(flistxattr, 3, long, int, fd, char*, list, size_t, size)
 
-SHIM_SYSCALL_RETURN_ENOSYS(removexattr, 2, int, const char*, path, const char*, name)
+SHIM_SYSCALL_RETURN_ENOSYS(removexattr, 2, long, const char*, path, const char*, name)
 
-SHIM_SYSCALL_RETURN_ENOSYS(lremovexattr, 2, int, const char*, path, const char*, name)
+SHIM_SYSCALL_RETURN_ENOSYS(lremovexattr, 2, long, const char*, path, const char*, name)
 
-SHIM_SYSCALL_RETURN_ENOSYS(fremovexattr, 2, int, int, fd, const char*, name)
+SHIM_SYSCALL_RETURN_ENOSYS(fremovexattr, 2, long, int, fd, const char*, name)
 
-DEFINE_SHIM_SYSCALL(tkill, 2, shim_do_tkill, int, pid_t, pid, int, sig)
+DEFINE_SHIM_SYSCALL(tkill, 2, shim_do_tkill, long, pid_t, pid, int, sig)
 
-DEFINE_SHIM_SYSCALL(time, 1, shim_do_time, time_t, time_t*, tloc)
+DEFINE_SHIM_SYSCALL(time, 1, shim_do_time, long, time_t*, tloc)
 
 /* futex: sys/shim_futex.c */
-DEFINE_SHIM_SYSCALL(futex, 6, shim_do_futex, int, int*, uaddr, int, op, int, val, void*, utime,
+DEFINE_SHIM_SYSCALL(futex, 6, shim_do_futex, long, int*, uaddr, int, op, int, val, void*, utime,
                     int*, uaddr2, int, val3)
 
 DEFINE_SHIM_SYSCALL(sched_setaffinity, 3, shim_do_sched_setaffinity, long, pid_t, pid,
                     unsigned int, len, unsigned long*, user_mask_ptr)
 
-DEFINE_SHIM_SYSCALL(sched_getaffinity, 3, shim_do_sched_getaffinity, int, pid_t, pid,
+DEFINE_SHIM_SYSCALL(sched_getaffinity, 3, shim_do_sched_getaffinity, long, pid_t, pid,
                     unsigned int, len, unsigned long*, user_mask_ptr)
 
 #if defined(__i386__) || defined(__x86_64__)
-SHIM_SYSCALL_RETURN_ENOSYS(set_thread_area, 1, int, struct user_desc*, u_info)
+SHIM_SYSCALL_RETURN_ENOSYS(set_thread_area, 1, long, struct user_desc*, u_info)
 #endif
 
 /* no glibc wrapper */
 
-SHIM_SYSCALL_RETURN_ENOSYS(io_setup, 2, int, unsigned, nr_reqs, aio_context_t*, ctx)
+SHIM_SYSCALL_RETURN_ENOSYS(io_setup, 2, long, unsigned, nr_reqs, aio_context_t*, ctx)
 
-SHIM_SYSCALL_RETURN_ENOSYS(io_destroy, 1, int, aio_context_t, ctx)
+SHIM_SYSCALL_RETURN_ENOSYS(io_destroy, 1, long, aio_context_t, ctx)
 
-SHIM_SYSCALL_RETURN_ENOSYS(io_getevents, 5, int, aio_context_t, ctx_id, long, min_nr, long, nr,
+SHIM_SYSCALL_RETURN_ENOSYS(io_getevents, 5, long, aio_context_t, ctx_id, long, min_nr, long, nr,
                            struct io_event*, events, struct timespec*, timeout)
 
-SHIM_SYSCALL_RETURN_ENOSYS(io_submit, 3, int, aio_context_t, ctx_id, long, nr, struct iocb**,
+SHIM_SYSCALL_RETURN_ENOSYS(io_submit, 3, long, aio_context_t, ctx_id, long, nr, struct iocb**,
                            iocbpp)
 
-SHIM_SYSCALL_RETURN_ENOSYS(io_cancel, 3, int, aio_context_t, ctx_id, struct iocb*, iocb,
+SHIM_SYSCALL_RETURN_ENOSYS(io_cancel, 3, long, aio_context_t, ctx_id, struct iocb*, iocb,
                            struct io_event*, result)
 
 #if defined(__i386__) || defined(__x86_64__)
-SHIM_SYSCALL_RETURN_ENOSYS(get_thread_area, 1, int, struct user_desc*, u_info)
+SHIM_SYSCALL_RETURN_ENOSYS(get_thread_area, 1, long, struct user_desc*, u_info)
 #endif
 
-SHIM_SYSCALL_RETURN_ENOSYS(lookup_dcookie, 3, int, unsigned long, cookie64, char*, buf, size_t, len)
+SHIM_SYSCALL_RETURN_ENOSYS(lookup_dcookie, 3, long, unsigned long, cookie64, char*, buf, size_t,
+                           len)
 
-DEFINE_SHIM_SYSCALL(epoll_create, 1, shim_do_epoll_create, int, int, size)
+DEFINE_SHIM_SYSCALL(epoll_create, 1, shim_do_epoll_create, long, int, size)
 
-SHIM_SYSCALL_RETURN_ENOSYS(remap_file_pages, 5, int, void*, start, size_t, size, int, prot, ssize_t,
-                           pgoff, int, flags)
+SHIM_SYSCALL_RETURN_ENOSYS(remap_file_pages, 5, long, void*, start, size_t, size, int, prot,
+                           ssize_t, pgoff, int, flags)
 
 /* getdents64: sys/shim_open.c */
-DEFINE_SHIM_SYSCALL(getdents64, 3, shim_do_getdents64, size_t, int, fd, struct linux_dirent64*, buf,
+DEFINE_SHIM_SYSCALL(getdents64, 3, shim_do_getdents64, long, int, fd, struct linux_dirent64*, buf,
                     size_t, count)
 
 /* set_tid_address: sys/shim_getpid.c */
-DEFINE_SHIM_SYSCALL(set_tid_address, 1, shim_do_set_tid_address, int, int*, tidptr)
+DEFINE_SHIM_SYSCALL(set_tid_address, 1, shim_do_set_tid_address, long, int*, tidptr)
 
-SHIM_SYSCALL_RETURN_ENOSYS(restart_syscall, 0, int)
+SHIM_SYSCALL_RETURN_ENOSYS(restart_syscall, 0, long)
 
 /* semtimedop: sys/shim_semget.c */
-DEFINE_SHIM_SYSCALL(semtimedop, 4, shim_do_semtimedop, int, int, semid, struct sembuf*, sops,
+DEFINE_SHIM_SYSCALL(semtimedop, 4, shim_do_semtimedop, long, int, semid, struct sembuf*, sops,
                     unsigned int, nsops, const struct timespec*, timeout)
 
-SHIM_SYSCALL_RETURN_ENOSYS(fadvise64, 4, int, int, fd, loff_t, offset, size_t, len, int, advice)
+SHIM_SYSCALL_RETURN_ENOSYS(fadvise64, 4, long, int, fd, loff_t, offset, size_t, len, int, advice)
 
-SHIM_SYSCALL_RETURN_ENOSYS(timer_create, 3, int, clockid_t, which_clock, struct sigevent*,
+SHIM_SYSCALL_RETURN_ENOSYS(timer_create, 3, long, clockid_t, which_clock, struct sigevent*,
                            timer_event_spec, timer_t*, created_timer_id)
 
-SHIM_SYSCALL_RETURN_ENOSYS(timer_settime, 4, int, timer_t, timer_id, int, flags,
+SHIM_SYSCALL_RETURN_ENOSYS(timer_settime, 4, long, timer_t, timer_id, int, flags,
                            const struct __kernel_itimerspec*, new_setting,
                            struct __kernel_itimerspec*, old_setting)
 
-SHIM_SYSCALL_RETURN_ENOSYS(timer_gettime, 2, int, timer_t, timer_id, struct __kernel_itimerspec*,
+SHIM_SYSCALL_RETURN_ENOSYS(timer_gettime, 2, long, timer_t, timer_id, struct __kernel_itimerspec*,
                            setting)
 
-SHIM_SYSCALL_RETURN_ENOSYS(timer_getoverrun, 1, int, timer_t, timer_id)
+SHIM_SYSCALL_RETURN_ENOSYS(timer_getoverrun, 1, long, timer_t, timer_id)
 
-SHIM_SYSCALL_RETURN_ENOSYS(timer_delete, 1, int, timer_t, timer_id)
+SHIM_SYSCALL_RETURN_ENOSYS(timer_delete, 1, long, timer_t, timer_id)
 
-SHIM_SYSCALL_RETURN_ENOSYS(clock_settime, 2, int, clockid_t, which_clock, const struct timespec*,
+SHIM_SYSCALL_RETURN_ENOSYS(clock_settime, 2, long, clockid_t, which_clock, const struct timespec*,
                            tp)
 
 /* clock_gettime: sys/shim_time.c */
-DEFINE_SHIM_SYSCALL(clock_gettime, 2, shim_do_clock_gettime, int, clockid_t, which_clock,
+DEFINE_SHIM_SYSCALL(clock_gettime, 2, shim_do_clock_gettime, long, clockid_t, which_clock,
                     struct timespec*, tp)
 
-DEFINE_SHIM_SYSCALL(clock_getres, 2, shim_do_clock_getres, int, clockid_t, which_clock,
+DEFINE_SHIM_SYSCALL(clock_getres, 2, shim_do_clock_getres, long, clockid_t, which_clock,
                     struct timespec*, tp)
 
 /* clock_nanosleep: sys/shim_sleep.c */
-DEFINE_SHIM_SYSCALL(clock_nanosleep, 4, shim_do_clock_nanosleep, int, clockid_t, which_clock, int,
+DEFINE_SHIM_SYSCALL(clock_nanosleep, 4, shim_do_clock_nanosleep, long, clockid_t, which_clock, int,
                     flags, const struct __kernel_timespec*, rqtp, struct __kernel_timespec*, rmtp)
 
 /* exit_group: sys/shim_exit.c */
-DEFINE_SHIM_SYSCALL(exit_group, 1, shim_do_exit_group, int, int, error_code)
+DEFINE_SHIM_SYSCALL(exit_group, 1, shim_do_exit_group, long, int, error_code)
 
-DEFINE_SHIM_SYSCALL(epoll_wait, 4, shim_do_epoll_wait, int, int, epfd, struct __kernel_epoll_event*,
-                    events, int, maxevents, int, timeout_ms)
+DEFINE_SHIM_SYSCALL(epoll_wait, 4, shim_do_epoll_wait, long, int, epfd,
+                    struct __kernel_epoll_event*, events, int, maxevents, int, timeout_ms)
 
-DEFINE_SHIM_SYSCALL(epoll_ctl, 4, shim_do_epoll_ctl, int, int, epfd, int, op, int, fd,
+DEFINE_SHIM_SYSCALL(epoll_ctl, 4, shim_do_epoll_ctl, long, int, epfd, int, op, int, fd,
                     struct __kernel_epoll_event*, event)
 
-DEFINE_SHIM_SYSCALL(tgkill, 3, shim_do_tgkill, int, pid_t, tgid, pid_t, pid, int, sig)
+DEFINE_SHIM_SYSCALL(tgkill, 3, shim_do_tgkill, long, pid_t, tgid, pid_t, pid, int, sig)
 
-SHIM_SYSCALL_RETURN_ENOSYS(utimes, 2, int, char*, filename, struct timeval*, utimes)
+SHIM_SYSCALL_RETURN_ENOSYS(utimes, 2, long, char*, filename, struct timeval*, utimes)
 
-DEFINE_SHIM_SYSCALL(mbind, 6, shim_do_mbind, int, void*, start, unsigned long, len, int, mode,
+DEFINE_SHIM_SYSCALL(mbind, 6, shim_do_mbind, long, void*, start, unsigned long, len, int, mode,
                     unsigned long*, nmask, unsigned long, maxnode, int, flags)
 
-SHIM_SYSCALL_RETURN_ENOSYS(set_mempolicy, 3, int, int, mode, unsigned long*, nmask, unsigned long,
+SHIM_SYSCALL_RETURN_ENOSYS(set_mempolicy, 3, long, int, mode, unsigned long*, nmask, unsigned long,
                            maxnode)
 
-SHIM_SYSCALL_RETURN_ENOSYS(get_mempolicy, 5, int, int*, policy, unsigned long*, nmask,
+SHIM_SYSCALL_RETURN_ENOSYS(get_mempolicy, 5, long, int*, policy, unsigned long*, nmask,
                            unsigned long, maxnode, unsigned long, addr, unsigned long, flags)
 
-SHIM_SYSCALL_RETURN_ENOSYS(mq_open, 4, int, const char*, name, int, oflag, mode_t, mode,
+SHIM_SYSCALL_RETURN_ENOSYS(mq_open, 4, long, const char*, name, int, oflag, mode_t, mode,
                            struct __kernel_mq_attr*, attr)
 
-SHIM_SYSCALL_RETURN_ENOSYS(mq_unlink, 1, int, const char*, name)
+SHIM_SYSCALL_RETURN_ENOSYS(mq_unlink, 1, long, const char*, name)
 
-SHIM_SYSCALL_RETURN_ENOSYS(mq_timedsend, 5, int, __kernel_mqd_t, mqdes, const char*, msg_ptr,
+SHIM_SYSCALL_RETURN_ENOSYS(mq_timedsend, 5, long, __kernel_mqd_t, mqdes, const char*, msg_ptr,
                            size_t, msg_len, unsigned int, msg_prio, const struct timespec*,
                            abs_timeout)
 
-SHIM_SYSCALL_RETURN_ENOSYS(mq_timedreceive, 5, int, __kernel_mqd_t, mqdes, char*, msg_ptr, size_t,
+SHIM_SYSCALL_RETURN_ENOSYS(mq_timedreceive, 5, long, __kernel_mqd_t, mqdes, char*, msg_ptr, size_t,
                            msg_len, unsigned int*, msg_prio, const struct timespec*, abs_timeout)
 
-SHIM_SYSCALL_RETURN_ENOSYS(mq_notify, 2, int, __kernel_mqd_t, mqdes, const struct sigevent*,
+SHIM_SYSCALL_RETURN_ENOSYS(mq_notify, 2, long, __kernel_mqd_t, mqdes, const struct sigevent*,
                            notification)
 
-SHIM_SYSCALL_RETURN_ENOSYS(mq_getsetattr, 3, int, __kernel_mqd_t, mqdes,
+SHIM_SYSCALL_RETURN_ENOSYS(mq_getsetattr, 3, long, __kernel_mqd_t, mqdes,
                            const struct __kernel_mq_attr*, mqstat, struct __kernel_mq_attr*,
                            omqstat)
 
-SHIM_SYSCALL_RETURN_ENOSYS(ioprio_set, 3, int, int, which, int, who, int, ioprio)
+SHIM_SYSCALL_RETURN_ENOSYS(ioprio_set, 3, long, int, which, int, who, int, ioprio)
 
-SHIM_SYSCALL_RETURN_ENOSYS(ioprio_get, 2, int, int, which, int, who)
+SHIM_SYSCALL_RETURN_ENOSYS(ioprio_get, 2, long, int, which, int, who)
 
-SHIM_SYSCALL_RETURN_ENOSYS(inotify_init, 0, int)
+SHIM_SYSCALL_RETURN_ENOSYS(inotify_init, 0, long)
 
-SHIM_SYSCALL_RETURN_ENOSYS(inotify_add_watch, 3, int, int, fd, const char*, path, unsigned int,
+SHIM_SYSCALL_RETURN_ENOSYS(inotify_add_watch, 3, long, int, fd, const char*, path, unsigned int,
                            mask)
 
-SHIM_SYSCALL_RETURN_ENOSYS(inotify_rm_watch, 2, int, int, fd, unsigned int, wd)
+SHIM_SYSCALL_RETURN_ENOSYS(inotify_rm_watch, 2, long, int, fd, unsigned int, wd)
 
-SHIM_SYSCALL_RETURN_ENOSYS(migrate_pages, 4, int, pid_t, pid, unsigned long, maxnode,
+SHIM_SYSCALL_RETURN_ENOSYS(migrate_pages, 4, long, pid_t, pid, unsigned long, maxnode,
                            const unsigned long*, from, const unsigned long*, to)
 
 /* openat: sys/shim_open.c */
-DEFINE_SHIM_SYSCALL(openat, 4, shim_do_openat, int, int, dfd, const char*, filename, int, flags,
+DEFINE_SHIM_SYSCALL(openat, 4, shim_do_openat, long, int, dfd, const char*, filename, int, flags,
                     int, mode)
 
 /* mkdirat: sys/shim_fs.c */
-DEFINE_SHIM_SYSCALL(mkdirat, 3, shim_do_mkdirat, int, int, dfd, const char*, pathname, int, mode)
+DEFINE_SHIM_SYSCALL(mkdirat, 3, shim_do_mkdirat, long, int, dfd, const char*, pathname, int, mode)
 
-DEFINE_SHIM_SYSCALL(mknodat, 4, shim_do_mknodat, int, int, dfd, const char*, filename, int, mode,
+DEFINE_SHIM_SYSCALL(mknodat, 4, shim_do_mknodat, long, int, dfd, const char*, filename, int, mode,
                     unsigned, dev)
 
-DEFINE_SHIM_SYSCALL(fchownat, 5, shim_do_fchownat, int, int, dfd, const char*, filename, uid_t,
+DEFINE_SHIM_SYSCALL(fchownat, 5, shim_do_fchownat, long, int, dfd, const char*, filename, uid_t,
                     user, gid_t, group, int, flag)
 
-SHIM_SYSCALL_RETURN_ENOSYS(futimesat, 3, int, int, dfd, const char*, filename, struct timeval*,
+SHIM_SYSCALL_RETURN_ENOSYS(futimesat, 3, long, int, dfd, const char*, filename, struct timeval*,
                            utimes)
 
 /* fstatat: sys/shim_stat.c */
-DEFINE_SHIM_SYSCALL(newfstatat, 4, shim_do_newfstatat, int, int, dfd, const char*, filename,
+DEFINE_SHIM_SYSCALL(newfstatat, 4, shim_do_newfstatat, long, int, dfd, const char*, filename,
                     struct stat*, statbuf, int, flag)
 
 /* unlinkat: sys/shim_fs.c */
-DEFINE_SHIM_SYSCALL(unlinkat, 3, shim_do_unlinkat, int, int, dfd, const char*, pathname, int, flag)
+DEFINE_SHIM_SYSCALL(unlinkat, 3, shim_do_unlinkat, long, int, dfd, const char*, pathname, int, flag)
 
 /* renameat: sys/shim_fs.c */
-DEFINE_SHIM_SYSCALL(renameat, 4, shim_do_renameat, int, int, olddfd, const char*, oldname, int,
+DEFINE_SHIM_SYSCALL(renameat, 4, shim_do_renameat, long, int, olddfd, const char*, oldname, int,
                     newdfd, const char*, newname)
 
-SHIM_SYSCALL_RETURN_ENOSYS(linkat, 5, int, int, olddfd, const char*, oldname, int, newdfd,
+SHIM_SYSCALL_RETURN_ENOSYS(linkat, 5, long, int, olddfd, const char*, oldname, int, newdfd,
                            const char*, newname, int, flags)
 
-SHIM_SYSCALL_RETURN_ENOSYS(symlinkat, 3, int, const char*, oldname, int, newdfd, const char*,
+SHIM_SYSCALL_RETURN_ENOSYS(symlinkat, 3, long, const char*, oldname, int, newdfd, const char*,
                            newname)
 
-DEFINE_SHIM_SYSCALL(readlinkat, 4, shim_do_readlinkat, int, int, dfd, const char*, path, char*, buf,
-                    int, bufsiz)
+DEFINE_SHIM_SYSCALL(readlinkat, 4, shim_do_readlinkat, long, int, dfd, const char*, path, char*,
+                    buf, int, bufsiz)
 
 /* fchmodat: sys/shim_fs.c */
-DEFINE_SHIM_SYSCALL(fchmodat, 3, shim_do_fchmodat, int, int, dfd, const char*, filename, mode_t,
+DEFINE_SHIM_SYSCALL(fchmodat, 3, shim_do_fchmodat, long, int, dfd, const char*, filename, mode_t,
                     mode)
 
 /* faccessat: sys/shim_access.c */
-DEFINE_SHIM_SYSCALL(faccessat, 3, shim_do_faccessat, int, int, dfd, const char*, filename, int,
+DEFINE_SHIM_SYSCALL(faccessat, 3, shim_do_faccessat, long, int, dfd, const char*, filename, int,
                     mode)
 
 /* pselect6: sys/shim_poll.c */
-DEFINE_SHIM_SYSCALL(pselect6, 6, shim_do_pselect6, int, int, nfds, fd_set*, readfds, fd_set*,
+DEFINE_SHIM_SYSCALL(pselect6, 6, shim_do_pselect6, long, int, nfds, fd_set*, readfds, fd_set*,
                     writefds, fd_set*, errorfds, const struct __kernel_timespec*, tsp,
                     const __sigset_t*, sigmask)
 
 /* ppoll: sys/shim_poll.c */
-DEFINE_SHIM_SYSCALL(ppoll, 5, shim_do_ppoll, int, struct pollfd*, fds, int, nfds, struct timespec*,
+DEFINE_SHIM_SYSCALL(ppoll, 5, shim_do_ppoll, long, struct pollfd*, fds, int, nfds, struct timespec*,
                     tsp, const __sigset_t*, sigmask, size_t, sigsetsize)
 
-SHIM_SYSCALL_RETURN_ENOSYS(unshare, 1, int, int, unshare_flags)
+SHIM_SYSCALL_RETURN_ENOSYS(unshare, 1, long, int, unshare_flags)
 
 /* set_robust_list: sys/shim_futex.c */
-DEFINE_SHIM_SYSCALL(set_robust_list, 2, shim_do_set_robust_list, int, struct robust_list_head*,
+DEFINE_SHIM_SYSCALL(set_robust_list, 2, shim_do_set_robust_list, long, struct robust_list_head*,
                     head, size_t, len)
 
 /* get_roubust_list: sys/shim_futex.c */
-DEFINE_SHIM_SYSCALL(get_robust_list, 3, shim_do_get_robust_list, int, pid_t, pid,
+DEFINE_SHIM_SYSCALL(get_robust_list, 3, shim_do_get_robust_list, long, pid_t, pid,
                     struct robust_list_head**, head, size_t*, len)
 
-SHIM_SYSCALL_RETURN_ENOSYS(splice, 6, int, int, fd_in, loff_t*, off_in, int, fd_out, loff_t*,
+SHIM_SYSCALL_RETURN_ENOSYS(splice, 6, long, int, fd_in, loff_t*, off_in, int, fd_out, loff_t*,
                            off_out, size_t, len, int, flags)
 
-SHIM_SYSCALL_RETURN_ENOSYS(tee, 4, int, int, fdin, int, fdout, size_t, len, unsigned int, flags)
+SHIM_SYSCALL_RETURN_ENOSYS(tee, 4, long, int, fdin, int, fdout, size_t, len, unsigned int, flags)
 
-SHIM_SYSCALL_RETURN_ENOSYS(sync_file_range, 4, int, int, fd, loff_t, offset, loff_t, nbytes, int,
+SHIM_SYSCALL_RETURN_ENOSYS(sync_file_range, 4, long, int, fd, loff_t, offset, loff_t, nbytes, int,
                            flags)
 
-SHIM_SYSCALL_RETURN_ENOSYS(vmsplice, 4, int, int, fd, const struct iovec*, iov, unsigned long,
+SHIM_SYSCALL_RETURN_ENOSYS(vmsplice, 4, long, int, fd, const struct iovec*, iov, unsigned long,
                            nr_segs, int, flags)
 
-SHIM_SYSCALL_RETURN_ENOSYS(move_pages, 6, int, pid_t, pid, unsigned long, nr_pages, void**, pages,
+SHIM_SYSCALL_RETURN_ENOSYS(move_pages, 6, long, pid_t, pid, unsigned long, nr_pages, void**, pages,
                            const int*, nodes, int*, status, int, flags)
 
-SHIM_SYSCALL_RETURN_ENOSYS(utimensat, 4, int, int, dfd, const char*, filename, struct timespec*,
+SHIM_SYSCALL_RETURN_ENOSYS(utimensat, 4, long, int, dfd, const char*, filename, struct timespec*,
                            utimes, int, flags)
 
-DEFINE_SHIM_SYSCALL(epoll_pwait, 6, shim_do_epoll_pwait, int, int, epfd,
+DEFINE_SHIM_SYSCALL(epoll_pwait, 6, shim_do_epoll_pwait, long, int, epfd,
                     struct __kernel_epoll_event*, events, int, maxevents, int, timeout_ms,
                     const __sigset_t*, sigmask, size_t, sigsetsize)
 
-SHIM_SYSCALL_RETURN_ENOSYS(signalfd, 3, int, int, ufd, __sigset_t*, user_mask, size_t, sizemask)
+SHIM_SYSCALL_RETURN_ENOSYS(signalfd, 3, long, int, ufd, __sigset_t*, user_mask, size_t, sizemask)
 
-SHIM_SYSCALL_RETURN_ENOSYS(timerfd_create, 2, int, int, clockid, int, flags)
+SHIM_SYSCALL_RETURN_ENOSYS(timerfd_create, 2, long, int, clockid, int, flags)
 
-SHIM_SYSCALL_RETURN_ENOSYS(fallocate, 4, int, int, fd, int, mode, loff_t, offset, loff_t, len)
+SHIM_SYSCALL_RETURN_ENOSYS(fallocate, 4, long, int, fd, int, mode, loff_t, offset, loff_t, len)
 
-SHIM_SYSCALL_RETURN_ENOSYS(timerfd_settime, 4, int, int, ufd, int, flags,
+SHIM_SYSCALL_RETURN_ENOSYS(timerfd_settime, 4, long, int, ufd, int, flags,
                            const struct __kernel_itimerspec*, utmr, struct __kernel_itimerspec*,
                            otmr)
 
-SHIM_SYSCALL_RETURN_ENOSYS(timerfd_gettime, 2, int, int, ufd, struct __kernel_itimerspec*, otmr)
+SHIM_SYSCALL_RETURN_ENOSYS(timerfd_gettime, 2, long, int, ufd, struct __kernel_itimerspec*, otmr)
 
 /* accept4: sys/shim_socket.c */
-DEFINE_SHIM_SYSCALL(accept4, 4, shim_do_accept4, int, int, sockfd, struct sockaddr*, addr, int*,
+DEFINE_SHIM_SYSCALL(accept4, 4, shim_do_accept4, long, int, sockfd, struct sockaddr*, addr, int*,
                     addrlen, int, flags)
 
-SHIM_SYSCALL_RETURN_ENOSYS(signalfd4, 4, int, int, ufd, __sigset_t*, user_mask, size_t, sizemask,
+SHIM_SYSCALL_RETURN_ENOSYS(signalfd4, 4, long, int, ufd, __sigset_t*, user_mask, size_t, sizemask,
                            int, flags)
 
-DEFINE_SHIM_SYSCALL(eventfd, 1, shim_do_eventfd, int, unsigned int, count)
+DEFINE_SHIM_SYSCALL(eventfd, 1, shim_do_eventfd, long, unsigned int, count)
 
-DEFINE_SHIM_SYSCALL(eventfd2, 2, shim_do_eventfd2, int, unsigned int, count, int, flags)
+DEFINE_SHIM_SYSCALL(eventfd2, 2, shim_do_eventfd2, long, unsigned int, count, int, flags)
 
 /* epoll_create1: sys/shim_epoll.c */
-DEFINE_SHIM_SYSCALL(epoll_create1, 1, shim_do_epoll_create1, int, int, flags)
+DEFINE_SHIM_SYSCALL(epoll_create1, 1, shim_do_epoll_create1, long, int, flags)
 
 /* dup3: sys/shim_dup.c */
-DEFINE_SHIM_SYSCALL(dup3, 3, shim_do_dup3, int, unsigned int, oldfd, unsigned int, newfd, int,
+DEFINE_SHIM_SYSCALL(dup3, 3, shim_do_dup3, long, unsigned int, oldfd, unsigned int, newfd, int,
                     flags)
 
 /* pipe2: sys/shim_pipe.c */
-DEFINE_SHIM_SYSCALL(pipe2, 2, shim_do_pipe2, int, int*, fildes, int, flags)
+DEFINE_SHIM_SYSCALL(pipe2, 2, shim_do_pipe2, long, int*, fildes, int, flags)
 
-SHIM_SYSCALL_RETURN_ENOSYS(inotify_init1, 1, int, int, flags)
+SHIM_SYSCALL_RETURN_ENOSYS(inotify_init1, 1, long, int, flags)
 
-SHIM_SYSCALL_RETURN_ENOSYS(preadv, 5, int, unsigned long, fd, const struct iovec*, vec,
+SHIM_SYSCALL_RETURN_ENOSYS(preadv, 5, long, unsigned long, fd, const struct iovec*, vec,
                            unsigned long, vlen, unsigned long, pos_l, unsigned long, pos_h)
 
-SHIM_SYSCALL_RETURN_ENOSYS(pwritev, 5, int, unsigned long, fd, const struct iovec*, vec,
+SHIM_SYSCALL_RETURN_ENOSYS(pwritev, 5, long, unsigned long, fd, const struct iovec*, vec,
                            unsigned long, vlen, unsigned long, pos_l, unsigned long, pos_h)
 
-SHIM_SYSCALL_RETURN_ENOSYS(rt_tgsigqueueinfo, 4, int, pid_t, tgid, pid_t, pid, int, sig, siginfo_t*,
-                           uinfo)
+SHIM_SYSCALL_RETURN_ENOSYS(rt_tgsigqueueinfo, 4, long, pid_t, tgid, pid_t, pid, int, sig,
+                           siginfo_t*, uinfo)
 
-SHIM_SYSCALL_RETURN_ENOSYS(perf_event_open, 5, int, struct perf_event_attr*, attr_uptr, pid_t, pid,
+SHIM_SYSCALL_RETURN_ENOSYS(perf_event_open, 5, long, struct perf_event_attr*, attr_uptr, pid_t, pid,
                            int, cpu, int, group_fd, int, flags)
 
-DEFINE_SHIM_SYSCALL(recvmmsg, 5, shim_do_recvmmsg, ssize_t, int, fd, struct mmsghdr*, msg,
+DEFINE_SHIM_SYSCALL(recvmmsg, 5, shim_do_recvmmsg, long, int, fd, struct mmsghdr*, msg,
                     unsigned int, vlen, int, flags, struct __kernel_timespec*, timeout)
 
-SHIM_SYSCALL_RETURN_ENOSYS(fanotify_init, 2, int, int, flags, int, event_f_flags)
+SHIM_SYSCALL_RETURN_ENOSYS(fanotify_init, 2, long, int, flags, int, event_f_flags)
 
-SHIM_SYSCALL_RETURN_ENOSYS(fanotify_mark, 5, int, int, fanotify_fd, int, flags, unsigned long, mask,
-                           int, fd, const char*, pathname)
+SHIM_SYSCALL_RETURN_ENOSYS(fanotify_mark, 5, long, int, fanotify_fd, int, flags, unsigned long,
+                           mask, int, fd, const char*, pathname)
 
-DEFINE_SHIM_SYSCALL(prlimit64, 4, shim_do_prlimit64, int, pid_t, pid, int, resource,
+DEFINE_SHIM_SYSCALL(prlimit64, 4, shim_do_prlimit64, long, pid_t, pid, int, resource,
                     const struct __kernel_rlimit64*, new_rlim, struct __kernel_rlimit64*, old_rlim)
 
-SHIM_SYSCALL_RETURN_ENOSYS(name_to_handle_at, 5, int, int, dfd, const char*, name,
+SHIM_SYSCALL_RETURN_ENOSYS(name_to_handle_at, 5, long, int, dfd, const char*, name,
                            struct linux_file_handle*, handle, int*, mnt_id, int, flag)
 
-SHIM_SYSCALL_RETURN_ENOSYS(open_by_handle_at, 3, int, int, mountdirfd, struct linux_file_handle*,
+SHIM_SYSCALL_RETURN_ENOSYS(open_by_handle_at, 3, long, int, mountdirfd, struct linux_file_handle*,
                            handle, int, flags)
 
-SHIM_SYSCALL_RETURN_ENOSYS(clock_adjtime, 2, int, clockid_t, which_clock, struct timex*, tx)
+SHIM_SYSCALL_RETURN_ENOSYS(clock_adjtime, 2, long, clockid_t, which_clock, struct timex*, tx)
 
-SHIM_SYSCALL_RETURN_ENOSYS(syncfs, 1, int, int, fd)
+SHIM_SYSCALL_RETURN_ENOSYS(syncfs, 1, long, int, fd)
 
-DEFINE_SHIM_SYSCALL(sendmmsg, 4, shim_do_sendmmsg, ssize_t, int, fd, struct mmsghdr*, msg,
+DEFINE_SHIM_SYSCALL(sendmmsg, 4, shim_do_sendmmsg, long, int, fd, struct mmsghdr*, msg,
                     unsigned int, vlen, int, flags)
 
-SHIM_SYSCALL_RETURN_ENOSYS(setns, 2, int, int, fd, int, nstype)
+SHIM_SYSCALL_RETURN_ENOSYS(setns, 2, long, int, fd, int, nstype)
 
-DEFINE_SHIM_SYSCALL(getcpu, 3, shim_do_getcpu, int, unsigned*, cpu, unsigned*, node,
+DEFINE_SHIM_SYSCALL(getcpu, 3, shim_do_getcpu, long, unsigned*, cpu, unsigned*, node,
                     struct getcpu_cache*, cache)
 
 SHIM_SYSCALL_RETURN_ENOSYS(process_vm_readv, 6, long, pid_t, pid, const struct iovec*, lvec,

--- a/LibOS/shim/src/sys/shim_wrappers.c
+++ b/LibOS/shim/src/sys/shim_wrappers.c
@@ -15,7 +15,7 @@
 #include "shim_table.h"
 #include "shim_utils.h"
 
-ssize_t shim_do_readv(int fd, const struct iovec* vec, int vlen) {
+long shim_do_readv(int fd, const struct iovec* vec, int vlen) {
     if (!vec || test_user_memory((void*)vec, sizeof(*vec) * vlen, false))
         return -EINVAL;
 
@@ -77,7 +77,7 @@ out:
  * actually written. Otherwise, it shall return a value of -1, the file-pointer
  * shall remain unchanged, and errno shall be set to indicate an error
  */
-ssize_t shim_do_writev(int fd, const struct iovec* vec, int vlen) {
+long shim_do_writev(int fd, const struct iovec* vec, int vlen) {
     if (!vec || test_user_memory((void*)vec, sizeof(*vec) * vlen, false))
         return -EINVAL;
 


### PR DESCRIPTION


## Description of the changes <!-- (reasons and measures) -->
See the commit messages.
This is split from #2071 

## How to test this PR? <!-- (if applicable) -->
Run some apps with `debug = inline` in manifest

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2077)
<!-- Reviewable:end -->
