### PR TITLE
[Pal] Fix {READ,WRITE}_ONCE macros

### DIFF
--- a/Pal/include/lib/api.h
+++ b/Pal/include/lib/api.h
@@ -204,24 +204,12 @@ void* calloc(size_t nmemb, size_t size);
 
 #define COMPILER_BARRIER() ({ __asm__ __volatile__("" ::: "memory"); })
 
-/* Idea taken from: https://elixir.bootlin.com/linux/v5.6/source/include/linux/compiler.h */
-#define READ_ONCE(x)                            \
-    ({                                          \
-        __typeof__(x) _y;                       \
-        COMPILER_BARRIER();                     \
-        __builtin_memcpy(&_y, &(x), sizeof(x)); \
-        COMPILER_BARRIER();                     \
-        _y;                                     \
-    })
+/* We need this artificial assignment in READ_ONCE because of a GCC bug:
+ * https://gcc.gnu.org/bugzilla/show_bug.cgi?id=99258
+ */
+#define READ_ONCE(x) ({ __typeof__(x) y = *(volatile __typeof__(x)*)&(x); y;})
 
-#define WRITE_ONCE(x, y)                        \
-    ({                                          \
-        __typeof__(x) _y = (__typeof__(x))(y);  \
-        COMPILER_BARRIER();                     \
-        __builtin_memcpy(&(x), &_y, sizeof(x)); \
-        COMPILER_BARRIER();                     \
-        _y;                                     \
-    })
+#define WRITE_ONCE(x, y) do { *(volatile __typeof__(x)*)&(x) = (y); } while (0)
 
 /* Libc printf functions. stdio.h/stdarg.h. */
 void fprintfmt(int (*_fputch)(void*, int, void*), void* f, void* putdat, const char* fmt, ...)

