### PR TITLE
[Make] Use proper dependencies for generated-offsets

### DIFF
--- a/Scripts/Makefile.rules
+++ b/Scripts/Makefile.rules
@@ -33,12 +33,13 @@ cmd = @$(echo-cmd) $(cmd_$(1))
 
 
 quiet_cmd_generated_offsets_s = [ $@ ]
-      cmd_generated_offsets_s = $(CC) $(CFLAGS) $(defs) -S $< -o $@
+      cmd_generated_offsets_s = $(CC) $(CFLAGS) -MD -MP -MF $@.d $(defs) -S $< -o $@
 
-generated-offsets.s: generated-offsets.c $(filter-out asm-offsets.h,$(headers))
+generated-offsets.s: generated-offsets.c
 	$(call cmd,generated_offsets_s)
-CLEAN_FILES += generated-offsets.s
+CLEAN_FILES += generated-offsets.s generated-offsets.s.d
 
+-include generated-offsets.s.d
 
 # Convert inline assembly into preprocessor directives.
 # The source line is something like:


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

The generated-offsets headers have to depend on the code that
defines the relevant data structures. Otherwise, when the data
structures change, the code will get compiled with wrong offsets
and will crash.

## How to test this PR? <!-- (if applicable) -->

Edit `shim_tcb.h` in `LibOS/shim` and run `make` there. The `asm-offsets.h` file should get rebuilt and contain the right offsets.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2126)
<!-- Reviewable:end -->
