### PR TITLE
[LibOS] Add tmpfs implementation that allows program to protect intermediate file

### DIFF
--- a/.ci/lib/stage-test.jenkinsfile
+++ b/.ci/lib/stage-test.jenkinsfile
@@ -39,7 +39,7 @@ stage('test') {
         }
     }
 
-    timeout(time: 5, unit: 'MINUTES') {
+    timeout(time: 15, unit: 'MINUTES') {
         sh '''
             cd LibOS/shim/test/fs
             make ${MAKEOPTS} all

--- a/Documentation/manifest-syntax.rst
+++ b/Documentation/manifest-syntax.rst
@@ -263,13 +263,34 @@ FS mount points
 
 ::
 
-    fs.mount.[identifier].type = "[chroot|...]"
+    fs.mount.[identifier].type = "[chroot|tmpfs]"
     fs.mount.[identifier].path = "[PATH]"
     fs.mount.[identifier].uri  = "[URI]"
 
 This syntax specifies how file systems are mounted inside the library OS. For
-dynamically linked binaries, usually at least one mount point is required in the
-manifest (the mount point of the Glibc library).
+dynamically linked binaries, usually at least one `chroot` mount point is
+required in the manifest (the mount point of the Glibc library).
+
+Graphene currently supports two types of mount points:
+
+* ``chroot``: Host-backed files. All host files and sub-directories found under
+  ``[URI]`` are forwarded to the Graphene instance and placed under ``[PATH]``.
+  For example, with a host-level path specified as
+  ``fs.mount.lib.uri = "file:graphene/Runtime/"`` and forwarded to Graphene via
+  ``fs.mount.lib.path = "/lib"``, a host-level file
+  ``graphene/Runtime/libc.so.6`` is visible to graphenized application as
+  ``/lib/libc.so.6``. This concept is similar to FreeBSD's chroot and to
+  Docker's named volumes. Files under ``chroot`` mount points support mmap and
+  fork/clone.
+
+* ``tmpfs``: Temporary in-memory-only files. These files are *not* backed by
+  host-level files. The tmpfs files are created under ``[PATH]`` (this path is
+  empty on Graphene instance startup) and are destroyed when a Graphene
+  instance terminates. The ``[URI]`` parameter is always ignored. ``tmpfs``
+  is especially useful in trusted environments (like Intel SGX) for securely
+  storing temporary files. This concept is similar to Linux's tmpfs. Files
+  under ``tmpfs`` mount points currently do *not* support mmap and each process
+  has its own, non-shared tmpfs (i.e. processes don't see each other's files).
 
 Start (current working) directory
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/Examples/lighttpd/Makefile
+++ b/Examples/lighttpd/Makefile
@@ -2,8 +2,8 @@ THIS_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 
 INSTALL_DIR ?= $(THIS_DIR)install
 
-LIGHTTPD_SRC ?= $(THIS_DIR)lighttpd-1.4.54
-LIGHTTPD_HASH ?= 5151d38cb7c4c40effa13710e77ebdbef899f945b062cf32befc02d128ac424c
+LIGHTTPD_SRC ?= $(THIS_DIR)lighttpd-1.4.59
+LIGHTTPD_HASH ?= e266e389ddb79bf17b8e8d9022aec95ae839c6f3159822f402df8d8df8a13f65
 
 LIGHTTPD_MIRRORS ?= \
     https://download.lighttpd.net/lighttpd/releases-1.4.x \
@@ -37,7 +37,7 @@ include ../../Scripts/Makefile.configs
 # installing the binaries.
 $(INSTALL_DIR)/sbin/lighttpd: $(LIGHTTPD_SRC)/configure
 	cd $(LIGHTTPD_SRC) && ./configure --prefix=$(abspath $(INSTALL_DIR)) \
-		--without-openssl --without-pcre --without-zlib --without-bzip2
+		--without-openssl --without-pcre --without-bzip2
 	cd $(LIGHTTPD_SRC) && $(MAKE)
 	cd $(LIGHTTPD_SRC) && $(MAKE) install
 
@@ -85,8 +85,8 @@ lighttpd-server.conf:
 
 lighttpd.conf:
 	@$(RM) $@
-	@echo "include \"lighttpd-server.conf\""                >> $@
-	@echo "include \"lighttpd-generic.conf\""               >> $@
+	@echo "include \"./lighttpd-server.conf\""              >> $@
+	@echo "include \"./lighttpd-generic.conf\""             >> $@
 
 # Generate variously-sized HTML files in $(RANDOM_DIR)
 RANDOM_DIR = $(INSTALL_DIR)/html/random

--- a/Examples/lighttpd/README.md
+++ b/Examples/lighttpd/README.md
@@ -31,9 +31,10 @@ or Graphene-SGX, respectively.
 Because these commands will start the lighttpd server in the foreground, you will need to open
 another console to run the client.
 
-Once the server has started, you can test it with `wget`
+Once the server has started, you can test it with `wget` or `curl`
 
     wget http://127.0.0.1:8003/random/10K.1.html
+    curl --compressed http://127.0.0.1:8003/random/10K.1.html -o 10K.1.html
 
 You may also run the benchmark script using `ab` (Apachebench)
 

--- a/Examples/lighttpd/lighttpd-generic.conf
+++ b/Examples/lighttpd/lighttpd-generic.conf
@@ -64,3 +64,11 @@ mimetype.assign            = (
 # make the default mime type application/octet-stream.
   ""              =>      "application/octet-stream",
 )
+
+server.modules           += ("mod_deflate")
+deflate.mimetypes         = ("text/plain", "text/html")
+deflate.allowed-encodings = ("brotli", "gzip", "deflate")
+deflate.cache-dir         = "/var/tmp/lighttpd/cache"
+deflate.max-compress-size = 131072
+deflate.min-compress-size = 256
+deflate.compression-level = 9

--- a/Examples/lighttpd/lighttpd.manifest.template
+++ b/Examples/lighttpd/lighttpd.manifest.template
@@ -47,9 +47,9 @@ fs.mount.cwd.path = "$(INSTALL_DIR_ABSPATH)"
 fs.mount.cwd.uri = "file:$(INSTALL_DIR)"
 
 # Mount lighttpd's default server.upload-dirs path
-fs.mount.var_tmp.type = "chroot"
+fs.mount.var_tmp.type = "tmpfs"
 fs.mount.var_tmp.path = "/var/tmp"
-fs.mount.var_tmp.uri = "file:/var/tmp"
+fs.mount.var_tmp.uri = "file:dummy-unused-by-tmpfs-uri"
 
 # SGX general options
 

--- a/LibOS/shim/include/shim_fs.h
+++ b/LibOS/shim/include/shim_fs.h
@@ -465,6 +465,9 @@ extern struct shim_d_ops chroot_d_ops;
 extern struct shim_fs_ops str_fs_ops;
 extern struct shim_d_ops str_d_ops;
 
+extern struct shim_fs_ops tmp_fs_ops;
+extern struct shim_d_ops tmp_d_ops;
+
 extern struct shim_mount chroot_builtin_fs;
 extern struct shim_mount pipe_builtin_fs;
 extern struct shim_mount fifo_builtin_fs;
@@ -549,6 +552,7 @@ ssize_t str_read(struct shim_handle* hdl, void* buf, size_t count);
 ssize_t str_write(struct shim_handle* hdl, const void* buf, size_t count);
 off_t str_seek(struct shim_handle* hdl, off_t offset, int whence);
 int str_flush(struct shim_handle* hdl);
+int str_truncate(struct shim_handle* hdl, off_t len);
 
 /* /sys fs related common APIs */
 /* This function extracts first number from a string. Returns a negative error code if no number is

--- a/LibOS/shim/src/Makefile
+++ b/LibOS/shim/src/Makefile
@@ -94,6 +94,7 @@ objs = \
 	fs/sys/cpu_info.o \
 	fs/sys/fs.o \
 	fs/sys/node_info.o \
+	fs/tmpfs/fs.o \
 	ipc/shim_ipc.o \
 	ipc/shim_ipc_child.o \
 	ipc/shim_ipc_helper.o \

--- a/LibOS/shim/src/fs/shim_fs.c
+++ b/LibOS/shim/src/fs/shim_fs.c
@@ -47,6 +47,11 @@ struct shim_fs mountable_fs[] = {
         .fs_ops = &sys_fs_ops,
         .d_ops  = &sys_d_ops,
     },
+    {
+        .name   = "tmpfs",
+        .fs_ops = &tmp_fs_ops,
+        .d_ops  = &tmp_d_ops,
+    },
 };
 
 struct shim_mount* builtin_fs[] = {

--- a/LibOS/shim/src/fs/tmpfs/fs.c
+++ b/LibOS/shim/src/fs/tmpfs/fs.c
@@ -1,0 +1,607 @@
+/* SPDX-License-Identifier: LGPL-3.0-or-later */
+/* Copyright (C) 2021 Intel Corporation
+ *                    Li Xun <xun.li@intel.com>
+ */
+
+/*
+ * This file contains code for implementation of 'tmpfs' filesystem.
+ * The tmpfs files are *not* cloned during fork/clone and cannot be synchronized between processes.
+ */
+
+#include <asm/mman.h>
+#include <asm/unistd.h>
+#include <errno.h>
+
+#include "perm.h"
+#include "shim_flags_conv.h"
+#include "shim_fs.h"
+#include "shim_handle.h"
+#include "shim_internal.h"
+#include "shim_lock.h"
+#include "shim_utils.h"
+#include "stat.h"
+
+struct shim_tmpfs_data {
+    struct shim_str_data str_data;
+    struct shim_lock lock;
+    enum shim_file_type type;
+    mode_t mode;
+    unsigned long atime;
+    unsigned long mtime;
+    unsigned long ctime;
+    unsigned long nlink;
+};
+
+static int tmpfs_mount(const char* uri, void** mount_data) {
+    __UNUSED(uri);
+    __UNUSED(mount_data);
+    return 0;
+}
+
+static int tmpfs_unmount(void* mount_data) {
+    __UNUSED(mount_data);
+    return 0;
+}
+
+static struct shim_tmpfs_data* __create_data(void) {
+    struct shim_tmpfs_data* data = calloc(1, sizeof(*data));
+    if (!data)
+        return NULL;
+
+    if (!create_lock(&data->lock)) {
+        free(data);
+        return NULL;
+    }
+    return data;
+}
+
+static void __destroy_data(struct shim_tmpfs_data* data) {
+    destroy_lock(&data->lock);
+    if (data->str_data.str)
+        free(data->str_data.str);
+    free(data);
+}
+
+static int create_data(struct shim_dentry* dent) {
+    assert(locked(&dent->lock));
+
+    if (dent->data)
+        return 0;
+
+    struct shim_tmpfs_data* data = __create_data();
+    if (!data)
+        return -ENOMEM;
+
+    data->type = FILE_UNKNOWN;
+    data->mode = NO_MODE;
+
+    uint64_t time = 0;
+    if (DkSystemTimeQuery(&time) < 0) {
+        __destroy_data(data);
+        return -EPERM;
+    }
+
+    data->atime = time / 1000000;
+    data->mtime = data->atime;
+    data->ctime = data->atime;
+    data->nlink = 1;
+
+    dent->data = data;
+    return 0;
+}
+
+static inline int get_or_create_tmpfs_data(struct shim_dentry* dent,
+                                           struct shim_tmpfs_data** dataptr) {
+    lock(&dent->lock);
+    if (!dent->data) {
+        int ret = create_data(dent);
+        if (ret < 0) {
+            unlock(&dent->lock);
+            return ret;
+        }
+    }
+    assert(dent->data);
+    *dataptr = (struct shim_tmpfs_data*)dent->data;
+    unlock(&dent->lock);
+    return 0;
+}
+
+static void tmpfs_update_ino(struct shim_dentry* dent) {
+    if (dent->state & DENTRY_INO_UPDATED)
+        return;
+
+    unsigned long ino = 1;
+    if (!qstrempty(&dent->rel_path))
+        ino = hash_path(qstrgetstr(&dent->rel_path), dent->rel_path.len);
+
+    dent->ino = ino;
+    dent->state |= DENTRY_INO_UPDATED;
+}
+
+static int tmpfs_open(struct shim_handle* hdl, struct shim_dentry* dent, int flags) {
+    int ret = 0;
+    struct shim_tmpfs_data* data;
+    ret = get_or_create_tmpfs_data(dent, &data);
+    if (ret < 0)
+        return ret;
+
+    lock(&data->lock);
+    if (dent->state & DENTRY_MOUNTPOINT) {
+        /* root of tmpfs */
+        data->type = FILE_DIR;
+        data->mode = PERM_rwxrwxrwx;
+        dent->type = S_IFDIR;
+        tmpfs_update_ino(dent);
+    }
+
+    if (data->type == FILE_UNKNOWN) {
+        if (!(flags & O_CREAT)) {
+            ret = -ENOENT;
+            goto out;
+        }
+        data->type = FILE_REGULAR;
+        data->mode = PERM_rwxrwxrwx;
+        dent->type = S_IFREG;
+        tmpfs_update_ino(dent);
+        /* always keep data for tmpfs until unlink */
+        REF_INC(data->str_data.ref_count);
+    }
+
+    switch (data->type) {
+        case FILE_REGULAR:
+            ret = str_open(hdl, dent, flags);
+            if (ret < 0)
+                goto out;
+            hdl->type          = TYPE_STR;
+            hdl->info.str.data = &data->str_data;
+            /* note that if file was just created, then `str` and `len` are guaranteed to be NULL
+             * and zero */
+            hdl->info.str.ptr = data->str_data.str;
+            if (flags & O_APPEND)
+                hdl->info.str.ptr += data->str_data.len;
+            break;
+        case FILE_DIR:
+            if (flags & (O_ACCMODE | O_CREAT | O_TRUNC | O_APPEND)) {
+                ret = -EISDIR;
+                goto out;
+            }
+            ret = str_open(hdl, dent, flags);
+            if (ret < 0)
+                goto out;
+            hdl->type = TYPE_DIR;
+            break;
+        default:
+            ret = -EACCES;
+            goto out;
+    }
+
+    hdl->acc_mode = ACC_MODE(flags & O_ACCMODE);
+    ret = 0;
+
+out:
+    unlock(&data->lock);
+
+    return ret;
+}
+
+static int tmpfs_dput(struct shim_dentry* dent) {
+    lock(&dent->lock);
+    struct shim_tmpfs_data* tmpfs_data = dent->data;
+
+    if (!tmpfs_data || REF_DEC(tmpfs_data->str_data.ref_count) > 1) {
+        unlock(&dent->lock);
+        return 0;
+    }
+    __destroy_data(tmpfs_data);
+
+    dent->data  = NULL;
+    dent->state = DENTRY_NEGATIVE;
+    dent->mode  = NO_MODE;
+    unlock(&dent->lock);
+    return 0;
+}
+
+static int tmpfs_flush(struct shim_handle* hdl) {
+    return str_flush(hdl);
+}
+
+static int tmpfs_close(struct shim_handle* hdl) {
+    if (hdl->flags & (O_WRONLY | O_RDWR)) {
+        int ret = tmpfs_flush(hdl);
+        if (ret < 0)
+            return ret;
+    }
+    return tmpfs_dput(hdl->dentry);
+}
+
+static ssize_t tmpfs_read(struct shim_handle* hdl, void* buf, size_t count) {
+    assert(hdl->dentry);
+    if (!(hdl->acc_mode & MAY_READ)) {
+        return -EBADF;
+    }
+
+    struct shim_tmpfs_data* tmpfs_data = hdl->dentry->data;
+    assert(tmpfs_data);
+    if (tmpfs_data->type != FILE_REGULAR) {
+        return -EISDIR;
+    }
+
+    lock(&hdl->lock);
+    ssize_t ret = str_read(hdl, buf, count);
+    /* technically, we should update access time here, but we skip this because it could hurt
+     * performance on Linux-SGX host */
+    unlock(&hdl->lock);
+    return ret;
+}
+
+static ssize_t tmpfs_write(struct shim_handle* hdl, const void* buf, size_t count) {
+    struct shim_tmpfs_data* tmpfs_data = hdl->dentry->data;
+    assert(tmpfs_data);
+    if (tmpfs_data->type != FILE_REGULAR) {
+        return -EISDIR;
+    }
+
+    uint64_t time = 0;
+    if (DkSystemTimeQuery(&time) < 0) {
+        return -EPERM;
+    }
+
+    lock(&hdl->lock);
+    ssize_t ret = str_write(hdl, buf, count);
+    if (ret < 0) {
+        goto out;
+    }
+
+    tmpfs_data->ctime = time / 1000000;
+    tmpfs_data->mtime = tmpfs_data->ctime;
+
+out:
+    unlock(&hdl->lock);
+    return ret;
+}
+
+/* TODO: tmpfs_mmap() function is not implemented because shim_do_mmap() and shim_do_munmap()
+   are currently not flexible enough for correct tmpfs implementation. In particular, shim_do_mmap()
+   pre-allocates memory region at a specific address (making it impossible to have two mmaps on the
+   same tmpfs file), and shim_do_munmap() doesn't have a callback into tmpfs at all. */
+static int tmpfs_mmap(struct shim_handle* hdl, void** addr, size_t size, int prot, int flags,
+                      uint64_t offset) {
+    __UNUSED(hdl);
+    __UNUSED(addr);
+    __UNUSED(size);
+    __UNUSED(prot);
+    __UNUSED(flags);
+    __UNUSED(offset);
+
+    log_error("tmpfs_mmap(): mmap() function for tmpfs mount type is not implemented.\n");
+    return -ENOSYS;
+}
+
+static off_t tmpfs_seek(struct shim_handle* hdl, off_t offset, int whence) {
+    return str_seek(hdl, offset, whence);
+}
+
+static int query_dentry(struct shim_dentry* dent, mode_t* mode, struct stat* stat) {
+    int ret = 0;
+
+    struct shim_tmpfs_data* data;
+    ret = get_or_create_tmpfs_data(dent, &data);
+    if (ret < 0)
+        return ret;
+
+    lock(&data->lock);
+
+    switch (data->type) {
+        case FILE_REGULAR:
+            dent->type = S_IFREG;
+            break;
+        case FILE_DIR:
+            dent->type = S_IFDIR;
+            break;
+        default:
+            unlock(&data->lock);
+            return -ENOENT;
+    }
+
+    if (mode)
+        *mode = data->mode;
+
+    if (stat) {
+        memset(stat, 0, sizeof(struct stat));
+
+        stat->st_mode  = (mode_t)data->mode;
+        stat->st_dev   = 0;
+        stat->st_ino   = dent->ino;
+        stat->st_size  = data->str_data.len;
+        stat->st_atime = (time_t)data->atime;
+        stat->st_mtime = (time_t)data->mtime;
+        stat->st_ctime = (time_t)data->ctime;
+        stat->st_nlink = data->nlink;
+
+        switch (data->type) {
+            case FILE_REGULAR:
+                stat->st_mode |= S_IFREG;
+                break;
+            case FILE_DIR:
+                stat->st_mode |= S_IFDIR;
+                break;
+            default:
+                unlock(&data->lock);
+                return -ENOENT;
+        }
+    }
+
+    unlock(&data->lock);
+    return 0;
+}
+
+static int tmpfs_mode(struct shim_dentry* dent, mode_t* mode) {
+    if (qstrempty(&dent->rel_path)) {
+        /* root of pseudo-FS */
+        return pseudo_dir_mode(/*name=*/NULL, mode);
+    }
+    return query_dentry(dent, mode, NULL);
+}
+
+static int tmpfs_stat(struct shim_dentry* dent, struct stat* statbuf) {
+    if (qstrempty(&dent->rel_path)) {
+        /* root of pseudo-FS */
+        return pseudo_dir_stat(/*name=*/NULL, statbuf);
+    }
+    return query_dentry(dent, NULL, statbuf);
+}
+
+static int tmpfs_lookup(struct shim_dentry* dent) {
+    if (qstrempty(&dent->rel_path)) {
+        /* root of pseudo-FS */
+        dent->ino = 1;
+        dent->state |= DENTRY_ISDIRECTORY;
+        return 0;
+    }
+    return query_dentry(dent, NULL, NULL);
+}
+
+static int tmpfs_creat(struct shim_handle* hdl, struct shim_dentry* dir, struct shim_dentry* dent,
+                       int flags, mode_t mode) {
+    int ret = 0;
+    assert(hdl);
+
+    struct shim_tmpfs_data* data;
+    ret = get_or_create_tmpfs_data(dent, &data);
+    if (ret < 0)
+        return ret;
+
+    if (data->type == FILE_DIR) {
+        return -EISDIR;
+    }
+    ret = tmpfs_open(hdl, dent, flags | O_CREAT | O_EXCL);
+    if (ret < 0) {
+        __destroy_data(data);
+        return ret;
+    }
+
+    data->mode = mode;
+
+    /* Increment the parent's link count */
+    struct shim_tmpfs_data* parent_data = (struct shim_tmpfs_data*)dir->data;
+    if (parent_data) {
+        lock(&parent_data->lock);
+        parent_data->nlink++;
+        unlock(&parent_data->lock);
+    }
+    return 0;
+}
+
+static int tmpfs_mkdir(struct shim_dentry* dir, struct shim_dentry* dent, mode_t mode) {
+    int ret = 0;
+    struct shim_tmpfs_data* data;
+    ret = get_or_create_tmpfs_data(dent, &data);
+    if (ret < 0)
+        return ret;
+
+    if (data->type != FILE_UNKNOWN)
+        return -EEXIST;
+    data->type = FILE_DIR;
+    data->mode = mode;
+
+    dent->type = S_IFDIR;
+
+    tmpfs_update_ino(dent);
+
+    /* Increment the parent's link count */
+    struct shim_tmpfs_data* parent_data = (struct shim_tmpfs_data*)dir->data;
+    if (parent_data) {
+        lock(&parent_data->lock);
+        parent_data->nlink++;
+        unlock(&parent_data->lock);
+    }
+    return 0;
+}
+
+static int tmpfs_hstat(struct shim_handle* hdl, struct stat* stat) {
+    assert(hdl->dentry);
+    if (qstrempty(&hdl->dentry->rel_path)) {
+        /* root of pseudo-FS */
+        return pseudo_dir_stat(/*name=*/NULL, stat);
+    }
+    return query_dentry(hdl->dentry, NULL, stat);
+}
+
+static int tmpfs_truncate(struct shim_handle* hdl, off_t len) {
+    int ret = 0;
+    lock(&hdl->lock);
+    ret = str_truncate(hdl, len);
+    unlock(&hdl->lock);
+    return ret;
+}
+
+static int tmpfs_readdir(struct shim_dentry* dent, struct shim_dirent** dirent) {
+    int ret = 0;
+    size_t dirent_buf_size = 0;
+    char* dirent_buf = NULL;
+
+    struct shim_tmpfs_data* tmpfs_data = dent->data;
+    assert(tmpfs_data);
+    if (tmpfs_data->type != FILE_DIR) {
+        return -ENOTDIR;
+    }
+
+    struct shim_dentry* tmp_dent = NULL;
+    struct shim_tmpfs_data* tmp_data = NULL;
+    LISTP_FOR_EACH_ENTRY(tmp_dent, &dent->children, siblings) {
+        assert((tmp_dent->state & DENTRY_INVALID_FLAGS) == 0);
+
+        if (tmp_dent->state & DENTRY_NEGATIVE)
+            continue;
+        tmp_data = tmp_dent->data;
+        if (!tmp_data || (tmp_data->type != FILE_DIR && tmp_data->type != FILE_REGULAR))
+            continue;
+        dirent_buf_size += SHIM_DIRENT_ALIGNED_SIZE(tmp_dent->name.len + 1);
+    }
+
+    dirent_buf = malloc(dirent_buf_size);
+    if (!dirent_buf) {
+        ret = -ENOMEM;
+        goto out;
+    }
+
+    size_t dirent_cur_off = 0;
+    struct shim_dirent** last = NULL;
+    LISTP_FOR_EACH_ENTRY(tmp_dent, &dent->children, siblings) {
+        if (tmp_dent->state & DENTRY_NEGATIVE)
+            continue;
+        tmp_data = tmp_dent->data;
+        if (!tmp_data || (tmp_data->type != FILE_DIR && tmp_data->type != FILE_REGULAR))
+            continue;
+
+        struct shim_dirent* dptr = (struct shim_dirent*)(dirent_buf + dirent_cur_off);
+        dptr->ino  = tmp_dent->ino;
+        dptr->type = tmp_data->type == FILE_DIR ? LINUX_DT_DIR : LINUX_DT_REG;
+        memcpy(dptr->name, qstrgetstr(&tmp_dent->name), tmp_dent->name.len + 1);
+        size_t len = SHIM_DIRENT_ALIGNED_SIZE(tmp_dent->name.len + 1);
+        dptr->next = (struct shim_dirent*)(dirent_buf + dirent_cur_off + len);
+        last = &dptr->next;
+        dirent_cur_off += len;
+    }
+    if (last) {
+        *last = NULL;
+    }
+    *dirent = (struct shim_dirent*)dirent_buf;
+
+out:
+    if (ret) {
+        free(dirent_buf);
+    }
+    return ret;
+}
+
+static int tmpfs_unlink(struct shim_dentry* dir, struct shim_dentry* dent) {
+    struct shim_tmpfs_data* tmpfs_data = dent->data;
+    if (!tmpfs_data)
+        return -ENOENT;
+
+    if (tmpfs_data->type == FILE_REGULAR) {
+        tmpfs_dput(dent);
+    } else if (tmpfs_data->type == FILE_DIR && dent->nchildren != 0) {
+        struct shim_dentry* tmp = NULL;
+        size_t nchildren = 0;
+        LISTP_FOR_EACH_ENTRY(tmp, &dent->children, siblings) {
+            if (tmp->state & DENTRY_NEGATIVE)
+                continue;
+            nchildren++;
+        }
+        if (nchildren != 0)
+            return -ENOTEMPTY;
+        dent->data = NULL;
+        dent->mode = NO_MODE;
+    }
+
+    struct shim_tmpfs_data* parent_data = dir->data;
+    if (parent_data) {
+        lock(&parent_data->lock);
+        parent_data->nlink--;
+        unlock(&parent_data->lock);
+    }
+
+    return 0;
+}
+
+static off_t tmpfs_poll(struct shim_handle* hdl, int poll_type) {
+    struct shim_str_data* data = hdl->info.str.data;
+    off_t size = data ? data->len : 0;
+
+    if (poll_type == FS_POLL_SZ)
+        return size;
+
+    return -EAGAIN;
+}
+
+static int tmpfs_rename(struct shim_dentry* old, struct shim_dentry* new) {
+    struct shim_tmpfs_data* tmpfs_data = new->data;
+    assert(tmpfs_data && tmpfs_data->str_data.str == NULL);
+
+    uint64_t time = 0;
+    if (DkSystemTimeQuery(&time) < 0) {
+        return -EPERM;
+    }
+
+    __destroy_data(tmpfs_data);
+
+    /* old file must be existing, otherwise some bug */
+    assert(REF_GET(old->ref_count) > 0);
+
+    new->data = old->data;
+    new->mode = old->mode;
+    new->type = old->type;
+
+    tmpfs_data        = new->data;
+    tmpfs_data->ctime = time / 1000000;
+
+    /* mark old file as non-existing now, after renaming */
+    old->state |= DENTRY_NEGATIVE;
+    return 0;
+}
+
+static int tmpfs_chmod(struct shim_dentry* dent, mode_t mode) {
+    struct shim_tmpfs_data* tmpfs_data = dent->data;
+    if (!tmpfs_data)
+        return -ENOENT;
+
+    uint64_t time = 0;
+    if (DkSystemTimeQuery(&time) < 0) {
+        return -EPERM;
+    }
+
+    dent->mode        = mode;
+    tmpfs_data->mode  = mode;
+    tmpfs_data->ctime = time / 1000000;
+    return 0;
+}
+
+struct shim_fs_ops tmp_fs_ops = {
+    .mount    = &tmpfs_mount,
+    .unmount  = &tmpfs_unmount,
+    .flush    = &tmpfs_flush,
+    .close    = &tmpfs_close,
+    .read     = &tmpfs_read,
+    .write    = &tmpfs_write,
+    .mmap     = &tmpfs_mmap,
+    .seek     = &tmpfs_seek,
+    .hstat    = &tmpfs_hstat,
+    .truncate = &tmpfs_truncate,
+    .poll     = &tmpfs_poll,
+};
+
+struct shim_d_ops tmp_d_ops = {
+    .open    = &tmpfs_open,
+    .mode    = &tmpfs_mode,
+    .lookup  = &tmpfs_lookup,
+    .creat   = &tmpfs_creat,
+    .mkdir   = &tmpfs_mkdir,
+    .stat    = &tmpfs_stat,
+    .dput    = &tmpfs_dput,
+    .readdir = &tmpfs_readdir,
+    .unlink  = &tmpfs_unlink,
+    .rename  = &tmpfs_rename,
+    .chmod   = &tmpfs_chmod,
+};

--- a/LibOS/shim/test/fs/.gitignore
+++ b/LibOS/shim/test/fs/.gitignore
@@ -18,6 +18,7 @@
 /seek_tell
 /stat
 /truncate
+
 /.cache
 
 /bin

--- a/LibOS/shim/test/fs/Makefile
+++ b/LibOS/shim/test/fs/Makefile
@@ -61,15 +61,23 @@ fs-test: $(target)
 	$(RM) fs-test.xml
 	$(MAKE) fs-test.xml
 
+.PHONY: tmpfs-test
+tmpfs-test: $(target)
+	$(RM) tmpfs-test.xml
+	$(MAKE) tmpfs-test.xml
+
 .PHONY: pf-test
 pf-test: $(target)
 	$(RM) pf-test.xml
 	$(MAKE) pf-test.xml
 
 .PHONY: test
-test: fs-test pf-test
+test: fs-test tmpfs-test pf-test
 
 fs-test.xml: test_fs.py $(call expand_target_to_token,$(target))
+	$(SCRIPTS_DIR)/run-pytest --junit-xml $@ -v $<
+
+tmpfs-test.xml: test_tmpfs.py $(call expand_target_to_token,$(target))
 	$(SCRIPTS_DIR)/run-pytest --junit-xml $@ -v $<
 
 pf-test.xml: test_pf.py $(call expand_target_to_token,$(target))

--- a/LibOS/shim/test/fs/README.md
+++ b/LibOS/shim/test/fs/README.md
@@ -17,6 +17,7 @@ How to execute
 
 - `make test` to run all tests
 - `make fs-test` to test regular files
+- `make tmpfs-test` to test tmpfs (temporary in-memory) files
 - `make pf-test` to test protected files (SGX only)
 
 (SGX only) Protected file tests assume that the SGX tools were installed in this directory:

--- a/LibOS/shim/test/fs/manifest.template
+++ b/LibOS/shim/test/fs/manifest.template
@@ -23,6 +23,10 @@ fs.mount.output.type = "chroot"
 fs.mount.output.path = "/mounted"
 fs.mount.output.uri = "file:tmp"
 
+fs.mount.tmpfs.type = "tmpfs"
+fs.mount.tmpfs.path = "/mnt-tmpfs"
+fs.mount.tmpfs.uri = "file:dummy-unused-by-tmpfs-uri"
+
 sgx.trusted_files.entrypoint = "file:$(ENTRYPOINT)"
 
 sgx.trusted_files.runtime = "file:../../../../Runtime/"

--- a/LibOS/shim/test/fs/test_tmpfs.py
+++ b/LibOS/shim/test/fs/test_tmpfs.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+
+import os
+import unittest
+
+# Named import, so that Pytest does not pick up TC_00_FileSystem as belonging to this module.
+import test_fs
+
+# pylint: disable=too-many-public-methods
+class TC_10_Tmpfs(test_fs.TC_00_FileSystem):
+    @classmethod
+    def setUpClass(cls):
+        cls.FILE_SIZES = [0, 1, 2, 15, 16, 17, 255, 256, 257, 1023, 1024, 1025, 65535, 65536, 65537,
+                          1048575, 1048576, 1048577]
+        cls.TEST_DIR = 'tmp'
+        cls.INDEXES = range(len(cls.FILE_SIZES))
+        cls.INPUT_DIR = os.path.join(cls.TEST_DIR, 'input')
+        cls.INPUT_FILES = [os.path.join(cls.INPUT_DIR, str(x)) for x in cls.FILE_SIZES]
+        cls.OUTPUT_DIR = os.path.abspath('/mnt-tmpfs')
+        cls.OUTPUT_FILES = [os.path.join(cls.OUTPUT_DIR, str(x)) for x in cls.FILE_SIZES]
+
+        # create directory structure and test files
+        os.mkdir(cls.TEST_DIR)
+        os.mkdir(cls.INPUT_DIR)
+        for i in cls.INDEXES:
+            with open(cls.INPUT_FILES[i], 'wb') as file:
+                file.write(os.urandom(cls.FILE_SIZES[i]))
+
+    # overrides TC_00_FileSystem to skip unnecessary steps
+    def setUp(self):
+        pass
+
+    # overrides TC_00_FileSystem to skip verification by python
+    def test_100_open_close(self):
+        output_path = os.path.join(self.OUTPUT_DIR, 'test_100') # new file to be created
+        stdout, stderr = self.run_binary(['open_close', 'W', output_path])
+        self.verify_open_close(stdout, stderr, output_path, 'output')
+
+    # overrides TC_00_FileSystem to skip verification by python
+    def test_110_read_write(self):
+        file_path = os.path.join(self.OUTPUT_DIR, 'test_110') # new file to be created
+        stdout, stderr = self.run_binary(['read_write', file_path])
+        self.assertNotIn('ERROR: ', stderr)
+        self.assertIn('open(' + file_path + ') RW OK', stdout)
+        self.assertIn('write(' + file_path + ') RW OK', stdout)
+        self.assertIn('seek(' + file_path + ') RW OK', stdout)
+        self.assertIn('read(' + file_path + ') RW OK', stdout)
+        self.assertIn('compare(' + file_path + ') RW OK', stdout)
+        self.assertIn('close(' + file_path + ') RW OK', stdout)
+
+    @unittest.skip("impossible to do setup on tmpfs with python only")
+    def test_115_seek_tell(self):
+        test_fs.TC_00_FileSystem.test_115_seek_tell(self)
+
+    @unittest.skip("impossible to do setup on tmpfs with python only")
+    def test_120_file_delete(self):
+        test_fs.TC_00_FileSystem.test_120_file_delete(self)
+
+    @unittest.skip("impossible to do setup on tmpfs with python only")
+    def test_130_file_stat(self):
+        test_fs.TC_00_FileSystem.test_130_file_stat(self)
+
+    @unittest.skip("impossible to do setup on tmpfs with python only")
+    def test_140_file_truncate(self):
+        test_fs.TC_00_FileSystem.test_140_file_truncate(self)
+
+    # overrides TC_00_FileSystem to skip verification by python
+    def verify_copy_content(self, input_path, output_path):
+        pass
+
+    @unittest.skip("mmap is not yet implemented in tmpfs")
+    def test_204_copy_dir_mmap_whole(self):
+        test_fs.TC_00_FileSystem.test_204_copy_dir_mmap_whole(self)
+
+    @unittest.skip("mmap is not yet implemented in tmpfs")
+    def test_205_copy_dir_mmap_seq(self):
+        test_fs.TC_00_FileSystem.test_205_copy_dir_mmap_seq(self)
+
+    @unittest.skip("mmap is not yet implemented in tmpfs")
+    def test_206_copy_dir_mmap_rev(self):
+        test_fs.TC_00_FileSystem.test_206_copy_dir_mmap_rev(self)
+
+    @unittest.skip("not applicable for tmpfs")
+    def test_210_copy_dir_mounted(self):
+        test_fs.TC_00_FileSystem.test_210_copy_dir_mounted(self)


### PR DESCRIPTION
## Description of the changes
When temporary files contain sensitive data, it's hard to add them to manifest as sgx.protected_files because the file name is usually contain generated random string.

In-memory tmpfs can solve this problem and avoid encryption/decryption overhead. Everything in tmpfs is temporary in the sense that no files will be created on your hard drive. All files and directories are stored in memory/EPC and will lost after Graphene exit.
- Usage:
tmpfs mount point can be assigned in manifest as
```
    fs.mount.[identifier].type = "tmpfs"
    fs.mount.[identifier].path = "[PATH]"
    fs.mount.[identifier].uri  = "[URI]"
```
`[PATH]` is the mount point. `[URI]` is ignored no matter what string it is.

Fixes #1787.

## How to test this PR? <!-- (if applicable) -->
regression test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2124)
<!-- Reviewable:end -->
