### PR TITLE
[Examples] Fix up Node.js examples

### DIFF
--- a/Examples/nodejs-express-server/nodejs.manifest.template
+++ b/Examples/nodejs-express-server/nodejs.manifest.template
@@ -1,6 +1,6 @@
-# Nodejs manifest file example
+# Node.js manifest file example
 #
-# This manifest was prepared and tested on Ubuntu 18.04.
+# This manifest was prepared and tested on Ubuntu 18.04. The tested version of Node.js was v13.14.0.
 
 libos.entrypoint = "file:$(NODEJS_DIR)/nodejs"
 
@@ -13,6 +13,12 @@ loader.log_level = "$(GRAPHENE_LOG_LEVEL)"
 
 # Read application arguments directly from the command line. Don't use this on production!
 loader.insecure__use_cmdline_argv = 1
+
+# Forward environment variables from the host. Don't use this on production!
+loader.insecure__use_host_env = 1
+
+# Node.js requires eventfd2() emulation otherwise fails on `(uv_loop_init(&tracing_loop_)) == (0)'
+sys.insecure__allow_eventfd = 1
 
 # Specify paths to search for libraries. The usual LD_LIBRARY_PATH syntax applies. Paths must be in-
 # Graphene visible paths, not host-OS paths (i.e., paths must be taken from fs.mount.xxx.path, not
@@ -40,11 +46,12 @@ fs.mount.lib3.uri = "file:/usr/$(ARCH_LIBDIR)"
 # time.
 sgx.enclave_size = "2G"
 
-sgx.nonpie_binary = 1
-
-# Set maximum number of in-enclave threads to 8. Recall that SGX v1 requires to specify the maximum
+# Set maximum number of in-enclave threads to 32. Recall that SGX v1 requires to specify the maximum
 # number of simultaneous threads at enclave creation time.
-sgx.thread_num = 8
+sgx.thread_num = 32
+
+# Node.js is a non-PIE binary
+sgx.nonpie_binary = 1
 
 # Specify all files used by Node.js and its dependencies (including all libs which can be loaded at
 # runtime via dlopen).

--- a/Examples/nodejs/nodejs.manifest.template
+++ b/Examples/nodejs/nodejs.manifest.template
@@ -1,6 +1,6 @@
-# Nodejs manifest file example
+# Node.js manifest file example
 #
-# This manifest was prepared and tested on Ubuntu 18.04.
+# This manifest was prepared and tested on Ubuntu 18.04. The tested version of Node.js was v13.14.0.
 
 libos.entrypoint = "file:$(NODEJS_DIR)/nodejs"
 
@@ -13,6 +13,12 @@ loader.log_level = "$(GRAPHENE_LOG_LEVEL)"
 
 # Read application arguments directly from the command line. Don't use this on production!
 loader.insecure__use_cmdline_argv = 1
+
+# Forward environment variables from the host. Don't use this on production!
+loader.insecure__use_host_env = 1
+
+# Node.js requires eventfd2() emulation otherwise fails on `(uv_loop_init(&tracing_loop_)) == (0)'
+sys.insecure__allow_eventfd = 1
 
 # Specify paths to search for libraries. The usual LD_LIBRARY_PATH syntax
 # applies. Paths must be in-Graphene visible paths, not host-OS paths (i.e.,
@@ -33,15 +39,18 @@ fs.mount.lib3.type = "chroot"
 fs.mount.lib3.path = "/usr/$(ARCH_LIBDIR)"
 fs.mount.lib3.uri = "file:/usr/$(ARCH_LIBDIR)"
 
-# Set enclave size to 2GB; NodeJS expects around 1.7GB of heap on startup,
+# Set enclave size to 2GB; Node.js expects around 1.7GB of heap on startup,
 # see e.g. https://github.com/nodejs/node/issues/13018.
 # Recall that SGX v1 requires to specify enclave size at enclave creation time.
 sgx.enclave_size = "2G"
 
-# Set maximum number of in-enclave threads (somewhat arbitrarily) to 8. Recall
+# Set maximum number of in-enclave threads (somewhat arbitrarily) to 32. Recall
 # that SGX v1 requires to specify the maximum number of simultaneous threads at
 # enclave creation time.
-sgx.thread_num = 8
+sgx.thread_num = 32
+
+# Node.js is a non-PIE binary
+sgx.nonpie_binary = 1
 
 # Specify all files used by Node.js and its dependencies (including all libs
 # which can be loaded at runtime via dlopen).
@@ -53,8 +62,6 @@ sgx.trusted_files.libdl = "file:$(GRAPHENEDIR)/Runtime/libdl.so.2"
 sgx.trusted_files.librt = "file:$(GRAPHENEDIR)/Runtime/librt.so.1"
 sgx.trusted_files.libutil = "file:$(GRAPHENEDIR)/Runtime/libutil.so.1"
 sgx.trusted_files.libpthread = "file:$(GRAPHENEDIR)/Runtime/libpthread.so.0"
-sgx.trusted_files.libstdcpp = "file:$(GRAPHENEDIR)/Runtime/libstdc++.so.6"
-sgx.trusted_files.libgcc_s = "file:$(GRAPHENEDIR)/Runtime/libgcc_s.so.1"
 
 # input file
 sgx.trusted_files.javascript = "file:helloworld.js"


### PR DESCRIPTION

## Description of the changes <!-- (reasons and measures) -->

Node.js examples were broken after the recent commits. Looks like no-one tested Node.js in Graphene for the last 2-3 months. Now they are fixed (to at least run on Ubuntu 18.04 with Node.js version v13.14.0.).

## How to test this PR? <!-- (if applicable) -->

Manually test Node.js.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2166)
<!-- Reviewable:end -->
