### PR TITLE
[LibOS] Add a patch for a glibc building bug

### DIFF
--- a/LibOS/glibc-patches/glibc-2.27.patch
+++ b/LibOS/glibc-patches/glibc-2.27.patch
@@ -11,6 +11,28 @@ index ef6abeac6d9dd0e9bb1aa68db7f1b64e64f9c9eb..e4872b3d632383b6d771a26cf6fbf745
  
  # This makes all the object files in the parent library archive.
  
+diff --git a/elf/Makefile b/elf/Makefile
+index 2a432d8beebcd207af7643af67379f0a9f527f3a..a58d773125d93a3b38f0185588bc7806c00504b0 100644
+--- a/elf/Makefile
++++ b/elf/Makefile
+@@ -442,7 +442,7 @@ $(objpfx)librtld.map: $(objpfx)dl-allobjs.os $(common-objpfx)libc_pic.a
+ 
+ $(objpfx)librtld.mk: $(objpfx)librtld.map Makefile
+ 	LC_ALL=C \
+-	sed -n 's@^$(common-objpfx)\([^(]*\)(\([^)]*\.os\)) *.*$$@\1 \2@p' \
++	sed -n 's@^$(subst @,\@,$(common-objpfx))\([^(]*\)(\([^)]*\.os\)) *.*$$@\1 \2@p' \
+ 	    $< | \
+ 	while read lib file; do \
+ 	  case $$lib in \
+@@ -450,7 +450,7 @@ $(objpfx)librtld.mk: $(objpfx)librtld.map Makefile
+ 	    LC_ALL=C fgrep -l /$$file \
+ 		  $(common-objpfx)stamp.os $(common-objpfx)*/stamp.os | \
+ 	    LC_ALL=C \
+-	    sed 's@^$(common-objpfx)\([^/]*\)/stamp\.os$$@rtld-\1'" +=$$file@"\
++	    sed 's@^$(subst @,\@,$(common-objpfx))\([^/]*\)/stamp\.os$$@rtld-\1'" +=$$file@"\
+ 	    ;; \
+ 	  */*.a) \
+ 	    echo rtld-$${lib%%/*} += $$file ;; \
 diff --git a/elf/dl-load.c b/elf/dl-load.c
 index 7554a99b5acb153762ab8967f330309ba9c69821..f79ca7fb57bc33b2757a795a527db6b565e09353 100644
 --- a/elf/dl-load.c

--- a/LibOS/glibc-patches/glibc-2.31.patch
+++ b/LibOS/glibc-patches/glibc-2.31.patch
@@ -11,6 +11,28 @@ index 1e9c18f0d866731910d29327b975e359dbb3ea33..3fa0d4a52489b6d05111e76ade0a68cc
  
  # This makes all the object files in the parent library archive.
  
+diff --git a/elf/Makefile b/elf/Makefile
+index 632a4d8b0f6a30e5be7e9d675a81b6e3fd0fdcad..66f178ae675e794c9cff4f6e4870598be77bd6b0 100644
+--- a/elf/Makefile
++++ b/elf/Makefile
+@@ -503,7 +503,7 @@ $(objpfx)librtld.map: $(objpfx)dl-allobjs.os $(common-objpfx)libc_pic.a
+ 
+ $(objpfx)librtld.mk: $(objpfx)librtld.map Makefile
+ 	LC_ALL=C \
+-	sed -n 's@^$(common-objpfx)\([^(]*\)(\([^)]*\.os\)) *.*$$@\1 \2@p' \
++	sed -n 's@^$(subst @,\@,$(common-objpfx))\([^(]*\)(\([^)]*\.os\)) *.*$$@\1 \2@p' \
+ 	    $< | \
+ 	while read lib file; do \
+ 	  case $$lib in \
+@@ -511,7 +511,7 @@ $(objpfx)librtld.mk: $(objpfx)librtld.map Makefile
+ 	    LC_ALL=C fgrep -l /$$file \
+ 		  $(common-objpfx)stamp.os $(common-objpfx)*/stamp.os | \
+ 	    LC_ALL=C \
+-	    sed 's@^$(common-objpfx)\([^/]*\)/stamp\.os$$@rtld-\1'" +=$$file@"\
++	    sed 's@^$(subst @,\@,$(common-objpfx))\([^/]*\)/stamp\.os$$@rtld-\1'" +=$$file@"\
+ 	    ;; \
+ 	  */*.a) \
+ 	    echo rtld-$${lib%%/*} += $$file ;; \
 diff --git a/elf/dl-load.c b/elf/dl-load.c
 index a6b80f93957199e1ef2bcbbcc12302830caae978..b5936e7f1c688001d48c27360f0c838c21bba682 100644
 --- a/elf/dl-load.c


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->
Glibc does not properly escape path when passing it to sed in one of the makefiles. Namely it uses @ as a separator in sed and if such character happens to be part of the path (which sometimes happens on Jenkins), the build blows with wounderful and totally uninformative errors.
This commit adds a Glibc patch to properly escaper @ in paths.

## How to test this PR? <!-- (if applicable) -->
Try building Graphene with `@` in any part of the path (e.g. `/tmp/wat@2/graphene`). Without this PR the build will fail.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2200)
<!-- Reviewable:end -->
