### PR TITLE
[Pal/Linux-SGX] Remove loader.nonpie_binary manifest option

### DIFF
--- a/Documentation/manifest-syntax.rst
+++ b/Documentation/manifest-syntax.rst
@@ -270,17 +270,6 @@ The PAL and library OS code/data count towards this size value, as well as the
 application memory itself: application's code, stack, heap, loaded application
 libraries, etc. The application cannot allocate memory that exceeds this limit.
 
-Non-PIE binaries
-^^^^^^^^^^^^^^^^
-
-::
-
-    sgx.nonpie_binary = [1|0]
-    (Default: 0)
-
-This setting tells Graphene whether to use a specially crafted memory layout,
-which is required to support non-relocatable binaries (non-PIE).
-
 Number of threads
 ^^^^^^^^^^^^^^^^^
 

--- a/Documentation/quickstart.rst
+++ b/Documentation/quickstart.rst
@@ -72,13 +72,6 @@ second command should list the process status of :command:`aesm_service`.
       # the console will prompt you for the path to the Intel SGX driver code
       # (simply press ENTER if you use the in-kernel Intel SGX driver)
 
-#. Set ``vm.mmap_min_addr=0`` in the system (*only required for the legacy SGX
-   driver and not needed for newer DCAP/in-kernel drivers*)::
-
-      sudo sysctl vm.mmap_min_addr=0
-
-   Note that this is an inadvisable configuration for production systems.
-
 #. Build and run :program:`helloworld`::
 
       cd $GRAPHENE_DIR/LibOS/shim/test/native

--- a/Examples/apache/httpd.manifest.template
+++ b/Examples/apache/httpd.manifest.template
@@ -44,8 +44,6 @@ fs.mount.cwd.uri = "file:$(INSTALL_DIR)"
 
 # SGX general options
 
-sgx.nonpie_binary = 1
-
 # Set the virtual memory size of the SGX enclave. For SGX v1, the enclave
 # size must be specified during signing. If Apache needs more virtual memory
 # than the enclave size, Graphene will not be able to allocate it.

--- a/Examples/bash/manifest.template
+++ b/Examples/bash/manifest.template
@@ -79,5 +79,3 @@ sgx.trusted_files.libnssfiles = "file:$(ARCH_LIBDIR)/libnss_files.so.2"
 sgx.trusted_files.libnssnis = "file:$(ARCH_LIBDIR)/libnss_nis.so.2"
 
 sgx.allowed_files.scripts = "file:scripts"
-
-sgx.nonpie_binary = 1

--- a/Examples/blender/blender.manifest.template
+++ b/Examples/blender/blender.manifest.template
@@ -53,7 +53,6 @@ sys.stack.size = "8M"
 
 sgx.enclave_size = "2048M"
 sgx.thread_num = 64
-sgx.nonpie_binary = 1
 
 sgx.trusted_files.blender = "file:$(BLENDER_DIR)/blender"
 sgx.trusted_files.ld = "file:$(GRAPHENE_DIR)/Runtime/ld-linux-x86-64.so.2"

--- a/Examples/gcc/gcc.manifest.template
+++ b/Examples/gcc/gcc.manifest.template
@@ -24,7 +24,6 @@ fs.mount.tmp.path = "/tmp"
 fs.mount.tmp.uri = "file:/tmp"
 
 sgx.enclave_size = "1G"
-sgx.nonpie_binary = 1
 
 sgx.trusted_files.ld = "file:$(GRAPHENEDIR)/Runtime/ld-linux-x86-64.so.2"
 sgx.trusted_files.libc = "file:$(GRAPHENEDIR)/Runtime/libc.so.6"

--- a/Examples/lighttpd/lighttpd.manifest.template
+++ b/Examples/lighttpd/lighttpd.manifest.template
@@ -62,8 +62,6 @@ sgx.enclave_size = "256M"
 # the application can create is (sgx.thread_num - 2).
 sgx.thread_num = 3
 
-sgx.nonpie_binary = 1
-
 # SGX trusted files
 
 sgx.trusted_files.lighttpd = "file:$(INSTALL_DIR)/sbin/lighttpd"

