### PR TITLE
[LibOS] Replace EM_X86_64 with SHIM_ELF_HOST_MACHINE

### DIFF
--- a/LibOS/shim/src/elf/shim_rtld.c
+++ b/LibOS/shim/src/elf/shim_rtld.c
@@ -575,7 +575,7 @@ static int __check_elf_header(void* fbp, size_t len) {
     }
 
     /* Now we check if the host match the elf machine profile */
-    if (ehdr->e_machine != EM_X86_64) {
+    if (ehdr->e_machine != SHIM_ELF_HOST_MACHINE) {
         errstring = "ELF file does not match with the host";
         goto verify_failed;
     }


### PR DESCRIPTION
Signed-off-by: Stefan Berger <stefanb@us.ibm.com>

## Description of the changes <!-- (reasons and measures) -->

Replace EM_X86_64 with SHIM_ELF_HOST_MACHINE

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2170)
<!-- Reviewable:end -->
