### PR TITLE
sync with upstreamed SGX in-kernel driver from mainline 5.11

### DIFF
--- a/Documentation/sgx-intro.rst
+++ b/Documentation/sgx-intro.rst
@@ -1,6 +1,8 @@
 Introduction to SGX
 ===================
 
+.. highlight:: sh
+
 Graphene project uses :term:`SGX` to securely run software. SGX is
 a |~| complicated topic, which may be hard to learn, because the documentation
 is scattered through official/reference documentation, blogposts and academic
@@ -80,7 +82,7 @@ Installation Instructions
 Linux kernel drivers
 ^^^^^^^^^^^^^^^^^^^^
 
-For historical reasons, there are three SGX drivers currently (March 2020):
+For historical reasons, there are three SGX drivers currently (January 2021):
 
 - https://github.com/intel/linux-sgx-driver -- old one, does not support DCAP,
   deprecated
@@ -90,13 +92,21 @@ For historical reasons, there are three SGX drivers currently (March 2020):
   old EPID remote-attestation technique) and the new DCAP (with new ECDSA and
   more "normal" PKI infrastructure).
 
-- Upstreaming in-kernel SGX driver (see LKML patches) -- will be upstreamed one
-  day, supports both non-DCAP and DCAP. The DCAP driver closely matches this
-  upstreaming version.
+- SGX support was upstreamed to the Linux mainline starting from 5.11.
+  It currently supports only DCAP attestation. The driver is accessible through
+  /dev/sgx_enclave and /dev/sgx_provision.
 
-  The in-tree driver will not be a |~| module
-  (https://lore.kernel.org/linux-sgx/20190401225717.GA13450@linux.intel.com/),
-  so "installation instructions" will likely be minimal.
+  The following udev rules are recommended for users to access the SGX node::
+
+    groupadd -r sgx
+    gpasswd -a USERNAME sgx
+    groupadd -r sgx_prv
+    gpasswd -a USERNAME sgx_prv
+    cat > /etc/udev/rules.d/65-graphene-sgx.rules << EOF
+      SUBSYSTEM=="misc",KERNEL=="sgx_enclave",MODE="0660",GROUP="sgx"
+      SUBSYSTEM=="misc",KERNEL=="sgx_provision",MODE="0660",GROUP="sgx_prv"
+      EOF
+    udevadm trigger
 
   Also it will not require :term:`IAS` and kernel maintainers consider
   non-writable :term:`FLC` MSRs as non-functional SGX:


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://graphene.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes
1. Intel SGX driver has been upstreamed to mainline from kernel version 5.11. To sync with upstreamed SGX in-kernel driver, as SGX device in the kernel is exposed to "/dev/sgx_enclave" instead of "/dev/sgx/enclave", graphene needs to support the upstreaned in-kernel SGX device node "dev/sgx_enclave" in link_intel_driver.py
Fixes #2007
2. Also we need to update documentation on sgx_intro.html for the upstreamed in-kernel SGX driver in linux mainline, exposed as /dev/sgx_enclave. And additional steps for user if they want the compatibility with OOT SGX driver exposed as /dev/sgx/enclave
3. For OOT drivers in DCAP from version 1.10, the header file is also changed, we need to sync with it. see:
https://github.com/intel/SGXDataCenterAttestationPrimitives/pull/155

## To test this PR:
1. the 1st time rebooting to 5.11 linux kernel, check:
    ls /dev | grep sgx ==> no /dev/sgx/enclave but /dev/sgx_enclave
2. Using upstreamed kernel 5.11, at Pal/src/host/Linux-SGX, run:
    ISGX_DRIVER_PATH="/usr/src/linux-headers-$(uname -r)/arch/x86" ./link-intel-driver.py < ./gsgx.h.in > ./gsgx.h

A proper gsgx.h header will be generated, compilation pass.

    

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2084)
<!-- Reviewable:end -->
