### PR TITLE
[PAL] Move x86_64-specific signal functions into arch-specific file

### DIFF
--- a/Pal/src/host/Linux/Makefile
+++ b/Pal/src/host/Linux/Makefile
@@ -47,6 +47,7 @@ objs = \
 	db_eventfd.o \
 	db_events.o \
 	db_exception.o \
+	db_exception-$(ARCH).o \
 	db_files.o \
 	db_main.o \
 	db_main-$(ARCH).o \

--- a/Pal/src/host/Linux/db_exception-x86_64.c
+++ b/Pal/src/host/Linux/db_exception-x86_64.c
@@ -1,0 +1,50 @@
+/* SPDX-License-Identifier: LGPL-3.0-or-later */
+/* Copyright (C) 2014 Stony Brook University
+ *               2020 Intel Labs
+ */
+
+#include <stddef.h> /* linux/signal.h misses this dependency (for size_t), at least on Ubuntu 16.04.
+                     * We must include it ourselves before including linux/signal.h.
+                     */
+
+#include <linux/signal.h>
+
+#include "sigset.h"
+#include "ucontext.h"
+
+/* in x86_64 kernels, sigaction is required to have a user-defined restorer */
+__asm__(
+".align 16\n"
+".LSTART_restore_rt:\n"
+".type __restore_rt,@function\n"
+"__restore_rt:\n"
+"movq $" XSTRINGIFY(__NR_rt_sigreturn) ", %rax\n"
+"syscall\n"
+);
+
+/* workaround for an old GAS (2.27) bug that incorrectly omits relocations when referencing this
+ * symbol */
+__attribute__((visibility("hidden"))) void __restore_rt(void);
+
+int arch_do_rt_sigprocmask(int sig, int how) {
+    __sigset_t mask;
+    __sigemptyset(&mask);
+    __sigaddset(&mask, sig);
+
+    return INLINE_SYSCALL(rt_sigprocmask, 4, how, &mask, NULL, sizeof(__sigset_t));
+}
+
+int arch_do_rt_sigaction(int sig, void* handler,
+                         const int* async_signals, size_t num_async_signals) {
+    struct sigaction action = {0};
+    action.sa_handler  = handler;
+    action.sa_flags    = SA_SIGINFO | SA_ONSTACK | SA_RESTORER;
+    action.sa_restorer = __restore_rt;
+
+    /* disallow nested asynchronous signals during exception handling */
+    __sigemptyset((__sigset_t*)&action.sa_mask);
+    for (size_t i = 0; i < num_async_signals; i++)
+        __sigaddset((__sigset_t*)&action.sa_mask, async_signals[i]);
+
+    return INLINE_SYSCALL(rt_sigaction, 4, sig, &action, NULL, sizeof(__sigset_t));
+}

--- a/Pal/src/host/Linux/db_exception.c
+++ b/Pal/src/host/Linux/db_exception.c
@@ -22,50 +22,19 @@
 #include "pal_linux.h"
 #include "pal_linux_defs.h"
 #include "pal_security.h"
-#include "sigset.h"
 #include "ucontext.h"
-
-#if defined(__x86_64__)
-/* in x86_64 kernels, sigaction is required to have a user-defined restorer */
-__asm__(
-".align 16\n"
-".LSTART_restore_rt:\n"
-".type __restore_rt,@function\n"
-"__restore_rt:\n"
-"movq $" XSTRINGIFY(__NR_rt_sigreturn) ", %rax\n"
-"syscall\n"
-);
-
-/* workaround for an old GAS (2.27) bug that incorrectly omits relocations when referencing this
- * symbol */
-__attribute__((visibility("hidden"))) void __restore_rt(void);
-#endif  /* defined(__x86_64__) */
 
 static const int ASYNC_SIGNALS[] = {SIGTERM, SIGCONT};
 
 static int block_signal(int sig, bool block) {
     int how = block ? SIG_BLOCK : SIG_UNBLOCK;
+    int ret = arch_do_rt_sigprocmask(sig, how);
 
-    __sigset_t mask;
-    __sigemptyset(&mask);
-    __sigaddset(&mask, sig);
-
-    int ret = INLINE_SYSCALL(rt_sigprocmask, 4, how, &mask, NULL, sizeof(__sigset_t));
     return IS_ERR(ret) ? unix_to_pal_error(ERRNO(ret)) : 0;
 }
 
 static int set_signal_handler(int sig, void* handler) {
-    struct sigaction action = {0};
-    action.sa_handler  = handler;
-    action.sa_flags    = SA_SIGINFO | SA_ONSTACK | SA_RESTORER;
-    action.sa_restorer = __restore_rt;
-
-    /* disallow nested asynchronous signals during exception handling */
-    __sigemptyset((__sigset_t*)&action.sa_mask);
-    for (size_t i = 0; i < ARRAY_SIZE(ASYNC_SIGNALS); i++)
-        __sigaddset((__sigset_t*)&action.sa_mask, ASYNC_SIGNALS[i]);
-
-    int ret = INLINE_SYSCALL(rt_sigaction, 4, sig, &action, NULL, sizeof(__sigset_t));
+    int ret = arch_do_rt_sigaction(sig, handler, ASYNC_SIGNALS, ARRAY_SIZE(ASYNC_SIGNALS));
     if (IS_ERR(ret))
         return unix_to_pal_error(ERRNO(ret));
 

--- a/Pal/src/host/Linux/pal_host.h
+++ b/Pal/src/host/Linux/pal_host.h
@@ -154,4 +154,8 @@ typedef struct pal_handle {
 
 #define HANDLE_TYPE(handle) ((handle)->hdr.type)
 
+int arch_do_rt_sigprocmask(int sig, int how);
+int arch_do_rt_sigaction(int sig, void* handler,
+                         const int* async_signals, size_t num_async_signals);
+
 #endif /* PAL_HOST_H */


### PR DESCRIPTION
Move x86_64-specific signal functions into arch-specific file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2212)
<!-- Reviewable:end -->
