### PR TITLE
[CI] Increase sleep times between server start and client start

### DIFF
--- a/.ci/lib/stage-test-direct.jenkinsfile
+++ b/.ci/lib/stage-test-direct.jenkinsfile
@@ -49,7 +49,7 @@ stage('test-direct') {
             cd Examples/memcached
             make -j8 all
             make start-graphene-server &
-            sleep 1
+            sleep 3
             # memcslap populates server but doesn't report errors, use
             # memcached-tool for this (must return two lines of stats)
             memcslap --servers=127.0.0.1 --concurrency=8
@@ -66,7 +66,7 @@ stage('test-direct') {
             fi
             make -j8 all
             make start-graphene-server &
-            sleep 1
+            sleep 3
             ./src/src/redis-benchmark
         '''
     }
@@ -75,7 +75,7 @@ stage('test-direct') {
             cd Examples/lighttpd
             make -j8 all
             make start-graphene-server &
-            sleep 1
+            sleep 3
             LOOP=1 CONCURRENCY_LIST="1 32" ../common_tools/benchmark-http.sh 127.0.0.1:8003
         '''
     }
@@ -84,7 +84,7 @@ stage('test-direct') {
             cd Examples/nginx
             make -j8 all
             make start-graphene-server &
-            sleep 1
+            sleep 3
             LOOP=1 CONCURRENCY_LIST="1 32" ../common_tools/benchmark-http.sh 127.0.0.1:8002
         '''
     }
@@ -93,7 +93,7 @@ stage('test-direct') {
             cd Examples/apache
             make -j8 all
             make start-graphene-server &
-            sleep 1
+            sleep 3
             LOOP=1 CONCURRENCY_LIST="1 32" ../common_tools/benchmark-http.sh 127.0.0.1:8001
             LOOP=1 CONCURRENCY_LIST="1 32" ../common_tools/benchmark-http.sh https://127.0.0.1:8443
         '''

--- a/Examples/curl/Makefile
+++ b/Examples/curl/Makefile
@@ -61,7 +61,7 @@ pal_loader:
 .PHONY: check
 check: all
 	(cd test-docroot; exec python3 -m http.server -b 127.0.0.1 19111) & httpd_pid=$$!; \
-	sleep 1; \
+	sleep 3; \
 	./pal_loader ./curl http://127.0.0.1:19111/ > OUTPUT; rc=$$?; \
 	kill $$httpd_pid; exit $$rc
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Sometimes one second of sleep between the server start and the client start is not enough for the server to completely initialize itself. In particular, in debug builds, the server process may output a lot of debug messages, which slows down its initialization significantly.

## How to test this PR? <!-- (if applicable) -->

This problem was observed on e.g. https://github.com/oscarlab/graphene/pull/2112 in the Jenkins-Debug CI job.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2138)
<!-- Reviewable:end -->
