### PR TITLE
[LibOS] Disable UBSAN sanitizer in test_user_memory to not trip on NULL pointer

### DIFF
--- a/LibOS/shim/src/bookkeep/shim_signal.c
+++ b/LibOS/shim/src/bookkeep/shim_signal.c
@@ -434,6 +434,9 @@ static bool is_sgx_pal(void) {
  * with a concurrent system call. The purpose of these functions is simply for
  * the compatibility with programs that rely on the error numbers, such as the
  * LTP test suite. */
+#ifdef UBSAN
+__attribute__((no_sanitize("undefined")))
+#endif
 bool test_user_memory(void* addr, size_t size, bool write) {
     if (!size)
         return false;
@@ -493,6 +496,9 @@ ret_fault:
  * This function tests a user string with unknown length. It only tests
  * whether the memory is readable.
  */
+#ifdef UBSAN
+__attribute__((no_sanitize("undefined")))
+#endif
 bool test_user_string(const char* addr) {
     if (!access_ok(addr, 1))
         return true;


### PR DESCRIPTION
This patch further prepares to enable UBSAN in Graphene. It disables the UBSAN sanitizer in `test_user_memory()` so that we do not trip on writing to the NULL pointer in when some of the syscalls call this function with a NULL pointer. This now allows to pass LPC tests calling the syscalls `getrandom`, `sethostname`, `setdomainname` and the ones that are calling into `chkmsg_hdr`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2123)
<!-- Reviewable:end -->
