### PR TITLE
[Examples] Add a script to wait for a TCP server

### DIFF
--- a/.ci/lib/stage-test-direct.jenkinsfile
+++ b/.ci/lib/stage-test-direct.jenkinsfile
@@ -49,7 +49,7 @@ stage('test-direct') {
             cd Examples/memcached
             make -j8 all
             make start-graphene-server &
-            sleep 1
+            ../../Scripts/wait_for_server 5 127.0.0.1 11211
             # memcslap populates server but doesn't report errors, use
             # memcached-tool for this (must return two lines of stats)
             memcslap --servers=127.0.0.1 --concurrency=8
@@ -66,7 +66,7 @@ stage('test-direct') {
             fi
             make -j8 all
             make start-graphene-server &
-            sleep 1
+            ../../Scripts/wait_for_server 5 127.0.0.1 6379
             ./src/src/redis-benchmark
         '''
     }
@@ -75,7 +75,7 @@ stage('test-direct') {
             cd Examples/lighttpd
             make -j8 all
             make start-graphene-server &
-            sleep 1
+            ../../Scripts/wait_for_server 5 127.0.0.1 8003
             LOOP=1 CONCURRENCY_LIST="1 32" ../common_tools/benchmark-http.sh 127.0.0.1:8003
         '''
     }
@@ -84,7 +84,7 @@ stage('test-direct') {
             cd Examples/nginx
             make -j8 all
             make start-graphene-server &
-            sleep 1
+            ../../Scripts/wait_for_server 5 127.0.0.1 8002
             LOOP=1 CONCURRENCY_LIST="1 32" ../common_tools/benchmark-http.sh 127.0.0.1:8002
         '''
     }
@@ -93,8 +93,9 @@ stage('test-direct') {
             cd Examples/apache
             make -j8 all
             make start-graphene-server &
-            sleep 1
+            ../../Scripts/wait_for_server 5 127.0.0.1 8001
             LOOP=1 CONCURRENCY_LIST="1 32" ../common_tools/benchmark-http.sh 127.0.0.1:8001
+            ../../Scripts/wait_for_server 5 127.0.0.1 8443
             LOOP=1 CONCURRENCY_LIST="1 32" ../common_tools/benchmark-http.sh https://127.0.0.1:8443
         '''
     }

--- a/.ci/lib/stage-test-sgx.jenkinsfile
+++ b/.ci/lib/stage-test-sgx.jenkinsfile
@@ -39,7 +39,7 @@ stage('test-sgx') {
             cd Examples/memcached
             make ${MAKEOPTS}
             make SGX=1 start-graphene-server &
-            sleep 30
+            ../../Scripts/wait_for_server 60 127.0.0.1 11211
             # memcslap populates server but doesn't report errors, use
             # memcached-tool for this (must return two lines of stats)
             memcslap --servers=127.0.0.1 --concurrency=8
@@ -59,7 +59,7 @@ stage('test-sgx') {
             cd Examples/redis
             make ${MAKEOPTS}
             make ${MAKEOPTS} start-graphene-server &
-            sleep 30
+            ../../Scripts/wait_for_server 60 127.0.0.1 6379
             ./src/src/redis-benchmark
         '''
     }
@@ -68,7 +68,7 @@ stage('test-sgx') {
             cd Examples/lighttpd
             make ${MAKEOPTS}
             make ${MAKEOPTS} start-graphene-server &
-            sleep 10
+            ../../Scripts/wait_for_server 60 127.0.0.1 8003
             LOOP=1 CONCURRENCY_LIST="1 32" ../common_tools/benchmark-http.sh 127.0.0.1:8003
         '''
     }
@@ -77,7 +77,7 @@ stage('test-sgx') {
             cd Examples/nginx
             make ${MAKEOPTS}
             make ${MAKEOPTS} start-graphene-server &
-            sleep 30
+            ../../Scripts/wait_for_server 60 127.0.0.1 8002
             LOOP=1 CONCURRENCY_LIST="1 32" ../common_tools/benchmark-http.sh 127.0.0.1:8002
         '''
     }
@@ -86,8 +86,9 @@ stage('test-sgx') {
             cd Examples/apache
             make ${MAKEOPTS}
             make ${MAKEOPTS} start-graphene-server &
-            sleep 30
+            ../../Scripts/wait_for_server 60 127.0.0.1 8001
             LOOP=1 CONCURRENCY_LIST="1 32" ../common_tools/benchmark-http.sh 127.0.0.1:8001
+            ../../Scripts/wait_for_server 60 127.0.0.1 8443
             LOOP=1 CONCURRENCY_LIST="1 32" ../common_tools/benchmark-http.sh https://127.0.0.1:8443
         '''
     }

--- a/.ci/ubuntu16.04.dockerfile
+++ b/.ci/ubuntu16.04.dockerfile
@@ -35,6 +35,7 @@ RUN apt-get update \
        libxxf86vm1 \
        linux-headers-4.4.0-161-generic \
        net-tools \
+       netcat-openbsd \
        ninja-build \
        pkg-config \
        protobuf-c-compiler \

--- a/.ci/ubuntu18.04.dockerfile
+++ b/.ci/ubuntu18.04.dockerfile
@@ -36,6 +36,7 @@ RUN apt-get update && env DEBIAN_FRONTEND=noninteractive apt-get install -y \
     linux-headers-4.15.0-20-generic \
     meson \
     net-tools \
+    netcat-openbsd \
     pkg-config \
     protobuf-c-compiler \
     pylint3 \

--- a/Examples/curl/Makefile
+++ b/Examples/curl/Makefile
@@ -61,7 +61,7 @@ pal_loader:
 .PHONY: check
 check: all
 	(cd test-docroot; exec python3 -m http.server -b 127.0.0.1 19111) & httpd_pid=$$!; \
-	sleep 1; \
+	../../Scripts/wait_for_server 5 127.0.0.1 19111; \
 	./pal_loader ./curl http://127.0.0.1:19111/ > OUTPUT; rc=$$?; \
 	kill $$httpd_pid; exit $$rc
 

--- a/Examples/nodejs-express-server/Makefile
+++ b/Examples/nodejs-express-server/Makefile
@@ -62,7 +62,7 @@ pal_loader:
 .PHONY: check
 check: all
 	./pal_loader ./nodejs helloworld.js 3000 & SERVER_ID=$$!; \
-	sleep 3; \
+	../../Scripts/wait_for_server 5 127.0.0.1 3000; \
 	curl localhost:3000 > OUTPUT; \
 	kill -9 $$SERVER_ID;
 	@grep -q "Hello World!" OUTPUT && echo "[ Success 1/1 ]"

--- a/Examples/python-simple/run-tests.sh
+++ b/Examples/python-simple/run-tests.sh
@@ -17,7 +17,8 @@ rm OUTPUT
 # === web server and client (on port 8005) ===
 echo -e "\n\nRunning HTTP server dummy-web-server.py in the background:"
 ./pal_loader ./python scripts/dummy-web-server.py 8005 & echo $! > server.PID
-sleep 30  # Graphene-SGX takes a lot of time to initialize
+# Graphene-SGX may take a lot of time to initialize
+../../Scripts/wait_for_server 60 127.0.0.1 8005
 
 echo -e "\n\nRunning HTTP client test-http.py:"
 ./pal_loader ./python scripts/test-http.py localhost 8005 > OUTPUT1

--- a/Scripts/wait_for_server
+++ b/Scripts/wait_for_server
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -eu
+
+usage() {
+    echo "Usage: wait_for_server TIMEOUT IP PORT"
+    exit 1
+}
+
+if [ $# -ne 3 ]; then
+    usage
+fi
+
+exec timeout $1 bash -c "while ! nc -z -w1 $2 $3; do sleep 1; done"


### PR DESCRIPTION

## Description of the changes <!-- (reasons and measures) -->
Previously miscelaneous TCP servers testing scripts used sleep to wait for the server to actually start. This was very fragile and sometimes requires unnecessary long sleeps. Now we actively poll the TCP server.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2227)
<!-- Reviewable:end -->
