### PR TITLE
[LibOS] Let `test_user_memory` check for NULL pointers

### DIFF
--- a/LibOS/shim/src/sys/shim_epoll.c
+++ b/LibOS/shim/src/sys/shim_epoll.c
@@ -132,7 +132,7 @@ long shim_do_epoll_ctl(int epfd, int op, int fd, struct __kernel_epoll_event* ev
         return -EINVAL;
 
     if (op == EPOLL_CTL_ADD || op == EPOLL_CTL_MOD)
-        if (!event || test_user_memory(event, sizeof(*event), false)) {
+        if (test_user_memory(event, sizeof(*event), false)) {
             /* surprisingly, man(epoll_ctl) does not specify EFAULT if event is invalid so
              * we re-use EINVAL; also note that EPOLL_CTL_DEL ignores event completely */
             return -EINVAL;

--- a/LibOS/shim/src/sys/shim_getrlimit.c
+++ b/LibOS/shim/src/sys/shim_getrlimit.c
@@ -80,7 +80,7 @@ void set_rlimit_cur(int resource, uint64_t rlim) {
 long shim_do_getrlimit(int resource, struct __kernel_rlimit* rlim) {
     if (resource < 0 || RLIM_NLIMITS <= resource)
         return -EINVAL;
-    if (!rlim || test_user_memory(rlim, sizeof(*rlim), true))
+    if (test_user_memory(rlim, sizeof(*rlim), true))
         return -EFAULT;
 
     lock(&rlimit_lock);
@@ -96,7 +96,7 @@ long shim_do_setrlimit(int resource, struct __kernel_rlimit* rlim) {
 
     if (resource < 0 || RLIM_NLIMITS <= resource)
         return -EINVAL;
-    if (!rlim || test_user_memory(rlim, sizeof(*rlim), false))
+    if (test_user_memory(rlim, sizeof(*rlim), false))
         return -EFAULT;
     if (rlim->rlim_cur > rlim->rlim_max)
         return -EINVAL;

--- a/LibOS/shim/src/sys/shim_open.c
+++ b/LibOS/shim/src/sys/shim_open.c
@@ -39,7 +39,7 @@ int do_handle_read(struct shim_handle* hdl, void* buf, int count) {
 }
 
 long shim_do_read(int fd, void* buf, size_t count) {
-    if (!buf || test_user_memory(buf, count, true))
+    if (test_user_memory(buf, count, true))
         return -EFAULT;
 
     struct shim_handle* hdl = get_fd_handle(fd, NULL, NULL);
@@ -74,7 +74,7 @@ int do_handle_write(struct shim_handle* hdl, const void* buf, int count) {
 }
 
 long shim_do_write(int fd, const void* buf, size_t count) {
-    if (!buf || test_user_memory((void*)buf, count, false))
+    if (test_user_memory((void*)buf, count, false))
         return -EFAULT;
 
     struct shim_handle* hdl = get_fd_handle(fd, NULL, NULL);
@@ -172,7 +172,7 @@ out:
 }
 
 long shim_do_pread64(int fd, char* buf, size_t count, loff_t pos) {
-    if (!buf || test_user_memory(buf, count, true))
+    if (test_user_memory(buf, count, true))
         return -EFAULT;
 
     if (pos < 0)
@@ -222,7 +222,7 @@ out:
 }
 
 long shim_do_pwrite64(int fd, char* buf, size_t count, loff_t pos) {
-    if (!buf || test_user_memory(buf, count, false))
+    if (test_user_memory(buf, count, false))
         return -EFAULT;
 
     if (pos < 0)
@@ -293,7 +293,7 @@ static inline int get_dirent_type(mode_t type) {
 }
 
 long shim_do_getdents(int fd, struct linux_dirent* buf, size_t count) {
-    if (!buf || test_user_memory(buf, count, true))
+    if (test_user_memory(buf, count, true))
         return -EFAULT;
 
     struct shim_handle* hdl = get_fd_handle(fd, NULL, NULL);
@@ -401,7 +401,7 @@ out_no_unlock:
 }
 
 long shim_do_getdents64(int fd, struct linux_dirent64* buf, size_t count) {
-    if (!buf || test_user_memory(buf, count, true))
+    if (test_user_memory(buf, count, true))
         return -EFAULT;
 
     struct shim_handle* hdl = get_fd_handle(fd, NULL, NULL);

--- a/LibOS/shim/src/sys/shim_pipe.c
+++ b/LibOS/shim/src/sys/shim_pipe.c
@@ -97,7 +97,7 @@ long shim_do_pipe2(int* filedes, int flags) {
         return -EINVAL;
     }
 
-    if (!filedes || test_user_memory(filedes, 2 * sizeof(int), true))
+    if (test_user_memory(filedes, 2 * sizeof(int), true))
         return -EFAULT;
 
     int vfd1 = -1;
@@ -172,7 +172,7 @@ long shim_do_socketpair(int domain, int type, int protocol, int* sv) {
     if ((type & ~(SOCK_NONBLOCK | SOCK_CLOEXEC)) != SOCK_STREAM)
         return -EPROTONOSUPPORT;
 
-    if (!sv || test_user_memory(sv, 2 * sizeof(int), true))
+    if (test_user_memory(sv, 2 * sizeof(int), true))
         return -EFAULT;
 
     int vfd1 = -1;

--- a/LibOS/shim/src/sys/shim_poll.c
+++ b/LibOS/shim/src/sys/shim_poll.c
@@ -187,7 +187,7 @@ static long _shim_do_poll(struct pollfd* fds, nfds_t nfds, int timeout_ms) {
 }
 
 long shim_do_poll(struct pollfd* fds, nfds_t nfds, int timeout_ms) {
-    if (!fds || test_user_memory(fds, sizeof(*fds) * nfds, true))
+    if (test_user_memory(fds, sizeof(*fds) * nfds, true))
         return -EFAULT;
 
     return _shim_do_poll(fds, nfds, timeout_ms);

--- a/LibOS/shim/src/sys/shim_sigaction.c
+++ b/LibOS/shim/src/sys/shim_sigaction.c
@@ -184,7 +184,7 @@ long shim_do_rt_sigsuspend(const __sigset_t* mask_ptr, size_t setsize) {
     if (setsize != sizeof(sigset_t)) {
         return -EINVAL;
     }
-    if (!mask_ptr || test_user_memory((void*)mask_ptr, sizeof(*mask_ptr), false))
+    if (test_user_memory((void*)mask_ptr, sizeof(*mask_ptr), false))
         return -EFAULT;
 
     __sigset_t mask = *mask_ptr;
@@ -227,7 +227,7 @@ long shim_do_rt_sigpending(__sigset_t* set, size_t sigsetsize) {
     if (sigsetsize != sizeof(*set))
         return -EINVAL;
 
-    if (!set || test_user_memory(set, sigsetsize, /*write=*/true))
+    if (test_user_memory(set, sigsetsize, /*write=*/true))
         return -EFAULT;
 
     get_all_pending_signals(set);

--- a/LibOS/shim/src/sys/shim_socket.c
+++ b/LibOS/shim/src/sys/shim_socket.c
@@ -437,7 +437,7 @@ long shim_do_bind(int sockfd, struct sockaddr* addr, int _addrlen) {
     if (_addrlen < 0)
         return -EINVAL;
     size_t addrlen = _addrlen;
-    if (!addr || test_user_memory(addr, addrlen, false))
+    if (test_user_memory(addr, addrlen, false))
         return -EFAULT;
 
     struct shim_handle* hdl = get_fd_handle(sockfd, NULL, NULL);
@@ -689,7 +689,7 @@ long shim_do_connect(int sockfd, struct sockaddr* addr, int _addrlen) {
         return -EINVAL;
     size_t addrlen = _addrlen;
 
-    if (!addr || test_user_memory(addr, addrlen, false))
+    if (test_user_memory(addr, addrlen, false))
         return -EFAULT;
 
     struct shim_handle* hdl = get_fd_handle(sockfd, NULL, NULL);
@@ -865,7 +865,7 @@ static int __do_accept(struct shim_handle* hdl, int flags, struct sockaddr* addr
     }
 
     if (addr) {
-        if (!addrlen || test_user_memory(addrlen, sizeof(*addrlen), /*write=*/true))
+        if (test_user_memory(addrlen, sizeof(*addrlen), /*write=*/true))
             return -EINVAL;
 
         if (*addrlen < 0 || (size_t)*addrlen < minimal_addrlen(sock->domain))
@@ -1162,7 +1162,7 @@ long shim_do_sendto(int sockfd, const void* buf, size_t len, int flags,
         return -EFAULT;
     }
 
-    if (!buf || test_user_memory((void*)buf, len, /*write=*/false)) {
+    if (test_user_memory((void*)buf, len, /*write=*/false)) {
         return -EFAULT;
     }
 
@@ -1202,7 +1202,7 @@ static int check_msghdr(struct msghdr* msg, bool is_recv) {
 }
 
 long shim_do_sendmsg(int sockfd, struct msghdr* msg, int flags) {
-    if (!msg || test_user_memory(msg, sizeof(*msg), /*write=*/false)) {
+    if (test_user_memory(msg, sizeof(*msg), /*write=*/false)) {
         return -EFAULT;
     }
 
@@ -1633,7 +1633,7 @@ long shim_do_getsockname(int sockfd, struct sockaddr* addr, int* addrlen) {
         goto out;
     }
 
-    if (!addr || !addrlen || test_user_memory(addrlen, sizeof(*addrlen), /*write=*/true)) {
+    if (test_user_memory(addrlen, sizeof(*addrlen), /*write=*/true)) {
         ret = -EFAULT;
         goto out;
     }
@@ -1670,7 +1670,7 @@ long shim_do_getpeername(int sockfd, struct sockaddr* addr, int* addrlen) {
         goto out;
     }
 
-    if (!addr || !addrlen || test_user_memory(addrlen, sizeof(*addrlen), /*write=*/true)) {
+    if (test_user_memory(addrlen, sizeof(*addrlen), /*write=*/true)) {
         ret = -EFAULT;
         goto out;
     }
@@ -1888,7 +1888,7 @@ long shim_do_setsockopt(int fd, int level, int optname, char* optval, int optlen
     if (optlen < (int)sizeof(int))
         return -EINVAL;
 
-    if (!optval || test_user_memory(optval, optlen, /*write=*/false))
+    if (test_user_memory(optval, optlen, /*write=*/false))
         return -EFAULT;
 
     struct shim_handle* hdl = get_fd_handle(fd, NULL, NULL);
@@ -1946,8 +1946,8 @@ long shim_do_getsockopt(int fd, int level, int optname, char* optval, int* optle
         goto out;
     }
 
-    if (!optlen || test_user_memory(optlen, sizeof(*optlen), /*write=*/true)
-        || !optval || test_user_memory(optval, *optlen, /*write=*/true)) {
+    if (test_user_memory(optlen, sizeof(*optlen), /*write=*/true)
+            || test_user_memory(optval, *optlen, /*write=*/true)) {
         ret = -EFAULT;
         goto out;
     }

--- a/LibOS/shim/src/sys/shim_stat.c
+++ b/LibOS/shim/src/sys/shim_stat.c
@@ -20,7 +20,7 @@ long shim_do_stat(const char* file, struct stat* stat) {
     if (!file || test_user_string(file))
         return -EFAULT;
 
-    if (!stat || test_user_memory(stat, sizeof(*stat), true))
+    if (test_user_memory(stat, sizeof(*stat), true))
         return -EFAULT;
 
     int ret;
@@ -47,7 +47,7 @@ long shim_do_lstat(const char* file, struct stat* stat) {
     if (!file || test_user_string(file))
         return -EFAULT;
 
-    if (!stat || test_user_memory(stat, sizeof(*stat), true))
+    if (test_user_memory(stat, sizeof(*stat), true))
         return -EFAULT;
 
     int ret;
@@ -146,7 +146,7 @@ long shim_do_readlink(const char* file, char* buf, int bufsize) {
 
 static int __do_statfs(struct shim_mount* fs, struct statfs* buf) {
     __UNUSED(fs);
-    if (!buf || test_user_memory(buf, sizeof(*buf), true))
+    if (test_user_memory(buf, sizeof(*buf), true))
         return -EFAULT;
 
     memset(buf, 0, sizeof(*buf));

--- a/LibOS/shim/src/sys/shim_uname.c
+++ b/LibOS/shim/src/sys/shim_uname.c
@@ -33,7 +33,7 @@ static struct new_utsname g_current_uname = {
 };
 
 long shim_do_uname(struct new_utsname* buf) {
-    if (!buf || test_user_memory(buf, sizeof(*buf), /*write=*/true))
+    if (test_user_memory(buf, sizeof(*buf), /*write=*/true))
         return -EFAULT;
 
     memcpy(buf, &g_current_uname, sizeof(g_current_uname));

--- a/LibOS/shim/src/sys/shim_wrappers.c
+++ b/LibOS/shim/src/sys/shim_wrappers.c
@@ -16,7 +16,7 @@
 #include "shim_utils.h"
 
 long shim_do_readv(int fd, const struct iovec* vec, int vlen) {
-    if (!vec || test_user_memory((void*)vec, sizeof(*vec) * vlen, false))
+    if (test_user_memory((void*)vec, sizeof(*vec) * vlen, false))
         return -EINVAL;
 
     for (int i = 0; i < vlen; i++) {
@@ -78,7 +78,7 @@ out:
  * shall remain unchanged, and errno shall be set to indicate an error
  */
 long shim_do_writev(int fd, const struct iovec* vec, int vlen) {
-    if (!vec || test_user_memory((void*)vec, sizeof(*vec) * vlen, false))
+    if (test_user_memory((void*)vec, sizeof(*vec) * vlen, false))
         return -EINVAL;
 
     for (int i = 0; i < vlen; i++) {

--- a/LibOS/shim/test/ltp/ltp.cfg
+++ b/LibOS/shim/test/ltp/ltp.cfg
@@ -1658,12 +1658,6 @@ skip = yes
 [pwrite01_64]
 timeout = 40
 
-[pwrite03]
-skip = yes
-
-[pwrite03_64]
-skip = yes
-
 [pwrite04]
 must-pass =
     2
@@ -2756,9 +2750,6 @@ skip = yes
 
 # uses futexes on memory shared between processes - unsupported
 [waitpid13]
-skip = yes
-
-[write02]
 skip = yes
 
 [write03]


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->
Previously `test_user_memory` was sometimes accompanied by NULL pointer checks. Those checks are not needed as `test_user_memory` is capable of noticing all kind of invalid pointers and NULL is sometimes a valid one (especially if paired with size equal to 0).

Fixes #2248

## How to test this PR? <!-- (if applicable) -->
Unlocked 2 LTP tests

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2252)
<!-- Reviewable:end -->