--- a/Pal/include/lib/spinlock.h
+++ b/Pal/include/lib/spinlock.h
@@ -24,7 +24,7 @@
 #endif // IN_SHIM
 
 typedef struct {
-    int lock;
+    uint32_t lock;
 #ifdef DEBUG_SPINLOCKS_SHIM
     unsigned int owner;
 #endif // DEBUG_SPINLOCKS_SHIM
@@ -94,7 +94,7 @@ static inline int spinlock_trylock(spinlock_t* lock) {
  * \brief Acquire spinlock.
  */
 static inline void spinlock_lock(spinlock_t* lock) {
-    int val;
+    uint32_t val;
 
     /* First check if lock is already free. */
     if (__atomic_exchange_n(&lock->lock, SPINLOCK_LOCKED, __ATOMIC_ACQUIRE) == SPINLOCK_UNLOCKED) {
@@ -122,7 +122,7 @@ out:
  * \return            0 if acquiring the lock succeeded, 1 if timed out.
  */
 static inline int spinlock_lock_timeout(spinlock_t* lock, unsigned long iterations) {
-    int val;
+    uint32_t val;
 
     /* First check if lock is already free. */
     if (__atomic_exchange_n(&lock->lock, SPINLOCK_LOCKED, __ATOMIC_ACQUIRE) == SPINLOCK_UNLOCKED) {
@@ -157,7 +157,7 @@ out_success:
  * of `*lock` are written into `*expected`. If `desired` is written into `*lock` then true is
  * returned.
  */
-static inline int spinlock_cmpxchg(spinlock_t* lock, int* expected, int desired) {
+static inline int spinlock_cmpxchg(spinlock_t* lock, uint32_t* expected, uint32_t desired) {
     static_assert(SAME_TYPE(&lock->lock, expected), "spinlock is not implemented as int*");
     return __atomic_compare_exchange_n(&lock->lock, expected, desired, /*weak=*/false,
                                        __ATOMIC_ACQUIRE, __ATOMIC_RELAXED);

--- a/Pal/src/host/Linux-SGX/db_main.c
+++ b/Pal/src/host/Linux-SGX/db_main.c
@@ -709,7 +709,7 @@ noreturn void pal_linux_main(char* uptr_libpal_uri, size_t libpal_uri_len, char*
     }
     if (preheat_enclave == 1) {
         for (uint8_t* i = g_pal_sec.heap_min; i < (uint8_t*)g_pal_sec.heap_max; i += g_page_size)
-            READ_ONCE(*i);
+            READ_ONCE(*(size_t*)i);
     }
 
     ret = toml_sizestring_in(g_pal_state.manifest_root, "loader.pal_internal_mem_size",

--- a/Pal/src/host/Linux-SGX/db_mutex.c
+++ b/Pal/src/host/Linux-SGX/db_mutex.c
@@ -31,12 +31,12 @@ int _DkMutexCreate(PAL_HANDLE* handle, int initialCount) {
     PAL_HANDLE mut = malloc(HANDLE_SIZE(mutex));
     SET_HANDLE_TYPE(mut, mutex);
     __atomic_store_n(&mut->mutex.mut.nwaiters.counter, 0, __ATOMIC_SEQ_CST);
-    mut->mutex.mut.locked = malloc_untrusted(sizeof(uint32_t));
+    mut->mutex.mut.locked = malloc_untrusted(sizeof(*mut->mutex.mut.locked));
     if (!mut->mutex.mut.locked) {
         free(mut);
         return -PAL_ERROR_NOMEM;
     }
-    *handle                  = mut;
+    *handle = mut;
     __atomic_store_n(mut->mutex.mut.locked, initialCount, __ATOMIC_SEQ_CST);
     return 0;
 }

--- a/Pal/src/host/Linux-SGX/enclave_ocalls.c
+++ b/Pal/src/host/Linux-SGX/enclave_ocalls.c
@@ -95,7 +95,7 @@ static long sgx_exitless_ocall(uint64_t code, void* ms) {
     if (timedout) {
         /* OCALL takes a lot of time, so fallback to waiting on a futex; at this point we exit
          * enclave to perform syscall; this code is based on Mutex 2 from Futexes are Tricky */
-        int c = SPINLOCK_UNLOCKED;
+        uint32_t c = SPINLOCK_UNLOCKED;
 
         /* at this point can be a subtle data race: RPC thread is only now done with OCALL and
          * moved lock in UNLOCKED state; in this racey case, lock = UNLOCKED = 0 and we do not

--- a/Pal/src/host/Linux/pal_host.h
+++ b/Pal/src/host/Linux/pal_host.h
@@ -146,7 +146,7 @@ typedef struct pal_handle {
             PAL_BOL isnotification;
         } event;
     };
-} * PAL_HANDLE;
+}* PAL_HANDLE;
 
 #define RFD(n)   (1 << (MAX_FDS * 0 + (n)))
 #define WFD(n)   (1 << (MAX_FDS * 1 + (n)))


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

As it turns out, our READ_ONCE macro isn't strong enough to convince GCC to always emit a read.

The interesting part is that we [ported that macro from Linux v5.6](https://elixir.bootlin.com/linux/v5.6/source/include/linux/compiler.h#L182), where it seems to work correctly only for sizes 1, 2, 4 and 8 (these special cases were if-ed out there), and not for other sizes, which it also tries to support. For a demo see https://godbolt.org/z/1Gzq9c.

This implementation in Linux was recently [refactored and simplified](https://github.com/torvalds/linux/commit/a5460b5e5fb82656807840d40d3deaecad094044), because Linux dropped support for old, buggy GCC, which required such workarounds. It seems that this particular bug was fixed during the refactoring, without even noticing that it existed.

So far so good, but when I tried to use [the new implementation](https://elixir.bootlin.com/linux/v5.11.1/source/include/asm-generic/rwonce.h#L44), it turned out to be still broken in some cases. But this time it seems to be a bug in GCC - we [reported it](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=99258) and GCC developers confirmed that it's a bug.

The bug was noticed because `sgx.preheat_enclave` didn't work on some configurations.

After the changes some type mismatches started to get detected by the compiler, so I also had to fix them.

Fixes #2172.

## How to test this PR? <!-- (if applicable) -->

Check if `sgx.preheat_enclave` works on your configuration.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2191)
<!-- Reviewable:end -->
