### PR TITLE
[GSC] Install python3-pip required to install toml Python package

### DIFF
--- a/Tools/gsc/templates/Dockerfile.ubuntu18.04.compile.template
+++ b/Tools/gsc/templates/Dockerfile.ubuntu18.04.compile.template
@@ -11,6 +11,8 @@ RUN env DEBIAN_FRONTEND=noninteractive apt-get update \
         libcurl4-openssl-dev \
         libprotobuf-c-dev \
         protobuf-c-compiler \
+        python3 \
+        python3-pip \
         python3-protobuf \
         wget \
     && python3 -B -m pip install toml>=0.10


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

After commit https://github.com/oscarlab/graphene/commit/d0d3533c348ec4c73b5f8d908390617749853b10, GSC stopped working. We forgot to do `apt-get install python3-pip` in one of the GSC files.

Fixes #2229 .

## How to test this PR? <!-- (if applicable) -->

Unfortunately, our GSC pipeline is dead in Jenkins, so we missed this bug. I tested locally on my machine, with this fix everything works again.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2230)
<!-- Reviewable:end -->
