### PR TITLE
[LibOS/shim] Add tests for multiple writers

### DIFF
--- a/LibOS/shim/test/fs/.gitignore
+++ b/LibOS/shim/test/fs/.gitignore
@@ -11,6 +11,7 @@
 /copy_seq
 /copy_whole
 /delete
+/multiple_writers
 /open_close
 /open_flags
 /read_write

--- a/LibOS/shim/test/fs/Makefile
+++ b/LibOS/shim/test/fs/Makefile
@@ -13,6 +13,7 @@ copy_execs = \
 execs = \
 	$(copy_execs) \
 	delete \
+	multiple_writers \
 	open_close \
 	open_flags \
 	read_write \
@@ -45,6 +46,8 @@ $(copy_execs): common_copy.o
 
 $(copy_mmap_execs): CFLAGS += -DCOPY_MMAP
 
+multiple_writers: LDLIBS += -lpthread
+
 %.o: %.c
 	$(call cmd,cc_o_c)
 
@@ -58,10 +61,13 @@ fs-test: $(target)
 	$(RM) fs-test.xml
 	$(MAKE) fs-test.xml
 
-.PHONY: test
-test: $(target)
+.PHONY: pf-test
+pf-test: $(target)
 	$(RM) pf-test.xml
 	$(MAKE) pf-test.xml
+
+.PHONY: test
+test: fs-test pf-test
 
 fs-test.xml: test_fs.py $(call expand_target_to_token,$(target))
 	$(SCRIPTS_DIR)/run-pytest --junit-xml $@ -v $<

--- a/LibOS/shim/test/fs/README.md
+++ b/LibOS/shim/test/fs/README.md
@@ -15,8 +15,9 @@ These tests perform common FS operations in various ways to exercise the Graphen
 How to execute
 --------------
 
-Run `make test` (tests both regular files and protected files).
-Run `make fs-test` to only test regular files.
+- `make test` to run all tests
+- `make fs-test` to test regular files
+- `make pf-test` to test protected files (SGX only)
 
 (SGX only) Protected file tests assume that the SGX tools were installed in this directory:
 

--- a/LibOS/shim/test/fs/manifest.template
+++ b/LibOS/shim/test/fs/manifest.template
@@ -35,3 +35,5 @@ sgx.protected_files.input = "file:tmp/pf_input"
 sgx.protected_files.output = "file:tmp/pf_output"
 
 sgx.nonpie_binary = 1
+
+sgx.thread_num = 16

