### PR TITLE
[Pal/Linux-SGX] Add sgx.preheat_enclave manifest option

### DIFF
--- a/Documentation/manifest-syntax.rst
+++ b/Documentation/manifest-syntax.rst
@@ -487,6 +487,24 @@ For DCAP/ECDSA based attestation, ``ra_client_spid`` must be an empty string
 (this is a hint to Graphene to use DCAP instead of EPID) and
 ``ra_client_linkable`` is ignored.
 
+Pre-heating enclave
+^^^^^^^^^^^^^^^^^^^
+
+::
+
+    sgx.preheat_enclave = [1|0]
+    (Default: 0)
+
+When enabled, this option instructs Graphene to pre-fault all heap pages during
+initialization. This has a negative impact on the total run time, but shifts the
+:term:`EPC` page faults cost to the initialization phase, which can be useful in
+a scenario where a server starts and receives connections / work packages only
+after some time. It also makes the later run time and latency much more
+predictable.
+
+Please note that using this option makes sense only when the :term:`EPC` is
+large enough to hold the whole heap area.
+
 Enabling per-thread and process-wide SGX stats
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/LibOS/shim/test/regression/openmp.manifest.template
+++ b/LibOS/shim/test/regression/openmp.manifest.template
@@ -4,9 +4,10 @@ loader.argv0_override = "openmp"
 
 loader.env.LD_LIBRARY_PATH = "/lib:/usrlib"
 
-# two manifest options below are added only for testing, they have no significance for OpenMP
+# the manifest options below are added only for testing, they have no significance for OpenMP
 libos.check_invalid_pointers = 0
 sys.enable_sigterm_injection = 1
+sgx.preheat_enclave = 1
 
 fs.mount.lib.type = "chroot"
 fs.mount.lib.path = "/lib"

--- a/Pal/src/host/Linux-SGX/db_main.c
+++ b/Pal/src/host/Linux-SGX/db_main.c
@@ -700,6 +700,18 @@ noreturn void pal_linux_main(char* uptr_libpal_uri, size_t libpal_uri_len, char*
     g_pal_state.raw_manifest_data = manifest_addr;
     g_pal_state.manifest_root = manifest_root;
 
+    int64_t preheat_enclave = 0;
+    ret = toml_int_in(g_pal_state.manifest_root, "sgx.preheat_enclave", /*defaultval=*/0,
+                      &preheat_enclave);
+    if (ret < 0 || (preheat_enclave != 0 && preheat_enclave != 1)) {
+        log_error("Cannot parse \'sgx.preheat_enclave\' (the value must be 0 or 1)\n");
+        ocall_exit(1, true);
+    }
+    if (preheat_enclave == 1) {
+        for (uint8_t* i = g_pal_sec.heap_min; i < (uint8_t*)g_pal_sec.heap_max; i += g_page_size)
+            READ_ONCE(*i);
+    }
+
     ret = toml_sizestring_in(g_pal_state.manifest_root, "loader.pal_internal_mem_size",
                              /*defaultval=*/0, &g_pal_internal_mem_size);
     if (ret < 0) {


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

A small performance trade-off option, allowing to "warm up" the heap during initialization.

I considered 3 different ideas for the implementation:
1. Access all the pages at enclave start.
2. Zero out and measure the whole heap.
3. Somehow pre-fault the pages from the outside of the enclave, but without measuring them.

Options 1. is pricey, because it generates a lot of enclave transitions, which are expensive. 2. doesn't have this problem, but requires hashing all the zeros. 3. should be optimal (it didn't even require zeroing out the memory), but I haven't found a way to implement it without modifying the SGX driver.

I tested 1. and 2. and got the following results: (`time ./pal_loader SGX ./pytorch ./pytorchexample.py`, `sgx.enclave_size = "4G"`, 256 threads)

| Config              | Time (real) | Time (user) | Time (sys) | Total AEXes | AEXes after init |
| :------------------ | ----------: | ----------: |----------: |-----------: | ---------------: |
| no zeroing          |   0m27.034s |   0m29.403s |  0m42.452s |     1025439 |           994590 |
| memset              |   0m37.364s |   0m29.563s |  0m10.830s |     1026071 |            16260 |
| READ_ONCE           |   0m34.778s |   0m31.798s |   0m9.342s |     1026794 |            16654 |
| EEXTEND 0x00        |    1m2.755s |   0m29.084s |   1m1.235s |     1026016 |           992796 |
| EEXTEND 0xFF unique pages |    1m2.755s |   0m29.084s |   1m1.235s |      992971 |           995798 |

As you can see, surprisingly, EEXTEND seems to not really bring pages to the EPC, which is weird. ~I can't explain these results, maybe it's a bug in the SGX driver? (this was tested on DCAP driver) Maybe they are in EPC, but somehow have wrong permissions and are fixed only after the first fault?~

Update: It seems that this is intended and both DCAP and in-tree drivers are mapping the whole enclave lazily. Unfortunately, they don't honor `MAP_POPULATE` nor `madvise`, so AFAIK we can't implement 2nd nor 3rd solution until the driver adds support for this.

Anyways, for this patch I selected the `READ_ONCE()` version. Seems that a better one would require some support from the driver team.

## How to test this PR? <!-- (if applicable) -->

Run some memory-heavy workload and check the SGX stats with and without this option and with resetting the stats after initialization. I did my experiments there: https://github.com/oscarlab/graphene/compare/master...mkow:mkow/heap-zero-test-debugging.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2154)
<!-- Reviewable:end -->
