### PR TITLE
[PAL] Fix buffer overflow in testcase (UBSAN)

### DIFF
--- a/Pal/regression/File.c
+++ b/Pal/regression/File.c
@@ -33,19 +33,16 @@ int main(int argc, char** argv, char** envp) {
 
         ret = DkStreamRead(file1, 0, 40, buffer1, NULL, 0);
         if (ret > 0) {
-            buffer1[ret] = 0;
             print_hex("Read Test 1 (0th - 40th): %s\n", buffer1, 40);
         }
 
         ret = DkStreamRead(file1, 0, 40, buffer1, NULL, 0);
         if (ret > 0) {
-            buffer1[ret] = 0;
             print_hex("Read Test 2 (0th - 40th): %s\n", buffer1, 40);
         }
 
         ret = DkStreamRead(file1, 200, 40, buffer2, NULL, 0);
         if (ret > 0) {
-            buffer2[ret] = 0;
             print_hex("Read Test 3 (200th - 240th): %s\n", buffer2, 40);
         }
 


### PR DESCRIPTION
buffer[ret = 40] overflows the buffer of size 40. It's not necessary to
NULL terminate this buffer, so just remove the offending statements.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2094)
<!-- Reviewable:end -->
