### PR TITLE
Patch uthash to stop using glibc headers

### DIFF
--- a/Pal/lib/.gitignore
+++ b/Pal/lib/.gitignore
@@ -1,3 +1,5 @@
 /toml.c
 /toml.h
 /toml.patched
+/uthash.h
+/uthash.patched

--- a/Pal/lib/Makefile
+++ b/Pal/lib/Makefile
@@ -146,7 +146,7 @@ objs += crypto/adapters/mbedtls_encoding.o
 endif
 
 .PHONY: all
-all: ../include/lib/uthash.h $(target)graphene-lib.a
+all: uthash.patched $(target)graphene-lib.a
 
 $(target)graphene-lib.a: $(addprefix $(target),$(objs))
 	@mkdir -p $(dir $@)
@@ -165,8 +165,13 @@ UTHASH_URI ?= \
 	https://packages.grapheneproject.io/distfiles/uthash-2.1.0/src/uthash.h
 UTHASH_CHECKSUM ?= ba9af0e8c902108cc40be8e742ff4fcbb0e93062d91aefd6070b70d4e067c2ac
 
-../include/lib/uthash.h:
+uthash.h:
 	../../Scripts/download --output $@ --sha256 $(UTHASH_CHECKSUM) $(foreach mirror,$(UTHASH_URI),--url $(mirror))
+
+uthash.patched: uthash.h
+	patch -p2 < uthash.patch || exit 255
+	cp uthash.h ../include/lib/uthash.h
+	touch $@
 
 TOML_COMMIT ?= 5be06807ad5f2230cad99e15380c4f4076c9dd83
 TOML_H_URI ?= \
@@ -196,5 +201,5 @@ clean:
 .PHONY: distclean
 distclean: clean
 	$(RM) -r crypto/$(MBEDTLS_SRC) crypto/$(MBEDCRYPTO_SRC) crypto/mbedtls
-	$(RM) ../include/lib/uthash.h
+	$(RM) ../include/lib/uthash.h uthash.h uthash.patched
 	$(RM) ../include/lib/toml.h toml.h toml.c toml.patched

--- a/Pal/lib/uthash.patch
+++ b/Pal/lib/uthash.patch
@@ -1,0 +1,35 @@
+diff --git a/src/uthash.h b/src/uthash.h
+index 76bdca6..c963283 100644
+--- a/src/uthash.h
++++ b/src/uthash.h
+@@ -26,9 +26,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ 
+ #define UTHASH_VERSION 2.1.0
+ 
+-#include <string.h>   /* memcmp, memset, strlen */
+-#include <stddef.h>   /* ptrdiff_t */
+-#include <stdlib.h>   /* exit */
++#include "api.h"      /* ptrdiff_t, memcmp, memset, strlen */
+ 
+ /* These macros use decltype or the earlier __typeof GNU extension.
+    As decltype is only available in newer compilers (VS2010 or gcc 4.3+
+@@ -128,7 +126,7 @@ typedef unsigned char uint8_t;
+ /* malloc failures result in lost memory, hash tables are unusable */
+ 
+ #ifndef uthash_fatal
+-#define uthash_fatal(msg) exit(-1)        /* fatal OOM error */
++#error You need to define uthash_fatal(msg)
+ #endif
+ 
+ #define HASH_RECORD_OOM(oomed) uthash_fatal("out of memory")
+@@ -519,7 +517,9 @@ do {
+  * This is for uthash developer only; it compiles away if HASH_DEBUG isn't defined.
+  */
+ #ifdef HASH_DEBUG
+-#define HASH_OOPS(...) do { fprintf(stderr,__VA_ARGS__); exit(-1); } while (0)
++#ifndef uthash_fatal
++#error You need to define HASH_OOPS(...)
++#endif
+ #define HASH_FSCK(hh,head,where)                                                 \
+ do {                                                                             \
+   struct UT_hash_handle *_thh;                                                   \

--- a/Pal/src/host/Linux-SGX/pal_linux.h
+++ b/Pal/src/host/Linux-SGX/pal_linux.h
@@ -14,6 +14,7 @@
 #include "pal.h"
 #include "pal_crypto.h"
 #include "pal_defs.h"
+#include "pal_internal.h"
 #include "pal_linux_defs.h"
 #include "protected_files.h"
 #include "sgx_api.h"
@@ -21,7 +22,6 @@
 #include "sgx_attest.h"
 #include "sgx_tls.h"
 #include "sysdep-arch.h"
-#include "uthash.h"
 
 #define IS_ERR_P    INTERNAL_SYSCALL_ERROR_P
 #define ERRNO_P     INTERNAL_SYSCALL_ERRNO_P
@@ -302,15 +302,6 @@ int sgx_create_process(const char* uri, size_t nargs, const char** args, int* st
 #endif
 
 #endif /* IN_ENCLAVE */
-
-#ifdef IN_ENCLAVE
-#undef uthash_fatal
-#define uthash_fatal(msg)               \
-    do {                                \
-        __UNUSED(msg);                  \
-        DkProcessExit(PAL_ERROR_NOMEM); \
-    } while (0)
-#endif
 
 #ifndef IN_ENCLAVE
 int clone(int (*__fn)(void* __arg), void* __child_stack, int __flags, const void* __arg, ...);

--- a/Pal/src/host/Linux-SGX/protected-files/lru_cache.c
+++ b/Pal/src/host/Linux-SGX/protected-files/lru_cache.c
@@ -6,11 +6,9 @@
 
 /* TODO: add regression tests for this */
 
-#include "lru_cache.h"
-
 #include "api.h"
+#include "lru_cache.h"
 #include "list.h"
-#include "uthash.h"
 
 #ifdef IN_PAL
 #include "assert.h"
@@ -19,6 +17,13 @@
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
+
+#define uthash_fatal(msg)                            \
+    do {                                             \
+        fprintf(stderr, "uthash error: %s\n", msg);  \
+        exit(-1);                                    \
+    } while(0)
+#include "uthash.h"
 #endif
 
 DEFINE_LIST(_lruc_list_node);

--- a/Pal/src/pal_internal.h
+++ b/Pal/src/pal_internal.h
@@ -315,4 +315,11 @@ void _log(int level, const char* fmt, ...) __attribute__((format(printf, 2, 3)))
 #define log_debug(fmt...)    _log(PAL_LOG_DEBUG, fmt)
 #define log_trace(fmt...)    _log(PAL_LOG_TRACE, fmt)
 
+#define uthash_fatal(msg)                      \
+    do {                                       \
+        log_error("uthash error: %s\n", msg);  \
+        DkProcessExit(PAL_ERROR_NOMEM);        \
+    } while (0)
+#include "uthash.h"
+
 #endif


### PR DESCRIPTION
This change enables me to use uthash in LibOS, without additional hack with disabling `_FORTIFY_SOURCE`.

(First discussed in #2267).

## How to test this PR? <!-- (if applicable) -->

If things still compile with no warnings, we should be OK.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2277)
<!-- Reviewable:end -->
