### PR TITLE
[Pal/Linux] Change `ADDR_IN_PAL` to `ADDR_IN_PAL_OR_VDSO`

### DIFF
--- a/Pal/src/Makefile
+++ b/Pal/src/Makefile
@@ -114,6 +114,14 @@ ifneq ($(pal_lib),)
 $(pal_lib): $(addprefix $(OBJ_DIR)/,$(objs)) \
 	    $(host_lib) $(graphene_lib) $(pal_lib_deps)
 	$(call cmd,ld_so_o)
+ifeq ($(PAL_HOST),Linux)
+	@if readelf -a $@ | grep -q NEEDED; then              \
+		echo Error: $@ should not be dynamically linked ; \
+		mv $@ $@.dynamic;                                 \
+		exit 1;                                           \
+	fi
+endif
+
 
 $(runtime_lib): $(pal_lib)
 	$(call cmd,ln_sfr)

--- a/Pal/src/host/Linux/db_rtld.c
+++ b/Pal/src/host/Linux/db_rtld.c
@@ -10,13 +10,26 @@
  */
 
 #include "api.h"
+#include "cpu.h"
 #include "debug_map.h"
 #include "elf-arch.h"
 #include "elf/elf.h"
 #include "pal.h"
 #include "pal_debug.h"
+#include "pal_internal.h"
 #include "pal_linux.h"
 #include "pal_rtld.h"
+
+static uintptr_t vdso_start = 0;
+static uintptr_t vdso_end = 0;
+
+uintptr_t get_vdso_start(void) {
+    return vdso_start;
+}
+
+bool is_in_vdso(uintptr_t addr) {
+    return (vdso_start || vdso_end) && vdso_start <= addr && addr < vdso_end;
+}
 
 void _DkDebugMapAdd(const char* name, void* addr) {
     int ret = debug_map_add(name, addr);
@@ -58,16 +71,28 @@ void setup_vdso_map(ElfW(Addr) addr) {
 
     ElfW(Addr) load_offset = 0;
     const ElfW(Phdr) * ph;
+    unsigned long pt_loads_count = 0;
     for (ph = vdso_map.l_phdr; ph < &vdso_map.l_phdr[vdso_map.l_phnum]; ph++)
         switch (ph->p_type) {
             case PT_LOAD:
                 load_offset = addr + (ElfW(Addr))ph->p_offset - (ElfW(Addr))ph->p_vaddr;
+                vdso_start = (uintptr_t)addr;
+                vdso_end = ALIGN_UP(vdso_start + (size_t)ph->p_memsz, PAGE_SIZE);
+                pt_loads_count++;
                 break;
             case PT_DYNAMIC:
                 vdso_map.l_real_ld = vdso_map.l_ld = (void*)addr + ph->p_offset;
                 vdso_map.l_ldnum = ph->p_memsz / sizeof(ElfW(Dyn));
                 break;
         }
+
+    if (pt_loads_count != 1) {
+        log_warning("The VDSO has %lu PT_LOAD segments, but only 1 was expected.\n",
+                    pt_loads_count);
+        vdso_start = 0;
+        vdso_end = 0;
+        return;
+    }
 
     ElfW(Dyn) local_dyn[4];
     int ndyn = 0;

--- a/Pal/src/host/Linux/pal_linux.h
+++ b/Pal/src/host/Linux/pal_linux.h
@@ -8,6 +8,8 @@
 #include <asm/stat.h>
 #include <linux/mman.h>
 #include <sigset.h>
+#include <stdbool.h>
+#include <stdint.h>
 #include <sys/syscall.h>
 #include <sys/types.h>
 #include <unistd.h>
@@ -103,6 +105,9 @@ int clone(int (*__fn)(void* __arg), void* __child_stack, int __flags, const void
 /* PAL main function */
 noreturn void pal_linux_main(void* initial_rsp, void* fini_callback);
 
+uintptr_t get_vdso_start(void);
+bool is_in_vdso(uintptr_t addr);
+
 struct link_map;
 void setup_pal_map(struct link_map* map);
 void setup_vdso_map(ElfW(Addr) addr);
@@ -133,8 +138,8 @@ extern char __text_start, __text_end, __data_start, __data_end;
 #define DATA_START ((void*)(&__text_start))
 #define DATA_END   ((void*)(&__text_end))
 
-#define ADDR_IN_PAL(addr) \
-        ((void*)(addr) > TEXT_START && (void*)(addr) < TEXT_END)
+#define ADDR_IN_PAL_OR_VDSO(addr) \
+        (((void*)(addr) > TEXT_START && (void*)(addr) < TEXT_END) || is_in_vdso(addr))
 
 typedef struct pal_tcb_linux {
     PAL_TCB common;


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->
When an async exception triggers, LibOS needs to know whether it
happened while inside PAL code. Since Linux-PAL sometimes call VDSO
functions, they need to be accounted for as well.

Closes #2155.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2156)
<!-- Reviewable:end -->
