### PR TITLE
[Pal] Log to stderr, not stdout

### DIFF
--- a/Documentation/manifest-syntax.rst
+++ b/Documentation/manifest-syntax.rst
@@ -36,7 +36,7 @@ Log level
 This configures Graphene's debug log. The ``log_level`` option specifies what
 messages to enable (e.g. ``loader.log_level = "debug"`` will enable all messages
 of type ``error``, ``info`` and ``debug``). By default, the messages are printed
-to the standard output. If ``log_file`` is specified, the messages will be
+to the standard error. If ``log_file`` is specified, the messages will be
 appended to that file.
 
 Preloaded libraries

--- a/LibOS/shim/test/regression/test_libos.py
+++ b/LibOS/shim/test/regression/test_libos.py
@@ -224,8 +224,8 @@ class TC_01_Bootstrap(RegressionTestCase):
         self.assertIn('FE_TOWARDZERO parent: 42.5 = 42.0, -42.5 = -42.0', stdout)
 
     def test_700_debug_log_inline(self):
-        stdout, _ = self.run_binary(['debug_log_inline'])
-        self._verify_debug_log(stdout)
+        _, stderr = self.run_binary(['debug_log_inline'])
+        self._verify_debug_log(stderr)
 
     def test_701_debug_log_file(self):
         log_path = 'tmp/debug_log_file.log'

--- a/Pal/regression/Symbols.c
+++ b/Pal/regression/Symbols.c
@@ -8,7 +8,7 @@
         _sym;                                                               \
     })
 
-#define PRINT_SYMBOL(sym) pal_printf(#sym " = %p\n", SYMBOL_ADDR(sym))
+#define PRINT_SYMBOL(sym) pal_printf("symbol: %s = %p\n", #sym, SYMBOL_ADDR(sym))
 
 int main(int argc, char** argv, char** envp) {
     PRINT_SYMBOL(DkVirtualMemoryAlloc);

--- a/Pal/regression/test_pal.py
+++ b/Pal/regression/test_pal.py
@@ -133,7 +133,7 @@ class TC_00_BasicSet2(RegressionTestCase):
 
 class TC_01_Bootstrap(RegressionTestCase):
     def test_100_basic_boostrapping(self):
-        stdout, stderr = self.run_binary(['Bootstrap'])
+        _, stderr = self.run_binary(['Bootstrap'])
 
         # Basic Bootstrapping
         self.assertIn('User Program Started', stderr)
@@ -146,7 +146,7 @@ class TC_01_Bootstrap(RegressionTestCase):
         self.assertIn('argv[0] = Bootstrap', stderr)
 
         # Control Block: Debug Stream (Inline)
-        self.assertIn('Written to Debug Stream', stdout)
+        self.assertIn('Written to Debug Stream', stderr)
 
         # Control Block: Allocation Alignment
         self.assertIn('Allocation Alignment: {}'.format(mmap.ALLOCATIONGRANULARITY), stderr)
@@ -259,8 +259,9 @@ class TC_02_Symbols(RegressionTestCase):
 
     def test_000_symbols(self):
         _, stderr = self.run_binary(['Symbols'])
-        found_symbols = dict(line.split(' = ')
-            for line in stderr.strip().split('\n') if line.startswith('Dk'))
+        prefix = 'symbol: '
+        found_symbols = dict(line[len(prefix):].split(' = ')
+            for line in stderr.strip().split('\n') if line.startswith(prefix))
         self.assertCountEqual(found_symbols, self.ALL_SYMBOLS)
         for k, value in found_symbols.items():
             value = ast.literal_eval(value)

--- a/Pal/src/host/Linux-SGX/db_memory.c
+++ b/Pal/src/host/Linux-SGX/db_memory.c
@@ -83,7 +83,7 @@ int _DkVirtualMemoryProtect(void* addr, uint64_t size, int prot) {
     int64_t t = 0;
     if (__atomic_compare_exchange_n(&at_cnt.counter, &t, 1, /*weak=*/false, __ATOMIC_SEQ_CST,
                                     __ATOMIC_RELAXED))
-        SGX_DBG(DBG_M, "[Warning] DkVirtualMemoryProtect is unimplemented in Linux-SGX PAL");
+        SGX_DBG(DBG_M, "[Warning] DkVirtualMemoryProtect is unimplemented in Linux-SGX PAL\n");
     return 0;
 }
 

--- a/Pal/src/pal_internal.h
+++ b/Pal/src/pal_internal.h
@@ -337,7 +337,7 @@ static inline void print_error(const char* msg, int err) {
 }
 
 #define PAL_LOG_DEFAULT_LEVEL  PAL_LOG_ERROR
-#define PAL_LOG_DEFAULT_FD     1
+#define PAL_LOG_DEFAULT_FD     2
 
 #define _log(level, fmt...)                          \
     do {                                             \


### PR DESCRIPTION
This seems to be the usual default. It's better because it allows easier separation of application output from logs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2110)
<!-- Reviewable:end -->
