### PR TITLE
[PAL/Linux-SGX] Fix sysfs socket sanitization check

### DIFF
--- a/Pal/src/host/Linux-SGX/db_main.c
+++ b/Pal/src/host/Linux-SGX/db_main.c
@@ -333,14 +333,14 @@ static int sanitize_core_topology_info(PAL_CORE_TOPO_INFO* core_topology, int64_
     return 0;
 }
 
-/* TODO: Cross verify against numa_topology[idx].cpumap to ensure that one core cannot be present
- * in 2 sockets */
-static int sanitize_socket_info(int* cpu_socket, int64_t num_nodes, int64_t num_cores) {
-    if (num_nodes == 0 || num_cores == 0)
+static int sanitize_socket_info(int* cpu_socket, int64_t num_cores) {
+    if (num_cores == 0)
         return -ENOENT;
 
     for (int64_t idx = 0; idx < num_cores; idx++) {
-        if (!IS_IN_RANGE_INCL(cpu_socket[idx], 0, num_nodes - 1))
+        /* Virtual environments such as QEMU may assign each core to a separate socket/package with
+         * one or more NUMA nodes. So we check against the number of online logical cores. */
+        if (!IS_IN_RANGE_INCL(cpu_socket[idx], 0, num_cores - 1))
             return -EINVAL;
     }
     return 0;
@@ -429,7 +429,7 @@ static int parse_host_topo_info(struct pal_sec* sec_info) {
     g_pal_sec.topo_info.num_cache_index = num_cache_index;
 
     /* Sanitize logical core -> socket mappings */
-    int ret = sanitize_socket_info(sec_info->cpu_socket, num_cache_index, online_logical_cores);
+    int ret = sanitize_socket_info(sec_info->cpu_socket, online_logical_cores);
     if (ret < 0) {
         log_error("Sanitization of logical core -> socket mappings failed\n");
         return -1;


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->
In graphene, the current assumption is that number of sockets is equal to the number of nodes which is true for most Intel platforms. But virtual environments like QEMU can have each core in separate socket/package and just have one numa node. For such cases check against number of online logical processors instead of number of numa nodes.

PS: Although checking against numa nodes against socket was the intention, current code checks against num of cache index which is incorrect.

Signed-off-by: Vijay Dhanraj <vijay.dhanraj@intel.com>

The figure below shows the case under virtual environment like QEMU.
![VM_Centos_topo](https://user-images.githubusercontent.com/37005992/110395532-28b39300-8023-11eb-8f4a-28dff0fe2f5c.png)

vs Baremetal Server
![baremetal_Ubuntu_topo](https://user-images.githubusercontent.com/37005992/110395609-4a147f00-8023-11eb-89d3-f2b74b13a7f1.png)


## How to test this PR? <!-- (if applicable) -->
Please run LibOS regression tests under virtual environments like QEMU.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2218)
<!-- Reviewable:end -->
