### PR TITLE
[Examples][Docs] Update lighttpd example and doc to utilize tmpfs feature

### DIFF
--- a/Documentation/manifest-syntax.rst
+++ b/Documentation/manifest-syntax.rst
@@ -263,21 +263,29 @@ FS mount points
 
 ::
 
-    fs.mount.[identifier].type = "[chroot|tmpfs|...]"
+    fs.mount.[identifier].type = "[chroot|tmpfs]"
     fs.mount.[identifier].path = "[PATH]"
     fs.mount.[identifier].uri  = "[URI]"
 
-This syntax specifies how file systems are mounted inside the library OS. For
-dynamically linked binaries, usually at least one `chroot` mount point is
-required in the manifest (the mount point of the Glibc library).
+Graphene currently supports two types of mount points:
 
-When`tmpfs` mount point used, files in "[PATH]" are stored in to memory instead
-of in to "[URI]". "[PATH]" is always empty when Graphene instance starts no
-matter what string "[URI]" is. On Graphene instance exit, files and directories
-in "[PATH]" will be lost. Note that `mmap` a tmpfs file is not implemented.
+* ``chroot``: Host-backed files. All host files and sub-directories found under
+  ``[URI]`` are forwarded to a Graphene instance and placed under ``[PATH]``.
+  For example, with a host-level path specified as
+  ``fs.mount.lib.uri = "file:graphene/Runtime/"`` and forwarded to Graphene via
+  ``fs.mount.lib.path = "/lib"``, a host-level file
+  ``graphene/Runtime/libc.so.6`` is visible to graphenized application as
+  ``/lib/libc.so.6``. This concept is similar to FreeBSD's chroot and to
+  Docker's named volumes. Files under ``chroot`` mount points support mmap and
+  fork/clone.
 
-**Note**: The tmpfs files are *not* cloned during fork/clone and cannot be
-synchronized between processes.
+* ``tmpfs``: Temporary in-memory-only files. These files are *not* backed by
+  host-level files. The tmpfs files are created under ``[PATH]`` (this path is
+  empty on Graphene instance startup) and are destroyed when a Graphene
+  instance terminates. The ``[URI]`` parameter is always ignored. ``tmpfs``
+  is especially useful in trusted environments (like Intel SGX) for securely
+  storing temporary files. This concept is similar to Linux's tmpfs. Files
+  under ``tmpfs`` mount points currently do *not* support mmap and fork/clone.
 
 ::
 

--- a/Documentation/manifest-syntax.rst
+++ b/Documentation/manifest-syntax.rst
@@ -263,16 +263,21 @@ FS mount points
 
 ::
 
-    fs.mount.[identifier].type = "[chroot|...]"
+    fs.mount.[identifier].type = "[chroot|tmpfs|...]"
     fs.mount.[identifier].path = "[PATH]"
     fs.mount.[identifier].uri  = "[URI]"
 
 This syntax specifies how file systems are mounted inside the library OS. For
-dynamically linked binaries, usually at least one mount point is required in the
-manifest (the mount point of the Glibc library).
+dynamically linked binaries, usually at least one `chroot` mount point is
+required in the manifest (the mount point of the Glibc library).
 
-Start (current working) directory
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+When`tmpfs` mount point used, files in "[PATH]" are stored in to memory instead
+of in to "[URI]". "[PATH]" is always empty when Graphene instance starts no
+matter what string "[URI]" is. On Graphene instance exit, files and directories
+in "[PATH]" will be lost. Note that `mmap` a tmpfs file is not implemented.
+
+**Note**: The tmpfs files are *not* cloned during fork/clone and cannot be
+synchronized between processes.
 
 ::
 

--- a/Documentation/manifest-syntax.rst
+++ b/Documentation/manifest-syntax.rst
@@ -267,6 +267,10 @@ FS mount points
     fs.mount.[identifier].path = "[PATH]"
     fs.mount.[identifier].uri  = "[URI]"
 
+This syntax specifies how file systems are mounted inside the library OS. For
+dynamically linked binaries, usually at least one `chroot` mount point is
+required in the manifest (the mount point of the Glibc library).
+
 Graphene currently supports two types of mount points:
 
 * ``chroot``: Host-backed files. All host files and sub-directories found under
@@ -286,6 +290,9 @@ Graphene currently supports two types of mount points:
   is especially useful in trusted environments (like Intel SGX) for securely
   storing temporary files. This concept is similar to Linux's tmpfs. Files
   under ``tmpfs`` mount points currently do *not* support mmap and fork/clone.
+
+Start (current working) directory
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 ::
 

--- a/Examples/lighttpd/Makefile
+++ b/Examples/lighttpd/Makefile
@@ -2,8 +2,8 @@ THIS_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 
 INSTALL_DIR ?= $(THIS_DIR)install
 
-LIGHTTPD_SRC ?= $(THIS_DIR)lighttpd-1.4.54
-LIGHTTPD_HASH ?= 5151d38cb7c4c40effa13710e77ebdbef899f945b062cf32befc02d128ac424c
+LIGHTTPD_SRC ?= $(THIS_DIR)lighttpd-1.4.59
+LIGHTTPD_HASH ?= e266e389ddb79bf17b8e8d9022aec95ae839c6f3159822f402df8d8df8a13f65
 
 LIGHTTPD_MIRRORS ?= \
 	https://download.lighttpd.net/lighttpd/releases-1.4.x/
