### PR TITLE
[LibOS] Change file type of /proc/self/exe from DIRECTORY to SYMLINK

### DIFF
--- a/LibOS/shim/src/fs/proc/thread.c
+++ b/LibOS/shim/src/fs/proc/thread.c
@@ -172,21 +172,16 @@ out:
 }
 
 static int proc_thread_link_stat(const char* name, struct stat* buf) {
-    struct shim_dentry* dent;
+    __UNUSED(name);
+    memset(buf, 0, sizeof(*buf));
 
-    int ret = find_thread_link(name, NULL, &dent);
-    if (ret < 0)
-        return ret;
+    buf->st_dev = buf->st_ino = 1;
+    buf->st_mode              = PERM_r________ | S_IFLNK;
+    buf->st_uid               = 0;
+    buf->st_gid               = 0;
+    buf->st_size              = 0;
 
-    if (!dent->fs || !dent->fs->d_ops || !dent->fs->d_ops->stat) {
-        ret = -EACCES;
-        goto out;
-    }
-
-    ret = dent->fs->d_ops->stat(dent, buf);
-out:
-    put_dentry(dent);
-    return ret;
+    return 0;
 }
 
 static int proc_thread_link_follow_link(const char* name, struct shim_qstr* link) {


### PR DESCRIPTION
Signed-off-by: aneessahib <anees.a.sahib@intel.com>

Currently, lstat for proc/self/exe return DIRECTORY for file type, since graphene resolves this to the actual binary and fills up the stat accordingly. The problem with returning file type as DIRECTORY for proc/self/exe is that when certain apps (eg Dotnet) attempts to locate other binaries relative to its executable path, the path resolves to "/proc/self/<binary". 
In this fix, the type is returned as SYMLINK, and hence the path to binary that the application seeks resolves to "/<binary". Support to resolve the links (readlink) to the exact paths are already present, hence no further code is needed to support the LINK status of exe. Furthermore, the pseudo entry for the same is also defined as LINUX_DT_LNK. The fix added also applies to other links within proc/self such as "cwd" and "root" for consistency.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2259)
<!-- Reviewable:end -->
