### PR TITLE
[PAL, LibOS] Move PAGE_SIZE to cpu.h and use it in LibOS test case

### DIFF
--- a/LibOS/shim/test/regression/mmap_file.c
+++ b/LibOS/shim/test/regression/mmap_file.c
@@ -17,29 +17,34 @@ static void SIGBUS_handler(int sig) {
 int main(int argc, const char** argv) {
     int rv;
 
-    /* Initalization: create a 1025-byte file */
-
     FILE* fp = fopen("testfile", "w+");
     if (!fp) {
         perror("fopen");
         return 1;
     }
 
-    rv = ftruncate(fileno(fp), 1024);
+    long page_size = sysconf(_SC_PAGESIZE);
+    if (page_size < 0) {
+        perror("sysconf");
+        return 1;
+    }
+    long quarter_page = page_size / 4;
+
+    rv = ftruncate(fileno(fp), quarter_page);
     if (rv) {
         perror("ftruncate");
         return 1;
     }
 
     volatile unsigned char* a =
-        mmap(NULL, 9162, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_FILE, fileno(fp), 0);
+        mmap(NULL, page_size * 2, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_FILE, fileno(fp), 0);
     if (a == MAP_FAILED) {
         perror("mmap");
         return 1;
     }
 
-    a[1023] = 0xff;
-    a[4095] = 0xff;
+    a[quarter_page - 1] = 0xff;
+    a[page_size - 1] = 0xff;
 
     __asm__ volatile("nop" ::: "memory");
 
@@ -60,15 +65,15 @@ int main(int argc, const char** argv) {
 
     a[0] = 0xff;
     printf(pid == 0 ? "mmap test 1 passed\n" : "mmap test 6 passed\n");
-    a[1024] = 0xff;
+    a[quarter_page] = 0xff;
     printf(pid == 0 ? "mmap test 2 passed\n" : "mmap test 7 passed\n");
 
     __asm__ volatile("nop" ::: "memory");
 
     if (pid == 0) {
-        if (a[1023] == 0xff)
+        if (a[quarter_page - 1] == 0xff)
             printf("mmap test 3 passed\n");
-        if (a[4095] == 0xff)
+        if (a[page_size - 1] == 0xff)
             printf("mmap test 4 passed\n");
     }
 
@@ -80,9 +85,9 @@ int main(int argc, const char** argv) {
     }
 
     message = pid == 0 ? "mmap test 5 passed\n" : "mmap test 8 passed\n";
-    /* need a barrier to assign message before SIGBUS due to a[4096] */
+    /* need a barrier to assign message before SIGBUS due to a[page_size] */
     __asm__ volatile("nop" ::: "memory");
-    a[4096] = 0xff;
+    a[page_size] = 0xff;
 
     if (signal(SIGBUS, SIG_DFL) == SIG_ERR) {
         perror("signal");

--- a/Pal/include/arch/x86_64/cpu.h
+++ b/Pal/include/arch/x86_64/cpu.h
@@ -5,6 +5,9 @@
 
 #include <stdint.h>
 
+#define PAGE_SIZE       (1 << 12)
+#define PRESET_PAGESIZE PAGE_SIZE
+
 enum PAL_CPUID_WORD {
     PAL_CPUID_WORD_EAX = 0,
     PAL_CPUID_WORD_EBX = 1,

--- a/Pal/include/arch/x86_64/pal-arch.h
+++ b/Pal/include/arch/x86_64/pal-arch.h
@@ -19,9 +19,6 @@
 #include "cpu.h"
 #include "pal.h"
 
-#define PAGE_SIZE       (1 << 12)
-#define PRESET_PAGESIZE PAGE_SIZE
-
 typedef struct pal_tcb PAL_TCB;
 
 #define PAL_LIBOS_TCB_SIZE 256


### PR DESCRIPTION
This PR moves the PAGE_SIZE to cpu.h and uses it in a test case to make this test case work on other architectures as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2080)
<!-- Reviewable:end -->