--- a/LibOS/shim/test/fs/multiple_writers.c
+++ b/LibOS/shim/test/fs/multiple_writers.c
@@ -1,0 +1,95 @@
+/* SPDX-License-Identifier: LGPL-3.0-or-later */
+/* Copyright (C) 2021 Intel Corporation
+ *                    Paweł Marczewski <pawel@invisiblethingslab.com>
+ */
+
+/*
+ * This is a test for concurrent writes to the same file descriptor. Depending on the command line,
+ * it spawns multiple processes, multiple threads, or both.
+ */
+
+#define _XOPEN_SOURCE 700
+#include <pthread.h>
+#include <sys/wait.h>
+
+#include "common.h"
+
+pthread_barrier_t g_barrier;
+const char* g_path;
+int g_fd;
+int g_proc_id;
+int g_n_lines;
+
+static void* writer(void* arg) {
+    int thread_id = *(int*)arg;
+
+    pthread_barrier_wait(&g_barrier);
+
+    for (int i = 0; i < g_n_lines; i++) {
+        char buf[100];
+        size_t size = snprintf(buf, sizeof(buf), "%04d %04d %04d: proc %d thread %d line %d\n",
+                               g_proc_id, thread_id, i, g_proc_id, thread_id, i);
+        write_fd(g_path, g_fd, buf, size);
+    }
+    return NULL;
+}
+
+static void multiple_writers(const char* path, int n_lines, int n_processes, int n_threads) {
+    g_fd = open_output_fd(path, /*rdwr=*/false);
+    if (ftruncate(g_fd, 0))
+        fatal_error("truncate(%s) failed: %d\n", path, path, errno);
+
+    g_path = path;
+    g_n_lines = n_lines;
+
+    g_proc_id = 0;
+    for (int i = 1; i < n_processes; i++) {
+        int ret = fork();
+        if (ret < 0) {
+            fatal_error("error on fork: %d\n", errno);
+        } else if (ret == 0) {
+            g_proc_id = i;
+            break;
+        }
+    }
+
+    pthread_barrier_init(&g_barrier, NULL, n_threads);
+    pthread_t threads[n_threads];
+    int ids[n_threads];
+    for (int i = 1; i < n_threads; i++) {
+        ids[i] = i;
+        pthread_create(&threads[i], NULL, writer, &ids[i]);
+    }
+
+    ids[0] = 0;
+    writer(&ids[0]);
+
+    for (int i = 1; i < n_threads; i++)
+        pthread_join(threads[i], NULL);
+
+    if (g_proc_id == 0) {
+        for (int i = 1; i < n_processes; i++)
+            wait(NULL);
+    }
+}
+
+int main(int argc, char* argv[]) {
+    if (argc != 5)
+        fatal_error("Usage: %s <file_path> <n_lines> <n_processes> <n_threads>\n", argv[0]);
+
+    int n_lines = atoi(argv[2]);
+    int n_processes = atoi(argv[3]);
+    int n_threads = atoi(argv[4]);
+
+    if (n_lines <= 0)
+        fatal_error("wrong number of lines\n");
+    if (n_processes <= 0)
+        fatal_error("wrong number of processes\n");
+    if (n_threads <= 0)
+        fatal_error("wrong number of threads\n");
+
+    setup();
+
+    multiple_writers(argv[1], n_lines, n_processes, n_threads);
+    return 0;
+}

--- a/LibOS/shim/test/fs/test_pf.py
+++ b/LibOS/shim/test/fs/test_pf.py
@@ -6,9 +6,8 @@ import shutil
 import subprocess
 import unittest
 
-from test_fs import (
-    TC_00_FileSystem,
-)
+# Named import, so that Pytest does not pick up TC_00_FileSystem as belonging to this module.
+import test_fs
 
 from regression import (
     HAS_SGX,
@@ -16,9 +15,11 @@ from regression import (
 )
 
 @unittest.skipUnless(HAS_SGX, 'Protected files require SGX support')
-class TC_50_ProtectedFiles(TC_00_FileSystem):
+class TC_50_ProtectedFiles(test_fs.TC_00_FileSystem):
     @classmethod
     def setUpClass(cls):
+        super().setUpClass()
+
         cls.PF_CRYPT = 'bin/pf_crypt'
         cls.PF_TAMPER = 'bin/pf_tamper'
         cls.WRAP_KEY = os.path.join(cls.TEST_DIR, 'wrap-key')
@@ -29,7 +30,6 @@ class TC_50_ProtectedFiles(TC_00_FileSystem):
         cls.ENCRYPTED_FILES = [os.path.join(cls.ENCRYPTED_DIR, str(v)) for v in cls.FILE_SIZES]
         cls.LIB_PATH = os.path.join(os.getcwd(), 'lib')
 
-        super().setUpClass()
         if not os.path.exists(cls.ENCRYPTED_DIR):
             os.mkdir(cls.ENCRYPTED_DIR)
         cls.OUTPUT_DIR = os.path.join(cls.TEST_DIR, 'pf_output')


### PR DESCRIPTION
Test if concurrent writes to the same file descriptor are handled correctly (for example, if they do not overlap each other). Right now, this is the case for multiple threads, but not multiple processes, so the multi-process tests are disabled.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2264)
<!-- Reviewable:end -->