@@ -36,7 +36,7 @@ include ../../Scripts/Makefile.configs
 # installing the binaries.
 $(INSTALL_DIR)/sbin/lighttpd: $(LIGHTTPD_SRC)/configure
 	cd $(LIGHTTPD_SRC) && ./configure --prefix=$(abspath $(INSTALL_DIR)) \
-		--without-openssl --without-pcre --without-zlib --without-bzip2
+		--without-openssl --without-pcre --without-bzip2
 	cd $(LIGHTTPD_SRC) && $(MAKE)
 	cd $(LIGHTTPD_SRC) && $(MAKE) install
 
@@ -95,8 +95,8 @@ lighttpd-server.conf:
 
 lighttpd.conf:
 	@$(RM) $@
-	@echo "include \"lighttpd-server.conf\""                >> $@
-	@echo "include \"lighttpd-generic.conf\""               >> $@
+	@echo "include \"./lighttpd-server.conf\""              >> $@
+	@echo "include \"./lighttpd-generic.conf\""             >> $@
 
 # Generate variously-sized HTML files in $(RANDOM_DIR)
 RANDOM_DIR = $(INSTALL_DIR)/html/random

--- a/Examples/lighttpd/README.md
+++ b/Examples/lighttpd/README.md
@@ -31,9 +31,10 @@ or Graphene-SGX, respectively.
 Because these commands will start the lighttpd server in the foreground, you will need to open
 another console to run the client.
 
-Once the server has started, you can test it with `wget`
+Once the server has started, you can test it with `wget` or `curl`
 
     wget http://127.0.0.1:8003/random/10K.1.html
+    curl --compressed http://127.0.0.1:8003/random/10K.1.html -o 10K.1.html
 
 You may also run the benchmark script using `ab` (Apachebench)
 

--- a/Examples/lighttpd/lighttpd-generic.conf
+++ b/Examples/lighttpd/lighttpd-generic.conf
@@ -64,3 +64,11 @@ mimetype.assign            = (
 # make the default mime type application/octet-stream.
   ""              =>      "application/octet-stream",
 )
+
+server.modules           += ("mod_deflate")
+deflate.mimetypes         = ("text/plain", "text/html")
+deflate.allowed-encodings = ("brotli", "gzip", "deflate")
+deflate.cache-dir         = "/var/tmp/lighttpd/cache"
+deflate.max-compress-size = 131072
+deflate.min-compress-size = 256
+deflate.compression-level = 9

--- a/Examples/lighttpd/lighttpd.manifest.template
+++ b/Examples/lighttpd/lighttpd.manifest.template
@@ -49,7 +49,7 @@ fs.mount.cwd.uri = "file:$(INSTALL_DIR)"
 # Mount lighttpd's default server.upload-dirs path
 fs.mount.var_tmp.type = "tmpfs"
 fs.mount.var_tmp.path = "/var/tmp"
-fs.mount.var_tmp.uri = "file:/var/tmp"
+fs.mount.var_tmp.uri = "file:dummy-unused-by-tmpfs-uri"
 
 # SGX general options
 

--- a/Examples/lighttpd/lighttpd.manifest.template
+++ b/Examples/lighttpd/lighttpd.manifest.template
@@ -47,7 +47,7 @@ fs.mount.cwd.path = "$(INSTALL_DIR_ABSPATH)"
 fs.mount.cwd.uri = "file:$(INSTALL_DIR)"
 
 # Mount lighttpd's default server.upload-dirs path
-fs.mount.var_tmp.type = "chroot"
+fs.mount.var_tmp.type = "tmpfs"
 fs.mount.var_tmp.path = "/var/tmp"
 fs.mount.var_tmp.uri = "file:/var/tmp"
 
@@ -87,6 +87,7 @@ sgx.trusted_files.nss_files = "file:$(ARCH_LIBDIR)/libnss_files.so.2"
 sgx.trusted_files.mod_indexfile = "file:$(INSTALL_DIR)/lib/mod_indexfile.so"
 sgx.trusted_files.mod_dirlisting = "file:$(INSTALL_DIR)/lib/mod_dirlisting.so"
 sgx.trusted_files.mod_staticfile = "file:$(INSTALL_DIR)/lib/mod_staticfile.so"
+sgx.trusted_files.mod_deflate = "file:$(INSTALL_DIR)/lib/mod_deflate.so"
 
 # Trusted configuration files
 sgx.trusted_files.conf = "file:lighttpd.conf"


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->
tmpfs mount point was added In #2124, followed by this one to utilize it.

Descriptions and usage are added to `FS mount points` section of `manifest-syntax` page.

`deflate.cache-dir` conf is introduced to `lighttpd` in 1.4.56.
[lighttpd wiki](https://redmine.lighttpd.net/projects/1/wiki/docs_moddeflate)
>Output compression reduces the network load and can improve the overall throughput of the webserver. All major http-clients support compression by announcing it in the Accept-Encoding header. 
>deflate.cache-dir (since 1.4.56) is the location under which to store cache of compressed files. Cleaning the cache is left to the user.

Cache can contain sensitive data. So tmpfs can be used for it.
`curl --compressed` explicitly requests a compressed response using one of the algorithms curl supports. It triggers lighttpd cache while `wget` doesn't.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2223)
<!-- Reviewable:end -->
