### PR TITLE
[PAL] Remove unused and empty `DkInstructionCacheFlush`

### DIFF
--- a/Pal/include/pal/pal.h
+++ b/Pal/include/pal/pal.h
@@ -696,11 +696,6 @@ PAL_NUM DkSystemTimeQuery(void);
  */
 PAL_NUM DkRandomBitsRead(PAL_PTR buffer, PAL_NUM size);
 
-/*!
- * \todo document DkInstructionCacheFlush
- */
-PAL_BOL DkInstructionCacheFlush(PAL_PTR addr, PAL_NUM size);
-
 enum PAL_SEGMENT {
     PAL_SEGMENT_FS = 1,
     PAL_SEGMENT_GS,

--- a/Pal/regression/Symbols.c
+++ b/Pal/regression/Symbols.c
@@ -56,7 +56,6 @@ int main(int argc, char** argv, char** envp) {
 
     PRINT_SYMBOL(DkSystemTimeQuery);
     PRINT_SYMBOL(DkRandomBitsRead);
-    PRINT_SYMBOL(DkInstructionCacheFlush);
 #if defined(__x86_64__)
     PRINT_SYMBOL(DkSegmentRegisterGet);
     PRINT_SYMBOL(DkSegmentRegisterSet);

--- a/Pal/regression/test_pal.py
+++ b/Pal/regression/test_pal.py
@@ -250,7 +250,6 @@ class TC_02_Symbols(RegressionTestCase):
         'DkObjectClose',
         'DkSystemTimeQuery',
         'DkRandomBitsRead',
-        'DkInstructionCacheFlush',
         'DkMemoryAvailableQuota',
     ]
     if ON_X86:

--- a/Pal/src/db_misc.c
+++ b/Pal/src/db_misc.c
@@ -50,22 +50,6 @@ PAL_BOL DkSegmentRegisterSet(PAL_FLG reg, PAL_PTR addr) {
 }
 #endif
 
-PAL_BOL DkInstructionCacheFlush(PAL_PTR addr, PAL_NUM size) {
-    if (!addr || !size) {
-        _DkRaiseFailure(PAL_ERROR_INVAL);
-        return PAL_FALSE;
-    }
-
-    int ret = _DkInstructionCacheFlush((void*)addr, size);
-
-    if (ret < 0) {
-        _DkRaiseFailure(-ret);
-        return PAL_FALSE;
-    }
-
-    return PAL_TRUE;
-}
-
 PAL_NUM DkMemoryAvailableQuota(void) {
     long quota = _DkMemoryAvailableQuota();
     if (quota < 0)

--- a/Pal/src/host/Linux-SGX/db_misc.c
+++ b/Pal/src/host/Linux-SGX/db_misc.c
@@ -93,13 +93,6 @@ int _DkSystemTimeQuery(uint64_t* out_usec) {
     return 0;
 }
 
-int _DkInstructionCacheFlush(const void* addr, int size) {
-    __UNUSED(addr);
-    __UNUSED(size);
-
-    return -PAL_ERROR_NOTIMPLEMENTED;
-}
-
 #define CPUID_CACHE_SIZE 64 /* cache only 64 distinct CPUID entries; sufficient for most apps */
 static struct pal_cpuid {
     unsigned int leaf, subleaf;

--- a/Pal/src/host/Linux/db_misc.c
+++ b/Pal/src/host/Linux/db_misc.c
@@ -57,13 +57,6 @@ size_t _DkRandomBitsRead(void* buffer, size_t size) {
     return 0;
 }
 
-int _DkInstructionCacheFlush(const void* addr, int size) {
-    __UNUSED(addr);
-    __UNUSED(size);
-
-    return -PAL_ERROR_NOTIMPLEMENTED;
-}
-
 int _DkAttestationReport(PAL_PTR user_report_data, PAL_NUM* user_report_data_size,
                          PAL_PTR target_info, PAL_NUM* target_info_size, PAL_PTR report,
                          PAL_NUM* report_size) {

--- a/Pal/src/host/Skeleton/db_misc.c
+++ b/Pal/src/host/Skeleton/db_misc.c
@@ -40,10 +40,6 @@ int _DkSegmentRegisterSet(int reg, void* addr) {
     return -PAL_ERROR_NOTIMPLEMENTED;
 }
 
-int _DkInstructionCacheFlush(const void* addr, int size) {
-    return -PAL_ERROR_NOTIMPLEMENTED;
-}
-
 int _DkCpuIdRetrieve(unsigned int leaf, unsigned int subleaf, unsigned int values[4]) {
     return -PAL_ERROR_NOTIMPLEMENTED;
 }

--- a/Pal/src/pal-symbols
+++ b/Pal/src/pal-symbols
@@ -34,7 +34,6 @@ DkProcessCreate
 DkProcessExit
 DkSystemTimeQuery
 DkRandomBitsRead
-DkInstructionCacheFlush
 DkCpuIdRetrieve
 DkObjectClose
 DkSetExceptionHandler

--- a/Pal/src/pal_internal.h
+++ b/Pal/src/pal_internal.h
@@ -245,7 +245,6 @@ int _DkSystemTimeQuery(uint64_t* out_usec);
 size_t _DkRandomBitsRead(void* buffer, size_t size);
 int _DkSegmentRegisterGet(int reg, void** addr);
 int _DkSegmentRegisterSet(int reg, void* addr);
-int _DkInstructionCacheFlush(const void* addr, int size);
 int _DkCpuIdRetrieve(unsigned int leaf, unsigned int subleaf, unsigned int values[4]);
 int _DkAttestationReport(PAL_PTR user_report_data, PAL_NUM* user_report_data_size,
                          PAL_PTR target_info, PAL_NUM* target_info_size, PAL_PTR report,


### PR DESCRIPTION

## Description of the changes <!-- (reasons and measures) -->
It was empty and there seems to be no reason to keep it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2171)
<!-- Reviewable:end -->
