### PR TITLE
 [LibOS] Connect to IPC leader at process startup

### DIFF
--- a/LibOS/shim/src/ipc/shim_ipc_helper.c
+++ b/LibOS/shim/src/ipc/shim_ipc_helper.c
@@ -48,11 +48,8 @@ typedef int (*ipc_callback)(struct shim_ipc_msg* msg, struct shim_ipc_port* port
 static ipc_callback ipc_callbacks[] = {
     [IPC_MSG_RESP]          = &ipc_resp_callback,
     [IPC_MSG_CHILDEXIT]     = &ipc_cld_exit_callback,
-    [IPC_MSG_FINDNS]        = &ipc_findns_callback,
-    [IPC_MSG_TELLNS]        = &ipc_tellns_callback,
     [IPC_MSG_LEASE]         = &ipc_lease_callback,
     [IPC_MSG_OFFER]         = &ipc_offer_callback,
-    [IPC_MSG_RENEW]         = &ipc_renew_callback,
     [IPC_MSG_SUBLEASE]      = &ipc_sublease_callback,
     [IPC_MSG_QUERY]         = &ipc_query_callback,
     [IPC_MSG_QUERYALL]      = &ipc_queryall_callback,
@@ -74,67 +71,68 @@ static ipc_callback ipc_callbacks[] = {
 };
 
 static int init_self_ipc_port(void) {
-    lock(&g_process_ipc_info.lock);
-
     assert(!g_process_ipc_info.self);
     /* very first process or clone/fork case: create IPC port from scratch */
     g_process_ipc_info.self = create_ipc_info_and_port(/*use_vmid_as_port_name=*/true);
     if (!g_process_ipc_info.self) {
-        unlock(&g_process_ipc_info.lock);
-        return -EACCES;
+        return -ENOMEM;
     }
 
-    unlock(&g_process_ipc_info.lock);
     return 0;
 }
 
 static int init_parent_ipc_port(void) {
-    if (!PAL_CB(parent_process) || !g_process_ipc_info.parent) {
+    if (!PAL_CB(parent_process)) {
         /* no parent process, no sense in creating parent IPC port */
         return 0;
     }
 
-    lock(&g_process_ipc_info.lock);
     assert(g_process_ipc_info.parent && g_process_ipc_info.parent->vmid);
 
     add_ipc_port_by_id(g_process_ipc_info.parent->vmid, PAL_CB(parent_process),
                        IPC_PORT_CONNECTION | IPC_PORT_DIRECTPARENT, /*fini=*/NULL,
                        &g_process_ipc_info.parent->port);
 
-    unlock(&g_process_ipc_info.lock);
     return 0;
+}
+
+static void ipc_leader_disconnect_callback(struct shim_ipc_port* port, IDTYPE vmid) {
+    __UNUSED(port);
+    __UNUSED(vmid);
+
+    log_error("IPC leader died\n");
+    DkProcessExit(1);
 }
 
 static int init_ns_ipc_port(void) {
     if (!g_process_ipc_info.ns) {
-        /* no NS info from parent process, no sense in creating NS IPC port */
+        assert(!g_process_ipc_info.parent);
+        assert(!PAL_CB(parent_process));
+
+        /* We are the very first Graphene process, hence also IPC leader. */
+        assert(g_process_ipc_info.self);
+        g_process_ipc_info.ns = create_ipc_info(g_process_ipc_info.self->vmid,
+                                                qstrgetstr(&g_process_ipc_info.self->uri),
+                                                g_process_ipc_info.self->uri.len);
+        if (!g_process_ipc_info.ns) {
+            return -ENOMEM;
+        }
+        assert(!g_process_ipc_info.ns->port);
         return 0;
     }
 
-    if (g_process_ipc_info.ns->port) {
-        return 0;
-    }
-
-    if (qstrempty(&g_process_ipc_info.ns->uri)) {
-        /* there is no connection to NS leader via PAL handle and there is no URI to find NS leader:
-         * do not create NS IPC port now, it will be created on-demand during NS leader lookup */
-        return 0;
-    }
-
-    lock(&g_process_ipc_info.lock);
+    assert(!g_process_ipc_info.ns->port);
+    assert(!qstrempty(&g_process_ipc_info.ns->uri));
 
     log_debug("Reconnecting IPC port %s\n", qstrgetstr(&g_process_ipc_info.ns->uri));
     PAL_HANDLE handle = NULL;
     int ret = DkStreamOpen(qstrgetstr(&g_process_ipc_info.ns->uri), 0, 0, 0, 0, &handle);
     if (ret < 0) {
-        unlock(&g_process_ipc_info.lock);
         return pal_to_unix_errno(ret);
     }
 
-    add_ipc_port_by_id(g_process_ipc_info.ns->vmid, handle, IPC_PORT_CONNECTION, /*fini=*/NULL,
-                       &g_process_ipc_info.ns->port);
-
-    unlock(&g_process_ipc_info.lock);
+    add_ipc_port_by_id(g_process_ipc_info.ns->vmid, handle, IPC_PORT_CONNECTION,
+                       ipc_leader_disconnect_callback, &g_process_ipc_info.ns->port);
     return 0;
 }
 

--- a/LibOS/shim/src/ipc/shim_ipc_pid.c
+++ b/LibOS/shim/src/ipc/shim_ipc_pid.c
@@ -23,16 +23,8 @@ int init_ns_pid(void) {
      * initialized), so we should have only one thread, whose tid is equal to the process pid. */
     assert(cur_thread->tid == g_process.pid);
 
-    struct shim_ipc_info* info = NULL;
-    int ret = get_ipc_info_cur_process(&info);
-    if (ret < 0) {
-        return ret;
-    }
-
-    ret = add_ipc_subrange(cur_thread->tid, info->vmid, qstrgetstr(&info->uri));
-
-    put_ipc_info(info);
-    return ret;
+    return add_ipc_subrange(cur_thread->tid, g_process_ipc_info.vmid,
+                            qstrgetstr(&g_process_ipc_info.self->uri));
 }
 
 // TODO: for KILL_THREAD we don't know which process has a thread with given id

--- a/LibOS/shim/src/ipc/shim_ipc_sysv.c
+++ b/LibOS/shim/src/ipc/shim_ipc_sysv.c
@@ -26,11 +26,7 @@ int ipc_sysv_findkey_send(struct sysv_key* key) {
     if (!ret)
         goto out;
 
-    IDTYPE dest;
-    struct shim_ipc_port* port = NULL;
-
-    if ((ret = connect_ns(&dest, &port)) < 0)
-        goto out;
+    IDTYPE dest = g_process_ipc_info.ns->vmid;
 
     if (dest == g_process_ipc_info.vmid) {
         ret = -ENOENT;
@@ -47,8 +43,7 @@ int ipc_sysv_findkey_send(struct sysv_key* key) {
 
     log_debug("ipc send to %u: IPC_MSG_SYSV_FINDKEY(%lu)\n", dest, key->key);
 
-    ret = send_ipc_message_with_ack(msg, port, NULL, NULL);
-    put_ipc_port(port);
+    ret = send_ipc_message_with_ack(msg, g_process_ipc_info.ns->port, NULL, NULL);
 
     if (!ret)
         ret = sysv_get_key(key, false);
@@ -78,8 +73,8 @@ int ipc_sysv_tellkey_send(struct shim_ipc_port* port, IDTYPE dest, struct sysv_k
         if ((ret = sysv_add_key(key, id)) < 0)
             goto out;
 
-        if ((ret = connect_ns(&dest, &port)) < 0)
-            goto out;
+        dest = g_process_ipc_info.ns->vmid;
+        port = g_process_ipc_info.ns->port;
 
         if (dest == g_process_ipc_info.vmid)
             goto out;
@@ -116,7 +111,6 @@ int ipc_sysv_tellkey_send(struct shim_ipc_port* port, IDTYPE dest, struct sysv_k
     log_debug("ipc send to %u: IPC_MSG_SYSV_TELLKEY(%lu, %u)\n", dest, key->key, id);
 
     ret = send_ipc_message_with_ack(msg, port, NULL, NULL);
-    put_ipc_port(port);
 out:
     return ret;
 }

--- a/LibOS/shim/src/shim_init.c
+++ b/LibOS/shim/src/shim_init.c
@@ -449,6 +449,8 @@ noreturn void* shim_init(int argc, void* args) {
     RUN_INIT(init_signal_handling);
     RUN_INIT(init_ipc_helper);
 
+    /* FIXME: `PAL_CB(parent_process)` was handed over to IPC code above so we should't be using it
+     * here. */
     if (PAL_CB(parent_process)) {
         /* Notify the parent process */
         IDTYPE child_vmid = g_process_ipc_info.vmid;

--- a/LibOS/shim/src/sys/shim_exit.c
+++ b/LibOS/shim/src/sys/shim_exit.c
@@ -19,6 +19,12 @@
 #include "shim_utils.h"
 
 static noreturn void libos_clean_and_exit(int exit_code) {
+    /*
+     * TODO: if we are the IPC leader, we need to either:
+     * 1) kill all other Graphene processes
+     * 2) wait for them to exit here, before we terminate the IPC helper
+     */
+
     struct shim_thread* async_thread = terminate_async_helper();
     if (async_thread) {
         /* TODO: wait for the thread to exit in host.

--- a/LibOS/shim/test/ltp/ltp.cfg
+++ b/LibOS/shim/test/ltp/ltp.cfg
@@ -2027,15 +2027,6 @@ skip = yes
 [sendfile04_64]
 skip = yes
 
-# Fails from time to time in CI on an assert in IPC code:
-# assert failed ipc/shim_ipc_ranges.c:706 !qstrempty(&g_process_ipc_info.ns->uri)
-[sendfile05]
-skip = yes
-
-# Same as sendfile05.
-[sendfile05_64]
-skip = yes
-
 [sendfile06]
 skip = yes
 

--- a/LibOS/shim/test/regression/.gitignore
+++ b/LibOS/shim/test/regression/.gitignore
@@ -32,6 +32,7 @@
 /debug_regs-x86_64
 /dev
 /device
+/double_fork
 /env_from_file
 /env_from_host
 /epoll_wait_timeout

--- a/LibOS/shim/test/regression/Makefile
+++ b/LibOS/shim/test/regression/Makefile
@@ -16,6 +16,7 @@ c_executables = \
 	debug \
 	dev \
 	device \
+	double_fork \
 	epoll_wait_timeout \
 	eventfd \
 	exec \

--- a/LibOS/shim/test/regression/double_fork.c
+++ b/LibOS/shim/test/regression/double_fork.c
@@ -1,0 +1,119 @@
+/* SPDX-License-Identifier: LGPL-3.0-or-later */
+/* Copyright (C) 2021 Intel Corporation
+ *                    Borys Popławski <borysp@invisiblethingslab.com>
+ */
+/*
+ * The main idea here is to test Graphene's internal connections between two processes.
+ * The main process forks a child, which in turns forks a grandchild (hence the name "double_fork").
+ * Then the intermediate (child process) exits and when parent receives information about that (via
+ * `wait` syscall), it notifies grandchild process (using a pipe) that the setup is done. Then
+ * the grandchild sends a signal to the main process, which receival should indicate that we have
+ * a working "main <-> grandchild" Graphene's internal connection.
+ */
+#define _GNU_SOURCE
+#include <err.h>
+#include <errno.h>
+#include <linux/futex.h>
+#include <signal.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <sys/syscall.h>
+#include <sys/time.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+static pid_t main_pid;
+
+static void do_grandchild(int fd) {
+    char c = 0;
+    if (read(fd, &c, 1) != 1 || c != 'a') {
+        err(1, "grandchild read");
+    }
+
+    if (kill(main_pid, SIGALRM) < 0) {
+        err(1, "grandchild kill");
+    }
+
+    _exit(42);
+}
+
+static uint32_t last_sig = 0;
+static void handler(int sig) {
+    __atomic_store_n(&last_sig, sig, __ATOMIC_RELAXED);
+}
+
+int main(void) {
+    int fds[2] = { -1, -1 };
+    if (pipe(fds) < 0) {
+        err(1, "pipe");
+    }
+
+    main_pid = getpid();
+
+    pid_t p = fork();
+    if (p < 0) {
+        err(1, "fork");
+    } else if (p == 0) {
+        // child
+        p = fork();
+        if (p < 0) {
+            err(1, "fork");
+        } else if (p == 0) {
+            if (close(fds[1]) < 0) {
+                err(1, "close");
+            }
+            do_grandchild(fds[0]);
+            return 1;
+        }
+        return 0;
+    }
+
+    if (close(fds[0]) < 0) {
+        err(1, "close");
+    }
+
+    int status = 0;
+    pid_t x = waitpid(p, &status, 0);
+    if (x < 0) {
+        err(1, "waitpid");
+    } else if (x != p) {
+        errx(1, "wrong child pid");
+    }
+
+    if (!WIFEXITED(status)) {
+        errx(1, "child died in an unknown manner: %d\n", status);
+    }
+    if (WEXITSTATUS(status) != 0) {
+        errx(1, "child returned wrong error code: %d\n", status);
+    }
+
+    struct sigaction sa = {
+        .sa_handler = handler,
+    };
+    if (sigaction(SIGALRM, &sa, NULL) < 0) {
+        err(1, "sigaction");
+    }
+
+    if (write(fds[1], "a", 1) != 1) {
+        err(1, "write");
+    }
+
+    struct timespec ts = {
+        .tv_sec = 10,
+    };
+    errno = 0;
+    long ret = syscall(SYS_futex, &last_sig, FUTEX_WAIT, 0, &ts, NULL, 0);
+    if (ret >= 0) {
+        errx(1, "unexpected futex success");
+    } else if (errno != EAGAIN && errno != EINTR) {
+        err(1, "unexpected futex error");
+    }
+
+    if (last_sig != SIGALRM) {
+        errx(1, "did not receive SIGALRM??");
+    }
+
+    puts("TEST OK");
+    return 0;
+}

--- a/LibOS/shim/test/regression/test_libos.py
+++ b/LibOS/shim/test/regression/test_libos.py
@@ -142,6 +142,11 @@ class TC_01_Bootstrap(RegressionTestCase):
         self.assertIn('child exited with status: 0', stdout)
         self.assertIn('test completed successfully', stdout)
 
+    def test_205_double_fork(self):
+        stdout, stderr = self.run_binary(['double_fork'])
+        self.assertIn('TEST OK', stdout)
+        self.assertNotIn('grandchild', stderr)
+
     def test_210_exec_invalid_args(self):
         stdout, _ = self.run_binary(['exec_invalid_args'])
 


### PR DESCRIPTION

## Description of the changes <!-- (reasons and measures) -->
Previously Graphene made IPC connections on demand and there was a hidden assumption that the main process is an IPC leader that never exits. Although there was some code to find new IPC leader in case the old one dies, it was broken and only partialy used.
This commit causes Graphene processes to connect to the IPC leader on startup and disconnect of the leader is treated as a fatal error in the child process.

## How to test this PR? <!-- (if applicable) -->
Added a new LibOS regression test, which checks if we have a working IPC connection even if our parent (intermediate process) dies.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2225)
<!-- Reviewable:end -->
