### PR TITLE
[Pal] Use WRITE_ONCE instead of READ_ONCE for sgx.preheat_enclave

### DIFF
--- a/Pal/src/host/Linux-SGX/db_main.c
+++ b/Pal/src/host/Linux-SGX/db_main.c
@@ -716,7 +716,7 @@ noreturn void pal_linux_main(char* uptr_libpal_uri, size_t libpal_uri_len, char*
     }
     if (preheat_enclave == 1) {
         for (uint8_t* i = g_pal_sec.heap_min; i < (uint8_t*)g_pal_sec.heap_max; i += g_page_size)
-            READ_ONCE(*(size_t*)i);
+            WRITE_ONCE(*(size_t*)i, 0);
     }
 
     ret = toml_sizestring_in(g_pal_state.manifest_root, "loader.pal_internal_mem_size",


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

This is a follow-up to #2191.

Turns out that in benchmarks WRITE_ONCE is strictly faster (by a few percents) than READ_ONCE (both in total runtime and in after-preheat performance). I verified assembly for both versions which were used in benchmarking and they seemed correct (i.e. looked exactly as expected).

I can't explain why writing gives better performance, but let's do what benchmarks say.

Kudos to @jinengandhi-intel for testing on 100 iterations of quite a big workload.

## How to test this PR? <!-- (if applicable) -->

Use preheat feature and compare performance.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2236)
<!-- Reviewable:end -->
