### PR TITLE
[Docs] Fix libcurl requirement in cloud deployment tutorial & add python3-pip

### DIFF
--- a/Documentation/building.rst
+++ b/Documentation/building.rst
@@ -63,14 +63,13 @@ Prerequisites
 Run the following commands on Ubuntu to install SGX-related dependencies::
 
     sudo apt-get install -y libprotobuf-c-dev protobuf-c-compiler \
-       libcurl4-openssl-dev
+       libcurl4-openssl-dev python3-pip
     python3 -m pip install toml>=0.10
 
     # For Ubuntu 18.04
     sudo apt-get install -y python3-protobuf
 
     # For Ubuntu 16.04
-    sudo apt install -y python3-pip
     sudo /usr/bin/pip3 install protobuf
 
 2a. Install the Linux kernel patched with FSGSBASE

--- a/Documentation/cloud-deployment.rst
+++ b/Documentation/cloud-deployment.rst
@@ -26,8 +26,9 @@ Prerequisites
 Update and install the required packages for Graphene::
 
    sudo apt update
-   sudo apt install -y build-essential autoconf gawk bison python3-protobuf \
-                       libprotobuf-c-dev protobuf-c-compiler libcurl4 python3
+   sudo apt install -y \
+       build-essential autoconf gawk bison wget python3 libcurl4-openssl-dev \
+       python3-protobuf libprotobuf-c-dev protobuf-c-compiler
    python3 -m pip install toml>=0.10
 
 Graphene requires the kernel to support FSGSBASE x86 instructions. Older Azure

--- a/Documentation/cloud-deployment.rst
+++ b/Documentation/cloud-deployment.rst
@@ -28,7 +28,7 @@ Update and install the required packages for Graphene::
    sudo apt update
    sudo apt install -y \
        build-essential autoconf gawk bison wget python3 libcurl4-openssl-dev \
-       python3-protobuf libprotobuf-c-dev protobuf-c-compiler
+       python3-protobuf libprotobuf-c-dev protobuf-c-compiler python3-pip
    python3 -m pip install toml>=0.10
 
 Graphene requires the kernel to support FSGSBASE x86 instructions. Older Azure

--- a/Documentation/quickstart.rst
+++ b/Documentation/quickstart.rst
@@ -64,7 +64,7 @@ second command should list the process status of :command:`aesm_service`.
 
       sudo apt-get install -y \
          build-essential autoconf gawk bison wget python3 libcurl4-openssl-dev \
-         python3-protobuf libprotobuf-c-dev protobuf-c-compiler
+         python3-protobuf libprotobuf-c-dev protobuf-c-compiler python3-pip
       python3 -m pip install toml>=0.10
       make
       ISGX_DRIVER_PATH=<path-to-sgx-driver-sources> make SGX=1


### PR DESCRIPTION
## Description of the changes

1. Change `libcurl4` to `libcurl4-openssl-dev` in the cloud deployment tutorial. Without the dev package, the headers for curl are missing, causing step 3 to fail. The quick start guide and the cloud deployment guide slightly differed at the listed requirements, so I basically just copy pasted the requirements from the quick start guide.
2. Add `python3-pip` as requirement. Ubuntu does not come preinstalled with pip, even when calling it as a python3 module specifically. This is listed in other places of the tutorial, but not at this point, so I added it to the building, quick start and cloud deployment guide too.

## How to test this PR? 
Reading and copy-pasting into a fresh Ubuntu installation, I guess?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2239)
<!-- Reviewable:end -->
