### PR TITLE
LibOS: Return -EFAULT on name = NULL for sethostname/setdomainname (UBSAN)

### DIFF
--- a/LibOS/shim/src/sys/shim_getrandom.c
+++ b/LibOS/shim/src/sys/shim_getrandom.c
@@ -20,7 +20,7 @@ long shim_do_getrandom(char* buf, size_t count, unsigned int flags) {
     if (count > INT_MAX)
         count = INT_MAX;
 
-    if (test_user_memory(buf, count, /*write=*/true))
+    if (!buf || test_user_memory(buf, count, /*write=*/true))
         return -EFAULT;
 
     /* In theory, DkRandomBitsRead may block on some PALs (which conflicts with GRND_NONBLOCK flag),

--- a/LibOS/shim/src/sys/shim_socket.c
+++ b/LibOS/shim/src/sys/shim_socket.c
@@ -1154,7 +1154,7 @@ static int check_msghdr(struct msghdr* msg, bool is_recv) {
         return -EMSGSIZE;
     }
 
-    if (test_user_memory(msg->msg_iov, size, /*write=*/false)) {
+    if (!msg->msg_iov || test_user_memory(msg->msg_iov, size, /*write=*/false)) {
         return -EFAULT;
     }
 

--- a/LibOS/shim/src/sys/shim_uname.c
+++ b/LibOS/shim/src/sys/shim_uname.c
@@ -44,7 +44,7 @@ long shim_do_sethostname(char* name, int len) {
     if (len < 0 || (size_t)len >= sizeof(g_current_uname.nodename))
         return -EINVAL;
 
-    if (test_user_memory(name, len, /*write=*/false))
+    if (!name || test_user_memory(name, len, /*write=*/false))
         return -EFAULT;
 
     memcpy(&g_current_uname.nodename, name, len);
@@ -56,7 +56,7 @@ long shim_do_setdomainname(char* name, int len) {
     if (len < 0 || (size_t)len >= sizeof(g_current_uname.domainname))
         return -EINVAL;
 
-    if (test_user_memory(name, len, /*write=*/false))
+    if (!name || test_user_memory(name, len, /*write=*/false))
         return -EFAULT;
 
     memcpy(&g_current_uname.domainname, name, len);


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://graphene.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

This patch fixes an error detected with UBSAN where we have to return -EFAULT on name = NULL for sethostname and setdomainname syscalls.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2102)
<!-- Reviewable:end -->
