### PR TITLE
[Docs,Pal/Linux-SGX] Improve build and documentation on ISGX_DRIVER_PATH

### DIFF
--- a/Documentation/building.rst
+++ b/Documentation/building.rst
@@ -186,7 +186,13 @@ Building
 To build Graphene with Intel SGX support, in the root directory of Graphene
 repo, run the following command::
 
-   make SGX=1
+   ISGX_DRIVER_PATH=<path-to-sgx-driver-sources> make SGX=1
+
+The path to the SGX driver sources must point to the absolute path where the SGX
+driver was downloaded or installed in the previous step. For example, for the
+DCAP version 33 of the SGX driver, you must specify
+``ISGX_DRIVER_PATH="/usr/src/sgx-1.33/"``. You can define
+``ISGX_DRIVER_PATH=""`` to use the default in-kernel driver's C header.
 
 Running :command:`make SGX=1 sgx-tokens` in the test or regression directory
 will automatically generate the required manifest signatures (``.sig`` files)

--- a/Documentation/cloud-deployment.rst
+++ b/Documentation/cloud-deployment.rst
@@ -43,8 +43,7 @@ Building
 
 #. Prepare the signing keys::
 
-       openssl genrsa -3 -out enclave-key.pem 3072
-       cp enclave-key.pem Pal/src/host/Linux-SGX/signer
+       openssl genrsa -3 -out Pal/src/host/Linux-SGX/signer/enclave-key.pem 3072
 
 #. Build Graphene::
 

--- a/Documentation/quickstart.rst
+++ b/Documentation/quickstart.rst
@@ -51,26 +51,22 @@ the DCAP driver requires Graphene to run as a root user to access it.
 The first command should list :command:`isgx` (or :command:`sgx`) and the
 second command should list the process status of :command:`aesm_service`.
 
-#. Clone the repository and set the home directory of Graphene::
+#. Clone the Graphene repository::
 
       git clone https://github.com/oscarlab/graphene.git
       cd graphene
-      export GRAPHENE_DIR=$PWD
 
 #. Prepare a signing key::
 
-      cd $GRAPHENE_DIR/Pal/src/host/Linux-SGX/signer
-      openssl genrsa -3 -out enclave-key.pem 3072
+      openssl genrsa -3 -out Pal/src/host/Linux-SGX/signer/enclave-key.pem 3072
 
-#. Build Graphene-SGX::
+#. Build Graphene and Graphene-SGX::
 
       sudo apt-get install -y \
          build-essential autoconf gawk bison wget python3 libcurl4-openssl-dev \
          python3-protobuf libprotobuf-c-dev protobuf-c-compiler
-      cd $GRAPHENE_DIR
-      make SGX=1
-      # the console will prompt you for the path to the Intel SGX driver code
-      # (simply press ENTER if you use the in-kernel Intel SGX driver)
+      make
+      ISGX_DRIVER_PATH=<path-to-sgx-driver-sources> make SGX=1
 
 #. Set ``vm.mmap_min_addr=0`` in the system (*only required for the legacy SGX
    driver and not needed for newer DCAP/in-kernel drivers*)::
@@ -81,7 +77,7 @@ second command should list the process status of :command:`aesm_service`.
 
 #. Build and run :program:`helloworld`::
 
-      cd $GRAPHENE_DIR/LibOS/shim/test/regression
+      cd LibOS/shim/test/regression
       make SGX=1 sgx-tokens
       SGX=1 ./pal_loader helloworld
 

--- a/Pal/src/host/Linux-SGX/Makefile
+++ b/Pal/src/host/Linux-SGX/Makefile
@@ -148,7 +148,7 @@ gdb_integration/sgx_gdb.so: gdb_integration/sgx_gdb.c
 enclave_entry.o sgx_entry.o: asm-offsets.h
 
 gsgx.h: gsgx.h.in
-	./link-intel-driver.py < $< > $@
+	./link-intel-driver.py --input $< --output $@
 
 ifeq ($(filter %clean,$(MAKECMDGOALS)),)
 include $(wildcard *.d) $(wildcard gdb_integration/*.d)


### PR DESCRIPTION

## Description of the changes <!-- (reasons and measures) -->

The merged PR https://github.com/oscarlab/graphene/pull/1997 changed Graphene to always require `ISGX_DRIVER_PATH=<path-to-sgx-driver-sources>` to be set, otherwise the SGX build fails.

Unfortunately, we forgot to update the Quick Start and the Building documentation of Graphene.

Also, the Makefile created an empty `gsgx.h` out of `gsgx.h.in` even if the Python script failed, which led to other parts of Graphene sources doing `#include "gsgx.h"` which didn't make sense (the file was empty), and this led to bizarre build errors that users don't understand and complain about.

This PR fixes this.

## How to test this PR? <!-- (if applicable) -->

All tests must work. Following the build docs must actually work now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2132)
<!-- Reviewable:end -->
