### PR TITLE
[LibOS] Make supplementary group IDs a per thread attribute

### DIFF
--- a/LibOS/shim/include/shim_thread.h
+++ b/LibOS/shim/include/shim_thread.h
@@ -72,6 +72,11 @@ struct shim_thread {
     /* credentials */
     IDTYPE uid, gid, euid, egid;
 
+    struct {
+        size_t count;
+        gid_t* groups;
+    } groups_info;
+
     /* thread pal handle */
     PAL_HANDLE pal_handle;
 

--- a/LibOS/shim/src/sys/shim_clone.c
+++ b/LibOS/shim/src/sys/shim_clone.c
@@ -118,7 +118,6 @@ static BEGIN_MIGRATION_DEF(fork, struct shim_process* process_description,
 #ifdef DEBUG
     DEFINE_MIGRATE(gdb_map, NULL, 0);
 #endif
-    DEFINE_MIGRATE(groups_info, NULL, 0);
 }
 END_MIGRATION_DEF(fork)
 

--- a/LibOS/shim/src/sys/shim_getuid.c
+++ b/LibOS/shim/src/sys/shim_getuid.c
@@ -62,12 +62,6 @@ long shim_do_setgid(gid_t gid) {
 
 #define NGROUPS_MAX 65536 /* # of supplemental group IDs; has to be same as host OS */
 
-/* TODO: group IDs should be thread based, not global. */
-static struct groups_info_t {
-    size_t count;
-    gid_t* groups;
-} g_groups_info = { .count = 0, .groups = NULL };
-
 long shim_do_setgroups(int gidsetsize, gid_t* grouplist) {
     if (gidsetsize < 0 || (unsigned int)gidsetsize > NGROUPS_MAX)
         return -EINVAL;
@@ -84,12 +78,11 @@ long shim_do_setgroups(int gidsetsize, gid_t* grouplist) {
         groups[i] = grouplist[i];
     }
 
+    struct shim_thread* current = get_cur_thread();
     void* old_groups = NULL;
-    lock(&g_process_ipc_info.lock);
-    g_groups_info.count = groups_len;
-    old_groups = g_groups_info.groups;
-    g_groups_info.groups = groups;
-    unlock(&g_process_ipc_info.lock);
+    current->groups_info.count = groups_len;
+    old_groups = current->groups_info.groups;
+    current->groups_info.groups = groups;
 
     free(old_groups);
 
@@ -103,52 +96,18 @@ long shim_do_getgroups(int gidsetsize, gid_t* grouplist) {
     if (gidsetsize && test_user_memory(grouplist, gidsetsize * sizeof(gid_t), /*write=*/true))
         return -EFAULT;
 
-    lock(&g_process_ipc_info.lock);
-    size_t ret_size = g_groups_info.count;
+    struct shim_thread* current = get_cur_thread();
+    size_t ret_size = current->groups_info.count;
 
     if (gidsetsize) {
         if (ret_size > (size_t)gidsetsize) {
-            unlock(&g_process_ipc_info.lock);
             return -EINVAL;
         }
 
-        for (size_t i = 0; i < g_groups_info.count; i++) {
-            grouplist[i] = g_groups_info.groups[i];
+        for (size_t i = 0; i < ret_size; i++) {
+            grouplist[i] = current->groups_info.groups[i];
         }
     }
 
-    unlock(&g_process_ipc_info.lock);
-
     return (int)ret_size;
 }
-
-BEGIN_CP_FUNC(groups_info) {
-    __UNUSED(size);
-    __UNUSED(objp);
-    __UNUSED(obj);
-
-    lock(&g_process_ipc_info.lock);
-
-    size_t copy_size = g_groups_info.count * sizeof(*g_groups_info.groups);
-
-    size_t off = ADD_CP_OFFSET(sizeof(size_t) + copy_size);
-
-    *(size_t*)((char*)base + off) = g_groups_info.count;
-    gid_t* new_groups = (gid_t*)((char*)base + off + sizeof(size_t));
-
-    memcpy(new_groups, g_groups_info.groups, copy_size);
-
-    unlock(&g_process_ipc_info.lock);
-
-    ADD_CP_FUNC_ENTRY(off);
-}
-END_CP_FUNC(groups_info)
-
-BEGIN_RS_FUNC(groups_info) {
-    __UNUSED(offset);
-    __UNUSED(rebase);
-    size_t off = GET_CP_FUNC_ENTRY();
-    g_groups_info.count = *(size_t*)((char*)base + off);
-    g_groups_info.groups = (gid_t*)((char*)base + off + sizeof(size_t));
-}
-END_RS_FUNC(groups_info)


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->
Previously supplementary group IDs were set process wide, while there should be set only per thread (i.e. two threads can have different sets of groups).

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->
We already had a *groups regression test in LibOS.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2238)
<!-- Reviewable:end -->
