### PR TITLE
[LibOS] Cast mask to unsigned long (UBSAN)

### DIFF
--- a/LibOS/shim/src/sys/shim_poll.c
+++ b/LibOS/shim/src/sys/shim_poll.c
@@ -18,7 +18,7 @@
 #include "shim_thread.h"
 #include "shim_utils.h"
 
-typedef long int __fd_mask;
+typedef unsigned long __fd_mask;
 
 #ifndef __NFDBITS
 #define __NFDBITS (8 * (int)sizeof(__fd_mask))


### PR DESCRIPTION
We need to cast the mask used in select() to an unsigned int, otherwise UBSAN complains about it being a negative number.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2097)
<!-- Reviewable:end -->
