### PR TITLE
[LibOS] Add manifest option libos.check_invalid_pointers

### DIFF
--- a/Documentation/manifest-syntax.rst
+++ b/Documentation/manifest-syntax.rst
@@ -143,6 +143,22 @@ This specifies whether to disable Address Space Layout Randomization (ASLR).
 Since disabling ASLR worsens security of the application, ASLR is enabled by
 default.
 
+Check invalid pointers
+^^^^^^^^^^^^^^^^^^^^^^
+
+::
+
+    libos.check_invalid_pointers = [1|0]
+    (Default: 1)
+
+This specifies whether to enable checks of invalid pointers on syscall
+invocations. In particular, when this manifest option is set to ``1``,
+Graphene's LibOS will return an EFAULT error code if a user-supplied buffer
+points to an invalid memory region. Setting this manifest option to ``0`` may
+improve performance for certain workloads but may also generate
+``SIGSEGV/SIGBUS`` exceptions for some applications that specifically use
+invalid pointers (though this is not expected for most real-world applications).
+
 Graphene internal metadata size
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/LibOS/shim/src/bookkeep/shim_signal.c
+++ b/LibOS/shim/src/bookkeep/shim_signal.c
@@ -30,6 +30,8 @@
 #include "shim_utils.h"
 #include "shim_vma.h"
 
+static bool g_check_invalid_ptrs = true;
+
 // __rt_sighandler_t is different from __sighandler_t in <asm-generic/signal-defs.h>:
 //    typedef void __signalfn_t(int);
 //    typedef __signalfn_t *__sighandler_t
@@ -439,6 +441,9 @@ bool test_user_memory(void* addr, size_t size, bool write) {
     if (!access_ok(addr, size))
         return true;
 
+    if (!g_check_invalid_ptrs)
+        return false;
+
     /* SGX path: check if [addr, addr+size) is addressable (in some VMA) */
     if (is_sgx_pal())
         return !is_in_adjacent_user_vmas(addr, size);
@@ -491,6 +496,9 @@ ret_fault:
 bool test_user_string(const char* addr) {
     if (!access_ok(addr, 1))
         return true;
+
+    if (!g_check_invalid_ptrs)
+        return false;
 
     size_t size, maxlen;
     const char* next = ALLOC_ALIGN_UP_PTR(addr + 1);
@@ -655,6 +663,17 @@ static void resume_upcall(PAL_NUM arg, PAL_CONTEXT* context) {
 }
 
 int init_signal(void) {
+    int ret;
+
+    int64_t check_invalid_ptrs_int;
+    ret = toml_int_in(g_manifest_root, "libos.check_invalid_pointers",
+                      /*defaultval=*/1, &check_invalid_ptrs_int);
+    if (ret < 0 || (check_invalid_ptrs_int != 0 && check_invalid_ptrs_int != 1)) {
+        debug("Cannot parse 'libos.check_invalid_pointers' (the value must be 0 or 1)\n");
+        return -EINVAL;
+    }
+    g_check_invalid_ptrs = !!check_invalid_ptrs_int;
+
     DkSetExceptionHandler(&arithmetic_error_upcall, PAL_EVENT_ARITHMETIC_ERROR);
     DkSetExceptionHandler(&memfault_upcall,         PAL_EVENT_MEMFAULT);
     DkSetExceptionHandler(&illegal_upcall,          PAL_EVENT_ILLEGAL);

--- a/LibOS/shim/test/regression/openmp.manifest.template
+++ b/LibOS/shim/test/regression/openmp.manifest.template
@@ -4,6 +4,9 @@ loader.argv0_override = "openmp"
 
 loader.env.LD_LIBRARY_PATH = "/lib:/usrlib"
 
+# the below manifest option is added only for testing, it has no significance for OpenMP
+libos.check_invalid_pointers = 0
+
 fs.mount.lib.type = "chroot"
 fs.mount.lib.path = "/lib"
 fs.mount.lib.uri = "file:../../../../Runtime"


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Previously, LibOS always checked whether user-supplied buffers for syscalls are invalid and generated `EFAULT` error codes if so. Since the invalid-buffer check needed to touch memory/traverse VMAs, it could affect performance of certain workloads.

This PR adds a manifest option to disable this behavior: most real-world applications never supply invalid buffers in syscalls.

## How to test this PR? <!-- (if applicable) -->

The manifest for the LibOS regression test `openmp` was modified to test this option. Use GDB to make sure there are no checks in `test_user_memory()` and `test_user_string()`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2121)
<!-- Reviewable:end -->
