### PR TITLE
[Pal] Clean up unix_to_pal_error()

### DIFF
--- a/Pal/include/arch/x86_64/Linux/sysdep-arch.h
+++ b/Pal/include/arch/x86_64/Linux/sysdep-arch.h
@@ -143,14 +143,8 @@
 #undef INTERNAL_SYSCALL
 #define INTERNAL_SYSCALL(name, err, nr, args...) INTERNAL_SYSCALL_NCS(__NR_##name, err, nr, ##args)
 
-#undef INTERNAL_SYSCALL_ERROR
-#define INTERNAL_SYSCALL_ERROR(val) ((val) < 0)
-
 #undef INTERNAL_SYSCALL_ERROR_P
 #define INTERNAL_SYSCALL_ERROR_P(val) ((unsigned long)(val) >= (unsigned long)-4095L)
-
-#undef INTERNAL_SYSCALL_ERRNO
-#define INTERNAL_SYSCALL_ERRNO(val) (-(val))
 
 #undef INTERNAL_SYSCALL_ERRNO_P
 #define INTERNAL_SYSCALL_ERRNO_P(val) (-((long)val))

--- a/Pal/src/host/Linux-SGX/db_events.c
+++ b/Pal/src/host/Linux-SGX/db_events.c
@@ -49,17 +49,17 @@ int _DkEventSet(PAL_HANDLE event, int wakeup) {
 
                 ret = ocall_futex(event->event.signaled, FUTEX_WAKE, nwaiters, -1);
 
-                if (IS_ERR(ret)) {
+                if (ret < 0) {
                     __atomic_store_n(event->event.signaled, 0, __ATOMIC_SEQ_CST);
-                    ret = unix_to_pal_error(ERRNO(ret));
+                    ret = unix_to_pal_error(ret);
                 }
             }
         }
     } else {
         // Only one thread wakes up, leave unsignaled
         ret = ocall_futex(event->event.signaled, FUTEX_WAKE, 1, -1);
-        if (IS_ERR(ret))
-            return unix_to_pal_error(ERRNO(ret));
+        if (ret < 0)
+            return unix_to_pal_error(ret);
     }
 
     return ret;
@@ -87,7 +87,7 @@ int _DkEventWaitTimeout(PAL_HANDLE event, int64_t timeout_us) {
                     ret = 0;
                     break;
                 } else {
-                    ret = unix_to_pal_error(-ret);
+                    ret = unix_to_pal_error(ret);
                     break;
                 }
             }

--- a/Pal/src/host/Linux-SGX/db_files.c
+++ b/Pal/src/host/Linux-SGX/db_files.c
@@ -62,8 +62,8 @@ static int file_open(PAL_HANDLE* handle, const char* type, const char* uri, int 
                              PAL_CREATE_TO_LINUX_OPEN(create)  |
                              PAL_OPTION_TO_LINUX_OPEN(options),
                         share);
