### PR TITLE
[Pal/Linux-SGX] Fallback to calculating TSC freq from Processor freq

### DIFF
--- a/Pal/src/host/Linux-SGX/db_exception.c
+++ b/Pal/src/host/Linux-SGX/db_exception.c
@@ -114,6 +114,9 @@ static void save_pal_context(PAL_CONTEXT* ctx, sgx_cpu_context_t* uc,
 static void emulate_rdtsc_and_print_warning(sgx_cpu_context_t* uc) {
     static int first = 0;
     if (__atomic_exchange_n(&first, 1, __ATOMIC_RELAXED) == 0) {
+        /* if we end up emulating RDTSC/RDTSCP instruction, we cannot use invariant TSC */
+        extern uint64_t g_tsc_hz;
+        g_tsc_hz = 0;
         log_warning("Warning: all RDTSC/RDTSCP instructions are emulated (imprecisely) via "
                     "gettime() syscall.\n");
     }

--- a/Pal/src/host/Linux-SGX/db_main.c
+++ b/Pal/src/host/Linux-SGX/db_main.c
@@ -625,7 +625,6 @@ noreturn void pal_linux_main(char* uptr_libpal_uri, size_t libpal_uri_len, char*
     init_enclave_key();
 
     init_cpuid();
-    init_tsc();
 
     /* now we can add a link map for PAL itself */
     setup_pal_map(&g_pal_map);
@@ -658,6 +657,14 @@ noreturn void pal_linux_main(char* uptr_libpal_uri, size_t libpal_uri_len, char*
     g_linux_state.process_id = g_pal_sec.pid;
 
     SET_ENCLAVE_TLS(ready_for_exceptions, 1UL);
+
+    /* initialize "Invariant TSC" HW feature for fast and accurate gettime and immediately probe
+     * RDTSC instruction inside SGX enclave (via dummy get_tsc) -- it is possible that
+     * the CPU supports invariant TSC but doesn't support executing RDTSC inside SGX enclave, in
+     * this case the SIGILL exception is generated and leads to emulate_rdtsc_and_print_warning()
+     * which unsets invariant TSC, and we end up falling back to the slower ocall_gettime() */
+    init_tsc();
+    (void)get_tsc(); /* must be after `ready_for_exceptions=1` since it may generate SIGILL */
 
     /* Now that enclave memory is set up, parse and store host topology info into g_pal_sec struct */
     ret = parse_host_topo_info(&sec_info);

--- a/Pal/src/host/Linux-SGX/db_misc.c
+++ b/Pal/src/host/Linux-SGX/db_misc.c
@@ -25,7 +25,7 @@
 
 #define TSC_REFINE_INIT_TIMEOUT_USECS 10000000
 
-static uint64_t g_tsc_hz = 0;
+uint64_t g_tsc_hz = 0; /* TSC frequency for fast and accurate time ("invariant TSC" HW feature) */
 static uint64_t g_start_tsc = 0;
 static uint64_t g_start_usec = 0;
 static PAL_LOCK g_tsc_lock = LOCK_INIT;


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Some Intel CPUs return ECX == 0 on CPUID 15H (TSC and Nominal Core Crystal Clock Information Leaf). Previously, Linux-SGX PAL considered this as "no support for invariant TSC" and fell back to issuing `ocall_gettime()`, which hurts SGX performance. In reality, Linux and other software devised a workaround by querying CPUID 16H (Processor Frequency Information Leaf) and calculating the TSC frequency via Processor Base Frequency. This PR adds this logic to Graphene and thus improves SGX performance.

For more context, see:
- https://github.com/torvalds/linux/blob/v5.11/arch/x86/kernel/tsc.c#L621
- https://bugzilla.kernel.org/show_bug.cgi?id=197299
- https://edk2.groups.io/g/devel/message/45750
- https://github.com/acidanthera/bugtracker/issues/448

## How to test this PR? <!-- (if applicable) -->

Performance improvement on some Intel CPUs. We've seen significant performance boost with this PR (Graphene-SGX overhead decreases from 20% to 5%).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2207)
<!-- Reviewable:end -->
