### PR TITLE
[GSC] Ignore allowed|trusted|protected files specified in user manifest

### DIFF
--- a/Tools/gsc/test/ubuntu18.04-python3.manifest
+++ b/Tools/gsc/test/ubuntu18.04-python3.manifest
@@ -1,2 +1,15 @@
 sgx.enclave_size = "4G"
 sgx.thread_num = 8
+
+# the below three lines are for testing internal GSC logic (they must be skipped); note that
+# the dummy3 line is skipped by GSC because it contains an illegal "=" inside filename
+
+# sgx.allowed_files.dummy1 = "file:commented-out-with-space"
+#sgx.allowed_files.dummy2 = "file:commented-out"
+sgx.allowed_files.dummy3 = "file:weird=file"
+
+# the below files may differ from Docker container to Docker container, so they are marked as
+# allowed (this may be insecure if untrusted host maliciously modified these files!)
+sgx.allowed_files.etchostname = "file:/etc/hostname"
+sgx.allowed_files.etchosts    = "file:/etc/hosts"
+sgx.allowed_files.etcresolv   = "file:/etc/resolv.conf"


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

GSC concatenates the user-provided manifest with the auto-generated manifest. Previously, the auto-generated manifest would include even those files which were already defined in the user-provided manifest. This led to runtime errors (Graphene complains about redefined manifest entries) and didn't allow to white-list files like `/etc/resolv.conf`.

This PR instructs GSC to skip already-defined files (using a heuristic that such manifest entries start with the strings "sgx.allowed_files", "sgx.trusted_files", "sgx.protected_files").

~~Must be rebased after https://github.com/oscarlab/graphene/pull/2203 is merged. First commit of this PR is from there.~~

## How to test this PR? <!-- (if applicable) -->

GSC. I added some lines to the Python3 example. You can check the final manifest manually by inspecting the resulting `gsc-ubuntu18.04-python3`  container.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2204)
<!-- Reviewable:end -->
