### PR TITLE
[LibOS] Error out on anonymous shared mappings in mmap syscall

### DIFF
--- a/LibOS/shim/src/sys/shim_mmap.c
+++ b/LibOS/shim/src/sys/shim_mmap.c
@@ -77,6 +77,8 @@ void* shim_do_mmap(void* addr, size_t length, int prot, int flags, int fd, off_t
     if (flags & MAP_ANONYMOUS) {
         switch (flags & MAP_TYPE) {
             case MAP_SHARED:
+                /* PAL API doesn't support anonymous shared memory. */
+                return (void*)-ENOSYS;
             case MAP_PRIVATE:
                 break;
             default:


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

LibOS can't implement such a combination of flags because PAL doesn't support shared mappings. I'm not sure about the non-anonymous shared case, as it currently works on Linux PAL, but only by an accident? (at least it seems...)

Fixes #2146.

## How to test this PR? <!-- (if applicable) -->

Check if `mmap(NULL, 4096, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_SHARED, -1, 0)` fails. And wait for CI to see if this breaks any of our examples.