### PR TITLE
[LibOS] Remove dead ipc code

### DIFF
--- a/LibOS/shim/include/shim_ipc.h
+++ b/LibOS/shim/include/shim_ipc.h
@@ -106,9 +106,6 @@ struct shim_ipc_msg {
     char msg[] __attribute__((aligned(16)));
 } __attribute__((packed));
 
-struct shim_ipc_port;
-struct shim_thread;
-
 DEFINE_LIST(shim_ipc_msg_with_ack);
 struct shim_ipc_msg_with_ack {
     struct shim_thread* thread;
@@ -423,7 +420,6 @@ void add_ipc_port_by_id(IDTYPE vmid, PAL_HANDLE hdl, IDTYPE type, port_fini fini
                         struct shim_ipc_port** portptr);
 void add_ipc_port(struct shim_ipc_port* port, IDTYPE vmid, IDTYPE type, port_fini fini);
 void del_ipc_port_fini(struct shim_ipc_port* port);
-struct shim_ipc_port* lookup_ipc_port(IDTYPE vmid, IDTYPE type);
 void get_ipc_port(struct shim_ipc_port* port);
 void put_ipc_port(struct shim_ipc_port* port);
 void del_all_ipc_ports(void);
@@ -434,7 +430,6 @@ void put_ipc_info(struct shim_ipc_info* port);
 
 struct shim_ipc_info* create_ipc_info_in_list(IDTYPE vmid, const char* uri, size_t len);
 void put_ipc_info_in_list(struct shim_ipc_info* info);
-struct shim_ipc_info* lookup_ipc_info(IDTYPE vmid);
 
 static inline size_t get_ipc_msg_size(size_t payload) {
     size_t size = sizeof(struct shim_ipc_msg) + payload;

--- a/LibOS/shim/include/shim_ipc.h
+++ b/LibOS/shim/include/shim_ipc.h
@@ -80,7 +80,6 @@ DEFINE_LIST(shim_ipc_info);
 struct shim_ipc_info {
     IDTYPE vmid;
     struct shim_ipc_port* port;
-    PAL_HANDLE pal_handle;
     struct shim_qstr uri;
     LIST_TYPE(shim_ipc_info) hlist;
     REFTYPE ref_count;

--- a/LibOS/shim/src/ipc/shim_ipc.c
+++ b/LibOS/shim/src/ipc/shim_ipc.c
@@ -83,10 +83,6 @@ static struct shim_ipc_info* __create_ipc_info(IDTYPE vmid, const char* uri, siz
 static void __free_ipc_info(struct shim_ipc_info* info) {
     assert(locked(&ipc_info_lock));
 
-    if (info->pal_handle) {
-        DkObjectClose(info->pal_handle);
-        info->pal_handle = NULL;
-    }
     if (info->port)
         put_ipc_port(info->port);
     qstrfree(&info->uri);
@@ -347,14 +343,17 @@ struct shim_ipc_info* create_ipc_info_and_port(bool use_vmid_as_port_name) {
     /* pipe for g_process_ipc_info.self is of format "pipe:<g_process_ipc_info.vmid>", others with
      * random name */
     char uri[PIPE_URI_SIZE];
-    if (create_pipe(NULL, uri, PIPE_URI_SIZE, &info->pal_handle, &info->uri,
-                    use_vmid_as_port_name) < 0) {
+    PAL_HANDLE handle = NULL;
+    if (create_pipe(NULL, uri, PIPE_URI_SIZE, &handle, &info->uri, use_vmid_as_port_name) < 0) {
         put_ipc_info(info);
         return NULL;
     }
 
-    add_ipc_port_by_id(g_process_ipc_info.vmid, info->pal_handle, IPC_PORT_LISTENING, NULL,
-                       &info->port);
+    add_ipc_port_by_id(g_process_ipc_info.vmid, handle, IPC_PORT_LISTENING, NULL, &info->port);
+
+    if (!info->port) {
+        DkObjectClose(handle);
+    }
 
     return info;
 }
@@ -394,19 +393,10 @@ BEGIN_CP_FUNC(ipc_info) {
         *new_info = *info;
         REF_SET(new_info->ref_count, 0);
 
+        assert(!new_info->port);
+
         /* call qstr-specific checkpointing function for new_info->uri */
         DO_CP_IN_MEMBER(qstr, new_info, uri);
-
-        if (info->pal_handle) {
-            struct shim_palhdl_entry* entry;
-            /* call palhdl-specific checkpointing function to checkpoint
-             * info->pal_handle and return created object in entry */
-            DO_CP(palhdl, info->pal_handle, &entry);
-            /* info's PAL handle will be re-opened with new URI during
-             * palhdl restore (see checkpoint.c) */
-            entry->uri     = &new_info->uri;
-            entry->phandle = &new_info->pal_handle;
-        }
     } else {
         /* already checkpointed */
         new_info = (struct shim_ipc_info*)(base + off);

--- a/LibOS/shim/src/ipc/shim_ipc.c
+++ b/LibOS/shim/src/ipc/shim_ipc.c
@@ -167,24 +167,6 @@ void put_ipc_info_in_list(struct shim_ipc_info* info) {
     unlock(&ipc_info_lock);
 }
 
-struct shim_ipc_info* lookup_ipc_info(IDTYPE vmid) {
-    assert(vmid);
-    lock(&ipc_info_lock);
-
-    struct shim_ipc_info* info;
-    LISTP_TYPE(shim_ipc_info)* info_bucket = &info_hlist[CLIENT_HASH(vmid)];
-    LISTP_FOR_EACH_ENTRY(info, info_bucket, hlist) {
-        if (info->vmid == vmid && !qstrempty(&info->uri)) {
-            __get_ipc_info(info);
-            unlock(&ipc_info_lock);
-            return info;
-        }
-    }
-
-    unlock(&ipc_info_lock);
-    return NULL;
-}
-
 struct shim_process_ipc_info* create_process_ipc_info(void) {
     struct shim_process_ipc_info* new_process_ipc_info = calloc(1, sizeof(*new_process_ipc_info));
     if (!new_process_ipc_info)

--- a/LibOS/shim/src/ipc/shim_ipc_helper.c
+++ b/LibOS/shim/src/ipc/shim_ipc_helper.c
@@ -17,9 +17,6 @@
 #include "shim_thread.h"
 #include "shim_utils.h"
 
-// TODO: There's some dead code left in this file after removal of execve-in-new-process quirk. We
-// need to clean it up.
-
 #define IPC_HELPER_STACK_SIZE (g_pal_alloc_align * 4)
 
 static struct shim_lock ipc_port_mgr_lock;
@@ -79,19 +76,12 @@ static ipc_callback ipc_callbacks[] = {
 static int init_self_ipc_port(void) {
     lock(&g_process_ipc_info.lock);
 
+    assert(!g_process_ipc_info.self);
+    /* very first process or clone/fork case: create IPC port from scratch */
+    g_process_ipc_info.self = create_ipc_info_and_port(/*use_vmid_as_port_name=*/true);
     if (!g_process_ipc_info.self) {
-        /* very first process or clone/fork case: create IPC port from scratch */
-        g_process_ipc_info.self = create_ipc_info_and_port(/*use_vmid_as_port_name=*/true);
-        if (!g_process_ipc_info.self) {
-            unlock(&g_process_ipc_info.lock);
-            return -EACCES;
-        }
-    } else {
-        /* execve case: inherited IPC port from parent process */
-        assert(g_process_ipc_info.self->pal_handle && !qstrempty(&g_process_ipc_info.self->uri));
-
-        add_ipc_port_by_id(g_process_ipc_info.self->vmid, g_process_ipc_info.self->pal_handle,
-                           IPC_PORT_LISTENING, /*fini=*/NULL, &g_process_ipc_info.self->port);
+        unlock(&g_process_ipc_info.lock);
+        return -EACCES;
     }
 
     unlock(&g_process_ipc_info.lock);
@@ -107,13 +97,8 @@ static int init_parent_ipc_port(void) {
     lock(&g_process_ipc_info.lock);
     assert(g_process_ipc_info.parent && g_process_ipc_info.parent->vmid);
 
-    /* for execve case, my parent is the parent of my parent (current process transparently inherits
-     * the "real" parent through already opened pal_handle on "temporary" parent's
-     * g_process_ipc_info.parent) */
-    if (!g_process_ipc_info.parent->pal_handle) {
-        /* for clone/fork case, parent is connected on parent_process */
-        g_process_ipc_info.parent->pal_handle = PAL_CB(parent_process);
-    }
+    assert(!g_process_ipc_info.parent->pal_handle);
+    g_process_ipc_info.parent->pal_handle = PAL_CB(parent_process);
 
     add_ipc_port_by_id(g_process_ipc_info.parent->vmid, g_process_ipc_info.parent->pal_handle,
                        IPC_PORT_CONNECTION | IPC_PORT_DIRECTPARENT, /*fini=*/NULL,
@@ -397,27 +382,6 @@ void del_all_ipc_ports(void) {
     }
 
     unlock(&ipc_helper_lock);
-}
-
-struct shim_ipc_port* lookup_ipc_port(IDTYPE vmid, IDTYPE type) {
-    struct shim_ipc_port* port = NULL;
-
-    assert(vmid && type);
-    lock(&ipc_helper_lock);
-
-    struct shim_ipc_port* tmp;
-    LISTP_FOR_EACH_ENTRY(tmp, &port_list, list) {
-        if (tmp->vmid == vmid && (tmp->type & type)) {
-            log_debug("Found port %p (handle %p) for process %u (type %04x)\n", tmp,
-                      tmp->pal_handle, tmp->vmid, tmp->type);
-            port = tmp;
-            __get_ipc_port(port);
-            break;
-        }
-    }
-
-    unlock(&ipc_helper_lock);
-    return port;
 }
 
 #define PORTS_ON_STACK_CNT 32


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->
There is some code in IPC that is not used anymore due to different cleanups.
Additionally `shim_ipc_info::pal_handle` seems not to be needed.

This is the first in probably many PRs cleaning up/rewriting IPC.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2206)
<!-- Reviewable:end -->
