### PR TITLE
[Docs] Drop "Deprecated Code" sections

### DIFF
--- a/Documentation/building.rst
+++ b/Documentation/building.rst
@@ -212,12 +212,3 @@ Additional build options
 
 - Each part of Graphene can be built separately in the subdirectories. For
   example, to build only the Pal component, use :command:`make -c Pal`.
-
-Deprecated features
--------------------
-
-Building with kernel-level sandboxing (optional)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-This feature is marked as EXPERIMENTAL and no longer exists on the master
-branch.

--- a/README.rst
+++ b/README.rst
@@ -82,16 +82,3 @@ For any questions, please send an email to support@graphene-project.io
 
 For bug reports, post an issue on our GitHub repository:
 https://github.com/oscarlab/graphene/issues.
-
-
-Deprecated Code
-===============
-
-We have some branches with legacy code (use at your own risk).
-
-Build with Kernel-Level Sandboxing
-----------------------------------
-
-This feature is marked as EXPERIMENTAL and no longer exists in the master branch.
-See `EXPERIMENTAL/linux-reference-monitor
-<https://github.com/oscarlab/graphene/tree/EXPERIMENTAL/linux-reference-monitor>`__.


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Seems that no one has used this feature since its deprecation 1.5 year ago. Let's not clutter the main readme with it.

Also dropped a section from building instructions, as it was quite useless.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2133)
<!-- Reviewable:end -->
