### PR TITLE
[LibOS] Fix `/sys/devices/system/[cpu|node]/` path resolution

### DIFF
--- a/LibOS/shim/src/fs/sys/fs.c
+++ b/LibOS/shim/src/fs/sys/fs.c
@@ -88,7 +88,8 @@ int sys_match_resource_num(const char* pathname) {
         goto out;
     }
 
-    if (num > totalcnt) {
+    /* sysfs resources like NUMA nodes, CPU cores, CPU caches have indexes from 0 to totalcnt - 1 */
+    if (num >= totalcnt) {
         debug("Incorrect index %d in file %s (max supported is %d)\n", num, pathname, totalcnt);
         ret = 0;
         goto out;

--- a/LibOS/shim/src/fs/sys/node_info.c
+++ b/LibOS/shim/src/fs/sys/node_info.c
@@ -18,24 +18,30 @@ static int node_info_open(struct shim_handle* hdl, const char* name, int flags) 
     if (ret < 0)
         return -ENOENT;
 
-    int nodenum = extract_first_num_from_string(name);
-    if (nodenum < 0)
-        return -ENOENT;
-
     const char* node_filebuf;
     if (!strcmp(filename, "online")) {
+        /* This file refers to /sys/devices/system/node/online */
         node_filebuf = pal_control.topo_info.online_nodes;
-    } else if (!strcmp(filename, "cpumap")) {
-        node_filebuf = pal_control.topo_info.numa_topology[nodenum].cpumap;
-    } else if (!strcmp(filename, "distance")) {
-        node_filebuf = pal_control.topo_info.numa_topology[nodenum].distance;
-    } else if (strendswith(name, "hugepages-2048kB/nr_hugepages")) {
-        node_filebuf = pal_control.topo_info.numa_topology[nodenum].hugepages[HUGEPAGES_2M].nr_hugepages;
-    } else if (strendswith(name, "hugepages-1048576kB/nr_hugepages")) {
-        node_filebuf = pal_control.topo_info.numa_topology[nodenum].hugepages[HUGEPAGES_1G].nr_hugepages;
     } else {
-        debug("Unrecognized file %s\n", name);
-        return -ENOENT;
+        /* The below files are under /sys/devices/system/node/nodeX/ */
+        int nodenum = extract_first_num_from_string(name);
+        if (nodenum < 0)
+            return -ENOENT;
+
+        if (!strcmp(filename, "cpumap")) {
+            node_filebuf = pal_control.topo_info.numa_topology[nodenum].cpumap;
+        } else if (!strcmp(filename, "distance")) {
+            node_filebuf = pal_control.topo_info.numa_topology[nodenum].distance;
+        } else if (strendswith(name, "hugepages-2048kB/nr_hugepages")) {
+            node_filebuf =
+                pal_control.topo_info.numa_topology[nodenum].hugepages[HUGEPAGES_2M].nr_hugepages;
+        } else if (strendswith(name, "hugepages-1048576kB/nr_hugepages")) {
+            node_filebuf =
+                pal_control.topo_info.numa_topology[nodenum].hugepages[HUGEPAGES_1G].nr_hugepages;
+        } else {
+            debug("Unrecognized file %s\n", name);
+            return -ENOENT;
+        }
     }
 
     size = strlen(node_filebuf) + 1;

--- a/LibOS/shim/test/regression/sysfs_common.c
+++ b/LibOS/shim/test/regression/sysfs_common.c
@@ -3,6 +3,7 @@
 #include <err.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -124,7 +125,7 @@ int main(int argc, char** argv) {
         if (dirent64->d_type == DT_DIR && strncmp(dirent64->d_name, "cpu", 3) == 0) {
             char *endp;
             unsigned long nr = strtoul(dirent64->d_name + 3, &endp, 10);
-            if (nr != _SC_ULONG_MAX && endp != dirent64->d_name + 3 && *endp == '\0')
+            if (nr != ULONG_MAX && endp != dirent64->d_name + 3 && *endp == '\0')
                 count++;
         }
     }
@@ -149,7 +150,7 @@ int main(int argc, char** argv) {
         if (strncmp(dirent->d_name, "node", 4) == 0) {
             char* endp;
             unsigned long nr = strtoul(dirent->d_name + 4,  &endp, 10);
-            if (nr != _SC_ULONG_MAX && endp != dirent64->d_name + 4 && *endp == '\0')
+            if (nr != ULONG_MAX && endp != dirent64->d_name + 4 && *endp == '\0')
                 count++;
         }
     }

--- a/LibOS/shim/test/regression/sysfs_common.c
+++ b/LibOS/shim/test/regression/sysfs_common.c
@@ -58,6 +58,10 @@ int main(int argc, char** argv) {
     if (ret)
         err(EXIT_FAILURE, "fclose failed for /sys/devices/system/node");
 
+    display_file_contents("/sys/devices/system/cpu/possible");
+
+    display_file_contents("/sys/devices/system/node/online");
+
     /* skip this test, if it is a single-core machine */
     if (maxprocs > 1) {
         display_file_contents("/sys/devices/system/cpu/cpu1/online");


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->
The current implementation of /sys fs will fail for paths such as
`/sys/devices/system/[cpu|node]/online` which doesn't have a
numeric value. This patch fixes this issue. This patch also adds
2 additional test cases as part of the /sys fs regression test.

Signed-off-by: Vijay Dhanraj <vijay.dhanraj@intel.com>

## How to test this PR? <!-- (if applicable) -->
Please run sysfs_common.c as part of LibOS regression tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2153)
<!-- Reviewable:end -->
