### PR TITLE
[GSC] Restrict NumPy and PyTorch examples to use only 8 threads

### DIFF
--- a/Tools/gsc/test/ubuntu18.04-numpy.manifest
+++ b/Tools/gsc/test/ubuntu18.04-numpy.manifest
@@ -1,3 +1,10 @@
 sgx.enclave_size = "2G"
 sgx.thread_num = 32
 sys.stack.size = "2M"
+
+# Python's memory allocator by default creates a new arena for each thread, and each new arena
+# allocates 128MB of memory. By default, NumPy creates as many threads as there are available CPU
+# cores, so this may quickly deplete available enclave memory (e.g. Python eats 2GB on a 16-core
+# platform). Let's restrict the number of created threads.
+loader.env.OMP_NUM_THREADS = "8"
+loader.env.MKL_NUM_THREADS = "8"

--- a/Tools/gsc/test/ubuntu18.04-pytorch.manifest
+++ b/Tools/gsc/test/ubuntu18.04-pytorch.manifest
@@ -1,3 +1,10 @@
 sgx.enclave_size = "4G"
 sgx.thread_num = 32
 sys.stack.size = "2M"
+
+# Python's memory allocator by default creates a new arena for each thread, and each new arena
+# allocates 128MB of memory. By default, PyTorch creates as many threads as there are available CPU
+# cores, so this may quickly deplete available enclave memory (e.g. Python eats 2GB on a 16-core
+# platform). Let's restrict the number of created threads.
+loader.env.OMP_NUM_THREADS = "8"
+loader.env.MKL_NUM_THREADS = "8"


### PR DESCRIPTION

## Description of the changes <!-- (reasons and measures) -->

Previously, there was no restriction on the number of threads, so both NumPy and PyTorch allocated as many threads as there are CPU cores on the platform. On many-core platforms, this led to OOM errors in these examples because enclave memory was quickly depleted (each thread in Python allocates 128MB for its "memory arena").


## How to test this PR? <!-- (if applicable) -->

GSC tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2275)
<!-- Reviewable:end -->
