### PR TITLE
[Examples] Update Apache to 2.4.46

### DIFF
--- a/Examples/apache/Makefile
+++ b/Examples/apache/Makefile
@@ -55,8 +55,11 @@ $(INSTALL_DIR)/bin/httpd: $(HTTPD_SRC)/configure
 	cd $(HTTPD_SRC) && $(MAKE)
 	cd $(HTTPD_SRC) && $(MAKE) install
 
+# We need to patch the Apache makefile: it has broken group-target, which does not work on
+# parallel builds.
 $(HTTPD_SRC)/configure: $(HTTPD_SRC).tar.gz
 	tar --touch -xzf $<
+	cd $(HTTPD_SRC) && patch -p1 -l < ../apache_makefile.patch
 
 $(HTTPD_SRC).tar.gz:
 	$(GRAPHENEDIR)/Scripts/download --output $@ --sha256 $(HTTPD_CHECKSUM) $(foreach mirror,$(HTTPD_MIRRORS),--url $(mirror)httpd/$(HTTPD_SRC).tar.gz)

--- a/Examples/apache/Makefile
+++ b/Examples/apache/Makefile
@@ -13,8 +13,8 @@
 THIS_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 
 INSTALL_DIR ?= $(THIS_DIR)install
-HTTPD_SRC ?= $(THIS_DIR)httpd-2.4.41
-HTTPD_CHECKSUM ?= 3c0f9663240beb0f008acf3b4501c4f339d7467ee345a36c86c46b4d6f3a5461
+HTTPD_SRC ?= $(THIS_DIR)httpd-2.4.46
+HTTPD_CHECKSUM ?= 44b759ce932dc090c0e75c0210b4485ebf6983466fb8ca1b446c8168e1a1aec2
 
 # Mirros for downloading the Apache source code
 HTTPD_MIRRORS ?= \

--- a/Examples/apache/apache_makefile.patch
+++ b/Examples/apache/apache_makefile.patch
@@ -1,0 +1,17 @@
+diff --git a/server/Makefile.in b/server/Makefile.in
+index 1fa334467d0877e014f6b0e29ca581d1ebe79724..dfc6ea87b470c172de75640436187b914dafb321 100644
+--- a/server/Makefile.in
++++ b/server/Makefile.in
+@@ -89,7 +89,11 @@ httpd.exp: exports.c export_vars.h
+ #   developer stuff
+ #   (we really don't expect end users to use these targets!)
+ #
+-util_expr_scan.c util_expr_parse.c util_expr_parse.h: util_expr_scan.l util_expr_parse.y
++util_expr_scan.c util_expr_parse.c util_expr_parse.h: util_expr_outputs
++	@:
++
++.INTERMEDIATE: util_expr_outputs
++util_expr_outputs: util_expr_scan.l util_expr_parse.y
+ 	bison -pap_expr_yy --defines=$(builddir)/util_expr_parse.h \
+ 	    -o $(builddir)/util_expr_parse.c $(srcdir)/util_expr_parse.y
+ 	flex -Pap_expr_yy -o $(builddir)/util_expr_scan.c $(srcdir)/util_expr_scan.l

--- a/Examples/blender/Makefile
+++ b/Examples/blender/Makefile
@@ -62,6 +62,7 @@ blender.manifest: blender.manifest.template trusted-libs | $(RUN_DIR)
 # Make on Ubuntu <= 20.04 doesn't support "Rules with Grouped Targets" (`&:`),
 # we need to hack around.
 blender.sig blender.manifest.sgx: sgx_outputs
+	@:
 
 .INTERMEDIATE: sgx_outputs
 sgx_outputs: $(BLENDER_DIR)/blender blender.manifest \

--- a/Examples/gcc/Makefile
+++ b/Examples/gcc/Makefile
@@ -57,6 +57,7 @@ trusted-libs: ../common_tools/get_deps.sh
 # Make on Ubuntu <= 20.04 doesn't support "Rules with Grouped Targets" (`&:`),
 # we need to hack around.
 gcc.sig gcc.manifest.sgx: sgx_outputs
+	@:
 
 .INTERMEDIATE: sgx_outputs
 sgx_outputs: gcc.manifest

--- a/Examples/pytorch/Makefile
+++ b/Examples/pytorch/Makefile
@@ -52,6 +52,7 @@ include ../../Scripts/Makefile.configs
 # Make on Ubuntu <= 20.04 doesn't support "Rules with Grouped Targets" (`&:`),
 # we need to hack around.
 pytorch.sig pytorch.manifest.sgx: sgx_outputs
+	@:
 
 .INTERMEDIATE: sgx_outputs
 sgx_outputs: pytorch.manifest

--- a/Examples/redis/Makefile
+++ b/Examples/redis/Makefile
@@ -92,6 +92,7 @@ redis-server.manifest: redis-server.manifest.template
 # Make on Ubuntu <= 20.04 doesn't support "Rules with Grouped Targets" (`&:`),
 # we need to hack around.
 redis-server.sig redis-server.manifest.sgx: sgx_outputs
+	@:
 
 .INTERMEDIATE: sgx_outputs
 sgx_outputs: redis-server.manifest $(SRCDIR)/src/redis-server


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Seems our Apache builds fail from time to time (see e.g. https://leeroy.cs.unc.edu/job/graphene/5981/console):
```
# work around flex bug
# http://sourceforge.net/tracker/?func=detail&aid=3029024&group_id=97492&atid=618177
perl -0777 -p -i -e 's,\n(void|int) ap_expr_yy[gs]et_column[^\n]+\)\n.*?\n\},,gs' \
	/home/jenkins/workspace/graphene/Examples/apache/httpd-2.4.41/server/util_expr_scan.c
/usr/share/apr-1.0/build/libtool --silent --mode=link x86_64-linux-gnu-gcc  -pthread         -o gen_test_char  gen_test_char.lo 
gawk -f /home/jenkins/workspace/graphene/Examples/apache/httpd-2.4.41/build/make_exports.awk `cat export_files` > exports.c
/home/jenkins/workspace/graphene/Examples/apache/httpd-2.4.41/server/util_expr_scan.c: In function 'ap_expr_yylex':
/home/jenkins/workspace/graphene/Examples/apache/httpd-2.4.41/server/util_expr_scan.c:1617:6: error: unterminated comment
      /* Note: because we've taken care in
      ^
```

After briefly looking at this it seems that the Apache we use has a race condition in its Makefiles - this very file, which looks like being trimmed when used for build is also preprocessed with some `perl` hacks.
And this is definitely a race condition, because the same file downloaded from Jenkins after the failed build isn't trimmed anymore.

For now let's just try updating Apache and hope that they've already fixed the bug.

## How to test this PR? <!-- (if applicable) -->

Run CI a few times on this PR and see if the bug triggers (OTOH, it was quite rare, so this may not be enough).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2193)
<!-- Reviewable:end -->
