### PR TITLE
[Pal/Linux-SGX] Allow CPUID leaves 0x40000000 - 0x4FFFFFFF

### DIFF
--- a/LibOS/shim/test/regression/cpuid.c
+++ b/LibOS/shim/test/regression/cpuid.c
@@ -68,8 +68,24 @@ static void test_cpuid_leaf_0xd(void) {
     memset(&r, 0, sizeof(r));
 }
 
+
+static void test_cpuid_leaf_invalid(void) {
+    /* Graphene returns all zeros for CPUID leaves 0x40000000 - 0x4FFFFFFF ("no virtualization") */
+    struct regs r = {0, };
+
+    cpuid(0x40000000, 0x00, &r); /* subleaf value doesn't matter */
+    if (r.eax || r.ebx || r.ecx || r.edx)
+        abort();
+    memset(&r, 0, sizeof(r));
+
+    cpuid(0x4FFFFFFF, 0x42, &r); /* subleaf value doesn't matter */
+    if (r.eax || r.ebx || r.ecx || r.edx)
+        abort();
+}
+
 int main(int argc, char** argv, char** envp) {
     test_cpuid_leaf_0xd();
+    test_cpuid_leaf_invalid();
     printf("CPUID test passed.\n");
     return 0;
 }

--- a/Pal/src/host/Linux-SGX/db_misc.c
+++ b/Pal/src/host/Linux-SGX/db_misc.c
@@ -325,6 +325,18 @@ static const struct cpuid_leaf cpuid_known_leaves[] = {
 };
 
 int _DkCpuIdRetrieve(unsigned int leaf, unsigned int subleaf, unsigned int values[4]) {
+    /* leaves 0x40000000 to 0x4FFFFFFF are used by virtualization software (KVM, Hyper-V, etc.),
+     * they return all zeros on bare metal; runtimes like JVM query these leaves to learn about
+     * the underlying virtualization software */
+    if (leaf >= 0x40000000 && leaf <= 0x4FFFFFFF) {
+        /* let Graphene report that there is no virtualization software */
+        values[0] = 0;
+        values[1] = 0;
+        values[2] = 0;
+        values[3] = 0;
+        return 0;
+    }
+
     const struct cpuid_leaf* known_leaf = NULL;
     for (unsigned int i = 0; i < ARRAY_SIZE(cpuid_known_leaves); i++) {
         if (leaf == cpuid_known_leaves[i].leaf) {


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

These CPUID leaves used by virtualization software (Hyper-V, KVM, etc.) and is zeroed out on bare metal. Some runtimes like JVM query these CPUID leaves to detect underlying virtualization software. This commit makes these leaves return zeroes ("no virtualization").

Some references:
1. Intel SDM
2. https://github.com/qemu/qemu/blob/master/docs/hyperv.txt
3. https://www.kernel.org/doc/html/latest/virt/kvm/cpuid.html

## How to test this PR? <!-- (if applicable) -->

LibOS test `cpuid` was augmented to test this (the test is run only on SGX).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2134)
<!-- Reviewable:end -->