--- a/Examples/memcached/memcached.manifest.template
+++ b/Examples/memcached/memcached.manifest.template
@@ -102,8 +102,6 @@ fs.mount.etc.uri = "file:/etc"
 # an issue in Memcached source code, not related to Graphene.
 sgx.enclave_size = "1024M"
 
-sgx.nonpie_binary = 1
-
 # Set maximum number of in-enclave threads (somewhat arbitrarily) to 16. Recall
 # that SGX v1 requires to specify the maximum number of simulteneous threads at
 # enclave creation time. If Memcached spawns more threads, Graphene-SGX fails.

--- a/Examples/nginx/nginx.manifest.template
+++ b/Examples/nginx/nginx.manifest.template
@@ -45,8 +45,6 @@ fs.mount.cwd.uri = "file:$(INSTALL_DIR)"
 # than the enclave size, Graphene will not be able to allocate it.
 sgx.enclave_size = "256M"
 
-sgx.nonpie_binary = 1
-
 # Set the maximum number of enclave threads. For SGX v1, the number of enclave
 # TCSes must be specified during signing, so the application cannot use more
 # threads than the number of TCSes. Note that Graphene also creates an internal

--- a/Examples/nodejs-express-server/nodejs.manifest.template
+++ b/Examples/nodejs-express-server/nodejs.manifest.template
@@ -37,8 +37,6 @@ fs.mount.lib3.uri = "file:/usr/$(ARCH_LIBDIR)"
 # time.
 sgx.enclave_size = "2G"
 
-sgx.nonpie_binary = 1
-
 # Set maximum number of in-enclave threads to 8. Recall that SGX v1 requires to specify the maximum
 # number of simultaneous threads at enclave creation time.
 sgx.thread_num = 8

--- a/Examples/python-scipy-insecure/python.manifest.template
+++ b/Examples/python-scipy-insecure/python.manifest.template
@@ -65,8 +65,6 @@ sys.stack.size = "2M"
 
 # SGX general options
 
-sgx.nonpie_binary = 1
-
 # Set the virtual memory size of the SGX enclave. For SGX v1, the enclave
 # size must be specified during signing. If Python needs more virtual memory
 # than the enclave size, Graphene will not be able to allocate it.

--- a/Examples/python-simple/python.manifest.template
+++ b/Examples/python-simple/python.manifest.template
@@ -72,8 +72,6 @@ sgx.enclave_size = "1G"
 # the application can create is (sgx.thread_num - 2).
 sgx.thread_num = 8
 
-sgx.nonpie_binary = 1
-
 # SGX trusted libraries
 
 sgx.trusted_files.python = "file:$(PYTHONEXEC)"

--- a/Examples/pytorch/pytorch.manifest.template
+++ b/Examples/pytorch/pytorch.manifest.template
@@ -164,8 +164,6 @@ sgx.allowed_files.resolv = "file:/etc/resolv.conf"
 # System's file system table
 sgx.allowed_files.fstab = "file:/etc/fstab"
 
-sgx.nonpie_binary = 1
-
 # Graphene optionally provides patched OpenMP runtime library that runs faster
 # inside SGX enclaves (execute `make -C LibOS gcc` to generate it). Uncomment
 # the lines below to use the patched library. PyTorch's SGX perf overhead

--- a/Examples/r/R.manifest.template
+++ b/Examples/r/R.manifest.template
@@ -57,8 +57,6 @@ sys.stack.size = "8M"
 
 # SGX general options
 
-sgx.nonpie_binary = 1
-
 # Set the virtual memory size of the SGX enclave. For SGX v1, the enclave size must be specified
 # during signing. If R needs more virtual memory than the enclave size, Graphene will not be able to
 # allocate it.

--- a/Examples/redis/redis-server.manifest.template
+++ b/Examples/redis/redis-server.manifest.template
@@ -74,8 +74,6 @@ fs.mount.etc.uri = "file:/etc"
 # typical Redis workloads.
 sgx.enclave_size = "1024M"
 
-sgx.nonpie_binary = 1
-
 # Set maximum number of in-enclave threads (somewhat arbitrarily) to 8. Recall
 # that SGX v1 requires to specify the maximum number of simulteneous threads at
 # enclave creation time.

