### PR TITLE
[LibOS] Align char msg[] in shim_ipc_msg to 8-bytes (UBSAN)

### DIFF
--- a/LibOS/shim/include/shim_ipc.h
+++ b/LibOS/shim/include/shim_ipc.h
@@ -101,7 +101,9 @@ struct shim_ipc_msg {
     size_t size;
     IDTYPE src, dst;
     unsigned long seq;
-    char msg[];
+    /* msg is used to store and read various structures, we need to ensure its proper alignment */
+    // TODO: this is only a temporary workaround until we rewrite the IPC subsystem.
+    char msg[] __attribute__((aligned(16)));
 } __attribute__((packed));
 
 struct shim_ipc_port;


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://graphene.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

The msg field of 'struct shim_ipc_msg' will for example be cast to
'struct shim_ipc_sysv_tellkey*' (in ipc_sysv_tellkey_callback()) and
needs to be properly aligned. There are also casts to other ipc
related structures that also require alignment.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2103)
<!-- Reviewable:end -->
