### PR TITLE
[LibOS] Make poll and epoll_wait pass errors from DkStreamsWaitEvents

### DIFF
--- a/LibOS/shim/src/sys/shim_poll.c
+++ b/LibOS/shim/src/sys/shim_poll.c
@@ -44,7 +44,7 @@ typedef unsigned long __fd_mask;
 
 #define POLL_NOTIMEOUT ((uint64_t)-1)
 
-static int _shim_do_poll(struct pollfd* fds, nfds_t nfds, int timeout_ms) {
+static long _shim_do_poll(struct pollfd* fds, nfds_t nfds, int timeout_ms) {
     if ((uint64_t)nfds > get_rlimit_cur(RLIMIT_NOFILE))
         return -EINVAL;
 
@@ -146,7 +146,14 @@ static int _shim_do_poll(struct pollfd* fds, nfds_t nfds, int timeout_ms) {
 
     unlock(&map->lock);
 
-    PAL_BOL polled = DkStreamsWaitEvents(pal_cnt, pals, pal_events, ret_events, timeout_us);
+    PAL_BOL polled = false;
+    long error = 0;
+    if (pal_cnt) {
+        polled = DkStreamsWaitEvents(pal_cnt, pals, pal_events, ret_events, timeout_us);
+        if (!polled) {
+            error = -PAL_ERRNO();
+        }
+    }
 
     for (nfds_t i = 0; i < nfds; i++) {
         if (!fds_mapping[i].hdl)
@@ -173,7 +180,11 @@ static int _shim_do_poll(struct pollfd* fds, nfds_t nfds, int timeout_ms) {
     free(pal_events);
     free(fds_mapping);
 
-    return nrevents;
+    if (error == -EAGAIN) {
+        /* `poll` returns 0 on timeout. */
+        error = 0;
+    }
+    return nrevents ? (long)nrevents : error;
 }
 
 long shim_do_poll(struct pollfd* fds, nfds_t nfds, int timeout_ms) {
@@ -255,7 +266,7 @@ long shim_do_select(int nfds, fd_set* readfds, fd_set* writefds, fd_set* errorfd
     unlock(&map->lock);
 
     uint64_t timeout_ms = tsv ? tsv->tv_sec * 1000ULL + tsv->tv_usec / 1000 : POLL_NOTIMEOUT;
-    int ret = _shim_do_poll(fds_poll, nfds_poll, timeout_ms);
+    long ret = _shim_do_poll(fds_poll, nfds_poll, timeout_ms);
 
     if (ret < 0) {
         free(fds_poll);


### PR DESCRIPTION


## Description of the changes <!-- (reasons and measures) -->
Previously `poll` and `epoll_wait` ignored all errors returned from `DkStreamsWaitEvents`, including `EINTR`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2135)
<!-- Reviewable:end -->
