### PR TITLE
[GSC] Always use absolute paths inside the Docker container

### DIFF
--- a/Tools/gsc/finalize_manifest.py
+++ b/Tools/gsc/finalize_manifest.py
@@ -84,7 +84,7 @@ def main(args=None):
     if not os.path.isdir(args.dir):
         argparser.error(f'\t[from inside Docker container] Could not find directory `{args.dir}`.')
 
-    env = jinja2.Environment(loader=jinja2.FileSystemLoader('.'))
+    env = jinja2.Environment(loader=jinja2.FileSystemLoader('/'))
     env.globals.update({'library_paths': generate_library_paths(), 'env_path': os.getenv('PATH')})
 
     manifest = 'entrypoint.manifest'

--- a/Tools/gsc/templates/Dockerfile.ubuntu18.04.build.template
+++ b/Tools/gsc/templates/Dockerfile.ubuntu18.04.build.template
@@ -56,17 +56,18 @@ COPY entrypoint.manifest /
 
 # Generate trusted arguments if required
 {% if not insecure_args %}
-RUN /graphene/Tools/argv_serializer {{binary}} {{binary_arguments}} "{{"\" \"".join(cmd)}}" > trusted_argv
+RUN /graphene/Tools/argv_serializer {{binary}} {{binary_arguments}} "{{"\" \"".join(cmd)}}" > /trusted_argv
 {% endif %}
 
 # Docker entrypoint/cmd typically contains only the basename of the executable so create a symlink
-RUN which {{binary}} | xargs ln -s || true
+RUN cd / \
+    && which {{binary}} | xargs ln -s || true
 
 # Mark apploader.sh executable, finalize manifest, and remove intermediate scripts
-RUN chmod u+x apploader.sh \
-    && python3 -B finalize_manifest.py \
-    && rm -f finalize_manifest.py
+RUN chmod u+x /apploader.sh \
+    && python3 -B /finalize_manifest.py \
+    && rm -f /finalize_manifest.py
 
 # Define default command
-ENTRYPOINT ["/bin/bash", "./apploader.sh"]
+ENTRYPOINT ["/bin/bash", "/apploader.sh"]
 CMD [{% if insecure_args %} "{{'", "'.join(cmd)}}" {% endif %}]

--- a/Tools/gsc/templates/apploader.template
+++ b/Tools/gsc/templates/apploader.template
@@ -6,8 +6,8 @@ set -ex
 if [ -z "$GSC_PAL" ] || [ "$GSC_PAL" == "Linux-SGX" ]
 then
     GSC_PAL=Linux-SGX
-    /graphene/python/graphene-sgx-get-token -output entrypoint.token -sig entrypoint.sig
-    /graphene/Runtime/pal-$GSC_PAL /graphene/Runtime/libpal-$GSC_PAL.so init entrypoint {% if insecure_args %}{{binary_arguments}} "${@}"{% endif %}
+    /graphene/python/graphene-sgx-get-token -output /entrypoint.token -sig /entrypoint.sig
+    /graphene/Runtime/pal-$GSC_PAL /graphene/Runtime/libpal-$GSC_PAL.so init /entrypoint {% if insecure_args %}{{binary_arguments}} "${@}"{% endif %}
 else
-    /graphene/Runtime/pal-$GSC_PAL /graphene/Runtime/libpal-$GSC_PAL.so init entrypoint {{binary_arguments}} "${@}"
+    /graphene/Runtime/pal-$GSC_PAL /graphene/Runtime/libpal-$GSC_PAL.so init /entrypoint {{binary_arguments}} "${@}"
 fi

--- a/Tools/gsc/templates/entrypoint.manifest.template
+++ b/Tools/gsc/templates/entrypoint.manifest.template
@@ -21,8 +21,8 @@ sgx.nonpie_binary = 1
 loader.arg0_override = "{{binary}}"
 loader.insecure__use_cmdline_argv = 1
 {% else %}
-loader.argv_src_file = "file:trusted_argv"
-sgx.trusted_files.trusted_argv = "file:trusted_argv"
+loader.argv_src_file = "file:/trusted_argv"
+sgx.trusted_files.trusted_argv = "file:/trusted_argv"
 {% endif %}
 
 # All trusted files and the user defined manifest specifications should be after this line


### PR DESCRIPTION

## Description of the changes <!-- (reasons and measures) -->

Previously, some GSC templates and scripts that execute inside Docker containers contained relative file paths. This led to failures if a base Docker image contained WORKDIR different from root (`/`), since all GSC scripts put Graphene-related files under root dir.

## How to test this PR? <!-- (if applicable) -->

GSC tests and tutorials (e.g. https://graphene.readthedocs.io/en/latest/manpages/gsc.html#example) must work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2151)
<!-- Reviewable:end -->
