### PR TITLE
[Pal/Linux-SGX] Fix GDB integration for some binaries

### DIFF
--- a/Pal/src/db_rtld.c
+++ b/Pal/src/db_rtld.c
@@ -800,6 +800,17 @@ static int relocate_elf_object(struct link_map* l) {
     return 0;
 }
 
+/*
+ * TODO: This function assumes that a "file:" URI describes a path that can be opened on a host
+ * directly (e.g. by GDB or other tools). This is mostly true, except for protected files in
+ * Linux-SGX, which are stored encrypted. As a result, if we load a binary that is a protected file,
+ * we will (incorrectly) report the encrypted file as the actual binary, and code that tries to
+ * parse this file will trip up.
+ *
+ * For now, this doesn't seem worth fixing, as there's no use case for running binaries from
+ * protected files system, and a workaround would be ugly. Instead, the protected files system needs
+ * rethinking.
+ */
 void DkDebugMapAdd(PAL_STR uri, PAL_PTR start_addr) {
 #ifndef DEBUG
     __UNUSED(uri);

--- a/Pal/src/host/Linux-SGX/db_rtld.c
+++ b/Pal/src/host/Linux-SGX/db_rtld.c
@@ -23,17 +23,6 @@
 
 void _DkDebugMapAdd(const char* name, void* addr) {
     ocall_debug_map_add(name, addr);
-
-    const ElfW(Ehdr)* ehdr = addr;
-    ElfW(Phdr)* phdr = (void*)(addr + ehdr->e_phoff);
-    const ElfW(Phdr)* ph;
-    for (ph = phdr; ph < &phdr[ehdr->e_phnum]; ++ph)
-        if (ph->p_type == PT_LOAD && ph->p_flags & PF_X) {
-            uint64_t mapstart = ALLOC_ALIGN_DOWN(ph->p_vaddr);
-            uint64_t mapend = ALLOC_ALIGN_UP(ph->p_vaddr + ph->p_filesz);
-            uint64_t offset = ALLOC_ALIGN_DOWN(ph->p_offset);
-            ocall_report_mmap(name, (uint64_t)addr + mapstart, mapend - mapstart, offset);
-        }
 }
 
 void _DkDebugMapRemove(void* addr) {

--- a/Pal/src/host/Linux-SGX/enclave_ocalls.c
+++ b/Pal/src/host/Linux-SGX/enclave_ocalls.c
@@ -1523,42 +1523,6 @@ int ocall_debug_map_remove(void* addr) {
     return retval;
 }
 
-int ocall_report_mmap(const char* filename, uint64_t addr, uint64_t len, uint64_t offset) {
-    int retval = 0;
-
-#ifdef DEBUG
-    size_t filename_len = filename ? strlen(filename) + 1 : 0;
-    ms_ocall_report_mmap_t* ms;
-
-    void* old_ustack = sgx_prepare_ustack();
-    ms = sgx_alloc_on_ustack_aligned(sizeof(*ms), alignof(*ms));
-    if (!ms) {
-        sgx_reset_ustack(old_ustack);
-        return -EPERM;
-    }
-    void* untrusted_filename = sgx_copy_to_ustack(filename, filename_len);
-    if (!untrusted_filename) {
-        sgx_reset_ustack(old_ustack);
-        return -EPERM;
-    }
-    WRITE_ONCE(ms->ms_filename, untrusted_filename);
-    WRITE_ONCE(ms->ms_addr, addr);
-    WRITE_ONCE(ms->ms_len, len);
-    WRITE_ONCE(ms->ms_offset, offset);
-
-    retval = sgx_exitless_ocall(OCALL_REPORT_MMAP, ms);
-
-    sgx_reset_ustack(old_ustack);
-#else
-    __UNUSED(filename);
-    __UNUSED(addr);
-    __UNUSED(len);
-    __UNUSED(offset);
-#endif
-
-    return retval;
-}
-
 int ocall_eventfd(unsigned int initval, int flags) {
     int retval = 0;
     ms_ocall_eventfd_t* ms;

--- a/Pal/src/host/Linux-SGX/enclave_ocalls.h
+++ b/Pal/src/host/Linux-SGX/enclave_ocalls.h
@@ -95,8 +95,6 @@ int ocall_debug_map_add(const char* name, void* addr);
 
 int ocall_debug_map_remove(void* addr);
 
-int ocall_report_mmap(const char* filename, uint64_t addr, uint64_t len, uint64_t offset);
-
 int ocall_eventfd(unsigned int initval, int flags);
 
 /*!

--- a/Pal/src/host/Linux-SGX/ocall_types.h
+++ b/Pal/src/host/Linux-SGX/ocall_types.h
@@ -61,7 +61,6 @@ enum {
     OCALL_DELETE,
     OCALL_DEBUG_MAP_ADD,
     OCALL_DEBUG_MAP_REMOVE,
-    OCALL_REPORT_MMAP,
     OCALL_EVENTFD,
     OCALL_GET_QUOTE,
     OCALL_NR,
@@ -295,13 +294,6 @@ typedef struct {
 typedef struct {
     void* ms_addr;
 } ms_ocall_debug_map_remove_t;
-
-typedef struct {
-    const char* ms_filename;
-    uint64_t ms_addr;
-    uint64_t ms_len;
-    uint64_t ms_offset;
-} ms_ocall_report_mmap_t;
 
 typedef struct {
     unsigned int ms_initval;

--- a/Pal/src/host/Linux-SGX/sgx_enclave.c
+++ b/Pal/src/host/Linux-SGX/sgx_enclave.c
@@ -652,6 +652,8 @@ static long sgx_ocall_debug_map_add(void* pms) {
     int ret = debug_map_add(ms->ms_name, ms->ms_addr);
     if (ret < 0)
         SGX_DBG(DBG_E, "debug_map_add(%s, %p): %d", ms->ms_name, ms->ms_addr, ret);
+
+    sgx_profile_report_elf(ms->ms_name, ms->ms_addr);
 #else
     __UNUSED(ms);
 #endif
@@ -665,18 +667,6 @@ static long sgx_ocall_debug_map_remove(void* pms) {
     int ret = debug_map_remove(ms->ms_addr);
     if (ret < 0)
         SGX_DBG(DBG_E, "debug_map_remove(%p): %d", ms->ms_addr, ret);
-#else
-    __UNUSED(ms);
-#endif
-    return 0;
-}
-
-static long sgx_ocall_report_mmap(void* pms) {
-    ms_ocall_report_mmap_t* ms = (ms_ocall_report_mmap_t*)pms;
-    ODEBUG(OCALL_REPORT_MMAP, ms);
-
-#ifdef DEBUG
-    sgx_profile_report_mmap(ms->ms_filename, ms->ms_addr, ms->ms_len, ms->ms_offset);
 #else
     __UNUSED(ms);
 #endif
@@ -730,7 +720,6 @@ sgx_ocall_fn_t ocall_table[OCALL_NR] = {
     [OCALL_DELETE]           = sgx_ocall_delete,
     [OCALL_DEBUG_MAP_ADD]    = sgx_ocall_debug_map_add,
     [OCALL_DEBUG_MAP_REMOVE] = sgx_ocall_debug_map_remove,
-    [OCALL_REPORT_MMAP]      = sgx_ocall_report_mmap,
     [OCALL_EVENTFD]          = sgx_ocall_eventfd,
     [OCALL_GET_QUOTE]        = sgx_ocall_get_quote,
 };

--- a/Pal/src/host/Linux-SGX/sgx_internal.h
+++ b/Pal/src/host/Linux-SGX/sgx_internal.h
@@ -177,8 +177,8 @@ void sgx_profile_finish(void);
 /* Record a sample */
 void sgx_profile_sample(void* tcs);
 
-/* Record a new mmap of executable region */
-void sgx_profile_report_mmap(const char* filename, uint64_t addr, uint64_t len, uint64_t offset);
+/* Record a new mapped ELF */
+void sgx_profile_report_elf(const char* filename, void* addr);
 #endif
 
 /* perf.data output (sgx_perf_data.h) */

--- a/Pal/src/host/Linux-SGX/sgx_profile.c
+++ b/Pal/src/host/Linux-SGX/sgx_profile.c
@@ -16,7 +16,10 @@
 #include <stddef.h>
 
 #include "cpu.h"
+#include "elf-x86_64.h"
+#include "elf/elf.h"
 #include "sgx_internal.h"
+#include "sgx_log.h"
 #include "sgx_tls.h"
 #include "spinlock.h"
 #include "string.h"
@@ -264,7 +267,9 @@ void sgx_profile_sample(void* tcs) {
     }
 }
 
-void sgx_profile_report_mmap(const char* filename, uint64_t addr, uint64_t len, uint64_t offset) {
+void sgx_profile_report_elf(const char* filename, void* addr) {
+    int ret;
+
     if (!g_profile_enabled)
         return;
 
@@ -273,17 +278,75 @@ void sgx_profile_report_mmap(const char* filename, uint64_t addr, uint64_t len, 
     char buf[PATH_MAX];
     char* path = realpath(filename, buf);
     if (!path) {
-        SGX_DBG(DBG_E, "sgx_profile_report_mmap: realpath(%s) failed\n", filename);
+        urts_log_error("sgx_profile_report_elf(%s): realpath failed\n", filename);
         return;
     }
 
+    // Open the file and mmap it.
+
+    int fd = INLINE_SYSCALL(open, 3, path, O_RDONLY, 0);
+    if (IS_ERR(fd)) {
+        urts_log_error("sgx_profile_report_elf(%s): open failed: %d\n", filename, fd);
+        return;
+    }
+
+    off_t elf_length = INLINE_SYSCALL(lseek, 3, fd, 0, SEEK_END);
+    if (IS_ERR(elf_length)) {
+        urts_log_error("sgx_profile_report_elf(%s): lseek failed: %ld\n", filename, elf_length);
+        goto out_close;
+    }
+
+    void* elf_addr = (void*)INLINE_SYSCALL(mmap, 6, NULL, elf_length, PROT_READ, MAP_PRIVATE, fd, 0);
+    if (IS_ERR_P(elf_addr)) {
+        urts_log_error("sgx_profile_report_elf(%s): mmap failed: %ld\n", filename, ERRNO_P(addr));
+        goto out_close;
+    }
+
+    // Perform a simple sanity check to verify if this looks like ELF (see TODO for DkDebugMapAdd in
+    // Pal/src/db_rtld.c).
+
+    const ElfW(Ehdr)* ehdr = elf_addr;
+
+    if (elf_length < (off_t)sizeof(*ehdr) || memcmp(ehdr->e_ident, ELFMAG, SELFMAG) != 0) {
+        urts_log_error("sgx_profile_report_elf(%s): invalid ELF binary\n", filename);
+        goto out_unmap;
+    }
+
+    // Read the program headers and record mmap events for the segments that should be mapped as
+    // executable.
+
     pid_t pid = g_pal_enclave.pal_sec.pid;
+    const ElfW(Phdr)* phdr = (const ElfW(Phdr)*)((uintptr_t)elf_addr + ehdr->e_phoff);
+    ret = 0;
 
     spinlock_lock(&g_perf_data_lock);
-    int ret = pd_event_mmap(g_perf_data, path, pid, addr, len, offset);
+    for (unsigned int i = 0; i < ehdr->e_phnum; i++) {
+        if (phdr[i].p_type == PT_LOAD && phdr[i].p_flags & PF_X) {
+            uint64_t mapstart = ALLOC_ALIGN_DOWN(phdr[i].p_vaddr);
+            uint64_t mapend = ALLOC_ALIGN_UP(phdr[i].p_vaddr + phdr[i].p_filesz);
+            uint64_t offset = ALLOC_ALIGN_DOWN(phdr[i].p_offset);
+            ret = pd_event_mmap(g_perf_data, path, pid,
+                                (uint64_t)addr + mapstart, mapend - mapstart, offset);
+            if (IS_ERR(ret))
+                break;
+        }
+    }
     spinlock_unlock(&g_perf_data_lock);
+
     if (IS_ERR(ret))
-        SGX_DBG(DBG_E, "sgx_profile_report_mmap: pd_event_mmap failed: %d\n", ret);
+        urts_log_error("sgx_profile_report_elf(%s): pd_event_mmap failed: %d\n", filename, ret);
+
+    // Clean up.
+
+out_unmap:
+    ret = INLINE_SYSCALL(munmap, 2, elf_addr, elf_length);
+    if (IS_ERR(ret))
+        urts_log_error("sgx_profile_report_elf(%s): munmap failed: %d\n", filename, ret);
+
+out_close:
+    ret = INLINE_SYSCALL(close, 1, fd);
+    if (IS_ERR(ret))
+        urts_log_error("sgx_profile_report_elf(%s): close failed: %d\n", filename, ret);
 }
 
 #endif /* DEBUG */


### PR DESCRIPTION
The _DkDebugMapAdd function looked for executable program segments
and reported them using ocall_report_mmap(). Unfortunately, the
code incorrectly assumed the ELF header is located at load address
and not start of the map, which is not true for some binaries
(e.g. Ubuntu build of Python), and segfaulted on these binaries.

Because the information about the segments is only important for
SGX profiling, this change simplifies things by removing
the ocall_report_mmap() path and parsing the ELF file in the SGX
subsystem itself.

## Why this way?

Having this code directly in `_DkDebugAddMap` was already kind of a hack. We could avoid re-parsing the ELF file by hooking all the places that do the actual mapping, but that's not a very good solution: there is PAL rtld, LibOS rtld, and also the application ld.so. We already collect information about mapping a new executable from all these places, so it's far easier to process the executable segments in one place (`sgx_profile.c`).

## How to test this PR? <!-- (if applicable) -->

Compile with DEBUG=1, run the `python-simple` example. It should crash on master (segfault inside `_DkDebugAddMap) and work on this branch.

(I didn't check if it crashes under Ubuntu 18, but verified it under Ubuntu 20).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2111)
<!-- Reviewable:end -->
