### PR TITLE
[LibOS] Allow ioctl(fd, FIONBIO, &off)

### DIFF
--- a/LibOS/shim/include/shim_handle.h
+++ b/LibOS/shim/include/shim_handle.h
@@ -357,8 +357,8 @@ struct shim_handle* get_new_handle(void);
 void get_handle(struct shim_handle* hdl);
 void put_handle(struct shim_handle* hdl);
 
-/* Set handle to non-blocking mode. */
-int set_handle_nonblocking(struct shim_handle* hdl);
+/* Set handle to non-blocking or blocking mode. */
+int set_handle_nonblocking(struct shim_handle* hdl, bool on);
 
 /* file descriptor table */
 struct shim_fd_handle {

--- a/LibOS/shim/src/sys/shim_fcntl.c
+++ b/LibOS/shim/src/sys/shim_fcntl.c
@@ -31,9 +31,9 @@ static int _set_handle_flags(struct shim_handle* hdl, unsigned long arg) {
     return 0;
 }
 
-int set_handle_nonblocking(struct shim_handle* hdl) {
+int set_handle_nonblocking(struct shim_handle* hdl, bool on) {
     lock(&hdl->lock);
-    int ret = _set_handle_flags(hdl, hdl->flags | O_NONBLOCK);
+    int ret = _set_handle_flags(hdl, on ? hdl->flags | O_NONBLOCK : hdl->flags & ~O_NONBLOCK);
     unlock(&hdl->lock);
     return ret;
 }

--- a/LibOS/shim/src/sys/shim_ioctl.c
+++ b/LibOS/shim/src/sys/shim_ioctl.c
@@ -50,7 +50,12 @@ long shim_do_ioctl(unsigned int fd, unsigned int cmd, unsigned long arg) {
             ret = 0;
             break;
         case FIONBIO:
-            ret = set_handle_nonblocking(hdl);
+            if (test_user_memory((void*)arg, sizeof(int), /*write=*/false)) {
+                ret = -EFAULT;
+                break;
+            }
+            int nonblocking_on = *(int*)arg;
+            ret = set_handle_nonblocking(hdl, !!nonblocking_on);
             break;
         case FIONCLEX:
             hdl->flags &= ~FD_CLOEXEC;

--- a/LibOS/shim/src/sys/shim_pipe.c
+++ b/LibOS/shim/src/sys/shim_pipe.c
@@ -54,7 +54,7 @@ static int create_pipes(struct shim_handle* srv, struct shim_handle* cli, int fl
 
     if (flags & O_NONBLOCK) {
         /* `cli` - `hdl2` - has this flag already set by the call to `DkStreamOpen`. */
-        ret = set_handle_nonblocking(srv);
+        ret = set_handle_nonblocking(srv, /*on=*/true);
         if (ret < 0) {
             /* Restore original handle, if any. */
             srv->pal_handle = tmp;


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Previously, Graphene always assumed that `ioctl(fd, FIONBIO)` sets non-blocking mode. In reality, the third argument to ioctl defines whether it marks the socket as blocking or non-blocking.

## How to test this PR? <!-- (if applicable) -->

I didn't find a regression test where to add this new functionality in a reasonable way. But one can try Python with: `python3 -c "import requests; req = requests.get('http://www.example.com'); print(req)"`. It doesn't work on master but works with this fix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2202)
<!-- Reviewable:end -->
