### PR TITLE
fix the deadlock of _DkSystemTimeQuery()

### DIFF
--- a/LibOS/shim/test/regression/Makefile
+++ b/LibOS/shim/test/regression/Makefile
@@ -73,6 +73,7 @@ c_executables = \
 	sigaction_per_process \
 	sigaltstack \
 	sighandler_reset \
+	sighandler_deadlock \
 	sighandler_sigpipe \
 	signal_multithread \
 	sigprocmask_pending \

--- a/LibOS/shim/test/regression/sighandler_deadlock.c
+++ b/LibOS/shim/test/regression/sighandler_deadlock.c
@@ -1,0 +1,72 @@
+#define _XOPEN_SOURCE 700
+#include <errno.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/time.h>
+#include <unistd.h>
+
+static int received = 0;
+#define SIGNAL     (SIGUSR1)
+#define NUM_SIGNAL (20000)
+static struct timeval *p_timeval = NULL;
+static void handler(int sig) {
+    if (sig == SIGNAL) {
+        received++;
+        int ret = gettimeofday(p_timeval, NULL);
+        if (ret != 0) {
+            fprintf(stderr, "handler received the signal, receive = %d ret %d, errno %d/%s \n", received, ret,
+                   errno, strerror(errno));
+            return;
+        }
+        printf("handler received the signal, receive = %d\n", received);
+    }
+}
+
+int main() {
+    int count = 0;
+
+    pid_t pid2 = fork();
+    if (pid2 < 0)
+        fprintf(stderr, "failed to create child process\n");
+    else if (pid2 == 0) {  // child
+        p_timeval = malloc(sizeof(*p_timeval));
+        struct sigaction new_action;
+        new_action.sa_handler = handler;
+        sigemptyset(&new_action.sa_mask);
+        new_action.sa_flags = 0;
+        int sigret = sigaction(SIGNAL, &new_action, NULL);
+        if (sigret < 0) {
+            fprintf(stderr, "sigaction failed, sigret = %d\n", sigret);
+            return 1;
+        }
+        struct timeval start;
+        int last_received = 0;
+        while (received < NUM_SIGNAL) {
+            if (received != last_received) {
+                printf("SIGNAL received = %d.\n", received);
+                last_received = received;
+            }
+            int ret = gettimeofday(&start, NULL);
+            if (ret != 0) {
+                fprintf(stderr, "child main, gettimeofdata failed %d\n", ret);
+            }
+        }
+
+        printf("child to exit received  %d\n", received);
+        free(p_timeval);
+        p_timeval = NULL;
+    } else {  // parent
+        sleep(5);
+        while (count <= NUM_SIGNAL) {
+            sleep(1);
+            kill(pid2, SIGNAL);
+            printf("kill count = %d\n", count);
+            count ++;
+        }
+        printf("parent to exit\n");
+    }
+
+    return 0;
+}


### PR DESCRIPTION
_DkSystemTimeQuery() can be interrupted by async signal when it holds spin lock,
signal handler can recursively issue _DkSystemTimeQuery() with tsc_lock held,
thus it can result in deadlock(self recursive lock).
Solve such deadlock by introducing sequential number for data integrity for
fast path and use spinlock_trylock() instead spinlock_lock() for slow path to
update start_usec, start_tsc.

Change-Id: Ia922676890cfaaa1ca9a32b74130f74bf540f719
Signed-off-by: Isaku Yamahata <saku.yamahata@intel.com>
Signed-off-by: Ying Liu <ying2.liu@intel.com>

<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://graphene.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

_DkSystemTimeQuery() can be interrupted by async signal when it holds spin lock,
signal handler can recursively issue _DkSystemTimeQuery() with tsc_lock held,
thus it can result in deadlock(self recursive lock).
Solve such deadlock by introducing sequential number for data integrity for
fast path and use spinlock_trylock() instead spinlock_lock() for slow path to
update start_usec, start_tsc.

## How to test this PR? <!-- (if applicable) -->
This commit also includes a unit test case.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2155)
<!-- Reviewable:end -->
