### PR TITLE
[PAL] Remove empty `ENTER_PAL_CALL`/`LEAVE_PAL_CALL` macros

### DIFF
--- a/Pal/src/db_events.c
+++ b/Pal/src/db_events.c
@@ -12,8 +12,6 @@
 #include "pal_internal.h"
 
 PAL_HANDLE DkNotificationEventCreate(PAL_BOL initialState) {
-    ENTER_PAL_CALL(DkNotificationEventCreate);
-
     PAL_HANDLE handle = NULL;
     int ret = _DkEventCreate(&handle, initialState, true);
 
@@ -22,12 +20,10 @@ PAL_HANDLE DkNotificationEventCreate(PAL_BOL initialState) {
         handle = NULL;
     }
 
-    LEAVE_PAL_CALL_RETURN(handle);
+    return handle;
 }
 
 PAL_HANDLE DkSynchronizationEventCreate(PAL_BOL initialState) {
-    ENTER_PAL_CALL(DkSynchronizationEventCreate);
-
     PAL_HANDLE handle = NULL;
     int ret = _DkEventCreate(&handle, initialState, false);
 
@@ -36,39 +32,31 @@ PAL_HANDLE DkSynchronizationEventCreate(PAL_BOL initialState) {
         handle = NULL;
     }
 
-    LEAVE_PAL_CALL_RETURN(handle);
+    return handle;
 }
 
 /* DkEventDestroy deprecated, replaced by DkObjectClose */
 
 void DkEventSet(PAL_HANDLE handle) {
-    ENTER_PAL_CALL(DkEventSet);
-
     if (!handle || !IS_HANDLE_TYPE(handle, event)) {
         _DkRaiseFailure(PAL_ERROR_INVAL);
-        LEAVE_PAL_CALL();
+        return;
     }
 
     int ret = _DkEventSet(handle, -1);
 
     if (ret < 0)
         _DkRaiseFailure(-ret);
-
-    LEAVE_PAL_CALL();
 }
 
 void DkEventClear(PAL_HANDLE handle) {
-    ENTER_PAL_CALL(DkEventClear);
-
     if (!handle || !IS_HANDLE_TYPE(handle, event)) {
         _DkRaiseFailure(PAL_ERROR_INVAL);
-        LEAVE_PAL_CALL();
+        return;
     }
 
     int ret = _DkEventClear(handle);
 
     if (ret < 0)
         _DkRaiseFailure(-ret);
-
-    LEAVE_PAL_CALL();
 }

