### PR TITLE
[Docs,LibOS] Move helloworld example from native/ to regression/

### DIFF
--- a/Documentation/cloud-deployment.rst
+++ b/Documentation/cloud-deployment.rst
@@ -52,7 +52,7 @@ Building
 
 #. Build and run :program:`helloworld`::
 
-       cd LibOS/shim/test/native
+       cd LibOS/shim/test/regression
        make SGX=1 sgx-tokens
        SGX=1 ../../../../Runtime/pal_loader helloworld
 

--- a/Documentation/devel/debugging.rst
+++ b/Documentation/devel/debugging.rst
@@ -39,7 +39,7 @@ After rebuilding Graphene with ``DEBUG=1``, you need to re-sign the manifest of
 the application. For instance, if you want to debug the ``helloworld`` program,
 run the following commands::
 
-    cd LibOS/shim/test/native
+    cd LibOS/shim/test/regression
     make SGX=1
     make SGX=1 sgx-tokens
 

--- a/Documentation/devel/performance.rst
+++ b/Documentation/devel/performance.rst
@@ -29,7 +29,7 @@ thread/process exit. Here is an example:
 
 ::
 
-   LibOS/shim/test/native$ SGX=1 perf stat graphene/Runtime/pal_loader helloworld
+   LibOS/shim/test/regression$ SGX=1 perf stat graphene/Runtime/pal_loader helloworld
    Hello world (helloworld)!
    ----- SGX stats for thread 87219 -----
    # of EENTERs:        224

--- a/Documentation/quickstart.rst
+++ b/Documentation/quickstart.rst
@@ -18,7 +18,7 @@ Quick start without SGX support
 
 #. Build and run :program:`helloworld`::
 
-      cd LibOS/shim/test/native
+      cd LibOS/shim/test/regression
       make
       ./pal_loader helloworld
 
@@ -81,7 +81,7 @@ second command should list the process status of :command:`aesm_service`.
 
 #. Build and run :program:`helloworld`::
 
-      cd $GRAPHENE_DIR/LibOS/shim/test/native
+      cd $GRAPHENE_DIR/LibOS/shim/test/regression
       make SGX=1 sgx-tokens
       SGX=1 ./pal_loader helloworld
 

--- a/LibOS/shim/test/native/.gitignore
+++ b/LibOS/shim/test/native/.gitignore
@@ -22,7 +22,6 @@
 /fs
 /futextest
 /get_time
-/helloworld
 /helloworld_pthread
 /kill
 /malloc

--- a/LibOS/shim/test/native/Makefile
+++ b/LibOS/shim/test/native/Makefile
@@ -18,7 +18,6 @@ c_executables = \
 	fs \
 	futextest \
 	get_time \
-	helloworld \
 	helloworld_pthread \
 	kill \
 	malloc \

--- a/LibOS/shim/test/native/helloworld.c
+++ b/LibOS/shim/test/native/helloworld.c
@@ -1,8 +1,0 @@
-/* a simple helloworld test */
-
-#include <stdio.h>
-
-int main(int argc, char** argv) {
-    printf("Hello world (%s)!\n", argv[0]);
-    return 0;
-}

--- a/LibOS/shim/test/native/system.c
+++ b/LibOS/shim/test/native/system.c
@@ -1,7 +1,7 @@
 #include <stdlib.h>
 
 int main(int argc, char** argv) {
-    if (system("./helloworld")) {
+    if (system("./helloworld_pthread")) {
         return 1;
     }
     return 0;

--- a/LibOS/shim/test/regression/.gitignore
+++ b/LibOS/shim/test/regression/.gitignore
@@ -62,6 +62,7 @@
 /getsockname
 /getsockopt
 /groups
+/helloworld
 /host_root_fs
 /init_fail
 /init_fail2

--- a/LibOS/shim/test/regression/Makefile
+++ b/LibOS/shim/test/regression/Makefile
@@ -41,6 +41,7 @@ c_executables = \
 	getsockname \
 	getsockopt \
 	groups \
+	helloworld \
 	host_root_fs \
 	init_fail \
 	large_mmap \

--- a/LibOS/shim/test/regression/helloworld.c
+++ b/LibOS/shim/test/regression/helloworld.c
@@ -1,0 +1,6 @@
+#include <stdio.h>
+
+int main(int argc, char** argv) {
+    printf("Hello world!\n");
+    return 0;
+}

--- a/LibOS/shim/test/regression/test_libos.py
+++ b/LibOS/shim/test/regression/test_libos.py
@@ -20,6 +20,10 @@ class TC_00_Unittests(RegressionTestCase):
         self.assertIn('Test successful!', stdout)
 
 class TC_01_Bootstrap(RegressionTestCase):
+    def test_001_helloworld(self):
+        stdout, _ = self.run_binary(['helloworld'])
+        self.assertIn('Hello world!', stdout)
+
     def test_100_basic_bootstrapping(self):
         stdout, _ = self.run_binary(['bootstrap'])
 


### PR DESCRIPTION

## Description of the changes <!-- (reasons and measures) -->

Applications under `native/` cannot be built after commit "Introduce one, central manifest, zero-config children and constant MRENCLAVE". Instead of fixing `native/`, this commit simply moves `helloworld` and all its mentions under `regression/`.

## How to test this PR? <!-- (if applicable) -->

New test `helloworld` is added to the LibOS regression tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2092)
<!-- Reviewable:end -->
