### PR TITLE
Fix race condition in example's Makefiles

### DIFF
--- a/Examples/blender/Makefile
+++ b/Examples/blender/Makefile
@@ -59,7 +59,12 @@ blender.manifest: blender.manifest.template trusted-libs | $(RUN_DIR)
 	     $<; \
     cat trusted-libs) > $@
 
-blender.sig blender.manifest.sgx &: $(BLENDER_DIR)/blender blender.manifest \
+# Make on Ubuntu <= 20.04 doesn't support "Rules with Grouped Targets" (`&:`),
+# we need to hack around.
+blender.sig blender.manifest.sgx: sgx_outputs
+
+.INTERMEDIATE: sgx_outputs
+sgx_outputs: $(BLENDER_DIR)/blender blender.manifest \
         $(GRAPHENE_DIR)/Runtime/libpal-Linux-SGX.so | $(RUN_DIR)
 	$(GRAPHENE_DIR)/Pal/src/host/Linux-SGX/signer/pal-sgx-sign \
 		-output blender.manifest.sgx \

--- a/Examples/gcc/Makefile
+++ b/Examples/gcc/Makefile
@@ -54,9 +54,12 @@ trusted-libs: ../common_tools/get_deps.sh
 		$<; \
 	cat trusted-libs) > $@
 
-# Rules to generate the SGX-specific manifest (.manifest.sgx), the enclave signature (.sig), and the
-# enclave initialization token (.token).
-gcc.sig gcc.manifest.sgx &: gcc.manifest
+# Make on Ubuntu <= 20.04 doesn't support "Rules with Grouped Targets" (`&:`),
+# we need to hack around.
+gcc.sig gcc.manifest.sgx: sgx_outputs
+
+.INTERMEDIATE: sgx_outputs
+sgx_outputs: gcc.manifest
 	$(GRAPHENEDIR)/Pal/src/host/Linux-SGX/signer/pal-sgx-sign \
 		-libpal $(GRAPHENEDIR)/Runtime/libpal-Linux-SGX.so \
 		-key $(SGX_SIGNER_KEY) \

--- a/Examples/pytorch/Makefile
+++ b/Examples/pytorch/Makefile
@@ -49,7 +49,12 @@ include ../../Scripts/Makefile.configs
 		-e 's|$$(ARCH_LIBDIR)|'"$(ARCH_LIBDIR)"'|g' \
 		$< > $@
 
-pytorch.sig pytorch.manifest.sgx &: pytorch.manifest
+# Make on Ubuntu <= 20.04 doesn't support "Rules with Grouped Targets" (`&:`),
+# we need to hack around.
+pytorch.sig pytorch.manifest.sgx: sgx_outputs
+
+.INTERMEDIATE: sgx_outputs
+sgx_outputs: pytorch.manifest
 	$(GRAPHENEDIR)/Pal/src/host/Linux-SGX/signer/pal-sgx-sign \
 		-libpal $(GRAPHENEDIR)/Runtime/libpal-Linux-SGX.so \
 		-key $(SGX_SIGNER_KEY) \

--- a/Examples/redis/Makefile
+++ b/Examples/redis/Makefile
@@ -30,6 +30,10 @@ else
 GRAPHENE_LOG_LEVEL = error
 endif
 
+DISTRIB_ID ?= $(shell lsb_release --short --id)
+DISTRIB_RELEASE ?= $(shell lsb_release --short --release)
+DISTRO = $(DISTRIB_ID)$(DISTRIB_RELEASE)
+
 .PHONY: all
 all: redis-server redis-server.manifest pal_loader
 ifeq ($(SGX),1)
@@ -72,6 +76,7 @@ redis-server.manifest: redis-server.manifest.template
 	sed -e 's|$$(GRAPHENEDIR)|'"$(GRAPHENEDIR)"'|g' \
 		-e 's|$$(GRAPHENE_LOG_LEVEL)|'"$(GRAPHENE_LOG_LEVEL)"'|g' \
 		-e 's|$$(ARCH_LIBDIR)|'"$(ARCH_LIBDIR)"'|g' \
+		-e 's|# '"$(DISTRO)"' ||g' \
 		$< > $@
 
 # Manifest for Graphene-SGX requires special "pal-sgx-sign" procedure. This procedure measures all

--- a/Examples/redis/Makefile
+++ b/Examples/redis/Makefile
@@ -89,7 +89,12 @@ redis-server.manifest: redis-server.manifest.template
 # EINITTOKEN must be generated on the machine where the application will run, not where it was
 # built.
 
-redis-server.sig redis-server.manifest.sgx &: redis-server.manifest $(SRCDIR)/src/redis-server
+# Make on Ubuntu <= 20.04 doesn't support "Rules with Grouped Targets" (`&:`),
+# we need to hack around.
+redis-server.sig redis-server.manifest.sgx: sgx_outputs
+
+.INTERMEDIATE: sgx_outputs
+sgx_outputs: redis-server.manifest $(SRCDIR)/src/redis-server
 	$(GRAPHENEDIR)/Pal/src/host/Linux-SGX/signer/pal-sgx-sign \
 		-libpal $(GRAPHENEDIR)/Runtime/libpal-Linux-SGX.so \
 		-key $(SGX_SIGNER_KEY) \

--- a/Examples/redis/redis-server.manifest.template
+++ b/Examples/redis/redis-server.manifest.template
@@ -135,9 +135,11 @@ sgx.trusted_files.libnsl = "file:$(ARCH_LIBDIR)/libnsl.so.1"
 # Additional dependant libraries for redis version 6+
 sgx.trusted_files.libsystemd = "file:$(ARCH_LIBDIR)/libsystemd.so.0"
 sgx.trusted_files.liblzma = "file:$(ARCH_LIBDIR)/liblzma.so.5"
-sgx.trusted_files.libgcrypt = "file:$(ARCH_LIBDIR)/libgcrypt.so.20"
 sgx.trusted_files.libgpgerror = "file:$(ARCH_LIBDIR)/libgpg-error.so.0"
 sgx.trusted_files.liblz4 = "file:/usr/$(ARCH_LIBDIR)/liblz4.so.1"
+# Ubuntu16.04 sgx.trusted_files.libgcrypt = "file:$(ARCH_LIBDIR)/libgcrypt.so.20"
+# Ubuntu18.04 sgx.trusted_files.libgcrypt = "file:$(ARCH_LIBDIR)/libgcrypt.so.20"
+# Ubuntu20.04 sgx.trusted_files.libgcrypt = "file:/usr/$(ARCH_LIBDIR)/libgcrypt.so.20"
 
 # Trusted no-library files include configuration files, read-only files, and
 # other static files. It is useful to specify such files here to make sure


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

I hate Make. We should really get rid of it finally...

It turns out that Make in versions that doesn't support the `&:` operator ("Rules with Grouped Targets") silently ignores it and calls the recipe for each target separately, without even a warning. When using parallel builds (`-j`) the result is a race, because a few command invocations write to the same set of target files at the same time.

Additionally, I ported the Redis example to Ubuntu 20.04 to test the fix.

## How to test this PR? <!-- (if applicable) -->

CI + build the examples manually with `-j8` and check the build log.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2163)
<!-- Reviewable:end -->
