### PR TITLE
[Pal/Linux-SGX] Increase number of cache set sanity limit

### DIFF
--- a/Pal/src/host/Linux-SGX/db_main.c
+++ b/Pal/src/host/Linux-SGX/db_main.c
@@ -290,7 +290,7 @@ static int sanitize_cache_topology_info(PAL_CORE_CACHE_INFO* cache, int64_t cach
             return -EINVAL;
 
         int64_t number_of_sets = extract_long_from_buffer(cache[lvl].number_of_sets);
-        if (!IS_IN_RANGE_INCL(number_of_sets, 1, 1 << 16))
+        if (!IS_IN_RANGE_INCL(number_of_sets, 1, 1 << 30))
             return -EINVAL;
 
         int64_t physical_line_partition =


### PR DESCRIPTION

## Description of the changes <!-- (reasons and measures) -->

On certain servers, the number of cache sets can be greater than
`1 << 16`. This patch increases the sanity check limit to `1 << 30`
to validate against such a large number of cache sets.

## How to test this PR? <!-- (if applicable) -->
Please use the regression test "sysfs_common.c" to test the PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2136)
<!-- Reviewable:end -->
