### PR TITLE
pal_loader: Print clearer error on invalid invocations

### DIFF
--- a/Runtime/pal_loader
+++ b/Runtime/pal_loader
@@ -67,7 +67,7 @@ else
     SGX=@SGX@
 fi
 
-MANIFEST=
+APPLICATION=
 ENVS=()
 PREFIX=()
 
@@ -97,8 +97,8 @@ fi
 
 while [ "$1" != "" ];
 do
-	if [ "$MANIFEST" == "" ]; then
-		MANIFEST=$1
+	if [ "$APPLICATION" == "" ]; then
+		APPLICATION=$1
 		shift
 		continue
 	fi
@@ -106,9 +106,23 @@ do
 	break
 done
 
-if [ "$MANIFEST" == "" ]; then
+if [ "$APPLICATION" == "" ]; then
 	echo "Usage: $0 [<application>] <args>..."
-	exit 1
+	exit 2
+fi
+
+if [ "$SGX" == "1" ] && [ ! -e "$APPLICATION.manifest.sgx" ]; then
+    echo "Invalid application path specified ($APPLICATION.manifest.sgx does not exist)." >&2
+    echo "The path should point to application configuration files, so that they can be" >&2
+    echo "found after appending corresponding extensions." >&2
+    exit 2
+fi
+
+if [ ! "$SGX" == "1" ] && [ ! -e "$APPLICATION.manifest" ]; then
+    echo "Invalid application path specified ($APPLICATION.manifest does not exist)." >&2
+    echo "The path should point to application configuration files, so that they can be" >&2
+    echo "found after appending corresponding extensions." >&2
+    exit 2
 fi
 
 if [ ! -f "$PAL_CMD" ]; then
@@ -118,5 +132,5 @@ fi
 
 CMD=("${ENVS[@]}")
 CMD+=("${PREFIX[@]}")
-CMD+=("$PAL_CMD" "$LIBPAL_PATH" init "$MANIFEST" "$@")
+CMD+=("$PAL_CMD" "$LIBPAL_PATH" init "$APPLICATION" "$@")
 exec env "${CMD[@]}"


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Previously (i.e.: before #2050), if the user used the old way of calling `pal_loader` they just got "Reading manifest failed" and that was all. Let's try to fix this.

I thought about moving this to PAL code, but the error handling on SGX currently doesn't allow for nice output formatting, and also this is just an UX improvement for the users of `pal_loader`, so I think it's fine to "pre-check" it on this layer.

## How to test this PR? <!-- (if applicable) -->

Run `pal_loader` with invalid arguments (both in SGX and non-SGX mode).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2100)
<!-- Reviewable:end -->
