### PR TITLE
[Pal,LibOS] Fix GDB integration in case of removing maps

### DIFF
--- a/LibOS/shim/src/shim_debug.c
+++ b/LibOS/shim/src/shim_debug.c
@@ -73,12 +73,18 @@ void remove_r_debug(void* addr) {
 
     debug("remove a library for gdb: %s\n", m->l_name);
 
-    if (m->l_prev)
+    if (m->l_prev) {
         m->l_prev->l_next = m->l_next;
-    if (m->l_next)
+    } else {
+        link_map_list = m->l_next;
+    }
+
+    if (m->l_next) {
         m->l_next->l_prev = m->l_prev;
+    }
 
     DkDebugMapRemove(addr);
+    free(m);
 }
 
 void append_r_debug(const char* uri, void* addr, void* dyn_addr) {

--- a/Pal/gdb_integration/debug_map_gdb.py
+++ b/Pal/gdb_integration/debug_map_gdb.py
@@ -114,9 +114,9 @@ class UpdateDebugMaps(gdb.Command):
                 print("Removing symbol file (was {}) from addr: 0x{:x}".format(
                     file_name, load_addr))
                 try:
-                    gdb.execute('remove-symbol-file -a 0x{:x}'.format(load_addr))
-                except gdb.error:
-                    print('warning: failed to remove symbol file')
+                    gdb.execute('remove-symbol-file -a 0x{:x}'.format(text_addr))
+                except gdb.error as e:
+                    print('warning: failed to remove symbol file: {}'.format(e))
 
             # Note that we escape text arguments to 'add-symbol-file' (file name and section names)
             # using shlex.quote(), because GDB commands use a shell-like argument syntax.


### PR DESCRIPTION
Follow-up to #2044.

- The GDB command for removing a symbol file takes text address
  (or any address inside the mapped memory area), not load offset
  (which might be before the area). Because of that, removing a 
  map in GDB did not actually work, and displayed a warning.
- The remove_r_debug() function in LibOS did not actually remove
  the map from list in LibOS. As a result, LibOS attempted to
  report the removal to PAL more than once, causing a harmless but
  annoying warning message.

## How to test this PR? <!-- (if applicable) -->

Compile with `DEBUG=1` and run a test case with exec, e.g. `./pal_loader exec_same 1 2 3` (in LibOS/shim/test/regression).
There should be no console warnings (on master, it says `debug_map_remove(...) failed: -22` multiple times).

When running the same example under GDB, there should also be no failure messages (on master, it says `warning: failed to remove symbol file`)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2099)
<!-- Reviewable:end -->
