### PR TITLE
[Pal] Set default log level early in enclave init

### DIFF
--- a/Pal/src/db_main.c
+++ b/Pal/src/db_main.c
@@ -19,7 +19,10 @@
 #include "sysdeps/generic/ldsodefs.h"
 #include "toml.h"
 
-PAL_CONTROL g_pal_control;
+PAL_CONTROL g_pal_control = {
+    /* Enable log to catch early initialization errors; it will be overwritten in pal_main(). */
+    .log_level = PAL_LOG_DEFAULT_LEVEL,
+};
 
 PAL_CONTROL* pal_control_addr(void) {
     return &g_pal_control;


### PR DESCRIPTION



## Description of the changes <!-- (reasons and measures) -->

Previously, `g_pal_control.log_level` was not explicitly initialized, so it was set to `0` which didn't print any log messages during early init phase (before parsing the manifest `log_level` setting).

## How to test this PR? <!-- (if applicable) -->

Add in your manifest something like this: `sgx.trusted_files.somefile = "some-real-file"` (note the missing `file:` prefix). Graphene-SGX will fail without any error message. With this PR, the error message will be printed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2201)
<!-- Reviewable:end -->
