### PR TITLE
[LibOS] Allow but ignore MSG_WAITALL flag in recv

### DIFF
--- a/LibOS/shim/include/shim_types.h
+++ b/LibOS/shim/include/shim_types.h
@@ -221,10 +221,12 @@ enum {
     MSG_OOB      = 0x01,   /* Process out-of-band data. */
     MSG_PEEK     = 0x02,   /* Peek at incoming messages. */
     MSG_DONTWAIT = 0x40,   /* Nonblocking IO. */
+    MSG_WAITALL  = 0x100,  /* Wait for full request or error */
     MSG_NOSIGNAL = 0x4000, /* Do not generate SIGPIPE. */
 #define MSG_OOB      MSG_OOB
 #define MSG_PEEK     MSG_PEEK
 #define MSG_DONTWAIT MSG_DONTWAIT
+#define MSG_WAITALL  MSG_WAITALL
 #define MSG_NOSIGNAL MSG_NOSIGNAL
 };
 

--- a/LibOS/shim/src/sys/shim_socket.c
+++ b/LibOS/shim/src/sys/shim_socket.c
@@ -1238,14 +1238,20 @@ static ssize_t do_recvmsg(int fd, struct iovec* bufs, size_t nbufs, int flags,
         expected_size += bufs[i].iov_len;
     }
 
-    if (flags & ~(MSG_PEEK | MSG_DONTWAIT)) {
-        debug("recvmsg()/recvmmsg()/recvfrom(): unknown flag (only MSG_PEEK and MSG_DONTWAIT are"
-              " supported).\n");
+    if (flags & ~(MSG_PEEK | MSG_DONTWAIT | MSG_WAITALL)) {
+        debug("recvmsg()/recvmmsg()/recvfrom(): unknown flag (only MSG_PEEK, MSG_DONTWAIT and"
+              " MSG_WAITALL are supported).\n");
         ret = -EOPNOTSUPP;
         goto out;
     }
 
     lock(&hdl->lock);
+
+    if (flags & MSG_WAITALL) {
+        log_debug("recvmsg()/recvmmsg()/recvfrom(): MSG_WAITALL is ignored, may lead to a read"
+                  " that returns less data.\n");
+        flags &= ~MSG_WAITALL;
+    }
 
     if (flags & MSG_DONTWAIT) {
         if (!(hdl->flags & O_NONBLOCK)) {

--- a/LibOS/shim/test/regression/tcp_msg_peek.c
+++ b/LibOS/shim/test/regression/tcp_msg_peek.c
@@ -173,9 +173,9 @@ static void client(void) {
         exit(1);
     }
 
-    /* we specify dummy MSG_DONTWAIT just to test this flag */
+    /* we specify dummy MSG_DONTWAIT and MSG_WAITALL just to test these flags */
     printf("[client] receiving with MSG_PEEK: ");
-    count = client_recv(server_socket, buffer, sizeof(buffer), MSG_DONTWAIT | MSG_PEEK);
+    count = client_recv(server_socket, buffer, sizeof(buffer), MSG_WAITALL | MSG_DONTWAIT | MSG_PEEK);
     fwrite(buffer, count, 1, stdout);
 
     printf("[client] receiving without MSG_PEEK: ");


### PR DESCRIPTION

## Description of the changes <!-- (reasons and measures) -->
 This PR adds dummy emulation (simply ignoring) the flag MSG_WAITALL in recv/recvmsg, etc. , similar to #1766.
with MSG_WAITALL, the call may still return less data than requested.

## How to test this PR?
tcp_msg_peek LibOS regression test

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2128)
<!-- Reviewable:end -->
