### PR TITLE
[Makefile] Use MAKEFILE_LIST before any includes

### DIFF
--- a/Scripts/Makefile.rules
+++ b/Scripts/Makefile.rules
@@ -32,6 +32,10 @@ echo-cmd = $(if $($(quiet)cmd_$(1)), echo '  $(call escsq,$($(quiet)cmd_$(1)))';
 cmd = @$(echo-cmd) $(cmd_$(1))
 
 
+# pal map
+PAL_SYMBOL_FILE := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))/../Pal/src/pal-symbols
+PAL_SYMBOLS = $(shell sed -e 's|$$|;|g' $(PAL_SYMBOL_FILE))
+
 quiet_cmd_generated_offsets_s = [ $@ ]
       cmd_generated_offsets_s = $(CC) $(CFLAGS) -MD -MP -MF $@.d $(defs) -S $< -o $@
 
@@ -154,10 +158,6 @@ quiet_cmd_sgx_sign_depend = [ $@ ]
 quiet_cmd_manifest = [ $@ ]
       cmd_manifest = \
   $(if $(2),sed $(3) -e 's:\$$(ENTRYPOINT):$(2):g' $< > $@,cp -f $< $@)
-
-# pal map
-PAL_SYMBOL_FILE := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))/../Pal/src/pal-symbols
-PAL_SYMBOLS = $(shell sed -e 's|$$|;|g' $(PAL_SYMBOL_FILE))
 
 quiet_cmd_pal_map = [ $@ ]
       cmd_pal_map = \


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

`Scripts/Makefile.rules` used MAKEFILE_LIST to obtain the current
makefile path, but it did so after including some other file, so it got
the included file path instead.
Fixes #2145 

I've also checked other makefiles, it was the only one with this issue.

## How to test this PR? <!-- (if applicable) -->
Build Graphene-SGX and run make again after the first build succeeded. It will report some errors without this commit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2148)
<!-- Reviewable:end -->
