### PR TITLE
[Pal/{lib,Linux-SGX}] Add seqlocks and use them in SGX's _DkSystemTimeQuery()

### DIFF
--- a/LibOS/shim/test/regression/.gitignore
+++ b/LibOS/shim/test/regression/.gitignore
@@ -61,6 +61,7 @@
 /getdents
 /getsockname
 /getsockopt
+/gettimeofday
 /groups
 /helloworld
 /host_root_fs

--- a/LibOS/shim/test/regression/Makefile
+++ b/LibOS/shim/test/regression/Makefile
@@ -40,6 +40,7 @@ c_executables = \
 	getdents \
 	getsockname \
 	getsockopt \
+	gettimeofday \
 	groups \
 	helloworld \
 	host_root_fs \
@@ -149,6 +150,7 @@ CFLAGS-spinlock += -I$(PALDIR)/../include/lib -I$(PALDIR)/../include/arch/$(ARCH
 CFLAGS-sigaction_per_process += -pthread
 CFLAGS-signal_multithread += -pthread
 CFLAGS-pthread_set_get_affinity += -pthread
+CFLAGS-gettimeofday += -pthread
 
 CFLAGS-attestation += -I$(PALDIR)/../lib/crypto/mbedtls/crypto/include \
                       -I$(PALDIR)/host/Linux-SGX \

--- a/LibOS/shim/test/regression/gettimeofday.c
+++ b/LibOS/shim/test/regression/gettimeofday.c
@@ -1,0 +1,62 @@
+#include <err.h>
+#include <errno.h>
+#include <pthread.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/time.h>
+#include <unistd.h>
+
+#define MAX_TIME_DIFF_SEC 20
+#define THREAD_NUM 4
+#define ITERATIONS 1000000
+
+struct timeval base_tv;
+
+static void* foo(void* arg) {
+    int ret;
+
+    for (size_t i = 0; i < ITERATIONS; i++) {
+        struct timeval tv;
+        ret = gettimeofday(&tv, NULL);
+        if (ret < 0)
+            err(1, "thread gettimeofday");
+
+        if (tv.tv_sec < base_tv.tv_sec || tv.tv_sec - base_tv.tv_sec > MAX_TIME_DIFF_SEC)
+            errx(1, "Retrieved time is more than 20 seconds away from base time");
+    }
+
+    return NULL;
+}
+
+int main(int argc, char** argv) {
+    int ret;
+
+    ret = gettimeofday(&base_tv, NULL);
+    if (ret < 0)
+        err(1, "base gettimeofday");
+
+    printf("Starting time: %lu sec, %lu usec\n", base_tv.tv_sec, base_tv.tv_usec);
+
+    pthread_t thread[THREAD_NUM];
+    for (size_t i = 0; i < THREAD_NUM; i++) {
+        pthread_create(&thread[i], NULL, foo, NULL);
+    }
+    for (size_t i = 0; i < THREAD_NUM; i++) {
+        pthread_join(thread[i], NULL);
+    }
+
+    struct timeval end_tv;
+    ret = gettimeofday(&end_tv, NULL);
+    if (ret < 0)
+        err(1, "base gettimeofday");
+
+    uint64_t sec_diff  = end_tv.tv_sec - base_tv.tv_sec -
+                         (end_tv.tv_usec < base_tv.tv_usec ? 1 : 0);
+    uint64_t usec_diff = end_tv.tv_usec > base_tv.tv_usec ? end_tv.tv_usec - base_tv.tv_usec
+                                                          : base_tv.tv_usec - end_tv.tv_usec;
+    printf("Finish time: %lu sec, %lu usec (passed: %lu sec, %lu usec)\n", end_tv.tv_sec,
+           end_tv.tv_usec, sec_diff, usec_diff);
+    puts("TEST OK");
+    return 0;
+}

--- a/LibOS/shim/test/regression/test_libos.py
+++ b/LibOS/shim/test/regression/test_libos.py
@@ -528,6 +528,10 @@ class TC_30_Syscall(RegressionTestCase):
         stdout, _ = self.run_binary(['pthread_set_get_affinity', '1000'])
         self.assertIn('TEST OK', stdout)
 
+    def test_103_gettimeofday(self):
+        stdout, _ = self.run_binary(['gettimeofday'])
+        self.assertIn('TEST OK', stdout)
+
 @unittest.skipUnless(HAS_SGX,
     'This test is only meaningful on SGX PAL because only SGX catches raw '
     'syscalls and redirects to Graphene\'s LibOS. If we will add seccomp to '

--- a/Pal/include/lib/seqlock.h
+++ b/Pal/include/lib/seqlock.h
@@ -1,0 +1,89 @@
+/* SPDX-License-Identifier: LGPL-3.0-or-later */
+/* Copyright (C) 2021 Intel Labs */
+
+/* NOTE: This seqlock implementation follows the spinlock one; see spinlock.h for details.
+ *       This seqlock implementation is based on the Linux one; see include/linux/seqlock.h.
+ *
+ * Reader/writer consistent mechanism with fast lock-free readers and without starving writers.
+ * Seqlocks allow readers to race with writers, but readers detect when a race occurs and retry the
+ * critical section (i.e., reads are speculative). Writers synchronize their accesses with other
+ * writers via a spinlock, but never wait for readers.
+ *
+ * Seqlocks can be only used when readers do not mutate any shared state and do not use pointers.
+ * For example, seqlocks are a perfect fit for time management routines. Typical usage for readers:
+ *     do {
+ *         seq = read_seqbegin(&foo);
+ *         ...
+ *     } while (read_seqretry(&foo, seq));
+ */
+
+#ifndef _SEQLOCK_H
+#define _SEQLOCK_H
+
+#include "api.h"
+#include "cpu.h"
+#include "spinlock.h"
+
+typedef struct {
+    uint32_t sequence;
+    spinlock_t lock;
+} seqlock_t;
+
+/*!
+ * \brief Initialize seqlock with *static* storage duration.
+ */
+#define INIT_SEQLOCK_UNLOCKED { .sequence = 0, .lock = INIT_SPINLOCK_UNLOCKED }
+
+
+/*!
+ * \brief Initialize seqlock with *dynamic* storage duration.
+ */
+static inline void seqlock_init(seqlock_t* sl) {
+    __atomic_store_n(&sl->sequence, 0, __ATOMIC_RELAXED);
+    spinlock_init(&sl->lock);
+}
+
+/*!
+ * \brief Start a reader-side critical section (no locking).
+ */
+static inline uint32_t read_seqbegin(seqlock_t* sl) {
+    uint32_t start;
+    while (true) {
+        start = __atomic_load_n(&sl->sequence, __ATOMIC_RELAXED);
+        if ((start & 1) == 0) {
+            /* there is no writer in the middle of an update, data is currently consistent */
+            break;
+        }
+        CPU_RELAX();
+    }
+    RMB();
+    return start;
+}
+
+/*!
+ * \brief Returns true if reader must retry the critical section.
+ */
+static inline bool read_seqretry(seqlock_t* sl, uint32_t start) {
+    RMB();
+    return start != __atomic_load_n(&sl->sequence, __ATOMIC_RELAXED);
+}
+
+/*!
+ * \brief Start a writer-side critical section (acquires spinlock).
+ */
+static inline void write_seqbegin(seqlock_t* sl) {
+    spinlock_lock(&sl->lock);
+    __atomic_add_fetch(&sl->sequence, 1, __ATOMIC_RELAXED);
+    WMB();
+}
+
+/*!
+ * \brief End a writer-side critical section (releases spinlock).
+ */
+static inline void write_seqend(seqlock_t* sl) {
+    WMB();
+    __atomic_add_fetch(&sl->sequence, 1, __ATOMIC_RELAXED);
+    spinlock_unlock(&sl->lock);
+}
+
+#endif // _SEQLOCK_H


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

For gettime emulation, Linux-SGX PAL uses RDTSC instruction if its execution is allowed inside the SGX enclave and if the CPU supports Invariant TSC. Previously, this code path used a global spinlock to synchronize read/write accesses to shared-time-variables (threads very frequently read these shared variables and very rarely update them).

Using a spinlock led to significant performance overhead due to contention between readers (on some systems, around 140 simultaneous reader threads). This commit introduces seqlocks to allow fast lock-free readers, and replaces spinlock with a seqlock in `_DkSystemTimeQuery()`.

## How to test this PR? <!-- (if applicable) -->

New test to sanity-check `gettimeofday()` emulation on Linux-SGX was added to LibOS regression suite.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2222)
<!-- Reviewable:end -->
