### PR TITLE
[CI] Fix problems with too new BIOS+microcode

### DIFF
--- a/.ci/lib/config.jenkinsfile
+++ b/.ci/lib/config.jenkinsfile
@@ -21,3 +21,5 @@ if (fileExists('/var/run/aesmd/aesm.socket')) {
 
 env.WERROR = '1'
 env.MAKEOPTS = '-j8'
+
+env.RA_TLS_ALLOW_OUTDATED_TCB_INSECURE = '1'

--- a/.ci/lib/stage-test-sgx.jenkinsfile
+++ b/.ci/lib/stage-test-sgx.jenkinsfile
@@ -116,12 +116,10 @@ stage('test-sgx') {
             then \
                 make check_epid RA_CLIENT_SPID=${ra_client_spid} \
                                         RA_TLS_EPID_API_KEY=${ra_client_key} \
-                                        RA_CLIENT_LINKABLE=0 \
-                                        RA_TLS_ALLOW_OUTDATED_TCB_INSECURE=1; \
+                                        RA_CLIENT_LINKABLE=0; \
                 make check_epid_fail RA_CLIENT_SPID=${ra_client_spid} \
                                             RA_TLS_EPID_API_KEY=${ra_client_key} \
-                                            RA_CLIENT_LINKABLE=0 \
-                                            RA_TLS_ALLOW_OUTDATED_TCB_INSECURE=1; \
+                                            RA_CLIENT_LINKABLE=0; \
             else \
                 echo "Failure: no ra_client_spid and/or ra_client_key!"; \
                 exit 1; \
@@ -138,8 +136,7 @@ stage('test-sgx') {
             then \
                 make SGX=1 check_epid RA_CLIENT_SPID=${ra_client_spid} \
                                         RA_TLS_EPID_API_KEY=${ra_client_key} \
-                                        RA_CLIENT_LINKABLE=0 \
-                                        RA_TLS_ALLOW_OUTDATED_TCB_INSECURE=1; \
+                                        RA_CLIENT_LINKABLE=0; \
             else \
                 echo "Failure: no ra_client_spid and/or ra_client_key!"; \
                 exit 1; \

--- a/Pal/src/host/Linux-SGX/tools/common/attestation.c
+++ b/Pal/src/host/Linux-SGX/tools/common/attestation.c
@@ -217,9 +217,14 @@ int verify_ias_report_extract_quote(const uint8_t* ias_report, size_t ias_report
     if (strcmp("OK", node->valuestring) == 0) {
         ret = 0;
         INFO("IAS report: quote status OK\n");
-    } else if (allow_outdated_tcb && strcmp("GROUP_OUT_OF_DATE", node->valuestring) == 0) {
+    } else if (allow_outdated_tcb && (
+               strcmp("GROUP_OUT_OF_DATE", node->valuestring) == 0
+            || strcmp("CONFIGURATION_NEEDED", node->valuestring) == 0
+            || strcmp("SW_HARDENING_NEEDED", node->valuestring) == 0
+            || strcmp("CONFIGURATION_AND_SW_HARDENING_NEEDED", node->valuestring) == 0
+            )) {
         ret = 0;
-        INFO("IAS report: allowing quote status GROUP_OUT_OF_DATE\n");
+        INFO("IAS report: allowing quote status %s\n", node->valuestring);
     }
 
     if (ret != 0) {

--- a/Pal/src/host/Linux-SGX/tools/common/attestation.h
+++ b/Pal/src/host/Linux-SGX/tools/common/attestation.h
@@ -36,7 +36,8 @@ void display_report_body(const sgx_report_body_t* body);
  *  \param[in] ias_report_size    Size of \a ias_report in bytes.
  *  \param[in] ias_sig_b64        IAS report signature (base64-encoded as returned by IAS).
  *  \param[in] ias_sig_b64_size   Size of \a ias_sig_b64 in bytes.
- *  \param[in] allow_outdated_tcb Treat IAS status GROUP_OUT_OF_DATE as OK.
+ *  \param[in] allow_outdated_tcb Treat IAS status codes: GROUP_OUT_OF_DATE, CONFIGURATION_NEEDED,
+ *                                SW_HARDENING_NEEDED, CONFIGURATION_AND_SW_HARDENING_NEEDED as OK.
  *  \param[in] nonce              (Optional) Nonce that's expected in the report.
  *  \param[in] mr_signer          (Optional) Expected mr_signer quote field.
  *  \param[in] mr_enclave         (Optional) Expected mr_enclave quote field.
@@ -68,7 +69,8 @@ int verify_ias_report(const uint8_t* ias_report, size_t ias_report_size, uint8_t
  *  \param[in] ias_report_size    Size of \a ias_report in bytes.
  *  \param[in] ias_sig_b64        IAS report signature (base64-encoded as returned by IAS).
  *  \param[in] ias_sig_b64_size   Size of \a ias_sig_b64 in bytes.
- *  \param[in] allow_outdated_tcb Treat IAS status GROUP_OUT_OF_DATE as OK.
+ *  \param[in] allow_outdated_tcb Treat IAS status codes: GROUP_OUT_OF_DATE, CONFIGURATION_NEEDED,
+ *                                SW_HARDENING_NEEDED, CONFIGURATION_AND_SW_HARDENING_NEEDED as OK.
  *  \param[in] nonce              (Optional) Nonce that's expected in the report.
  *  \param[in] ias_pub_key_pem    (Optional) IAS public RSA key (PEM format, NULL-terminated).
  *                                If not specified, a hardcoded Intel's key is used.


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://graphene.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

In `Examples/ra-tls-mbedtls` IAS API reports quote status, and on CI machines this was always `GROUP_OUT_OF_DATE`, because, well, BIOS and/or microcode is out of date on those. But recently we've got some new machines, one among them is surprisingly updated and for this machine another error, `CONFIGURATION_AND_SW_HARDENING_NEEDED` is returned instead, which confuses our tooling. This PR makes the attestation code to ignore also this problem.

An `ias.py` python module and `graphene-ias-query` tool, which aided debugging this problem, are included. This was necessary to write, as the existing tools in `Pal/**/Linux-SGX/tools` use IAS API v3, and I needed v4 API.

## How to test this PR? <!-- (if applicable) -->

For this PR only, the problematic CI pipeline was pinned to the machine in question, which for now only serves for this PR. The 18.04-sgx-apps pipeline should pass. Before merging (maybe as part of final rebase) the commit with pinning should be dropped. After merging this PR the Jenkins node will be made available for all SGX pipelines, and possibly all other SGX nodes will be brought up-to-date.

`ias.py` tool lacks tests, because it's complicated to provoke every possible IAS response. It would require multiple carefully setup boxen, each with it's own bespoke set of problems. Please review thoroughly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2258)
<!-- Reviewable:end -->
