### PR TITLE
[GSC] Allow in-kernel Intel SGX driver; improve GSC testing

### DIFF
--- a/Tools/gsc/config.yaml.template
+++ b/Tools/gsc/config.yaml.template
@@ -1,7 +1,26 @@
+# The only currently supported distro is Ubuntu 18.04; to add another distro, you must add three new
+# Dockerfiles (compile, build, sign) under templates/
 Distro: "ubuntu18.04"
+
+# If you're using your own fork and branch of Graphene, specify the GitHub link and the branch name
+# below; typically, you want to keep the default values though
 Graphene:
     Repository: "https://github.com/oscarlab/graphene.git"
-    Branch: "master"
+    Branch:     "master"
+
+# Specify the Intel SGX driver installed on your machine (more specifically, on the machine where
+# the graphenized Docker container will run); there are several variants of the SGX driver:
+#
+#   - legacy out-of-tree driver: use the defaults below, but adjust the branch name
+#
+#   - DCAP out-of-tree driver: use something like the below values
+#         Repository: "https://github.com/intel/SGXDataCenterAttestationPrimitives.git"
+#         Branch:     "DCAP_1.6 && cp -r driver/linux/* ."
+#
+#   - DCAP in-kernel driver: use empty values like below
+#         Repository: ""
+#         Branch:     ""
+#
 SGXDriver:
     Repository: "https://github.com/01org/linux-sgx-driver.git"
-    Branch: "sgx_driver_1.9"
+    Branch:     "sgx_driver_1.9"

--- a/Tools/gsc/finalize_manifest.py
+++ b/Tools/gsc/finalize_manifest.py
@@ -21,18 +21,15 @@ def is_utf8(filename_bytes):
 
 
 def generate_trusted_files(root_dir):
-    cwd = os.getcwd() if os.getcwd() != '/' else ''
     excluded_paths_regex = (r'^/('
                                 r'boot/.*'
                                 r'|dev/.*'
                                 r'|etc/rc(\d|.)\.d/.*'
                                 r'|graphene/python/.*'
+                                r'|finalize_manifest\.py'
                                 r'|proc/.*'
                                 r'|sys/.*'
-                                r'|var/.*)'
-                            f'|^{cwd}/('
-                                r'.*\.manifest'
-                                r'|finalize_manifest\.py)$')
+                                r'|var/.*)$')
     exclude_re = re.compile(excluded_paths_regex)
 
     num_trusted = 0
@@ -87,7 +84,7 @@ def main(args=None):
     env = jinja2.Environment(loader=jinja2.FileSystemLoader('/'))
     env.globals.update({'library_paths': generate_library_paths(), 'env_path': os.getenv('PATH')})
 
-    manifest = 'entrypoint.manifest'
+    manifest = '/entrypoint.manifest'
     rendered_manifest = env.get_template(manifest).render()
     trusted_files = generate_trusted_files(args.dir)
     with open(manifest, 'wb') as manifest_file:

--- a/Tools/gsc/templates/Dockerfile.ubuntu18.04.compile.template
+++ b/Tools/gsc/templates/Dockerfile.ubuntu18.04.compile.template
@@ -20,14 +20,18 @@ RUN cd /graphene \
     && git fetch origin {{Graphene.Branch}} \
     && git checkout {{Graphene.Branch}}
 
+{% if SGXDriver.Repository %}
 RUN cd /graphene/Pal/src/host/Linux-SGX \
     && git clone {{SGXDriver.Repository}} linux-sgx-driver \
     && cd linux-sgx-driver \
     && git checkout {{SGXDriver.Branch}}
+ENV ISGX_DRIVER_PATH "/graphene/Pal/src/host/Linux-SGX/linux-sgx-driver"
+{% else %}
+ENV ISGX_DRIVER_PATH ""
+{% endif %}
 
 RUN cd /graphene \
-    && ISGX_DRIVER_PATH=/graphene/Pal/src/host/Linux-SGX/linux-sgx-driver \
-    make -s -j WERROR=1 SGX=1 {% if debug %} DEBUG=1 {% endif %}
+    && make -s -j WERROR=1 SGX=1 {% if debug %} DEBUG=1 {% endif %}
 
 {% if linux %}
 RUN cd /graphene \

