### PR TITLE
[Pal,LibOS] Enable UBSAN via 'make UBSAN=1'

### DIFF
--- a/LibOS/shim/src/Makefile
+++ b/LibOS/shim/src/Makefile
@@ -39,7 +39,7 @@ CFLAGS += -Wno-address-of-packed-member
 ASFLAGS += -Wa,--noexecstack -x assembler-with-cpp -I../include -I../include/arch/$(ARCH)
 
 LDFLAGS += -shared -nostdlib -z combreloc -z relro -z now -z defs \
-	  -rpath-link=$(abspath $(RUNTIME_DIR))
+	  -rpath-link=$(abspath $(RUNTIME_DIR)) $(UBSAN_LDFLAGS)
 
 files_to_build = libsysdb.a libsysdb.so
 files_to_install = $(addprefix $(RUNTIME_DIR)/,$(files_to_build))

--- a/LibOS/shim/src/fs/sys/fs.c
+++ b/LibOS/shim/src/fs/sys/fs.c
@@ -125,7 +125,8 @@ int sys_list_resource_num(const char* pathname, struct shim_dirent** buf, size_t
         char ent_name[32];
         snprintf(ent_name, sizeof(ent_name), "%s%d", filename, i);
         size_t name_size   = strlen(ent_name) + 1;
-        size_t dirent_size = sizeof(struct shim_dirent) + name_size;
+        size_t dirent_size = ALIGN_UP(sizeof(struct shim_dirent) + name_size,
+                                      alignof(struct shim_dirent));
 
         total_size += dirent_size;
         if (total_size > size)

--- a/LibOS/shim/test/regression/Makefile
+++ b/LibOS/shim/test/regression/Makefile
@@ -3,17 +3,19 @@ include ../../../../Scripts/Makefile.configs
 c_executables-x86_64 = \
 	attestation \
 	cpuid \
-	debug_regs-x86_64 \
 	rdtsc \
 	sighandler_divbyzero
+
+ifneq ($(IS_UBSAN_ENABLED),1)
+c_executables-x86_64 += \
+	debug_regs-x86_64
+endif
 
 c_executables = \
 	abort \
 	abort_multithread \
 	bootstrap \
 	bootstrap_pie \
-	bootstrap_static \
-	debug \
 	dev \
 	device \
 	epoll_wait_timeout \
@@ -89,7 +91,13 @@ c_executables = \
 	vfork_and_exec \
 	$(c_executables-$(ARCH))
 
+ifneq ($(IS_UBSAN_ENABLED),1)
+c_executables += \
+	bootstrap_static \
+	debug
+
 cxx_executables = bootstrap_cpp
+endif
 
 repo_manifests = \
 	argv_from_file.manifest \

--- a/LibOS/shim/test/regression/sysfs_common.c
+++ b/LibOS/shim/test/regression/sysfs_common.c
@@ -150,7 +150,7 @@ int main(int argc, char** argv) {
         if (strncmp(dirent->d_name, "node", 4) == 0) {
             char* endp;
             unsigned long nr = strtoul(dirent->d_name + 4,  &endp, 10);
-            if (nr != ULONG_MAX && endp != dirent64->d_name + 4 && *endp == '\0')
+            if (nr != ULONG_MAX && endp != dirent->d_name + 4 && *endp == '\0')
                 count++;
         }
     }

--- a/LibOS/shim/test/regression/test_libos.py
+++ b/LibOS/shim/test/regression/test_libos.py
@@ -103,6 +103,8 @@ class TC_01_Bootstrap(RegressionTestCase):
         self.assertIn('argv[0] = bootstrap_pie', stdout)
 
     def test_110_basic_bootstrapping_cpp(self):
+        if not os.path.exists('bootstrap_cpp'):
+            self.skipTest('bootstrap_cpp executable was not built')
         stdout, _ = self.run_binary(['bootstrap_cpp'])
         self.assertIn('User Program Started', stdout)
 
@@ -634,6 +636,8 @@ class TC_50_GDB(RegressionTestCase):
         # While the stack trace in SGX is unbroken, it currently starts at _start inside
         # enclave, instead of including eclave entry.
 
+        if not os.path.exists('debug'):
+            self.skipTest('debug executable was not built')
         stdout, _ = self.run_gdb(['debug'], 'debug.gdb')
 
         backtrace_1 = self.find('backtrace 1', stdout)
@@ -661,6 +665,8 @@ class TC_50_GDB(RegressionTestCase):
     def test_010_regs_x86_64(self):
         # To run this test manually, use:
         # GDB=1 GDB_SCRIPT=debug_regs-x86_64.gdb ./pal_loader debug_regs-x86_64
+        if not os.path.exists('debug_regs-x86_64'):
+            self.skipTest('debug_regs-x86_64 executable was not built')
 
         stdout, _ = self.run_gdb(['debug_regs-x86_64'], 'debug_regs-x86_64.gdb')
 

--- a/Pal/regression/Makefile
+++ b/Pal/regression/Makefile
@@ -109,7 +109,7 @@ $(preloads): %.so: %.c $(LDLIBS-preloads)
 
 LDLIBS-executables = ../crt_init/user_start.o $(graphene_lib) $(pal_lib) $(preloads)
 $(executables): %: %.c $(LDLIBS-executables)
-	$(call cmd,csingle) -no-pie $(LDLIBS-executables)
+	$(call cmd,csingle) -no-pie $(LDLIBS-executables) $(UBSAN_LDFLAGS)
 
 pal_loader:
 	ln -s ../../Runtime/pal_loader $@

--- a/Pal/src/host/Linux/Makefile.am
+++ b/Pal/src/host/Linux/Makefile.am
@@ -8,7 +8,7 @@ ASFLAGS += -DPIC -DSHARED -fPIC -DASSEMBLER -Wa,--noexecstack \
 LDFLAGS += -shared -nostdlib -z combreloc -z defs \
 	  --version-script $(HOST_DIR)/pal.map -T $(HOST_DIR)/arch/$(ARCH)/pal.lds \
 	  --eh-frame-hdr \
-	  -z relro -z now
+	  -z relro -z now $(UBSAN_LDFLAGS)
 
 pal_loader = $(HOST_DIR)/libpal.so
 pal_lib = $(HOST_DIR)/libpal.so

--- a/Runtime/.gitignore
+++ b/Runtime/.gitignore
@@ -1,2 +1,3 @@
+.compiler-options
 /pal-Linux
 /pal-Linux-SGX

--- a/Runtime/Makefile
+++ b/Runtime/Makefile
@@ -3,7 +3,7 @@ all:
 
 .PHONY: clean
 clean:
-	$(RM) *.a *.o *.so *.so.* pal-*
+	$(RM) *.a *.o *.so *.so.* pal-* .compiler-options
 
 .PHONY: distclean
 distclean: clean

--- a/Scripts/Makefile.configs
+++ b/Scripts/Makefile.configs
@@ -1,5 +1,7 @@
 MAKEFILE_CONFIGS_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 
+RUNTIME = $(abspath $(MAKEFILE_CONFIGS_DIR)/../Runtime)
+
 ifeq ($(origin CC),default)
 CC	= gcc
 endif
@@ -68,6 +70,23 @@ ifeq ($(WERROR),1)
 CFLAGS += -Werror
 CXXFLAGS += -Werror
 endif
+
+IS_UBSAN_ENABLED = $(shell $(MAKEFILE_CONFIGS_DIR)/compiler-options is-ubsan-enabled --runtimedir $(RUNTIME))
+ifneq ($(IS_UBSAN_ENABLED),1)
+ifeq ($(UBSAN),1)
+$(info Enabling UBSAN)
+$(shell $(MAKEFILE_CONFIGS_DIR)/compiler-options enable-ubsan --runtimedir $(RUNTIME) --libdir "/usr/$(ARCH_LIBDIR)")
+#$(info $(RES))
+IS_UBSAN_ENABLED=1
+endif
+endif
+
+ifeq ($(IS_UBSAN_ENABLED),1)
+CFLAGS += -fsanitize=undefined -fno-omit-frame-pointer -fno-sanitize-recover -DUBSAN
+CXXFLAGS += -fsanitize=undefined -fno-omit-frame-pointer -fno-sanitize-recover
+UBSAN_LDFLAGS = -L$(RUNTIME) -lubsan
+endif
+$(info IS_UBSAN_ENABLED=$(IS_UBSAN_ENABLED))
 
 MAKEFILE_CONFIGS_INCLUDED = y
 include $(MAKEFILE_CONFIGS_DIR)/Makefile.Host

--- a/Scripts/Makefile.rules
+++ b/Scripts/Makefile.rules
@@ -91,7 +91,7 @@ cc-option = $(shell set -e; \
 
 # .c
 quiet_cmd_cc_o_c = [ $@ ]
-      cmd_cc_o_c = $(CC) -MD -MP $(CFLAGS) $(CFLAGS-$@) -c -o $@ $<
+      cmd_cc_o_c = $(CC) -MD -MP $(CFLAGS) $(CFLAGS-$@) -c -o $@ $< $(UBSAN_LDFLAGS)
 
 quiet_cmd_cpp_i_c = [ $@ ]
       cmd_cpp_i_c = $(CC) -MD -MP -MF $@.d $(CFLAGS) $(CFLAGS-$@) -E -o $@ $<

--- a/Scripts/compiler-options
+++ b/Scripts/compiler-options
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+
+DIR=$(dirname "$0")
+
+enable_ubsan() {
+	local runtimedir="$1"
+	local libdir="$2"
+
+	local out src
+	local libubsan="${libdir}/libubsan.so"
+	local compiler_opts="${runtimedir}/.compiler-options"
+
+	if [ -z "${libdir}" ]; then
+		echo "Missing libdir parameter."
+		return 1
+	fi
+
+	if [ -z "${runtimedir}" ]; then
+		echo "Missing runtimedir parameter."
+		return 1
+	fi
+
+	out=$(readlink -f "${libubsan}" 2>&1)
+	if [ $? -ne 0 ]; then
+		echo "Error: Could not find libubsan at ${libubsan}." >&2
+		echo "${out}" >&2
+		return 1
+	fi
+
+	cp ${out} "${runtimedir}/libubsan.so"
+	cp ${out} "${runtimedir}/$(basename $(readlink "${libubsan}"))"
+	# Copy over all known dependencies that Graphene's glibc won't build
+	for dep in libstdc++ libgcc_s; do
+		src="$(ldd ${libubsan} | grep ${dep} | gawk '{print $3}')"
+		cp "${src}" "${runtimedir}/$(basename "${src}")"
+	done
+
+	touch "${compiler_opts}"
+	if [ -z "$(grep ubsan "${compiler_opts}")" ]; then
+		echo "ubsan" >> "${compiler_opts}"
+	fi
+
+	return 0
+}
+
+is_ubsan_enabled() {
+	local runtimedir="$1"
+	local compiler_opts="${runtimedir}/.compiler-options"
+
+	if [ -z "${runtimedir}" ]; then
+		echo "Missing runtimedir parameter."
+		return 1
+	fi
+
+	if [ -n "$(grep -E "^ubsan$" "${compiler_opts}" 2>/dev/null)" ]; then
+		echo "1"
+	else
+		echo "0"
+	fi
+	return 0
+}
+
+usage() {
+	cat <<_EOF_
+Usage: $0 command [options]
+
+Valid commands are:
+enable-ubsan        : Enable ubsan
+is-ubsan-enabled    : Check whether UBSAN is enabled; prints '1' if yes,
+                      '0' otherwise
+
+--runtimedir <dir>  : Path to the Runtime dir
+--libdir <dir>      : Directory where libraries such as libubsan can be found
+
+--help|-h|-?        : Display this help screen and exit
+
+_EOF_
+}
+
+main() {
+	local runtimedir libdir cmd
+
+	cmd="$1"
+	shift
+
+	while [ $# -ne 0 ]; do
+		case $1 in
+		--runtimedir) shift 1; runtimedir="$1";;
+		--libdir) shift 1; libdir="$1";;
+		--help|-h|-?) usage "$0"; exit 0;;
+		*) echo "Unkown option $1." >&2; exit 1;;
+		esac
+		shift
+	done
+
+	case "$cmd" in
+	enable-ubsan)
+		enable_ubsan "${runtimedir}" "${libdir}"
+		;;
+	is-ubsan-enabled)
+		is_ubsan_enabled "${runtimedir}"
+		;;
+	*)
+		echo "Unsupported command '${cmd}'." >&2;
+		exit 1
+		;;
+	esac
+
+	exit $?
+}
+
+main "$@"


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://graphene.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

This PR enables a build with UBSAN enable by using 'make USBAN=1' as shown below. Some test cases that do not work under UBSAN are deactivated when USBAN is used. The regression tests on the PAL and LibOS level are passing now. LTP, however, has several failing tests.


<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->

```
make clean
make USBAN=1 DEBUG=1 -j32
pushd Pal/regression
make USBAN=1 DEBUG=1 regression -j32
popd
pushd LibOS/shim/test/regression
make USBAN=1 DEBUG=1 regression -j32
popd
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2101)
<!-- Reviewable:end -->