--- a/Examples/tensorflow-lite/label_image.manifest.template
+++ b/Examples/tensorflow-lite/label_image.manifest.template
@@ -14,8 +14,6 @@ fs.mount.lib1.uri = "file:$(GRAPHENEDIR)/Runtime"
 # Minimum amount of memory to make it work.
 sgx.enclave_size = "512M"
 
-sgx.nonpie_binary = 1
-
 # We test with 4 TensorFlow threads, so over-approximate to 16 enclave threads.
 sgx.thread_num = 16
 

--- a/LibOS/shim/src/elf/shim_rtld.c
+++ b/LibOS/shim/src/elf/shim_rtld.c
@@ -1451,11 +1451,7 @@ int init_loader(void) {
     if (!exec_map) {
         ret = load_elf_object(exec);
         if (ret < 0) {
-            // TODO: Actually verify that the non-PIE-ness was the real cause of loading failure.
-            warn("ERROR: Failed to load %s. This may be caused by the binary being non-PIE, in "
-                 "which case Graphene requires a specially-crafted memory layout. You can enable "
-                 "it by adding 'sgx.nonpie_binary = 1' to the manifest.\n",
-                 qstrgetstr(&exec->path));
+            warn("ERROR: Failed to load %s\n", qstrgetstr(&exec->path));
             goto out;
         }
 

--- a/LibOS/shim/test/fs/manifest.template
+++ b/LibOS/shim/test/fs/manifest.template
@@ -38,5 +38,3 @@ sgx.allowed_files.tmp_dir = "file:tmp/"
 sgx.protected_files_key = "ffeeddccbbaa99887766554433221100"
 sgx.protected_files.input = "file:tmp/pf_input"
 sgx.protected_files.output = "file:tmp/pf_output"
-
-sgx.nonpie_binary = 1

--- a/LibOS/shim/test/ltp/manifest.template
+++ b/LibOS/shim/test/ltp/manifest.template
@@ -32,8 +32,6 @@ fs.mount.tmp.uri = "file:/tmp"
 sys.brk.max_size = "32M"
 sys.stack.size = "4M"
 
-sgx.nonpie_binary = 1
-
 sgx.trusted_files.entrypoint = "file:$(ENTRYPOINT)"
 
 sgx.trusted_files.ld = "file:$(LIBCDIR)/ld-linux-x86-64.so.2"

--- a/LibOS/shim/test/regression/argv_from_file.manifest
+++ b/LibOS/shim/test/regression/argv_from_file.manifest
@@ -15,5 +15,3 @@ sgx.allowed_files.argv = "file:argv_test_input"
 sgx.trusted_files.ld = "file:../../../../Runtime/ld-linux-x86-64.so.2"
 sgx.trusted_files.libc = "file:../../../../Runtime/libc.so.6"
 sgx.trusted_files.bootstrap = "file:bootstrap"
-
-sgx.nonpie_binary = 1

--- a/LibOS/shim/test/regression/attestation.manifest.template
+++ b/LibOS/shim/test/regression/attestation.manifest.template
@@ -21,8 +21,6 @@ sgx.trusted_files.libdl = "file:../../../../Runtime/libdl.so.2"
 sgx.trusted_files.libm = "file:../../../../Runtime/libm.so.6"
 sgx.trusted_files.attestation = "file:attestation"
 
-sgx.nonpie_binary = 1
-
 sgx.remote_attestation = 1
 sgx.ra_client_spid = "$(RA_CLIENT_SPID)"
 sgx.ra_client_linkable = $(RA_CLIENT_LINKABLE)

--- a/LibOS/shim/test/regression/debug_log_file.manifest
+++ b/LibOS/shim/test/regression/debug_log_file.manifest
@@ -13,5 +13,3 @@ fs.mount.lib.uri = "file:../../../../Runtime"
 sgx.trusted_files.ld = "file:../../../../Runtime/ld-linux-x86-64.so.2"
 sgx.trusted_files.libc = "file:../../../../Runtime/libc.so.6"
 sgx.trusted_files.bootstrap = "file:bootstrap"
-
-sgx.nonpie_binary = 1

--- a/LibOS/shim/test/regression/debug_log_inline.manifest
+++ b/LibOS/shim/test/regression/debug_log_inline.manifest
@@ -12,5 +12,3 @@ fs.mount.lib.uri = "file:../../../../Runtime"
 sgx.trusted_files.ld = "file:../../../../Runtime/ld-linux-x86-64.so.2"
 sgx.trusted_files.libc = "file:../../../../Runtime/libc.so.6"
 sgx.trusted_files.bootstrap = "file:bootstrap"
-
-sgx.nonpie_binary = 1

--- a/LibOS/shim/test/regression/env_from_file.manifest
+++ b/LibOS/shim/test/regression/env_from_file.manifest
@@ -14,5 +14,3 @@ sgx.allowed_files.env = "file:env_test_input"
 sgx.trusted_files.ld = "file:../../../../Runtime/ld-linux-x86-64.so.2"
 sgx.trusted_files.libc = "file:../../../../Runtime/libc.so.6"
 sgx.trusted_files.bootstrap = "file:bootstrap"
-
-sgx.nonpie_binary = 1

--- a/LibOS/shim/test/regression/env_from_host.manifest
+++ b/LibOS/shim/test/regression/env_from_host.manifest
@@ -13,5 +13,3 @@ fs.mount.lib.uri = "file:../../../../Runtime"
 sgx.trusted_files.ld = "file:../../../../Runtime/ld-linux-x86-64.so.2"
 sgx.trusted_files.libc = "file:../../../../Runtime/libc.so.6"
 sgx.trusted_files.bootstrap = "file:bootstrap"
-
-sgx.nonpie_binary = 1

--- a/LibOS/shim/test/regression/file_check_policy_allow_all_but_log.manifest
+++ b/LibOS/shim/test/regression/file_check_policy_allow_all_but_log.manifest
@@ -17,5 +17,3 @@ sgx.trusted_files.libc = "file:../../../../Runtime/libc.so.6"
 sgx.trusted_files.file_check_policy = "file:file_check_policy"
 
 sgx.trusted_files.test = "file:trusted_testfile"
-
-sgx.nonpie_binary = 1

--- a/LibOS/shim/test/regression/file_check_policy_strict.manifest
+++ b/LibOS/shim/test/regression/file_check_policy_strict.manifest
@@ -17,5 +17,3 @@ sgx.trusted_files.libc = "file:../../../../Runtime/libc.so.6"
 sgx.trusted_files.file_check_policy = "file:file_check_policy"
 
 sgx.trusted_files.test = "file:trusted_testfile"
-
-sgx.nonpie_binary = 1

--- a/LibOS/shim/test/regression/host_root_fs.manifest
+++ b/LibOS/shim/test/regression/host_root_fs.manifest
@@ -17,5 +17,3 @@ sgx.trusted_files.ld = "file:../../../../Runtime/ld-linux-x86-64.so.2"
 sgx.trusted_files.libc = "file:../../../../Runtime/libc.so.6"
 sgx.trusted_files.libdl = "file:../../../../Runtime/libdl.so.2"
 sgx.trusted_files.host_root_fs = "file:host_root_fs"
-
-sgx.nonpie_binary = 1

--- a/LibOS/shim/test/regression/init_fail.manifest
+++ b/LibOS/shim/test/regression/init_fail.manifest
@@ -17,5 +17,3 @@ fs.mount.test.uri = "file:I_DONT_EXIST"
 sgx.trusted_files.ld = "file:../../../../Runtime/ld-linux-x86-64.so.2"
 sgx.trusted_files.libc = "file:../../../../Runtime/libc.so.6"
 sgx.trusted_files.init_fail = "file:init_fail"
-
-sgx.nonpie_binary = 1

--- a/LibOS/shim/test/regression/init_fail2.manifest
+++ b/LibOS/shim/test/regression/init_fail2.manifest
@@ -13,8 +13,6 @@ sgx.trusted_files.ld = "file:../../../../Runtime/ld-linux-x86-64.so.2"
 sgx.trusted_files.libc = "file:../../../../Runtime/libc.so.6"
 sgx.trusted_files.init_fail = "file:init_fail"
 
-sgx.nonpie_binary = 1
-
 # this is an impossible combination of options, LibOS must fail very early in init process
 sgx.enclave_size = "256M"
 sys.brk.max_size = "512M"

--- a/LibOS/shim/test/regression/large_mmap.manifest
+++ b/LibOS/shim/test/regression/large_mmap.manifest
@@ -20,5 +20,3 @@ sgx.trusted_files.large_mmap = "file:large_mmap"
 sgx.allowed_files.testfile = "file:testfile"
 
 sgx.enclave_size = "8G"
-
-sgx.nonpie_binary = 1

--- a/LibOS/shim/test/regression/manifest.template
+++ b/LibOS/shim/test/regression/manifest.template
@@ -43,5 +43,3 @@ sgx.allowed_files.root = "file:root" # for getdents test
 sgx.allowed_files.testfile = "file:testfile" # for mmap_file test
 
 sgx.thread_num = 16
-
-sgx.nonpie_binary = 1

--- a/LibOS/shim/test/regression/multi_pthread.manifest
+++ b/LibOS/shim/test/regression/multi_pthread.manifest
@@ -16,5 +16,4 @@ sgx.trusted_files.multi_pthread = "file:multi_pthread"
 # app runs with 4 parallel threads + Graphene has couple internal threads
 sgx.thread_num = 8
 
-sgx.nonpie_binary = 1
 sgx.enable_stats = 1

--- a/LibOS/shim/test/regression/multi_pthread_exitless.manifest
+++ b/LibOS/shim/test/regression/multi_pthread_exitless.manifest
@@ -17,5 +17,4 @@ sgx.trusted_files.multi_pthread = "file:multi_pthread"
 sgx.thread_num = 8
 sgx.rpc_thread_num = 8
 
-sgx.nonpie_binary = 1
 sgx.enable_stats = 1

--- a/LibOS/shim/test/regression/openmp.manifest.template
+++ b/LibOS/shim/test/regression/openmp.manifest.template
@@ -33,5 +33,3 @@ sgx.trusted_files.libgomp_native = "file:/usr$(ARCH_LIBDIR)/libgomp.so.1"
 # native one because Graphene's Runtime path has priority in LD_LIBRARY_PATH.
 
 #sgx.trusted_files.libgomp_graphene = "file:../../../../Runtime/libgomp.so.1"
-
-sgx.nonpie_binary = 1

--- a/Pal/regression/Bootstrap3.manifest
+++ b/Pal/regression/Bootstrap3.manifest
@@ -4,4 +4,3 @@ loader.preload = "file:Preload1.so,file:Preload2.so"
 loader.argv0_override = "Bootstrap3"
 
 sgx.trusted_files.entrypoint = "file:Bootstrap3"
-sgx.nonpie_binary = 1

--- a/Pal/regression/Bootstrap6.manifest
+++ b/Pal/regression/Bootstrap6.manifest
@@ -6,6 +6,5 @@ loader.argv0_override = "Bootstrap"
 fs.mount.root.uri = "file:"
 
 sgx.enclave_size = "8192M"
-sgx.nonpie_binary = 1
 
 sgx.trusted_files.entrypoint = "file:Bootstrap"

--- a/Pal/regression/Bootstrap7.manifest
+++ b/Pal/regression/Bootstrap7.manifest
@@ -2,7 +2,6 @@ pal.entrypoint = "file:Bootstrap7"
 loader.argv0_override = "Bootstrap7"
 
 sgx.trusted_files.entrypoint = "file:Bootstrap7"
-sgx.nonpie_binary = 1
 
 loader.env.key1 = "na"
 loader.env.key2 = "na"

--- a/Pal/regression/File.manifest
+++ b/Pal/regression/File.manifest
@@ -4,8 +4,6 @@ loader.debug_type = "inline"
 
 fs.mount.root.uri = "file:"
 
-sgx.nonpie_binary = 1
-
 sgx.trusted_files.tmp1 = "file:File"
 sgx.trusted_files.tmp2 = "file:../regression/File"
 sgx.allowed_files.tmp3 = "file:file_nonexist.tmp"

--- a/Pal/regression/Process3.manifest
+++ b/Pal/regression/Process3.manifest
@@ -3,6 +3,4 @@ loader.debug_type = "inline"
 loader.preload = "file:Preload1.so,file:Preload2.so"
 loader.insecure__use_cmdline_argv = 1
 
-sgx.nonpie_binary = 1
-
 sgx.trusted_files.entrypoint = "file:Process3"

--- a/Pal/regression/Thread2.manifest
+++ b/Pal/regression/Thread2.manifest
@@ -3,6 +3,5 @@ loader.argv0_override = "Thread2"
 
 sgx.thread_num = 2
 sgx.enable_stats = 1
-sgx.nonpie_binary = 1
 
 sgx.trusted_files.entrypoint = "file:Thread2"

--- a/Pal/regression/Thread2_exitless.manifest
+++ b/Pal/regression/Thread2_exitless.manifest
@@ -4,6 +4,5 @@ loader.argv0_override = "Thread2"
 sgx.thread_num = 2
 sgx.rpc_thread_num = 2
 sgx.enable_stats = 1
-sgx.nonpie_binary = 1
 
 sgx.trusted_files.entrypoint = "file:Thread2"

--- a/Pal/regression/manifest.template
+++ b/Pal/regression/manifest.template
@@ -4,6 +4,5 @@ loader.insecure__use_cmdline_argv = 1
 
 fs.mount.root.uri = "file:"
 sgx.trusted_files.entrypoint = "file:$(ENTRYPOINT)"
-sgx.nonpie_binary = 1 # all tests are currently non-PIE unless overridden
 
 sgx.allowed_files.to_send_tmp = "file:to_send.tmp" # for SendHandle test

--- a/Pal/src/host/Linux-SGX/sgx_internal.h
+++ b/Pal/src/host/Linux-SGX/sgx_internal.h
@@ -59,7 +59,6 @@ struct pal_enclave {
     unsigned long thread_num;
     unsigned long rpc_thread_num;
     unsigned long ssaframesize;
-    bool nonpie_binary;
     bool remote_attestation_enabled;
     bool use_epid_attestation; /* Valid only if `remote_attestation_enabled` is true, selects
                                 * EPID/DCAP attestation scheme. */

--- a/Tools/gsc/templates/manifest.template
+++ b/Tools/gsc/templates/manifest.template
@@ -16,9 +16,6 @@ fs.root.uri = "file:/"
 # working directory to the desired location
 fs.start_dir = "{{working_dir}}"
 
-# Start at static addresses (otherwise breaks when non-relocatable executables are used)
-sgx.nonpie_binary = 1
-
 {% if insecure_args %}
 # !! INSECURE !! Allow passing command-line arguments from the host without validation
 # Most Docker images rely on runtime arguments and hence, a more general technique is required.

--- a/python/graphenelibos/sgx_sign.py
+++ b/python/graphenelibos/sgx_sign.py
@@ -781,12 +781,8 @@ def main_sign(args):
     # Try populate memory areas
     memory_areas = get_memory_areas(attr, args)
 
-    if manifest.get('sgx.nonpie_binary', None) == '1':
-        enclave_base = offs.DEFAULT_ENCLAVE_BASE
-        enclave_heap_min = offs.MMAP_MIN_ADDR
-    else:
-        enclave_base = attr['enclave_size']
-        enclave_heap_min = enclave_base
+    enclave_base = offs.DEFAULT_ENCLAVE_BASE
+    enclave_heap_min = offs.MMAP_MIN_ADDR
 
     if manifest.get('sgx.enable_stats', None) is None:
         manifest['sgx.enable_stats'] = '0'

--- a/tests/benchmarks/basic.manifest.template
+++ b/tests/benchmarks/basic.manifest.template
@@ -17,5 +17,3 @@ sgx.trusted_files.libm = file:@GRAPHENEDIR@/Runtime/libm.so.6
 sgx.trusted_files.libpthread = file:@GRAPHENEDIR@/Runtime/libpthread.so.0
 
 sgx.thread_num = 3
-
-#sgx.nonpie_binary = 1


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Non-PIE binaries support requires ELRANGE to start at low addresses, which on older SGX drivers required root permissions or reconfiguring the host, so this mapping strategy was made optional by us. This issue was fixed long time ago, so we can drop this option and always start enclaves at 0.

## How to test this PR? <!-- (if applicable) -->

Run this on various SGX drivers and check if everything still works.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2079)
<!-- Reviewable:end -->
