### PR TITLE
[LibOS] Set return value on all paths in `do_waitid`

### DIFF
--- a/LibOS/shim/src/sys/shim_wait.c
+++ b/LibOS/shim/src/sys/shim_wait.c
@@ -183,6 +183,8 @@ static long do_waitid(int which, pid_t id, siginfo_t* infop, int options) {
         COMPILER_BARRIER();
         /* Check that we are still supposed to sleep. */
         if (!__atomic_load_n(&qnode.in_use, __ATOMIC_ACQUIRE)) {
+            /* Something woke us up and took of the list in the meantime. */
+            ret = -ERESTARTSYS;
             break;
         }
         ret = thread_sleep(NO_TIMEOUT, /*ignore_pending_signals=*/false);


### PR DESCRIPTION

## Description of the changes <!-- (reasons and measures) -->
In `do_waitid` if the thread was woken up right after it enqueued itself on a wait queue, the return value was not set and hence used the default `0`, instead indicating an error or restarting the syscall.
<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->
Unfortunately I was not able to reproduce the issue locally (race window too tight probably).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2241)
<!-- Reviewable:end -->