--- a/Tools/gsc/test/Makefile
+++ b/Tools/gsc/test/Makefile
@@ -1,5 +1,8 @@
-TESTCASES ?= python3 python3-trusted-args base-python3 hello-world nodejs bash numpy pytorch
 DISTRIBUTIONS ?= ubuntu18.04
+
+TESTCASES ?= python3 python3-trusted-args base-python3 hello-world nodejs bash numpy pytorch
+MAXTESTNUM ?= 12
+TESTS = $(foreach D,$(DISTRIBUTIONS),$(foreach T,$(TESTCASES),$D-$T))
 
 GRAPHENE_REPO ?= https://github.com/oscarlab/graphene.git
 GRAPHENE_BRANCH ?= master
@@ -8,17 +11,18 @@ SGXDRIVER_BRANCH ?= sgx_driver_1.9
 
 DOCKER_BUILD_FLAGS ?= --rm --no-cache
 GSC_BUILD_FLAGS ?= --rm --no-cache
-TESTS = $(foreach D,$(DISTRIBUTIONS),$(foreach T,$(TESTCASES),$D-$T))
-MAXTESTNUM ?= 12
 KEY_FILE ?= ../enclave-key.pem
-ifeq ($(wildcard /dev/isgx), )
-	SGX_DEVICE = sgx
-else
-	SGX_DEVICE = isgx
-endif
-DEVICES_VOLUMES = --device=/dev/gsgx --device=/dev/${SGX_DEVICE} -v /var/run/aesmd/aesm.socket:/var/run/aesmd/aesm.socket
 ENV_VARS ?=
 IMAGE_SUFFIX ?=
+
+# use "isgx" for legacy driver, "sgx/enclave" for DCAP driver, "sgx_enclave" for in-kernel driver
+INTEL_SGX_DEVICE ?= isgx
+# "gsgx" is needed on Linux before v5.9 (before FSGSBASE was merged), otherwise leave empty
+ADDITIONAL_DEVICES ?= --device=/dev/gsgx
+# use if AESM daemon from the host is needed (e.g. for remote attestation), otherwise leave empty
+ADDITIONAL_VOLUMES ?= --volume /var/run/aesmd/aesm.socket:/var/run/aesmd/aesm.socket
+
+DEVICES_VOLUMES = --device=/dev/${INTEL_SGX_DEVICE} ${ADDITIONAL_DEVICES} ${ADDITIONAL_VOLUMES}
 
 .PHONY: all
 all: $(KEY_FILE)
@@ -137,7 +141,7 @@ test-4-%: gsc-%-python3
 .PHONY: test-5-%
 test-5-%: gsc-%-python3
 	docker run $(addprefix -e , $(ENV_VARS)) $(DEVICES_VOLUMES) $(addsuffix $(IMAGE_SUFFIX), gsc-$*-python3) -c 'import os;os.system("ls")' 2>&1 | tee out
-	grep -q "ls.manifest.sgx" out
+	grep -q "entrypoint.manifest.sgx" out
 	$(RM) out
 
 .PHONY: test-6-%
@@ -176,7 +180,7 @@ test-10-%: gsc-%-numpy
 .PHONY: test-11-%
 test-11-%: gsc-%-bash
 	docker run $(addprefix -e , $(ENV_VARS)) $(DEVICES_VOLUMES) $(addsuffix $(IMAGE_SUFFIX), gsc-$*-bash) -c 'ls' 2>&1 | tee out
-	grep -q "ls.manifest.sgx" out
+	grep -q "entrypoint.manifest.sgx" out
 	$(RM) out
 
 .PHONY: test-12-%


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Previously, GSC required to use an out-of-tree SGX driver (either the legacy one or the DCAP one) but could not support the in-kernel SGX driver (merged into Linux 5.11). This PR allows to specify the in-kernel SGX driver in the configuration file `config.yaml` for GSC.

This PR also fixes a couple tiny bugs in the testing Makefile.

## How to test this PR? <!-- (if applicable) -->

GSC in Jenkins must succeed. Manual testing on Linux 5.11 with the in-kernel SGX driver is in progress.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2165)
<!-- Reviewable:end -->
