### PR TITLE
[LibOS] Change `mmap` signature so that the file offset is unsigned

### DIFF
--- a/LibOS/shim/include/shim_fs.h
+++ b/LibOS/shim/include/shim_fs.h
@@ -8,8 +8,9 @@
 #ifndef _SHIM_FS_H_
 #define _SHIM_FS_H_
 
-#include <stdbool.h>
 #include <asm/stat.h>
+#include <stdbool.h>
+#include <stdint.h>
 
 #include "list.h"
 #include "pal.h"
@@ -41,7 +42,7 @@ struct shim_fs_ops {
 
     /* mmap: mmap handle to address */
     int (*mmap)(struct shim_handle* hdl, void** addr, size_t size, int prot, int flags,
-                off_t offset);
+                uint64_t offset);
 
     /* flush: flush out user buffer */
     int (*flush)(struct shim_handle* hdl);

--- a/LibOS/shim/include/shim_handle.h
+++ b/LibOS/shim/include/shim_handle.h
@@ -15,6 +15,7 @@
 #include <linux/shm.h>
 #include <linux/un.h>
 #include <stdalign.h>
+#include <stdint.h>
 
 #include "atomic.h"  // TODO: migrate to stdatomic.h
 #include "list.h"
@@ -417,7 +418,7 @@ int walk_handle_map(int (*callback)(struct shim_fd_handle*, struct shim_handle_m
 int init_handle(void);
 int init_important_handles(void);
 
-off_t get_file_size(struct shim_handle* file);
+int get_file_size(struct shim_handle* file, uint64_t* size);
 
 int do_handle_read(struct shim_handle* hdl, void* buf, int count);
 int do_handle_write(struct shim_handle* hdl, const void* buf, int count);

--- a/LibOS/shim/include/shim_table.h
+++ b/LibOS/shim/include/shim_table.h
@@ -30,7 +30,7 @@ long shim_do_statfs(const char* path, struct statfs* buf);
 long shim_do_fstatfs(int fd, struct statfs* buf);
 long shim_do_poll(struct pollfd* fds, nfds_t nfds, int timeout);
 long shim_do_lseek(int fd, off_t offset, int origin);
-void* shim_do_mmap(void* addr, size_t length, int prot, int flags, int fd, off_t offset);
+void* shim_do_mmap(void* addr, size_t length, int prot, int flags, int fd, unsigned long offset);
 long shim_do_mprotect(void* addr, size_t len, int prot);
 long shim_do_munmap(void* addr, size_t len);
 void* shim_do_brk(void* brk);

--- a/LibOS/shim/include/shim_vma.h
+++ b/LibOS/shim/include/shim_vma.h
@@ -12,6 +12,7 @@
 
 #include <linux/mman.h>
 #include <stdbool.h>
+#include <stdint.h>
 
 #include "api.h"
 #include "pal.h"
@@ -29,7 +30,7 @@ struct shim_vma_info {
     int prot;  // memory protection flags: PROT_*
     int flags; // MAP_* and VMA_*
     struct shim_handle* file;
-    off_t file_offset;
+    uint64_t file_offset;
     char comment[VMA_COMMENT_LEN];
 };
 
@@ -80,7 +81,7 @@ int bkeep_mprotect(void* addr, size_t length, int prot, bool is_internal);
  * atomically checks for overlaps and fails if one is found.
  */
 int bkeep_mmap_fixed(void* addr, size_t length, int prot, int flags, struct shim_handle* file,
-                     off_t offset, const char* comment);
+                     uint64_t offset, const char* comment);
 
 /*
  * Bookkeeping an allocation of memory at any address in the range [`bottom_addr`, `top_addr`).
@@ -89,18 +90,18 @@ int bkeep_mmap_fixed(void* addr, size_t length, int prot, int flags, struct shim
  * Start of bookkept range is returned in `*ret_val_ptr`.
  */
 int bkeep_mmap_any_in_range(void* bottom_addr, void* top_addr, size_t length, int prot, int flags,
-                            struct shim_handle* file, off_t offset, const char* comment,
+                            struct shim_handle* file, uint64_t offset, const char* comment,
                             void** ret_val_ptr);
 
 /* Shorthand for `bkeep_mmap_any_in_range` with the range
  * [`PAL_CB(user_address.start)`, `PAL_CB(user_address.end)`). */
-int bkeep_mmap_any(size_t length, int prot, int flags, struct shim_handle* file, off_t offset,
+int bkeep_mmap_any(size_t length, int prot, int flags, struct shim_handle* file, uint64_t offset,
                    const char* comment, void** ret_val_ptr);
 
 /* First tries to bookkeep in the range [`PAL_CB(user_address.start)`, `aslr_addr_top`) and if it
  * fails calls `bkeep_mmap_any`. `aslr_addr_top` is a value randomized on each program run. */
-int bkeep_mmap_any_aslr(size_t length, int prot, int flags, struct shim_handle* file, off_t offset,
-                        const char* comment, void** ret_val_ptr);
+int bkeep_mmap_any_aslr(size_t length, int prot, int flags, struct shim_handle* file,
+                        uint64_t offset, const char* comment, void** ret_val_ptr);
 
 /* Looking up VMA that contains `addr`. If one is found, returns its description in `vma_info`.
  * This function increases ref-count of `vma_info->file` by one (if it is not NULL). */

--- a/LibOS/shim/src/bookkeep/shim_handle.c
+++ b/LibOS/shim/src/bookkeep/shim_handle.c
@@ -474,21 +474,33 @@ void put_handle(struct shim_handle* hdl) {
     }
 }
 
-off_t get_file_size(struct shim_handle* hdl) {
+int get_file_size(struct shim_handle* hdl, uint64_t* size) {
     if (!hdl->fs || !hdl->fs->fs_ops)
         return -EINVAL;
 
-    if (hdl->fs->fs_ops->poll)
-        return hdl->fs->fs_ops->poll(hdl, FS_POLL_SZ);
+    if (hdl->fs->fs_ops->poll) {
+        off_t x = hdl->fs->fs_ops->poll(hdl, FS_POLL_SZ);
+        if (x < 0) {
+            return -EINVAL;
+        }
+        *size = (uint64_t)x;
+        return 0;
+    }
 
     if (hdl->fs->fs_ops->hstat) {
         struct stat stat;
         int ret = hdl->fs->fs_ops->hstat(hdl, &stat);
-        if (ret < 0)
+        if (ret < 0) {
             return ret;
-        return stat.st_size;
+        }
+        if (stat.st_size < 0) {
+            return -EINVAL;
+        }
+        *size = (uint64_t)stat.st_size;
+        return 0;
     }
 
+    *size = 0;
     return 0;
 }
 

--- a/LibOS/shim/src/bookkeep/shim_vma.c
+++ b/LibOS/shim/src/bookkeep/shim_vma.c
@@ -46,7 +46,7 @@ struct shim_vma {
     int prot;
     int flags;
     struct shim_handle* file;
-    off_t offset; // offset inside `file`, where `begin` starts
+    uint64_t offset; // offset inside `file`, where `begin` starts
     union {
         /* If this `vma` is used, it is included in `vma_tree` using this node. */
         struct avl_tree_node tree_node;
@@ -722,7 +722,7 @@ static bool is_file_prot_matching(struct shim_handle* file_hdl, int prot) {
 }
 
 int bkeep_mmap_fixed(void* addr, size_t length, int prot, int flags, struct shim_handle* file,
-                     off_t offset, const char* comment) {
+                     uint64_t offset, const char* comment) {
     assert(flags & (MAP_FIXED | MAP_FIXED_NOREPLACE));
 
     if (!length || !IS_ALLOC_ALIGNED(length) || !IS_ALLOC_ALIGNED_PTR(addr)) {
@@ -937,7 +937,7 @@ int bkeep_mprotect(void* addr, size_t length, int prot, bool is_internal) {
 /* This function allocates at most 1 vma. If in the future it uses more, `_vma_malloc` should be
  * updated as well. */
 int bkeep_mmap_any_in_range(void* _bottom_addr, void* _top_addr, size_t length, int prot, int flags,
-                            struct shim_handle* file, off_t offset, const char* comment,
+                            struct shim_handle* file, uint64_t offset, const char* comment,
                             void** ret_val_ptr) {
     assert(_bottom_addr < _top_addr);
 
@@ -1024,14 +1024,14 @@ out:
     return ret;
 }
 
-int bkeep_mmap_any(size_t length, int prot, int flags, struct shim_handle* file, off_t offset,
+int bkeep_mmap_any(size_t length, int prot, int flags, struct shim_handle* file, uint64_t offset,
                    const char* comment, void** ret_val_ptr) {
     return bkeep_mmap_any_in_range(PAL_CB(user_address.start), PAL_CB(user_address.end), length,
                                    prot, flags, file, offset, comment, ret_val_ptr);
 }
 
-int bkeep_mmap_any_aslr(size_t length, int prot, int flags, struct shim_handle* file, off_t offset,
-                        const char* comment, void** ret_val_ptr) {
+int bkeep_mmap_any_aslr(size_t length, int prot, int flags, struct shim_handle* file,
+                        uint64_t offset, const char* comment, void** ret_val_ptr) {
     int ret;
     ret = bkeep_mmap_any_in_range(PAL_CB(user_address.start), g_aslr_addr_top, length, prot, flags,
                                   file, offset, comment, ret_val_ptr);
@@ -1248,8 +1248,9 @@ BEGIN_CP_FUNC(vma) {
                  * (3) Data in the last file-backed page is valid before or after
                  *     forking. Has to be included in process migration.
                  */
-                off_t file_len = get_file_size(vma->file);
-                if (file_len >= 0 && (off_t)(vma->file_offset + vma->length) > file_len) {
+                uint64_t file_len = 0;
+                if (!get_file_size(vma->file, &file_len)
+                        && vma->file_offset + vma->length > file_len) {
                     send_size = file_len > vma->file_offset ? file_len - vma->file_offset : 0;
                     send_size = ALLOC_ALIGN_UP(send_size);
                 }

--- a/LibOS/shim/src/fs/chroot/fs.c
+++ b/LibOS/shim/src/fs/chroot/fs.c
@@ -691,7 +691,7 @@ out:
 }
 
 static int chroot_mmap(struct shim_handle* hdl, void** addr, size_t size, int prot, int flags,
-                       off_t offset) {
+                       uint64_t offset) {
     int ret;
     if (NEED_RECREATE(hdl) && (ret = chroot_recreate(hdl)) < 0)
         return ret;

--- a/LibOS/shim/src/sys/shim_mmap.c
+++ b/LibOS/shim/src/sys/shim_mmap.c
@@ -46,7 +46,7 @@
                        | MAP_HUGE_2MB           \
                        | MAP_HUGE_1GB)
 
-void* shim_do_mmap(void* addr, size_t length, int prot, int flags, int fd, off_t offset) {
+void* shim_do_mmap(void* addr, size_t length, int prot, int flags, int fd, unsigned long offset) {
     struct shim_handle* hdl = NULL;
     long ret = 0;
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->
On Linux `mmap` syscall takes the file offset as `unsigned long`, only the POSIX wrapper has it as `off_t` (which is signed).

Interesting fact: on powerpc the syscall signature has `off_t`, but then instantly recasts it into `unsigned long` (https://elixir.bootlin.com/linux/v5.11.6/source/arch/powerpc/kernel/syscalls.c#L71).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2244)
<!-- Reviewable:end -->
