### PR TITLE
[LibOS] Add dummy lseek emulation for /dev/{zero,random,null}

### DIFF
--- a/LibOS/shim/src/fs/dev/fs.c
+++ b/LibOS/shim/src/fs/dev/fs.c
@@ -117,15 +117,15 @@ static ssize_t dev_write(struct shim_handle* hdl, const void* buf, size_t count)
     return hdl->info.dev.dev_ops.write(hdl, buf, count);
 }
 
-static off_t dev_seek(struct shim_handle* hdl, off_t offset, int wence) {
+static off_t dev_seek(struct shim_handle* hdl, off_t offset, int whence) {
     if (hdl->type == TYPE_STR) {
-        return str_seek(hdl, offset, wence);
+        return str_seek(hdl, offset, whence);
     }
 
     assert(hdl->type == TYPE_DEV);
     if (!hdl->info.dev.dev_ops.seek)
         return -EACCES;
-    return hdl->info.dev.dev_ops.seek(hdl, offset, wence);
+    return hdl->info.dev.dev_ops.seek(hdl, offset, whence);
 }
 
 static int dev_truncate(struct shim_handle* hdl, off_t len) {

--- a/LibOS/shim/src/fs/dev/null.c
+++ b/LibOS/shim/src/fs/dev/null.c
@@ -24,6 +24,13 @@ static ssize_t dev_null_write(struct shim_handle* hdl, const void* buf, size_t c
     return count;
 }
 
+static off_t dev_null_seek(struct shim_handle* hdl, off_t offset, int whence) {
+    __UNUSED(hdl);
+    __UNUSED(offset);
+    __UNUSED(whence);
+    return 0;
+}
+
 static int dev_null_truncate(struct shim_handle* hdl, uint64_t size) {
     __UNUSED(hdl);
     __UNUSED(size);
@@ -61,6 +68,7 @@ static int dev_null_open(struct shim_handle* hdl, const char* name, int flags) {
 
     struct shim_dev_ops ops = {.read     = &dev_null_read,
                                .write    = &dev_null_write,
+                               .seek     = &dev_null_seek,
                                .truncate = &dev_null_truncate,
                                .mode     = &dev_null_mode,
                                .stat     = &dev_null_stat,

--- a/LibOS/shim/src/fs/dev/random.c
+++ b/LibOS/shim/src/fs/dev/random.c
@@ -27,6 +27,13 @@ static ssize_t dev_random_write(struct shim_handle* hdl, const void* buf, size_t
     return count;
 }
 
+static off_t dev_random_seek(struct shim_handle* hdl, off_t offset, int whence) {
+    __UNUSED(hdl);
+    __UNUSED(offset);
+    __UNUSED(whence);
+    return 0;
+}
+
 static int dev_random_mode(const char* name, mode_t* mode) {
     __UNUSED(name);
     *mode = FILE_RW_MODE | S_IFCHR;
@@ -52,6 +59,7 @@ static int dev_random_open(struct shim_handle* hdl, const char* name, int flags)
 
     struct shim_dev_ops ops = {.read  = &dev_random_read,
                                .write = &dev_random_write,
+                               .seek  = &dev_random_seek,
                                .mode  = &dev_random_mode,
                                .stat  = &dev_random_stat,
                                .hstat = &dev_random_hstat};

--- a/LibOS/shim/src/fs/dev/zero.c
+++ b/LibOS/shim/src/fs/dev/zero.c
@@ -23,6 +23,13 @@ static ssize_t dev_zero_write(struct shim_handle* hdl, const void* buf, size_t c
     return count;
 }
 
+static off_t dev_zero_seek(struct shim_handle* hdl, off_t offset, int whence) {
+    __UNUSED(hdl);
+    __UNUSED(offset);
+    __UNUSED(whence);
+    return 0;
+}
+
 static int dev_zero_truncate(struct shim_handle* hdl, uint64_t size) {
     __UNUSED(hdl);
     __UNUSED(size);
@@ -54,6 +61,7 @@ static int dev_zero_open(struct shim_handle* hdl, const char* name, int flags) {
 
     struct shim_dev_ops ops = {.read     = &dev_zero_read,
                                .write    = &dev_zero_write,
+                               .seek     = &dev_zero_seek,
                                .truncate = &dev_zero_truncate,
                                .mode     = &dev_zero_mode,
                                .stat     = &dev_zero_stat,

--- a/LibOS/shim/test/regression/dev.c
+++ b/LibOS/shim/test/regression/dev.c
@@ -1,11 +1,8 @@
 #include <dirent.h>
 #include <errno.h>
-#include <fcntl.h>
-#include <pthread.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/wait.h>
 #include <unistd.h>
 
 int main(int argc, char** argv) {
@@ -63,6 +60,12 @@ int main(int argc, char** argv) {
         return 1;
     }
 
+    ret = fseek(f, /*offset=*/0, SEEK_CUR);
+    if (ret < 0) {
+        perror("fseek /dev/urandom");
+        return 1;
+    }
+
     memset(buf, 0, sizeof(buf));
     ret = fread(buf, 1, sizeof(buf), f);
     if (ferror(f)) {
@@ -70,7 +73,10 @@ int main(int argc, char** argv) {
         return 1;
     }
 
-    printf("Four bytes from /dev/urandom: %x:%x:%x:%x\n", buf[0], buf[1], buf[2], buf[3]);
+    printf("Four bytes from /dev/urandom:");
+    for (int i = 0; i < 4; i++)
+        printf(" %02hhx", (unsigned char)buf[i]);
+    printf("\n");
 
     ret = fclose(f);
     if (ret) {
@@ -82,6 +88,12 @@ int main(int argc, char** argv) {
     f = fopen("/dev/null", "w");
     if (!f) {
         perror("fopen /dev/null");
+        return 1;
+    }
+
+    ret = fseek(f, /*offset=*/0, SEEK_CUR);
+    if (ret < 0) {
+        perror("fseek /dev/null");
         return 1;
     }
 
@@ -122,5 +134,6 @@ int main(int argc, char** argv) {
     }
 #endif
 
+    puts("TEST OK!");
     return 0;
 }

--- a/LibOS/shim/test/regression/test_libos.py
+++ b/LibOS/shim/test/regression/test_libos.py
@@ -580,6 +580,7 @@ class TC_40_FileSystem(RegressionTestCase):
         self.assertIn('/dev/stdout', stdout)
         self.assertIn('/dev/stderr', stdout)
         self.assertIn('Four bytes from /dev/urandom', stdout)
+        self.assertIn('TEST OK', stdout)
 
     def test_002_device(self):
         stdout, _ = self.run_binary(['device'])


### PR DESCRIPTION


## Description of the changes <!-- (reasons and measures) -->

Some apps (e.g., Python Dill module) perform a dummy `lseek()` on these `/dev/` files.

## How to test this PR? <!-- (if applicable) -->

Added more sub-tests in `dev` LibOS regression test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2122)
<!-- Reviewable:end -->