-    if (IS_ERR(fd)) {
-        ret = unix_to_pal_error(ERRNO(fd));
+    if (fd < 0) {
+        ret = unix_to_pal_error(fd);
         goto out;
     }
 
@@ -71,9 +71,9 @@ static int file_open(PAL_HANDLE* handle, const char* type, const char* uri, int 
 
     /* check if the file is seekable and get real file size */
     ret = ocall_fstat(fd, &st);
-    if (IS_ERR(ret)) {
+    if (ret < 0) {
         log_error("file_open(%s): fstat failed: %d\n", path, ret);
-        ret = unix_to_pal_error(ERRNO(ret));
+        ret = unix_to_pal_error(ret);
         goto out;
     }
 
@@ -188,8 +188,8 @@ static int64_t file_read(PAL_HANDLE handle, uint64_t offset, uint64_t count, voi
             ret = ocall_read(handle->file.fd, buffer, count);
         }
 
-        if (IS_ERR(ret))
-            return unix_to_pal_error(ERRNO(ret));
+        if (ret < 0)
+            return unix_to_pal_error(ret);
 
         return ret;
     }
@@ -251,8 +251,8 @@ static int64_t file_write(PAL_HANDLE handle, uint64_t offset, uint64_t count, co
             ret = ocall_write(handle->file.fd, buffer, count);
         }
 
-        if (IS_ERR(ret))
-            return unix_to_pal_error(ERRNO(ret));
+        if (ret < 0)
+            return unix_to_pal_error(ret);
 
         return ret;
     }
@@ -314,7 +314,7 @@ static int file_delete(PAL_HANDLE handle, int access) {
         return -PAL_ERROR_INVAL;
 
     int ret = ocall_delete(handle->file.realpath);
-    return IS_ERR(ret) ? unix_to_pal_error(ERRNO(ret)) : ret;
+    return ret < 0 ? unix_to_pal_error(ret) : ret;
 }
 
 static int pf_file_map(struct protected_file* pf, PAL_HANDLE handle, void** addr, int prot,
@@ -427,9 +427,9 @@ static int file_map(PAL_HANDLE handle, void** addr, int prot, uint64_t offset, u
     if (!mem && !stubs && !(prot & PAL_PROT_WRITECOPY)) {
         ret = ocall_mmap_untrusted(&mem, size, PAL_PROT_TO_LINUX(prot), MAP_SHARED, handle->file.fd,
                                    offset);
-        if (!IS_ERR(ret))
+        if (ret >= 0)
             *addr = mem;
-        return IS_ERR(ret) ? unix_to_pal_error(ERRNO(ret)) : ret;
+        return ret < 0 ? unix_to_pal_error(ret) : ret;
     }
 
     if (!(prot & PAL_PROT_WRITECOPY) && (prot & PAL_PROT_WRITE)) {
@@ -492,11 +492,11 @@ static int file_map(PAL_HANDLE handle, void** addr, int prot, uint64_t offset, u
                 bytes_read += bytes;
             } else if (bytes == 0) {
                 break; /* EOF */
-            } else if (ERRNO(bytes) == EINTR || ERRNO(bytes) == EAGAIN) {
+            } else if (bytes == -EINTR || bytes == -EAGAIN) {
                 continue;
             } else {
                 log_error("file_map - ocall_pread on allowed file returned %ld\n", bytes);
-                ret = unix_to_pal_error(ERRNO(bytes));
+                ret = unix_to_pal_error(bytes);
                 goto out;
             }
         }
@@ -537,8 +537,8 @@ static int64_t file_setlength(PAL_HANDLE handle, uint64_t length) {
         return pf_file_setlength(pf, handle, length);
 
     int ret = ocall_ftruncate(handle->file.fd, length);
-    if (IS_ERR(ret))
-        return unix_to_pal_error(ERRNO(ret));
+    if (ret < 0)
+        return unix_to_pal_error(ret);
 
     handle->file.total = length;
     return (int64_t)length;
@@ -633,16 +633,16 @@ static int file_attrquery(const char* type, const char* uri, PAL_STREAM_ATTR* at
     /* open the file with O_NONBLOCK to avoid blocking the current thread if it is actually a FIFO
      * pipe; O_NONBLOCK will be reset below if it is a regular file */
     int fd = ocall_open(uri, O_NONBLOCK, 0);
-    if (IS_ERR(fd))
-        return unix_to_pal_error(ERRNO(fd));
+    if (fd < 0)
+        return unix_to_pal_error(fd);
 
     char* path = NULL;
     struct stat stat_buf;
     int ret = ocall_fstat(fd, &stat_buf);
 
     /* if it failed, return the right error code */
-    if (IS_ERR(ret)) {
-        ret = unix_to_pal_error(ERRNO(ret));
+    if (ret < 0) {
+        ret = unix_to_pal_error(ret);
         goto out;
     }
 
@@ -668,8 +668,8 @@ static int file_attrquery(const char* type, const char* uri, PAL_STREAM_ATTR* at
         /* reset O_NONBLOCK because pf_file_attrquery() may issue reads which don't expect
          * non-blocking mode */
         ret = ocall_fsetnonblock(fd, 0);
-        if (IS_ERR(ret)) {
-            ret = unix_to_pal_error(ERRNO(ret));
+        if (ret < 0) {
+            ret = unix_to_pal_error(ret);
             goto out;
         }
 
@@ -690,8 +690,8 @@ static int file_attrquerybyhdl(PAL_HANDLE handle, PAL_STREAM_ATTR* attr) {
     struct stat stat_buf;
 
     int ret = ocall_fstat(fd, &stat_buf);
-    if (IS_ERR(ret))
-        return unix_to_pal_error(ERRNO(ret));
+    if (ret < 0)
+        return unix_to_pal_error(ret);
 
     file_attrcopy(attr, &stat_buf);
 
@@ -716,8 +716,8 @@ static int file_attrquerybyhdl(PAL_HANDLE handle, PAL_STREAM_ATTR* attr) {
 static int file_attrsetbyhdl(PAL_HANDLE handle, PAL_STREAM_ATTR* attr) {
     int fd  = handle->file.fd;
     int ret = ocall_fchmod(fd, attr->share_flags | PERM_rw_______);
-    if (IS_ERR(ret))
-        return unix_to_pal_error(ERRNO(ret));
+    if (ret < 0)
+        return unix_to_pal_error(ret);
 
     return 0;
 }
@@ -731,9 +731,9 @@ static int file_rename(PAL_HANDLE handle, const char* type, const char* uri) {
         return -PAL_ERROR_NOMEM;
 
     int ret = ocall_rename(handle->file.realpath, uri);
-    if (IS_ERR(ret)) {
+    if (ret < 0) {
         free(tmp);
-        return unix_to_pal_error(ERRNO(ret));
+        return unix_to_pal_error(ret);
     }
 
     /* initial realpath is part of handle object and will be freed with it */
@@ -795,18 +795,18 @@ static int dir_open(PAL_HANDLE* handle, const char* type, const char* uri, int a
     if (create & PAL_CREATE_TRY || create & PAL_CREATE_ALWAYS) {
         ret = ocall_mkdir(uri, share);
 
-        if (IS_ERR(ret)) {
-            if (ERRNO(ret) == EEXIST && create & PAL_CREATE_ALWAYS)
+        if (ret < 0) {
+            if (ret == -EEXIST && create & PAL_CREATE_ALWAYS)
                 return -PAL_ERROR_STREAMEXIST;
-            if (ERRNO(ret) != EEXIST)
-                return unix_to_pal_error(ERRNO(ret));
-            assert(ERRNO(ret) == EEXIST && create & PAL_CREATE_TRY);
+            if (ret != -EEXIST)
+                return unix_to_pal_error(ret);
+            assert(ret == -EEXIST && create & PAL_CREATE_TRY);
         }
     }
 
     ret = ocall_open(uri, O_DIRECTORY | PAL_OPTION_TO_LINUX_OPEN(options), 0);
-    if (IS_ERR(ret))
-        return unix_to_pal_error(ERRNO(ret));
+    if (ret < 0)
+        return unix_to_pal_error(ret);
 
     int len        = strlen(uri);
     PAL_HANDLE hdl = malloc(HANDLE_SIZE(dir) + len + 1);
@@ -884,7 +884,7 @@ static int64_t dir_read(PAL_HANDLE handle, uint64_t offset, size_t count, void* 
         }
 
         int size = ocall_getdents(handle->dir.fd, handle->dir.buf, DIRBUF_SIZE);
-        if (IS_ERR(size)) {
+        if (size < 0) {
             /*
              * If something was written just return that and pretend no error
              * was seen - it will be caught next time.
@@ -892,7 +892,7 @@ static int64_t dir_read(PAL_HANDLE handle, uint64_t offset, size_t count, void* 
             if (bytes_written) {
                 return bytes_written;
             }
-            return unix_to_pal_error(ERRNO(size));
+            return unix_to_pal_error(size);
         }
 
         if (!size) {
@@ -936,7 +936,7 @@ static int dir_delete(PAL_HANDLE handle, int access) {
         return ret;
 
     ret = ocall_delete(handle->dir.realpath);
-    return IS_ERR(ret) ? unix_to_pal_error(ERRNO(ret)) : ret;
+    return ret < 0 ? unix_to_pal_error(ret) : ret;
 }
 
 static int dir_rename(PAL_HANDLE handle, const char* type, const char* uri) {
@@ -948,9 +948,9 @@ static int dir_rename(PAL_HANDLE handle, const char* type, const char* uri) {
         return -PAL_ERROR_NOMEM;
 
     int ret = ocall_rename(handle->dir.realpath, uri);
-    if (IS_ERR(ret)) {
+    if (ret < 0) {
         free(tmp);
-        return unix_to_pal_error(ERRNO(ret));
+        return unix_to_pal_error(ret);
     }
 
     /* initial realpath is part of handle object and will be freed with it */

--- a/Pal/src/host/Linux-SGX/db_misc.c
+++ b/Pal/src/host/Linux-SGX/db_misc.c
@@ -371,7 +371,7 @@ int _DkCpuIdRetrieve(unsigned int leaf, unsigned int subleaf, unsigned int value
     if (known_leaf->cache && !get_cpuid_from_cache(leaf, subleaf, values))
         return 0;
 
-    if (IS_ERR(ocall_cpuid(leaf, subleaf, values)))
+    if (ocall_cpuid(leaf, subleaf, values) < 0)
         return -PAL_ERROR_DENIED;
 
     sanity_check_cpuid(leaf, subleaf, values);

--- a/Pal/src/host/Linux-SGX/db_mutex.c
+++ b/Pal/src/host/Linux-SGX/db_mutex.c
@@ -69,11 +69,11 @@ int _DkMutexLockTimeout(struct mutex_handle* m, int64_t timeout_us) {
          */
         ret = ocall_futex(m->locked, FUTEX_WAIT, MUTEX_LOCKED, timeout_us);
 
-        if (IS_ERR(ret)) {
-            if (ERRNO(ret) == EWOULDBLOCK) {
+        if (ret < 0) {
+            if (ret == -EWOULDBLOCK) {
                 ret = -PAL_ERROR_TRYAGAIN;
             } else {
-                ret = unix_to_pal_error(ERRNO(ret));
+                ret = unix_to_pal_error(ret);
             }
             __atomic_sub_fetch(&m->nwaiters.counter, 1, __ATOMIC_SEQ_CST);
             goto out;

--- a/Pal/src/host/Linux-SGX/db_object.c
+++ b/Pal/src/host/Linux-SGX/db_object.c
@@ -108,14 +108,14 @@ int _DkStreamsWaitEvents(size_t count, PAL_HANDLE* handle_array, PAL_FLG* events
 
     ret = ocall_poll(fds, nfds, timeout_us);
 
-    if (IS_ERR(ret)) {
-        switch (ERRNO(ret)) {
-            case EINTR:
-            case ERESTART:
+    if (ret < 0) {
+        switch (ret) {
+            case -EINTR:
+            case -ERESTART:
                 ret = -PAL_ERROR_INTERRUPTED;
                 break;
             default:
-                ret = unix_to_pal_error(ERRNO(ret));
+                ret = unix_to_pal_error(ret);
                 break;
         }
         goto out;

--- a/Pal/src/host/Linux-SGX/db_pipes.c
+++ b/Pal/src/host/Linux-SGX/db_pipes.c
@@ -103,7 +103,7 @@ static int pipe_listen(PAL_HANDLE* handle, const char* name, int options) {
 
     struct sockaddr_un addr;
     ret = pipe_addr(name, &addr);
-    if (IS_ERR(ret))
+    if (ret < 0)
         return -PAL_ERROR_DENIED;
 
     struct sockopt sock_options;
@@ -112,8 +112,8 @@ static int pipe_listen(PAL_HANDLE* handle, const char* name, int options) {
 
     ret = ocall_listen(AF_UNIX, SOCK_STREAM | nonblock, 0, /*ipv6_v6only=*/0,
                        (struct sockaddr*)&addr, &addrlen, &sock_options);
-    if (IS_ERR(ret))
-        return unix_to_pal_error(ERRNO(ret));
+    if (ret < 0)
+        return unix_to_pal_error(ret);
 
     PAL_HANDLE hdl = malloc(HANDLE_SIZE(pipe));
     if (!hdl) {
@@ -162,8 +162,8 @@ static int pipe_waitforclient(PAL_HANDLE handle, PAL_HANDLE* client) {
 
     struct sockopt sock_options;
     int ret = ocall_accept(handle->pipe.fd, NULL, NULL, &sock_options);
-    if (IS_ERR(ret))
-        return unix_to_pal_error(ERRNO(ret));
+    if (ret < 0)
+        return unix_to_pal_error(ret);
 
     PAL_HANDLE clnt = malloc(HANDLE_SIZE(pipe));
     if (!clnt) {
@@ -184,7 +184,7 @@ static int pipe_waitforclient(PAL_HANDLE handle, PAL_HANDLE* client) {
     clnt->pipe.handshake_done = 0;
 
     ret = pipe_session_key(&clnt->pipe.name, &clnt->pipe.session_key);
-    if (IS_ERR(ret)) {
+    if (ret < 0) {
         ocall_close(clnt->pipe.fd);
         free(clnt);
         return -PAL_ERROR_DENIED;
@@ -221,7 +221,7 @@ static int pipe_connect(PAL_HANDLE* handle, const char* name, int options) {
 
     struct sockaddr_un addr;
     ret = pipe_addr(name, &addr);
-    if (IS_ERR(ret))
+    if (ret < 0)
         return -PAL_ERROR_DENIED;
 
     struct sockopt sock_options;
@@ -230,8 +230,8 @@ static int pipe_connect(PAL_HANDLE* handle, const char* name, int options) {
 
     ret = ocall_connect(AF_UNIX, SOCK_STREAM | nonblock, 0, /*ipv6_v6only=*/0,
                         (const struct sockaddr*)&addr, addrlen, NULL, NULL, &sock_options);
-    if (IS_ERR(ret))
-        return unix_to_pal_error(ERRNO(ret));
+    if (ret < 0)
+        return unix_to_pal_error(ret);
 
     PAL_HANDLE hdl = malloc(HANDLE_SIZE(pipe));
     if (!hdl) {
@@ -250,7 +250,7 @@ static int pipe_connect(PAL_HANDLE* handle, const char* name, int options) {
 
     /* create the SSL pre-shared key for this end of the pipe and initialize SSL context */
     ret = pipe_session_key(&hdl->pipe.name, &hdl->pipe.session_key);
-    if (IS_ERR(ret)) {
+    if (ret < 0) {
         ocall_close(hdl->pipe.fd);
         free(hdl);
         return -PAL_ERROR_DENIED;
@@ -265,7 +265,7 @@ static int pipe_connect(PAL_HANDLE* handle, const char* name, int options) {
      * and assumes that client and server are two parallel entities (e.g., two threads) */
     PAL_HANDLE thread_hdl;
     ret = _DkThreadCreate(&thread_hdl, thread_handshake_func, /*param=*/hdl);
-    if (IS_ERR(ret)) {
+    if (ret < 0) {
         ocall_close(hdl->pipe.fd);
         free(hdl);
         return -PAL_ERROR_DENIED;
@@ -292,8 +292,8 @@ static int pipe_private(PAL_HANDLE* handle, int options) {
     int nonblock = options & PAL_OPTION_NONBLOCK ? SOCK_NONBLOCK : 0;
 
     int ret = ocall_socketpair(AF_UNIX, SOCK_STREAM | nonblock, 0, fds);
-    if (IS_ERR(ret))
-        return unix_to_pal_error(ERRNO(ret));
+    if (ret < 0)
+        return unix_to_pal_error(ret);
 
     PAL_HANDLE hdl = malloc(HANDLE_SIZE(pipeprv));
     if (!hdl) {
@@ -381,8 +381,8 @@ static int64_t pipe_read(PAL_HANDLE handle, uint64_t offset, uint64_t len, void*
     if (IS_HANDLE_TYPE(handle, pipeprv)) {
         /* pipeprv are currently not encrypted, see pipe_private() */
         bytes = ocall_recv(handle->pipeprv.fds[0], buffer, len, NULL, NULL, NULL, NULL);
-        if (IS_ERR(bytes))
-            return unix_to_pal_error(ERRNO(bytes));
+        if (bytes < 0)
+            return unix_to_pal_error(bytes);
     } else {
         /* normal pipe, use a secure session (should be already initialized) */
         while (!__atomic_load_n(&handle->pipe.handshake_done, __ATOMIC_ACQUIRE))
@@ -418,8 +418,8 @@ static int64_t pipe_write(PAL_HANDLE handle, uint64_t offset, uint64_t len, cons
     if (IS_HANDLE_TYPE(handle, pipeprv)) {
         /* pipeprv are currently not encrypted, see pipe_private() */
         bytes = ocall_send(handle->pipeprv.fds[1], buffer, len, NULL, 0, NULL, 0);
-        if (IS_ERR(bytes))
-            return unix_to_pal_error(ERRNO(bytes));
+        if (bytes < 0)
+            return unix_to_pal_error(bytes);
     } else {
         /* normal pipe, use a secure session (should be already initialized) */
         while (!__atomic_load_n(&handle->pipe.handshake_done, __ATOMIC_ACQUIRE))
@@ -536,8 +536,8 @@ static int pipe_attrquerybyhdl(PAL_HANDLE handle, PAL_STREAM_ATTR* attr) {
     attr->pending_size = 0;
     if (!IS_HANDLE_TYPE(handle, pipesrv)) {
         ret = ocall_fionread(handle->pipe.fd);
-        if (IS_ERR(ret))
-            return unix_to_pal_error(ERRNO(ret));
+        if (ret < 0)
+            return unix_to_pal_error(ret);
 
         attr->pending_size = ret;
     }
@@ -548,8 +548,8 @@ static int pipe_attrquerybyhdl(PAL_HANDLE handle, PAL_STREAM_ATTR* attr) {
         struct pollfd pfd[2] = {{.fd = handle->pipeprv.fds[0], .events = POLLIN,  .revents = 0},
                                 {.fd = handle->pipeprv.fds[1], .events = POLLOUT, .revents = 0}};
         ret = ocall_poll(&pfd[0], 2, 0);
-        if (IS_ERR(ret))
-            return unix_to_pal_error(ERRNO(ret));
+        if (ret < 0)
+            return unix_to_pal_error(ret);
 
         attr->readable = ret >= 1 && (pfd[0].revents & (POLLIN | POLLERR | POLLHUP)) == POLLIN;
         attr->writable = ret >= 1 && (pfd[1].revents & (POLLOUT | POLLERR | POLLHUP)) == POLLOUT;
@@ -568,8 +568,8 @@ static int pipe_attrquerybyhdl(PAL_HANDLE handle, PAL_STREAM_ATTR* attr) {
 
         struct pollfd pfd = {.fd = handle->pipe.fd, .events = pfd_events, .revents = 0};
         ret = ocall_poll(&pfd, 1, 0);
-        if (IS_ERR(ret))
-            return unix_to_pal_error(ERRNO(ret));
+        if (ret < 0)
+            return unix_to_pal_error(ret);
 
         attr->readable = ret == 1 && (pfd.revents & (POLLIN | POLLERR | POLLHUP)) == POLLIN;
         attr->writable = ret == 1 && (pfd.revents & (POLLOUT | POLLERR | POLLHUP)) == POLLOUT;
@@ -604,8 +604,8 @@ static int pipe_attrsetbyhdl(PAL_HANDLE handle, PAL_STREAM_ATTR* attr) {
 
     if (attr->nonblocking != *nonblocking) {
         int ret = ocall_fsetnonblock(handle->generic.fds[0], attr->nonblocking);
-        if (IS_ERR(ret))
-            return unix_to_pal_error(ERRNO(ret));
+        if (ret < 0)
+            return unix_to_pal_error(ret);
 
         *nonblocking = attr->nonblocking;
     }

--- a/Pal/src/host/Linux-SGX/db_streams.c
+++ b/Pal/src/host/Linux-SGX/db_streams.c
@@ -278,9 +278,9 @@ int _DkSendHandle(PAL_HANDLE hdl, PAL_HANDLE cargo) {
 
     /* first send hdl_hdr so the recipient knows how many FDs were transferred + how large is cargo */
     ret = ocall_send(fd, &hdl_hdr, sizeof(struct hdl_header), NULL, 0, NULL, 0);
-    if (IS_ERR(ret)) {
+    if (ret < 0) {
         free(hdl_data);
-        return unix_to_pal_error(ERRNO(ret));
+        return unix_to_pal_error(ret);
     }
 
     /* construct ancillary data of FDs-to-transfer in a control message */
@@ -296,9 +296,9 @@ int _DkSendHandle(PAL_HANDLE hdl, PAL_HANDLE cargo) {
     /* next send FDs-to-transfer as ancillary data */
     ret = ocall_send(fd, DUMMYPAYLOAD, DUMMYPAYLOADSIZE, NULL, 0, control_hdr,
                      control_hdr->cmsg_len);
-    if (IS_ERR(ret)) {
+    if (ret < 0) {
         free(hdl_data);
-        return unix_to_pal_error(ERRNO(ret));
+        return unix_to_pal_error(ret);
     }
 
     /* finally send the serialized cargo as payload (possibly encrypted) */
@@ -306,11 +306,11 @@ int _DkSendHandle(PAL_HANDLE hdl, PAL_HANDLE cargo) {
         ret = _DkStreamSecureWrite(hdl->process.ssl_ctx, (uint8_t*)hdl_data, hdl_hdr.data_size);
     } else {
         ret = ocall_write(fd, hdl_data, hdl_hdr.data_size);
-        ret = IS_ERR(ret) ? unix_to_pal_error(ERRNO(ret)) : ret;
+        ret = ret < 0 ? unix_to_pal_error(ret) : ret;
     }
 
     free(hdl_data);
-    return IS_ERR(ret) ? ret : 0;
+    return ret < 0 ? ret : 0;
 }
 
 /*!
@@ -332,8 +332,8 @@ int _DkReceiveHandle(PAL_HANDLE hdl, PAL_HANDLE* cargo) {
 
     /* first receive hdl_hdr so that we know how many FDs were transferred + how large is cargo */
     ret = ocall_recv(fd, &hdl_hdr, sizeof(hdl_hdr), NULL, NULL, NULL, NULL);
-    if (IS_ERR(ret))
-        return unix_to_pal_error(ERRNO(ret));
+    if (ret < 0)
+        return unix_to_pal_error(ret);
 
     if ((size_t)ret != sizeof(hdl_hdr)) {
         /* This check is to shield from a Iago attack. We know that ocall_send() in _DkSendHandle()
@@ -357,8 +357,8 @@ int _DkReceiveHandle(PAL_HANDLE hdl, PAL_HANDLE* cargo) {
     char dummypayload[DUMMYPAYLOADSIZE];
     ret = ocall_recv(fd, dummypayload, DUMMYPAYLOADSIZE, NULL, NULL, control_buf,
                      &control_buf_size);
-    if (IS_ERR(ret))
-        return unix_to_pal_error(ERRNO(ret));
+    if (ret < 0)
+        return unix_to_pal_error(ret);
 
     /* finally receive the serialized cargo as payload (possibly encrypted) */
     char hdl_data[hdl_hdr.data_size];
@@ -367,9 +367,9 @@ int _DkReceiveHandle(PAL_HANDLE hdl, PAL_HANDLE* cargo) {
         ret = _DkStreamSecureRead(hdl->process.ssl_ctx, (uint8_t*)hdl_data, hdl_hdr.data_size);
     } else {
         ret = ocall_read(fd, hdl_data, hdl_hdr.data_size);
-        ret = IS_ERR(ret) ? unix_to_pal_error(ERRNO(ret)) : ret;
+        ret = ret < 0 ? unix_to_pal_error(ret) : ret;
     }
-    if (IS_ERR(ret))
+    if (ret < 0)
         return ret;
 
     /* prepare array of FDs from the received FDs-to-transfer */
@@ -382,7 +382,7 @@ int _DkReceiveHandle(PAL_HANDLE hdl, PAL_HANDLE* cargo) {
     /* deserialize cargo handle from a blob hdl_data */
     PAL_HANDLE handle = NULL;
     ret = handle_deserialize(&handle, hdl_data, hdl_hdr.data_size, fds);
-    if (IS_ERR(ret))
+    if (ret < 0)
         return ret;
 
     /* restore cargo handle's FDs from the received FDs-to-transfer */
@@ -408,12 +408,12 @@ int _DkInitDebugStream(const char* path) {
         ret = ocall_close(g_log_fd);
         g_log_fd = PAL_LOG_DEFAULT_FD;
         if (ret < 0)
-            return unix_to_pal_error(ERRNO(ret));
+            return unix_to_pal_error(ret);
     }
 
     ret = ocall_open(path, O_WRONLY | O_APPEND | O_CREAT, PERM_rw_______);
     if (ret < 0)
-        return unix_to_pal_error(ERRNO(ret));
+        return unix_to_pal_error(ret);
     g_log_fd = ret;
     return 0;
 }
@@ -423,6 +423,6 @@ ssize_t _DkDebugLog(const void* buf, size_t size) {
         return -PAL_ERROR_BADHANDLE;
 
     ssize_t ret = ocall_write(g_log_fd, buf, size);
-    ret = IS_ERR(ret) ? unix_to_pal_error(ERRNO(ret)) : ret;
+    ret = ret < 0 ? unix_to_pal_error(ret) : ret;
     return ret;
 }

--- a/Pal/src/host/Linux-SGX/db_threading.c
+++ b/Pal/src/host/Linux-SGX/db_threading.c
@@ -114,8 +114,8 @@ int _DkThreadCreate(PAL_HANDLE* handle, int (*callback)(void*), const void* para
     _DkInternalUnlock(&g_thread_list_lock);
 
     int ret = ocall_clone_thread();
-    if (IS_ERR(ret))
-        return unix_to_pal_error(ERRNO(ret));
+    if (ret < 0)
+        return unix_to_pal_error(ret);
 
     /* There can be subtle race between the parent and child so hold the parent until child updates
        its tcs. */
@@ -128,7 +128,7 @@ int _DkThreadCreate(PAL_HANDLE* handle, int (*callback)(void*), const void* para
 
 int _DkThreadDelayExecution(uint64_t* duration_us) {
     int ret = ocall_sleep(duration_us);
-    return IS_ERR(ret) ? unix_to_pal_error(ERRNO(ret)) : ret;
+    return ret < 0 ? unix_to_pal_error(ret) : ret;
 }
 
 /* PAL call DkThreadYieldExecution. Yield the execution
@@ -159,17 +159,17 @@ noreturn void _DkThreadExit(int* clear_child_tid) {
 
 int _DkThreadResume(PAL_HANDLE threadHandle) {
     int ret = ocall_resume_thread(threadHandle->thread.tcs);
-    return IS_ERR(ret) ? unix_to_pal_error(ERRNO(ret)) : ret;
+    return ret < 0 ? unix_to_pal_error(ret) : ret;
 }
 
 int _DkThreadSetCpuAffinity(PAL_HANDLE thread, PAL_NUM cpumask_size, PAL_PTR cpu_mask) {
     int ret = ocall_sched_setaffinity(thread->thread.tcs, cpumask_size, cpu_mask);
-    return IS_ERR(ret) ? unix_to_pal_error(ERRNO(ret)) : ret;
+    return ret < 0 ? unix_to_pal_error(ret) : ret;
 }
 
 int _DkThreadGetCpuAffinity(PAL_HANDLE thread, PAL_NUM cpumask_size, PAL_PTR cpu_mask) {
     int ret = ocall_sched_getaffinity(thread->thread.tcs, cpumask_size, cpu_mask);
-    return IS_ERR(ret) ? unix_to_pal_error(ERRNO(ret)) : ret;
+    return ret < 0 ? unix_to_pal_error(ret) : ret;
 }
 
 struct handle_ops g_thread_ops = {

--- a/Pal/src/host/Linux-SGX/enclave_framework.c
+++ b/Pal/src/host/Linux-SGX/enclave_framework.c
@@ -400,9 +400,9 @@ int load_trusted_file(PAL_HANDLE file, sgx_stub_t** stubptr, uint64_t* sizeptr, 
     *sizeptr = tf->size;
     if (*sizeptr) {
         ret = ocall_mmap_untrusted(umem, tf->size, PROT_READ, MAP_SHARED, fd, /*offset=*/0);
-        if (IS_ERR(ret)) {
+        if (ret < 0) {
             *umem = NULL;
-            ret = unix_to_pal_error(ERRNO(ret));
+            ret = unix_to_pal_error(ret);
             goto failed;
         }
     }

--- a/Pal/src/host/Linux-SGX/enclave_platform.c
+++ b/Pal/src/host/Linux-SGX/enclave_platform.c
@@ -23,7 +23,7 @@ int sgx_get_quote(const sgx_spid_t* spid, const sgx_quote_nonce_t* nonce,
     ret = ocall_get_quote(spid, linkable, &report, nonce, quote, quote_len);
     if (ret < 0) {
         log_error("Failed to get quote\n");
-        return unix_to_pal_error(ERRNO(ret));
+        return unix_to_pal_error(ret);
     }
     return 0;
 }

--- a/Pal/src/host/Linux-SGX/enclave_untrusted.c
+++ b/Pal/src/host/Linux-SGX/enclave_untrusted.c
@@ -21,7 +21,7 @@ static inline void* __malloc(size_t size) {
     void* addr = NULL;
     int ret = ocall_mmap_untrusted(&addr, size, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_PRIVATE,
                                    /*fd=*/-1, /*offset=*/0);
-    return IS_ERR(ret) ? NULL : addr;
+    return ret < 0 ? NULL : addr;
 }
 
 #define system_malloc(size) __malloc(size)

--- a/Pal/src/host/Linux-SGX/pal_linux.h
+++ b/Pal/src/host/Linux-SGX/pal_linux.h
@@ -23,9 +23,7 @@
 #include "sysdep-arch.h"
 #include "uthash.h"
 
-#define IS_ERR      INTERNAL_SYSCALL_ERROR
 #define IS_ERR_P    INTERNAL_SYSCALL_ERROR_P
-#define ERRNO       INTERNAL_SYSCALL_ERRNO
 #define ERRNO_P     INTERNAL_SYSCALL_ERRNO_P
 #define IS_UNIX_ERR INTERNAL_SYSCALL_ERRNO_RANGE
 

--- a/Pal/src/host/Linux-SGX/pal_linux_error.h
+++ b/Pal/src/host/Linux-SGX/pal_linux_error.h
@@ -5,44 +5,59 @@
 
 #include <asm/errno.h>
 
+#include "assert.h"
 #include "pal_error.h"
 
-static inline __attribute__((unused)) int unix_to_pal_error(int unix_errno) {
+static int unix_to_pal_error_positive(int unix_errno) {
+    assert(unix_errno > 0);
     switch (unix_errno) {
         case ENOENT:
-            return -PAL_ERROR_STREAMNOTEXIST;
+            return PAL_ERROR_STREAMNOTEXIST;
         case EINTR:
-            return -PAL_ERROR_INTERRUPTED;
+            return PAL_ERROR_INTERRUPTED;
         case EBADF:
-            return -PAL_ERROR_BADHANDLE;
+            return PAL_ERROR_BADHANDLE;
         case ETIMEDOUT:
         case EAGAIN:
-            return -PAL_ERROR_TRYAGAIN;
+            return PAL_ERROR_TRYAGAIN;
         case ENOMEM:
-            return -PAL_ERROR_NOMEM;
+            return PAL_ERROR_NOMEM;
         case EFAULT:
-            return -PAL_ERROR_BADADDR;
+            return PAL_ERROR_BADADDR;
         case EEXIST:
         case EADDRINUSE:
-            return -PAL_ERROR_STREAMEXIST;
+            return PAL_ERROR_STREAMEXIST;
         case ENOTDIR:
-            return -PAL_ERROR_STREAMISFILE;
+            return PAL_ERROR_STREAMISFILE;
         case EINVAL:
-            return -PAL_ERROR_INVAL;
+            return PAL_ERROR_INVAL;
         case ENAMETOOLONG:
-            return -PAL_ERROR_TOOLONG;
+            return PAL_ERROR_TOOLONG;
         case EISDIR:
-            return -PAL_ERROR_STREAMISDIR;
+            return PAL_ERROR_STREAMISDIR;
         case ECONNRESET:
-            return -PAL_ERROR_CONNFAILED;
+            return PAL_ERROR_CONNFAILED;
         case EPIPE:
-            return -PAL_ERROR_CONNFAILED_PIPE;
+            return PAL_ERROR_CONNFAILED_PIPE;
         case EAFNOSUPPORT:
-            return -PAL_ERROR_AFNOSUPPORT;
+            return PAL_ERROR_AFNOSUPPORT;
         default:
-            return -PAL_ERROR_DENIED;
+            return PAL_ERROR_DENIED;
     }
 }
+
+/*!
+ * \brief Translate UNIX error code into PAL error code.
+ *
+ * The sign of the error code is preserved.
+ */
+static __attribute__((unused)) int unix_to_pal_error(int unix_errno) {
+    if (unix_errno >= 0) {
+        return unix_to_pal_error_positive(unix_errno);
+    }
+    return -unix_to_pal_error_positive(-unix_errno);
+}
+
 #endif /* IN_PAL */
 
 #endif /* PAL_LINUX_ERROR_H */

--- a/Pal/src/host/Linux-SGX/sgx_exception.c
+++ b/Pal/src/host/Linux-SGX/sgx_exception.c
@@ -61,7 +61,7 @@ static int block_signal(int sig, bool block) {
     __sigaddset(&mask, sig);
 
     int ret = INLINE_SYSCALL(rt_sigprocmask, 4, how, &mask, NULL, sizeof(__sigset_t));
-    return IS_ERR(ret) ? -ERRNO(ret) : 0;
+    return ret < 0 ? ret : 0;
 }
 
 static int set_signal_handler(int sig, void* handler) {
@@ -76,8 +76,8 @@ static int set_signal_handler(int sig, void* handler) {
         __sigaddset((__sigset_t*)&action.sa_mask, ASYNC_SIGNALS[i]);
 
     int ret = INLINE_SYSCALL(rt_sigaction, 4, sig, &action, NULL, sizeof(__sigset_t));
-    if (IS_ERR(ret))
-        return -ERRNO(ret);
+    if (ret < 0)
+        return ret;
 
     return block_signal(sig, /*block=*/false);
 }
@@ -85,8 +85,8 @@ static int set_signal_handler(int sig, void* handler) {
 int block_async_signals(bool block) {
     for (size_t i = 0; i < ARRAY_SIZE(ASYNC_SIGNALS); i++) {
         int ret = block_signal(ASYNC_SIGNALS[i], block);
-        if (IS_ERR(ret))
-            return -ERRNO(ret);
+        if (ret < 0)
+            return ret;
     }
     return 0;
 }

--- a/Pal/src/host/Linux-SGX/sgx_internal.h
+++ b/Pal/src/host/Linux-SGX/sgx_internal.h
@@ -16,9 +16,7 @@
 #include "sysdep-arch.h"
 #include "toml.h"
 
-#define IS_ERR   INTERNAL_SYSCALL_ERROR
 #define IS_ERR_P INTERNAL_SYSCALL_ERROR_P
-#define ERRNO    INTERNAL_SYSCALL_ERRNO
 #define ERRNO_P  INTERNAL_SYSCALL_ERRNO_P
 
 int printf(const char* fmt, ...) __attribute__((format(printf, 1, 2)));

--- a/Pal/src/host/Linux-SGX/sgx_platform.c
+++ b/Pal/src/host/Linux-SGX/sgx_platform.c
@@ -50,8 +50,8 @@ static const sgx_ql_att_key_id_t g_default_ecdsa_p256_att_key_id = {
  */
 static int connect_aesm_service(void) {
     int sock = INLINE_SYSCALL(socket, 3, AF_UNIX, SOCK_STREAM, 0);
-    if (IS_ERR(sock))
-        return -ERRNO(sock);
+    if (sock < 0)
+        return sock;
 
     struct sockaddr_un addr;
     memset(&addr, 0, sizeof(addr));
@@ -59,9 +59,9 @@ static int connect_aesm_service(void) {
     (void)strcpy_static(addr.sun_path, "\0" AESM_SOCKET_NAME_LEGACY, sizeof(addr.sun_path));
 
     int ret = INLINE_SYSCALL(connect, 3, sock, &addr, sizeof(addr));
-    if (!IS_ERR(ret))
+    if (ret >= 0)
         return sock;
-    if (ERRNO(ret) != ECONNREFUSED)
+    if (ret != -ECONNREFUSED)
         goto err;
 
     memset(&addr, 0, sizeof(addr));
@@ -69,7 +69,7 @@ static int connect_aesm_service(void) {
     (void)strcpy_static(addr.sun_path, AESM_SOCKET_NAME_NEW, sizeof(addr.sun_path));
 
     ret = INLINE_SYSCALL(connect, 3, sock, &addr, sizeof(addr));
-    if (!IS_ERR(ret))
+    if (ret >= 0)
         return sock;
 
 err:
@@ -77,7 +77,7 @@ err:
     urts_log_error("Cannot connect to aesm_service (tried " AESM_SOCKET_NAME_LEGACY " and "
                    AESM_SOCKET_NAME_NEW " UNIX sockets).\nPlease check its status! (`service aesmd "
                    "status` on Ubuntu)\n");
-    return -ERRNO(ret);
+    return ret;
 }
 
 /*
@@ -95,21 +95,21 @@ static int request_aesm_service(Request* req, Response** res) {
     request__pack(req, req_buf);
 
     int ret = INLINE_SYSCALL(write, 3, aesm_socket, &req_len, sizeof(req_len));
-    if (IS_ERR(ret))
+    if (ret < 0)
         goto out;
 
     ret = INLINE_SYSCALL(write, 3, aesm_socket, req_buf, req_len);
-    if (IS_ERR(ret))
+    if (ret < 0)
         goto out;
 
     uint32_t res_len;
     ret = INLINE_SYSCALL(read, 3, aesm_socket, &res_len, sizeof(res_len));
-    if (IS_ERR(ret))
+    if (ret < 0)
         goto out;
 
     uint8_t* res_buf = __alloca(res_len);
     ret = INLINE_SYSCALL(read, 3, aesm_socket, res_buf, res_len);
-    if (IS_ERR(ret))
+    if (ret < 0)
         goto out;
 
     *res = response__unpack(NULL, res_len, res_buf);
@@ -118,9 +118,9 @@ out:
     INLINE_SYSCALL(close, 1, aesm_socket);
     if (ret < 0) {
         urts_log_error("Cannot communicate with aesm_service (read/write returned error %d).\n"
-                       "Please check its status! (`service aesmd status` on Ubuntu)\n", ERRNO(ret));
+                       "Please check its status! (`service aesmd status` on Ubuntu)\n", ret);
     }
-    return -ERRNO(ret);
+    return ret;
 }
 
 int init_quoting_enclave_targetinfo(bool is_epid, sgx_target_info_t* qe_targetinfo) {

--- a/Pal/src/host/Linux-SGX/sgx_profile.c
+++ b/Pal/src/host/Linux-SGX/sgx_profile.c
@@ -47,10 +47,10 @@ static ssize_t debug_read(void* dest, void* addr, size_t size) {
         ret = INLINE_SYSCALL(pread, 4, g_mem_fd, (uint8_t*)dest + total, size - total,
                              (off_t)addr + total);
 
-        if (IS_ERR(ret) && ERRNO(ret) == EINTR)
+        if (ret == -EINTR)
             continue;
 
-        if (IS_ERR(ret))
+        if (ret < 0)
             return ret;
 
         if (ret == 0)
@@ -65,7 +65,7 @@ static ssize_t debug_read(void* dest, void* addr, size_t size) {
 
 static int debug_read_all(void* dest, void* addr, size_t size) {
     ssize_t ret = debug_read(dest, addr, size);
-    if (IS_ERR(ret))
+    if (ret < 0)
         return ret;
     if ((size_t)ret < size)
         return -EINVAL;
@@ -106,7 +106,7 @@ int sgx_profile_init(void) {
     g_profile_mode = g_pal_enclave.profile_mode;
 
     ret = INLINE_SYSCALL(open, 3, "/proc/self/mem", O_RDONLY | O_LARGEFILE, 0);
-    if (IS_ERR(ret)) {
+    if (ret < 0) {
         urts_log_error("sgx_profile_init: opening /proc/self/mem failed: %d\n", ret);
         goto out;
     }
@@ -133,15 +133,15 @@ int sgx_profile_init(void) {
 out:
     if (g_mem_fd > 0) {
         int close_ret = INLINE_SYSCALL(close, 1, g_mem_fd);
-        if (IS_ERR(close_ret))
+        if (close_ret < 0)
             urts_log_error("sgx_profile_init: closing /proc/self/mem failed: %d\n",
-                           ERRNO(close_ret));
+                           close_ret);
         g_mem_fd = -1;
     }
 
     if (g_perf_data) {
         ssize_t close_ret = pd_close(g_perf_data);
-        if (IS_ERR(close_ret))
+        if (close_ret < 0)
             urts_log_error("sgx_profile_init: pd_close failed: %ld\n", close_ret);
             g_perf_data = NULL;
     }
@@ -158,14 +158,14 @@ void sgx_profile_finish(void) {
     spinlock_lock(&g_perf_data_lock);
 
     size = pd_close(g_perf_data);
-    if (IS_ERR(size))
+    if (size < 0)
         urts_log_error("sgx_profile_finish: pd_close failed: %ld\n", size);
     g_perf_data = NULL;
 
     spinlock_unlock(&g_perf_data_lock);
 
     ret = INLINE_SYSCALL(close, 1, g_mem_fd);
-    if (IS_ERR(ret))
+    if (ret < 0)
         urts_log_error("sgx_profile_finish: closing /proc/self/mem failed: %d\n", ret);
     g_mem_fd = -1;
 
@@ -186,7 +186,7 @@ static void sample_simple(uint64_t rip) {
     ret = pd_event_sample_simple(g_perf_data, rip, pid, tid, g_profile_period);
     spinlock_unlock(&g_perf_data_lock);
 
-    if (IS_ERR(ret)) {
+    if (ret < 0) {
         urts_log_error("error recording sample: %d\n", ret);
     }
 }
@@ -201,7 +201,7 @@ static void sample_stack(sgx_pal_gpr_t* gpr) {
     uint8_t stack[PD_STACK_SIZE];
     size_t stack_size;
     ret = debug_read(stack, (void*)gpr->rsp, sizeof(stack));
-    if (IS_ERR(ret)) {
+    if (ret < 0) {
         urts_log_error("error reading stack: %d\n", ret);
         return;
     }
@@ -212,7 +212,7 @@ static void sample_stack(sgx_pal_gpr_t* gpr) {
                                 gpr, stack, stack_size);
     spinlock_unlock(&g_perf_data_lock);
 
-    if (IS_ERR(ret)) {
+    if (ret < 0) {
         urts_log_error("error recording sample: %d\n", ret);
     }
 }
@@ -229,7 +229,7 @@ static bool update_time(void) {
     // Check current CPU time
     struct timespec ts;
     int ret = INLINE_SYSCALL(clock_gettime, 2, CLOCK_THREAD_CPUTIME_ID, &ts);
-    if (IS_ERR(ret)) {
+    if (ret < 0) {
         urts_log_error("sgx_profile_sample: clock_gettime failed: %d\n", ret);
         return false;
     }
@@ -261,7 +261,7 @@ void sgx_profile_sample_aex(void* tcs) {
 
     sgx_pal_gpr_t gpr;
     ret = get_sgx_gpr(&gpr, tcs);
-    if (IS_ERR(ret)) {
+    if (ret < 0) {
         urts_log_error("sgx_profile_sample_aex: error reading GPR: %d\n", ret);
         return;
     }
@@ -284,7 +284,7 @@ void sgx_profile_sample_ocall_inner(void* enclave_gpr) {
 
     sgx_pal_gpr_t gpr;
     ret = debug_read_all(&gpr, enclave_gpr, sizeof(gpr));
-    if (IS_ERR(ret)) {
+    if (ret < 0) {
         urts_log_error("sgx_profile_sample_ocall_inner: error reading GPR: %d\n", ret);
         return;
     }
@@ -329,13 +329,13 @@ void sgx_profile_report_elf(const char* filename, void* addr) {
     // Open the file and mmap it.
 
     int fd = INLINE_SYSCALL(open, 3, path, O_RDONLY, 0);
-    if (IS_ERR(fd)) {
+    if (fd < 0) {
         urts_log_error("sgx_profile_report_elf(%s): open failed: %d\n", filename, fd);
         return;
     }
 
     off_t elf_length = INLINE_SYSCALL(lseek, 3, fd, 0, SEEK_END);
-    if (IS_ERR(elf_length)) {
+    if (elf_length < 0) {
         urts_log_error("sgx_profile_report_elf(%s): lseek failed: %ld\n", filename, elf_length);
         goto out_close;
     }
@@ -371,25 +371,25 @@ void sgx_profile_report_elf(const char* filename, void* addr) {
             uint64_t offset = ALLOC_ALIGN_DOWN(phdr[i].p_offset);
             ret = pd_event_mmap(g_perf_data, path, pid,
                                 (uint64_t)addr + mapstart, mapend - mapstart, offset);
-            if (IS_ERR(ret))
+            if (ret < 0)
                 break;
         }
     }
     spinlock_unlock(&g_perf_data_lock);
 
-    if (IS_ERR(ret))
+    if (ret < 0)
         urts_log_error("sgx_profile_report_elf(%s): pd_event_mmap failed: %d\n", filename, ret);
 
     // Clean up.
 
 out_unmap:
     ret = INLINE_SYSCALL(munmap, 2, elf_addr, elf_length);
-    if (IS_ERR(ret))
+    if (ret < 0)
         urts_log_error("sgx_profile_report_elf(%s): munmap failed: %d\n", filename, ret);
 
 out_close:
     ret = INLINE_SYSCALL(close, 1, fd);
-    if (IS_ERR(ret))
+    if (ret < 0)
         urts_log_error("sgx_profile_report_elf(%s): close failed: %d\n", filename, ret);
 }
 

--- a/Pal/src/host/Linux-SGX/sgx_thread.c
+++ b/Pal/src/host/Linux-SGX/sgx_thread.c
@@ -156,7 +156,7 @@ int pal_thread_init(void* tcbptr) {
 
     /* set GS reg of this thread to thread's TCB; after this point, can use get_tcb_urts() */
     ret = INLINE_SYSCALL(arch_prctl, 2, ARCH_SET_GS, tcb);
-    if (IS_ERR(ret)) {
+    if (ret < 0) {
         ret = -EPERM;
         goto out;
     }
@@ -168,7 +168,7 @@ int pal_thread_init(void* tcbptr) {
             .ss_size  = ALT_STACK_SIZE - sizeof(*tcb)
         };
         ret = INLINE_SYSCALL(sigaltstack, 2, &ss, NULL);
-        if (IS_ERR(ret)) {
+        if (ret < 0) {
             ret = -EPERM;
             goto out;
         }
@@ -280,9 +280,9 @@ int clone_thread(void) {
                     CLONE_PARENT_SETTID,
                 (void*)tcb, &dummy_parent_tid_field, NULL);
 
-    if (IS_ERR(ret)) {
+    if (ret < 0) {
         INLINE_SYSCALL(munmap, 2, stack, THREAD_STACK_SIZE + ALT_STACK_SIZE);
-        return -ERRNO(ret);
+        return ret;
     }
     return 0;
 }

--- a/Pal/src/host/Linux-common/topo_info.c
+++ b/Pal/src/host/Linux-common/topo_info.c
@@ -17,14 +17,14 @@
 
 int get_hw_resource(const char* filename, bool count) {
     int fd = INLINE_SYSCALL(open, 3, filename, O_RDONLY | O_CLOEXEC, 0);
-    if (IS_ERR(fd))
-        return -ERRNO(fd);
+    if (fd < 0)
+        return fd;
 
     char buf[64];
     int ret = INLINE_SYSCALL(read, 3, fd, buf, sizeof(buf) - 1);
     INLINE_SYSCALL(close, 1, fd);
-    if (IS_ERR(ret))
-        return -ERRNO(ret);
+    if (ret < 0)
+        return ret;
 
     buf[ret] = '\0'; /* ensure null-terminated buf even in partial read */
 
@@ -80,13 +80,13 @@ int get_hw_resource(const char* filename, bool count) {
 
 int read_file_buffer(const char* filename, char* buf, size_t count) {
     int fd = INLINE_SYSCALL(open, 2, filename, O_RDONLY);
-    if (IS_ERR(fd))
-        return -ERRNO(fd);
+    if (fd < 0)
+        return fd;
 
     int ret = INLINE_SYSCALL(read, 3, fd, buf, count);
     INLINE_SYSCALL(close, 1, fd);
-    if (IS_ERR(ret))
-        return -ERRNO(ret);
+    if (ret < 0)
+        return ret;
 
     return ret;
 }
@@ -106,13 +106,13 @@ static int get_num_cache_level(const char* path) {
     int num_dirs = 0;
 
     int fd = INLINE_SYSCALL(open, 2, path, O_RDONLY | O_DIRECTORY);
-    if (IS_ERR(fd))
-        return -ERRNO(fd);
+    if (fd < 0)
+        return fd;
 
     while (true) {
         int nread = INLINE_SYSCALL(getdents64, 3, fd, buf, 1024);
-        if (IS_ERR(nread)) {
-            num_dirs = -ERRNO(nread);
+        if (nread < 0) {
+            num_dirs = nread;
             goto out;
         }
 

--- a/Pal/src/host/Linux/arch/x86_64/db_arch_misc.c
+++ b/Pal/src/host/Linux/arch/x86_64/db_arch_misc.c
@@ -112,7 +112,7 @@ int _DkGetCPUInfo(PAL_CPU_INFO* ci) {
      * SMT support etc. by parsing sysfs pseudo-files */
     int online_logical_cores = get_hw_resource("/sys/devices/system/cpu/online", /*count=*/true);
     if (online_logical_cores < 0) {
-        rv = unix_to_pal_error(ERRNO(online_logical_cores));
+        rv = unix_to_pal_error(online_logical_cores);
         goto out_brand;
     }
     ci->online_logical_cores = online_logical_cores;
@@ -120,7 +120,7 @@ int _DkGetCPUInfo(PAL_CPU_INFO* ci) {
     int possible_logical_cores = get_hw_resource("/sys/devices/system/cpu/possible",
                                                  /*count=*/true);
     if (possible_logical_cores < 0) {
-        rv = unix_to_pal_error(ERRNO(possible_logical_cores));
+        rv = unix_to_pal_error(possible_logical_cores);
         goto out_brand;
     }
     ci->possible_logical_cores = possible_logical_cores;
@@ -134,14 +134,14 @@ int _DkGetCPUInfo(PAL_CPU_INFO* ci) {
     int core_siblings = get_hw_resource("/sys/devices/system/cpu/cpu0/topology/core_siblings_list",
                                         /*count=*/true);
     if (core_siblings < 0) {
-        rv = unix_to_pal_error(ERRNO(core_siblings));
+        rv = unix_to_pal_error(core_siblings);
         goto out_brand;
     }
 
     int smt_siblings = get_hw_resource("/sys/devices/system/cpu/cpu0/topology/thread_siblings_list",
                                        /*count=*/true);
     if (smt_siblings < 0) {
-        rv = unix_to_pal_error(ERRNO(smt_siblings));
+        rv = unix_to_pal_error(smt_siblings);
         goto out_brand;
     }
     ci->physical_cores_per_socket = core_siblings / smt_siblings;
@@ -160,7 +160,7 @@ int _DkGetCPUInfo(PAL_CPU_INFO* ci) {
         cpu_socket[idx] = get_hw_resource(filename, /*count=*/false);
         if (cpu_socket[idx] < 0) {
             printf("Cannot read %s\n", filename);
-            rv = unix_to_pal_error(ERRNO(cpu_socket[idx]));
+            rv = unix_to_pal_error(cpu_socket[idx]);
             goto out_phy_id;
         }
     }
@@ -258,7 +258,7 @@ int _DkCpuIdRetrieve(unsigned int leaf, unsigned int subleaf, unsigned int value
 int _DkGetTopologyInfo(PAL_TOPO_INFO* topo_info) {
     int ret = get_topology_info(topo_info);
     if (ret < 0)
-        return unix_to_pal_error(ERRNO(ret));
+        return unix_to_pal_error(ret);
 
     return 0;
 }

--- a/Pal/src/host/Linux/db_events.c
+++ b/Pal/src/host/Linux/db_events.c
@@ -44,7 +44,7 @@ int _DkEventSet(PAL_HANDLE event, int wakeup) {
 
                 ret = INLINE_SYSCALL(futex, 6, &event->event.signaled, FUTEX_WAKE, nwaiters, NULL,
                                      NULL, 0);
-                if (IS_ERR(ret))
+                if (ret < 0)
                     __atomic_store_n(&event->event.signaled, 0, __ATOMIC_SEQ_CST);
             }
         }
@@ -53,7 +53,7 @@ int _DkEventSet(PAL_HANDLE event, int wakeup) {
         ret = INLINE_SYSCALL(futex, 6, &event->event.signaled, FUTEX_WAKE, 1, NULL, NULL, 0);
     }
 
-    return IS_ERR(ret) ? -PAL_ERROR_TRYAGAIN : ret;
+    return ret < 0 ? -PAL_ERROR_TRYAGAIN : ret;
 }
 
 int _DkEventWaitTimeout(PAL_HANDLE event, int64_t timeout_us) {
@@ -87,7 +87,7 @@ int _DkEventWaitTimeout(PAL_HANDLE event, int64_t timeout_us) {
                     ret = 0;
                     break;
                 } else {
-                    ret = unix_to_pal_error(-ret);
+                    ret = unix_to_pal_error(ret);
                     break;
                 }
             }

--- a/Pal/src/host/Linux/db_exception.c
+++ b/Pal/src/host/Linux/db_exception.c
@@ -30,13 +30,13 @@ static int block_signal(int sig, bool block) {
     int how = block ? SIG_BLOCK : SIG_UNBLOCK;
     int ret = arch_do_rt_sigprocmask(sig, how);
 
-    return IS_ERR(ret) ? unix_to_pal_error(ERRNO(ret)) : 0;
+    return ret < 0 ? unix_to_pal_error(ret) : 0;
 }
 
 static int set_signal_handler(int sig, void* handler) {
     int ret = arch_do_rt_sigaction(sig, handler, ASYNC_SIGNALS, ARRAY_SIZE(ASYNC_SIGNALS));
-    if (IS_ERR(ret))
-        return unix_to_pal_error(ERRNO(ret));
+    if (ret < 0)
+        return unix_to_pal_error(ret);
 
     return block_signal(sig, /*block=*/false);
 }
@@ -44,8 +44,8 @@ static int set_signal_handler(int sig, void* handler) {
 int block_async_signals(bool block) {
     for (size_t i = 0; i < ARRAY_SIZE(ASYNC_SIGNALS); i++) {
         int ret = block_signal(ASYNC_SIGNALS[i], block);
-        if (IS_ERR(ret))
-            return unix_to_pal_error(ERRNO(ret));
+        if (ret < 0)
+            return unix_to_pal_error(ret);
     }
     return 0;
 }

--- a/Pal/src/host/Linux/db_misc.c
+++ b/Pal/src/host/Linux/db_misc.c
@@ -27,8 +27,8 @@ int _DkSystemTimeQuery(uint64_t* out_usec) {
         ret = INLINE_SYSCALL(clock_gettime, 2, CLOCK_REALTIME, &time);
     }
 
-    if (IS_ERR(ret))
-        return ret;
+    if (ret < 0)
+        return unix_to_pal_error(ret);
 
     /* in microseconds */
     *out_usec = 1000000 * (uint64_t)time.tv_sec + time.tv_nsec / 1000;
@@ -38,7 +38,7 @@ int _DkSystemTimeQuery(uint64_t* out_usec) {
 size_t _DkRandomBitsRead(void* buffer, size_t size) {
     if (!g_pal_sec.random_device) {
         int fd = INLINE_SYSCALL(open, 3, RANDGEN_DEVICE, O_RDONLY, 0);
-        if (IS_ERR(fd))
+        if (fd < 0)
             return -PAL_ERROR_DENIED;
 
         g_pal_sec.random_device = fd;
@@ -48,7 +48,7 @@ size_t _DkRandomBitsRead(void* buffer, size_t size) {
     do {
         int bytes = INLINE_SYSCALL(read, 3, g_pal_sec.random_device, buffer + total_bytes,
                                    size - total_bytes);
-        if (IS_ERR(bytes))
+        if (bytes < 0)
             return -PAL_ERROR_DENIED;
 
         total_bytes += (size_t)bytes;

--- a/Pal/src/host/Linux/db_mutex.c
+++ b/Pal/src/host/Linux/db_mutex.c
@@ -109,8 +109,8 @@ int _DkMutexLockTimeout(struct mutex_handle* m, int64_t timeout_us) {
 
         ret = INLINE_SYSCALL(futex, 6, &m->locked, FUTEX_WAIT, MUTEX_LOCKED, waittimep, NULL, 0);
 
-        if (IS_ERR(ret)) {
-            if (ERRNO(ret) == EWOULDBLOCK) {
+        if (ret < 0) {
+            if (ret == -EWOULDBLOCK) {
                 if (timeout_us >= 0) {
                     ret = -PAL_ERROR_TRYAGAIN;
                     __atomic_sub_fetch(&m->nwaiters.counter, 1, __ATOMIC_SEQ_CST);
@@ -118,9 +118,9 @@ int _DkMutexLockTimeout(struct mutex_handle* m, int64_t timeout_us) {
                 }
             } else {
 #ifdef DEBUG_MUTEX
-                printf("futex failed (err = %d)\n", ERRNO(ret));
+                printf("futex failed (err = %d)\n", ret);
 #endif
-                ret = unix_to_pal_error(ERRNO(ret));
+                ret = unix_to_pal_error(ret);
                 __atomic_sub_fetch(&m->nwaiters.counter, 1, __ATOMIC_SEQ_CST);
                 goto out;
             }

--- a/Pal/src/host/Linux/db_object.c
+++ b/Pal/src/host/Linux/db_object.c
@@ -114,14 +114,14 @@ int _DkStreamsWaitEvents(size_t count, PAL_HANDLE* handle_array, PAL_FLG* events
 
     ret = INLINE_SYSCALL(ppoll, 5, fds, nfds, timeout_us >= 0 ? &timeout_ts : NULL, NULL, 0);
 
-    if (IS_ERR(ret)) {
-        switch (ERRNO(ret)) {
-            case EINTR:
-            case ERESTART:
+    if (ret < 0) {
+        switch (ret) {
+            case -EINTR:
+            case -ERESTART:
                 ret = -PAL_ERROR_INTERRUPTED;
                 break;
             default:
-                ret = unix_to_pal_error(ERRNO(ret));
+                ret = unix_to_pal_error(ret);
                 break;
         }
         goto out;

--- a/Pal/src/host/Linux/db_sockets.c
+++ b/Pal/src/host/Linux/db_sockets.c
@@ -260,10 +260,10 @@ static inline PAL_HANDLE socket_create_handle(int type, int fd, int options,
         int len = sizeof(int);
 
         ret = INLINE_SYSCALL(getsockopt, 5, fd, SOL_SOCKET, SO_RCVBUF, &val, &len);
-        hdl->sock.receivebuf = IS_ERR(ret) ? 0 : val;
+        hdl->sock.receivebuf = ret < 0 ? 0 : val;
 
         ret = INLINE_SYSCALL(getsockopt, 5, fd, SOL_SOCKET, SO_SNDBUF, &val, &len);
-        hdl->sock.sendbuf = IS_ERR(ret) ? 0 : val;
+        hdl->sock.sendbuf = ret < 0 ? 0 : val;
     }
 
     hdl->sock.receivetimeout = 0;
@@ -293,14 +293,14 @@ static int tcp_listen(PAL_HANDLE* handle, char* uri, int create, int options) {
     fd = INLINE_SYSCALL(socket, 3, bind_addr->sa_family, SOCK_STREAM | SOCK_CLOEXEC | sock_options,
                         0);
 
-    if (IS_ERR(fd))
+    if (fd < 0)
         return -PAL_ERROR_DENIED;
 
     /* must set the socket to be reuseable */
     int reuseaddr = 1;
     ret = INLINE_SYSCALL(setsockopt, 5, fd, SOL_SOCKET, SO_REUSEADDR, &reuseaddr,
                          sizeof(reuseaddr));
-    if (IS_ERR(ret))
+    if (ret < 0)
         return -PAL_ERROR_INVAL;
 
     if (bind_addr->sa_family == AF_INET6) {
@@ -308,18 +308,18 @@ static int tcp_listen(PAL_HANDLE* handle, char* uri, int create, int options) {
         int ipv6_v6only = create & PAL_CREATE_DUALSTACK ? 0 : 1;
         ret = INLINE_SYSCALL(setsockopt, 5, fd, IPPROTO_IPV6, IPV6_V6ONLY, &ipv6_v6only,
                              sizeof(ipv6_v6only));
-        if (IS_ERR(ret))
+        if (ret < 0)
             return -PAL_ERROR_INVAL;
     }
 
     ret = INLINE_SYSCALL(bind, 3, fd, bind_addr, bind_addrlen);
 
-    if (IS_ERR(ret)) {
-        switch (ERRNO(ret)) {
-            case EINVAL:
+    if (ret < 0) {
+        switch (ret) {
+            case -EINVAL:
                 ret = -PAL_ERROR_INVAL;
                 goto failed;
-            case EADDRINUSE:
+            case -EADDRINUSE:
                 ret = -PAL_ERROR_STREAMEXIST;
                 goto failed;
             default:
@@ -329,15 +329,20 @@ static int tcp_listen(PAL_HANDLE* handle, char* uri, int create, int options) {
     }
 
     /* call getsockname to get socket address */
-    if ((ret = INLINE_SYSCALL(getsockname, 3, fd, bind_addr, &bind_addrlen)) < 0)
+    ret = INLINE_SYSCALL(getsockname, 3, fd, bind_addr, &bind_addrlen);
+    if (ret < 0) {
+        ret = unix_to_pal_error(ret);
         goto failed;
+    }
 
     ret = INLINE_SYSCALL(listen, 2, fd, DEFAULT_BACKLOG);
-    if (IS_ERR(ret))
-        return -PAL_ERROR_DENIED;
+    if (ret < 0) {
+        ret = unix_to_pal_error(ret);
+        goto failed;
+    }
 
     *handle = socket_create_handle(pal_type_tcpsrv, fd, options, bind_addr, bind_addrlen, NULL, 0);
-    if (!(*handle)) {
+    if (!*handle) {
         ret = -PAL_ERROR_NOMEM;
         goto failed;
     }
@@ -365,14 +370,14 @@ static int tcp_accept(PAL_HANDLE handle, PAL_HANDLE* client) {
 
     int newfd = INLINE_SYSCALL(accept4, 4, handle->sock.fd, &buffer, &addrlen, SOCK_CLOEXEC);
 
-    if (IS_ERR(newfd))
-        switch (ERRNO(newfd)) {
-            case EWOULDBLOCK:
+    if (newfd < 0)
+        switch (newfd) {
+            case -EWOULDBLOCK:
                 return -PAL_ERROR_TRYAGAIN;
-            case ECONNABORTED:
+            case -ECONNABORTED:
                 return -PAL_ERROR_STREAMNOTEXIST;
             default:
-                return unix_to_pal_error(ERRNO(newfd));
+                return unix_to_pal_error(newfd);
         }
 
     struct sockaddr* dest_addr = (struct sockaddr*)&buffer;
@@ -416,21 +421,21 @@ static int tcp_connect(PAL_HANDLE* handle, char* uri, int options) {
     int sock_options = options & PAL_OPTION_NONBLOCK ? SOCK_NONBLOCK : 0;
     fd = INLINE_SYSCALL(socket, 3, dest_addr->sa_family, SOCK_STREAM | SOCK_CLOEXEC | sock_options,
                         0);
-    if (IS_ERR(fd))
+    if (fd < 0)
         return -PAL_ERROR_DENIED;
 
     if (bind_addr) {
-        if (IS_ERR(ret)) {
+        if (ret < 0) {
             INLINE_SYSCALL(close, 1, fd);
-            switch (ERRNO(ret)) {
-                case EADDRINUSE:
+            switch (ret) {
+                case -EADDRINUSE:
                     ret = -PAL_ERROR_STREAMEXIST;
                     goto failed;
-                case EADDRNOTAVAIL:
+                case -EADDRNOTAVAIL:
                     ret = -PAL_ERROR_ADDRNOTEXIST;
                     goto failed;
                 default:
-                    ret = unix_to_pal_error(ERRNO(ret));
+                    ret = unix_to_pal_error(ret);
                     goto failed;
             }
         }
@@ -438,13 +443,13 @@ static int tcp_connect(PAL_HANDLE* handle, char* uri, int options) {
 
     ret = INLINE_SYSCALL(connect, 3, fd, dest_addr, dest_addrlen);
 
-    if (IS_ERR(ret) && ERRNO(ret) == EINPROGRESS) {
+    if (ret == -EINPROGRESS) {
         struct pollfd pfd = {.fd = fd, .events = POLLOUT, .revents = 0};
         ret = INLINE_SYSCALL(ppoll, 5, &pfd, 1, NULL, NULL, 0);
     }
 
-    if (IS_ERR(ret)) {
-        ret = unix_to_pal_error(ERRNO(ret));
+    if (ret < 0) {
+        ret = unix_to_pal_error(ret);
         goto failed;
     }
 
@@ -526,8 +531,8 @@ static int64_t tcp_read(PAL_HANDLE handle, uint64_t offset, size_t len, void* bu
 
     int64_t bytes = INLINE_SYSCALL(recvmsg, 3, handle->sock.fd, &hdr, 0);
 
-    if (IS_ERR(bytes))
-        return unix_to_pal_error(ERRNO(bytes));
+    if (bytes < 0)
+        return unix_to_pal_error(bytes);
 
     return bytes;
 }
@@ -556,8 +561,8 @@ static int64_t tcp_write(PAL_HANDLE handle, uint64_t offset, size_t len, const v
     hdr.msg_flags      = 0;
 
     int64_t bytes = INLINE_SYSCALL(sendmsg, 3, handle->sock.fd, &hdr, MSG_NOSIGNAL);
-    if (IS_ERR(bytes))
-        bytes = unix_to_pal_error(ERRNO(bytes));
+    if (bytes < 0)
+        bytes = unix_to_pal_error(bytes);
 
     return bytes;
 }
@@ -581,7 +586,7 @@ static int udp_bind(PAL_HANDLE* handle, char* uri, int create, int options) {
     fd = INLINE_SYSCALL(socket, 3, bind_addr->sa_family, SOCK_DGRAM | SOCK_CLOEXEC | sock_options,
                         0);
 
-    if (IS_ERR(fd))
+    if (fd < 0)
         return -PAL_ERROR_DENIED;
 
     /* IPV6_V6ONLY socket option can only be set before first bind */
@@ -589,22 +594,22 @@ static int udp_bind(PAL_HANDLE* handle, char* uri, int create, int options) {
         int ipv6_v6only = create & PAL_CREATE_DUALSTACK ? 0 : 1;
         ret = INLINE_SYSCALL(setsockopt, 5, fd, IPPROTO_IPV6, IPV6_V6ONLY, &ipv6_v6only,
                              sizeof(ipv6_v6only));
-        if (IS_ERR(ret))
+        if (ret < 0)
             return -PAL_ERROR_INVAL;
     }
 
     ret = INLINE_SYSCALL(bind, 3, fd, bind_addr, bind_addrlen);
 
-    if (IS_ERR(ret)) {
-        switch (ERRNO(ret)) {
-            case EADDRINUSE:
+    if (ret < 0) {
+        switch (ret) {
+            case -EADDRINUSE:
                 ret = -PAL_ERROR_STREAMEXIST;
                 goto failed;
-            case EADDRNOTAVAIL:
+            case -EADDRNOTAVAIL:
                 ret = -PAL_ERROR_ADDRNOTEXIST;
                 goto failed;
             default:
-                ret = unix_to_pal_error(ERRNO(ret));
+                ret = unix_to_pal_error(ret);
                 goto failed;
         }
     }
@@ -639,7 +644,7 @@ static int udp_connect(PAL_HANDLE* handle, char* uri, int create, int options) {
     fd = INLINE_SYSCALL(socket, 3, dest_addr ? dest_addr->sa_family : AF_INET,
                         SOCK_DGRAM | SOCK_CLOEXEC | sock_options, 0);
 
-    if (IS_ERR(fd))
+    if (fd < 0)
         return -PAL_ERROR_DENIED;
 
     if (bind_addr) {
@@ -648,22 +653,22 @@ static int udp_connect(PAL_HANDLE* handle, char* uri, int create, int options) {
             int ipv6_v6only = create & PAL_CREATE_DUALSTACK ? 0 : 1;
             ret = INLINE_SYSCALL(setsockopt, 5, fd, IPPROTO_IPV6, IPV6_V6ONLY, &ipv6_v6only,
                                  sizeof(ipv6_v6only));
-            if (IS_ERR(ret))
+            if (ret < 0)
                 return -PAL_ERROR_INVAL;
         }
 
         ret = INLINE_SYSCALL(bind, 3, fd, bind_addr, bind_addrlen);
 
-        if (IS_ERR(ret)) {
-            switch (ERRNO(ret)) {
-                case EADDRINUSE:
+        if (ret < 0) {
+            switch (ret) {
+                case -EADDRINUSE:
                     ret = -PAL_ERROR_STREAMEXIST;
                     goto failed;
-                case EADDRNOTAVAIL:
+                case -EADDRNOTAVAIL:
                     ret = -PAL_ERROR_ADDRNOTEXIST;
                     goto failed;
                 default:
-                    ret = unix_to_pal_error(ERRNO(ret));
+                    ret = unix_to_pal_error(ret);
                     goto failed;
             }
         }
@@ -735,8 +740,8 @@ static int64_t udp_receive(PAL_HANDLE handle, uint64_t offset, size_t len, void*
 
     int64_t bytes = INLINE_SYSCALL(recvmsg, 3, handle->sock.fd, &hdr, 0);
 
-    if (IS_ERR(bytes))
-        return unix_to_pal_error(ERRNO(bytes));
+    if (bytes < 0)
+        return unix_to_pal_error(bytes);
 
     return bytes;
 }
@@ -768,8 +773,8 @@ static int64_t udp_receivebyaddr(PAL_HANDLE handle, uint64_t offset, size_t len,
 
     int64_t bytes = INLINE_SYSCALL(recvmsg, 3, handle->sock.fd, &hdr, 0);
 
-    if (IS_ERR(bytes))
-        return unix_to_pal_error(ERRNO(bytes));
+    if (bytes < 0)
+        return unix_to_pal_error(bytes);
 
     char* addr_uri = strcpy_static(addr, URI_PREFIX_UDP, addrlen);
     if (!addr_uri)
@@ -806,8 +811,8 @@ static int64_t udp_send(PAL_HANDLE handle, uint64_t offset, size_t len, const vo
     hdr.msg_flags      = 0;
 
     int64_t bytes = INLINE_SYSCALL(sendmsg, 3, handle->sock.fd, &hdr, MSG_NOSIGNAL);
-    if (IS_ERR(bytes))
-        bytes = unix_to_pal_error(ERRNO(bytes));
+    if (bytes < 0)
+        bytes = unix_to_pal_error(bytes);
 
     return bytes;
 }
@@ -852,8 +857,8 @@ static int64_t udp_sendbyaddr(PAL_HANDLE handle, uint64_t offset, size_t len, co
     hdr.msg_flags      = 0;
 
     int64_t bytes = INLINE_SYSCALL(sendmsg, 3, handle->sock.fd, &hdr, MSG_NOSIGNAL);
-    if (IS_ERR(bytes))
-        bytes = unix_to_pal_error(ERRNO(bytes));
+    if (bytes < 0)
+        bytes = unix_to_pal_error(bytes);
 
     return bytes;
 }
@@ -931,8 +936,8 @@ static int socket_attrquerybyhdl(PAL_HANDLE handle, PAL_STREAM_ATTR* attr) {
     if (!IS_HANDLE_TYPE(handle, tcpsrv)) {
         int val;
         ret = INLINE_SYSCALL(ioctl, 3, handle->sock.fd, FIONREAD, &val);
-        if (IS_ERR(ret))
-            return unix_to_pal_error(ERRNO(ret));
+        if (ret < 0)
+            return unix_to_pal_error(ret);
 
         attr->pending_size = val;
     }
@@ -941,8 +946,8 @@ static int socket_attrquerybyhdl(PAL_HANDLE handle, PAL_STREAM_ATTR* attr) {
     struct pollfd pfd  = {.fd = handle->sock.fd, .events = POLLIN | POLLOUT, .revents = 0};
     struct timespec tp = {0, 0};
     ret = INLINE_SYSCALL(ppoll, 5, &pfd, 1, &tp, NULL, 0);
-    if (IS_ERR(ret))
-        return unix_to_pal_error(ERRNO(ret));
+    if (ret < 0)
+        return unix_to_pal_error(ret);
 
     attr->readable = ret == 1 && (pfd.revents & (POLLIN | POLLERR | POLLHUP)) == POLLIN;
     attr->writable = ret == 1 && (pfd.revents & (POLLOUT | POLLERR | POLLHUP)) == POLLOUT;
@@ -958,8 +963,8 @@ static int socket_attrsetbyhdl(PAL_HANDLE handle, PAL_STREAM_ATTR* attr) {
     if (attr->nonblocking != handle->sock.nonblocking) {
         ret = INLINE_SYSCALL(fcntl, 3, fd, F_SETFL, attr->nonblocking ? O_NONBLOCK : 0);
 
-        if (IS_ERR(ret))
-            return unix_to_pal_error(ERRNO(ret));
+        if (ret < 0)
+            return unix_to_pal_error(ret);
 
         handle->sock.nonblocking = attr->nonblocking;
     }
@@ -972,8 +977,8 @@ static int socket_attrsetbyhdl(PAL_HANDLE handle, PAL_STREAM_ATTR* attr) {
             ret = INLINE_SYSCALL(setsockopt, 5, fd, SOL_SOCKET, SO_LINGER, &l,
                                  sizeof(struct __kernel_linger));
 
-            if (IS_ERR(ret))
-                return unix_to_pal_error(ERRNO(ret));
+            if (ret < 0)
+                return unix_to_pal_error(ret);
 
             handle->sock.linger = attr->socket.linger;
         }
@@ -982,8 +987,8 @@ static int socket_attrsetbyhdl(PAL_HANDLE handle, PAL_STREAM_ATTR* attr) {
             int val = attr->socket.receivebuf;
             ret = INLINE_SYSCALL(setsockopt, 5, fd, SOL_SOCKET, SO_RCVBUF, &val, sizeof(int));
 
-            if (IS_ERR(ret))
-                return unix_to_pal_error(ERRNO(ret));
+            if (ret < 0)
+                return unix_to_pal_error(ret);
 
             handle->sock.receivebuf = attr->socket.receivebuf;
         }
@@ -992,8 +997,8 @@ static int socket_attrsetbyhdl(PAL_HANDLE handle, PAL_STREAM_ATTR* attr) {
             int val = attr->socket.sendbuf;
             ret = INLINE_SYSCALL(setsockopt, 5, fd, SOL_SOCKET, SO_SNDBUF, &val, sizeof(int));
 
-            if (IS_ERR(ret))
-                return unix_to_pal_error(ERRNO(ret));
+            if (ret < 0)
+                return unix_to_pal_error(ret);
 
             handle->sock.sendbuf = attr->socket.sendbuf;
         }
@@ -1002,8 +1007,8 @@ static int socket_attrsetbyhdl(PAL_HANDLE handle, PAL_STREAM_ATTR* attr) {
             int val = attr->socket.receivetimeout;
             ret = INLINE_SYSCALL(setsockopt, 5, fd, SOL_SOCKET, SO_RCVTIMEO, &val, sizeof(int));
 
-            if (IS_ERR(ret))
-                return unix_to_pal_error(ERRNO(ret));
+            if (ret < 0)
+                return unix_to_pal_error(ret);
 
             handle->sock.receivetimeout = attr->socket.receivetimeout;
         }
@@ -1012,8 +1017,8 @@ static int socket_attrsetbyhdl(PAL_HANDLE handle, PAL_STREAM_ATTR* attr) {
             int val = attr->socket.sendtimeout;
             ret = INLINE_SYSCALL(setsockopt, 5, fd, SOL_SOCKET, SO_SNDTIMEO, &val, sizeof(int));
 
-            if (IS_ERR(ret))
-                return unix_to_pal_error(ERRNO(ret));
+            if (ret < 0)
+                return unix_to_pal_error(ret);
 
             handle->sock.sendtimeout = attr->socket.sendtimeout;
         }
@@ -1024,8 +1029,8 @@ static int socket_attrsetbyhdl(PAL_HANDLE handle, PAL_STREAM_ATTR* attr) {
             val = attr->socket.tcp_cork ? 1 : 0;
             ret = INLINE_SYSCALL(setsockopt, 5, fd, SOL_TCP, TCP_CORK, &val, sizeof(int));
 
-            if (IS_ERR(ret))
-                return unix_to_pal_error(ERRNO(ret));
+            if (ret < 0)
+                return unix_to_pal_error(ret);
 
             handle->sock.tcp_cork = attr->socket.tcp_cork;
         }
@@ -1034,8 +1039,8 @@ static int socket_attrsetbyhdl(PAL_HANDLE handle, PAL_STREAM_ATTR* attr) {
             val = attr->socket.tcp_keepalive ? 1 : 0;
             ret = INLINE_SYSCALL(setsockopt, 5, fd, SOL_SOCKET, SO_KEEPALIVE, &val, sizeof(int));
 
-            if (IS_ERR(ret))
-                return unix_to_pal_error(ERRNO(ret));
+            if (ret < 0)
+                return unix_to_pal_error(ret);
 
             handle->sock.tcp_keepalive = attr->socket.tcp_keepalive;
         }
@@ -1044,8 +1049,8 @@ static int socket_attrsetbyhdl(PAL_HANDLE handle, PAL_STREAM_ATTR* attr) {
             val = attr->socket.tcp_nodelay ? 1 : 0;
             ret = INLINE_SYSCALL(setsockopt, 5, fd, SOL_TCP, TCP_NODELAY, &val, sizeof(int));
 
-            if (IS_ERR(ret))
-                return unix_to_pal_error(ERRNO(ret));
+            if (ret < 0)
+                return unix_to_pal_error(ret);
 
             handle->sock.tcp_nodelay = attr->socket.tcp_nodelay;
         }

--- a/Pal/src/host/Linux/db_threading.c
+++ b/Pal/src/host/Linux/db_threading.c
@@ -91,13 +91,13 @@ __attribute__((__optimize__("-fno-stack-protector"))) int pal_thread_init(void* 
      * _DkRandomBitsRead), so let's install a default canary in the child's TCB */
     pal_tcb_set_stack_canary(&tcb->common, STACK_PROTECTOR_CANARY_DEFAULT);
     ret = pal_set_tcb(&tcb->common);
-    if (IS_ERR(ret))
-        return -ERRNO(ret);
+    if (ret < 0)
+        return ret;
 
     /* each newly-created thread (including the first thread) has its own random stack canary */
     uint64_t stack_protector_canary;
     ret = _DkRandomBitsRead(&stack_protector_canary, sizeof(stack_protector_canary));
-    if (IS_ERR(ret))
+    if (ret < 0)
         return -EPERM;
 
     pal_tcb_set_stack_canary(&tcb->common, stack_protector_canary);
@@ -110,8 +110,8 @@ __attribute__((__optimize__("-fno-stack-protector"))) int pal_thread_init(void* 
         };
 
         ret = INLINE_SYSCALL(sigaltstack, 2, &ss, NULL);
-        if (IS_ERR(ret))
-            return -ERRNO(ret);
+        if (ret < 0)
+            return ret;
     }
 
     if (tcb->callback)
@@ -128,7 +128,7 @@ int _DkThreadCreate(PAL_HANDLE* handle, int (*callback)(void*), const void* para
     PAL_HANDLE hdl = NULL;
     void* stack = get_thread_stack();
     if (!stack) {
-        ret = -ENOMEM;
+        ret = -PAL_ERROR_NOMEM;
         goto err;
     }
 
@@ -153,7 +153,7 @@ int _DkThreadCreate(PAL_HANDLE* handle, int (*callback)(void*), const void* para
 
     hdl = malloc(HANDLE_SIZE(thread));
     if (!hdl) {
-        ret = -ENOMEM;
+        ret = -PAL_ERROR_NOMEM;
         goto err;
     }
     SET_HANDLE_TYPE(hdl, thread);
@@ -172,7 +172,7 @@ int _DkThreadCreate(PAL_HANDLE* handle, int (*callback)(void*), const void* para
                     CLONE_PARENT_SETTID,
                 (void*)tcb, &hdl->thread.tid, NULL);
 
-    if (IS_ERR(ret)) {
+    if (ret < 0) {
         ret = -PAL_ERROR_DENIED;
         goto err;
     }
@@ -202,7 +202,7 @@ int _DkThreadDelayExecution(uint64_t* duration_us) {
 
     int ret = INLINE_SYSCALL(nanosleep, 2, &sleeptime, &remainingtime);
 
-    if (IS_ERR(ret)) {
+    if (ret < 0) {
         PAL_NUM remaining = remainingtime.tv_sec * 1000000 + remainingtime.tv_nsec / 1000;
         *duration_us -= remaining;
         return -PAL_ERROR_INTERRUPTED;
@@ -279,7 +279,7 @@ noreturn void _DkThreadExit(int* clear_child_tid) {
 int _DkThreadResume(PAL_HANDLE threadHandle) {
     int ret = INLINE_SYSCALL(tgkill, 3, g_linux_state.pid, threadHandle->thread.tid, SIGCONT);
 
-    if (IS_ERR(ret))
+    if (ret < 0)
         return -PAL_ERROR_DENIED;
 
     return 0;
@@ -288,13 +288,13 @@ int _DkThreadResume(PAL_HANDLE threadHandle) {
 int _DkThreadSetCpuAffinity(PAL_HANDLE thread, PAL_NUM cpumask_size, PAL_PTR cpu_mask) {
     int ret = INLINE_SYSCALL(sched_setaffinity, 3, thread->thread.tid, cpumask_size, cpu_mask);
 
-    return IS_ERR(ret) ? unix_to_pal_error(ERRNO(ret)) : ret;
+    return ret < 0 ? unix_to_pal_error(ret) : ret;
 }
 
 int _DkThreadGetCpuAffinity(PAL_HANDLE thread, PAL_NUM cpumask_size, PAL_PTR cpu_mask) {
     int ret = INLINE_SYSCALL(sched_getaffinity, 3, thread->thread.tid, cpumask_size, cpu_mask);
 
-    return IS_ERR(ret) ? unix_to_pal_error(ERRNO(ret)) : ret;
+    return ret < 0 ? unix_to_pal_error(ret) : ret;
 }
 
 struct handle_ops g_thread_ops = {

--- a/Pal/src/host/Linux/pal_linux.h
+++ b/Pal/src/host/Linux/pal_linux.h
@@ -24,9 +24,7 @@
 #include "sysdep-arch.h"
 #include "sysdeps/generic/ldsodefs.h"
 
-#define IS_ERR   INTERNAL_SYSCALL_ERROR
 #define IS_ERR_P INTERNAL_SYSCALL_ERROR_P
-#define ERRNO    INTERNAL_SYSCALL_ERRNO
 #define ERRNO_P  INTERNAL_SYSCALL_ERRNO_P
 
 struct timespec;

--- a/Pal/src/host/Linux/pal_linux_error.h
+++ b/Pal/src/host/Linux/pal_linux_error.h
@@ -5,44 +5,59 @@
 
 #include <asm/errno.h>
 
+#include "assert.h"
 #include "pal_error.h"
 
-static inline __attribute__((unused)) int unix_to_pal_error(int unix_errno) {
+static int unix_to_pal_error_positive(int unix_errno) {
+    assert(unix_errno > 0);
     switch (unix_errno) {
         case ENOENT:
-            return -PAL_ERROR_STREAMNOTEXIST;
+            return PAL_ERROR_STREAMNOTEXIST;
         case EINTR:
-            return -PAL_ERROR_INTERRUPTED;
+            return PAL_ERROR_INTERRUPTED;
         case EBADF:
-            return -PAL_ERROR_BADHANDLE;
+            return PAL_ERROR_BADHANDLE;
         case ETIMEDOUT:
         case EAGAIN:
-            return -PAL_ERROR_TRYAGAIN;
+            return PAL_ERROR_TRYAGAIN;
         case ENOMEM:
-            return -PAL_ERROR_NOMEM;
+            return PAL_ERROR_NOMEM;
         case EFAULT:
-            return -PAL_ERROR_BADADDR;
+            return PAL_ERROR_BADADDR;
         case EEXIST:
         case EADDRINUSE:
-            return -PAL_ERROR_STREAMEXIST;
+            return PAL_ERROR_STREAMEXIST;
         case ENOTDIR:
-            return -PAL_ERROR_STREAMISFILE;
+            return PAL_ERROR_STREAMISFILE;
         case EINVAL:
-            return -PAL_ERROR_INVAL;
+            return PAL_ERROR_INVAL;
         case ENAMETOOLONG:
-            return -PAL_ERROR_TOOLONG;
+            return PAL_ERROR_TOOLONG;
         case EISDIR:
-            return -PAL_ERROR_STREAMISDIR;
+            return PAL_ERROR_STREAMISDIR;
         case ECONNRESET:
-            return -PAL_ERROR_CONNFAILED;
+            return PAL_ERROR_CONNFAILED;
         case EPIPE:
-            return -PAL_ERROR_CONNFAILED_PIPE;
+            return PAL_ERROR_CONNFAILED_PIPE;
         case EAFNOSUPPORT:
-            return -PAL_ERROR_AFNOSUPPORT;
+            return PAL_ERROR_AFNOSUPPORT;
         default:
-            return -PAL_ERROR_DENIED;
+            return PAL_ERROR_DENIED;
     }
 }
+
+/*!
+ * \brief Translate UNIX error code into PAL error code.
+ *
+ * The sign of the error code is preserved.
+ */
+static __attribute__((unused)) int unix_to_pal_error(int unix_errno) {
+    if (unix_errno >= 0) {
+        return unix_to_pal_error_positive(unix_errno);
+    }
+    return -unix_to_pal_error_positive(-unix_errno);
+}
+
 #endif /* IN_PAL */
 
 #endif /* PAL_LINUX_ERROR_H */


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

A split-off from #2232. I decided to get rid of `ERRNO()` and `IS_ERR()` macros altogether, after making `unix_to_pal_error()` more intuitive (i.e. preserving the sign, not flipping it) the code looks much simpler without these macros.

This change is based on assumption that Linux always returns errors as "-error_code" on all archs (not e.g. with a bitmask or something similar), which I think is true.

## How to test this PR? <!-- (if applicable) -->

CI.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2234)
<!-- Reviewable:end -->
