### PR TITLE
[Pal/Linux-SGX] Add OCALL profiling modes

### DIFF
--- a/Documentation/devel/performance.rst
+++ b/Documentation/devel/performance.rst
@@ -533,6 +533,33 @@ measuring the value of instruction pointer on each asynchronous enclave exit
 as page faults. While we attempt to measure time (and not only count
 occurences), the results might be inaccurate.
 
+.. _sgx-profile-ocall:
+
+OCALL profiling
+"""""""""""""""
+
+It's also possible to discover what OCALLs are being executed, which should help
+attribute the EEXIT numbers given by ``sgx.enable_stats``. There are two ways to
+do that:
+
+* Use ``sgx.profile.mode = "ocall_inner"`` and ``sgx.profile.with_stack =
+  1``. This will give you a report on what enclave code is causing the OCALLs
+  (best viewed with ``perf report --no-children``).
+
+  The ``with_stack`` option is important: without it, the report will only show
+  the last function before enclave exit, which is usually the same regardless of
+  which OCALL we're executing.
+
+* Use ``sgx.profile.mode = "ocall_outer"``. This will give you a report on what
+  outer PAL code is handling the OCALLs (``sgx_ocall_open``, ``sgx_ocall_write``
+  etc.)
+
+**Warning**: The report for OCALL modes should be interpreted in term of *number
+of OCALLs*, not time spent in them. The profiler records a sample every time an
+OCALL is executed, and ``perf report`` displays percentages based on the number
+of samples.
+
+
 Other useful tools for profiling
 --------------------------------
 

--- a/Documentation/manifest-syntax.rst
+++ b/Documentation/manifest-syntax.rst
@@ -551,11 +551,30 @@ collect samples and save them to ``sgx-perf-<PID>.data``.
 The saved files can be viewed with the ``perf`` tool, e.g. ``perf report -i
 sgx-perf.data``.
 
-See :doc:`devel/performance` for more information.
+See :ref:`sgx-profile` for more information.
 
 *Note:* this option is insecure and cannot be used with production enclaves
 (``sgx.debug = 0``). If the production enclave is started with this option set,
 Graphene will fail initialization of the enclave.
+
+::
+
+    sgx.profile.mode = ["aex"|"ocall_inner"|"ocall_outer"]
+    (Default: "aex")
+
+Specifies what events to record:
+
+* ``aex``: Records enclave state during asynchronous enclave exit (AEX). Use
+  this to check where the CPU time is spent in the enclave.
+
+* ``ocall_inner``: Records enclave state during OCALL.
+
+* ``ocall_outer``: Records the outer OCALL function, i.e. what OCALL handlers
+  are going to be executed. Does not include stack information (cannot be used
+  with ``sgx.profile.with_stack = 1``).
+
+See also :ref:`sgx-profile-ocall` for more detailed advice regarding the OCALL
+modes.
 
 ::
 
@@ -577,3 +596,6 @@ lower overhead.
 
 Note that the accuracy is limited by how often the process is interrupted by
 Linux scheduler: the effective maximum is 250 samples per second.
+
+**Note**: This option applies only to ``aex`` mode. In the ``ocall_*`` modes,
+currently all samples are taken.

--- a/Pal/src/host/Linux-SGX/Makefile
+++ b/Pal/src/host/Linux-SGX/Makefile
@@ -78,6 +78,7 @@ urts-objs = \
 	sgx_platform.o \
 	sgx_process.o \
 	sgx_profile.o \
+	sgx_profile_glibc.o \
 	sgx_gdb_info.o \
 	sgx_thread.o \
 	quote/aesm.pb-c.o \

--- a/Pal/src/host/Linux-SGX/enclave_entry.S
+++ b/Pal/src/host/Linux-SGX/enclave_entry.S
@@ -631,13 +631,16 @@ sgx_ocall:
 	# %rax is argument to EEXIT
 	# %rbx is argument to EEXIT
 	# %rcx is set to AEP by EEXIT
-	xorq %rdx, %rdx
 	# %rsi, %rdi are arguments to the untrusted code
 
 #ifdef DEBUG
+	# Store pointer to context in RDX, for the SGX profiler.
+	movq %gs:SGX_PRE_OCALL_STACK, %rdx
+
 	# Keep callee-saved registers in order to recover stack later (see __morestack() below).
 #else
 	# In non-debug mode, clear these registers to prevent information leaks.
+	xorq %rdx, %rdx
 	xorq %rbp, %rbp
 	xorq %r12, %r12
 	xorq %r13, %r13

--- a/Pal/src/host/Linux-SGX/sgx_entry.S
+++ b/Pal/src/host/Linux-SGX/sgx_entry.S
@@ -84,9 +84,9 @@ async_exit_pointer:
 	.cfi_def_cfa_register %rbp
 	andq $~0xF, %rsp
 
-	# Call sgx_profile_sample with %rdi = TCS
+	# Call sgx_profile_sample_aex with %rdi = TCS
 	movq %rbx, %rdi
-	call sgx_profile_sample
+	call sgx_profile_sample_aex
 
 	# Restore stack
 	movq %rbp, %rsp
@@ -139,7 +139,26 @@ sgx_raise:
 	movq %rsp, %rbp
 	.cfi_offset %rbp, -16
 	.cfi_def_cfa_register %rbp
+
+#if DEBUG
+    # Adjust stack and save RDI
+	subq $8, %rsp
 	andq $~0xF, %rsp  # Required by System V AMD64 ABI.
+	movq %rdi, -8(%rbp)
+
+	# Call sgx_profile_sample_ocall_outer with RBX (ocall handler)
+	movq %rbx, %rdi
+	call sgx_profile_sample_ocall_outer
+
+	# Call sgx_profile_sample_ocall_inner with RDX (pointer to in-enclave context)
+	movq %rdx, %rdi
+	call sgx_profile_sample_ocall_inner
+
+	# Restore RDI
+	movq -8(%rbp), %rdi
+#else
+	andq $~0xF, %rsp  # Required by System V AMD64 ABI.
+#endif
 
 	callq *%rbx
 

--- a/Pal/src/host/Linux-SGX/sgx_internal.h
+++ b/Pal/src/host/Linux-SGX/sgx_internal.h
@@ -73,6 +73,7 @@ struct pal_enclave {
 #ifdef DEBUG
     /* profiling */
     bool profile_enable;
+    int profile_mode;
     char profile_filename[64];
     bool profile_with_stack;
     int profile_frequency;
@@ -164,6 +165,12 @@ void update_debugger(void);
 #define SGX_PROFILE_DEFAULT_FREQUENCY 50
 #define SGX_PROFILE_MAX_FREQUENCY 250
 
+enum {
+    SGX_PROFILE_MODE_AEX = 1,
+    SGX_PROFILE_MODE_OCALL_INNER = 2,
+    SGX_PROFILE_MODE_OCALL_OUTER = 3,
+};
+
 /* Filenames for saved data */
 #define SGX_PROFILE_FILENAME "sgx-perf.data"
 #define SGX_PROFILE_FILENAME_WITH_PID "sgx-perf-%d.data"
@@ -174,11 +181,20 @@ int sgx_profile_init(void);
 /* Finalize and close file */
 void sgx_profile_finish(void);
 
-/* Record a sample */
-void sgx_profile_sample(void* tcs);
+/* Record a sample during AEX */
+void sgx_profile_sample_aex(void* tcs);
+
+/* Record a sample during OCALL (inner state) */
+void sgx_profile_sample_ocall_inner(void* enclave_gpr);
+
+/* Record a sample during OCALL (function to be executed) */
+void sgx_profile_sample_ocall_outer(void* ocall_func);
 
 /* Record a new mapped ELF */
 void sgx_profile_report_elf(const char* filename, void* addr);
+
+/* Record all ELFs from outer PAL */
+void sgx_profile_report_urts_elfs(void);
 #endif
 
 /* perf.data output (sgx_perf_data.h) */

--- a/Pal/src/host/Linux-SGX/sgx_main.c
+++ b/Pal/src/host/Linux-SGX/sgx_main.c
@@ -534,6 +534,9 @@ static int initialize_enclave(struct pal_enclave* enclave, const char* manifest_
 
     debug_map_add(enclave->libpal_uri + URI_PREFIX_FILE_LEN, (void*)pal_area->addr);
     sgx_profile_report_elf(enclave->libpal_uri + URI_PREFIX_FILE_LEN, (void*)pal_area->addr);
+
+    /* Report outer PAL maps to profiler, so that we can record samples pointing to outer PAL. */
+    sgx_profile_report_urts_elfs();
 #endif
 
     ret = 0;
@@ -765,6 +768,29 @@ static int parse_loader_config(char* manifest, struct pal_enclave* enclave_info)
         goto out;
     }
 
+    char* profile_mode_str = NULL;
+    ret = toml_string_in(manifest_root, "sgx.profile.mode", &profile_mode_str);
+    if (ret < 0) {
+        urts_log_error("Cannot parse 'sgx.profile.mode' "
+                       "(the value must be \"aex\", \"ocall_inner\" or \"ocall_outer\")\n");
+        ret = -EINVAL;
+        goto out;
+    }
+    if (!profile_mode_str) {
+        enclave_info->profile_mode = SGX_PROFILE_MODE_AEX;
+    } else if (!strcmp(profile_mode_str, "aex")) {
+        enclave_info->profile_mode = SGX_PROFILE_MODE_AEX;
+    } else if (!strcmp(profile_mode_str, "ocall_inner")) {
+        enclave_info->profile_mode = SGX_PROFILE_MODE_OCALL_INNER;
+    } else if (!strcmp(profile_mode_str, "ocall_outer")) {
+        enclave_info->profile_mode = SGX_PROFILE_MODE_OCALL_OUTER;
+    } else {
+        urts_log_error("Invalid 'sgx.profile.mode' "
+                       "(the value must be \"aex\", \"ocall_inner\" or \"ocall_outer\")\n");
+        ret = -EINVAL;
+        goto out;
+    }
+
     int64_t profile_with_stack;
     ret = toml_int_in(manifest_root, "sgx.profile.with_stack", /*defaultval=*/0,
                       &profile_with_stack);
@@ -774,6 +800,15 @@ static int parse_loader_config(char* manifest, struct pal_enclave* enclave_info)
         goto out;
     }
     enclave_info->profile_with_stack = profile_with_stack;
+
+    if (enclave_info->profile_with_stack &&
+        enclave_info->profile_mode == SGX_PROFILE_MODE_OCALL_OUTER) {
+
+        urts_log_error("Invalid 'sgx.profile.mode' and 'sgx.profile.with_stack' combination "
+                       "(\"ocall_outer\" mode cannot be used with stack)\n");
+        ret = -EINVAL;
+        goto out;
+    }
 
     int64_t profile_frequency;
     ret = toml_int_in(manifest_root, "sgx.profile.frequency", SGX_PROFILE_DEFAULT_FREQUENCY,

--- a/Pal/src/host/Linux-SGX/sgx_profile.c
+++ b/Pal/src/host/Linux-SGX/sgx_profile.c
@@ -18,6 +18,7 @@
 #include "cpu.h"
 #include "elf-x86_64.h"
 #include "elf/elf.h"
+#include "linux_utils.h"
 #include "sgx_internal.h"
 #include "sgx_log.h"
 #include "sgx_tls.h"
@@ -33,6 +34,7 @@ static spinlock_t g_perf_data_lock = INIT_SPINLOCK_UNLOCKED;
 static struct perf_data* g_perf_data = NULL;
 
 static bool g_profile_enabled = false;
+static int g_profile_mode;
 static uint64_t g_profile_period;
 static int g_mem_fd = -1;
 
@@ -101,6 +103,7 @@ int sgx_profile_init(void) {
     assert(!g_perf_data);
 
     g_profile_period = NSEC_IN_SEC / g_pal_enclave.profile_frequency;
+    g_profile_mode = g_pal_enclave.profile_mode;
 
     ret = INLINE_SYSCALL(open, 3, "/proc/self/mem", O_RDONLY | O_LARGEFILE, 0);
     if (IS_ERR(ret)) {
@@ -172,18 +175,15 @@ void sgx_profile_finish(void) {
     g_profile_enabled = false;
 }
 
-static void sample_simple(void* tcs, pid_t pid, pid_t tid) {
+static void sample_simple(uint64_t rip) {
     int ret;
-    sgx_pal_gpr_t gpr;
 
-    ret = get_sgx_gpr(&gpr, tcs);
-    if (IS_ERR(ret)) {
-        urts_log_error("error reading GPR: %d\n", ret);
-        return;
-    }
+    // Report all events as the same PID so that they are grouped in report.
+    pid_t pid = g_pal_enclave.pal_sec.pid;
+    pid_t tid = pid;
 
     spinlock_lock(&g_perf_data_lock);
-    ret = pd_event_sample_simple(g_perf_data, gpr.rip, pid, tid, g_profile_period);
+    ret = pd_event_sample_simple(g_perf_data, rip, pid, tid, g_profile_period);
     spinlock_unlock(&g_perf_data_lock);
 
     if (IS_ERR(ret)) {
@@ -191,19 +191,16 @@ static void sample_simple(void* tcs, pid_t pid, pid_t tid) {
     }
 }
 
-static void sample_stack(void* tcs, pid_t pid, pid_t tid) {
+static void sample_stack(sgx_pal_gpr_t* gpr) {
     int ret;
-    sgx_pal_gpr_t gpr;
 
-    ret = get_sgx_gpr(&gpr, tcs);
-    if (IS_ERR(ret)) {
-        urts_log_error("error reading GPR: %d\n", ret);
-        return;
-    }
+    // Report all events as the same PID so that they are grouped in report.
+    pid_t pid = g_pal_enclave.pal_sec.pid;
+    pid_t tid = pid;
 
     uint8_t stack[PD_STACK_SIZE];
     size_t stack_size;
-    ret = debug_read(stack, (void*)gpr.rsp, sizeof(stack));
+    ret = debug_read(stack, (void*)gpr->rsp, sizeof(stack));
     if (IS_ERR(ret)) {
         urts_log_error("error reading stack: %d\n", ret);
         return;
@@ -211,8 +208,8 @@ static void sample_stack(void* tcs, pid_t pid, pid_t tid) {
     stack_size = ret;
 
     spinlock_lock(&g_perf_data_lock);
-    ret = pd_event_sample_stack(g_perf_data, gpr.rip, pid, tid, g_profile_period,
-                                &gpr, stack, stack_size);
+    ret = pd_event_sample_stack(g_perf_data, gpr->rip, pid, tid, g_profile_period,
+                                gpr, stack, stack_size);
     spinlock_unlock(&g_perf_data_lock);
 
     if (IS_ERR(ret)) {
@@ -221,25 +218,20 @@ static void sample_stack(void* tcs, pid_t pid, pid_t tid) {
 }
 
 /*
- * Take a sample after an exit from enclave.
+ * Update sample time, and return true if we should record a new sample.
  *
- * Use CPU time to record a sample approximately every 'g_profile_period' nanoseconds. Note that we
- * rely on Linux scheduler to generate an AEX event 250 times per second (although other events may
- * cause an AEX to happen more often), so sampling frequency greater than 250 cannot be reliably
- * achieved.
+ * In case of AEX, we can use it to record a sample approximately every 'g_profile_period'
+ * nanoseconds. Note that we rely on Linux scheduler to generate an AEX event 250 times per second
+ * (although other events may cause an AEX to happen more often), so sampling frequency greater than
+ * 250 cannot be reliably achieved.
  */
-void sgx_profile_sample(void* tcs) {
-    int ret;
-
-    if (!g_profile_enabled)
-        return;
-
+static bool update_time(void) {
     // Check current CPU time
     struct timespec ts;
-    ret = INLINE_SYSCALL(clock_gettime, 2, CLOCK_THREAD_CPUTIME_ID, &ts);
+    int ret = INLINE_SYSCALL(clock_gettime, 2, CLOCK_THREAD_CPUTIME_ID, &ts);
     if (IS_ERR(ret)) {
         urts_log_error("sgx_profile_sample: clock_gettime failed: %d\n", ret);
-        return;
+        return false;
     }
     uint64_t sample_time = ts.tv_sec * NSEC_IN_SEC + ts.tv_nsec;
 
@@ -247,30 +239,82 @@ void sgx_profile_sample(void* tcs) {
     PAL_TCB_URTS* tcb = get_tcb_urts();
     if (tcb->profile_sample_time == 0) {
         tcb->profile_sample_time = sample_time;
+        return false;
+    }
+
+    if (sample_time - tcb->profile_sample_time >= g_profile_period) {
+        tcb->profile_sample_time = sample_time;
+        assert(sample_time >= tcb->profile_sample_time);
+        return true;
+    }
+    return false;
+}
+
+void sgx_profile_sample_aex(void* tcs) {
+    int ret;
+
+    if (!(g_profile_enabled && g_profile_mode == SGX_PROFILE_MODE_AEX))
+        return;
+
+    if (!update_time())
+        return;
+
+    sgx_pal_gpr_t gpr;
+    ret = get_sgx_gpr(&gpr, tcs);
+    if (IS_ERR(ret)) {
+        urts_log_error("sgx_profile_sample_aex: error reading GPR: %d\n", ret);
         return;
     }
 
-    assert(sample_time >= tcb->profile_sample_time);
-    // Report a sample, if necessary
-    if (sample_time - tcb->profile_sample_time >= g_profile_period) {
-        tcb->profile_sample_time = sample_time;
-
-        // Report all events as the same PID so that they are grouped in report.
-        pid_t pid = g_pal_enclave.pal_sec.pid;
-        pid_t tid = pid;
-
-        if (g_pal_enclave.profile_with_stack) {
-            sample_stack(tcs, pid, tid);
-        } else {
-            sample_simple(tcs, pid, tid);
-        }
+    if (g_pal_enclave.profile_with_stack) {
+        sample_stack(&gpr);
+    } else {
+        sample_simple(gpr.rip);
     }
+}
+
+void sgx_profile_sample_ocall_inner(void* enclave_gpr) {
+    int ret;
+
+    if (!(g_profile_enabled && g_profile_mode == SGX_PROFILE_MODE_OCALL_INNER))
+        return;
+
+    if (!enclave_gpr)
+        return;
+
+    sgx_pal_gpr_t gpr;
+    ret = debug_read_all(&gpr, enclave_gpr, sizeof(gpr));
+    if (IS_ERR(ret)) {
+        urts_log_error("sgx_profile_sample_ocall_inner: error reading GPR: %d\n", ret);
+        return;
+    }
+
+    if (g_pal_enclave.profile_with_stack) {
+        sample_stack(&gpr);
+    } else {
+        sample_simple(gpr.rip);
+    }
+}
+
+void sgx_profile_sample_ocall_outer(void* ocall_func) {
+    if (!(g_profile_enabled && g_profile_mode == SGX_PROFILE_MODE_OCALL_OUTER))
+        return;
+
+    assert(ocall_func);
+    assert(!g_pal_enclave.profile_with_stack);
+    sample_simple((uint64_t)ocall_func);
 }
 
 void sgx_profile_report_elf(const char* filename, void* addr) {
     int ret;
 
     if (!g_profile_enabled)
+        return;
+
+    if (!strcmp(filename, ""))
+        filename = get_main_exec_path();
+
+    if (!strcmp(filename, "linux-vdso.so.1"))
         return;
 
     // Convert filename to absolute path - some tools (e.g. libunwind in 'perf report') refuse to

--- a/Pal/src/host/Linux-SGX/sgx_profile_glibc.c
+++ b/Pal/src/host/Linux-SGX/sgx_profile_glibc.c
@@ -1,0 +1,38 @@
+/* SPDX-License-Identifier: LGPL-3.0-or-later */
+/* Copyright (C) 2021 Intel Corporation
+ *                    Paweł Marczewski <pawel@invisiblethingslab.com>
+ */
+
+/*
+ * This file defines glibc-dependent function for profiling (sgx_profile_report_host_elfs).
+ * The function uses dl_iterate_phdr() to retrieve a list of host libraries.
+ *
+ * It is implemented in separate file, because PAL headers and glibc headers conflict with each
+ * other.
+ */
+
+#ifdef DEBUG
+
+#define _GNU_SOURCE
+#include <link.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* Function prototypes. Declared also in sgx_internal.h, but we cannot include it here due to header
+ * conflict. */
+void sgx_profile_report_urts_elfs(void);
+void sgx_profile_report_elf(const char* filename, void* addr);
+
+static int callback(struct dl_phdr_info* info,
+                    __attribute__((unused)) size_t size,
+                    __attribute__((unused)) void* data) {
+
+    sgx_profile_report_elf(info->dlpi_name, (void*)info->dlpi_addr);
+    return 0;
+}
+
+void sgx_profile_report_urts_elfs(void) {
+    dl_iterate_phdr(&callback, NULL);
+}
+
+#endif


### PR DESCRIPTION
Based on #2168, I'll rebase once that is merged.

@dimakuv You might be interested in this :)

## Description of the changes <!-- (reasons and measures) -->

This change extends the SGX profiler to handle OCALLs, not only asynchronous enclave exit. Depending on settings, we either record enclave state during OCALL, or the outer OCALL handler being executed.

Example output (mode = "ocall_outer"):

```
# Overhead  Command  Shared Object  Symbol                        
# ........  .......  .............  ..............................
#
    28.91%  pal-sgx  pal-sgx        [.] sgx_ocall_open
    27.61%  pal-sgx  pal-sgx        [.] sgx_ocall_close
    22.41%  pal-sgx  pal-sgx        [.] sgx_ocall_fstat
    17.03%  pal-sgx  pal-sgx        [.] sgx_ocall_getdents
     1.13%  pal-sgx  pal-sgx        [.] sgx_ocall_mmap_untrusted
     0.90%  pal-sgx  pal-sgx        [.] sgx_ocall_cpuid
     0.70%  pal-sgx  pal-sgx        [.] sgx_ocall_munmap_untrusted
     0.53%  pal-sgx  pal-sgx        [.] sgx_ocall_write
     0.25%  pal-sgx  pal-sgx        [.] sgx_ocall_debug_map_add
     0.13%  pal-sgx  pal-sgx        [.] sgx_ocall_pread
     0.05%  pal-sgx  pal-sgx        [.] sgx_ocall_futex
     0.05%  pal-sgx  pal-sgx        [.] sgx_ocall_gettime
     0.05%  pal-sgx  pal-sgx        [.] sgx_ocall_poll
     0.05%  pal-sgx  pal-sgx        [.] sgx_ocall_sleep
     0.05%  pal-sgx  pal-sgx        [.] sgx_ocall_socketpair
     0.03%  pal-sgx  pal-sgx        [.] sgx_ocall_clone_thread
     0.03%  pal-sgx  pal-sgx        [.] sgx_ocall_exit
     0.03%  pal-sgx  pal-sgx        [.] sgx_ocall_listen
     0.03%  pal-sgx  pal-sgx        [.] sgx_ocall_read
     0.03%  pal-sgx  pal-sgx        [.] sgx_ocall_send
     0.03%  pal-sgx  pal-sgx        [.] sgx_ocall_shutdown
```

Example output (mode = "ocall_inner"):

```
#
    99.05%  pal-sgx  libpal.so      [.] sgx_exitless_ocall
            |
            ---sgx_exitless_ocall
               |          
               |--28.92%--ocall_open
               |          |          
               |          |--22.01%--file_attrquery
               |          |          
               |          |--5.40%--dir_open
               |          |          
               |           --1.48%--file_open
               |          
               |--27.61%--ocall_close
               |          |          
               |          |--20.93%--file_attrquery
               |          |          
               |          |--5.40%--dir_close
               |          |          
               |          |--0.73%--file_close
               |          |          
               |           --0.53%--file_open
               |          
               |--22.41%--ocall_fstat
               |          |          
               |          |--20.93%--file_attrquery
               |          |          
               |           --1.48%--file_open
               |          
               |--17.04%--ocall_getdents
               |          dir_read
               |          
               |--1.13%--ocall_mmap_untrusted
               |          |          
               |           --0.90%--load_trusted_file
               |          
               |--0.70%--ocall_munmap_untrusted
               |          file_close
               |          
                --0.53%--ocall_write
                          _DkDebugLog
```

Note that these percentages are all ocall counts, not time spent.

## How to test this PR? <!-- (if applicable) -->

Follow the instructions in documentation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2169)
<!-- Reviewable:end -->
