### PR TITLE
[CI] LTP: Disable flaky sendfile{05,08}{,_64} tests

### DIFF
--- a/LibOS/shim/test/ltp/ltp.cfg
+++ b/LibOS/shim/test/ltp/ltp.cfg
@@ -2036,6 +2036,15 @@ skip = yes
 [sendfile04_64]
 skip = yes
 
+# Fails from time to time in CI on an assert in IPC code:
+# assert failed ipc/shim_ipc_ranges.c:706 !qstrempty(&g_process_ipc_info.ns->uri)
+[sendfile05]
+skip = yes
+
+# Same as sendfile05.
+[sendfile05_64]
+skip = yes
+
 [sendfile06]
 skip = yes
 
@@ -2046,6 +2055,14 @@ skip = yes
 skip = yes
 
 [sendfile07_64]
+skip = yes
+
+# Fails from time to time in CI.
+[sendfile08]
+skip = yes
+
+# Fails from time to time in CI.
+[sendfile08_64]
 skip = yes
 
 [sendfile09]


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

These tests are failing pretty often in CI, let's take them out until IPC subsystem is rewritten (see #2107).

## How to test this PR? <!-- (if applicable) -->

CI.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2215)
<!-- Reviewable:end -->