--- a/Pal/src/db_exception.c
+++ b/Pal/src/db_exception.c
@@ -24,15 +24,13 @@ PAL_EVENT_HANDLER _DkGetExceptionHandler(PAL_NUM event) {
 
 PAL_BOL
 DkSetExceptionHandler(PAL_EVENT_HANDLER handler, PAL_NUM event) {
-    ENTER_PAL_CALL(DkSetExceptionHandler);
-
     if (!handler || event == 0 || event >= ARRAY_SIZE(g_handlers)) {
         _DkRaiseFailure(PAL_ERROR_INVAL);
-        LEAVE_PAL_CALL_RETURN(PAL_FALSE);
+        return PAL_FALSE;
     }
 
     __atomic_store_n(&g_handlers[event], handler, __ATOMIC_RELEASE);
-    LEAVE_PAL_CALL_RETURN(PAL_TRUE);
+    return PAL_TRUE;
 }
 
 /* This does not return */

--- a/Pal/src/db_memory.c
+++ b/Pal/src/db_memory.c
@@ -13,17 +13,16 @@
 #include "pal_internal.h"
 
 PAL_PTR DkVirtualMemoryAlloc(PAL_PTR addr, PAL_NUM size, PAL_FLG alloc_type, PAL_FLG prot) {
-    ENTER_PAL_CALL(DkVirtualMemoryAlloc);
     void* map_addr = (void*)addr;
 
     if ((addr && !IS_ALLOC_ALIGNED_PTR(addr)) || !size || !IS_ALLOC_ALIGNED(size)) {
         _DkRaiseFailure(PAL_ERROR_INVAL);
-        LEAVE_PAL_CALL_RETURN((PAL_PTR)NULL);
+        return (PAL_PTR)NULL;
     }
 
     if (map_addr && _DkCheckMemoryMappable(map_addr, size)) {
         _DkRaiseFailure(PAL_ERROR_DENIED);
-        LEAVE_PAL_CALL_RETURN((PAL_PTR)NULL);
+        return (PAL_PTR)NULL;
     }
 
     int ret = _DkVirtualMemoryAlloc(&map_addr, size, alloc_type, prot);
@@ -33,25 +32,23 @@ PAL_PTR DkVirtualMemoryAlloc(PAL_PTR addr, PAL_NUM size, PAL_FLG alloc_type, PAL
         map_addr = NULL;
     }
 
-    LEAVE_PAL_CALL_RETURN((PAL_PTR)map_addr);
+    return (PAL_PTR)map_addr;
 }
 
 void DkVirtualMemoryFree(PAL_PTR addr, PAL_NUM size) {
-    ENTER_PAL_CALL(DkVirtualMemoryFree);
-
     if (!addr || !size) {
         _DkRaiseFailure(PAL_ERROR_INVAL);
-        LEAVE_PAL_CALL();
+        return;
     }
 
     if (!IS_ALLOC_ALIGNED_PTR(addr) || !IS_ALLOC_ALIGNED(size)) {
         _DkRaiseFailure(PAL_ERROR_INVAL);
-        LEAVE_PAL_CALL();
+        return;
     }
 
     if (_DkCheckMemoryMappable((void*)addr, size)) {
         _DkRaiseFailure(PAL_ERROR_DENIED);
-        LEAVE_PAL_CALL();
+        return;
     }
 
     int ret = _DkVirtualMemoryFree((void*)addr, size);
@@ -59,35 +56,31 @@ void DkVirtualMemoryFree(PAL_PTR addr, PAL_NUM size) {
     if (ret < 0) {
         _DkRaiseFailure(-ret);
     }
-
-    LEAVE_PAL_CALL();
 }
 
 PAL_BOL
 DkVirtualMemoryProtect(PAL_PTR addr, PAL_NUM size, PAL_FLG prot) {
-    ENTER_PAL_CALL(DkVirtualMemoryProtect);
-
     if (!addr || !size) {
         _DkRaiseFailure(PAL_ERROR_INVAL);
-        LEAVE_PAL_CALL_RETURN(PAL_FALSE);
+        return PAL_FALSE;
     }
 
     if (!IS_ALLOC_ALIGNED_PTR(addr) || !IS_ALLOC_ALIGNED(size)) {
         _DkRaiseFailure(PAL_ERROR_INVAL);
-        LEAVE_PAL_CALL_RETURN(PAL_FALSE);
+        return PAL_FALSE;
     }
 
     if (_DkCheckMemoryMappable((void*)addr, size)) {
         _DkRaiseFailure(PAL_ERROR_DENIED);
-        LEAVE_PAL_CALL_RETURN(PAL_FALSE);
+        return PAL_FALSE;
     }
 
     int ret = _DkVirtualMemoryProtect((void*)addr, size, prot);
 
     if (ret < 0) {
         _DkRaiseFailure(-ret);
-        LEAVE_PAL_CALL_RETURN(PAL_FALSE);
+        return PAL_FALSE;
     }
 
-    LEAVE_PAL_CALL_RETURN(PAL_TRUE);
+    return PAL_TRUE;
 }

--- a/Pal/src/db_misc.c
+++ b/Pal/src/db_misc.c
@@ -12,7 +12,6 @@
 #include "pal_internal.h"
 
 PAL_NUM DkSystemTimeQuery(void) {
-    ENTER_PAL_CALL(DkSystemTimeQuery);
     uint64_t time;
     int ret = _DkSystemTimeQuery(&time);
     if (ret < 0) {
@@ -20,82 +19,68 @@ PAL_NUM DkSystemTimeQuery(void) {
         // TODO: Fix this interface to allow returning errors.
         time = 0;
     }
-    LEAVE_PAL_CALL_RETURN(time);
+    return time;
 }
 
 PAL_NUM DkRandomBitsRead(PAL_PTR buffer, PAL_NUM size) {
-    ENTER_PAL_CALL(DkRandomBitsRead);
-
-    int ret = _DkRandomBitsRead((void*)buffer, size);
-
-    LEAVE_PAL_CALL_RETURN(ret);
+    return _DkRandomBitsRead((void*)buffer, size);
 }
 
 #if defined(__x86_64__)
 PAL_BOL DkSegmentRegisterGet(PAL_FLG reg, PAL_PTR* addr) {
-    ENTER_PAL_CALL(DkSegmentRegisterGet);
-
     int ret = _DkSegmentRegisterGet(reg, addr);
 
     if (ret < 0) {
         _DkRaiseFailure(-ret);
-        LEAVE_PAL_CALL_RETURN(PAL_FALSE);
+        return PAL_FALSE;
     }
 
-    LEAVE_PAL_CALL_RETURN(PAL_TRUE);
+    return PAL_TRUE;
 }
 
 PAL_BOL DkSegmentRegisterSet(PAL_FLG reg, PAL_PTR addr) {
-    ENTER_PAL_CALL(DkSegmentRegisterSet);
-
     int ret = _DkSegmentRegisterSet(reg, addr);
 
     if (ret < 0) {
         _DkRaiseFailure(-ret);
-        LEAVE_PAL_CALL_RETURN(PAL_FALSE);
+        return PAL_FALSE;
     }
 
-    LEAVE_PAL_CALL_RETURN(PAL_TRUE);
+    return PAL_TRUE;
 }
 #endif
 
 PAL_BOL DkInstructionCacheFlush(PAL_PTR addr, PAL_NUM size) {
-    ENTER_PAL_CALL(DkInstructionCacheFlush);
-
     if (!addr || !size) {
         _DkRaiseFailure(PAL_ERROR_INVAL);
-        LEAVE_PAL_CALL_RETURN(PAL_FALSE);
+        return PAL_FALSE;
     }
 
     int ret = _DkInstructionCacheFlush((void*)addr, size);
 
     if (ret < 0) {
         _DkRaiseFailure(-ret);
-        LEAVE_PAL_CALL_RETURN(PAL_FALSE);
+        return PAL_FALSE;
     }
 
-    LEAVE_PAL_CALL_RETURN(PAL_TRUE);
+    return PAL_TRUE;
 }
 
 PAL_NUM DkMemoryAvailableQuota(void) {
-    ENTER_PAL_CALL(DkMemoryAvailableQuota);
-
     long quota = _DkMemoryAvailableQuota();
     if (quota < 0)
         quota = 0;
 
-    LEAVE_PAL_CALL_RETURN((PAL_NUM)quota);
+    return (PAL_NUM)quota;
 }
 
 PAL_BOL
 DkCpuIdRetrieve(PAL_IDX leaf, PAL_IDX subleaf, PAL_IDX values[4]) {
-    ENTER_PAL_CALL(DkCpuIdRetrieve);
-
     unsigned int vals[4];
     int ret = _DkCpuIdRetrieve(leaf, subleaf, vals);
     if (ret < 0) {
         _DkRaiseFailure(-ret);
-        LEAVE_PAL_CALL_RETURN(PAL_FALSE);
+        return PAL_FALSE;
     }
 
     values[0] = vals[0];
@@ -103,42 +88,36 @@ DkCpuIdRetrieve(PAL_IDX leaf, PAL_IDX subleaf, PAL_IDX values[4]) {
     values[2] = vals[2];
     values[3] = vals[3];
 
-    LEAVE_PAL_CALL_RETURN(PAL_TRUE);
+    return PAL_TRUE;
 }
 
 PAL_BOL DkAttestationReport(PAL_PTR user_report_data, PAL_NUM* user_report_data_size,
                             PAL_PTR target_info, PAL_NUM* target_info_size, PAL_PTR report,
                             PAL_NUM* report_size) {
-    ENTER_PAL_CALL(DkAttestationReport);
-
     int ret = _DkAttestationReport(user_report_data, user_report_data_size, target_info,
                                    target_info_size, report, report_size);
     if (ret < 0) {
         _DkRaiseFailure(-ret);
-        LEAVE_PAL_CALL_RETURN(PAL_FALSE);
+        return PAL_FALSE;
     }
-    LEAVE_PAL_CALL_RETURN(PAL_TRUE);
+    return PAL_TRUE;
 }
 
 PAL_BOL DkAttestationQuote(PAL_PTR user_report_data, PAL_NUM user_report_data_size, PAL_PTR quote,
                            PAL_NUM* quote_size) {
-    ENTER_PAL_CALL(DkAttestationQuote);
-
     int ret = _DkAttestationQuote(user_report_data, user_report_data_size, quote, quote_size);
     if (ret < 0) {
         _DkRaiseFailure(-ret);
-        LEAVE_PAL_CALL_RETURN(PAL_FALSE);
+        return PAL_FALSE;
     }
-    LEAVE_PAL_CALL_RETURN(PAL_TRUE);
+    return PAL_TRUE;
 }
 
 PAL_BOL DkSetProtectedFilesKey(PAL_PTR pf_key_hex) {
-    ENTER_PAL_CALL(DkSetProtectedFilesKey);
-
     int ret = _DkSetProtectedFilesKey(pf_key_hex);
     if (ret < 0) {
         _DkRaiseFailure(-ret);
-        LEAVE_PAL_CALL_RETURN(PAL_FALSE);
+        return PAL_FALSE;
     }
-    LEAVE_PAL_CALL_RETURN(PAL_TRUE);
+    return PAL_TRUE;
 }

--- a/Pal/src/db_mutex.c
+++ b/Pal/src/db_mutex.c
@@ -13,8 +13,6 @@
 
 PAL_HANDLE
 DkMutexCreate(PAL_NUM initialCount) {
-    ENTER_PAL_CALL(DkMutexCreate);
-
     PAL_HANDLE handle = NULL;
     int ret = _DkMutexCreate(&handle, initialCount);
 
@@ -23,17 +21,14 @@ DkMutexCreate(PAL_NUM initialCount) {
         handle = NULL;
     }
 
-    LEAVE_PAL_CALL_RETURN(handle);
+    return handle;
 }
 
 void DkMutexRelease(PAL_HANDLE handle) {
-    ENTER_PAL_CALL(DkMutexRelease);
-
     if (!handle || !IS_HANDLE_TYPE(handle, mutex)) {
         _DkRaiseFailure(PAL_ERROR_INVAL);
-        LEAVE_PAL_CALL();
+        return;
     }
 
     _DkMutexRelease(handle);
-    LEAVE_PAL_CALL();
 }

--- a/Pal/src/db_object.c
+++ b/Pal/src/db_object.c
@@ -39,62 +39,54 @@ int _DkObjectClose(PAL_HANDLE objectHandle) {
 
 /* PAL call DkObjectClose: Close the given object handle. */
 void DkObjectClose(PAL_HANDLE objectHandle) {
-    ENTER_PAL_CALL(DkObjectClose);
-
     if (!objectHandle) {
         _DkRaiseFailure(PAL_ERROR_INVAL);
-        LEAVE_PAL_CALL();
+        return;
     }
 
     int ret = _DkObjectClose(objectHandle);
     if (ret < 0)
         _DkRaiseFailure(-ret);
-
-    LEAVE_PAL_CALL();
 }
 
 /* Wait on a synchronization handle and return true if this handle's event was triggered,
  * otherwise return false and additionally raise failure. */
 PAL_BOL DkSynchronizationObjectWait(PAL_HANDLE handle, PAL_NUM timeout_us) {
-    ENTER_PAL_CALL(DkSynchronizationObjectWait);
-
     if (!handle) {
         _DkRaiseFailure(PAL_ERROR_INVAL);
-        LEAVE_PAL_CALL_RETURN(PAL_FALSE);
+        return PAL_FALSE;
     }
 
     int ret = _DkSynchronizationObjectWait(handle, timeout_us);
     if (ret < 0) {
         _DkRaiseFailure(-ret);
-        LEAVE_PAL_CALL_RETURN(PAL_FALSE);
+        return PAL_FALSE;
     }
 
-    LEAVE_PAL_CALL_RETURN(PAL_TRUE);
+    return PAL_TRUE;
 }
 
 /* Wait for user-specified events of handles in the handle array. The wait can be timed out, unless
  * NO_TIMEOUT is given in the timeout_us argument. Returns PAL_TRUE if waiting was successful. */
 PAL_BOL DkStreamsWaitEvents(PAL_NUM count, PAL_HANDLE* handle_array, PAL_FLG* events,
                             PAL_FLG* ret_events, PAL_NUM timeout_us) {
-    ENTER_PAL_CALL(DkStreamsWaitEvents);
-
     if (!count || !handle_array || !events || !ret_events) {
         _DkRaiseFailure(PAL_ERROR_INVAL);
-        LEAVE_PAL_CALL_RETURN(PAL_FALSE);
+        return PAL_FALSE;
     }
 
     for (PAL_NUM i = 0; i < count; i++) {
         if (UNKNOWN_HANDLE(handle_array[i])) {
             _DkRaiseFailure(PAL_ERROR_INVAL);
-            LEAVE_PAL_CALL_RETURN(PAL_FALSE);
+            return PAL_FALSE;
         }
     }
 
     int ret = _DkStreamsWaitEvents(count, handle_array, events, ret_events, timeout_us);
     if (ret < 0) {
         _DkRaiseFailure(-ret);
-        LEAVE_PAL_CALL_RETURN(PAL_FALSE);
+        return PAL_FALSE;
     }
 
-    LEAVE_PAL_CALL_RETURN(PAL_TRUE);
+    return PAL_TRUE;
 }

--- a/Pal/src/db_process.c
+++ b/Pal/src/db_process.c
@@ -17,7 +17,6 @@
 #include "pal_internal.h"
 
 PAL_HANDLE DkProcessCreate(PAL_STR exec_uri, PAL_STR* args) {
-    ENTER_PAL_CALL(DkProcessCreate);
     assert(exec_uri);
 
     PAL_HANDLE handle = NULL;
@@ -28,13 +27,11 @@ PAL_HANDLE DkProcessCreate(PAL_STR exec_uri, PAL_STR* args) {
         handle = NULL;
     }
 
-    LEAVE_PAL_CALL_RETURN(handle);
+    return handle;
 }
 
 noreturn void DkProcessExit(PAL_NUM exitcode) {
-    ENTER_PAL_CALL(DkProcessExit);
     _DkProcessExit(exitcode);
     _DkRaiseFailure(PAL_ERROR_NOTKILLABLE);
     die_or_inf_loop();
-    LEAVE_PAL_CALL();
 }

--- a/Pal/src/db_streams.c
+++ b/Pal/src/db_streams.c
@@ -165,20 +165,18 @@ int _DkStreamOpen(PAL_HANDLE* handle, const char* uri, int access, int share, in
  */
 PAL_HANDLE DkStreamOpen(PAL_STR uri, PAL_FLG access, PAL_FLG share, PAL_FLG create,
                         PAL_FLG options) {
-    ENTER_PAL_CALL(DkStreamOpen);
-
     PAL_HANDLE handle = NULL;
     int ret = _DkStreamOpen(&handle, uri, access, share, create, options);
 
     if (ret < 0) {
         _DkRaiseFailure(-ret);
-        LEAVE_PAL_CALL_RETURN(NULL);
+        return NULL;
     }
 
     assert(handle);
     assert(!UNKNOWN_HANDLE(handle));
 
-    LEAVE_PAL_CALL_RETURN(handle);
+    return handle;
 }
 
 static int _DkStreamWaitForClient(PAL_HANDLE handle, PAL_HANDLE* client) {
@@ -197,8 +195,6 @@ static int _DkStreamWaitForClient(PAL_HANDLE handle, PAL_HANDLE* client) {
 
 PAL_HANDLE
 DkStreamWaitForClient(PAL_HANDLE handle) {
-    ENTER_PAL_CALL(DkStreamWaitForClient);
-
     PAL_HANDLE client;
     int ret = _DkStreamWaitForClient(handle, &client);
 
@@ -207,7 +203,7 @@ DkStreamWaitForClient(PAL_HANDLE handle) {
         client = NULL;
     }
 
-    LEAVE_PAL_CALL_RETURN(client);
+    return client;
 }
 
 /* _DkStreamDelete for internal use. This function will explicit delete
@@ -230,19 +226,15 @@ int _DkStreamDelete(PAL_HANDLE handle, int access) {
 /* PAL call DkStreamDelete: Explicitly delete stream as given handle. No
    return value, error code is notified. */
 void DkStreamDelete(PAL_HANDLE handle, PAL_FLG access) {
-    ENTER_PAL_CALL(DkStreamDelete);
-
     if (!handle) {
         _DkRaiseFailure(PAL_ERROR_INVAL);
-        LEAVE_PAL_CALL();
+        return;
     }
 
     int ret = _DkStreamDelete(handle, access);
 
     if (ret < 0)
         _DkRaiseFailure(-ret);
-
-    LEAVE_PAL_CALL();
 }
 
 /* _DkStreamRead for internal use. Read from stream as absolute offset.
@@ -277,11 +269,9 @@ int64_t _DkStreamRead(PAL_HANDLE handle, uint64_t offset, uint64_t count, void* 
 PAL_NUM
 DkStreamRead(PAL_HANDLE handle, PAL_NUM offset, PAL_NUM count, PAL_PTR buffer, PAL_PTR source,
              PAL_NUM size) {
-    ENTER_PAL_CALL(DkStreamRead);
-
     if (!handle || !buffer) {
         _DkRaiseFailure(PAL_ERROR_INVAL);
-        LEAVE_PAL_CALL_RETURN(PAL_STREAM_ERROR);
+        return PAL_STREAM_ERROR;
     }
 
     int64_t ret = _DkStreamRead(handle, offset, count, (void*)buffer, size ? (char*)source : NULL,
@@ -292,7 +282,7 @@ DkStreamRead(PAL_HANDLE handle, PAL_NUM offset, PAL_NUM count, PAL_PTR buffer, P
         ret = PAL_STREAM_ERROR;
     }
 
-    LEAVE_PAL_CALL_RETURN(ret);
+    return ret;
 }
 
 /* _DkStreamWrite for internal use, write to stream at absolute offset.
@@ -326,11 +316,9 @@ int64_t _DkStreamWrite(PAL_HANDLE handle, uint64_t offset, uint64_t count, const
    or PAL_STREAM_ERROR for failure. Error code is notified. */
 PAL_NUM
 DkStreamWrite(PAL_HANDLE handle, PAL_NUM offset, PAL_NUM count, PAL_PTR buffer, PAL_STR dest) {
-    ENTER_PAL_CALL(DkStreamWrite);
-
     if (!handle || !buffer) {
         _DkRaiseFailure(PAL_ERROR_INVAL);
-        LEAVE_PAL_CALL_RETURN(PAL_STREAM_ERROR);
+        return PAL_STREAM_ERROR;
     }
 
     int64_t ret =
@@ -341,7 +329,7 @@ DkStreamWrite(PAL_HANDLE handle, PAL_NUM offset, PAL_NUM count, PAL_PTR buffer, 
         ret = PAL_STREAM_ERROR;
     }
 
-    LEAVE_PAL_CALL_RETURN(ret);
+    return ret;
 }
 
 /* _DkStreamAttributesQuery of internal use. The function query attribute
@@ -367,11 +355,9 @@ int _DkStreamAttributesQuery(const char* uri, PAL_STREAM_ATTR* attr) {
    URI, attr is memory given by user space. Return TRUE if succeeded
    or FALSE if failed. Error code is notified */
 PAL_BOL DkStreamAttributesQuery(PAL_STR uri, PAL_STREAM_ATTR* attr) {
-    ENTER_PAL_CALL(DkStreamAttributesQuery);
-
     if (!uri || !attr) {
         _DkRaiseFailure(PAL_ERROR_INVAL);
-        LEAVE_PAL_CALL_RETURN(PAL_FALSE);
+        return PAL_FALSE;
     }
 
     PAL_STREAM_ATTR attr_buf;
@@ -380,11 +366,11 @@ PAL_BOL DkStreamAttributesQuery(PAL_STR uri, PAL_STREAM_ATTR* attr) {
 
     if (ret < 0) {
         _DkRaiseFailure(-ret);
-        LEAVE_PAL_CALL_RETURN(PAL_FALSE);
+        return PAL_FALSE;
     }
 
     memcpy(attr, &attr_buf, sizeof(PAL_STREAM_ATTR));
-    LEAVE_PAL_CALL_RETURN(PAL_TRUE);
+    return PAL_TRUE;
 }
 
 /* _DkStreamAttributesQueryByHandle for internal use. Query attribute
@@ -405,53 +391,49 @@ int _DkStreamAttributesQueryByHandle(PAL_HANDLE hdl, PAL_STREAM_ATTR* attr) {
    its handle, attr is memory given by user space. Return TRUE if succeeded
    or FALSE if failed. Error code is notified */
 PAL_BOL DkStreamAttributesQueryByHandle(PAL_HANDLE handle, PAL_STREAM_ATTR* attr) {
-    ENTER_PAL_CALL(DkStreamAttributesQueryByHandle);
-
     if (!handle || !attr) {
         _DkRaiseFailure(PAL_ERROR_INVAL);
-        LEAVE_PAL_CALL_RETURN(PAL_FALSE);
+        return PAL_FALSE;
     }
 
     int ret = _DkStreamAttributesQueryByHandle(handle, attr);
 
     if (ret < 0) {
         _DkRaiseFailure(-ret);
-        LEAVE_PAL_CALL_RETURN(PAL_FALSE);
+        return PAL_FALSE;
     }
 
-    LEAVE_PAL_CALL_RETURN(PAL_TRUE);
+    return PAL_TRUE;
 }
 
 /* PAL call DkStreamAttributesSetByHandle: Set attribute of a stream by
    its handle, attr is memory given by user space. Return TRUE if succeeded
    or FALSE if failed. Error code is notified */
 PAL_BOL DkStreamAttributesSetByHandle(PAL_HANDLE handle, PAL_STREAM_ATTR* attr) {
-    ENTER_PAL_CALL(DkStreamAttributesSetByHandle);
-
     if (!handle || !attr) {
         _DkRaiseFailure(PAL_ERROR_INVAL);
-        LEAVE_PAL_CALL_RETURN(PAL_FALSE);
+        return PAL_FALSE;
     }
 
     const struct handle_ops* ops = HANDLE_OPS(handle);
     if (!ops) {
         _DkRaiseFailure(PAL_ERROR_BADHANDLE);
-        LEAVE_PAL_CALL_RETURN(PAL_FALSE);
+        return PAL_FALSE;
     }
 
     if (!ops->attrsetbyhdl) {
         _DkRaiseFailure(PAL_ERROR_NOTSUPPORT);
-        LEAVE_PAL_CALL_RETURN(PAL_FALSE);
+        return PAL_FALSE;
     }
 
     int ret = ops->attrsetbyhdl(handle, attr);
 
     if (ret < 0) {
         _DkRaiseFailure(-ret);
-        LEAVE_PAL_CALL_RETURN(PAL_FALSE);
+        return PAL_FALSE;
     }
 
-    LEAVE_PAL_CALL_RETURN(PAL_TRUE);
+    return PAL_TRUE;
 }
 
 int _DkStreamGetName(PAL_HANDLE handle, char* buffer, int size) {
@@ -475,11 +457,9 @@ int _DkStreamGetName(PAL_HANDLE handle, char* buffer, int size) {
 /* PAL call DkStreamGetName: Copy handle name into buffer. Return size of
  * name if succeeded or 0 if failed. Error code is notified */
 PAL_NUM DkStreamGetName(PAL_HANDLE handle, PAL_PTR buffer, PAL_NUM size) {
-    ENTER_PAL_CALL(DkStreamGetName);
-
     if (!handle || !buffer || !size) {
         _DkRaiseFailure(PAL_ERROR_INVAL);
-        LEAVE_PAL_CALL_RETURN(0);
+        return 0;
     }
 
     int ret = _DkStreamGetName(handle, (void*)buffer, size);
@@ -489,7 +469,7 @@ PAL_NUM DkStreamGetName(PAL_HANDLE handle, PAL_PTR buffer, PAL_NUM size) {
         ret = 0;
     }
 
-    LEAVE_PAL_CALL_RETURN(ret);
+    return ret;
 }
 
 /* _DkStreamMap for internal use. Map specific handle to certain memory,
@@ -520,24 +500,23 @@ int _DkStreamMap(PAL_HANDLE handle, void** paddr, int prot, uint64_t offset, uin
    mapping. Return the address if succeeded or NULL if failed. Error code
    is notified. */
 PAL_PTR DkStreamMap(PAL_HANDLE handle, PAL_PTR addr, PAL_FLG prot, PAL_NUM offset, PAL_NUM size) {
-    ENTER_PAL_CALL(DkStreamMap);
     void* map_addr = (void*)addr;
 
     if (!handle) {
         _DkRaiseFailure(PAL_ERROR_INVAL);
-        LEAVE_PAL_CALL_RETURN((PAL_PTR)NULL);
+        return (PAL_PTR)NULL;
     }
 
     /* Check that all addresses and sizes are aligned */
     if ((addr && !IS_ALLOC_ALIGNED_PTR(addr)) || !size || !IS_ALLOC_ALIGNED(size) || 
             !IS_ALLOC_ALIGNED(offset)) {
         _DkRaiseFailure(PAL_ERROR_INVAL);
-        LEAVE_PAL_CALL_RETURN((PAL_PTR)NULL);
+        return (PAL_PTR)NULL;
     }
 
     if (map_addr && _DkCheckMemoryMappable(map_addr, size)) {
         _DkRaiseFailure(PAL_ERROR_DENIED);
-        LEAVE_PAL_CALL_RETURN((PAL_PTR)NULL);
+        return (PAL_PTR)NULL;
     }
 
     int ret = _DkStreamMap(handle, &map_addr, prot, offset, size);
@@ -547,31 +526,27 @@ PAL_PTR DkStreamMap(PAL_HANDLE handle, PAL_PTR addr, PAL_FLG prot, PAL_NUM offse
         map_addr = NULL;
     }
 
-    LEAVE_PAL_CALL_RETURN((PAL_PTR)map_addr);
+    return (PAL_PTR)map_addr;
 }
 
 /* PAL call DkStreamUnmap: Unmap memory mapped at an address. The memory has
    to be a stream map, and it got unmapped as a whole memory area. No
    return value. Error code is notified */
 void DkStreamUnmap(PAL_PTR addr, PAL_NUM size) {
-    ENTER_PAL_CALL(DkStreamUnmap);
-
     if (!addr || !IS_ALLOC_ALIGNED_PTR(addr) || !size || !IS_ALLOC_ALIGNED(size)) {
         _DkRaiseFailure(PAL_ERROR_INVAL);
-        LEAVE_PAL_CALL();
+        return;
     }
 
     if (_DkCheckMemoryMappable((void*)addr, size)) {
         _DkRaiseFailure(PAL_ERROR_DENIED);
-        LEAVE_PAL_CALL();
+        return;
     }
 
     int ret = _DkStreamUnmap((void*)addr, size);
 
     if (ret < 0)
         _DkRaiseFailure(-ret);
-
-    LEAVE_PAL_CALL();
 }
 
 /* _DkStreamSetLength for internal use. This function truncate the stream
@@ -592,22 +567,20 @@ int64_t _DkStreamSetLength(PAL_HANDLE handle, uint64_t length) {
    Return 0 if succeeded or positive error code if failed. Error code
    is additionally notified. */
 PAL_NUM DkStreamSetLength(PAL_HANDLE handle, PAL_NUM length) {
-    ENTER_PAL_CALL(DkStreamSetLength);
-
     if (!handle) {
         _DkRaiseFailure(PAL_ERROR_INVAL);
-        LEAVE_PAL_CALL_RETURN(PAL_ERROR_INVAL);
+        return PAL_ERROR_INVAL;
     }
 
     int64_t ret = _DkStreamSetLength(handle, length);
 
     if (ret < 0) {
         _DkRaiseFailure(-ret);
-        LEAVE_PAL_CALL_RETURN(-ret);
+        return -ret;
     }
 
     assert((uint64_t)ret == length);
-    LEAVE_PAL_CALL_RETURN(0);
+    return 0;
 }
 
 /* _DkStreamFlush for internal use. This function sync up the handle with
@@ -630,32 +603,28 @@ int _DkStreamFlush(PAL_HANDLE handle) {
 /* PAL call DkStreamFlush: Sync up a stream of a given handle. Return TRUE
  * if succeeded or FALSE if failed. Error code is notified. */
 PAL_BOL DkStreamFlush(PAL_HANDLE handle) {
-    ENTER_PAL_CALL(DkStreamFlush);
-
     if (!handle) {
         _DkRaiseFailure(PAL_ERROR_INVAL);
-        LEAVE_PAL_CALL_RETURN(PAL_FALSE);
+        return PAL_FALSE;
     }
 
     int ret = _DkStreamFlush(handle);
 
     if (ret < 0) {
         _DkRaiseFailure(-ret);
-        LEAVE_PAL_CALL_RETURN(PAL_FALSE);
+        return PAL_FALSE;
     }
 
-    LEAVE_PAL_CALL_RETURN(PAL_TRUE);
+    return PAL_TRUE;
 }
 
 /* PAL call DkSendHandle: Write to a process handle.
    Return TRUE on success and FALSE on failure */
 PAL_BOL DkSendHandle(PAL_HANDLE handle, PAL_HANDLE cargo) {
-    ENTER_PAL_CALL(DkSendHandle);
-
     // Return error if any of the handle is NULL
     if (!handle || !cargo) {
         _DkRaiseFailure(PAL_ERROR_INVAL);
-        LEAVE_PAL_CALL_RETURN(PAL_FALSE);
+        return PAL_FALSE;
     }
 
     // Call the internal function after validating input args
@@ -663,10 +632,10 @@ PAL_BOL DkSendHandle(PAL_HANDLE handle, PAL_HANDLE cargo) {
 
     if (ret < 0) {
         _DkRaiseFailure(-ret);
-        LEAVE_PAL_CALL_RETURN(PAL_FALSE);
+        return PAL_FALSE;
     }
 
-    LEAVE_PAL_CALL_RETURN(PAL_TRUE);
+    return PAL_TRUE;
 }
 
 /* PAL call DkRecvHandle: Read a handle to a pipe/process handle.
@@ -683,12 +652,10 @@ PAL_BOL DkSendHandle(PAL_HANDLE handle, PAL_HANDLE cargo) {
     Ans - Variables members have to allocated data again.
 */
 PAL_HANDLE DkReceiveHandle(PAL_HANDLE handle) {
-    ENTER_PAL_CALL(DkReceiveHandle);
-
     // return error if any of the handle is NULL
     if (!handle) {
         _DkRaiseFailure(PAL_ERROR_INVAL);
-        LEAVE_PAL_CALL_RETURN(NULL);
+        return NULL;
     }
 
     // create a reference for the received PAL_HANDLE
@@ -699,16 +666,14 @@ PAL_HANDLE DkReceiveHandle(PAL_HANDLE handle) {
     // notify failure would have been called from other functions
     if (ret < 0) {
         _DkRaiseFailure(-ret);
-        LEAVE_PAL_CALL_RETURN(NULL);
+        return NULL;
     }
 
     assert(cargo);
-    LEAVE_PAL_CALL_RETURN(cargo);
+    return cargo;
 }
 
 PAL_BOL DkStreamChangeName(PAL_HANDLE hdl, PAL_STR uri) {
-    ENTER_PAL_CALL(DkStreamChangeName);
-
     struct handle_ops* ops = NULL;
     char* type             = NULL;
     int ret;
@@ -718,7 +683,7 @@ PAL_BOL DkStreamChangeName(PAL_HANDLE hdl, PAL_STR uri) {
 
         if (ret < 0) {
             _DkRaiseFailure(-ret);
-            LEAVE_PAL_CALL_RETURN(PAL_FALSE);
+            return PAL_FALSE;
         }
     }
 
@@ -727,7 +692,7 @@ PAL_BOL DkStreamChangeName(PAL_HANDLE hdl, PAL_STR uri) {
     if (!hops || !hops->rename || (ops && hops != ops)) {
         free(type);
         _DkRaiseFailure(PAL_ERROR_NOTSUPPORT);
-        LEAVE_PAL_CALL_RETURN(PAL_FALSE);
+        return PAL_FALSE;
     }
 
     ret = hops->rename(hdl, type, uri);
@@ -735,10 +700,10 @@ PAL_BOL DkStreamChangeName(PAL_HANDLE hdl, PAL_STR uri) {
 
     if (ret < 0) {
         _DkRaiseFailure(-ret);
-        LEAVE_PAL_CALL_RETURN(PAL_FALSE);
+        return PAL_FALSE;
     }
 
-    LEAVE_PAL_CALL_RETURN(PAL_TRUE);
+    return PAL_TRUE;
 }
 
 /* _DkStreamRealpath is used to obtain the real path of a stream. Some
@@ -753,13 +718,11 @@ const char* _DkStreamRealpath(PAL_HANDLE hdl) {
 }
 
 PAL_NUM DkDebugLog(PAL_PTR buffer, PAL_NUM size) {
-    ENTER_PAL_CALL(DkDebugLog);
-
     ssize_t ret = _DkDebugLog(buffer, size);
     if (ret < 0) {
         _DkRaiseFailure(-ret);
         ret = PAL_STREAM_ERROR;
     }
 
-    LEAVE_PAL_CALL_RETURN(ret);
+    return ret;
 }

--- a/Pal/src/db_threading.c
+++ b/Pal/src/db_threading.c
@@ -14,8 +14,6 @@
 
 /* PAL call DkThreadCreate: create a thread inside the current process */
 PAL_HANDLE DkThreadCreate(PAL_PTR addr, PAL_PTR param) {
-    ENTER_PAL_CALL(DkThreadCreate);
-
     PAL_HANDLE handle = NULL;
     int ret = _DkThreadCreate(&handle, (int (*)(void*))addr, (const void*)param);
 
@@ -24,13 +22,11 @@ PAL_HANDLE DkThreadCreate(PAL_PTR addr, PAL_PTR param) {
         handle = NULL;
     }
 
-    LEAVE_PAL_CALL_RETURN(handle);
+    return handle;
 }
 
 /* PAL call DkThreadDelayExecution. Delay the current thread (sleep) for the given duration */
 PAL_NUM DkThreadDelayExecution(PAL_NUM duration) {
-    ENTER_PAL_CALL(DkThreadDelayExecution);
-
     unsigned long dur = duration;
     int ret = _DkThreadDelayExecution(&dur);
 
@@ -39,64 +35,55 @@ PAL_NUM DkThreadDelayExecution(PAL_NUM duration) {
         duration = dur;
     }
 
-    LEAVE_PAL_CALL_RETURN(duration);
+    return duration;
 }
 
 /* PAL call DkThreadYieldExecution. Yield the execution of the current thread. */
 void DkThreadYieldExecution(void) {
-    ENTER_PAL_CALL(DkThreadYieldExecution);
     _DkThreadYieldExecution();
-    LEAVE_PAL_CALL();
 }
 
 /* PAL call DkThreadExit: simply exit the current thread no matter what */
 noreturn void DkThreadExit(PAL_PTR clear_child_tid) {
-    ENTER_PAL_CALL(DkThreadExit);
     _DkThreadExit((int*)clear_child_tid);
     /* UNREACHABLE */
 }
 
 /* PAL call DkThreadResume: resume the execution of a thread which is delayed before */
 PAL_BOL DkThreadResume(PAL_HANDLE threadHandle) {
-    ENTER_PAL_CALL(DkThreadResume);
-
     if (!threadHandle || !IS_HANDLE_TYPE(threadHandle, thread)) {
         _DkRaiseFailure(PAL_ERROR_INVAL);
-        LEAVE_PAL_CALL_RETURN(PAL_FALSE);
+        return PAL_FALSE;
     }
 
     int ret = _DkThreadResume(threadHandle);
 
     if (ret < 0) {
         _DkRaiseFailure(PAL_ERROR_DENIED);
-        LEAVE_PAL_CALL_RETURN(PAL_FALSE);
+        return PAL_FALSE;
     }
 
-    LEAVE_PAL_CALL_RETURN(PAL_TRUE);
+    return PAL_TRUE;
 }
 
 PAL_BOL DkThreadSetCpuAffinity(PAL_HANDLE thread, PAL_NUM cpumask_size, PAL_PTR cpu_mask) {
-    ENTER_PAL_CALL(DkThreadSetCpuAffinity);
-
     int ret = _DkThreadSetCpuAffinity(thread, cpumask_size, cpu_mask);
 
     if (ret < 0) {
         _DkRaiseFailure(-ret);
-        LEAVE_PAL_CALL_RETURN(PAL_FALSE);
+        return PAL_FALSE;
     }
 
-    LEAVE_PAL_CALL_RETURN(PAL_TRUE);
+    return PAL_TRUE;
 }
 
 PAL_BOL DkThreadGetCpuAffinity(PAL_HANDLE thread, PAL_NUM cpumask_size, PAL_PTR cpu_mask) {
-    ENTER_PAL_CALL(DkThreadGetCpuAffinity);
-
     int ret = _DkThreadGetCpuAffinity(thread, cpumask_size, cpu_mask);
 
     if (ret < 0) {
         _DkRaiseFailure(-ret);
-        LEAVE_PAL_CALL_RETURN(PAL_FALSE);
+        return PAL_FALSE;
     }
 
-    LEAVE_PAL_CALL_RETURN(PAL_TRUE);
+    return PAL_TRUE;
 }

--- a/Pal/src/host/Linux-SGX/db_exception.c
+++ b/Pal/src/host/Linux-SGX/db_exception.c
@@ -301,8 +301,6 @@ noreturn void _DkHandleExternalEvent(PAL_NUM event, sgx_cpu_context_t* uc,
 
     /* modification to PAL_CONTEXT is discarded; it is assumed that LibOS won't change context
      * (GPRs, FP registers) if RIP is in PAL.
-     *
-     * TODO: in long term, record the signal and trigger the signal handler when returning from PAL
-     * via ENTER_PAL_CALL/LEAVE_PAL_CALL/LEAVE_PAL_CALL_RETURN. */
+     */
     restore_sgx_context(uc, xregs_state);
 }

--- a/Pal/src/host/Linux/pal_host.h
+++ b/Pal/src/host/Linux/pal_host.h
@@ -154,15 +154,4 @@ typedef struct pal_handle {
 
 #define HANDLE_TYPE(handle) ((handle)->hdr.type)
 
-/* TODO: remove these
- * Tracked: https://github.com/oscarlab/graphene/issues/2140 */
-#define LEAVE_PAL_CALL()         \
-    do {                         \
-    } while (0)
-
-#define LEAVE_PAL_CALL_RETURN(retval) \
-    do {                              \
-        return (retval);              \
-    } while (0)
-
 #endif /* PAL_HOST_H */

--- a/Pal/src/pal_internal.h
+++ b/Pal/src/pal_internal.h
@@ -111,21 +111,6 @@ static inline int handle_size(PAL_HANDLE handle) {
     return sizeof(*handle);
 }
 
-#ifndef ENTER_PAL_CALL
-#define ENTER_PAL_CALL(name)
-#endif
-
-#ifndef LEAVE_PAL_CALL
-#define LEAVE_PAL_CALL()
-#endif
-
-#ifndef LEAVE_PAL_CALL_RETURN
-#define LEAVE_PAL_CALL_RETURN(retval) \
-    do {                              \
-        return (retval);              \
-    } while (0)
-#endif
-
 /*
  * failure notify. The rountine is called whenever a PAL call return error code. As the current
  * design of PAL does not return error code directly, we rely on DkAsynchronousEventUpcall to handle


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->
These macros were empty and not used anymore. Additionally there was
a bug: `LEAVE_PAL_CALL` actually did not perform `return` and the
execution continued after it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2149)
<!-- Reviewable:end -->
