### PR TITLE
[GSC] Improve GSC debugging experience

### DIFF
--- a/Documentation/manpages/gsc.rst
+++ b/Documentation/manpages/gsc.rst
@@ -421,6 +421,15 @@ This example assumes that all prerequisites are installed and configured.
          -v /var/run/aesmd/aesm.socket:/var/run/aesmd/aesm.socket \
          gsc-python -c 'print("HelloWorld!")'
 
+#. You can also start a Bash interactive session in the graphenized Docker
+   image (useful for debugging):
+
+   .. code-block:: sh
+
+      docker run --device=/dev/gsgx --device=/dev/isgx \
+         -v /var/run/aesmd/aesm.socket:/var/run/aesmd/aesm.socket \
+         -it --entrypoint /bin/bash gsc-python
+
 Limitations
 ===========
 

--- a/Tools/gsc/templates/Dockerfile.ubuntu18.04.build.template
+++ b/Tools/gsc/templates/Dockerfile.ubuntu18.04.build.template
@@ -21,7 +21,7 @@ RUN apt-get update \
     && python3 -B -m pip install protobuf jinja2
 
 {% if debug %}
-RUN env DEBIAN_FRONTEND=noninteractive apt-get install -y gdb less strace vim
+RUN env DEBIAN_FRONTEND=noninteractive apt-get install -y gdb less strace vim python3-pyelftools
 {% endif %}
 
 RUN locale-gen en_US.UTF-8
@@ -31,28 +31,46 @@ ENV LANGUAGE en_US.UTF-8
 
 # Copy Graphene runtime and signer tools to /graphene
 RUN mkdir -p /graphene \
+    && mkdir -p /graphene/Pal/src \
     && mkdir -p /graphene/Runtime \
-    && mkdir -p /graphene/python \
+    && mkdir -p /graphene/Scripts \
     && mkdir -p /graphene/Tools \
-    && mkdir -p /graphene/Pal/src
-COPY --from=graphene /graphene/Runtime/ /graphene/Runtime
-COPY --from=graphene /graphene/python /graphene/python
+    && mkdir -p /graphene/python
 COPY --from=graphene /graphene/Pal/src/host/Linux-SGX/generated_offsets.py /graphene/python/
+COPY --from=graphene /graphene/Runtime/ /graphene/Runtime
+COPY --from=graphene /graphene/Scripts/Makefile.configs /graphene/Scripts
+COPY --from=graphene /graphene/Scripts/Makefile.Host /graphene/Scripts
 COPY --from=graphene /graphene/Tools/argv_serializer /graphene/Tools
+COPY --from=graphene /graphene/python /graphene/python
 
 {% if debug %}
+COPY --from=graphene /graphene/Pal/gdb_integration/debug_map_gdb.py \
+                     /graphene/Pal/gdb_integration/
+COPY --from=graphene /graphene/Pal/gdb_integration/pagination_gdb.py \
+                     /graphene/Pal/gdb_integration/
+COPY --from=graphene /graphene/Pal/gdb_integration/graphene.gdb \
+                     /graphene/Pal/gdb_integration/
+
+COPY --from=graphene /graphene/Pal/src/host/Linux/gdb_integration/graphene_linux_gdb.py \
+                     /graphene/Pal/src/host/Linux/gdb_integration/
+RUN ln -sf /graphene/Pal/gdb_integration /graphene/Pal/src/host/Linux/gdb_integration/common
+
 COPY --from=graphene /graphene/Pal/src/host/Linux-SGX/gdb_integration/sgx_gdb.so \
                      /graphene/Pal/src/host/Linux-SGX/gdb_integration/
 COPY --from=graphene /graphene/Pal/src/host/Linux-SGX/gdb_integration/graphene_sgx_gdb.py \
                      /graphene/Pal/src/host/Linux-SGX/gdb_integration/
 COPY --from=graphene /graphene/Pal/src/host/Linux-SGX/gdb_integration/graphene_sgx.gdb \
                      /graphene/Pal/src/host/Linux-SGX/gdb_integration/
+RUN ln -sf /graphene/Pal/gdb_integration /graphene/Pal/src/host/Linux-SGX/gdb_integration/common
 {% endif %}
 
 # Copy helper scripts and Graphene manifest
 COPY *.py /
 COPY apploader.sh /
 COPY entrypoint.manifest /
+
+# For convenience (e.g. for debugging), create a link to pal_loader in the root dir
+RUN ln -sf /graphene/Runtime/pal_loader
 
 # Generate trusted arguments if required
 {% if not insecure_args %}

--- a/Tools/gsc/templates/entrypoint.manifest.template
+++ b/Tools/gsc/templates/entrypoint.manifest.template
@@ -3,7 +3,7 @@ loader.preload = "file:/graphene/Runtime/libsysdb.so"
 
 loader.env.LD_LIBRARY_PATH = "/graphene/Runtime:{{"{{library_paths}}"}}"
 loader.env.PATH = "{{"{{env_path}}"}}"
-loader.log_level = {% if debug %} "debug" {% else %} "error" {% endif %}
+loader.log_level = {% if debug %} "all" {% else %} "error" {% endif %}
 
 fs.root.type = "chroot"
 fs.root.path = "/"


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

This PR makes GDB work correctly inside the Docker container. This PR also changes the log level from "debug" to "all" because it makes more sense to show the complete Graphene trace when debugging GSC.

## How to test this PR? <!-- (if applicable) -->

Manually. Try things like:
```
# cd graphene/Tools/gsc/test

$ SGXDRIVER_REPO=https://github.com/intel/SGXDataCenterAttestationPrimitives.git \
SGXDRIVER_BRANCH="DCAP_1.6 && cp -r driver/linux/* ." \
INTEL_SGX_DEVICE="sgx/enclave" GSC_BUILD_FLAGS="--rm --no-cache -d -L" \
make gsc-ubuntu18.04-numpy

$ docker run --device=/dev/gsgx --device=/dev/sgx/enclave \
-v /var/run/aesmd/aesm.socket:/var/run/aesmd/aesm.socket \
-it --entrypoint /bin/bash gsc-ubuntu18.04-numpy

# inside the Docker container, you can do the usual Graphene stuff
$$$ SGX=1 GDB=1 ./pal_loader entrypoint "-c print('HELLO WORLD')"
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2203)
<!-- Reviewable:end -->
