### PR TITLE
[LibOS] Fix readlink proc/self/exe

### DIFF
--- a/Examples/bash/Makefile
+++ b/Examples/bash/Makefile
@@ -63,18 +63,22 @@ regression: all
 	@mkdir -p scripts/testdir
 
 	./pal_loader ./bash -c "ls" > OUTPUT
-	@grep -q "Makefile" OUTPUT && echo "[ Success 1/6 ]"
+	@grep -q "Makefile" OUTPUT && echo "[ Success 1/7 ]"
 	@rm OUTPUT
 
 	./pal_loader ./bash -c "cd scripts && bash bash_test.sh 1" > OUTPUT
-	@grep -q "hello 1" OUTPUT      && echo "[ Success 2/6 ]"
-	@grep -q "createdfile" OUTPUT  && echo "[ Success 3/6 ]"
-	@grep -q "somefile" OUTPUT     && echo "[ Success 4/6 ]"
-	@grep -q "current date" OUTPUT && echo "[ Success 5/6 ]"
+	@grep -q "hello 1" OUTPUT      && echo "[ Success 2/7 ]"
+	@grep -q "createdfile" OUTPUT  && echo "[ Success 3/7 ]"
+	@grep -q "somefile" OUTPUT     && echo "[ Success 4/7 ]"
+	@grep -q "current date" OUTPUT && echo "[ Success 5/7 ]"
 	@rm OUTPUT
 
 	./pal_loader ./bash -c "cd scripts && bash bash_test.sh 3" > OUTPUT
-	@grep -q "hello 3" OUTPUT      && echo "[ Success 6/6 ]"
+	@grep -q "hello 3" OUTPUT      && echo "[ Success 6/7 ]"
+	@rm OUTPUT
+
+	./pal_loader ./bash -c "readlink /proc/self/exe" > OUTPUT
+	@grep -qE "^(/usr)?/bin/readlink" OUTPUT && echo "[ Success 7/7 ]"
 	@rm OUTPUT
 
 	@rm -rf scripts/testdir

--- a/Examples/bash/manifest.template
+++ b/Examples/bash/manifest.template
@@ -24,16 +24,12 @@ fs.mount.lib.uri = "file:$(GRAPHENEDIR)/Runtime"
 
 # Host-level libraries (e.g., /lib/x86_64-linux-gnu) required by Bash
 fs.mount.lib64.type = "chroot"
-fs.mount.lib64.path = "/lib64"
-fs.mount.lib64.uri = "file:/lib64"
+fs.mount.lib64.path = "$(ARCH_LIBDIR)"
+fs.mount.lib64.uri = "file:$(ARCH_LIBDIR)"
 
 fs.mount.usr_lib.type = "chroot"
 fs.mount.usr_lib.path = "/usr/lib"
 fs.mount.usr_lib.uri = "file:/usr/lib"
-
-fs.mount.lib2.type = "chroot"
-fs.mount.lib2.path = "$(ARCH_LIBDIR)"
-fs.mount.lib2.uri = "file:$(ARCH_LIBDIR)"
 
 # Mount /bin
 fs.mount.bin.type = "chroot"
@@ -63,6 +59,7 @@ sgx.trusted_files.cat = "file:$(EXECDIR)/cat"
 sgx.trusted_files.rm = "file:$(EXECDIR)/rm"
 sgx.trusted_files.cp = "file:$(EXECDIR)/cp"
 sgx.trusted_files.date = "file:$(EXECDIR)/date"
+sgx.trusted_files.readlink = "file:$(EXECDIR)/readlink"
 
 # Glibc libraries
 sgx.trusted_files.ld = "file:$(GRAPHENEDIR)/Runtime/ld-linux-x86-64.so.2"


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://graphene.readthedocs.io/en/latest/devel/coding-style.html -->

This PR addresses issue #2185. The missing dentry is added to the shim_handle to make `/proc/self/exe` accessible. A test case is added for the bash.

Fixes #2185

## How to test this PR? <!-- (if applicable) -->

Run the bash regression tests:
```
cd Examples/bash
make regression
```

Or run this 'manually':

```
~/graphene/Examples/bash$ ./pal_loader bash -c "readlink /proc/self/exe" 
WARNING: Using insecure argv source. Don't use this configuration in production!
/bin/readlink
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2228)
<!-- Reviewable:end -->
