### PR TITLE
[Pal/lib] Update mbedTLS from version 2.21.0 to 2.26.0

### DIFF
--- a/Examples/ra-tls-mbedtls/Makefile
+++ b/Examples/ra-tls-mbedtls/Makefile
@@ -3,7 +3,7 @@
 # - make          -- build SGX version with apps built in release mode and no logs
 # - make DEBUG=1  -- build SGX version with apps built in debug mode and with logs
 #
-# Any of these invocations clones mbedTLS' git repository (version 2.21.0) and
+# Any of these invocations clones mbedTLS' git repository (version 2.26.0) and
 # builds it in default configuration. Also, server and client programs are
 # built. See README for details.
 #
@@ -43,20 +43,12 @@ dcap: libs/.dcap_libs_copied client_dcap.manifest.sgx client_dcap.sig client_dca
 
 ############################# MBEDTLS DEPENDENCY ##############################
 
-MBEDTLS_VERSION ?= 2.21.0
+MBEDTLS_VERSION ?= 2.26.0
 MBEDTLS_SRC ?= mbedtls-$(MBEDTLS_VERSION).tar.gz
 MBEDTLS_URI ?= \
 	https://github.com/ARMmbed/mbedtls/archive \
 	https://packages.grapheneproject.io/distfiles
-MBEDTLS_CHECKSUM ?= 320e930b7596ade650ae4fc9ba94b510d05e3a7d63520e121d8fdc7a21602db9
-
-# mbedTLS uses a submodule mbedcrypto, need to download it and move under mbedtls/crypto
-MBEDCRYPTO_VERSION ?= 3.1.0
-MBEDCRYPTO_SRC ?= mbedcrypto-$(MBEDCRYPTO_VERSION).tar.gz
-MBEDCRYPTO_URI ?= \
-	https://github.com/ARMmbed/mbed-crypto/archive \
-	https://packages.grapheneproject.io/distfiles
-MBEDCRYPTO_CHECKSUM ?= 7e171df03560031bc712489930831e70ae4b70ff521a609c6361f36bd5f8b76b
+MBEDTLS_CHECKSUM ?= 35d8d87509cd0d002bddbd5508b9d2b931c5e83747d087234cc7ad551d53fe05
 
 ifeq ($(DEBUG),1)
 MBED_BUILD_TYPE=Debug
@@ -67,17 +59,10 @@ endif
 $(MBEDTLS_SRC):
 	$(GRAPHENEDIR)/Scripts/download --output $@ $(foreach mirror,$(MBEDTLS_URI),--url $(mirror)/$(MBEDTLS_SRC)) --sha256 $(MBEDTLS_CHECKSUM)
 
-$(MBEDCRYPTO_SRC):
-	$(GRAPHENEDIR)/Scripts/download --output $@ $(foreach mirror,$(MBEDCRYPTO_URI),--url $(mirror)/$(MBEDCRYPTO_SRC)) --sha256 $(MBEDCRYPTO_CHECKSUM)
-
 .SECONDARY: mbedtls/.mbedtls_downloaded
-mbedtls/.mbedtls_downloaded: $(MBEDTLS_SRC) $(MBEDCRYPTO_SRC)
+mbedtls/.mbedtls_downloaded: $(MBEDTLS_SRC)
 	tar --touch -xzf $(MBEDTLS_SRC)
-	tar --touch -xzf $(MBEDCRYPTO_SRC)
 	mv mbedtls-mbedtls-$(MBEDTLS_VERSION) mbedtls
-	$(RM) -r mbedtls/crypto
-	mv mbed-crypto-mbedcrypto-$(MBEDCRYPTO_VERSION) mbedtls
-	mv mbedtls/mbed-crypto-mbedcrypto-$(MBEDCRYPTO_VERSION) mbedtls/crypto
 	touch $@
 
 .SECONDARY: mbedtls/.mbedtls_configured
@@ -93,7 +78,7 @@ mbedtls/.mbedtls_built: mbedtls/.mbedtls_configured
 
 ######################### CLIENT/SERVER EXECUTABLES ###########################
 
-CFLAGS += -I./mbedtls/install/include -I./mbedtls/crypto/include
+CFLAGS += -I./mbedtls/install/include
 # These flags are *NOT* for production, setting rpath is here only to simplify the test setup.
 LFLAGS += -Wl,-rpath-link,./libs/ -L./libs/ -ldl -lmbedcrypto -lmbedtls -lmbedx509
 

--- a/Examples/ra-tls-mbedtls/README.md
+++ b/Examples/ra-tls-mbedtls/README.md
@@ -1,10 +1,10 @@
 # RA-TLS Minimal Example
 
 This directory contains the Makefile, the template server manifest, and the minimal server and
-client written against the mbedTLS 2.21.0 library.  This was tested on a machine with SGX v1 and
+client written against the mbedTLS 2.26.0 library.  This was tested on a machine with SGX v1 and
 Ubuntu 18.04.
 
-The server and client are based on `ssl_server.c` and `ssl_client.c` example programs shipped with
+The server and client are based on `ssl_server.c` and `ssl_client1.c` example programs shipped with
 mbedTLS. We modified them to allow using RA-TLS flows if the programs are given the command-line
 argument `epid`/`dcap`.  In particular, the server uses a self-signed RA-TLS cert with the SGX quote
 embedded in it via `ra_tls_create_key_and_crt()`. The client uses an RA-TLS verification callback to
@@ -91,6 +91,9 @@ kill %%
 - RA-TLS flows with SGX and with Graphene, ECDSA-based (DCAP) attestation:
 
 ```sh
+# make sure RA-TLS DCAP libraries are built in Graphene via:
+#   cd graphene/Pal/src/host/Linux-SGX/tools/ra-tls && make dcap
+
 # replace dummy values with your MRENCLAVE, MRSIGNER, etc!
 make clean
 make app dcap

--- a/Examples/ra-tls-mbedtls/src/client.c
+++ b/Examples/ra-tls-mbedtls/src/client.c
@@ -1,6 +1,6 @@
 /*
  *  SSL client demonstration program (with RA-TLS).
- *  This program is heavily based on an mbedTLS 2.21.0 example ssl_client.c
+ *  This program is heavily based on an mbedTLS 2.26.0 example ssl_client1.c
  *  but uses RA-TLS flows (SGX Remote Attestation flows) if RA-TLS library
  *  is required by user.
  *

--- a/Examples/ra-tls-mbedtls/src/server.c
+++ b/Examples/ra-tls-mbedtls/src/server.c
@@ -1,6 +1,6 @@
 /*
  *  SSL server demonstration program (with RA-TLS)
- *  This program is heavily based on an mbedTLS 2.21.0 example ssl_server.c
+ *  This program is heavily based on an mbedTLS 2.26.0 example ssl_server.c
  *  but uses RA-TLS flows (SGX Remote Attestation flows) if RA-TLS library
  *  is required by user.
  *

--- a/Examples/ra-tls-secret-prov/Makefile
+++ b/Examples/ra-tls-secret-prov/Makefile
@@ -3,7 +3,7 @@
 # - make          -- build SGX version with apps built in release mode and no logs
 # - make DEBUG=1  -- build SGX version with apps built in debug mode and with logs
 #
-# Any of these invocations clones mbedTLS' git repository (version 2.21.0) and
+# Any of these invocations clones mbedTLS' git repository (version 2.26.0) and
 # builds it in default configuration. Also, server and client programs are
 # built. See README for details.
 #
@@ -46,20 +46,12 @@ dcap: secret_prov_server_dcap libs/.dcap_libs_copied
 
 ############################# MBEDTLS DEPENDENCY ##############################
 
-MBEDTLS_VERSION ?= 2.21.0
+MBEDTLS_VERSION ?= 2.26.0
 MBEDTLS_SRC ?= mbedtls-$(MBEDTLS_VERSION).tar.gz
 MBEDTLS_URI ?= \
 	https://github.com/ARMmbed/mbedtls/archive \
 	https://packages.grapheneproject.io/distfiles
-MBEDTLS_CHECKSUM ?= 320e930b7596ade650ae4fc9ba94b510d05e3a7d63520e121d8fdc7a21602db9
-
-# mbedTLS uses a submodule mbedcrypto, need to download it and move under mbedtls/crypto
-MBEDCRYPTO_VERSION ?= 3.1.0
-MBEDCRYPTO_SRC ?= mbedcrypto-$(MBEDCRYPTO_VERSION).tar.gz
-MBEDCRYPTO_URI ?= \
-	https://github.com/ARMmbed/mbed-crypto/archive \
-	https://packages.grapheneproject.io/distfiles
-MBEDCRYPTO_CHECKSUM ?= 7e171df03560031bc712489930831e70ae4b70ff521a609c6361f36bd5f8b76b
+MBEDTLS_CHECKSUM ?= 35d8d87509cd0d002bddbd5508b9d2b931c5e83747d087234cc7ad551d53fe05
 
 ifeq ($(DEBUG),1)
 MBED_BUILD_TYPE=Debug
@@ -70,17 +62,10 @@ endif
 $(MBEDTLS_SRC):
 	$(GRAPHENEDIR)/Scripts/download --output $@ $(foreach mirror,$(MBEDTLS_URI),--url $(mirror)/$(MBEDTLS_SRC)) --sha256 $(MBEDTLS_CHECKSUM)
 
-$(MBEDCRYPTO_SRC):
-	$(GRAPHENEDIR)/Scripts/download --output $@ $(foreach mirror,$(MBEDCRYPTO_URI),--url $(mirror)/$(MBEDCRYPTO_SRC)) --sha256 $(MBEDCRYPTO_CHECKSUM)
-
 .SECONDARY: mbedtls/.mbedtls_downloaded
-mbedtls/.mbedtls_downloaded: $(MBEDTLS_SRC) $(MBEDCRYPTO_SRC)
+mbedtls/.mbedtls_downloaded: $(MBEDTLS_SRC)
 	tar --touch -xzf $(MBEDTLS_SRC)
-	tar --touch -xzf $(MBEDCRYPTO_SRC)
 	mv mbedtls-mbedtls-$(MBEDTLS_VERSION) mbedtls
-	$(RM) -r mbedtls/crypto
-	mv mbed-crypto-mbedcrypto-$(MBEDCRYPTO_VERSION) mbedtls
-	mv mbedtls/mbed-crypto-mbedcrypto-$(MBEDCRYPTO_VERSION) mbedtls/crypto
 	touch $@
 
 .SECONDARY: mbedtls/.mbedtls_configured

--- a/Examples/ra-tls-secret-prov/README.md
+++ b/Examples/ra-tls-secret-prov/README.md
@@ -82,6 +82,9 @@ kill %%
 - Secret Provisioning flows, ECDSA-based (DCAP) attestation:
 
 ```sh
+# make sure RA-TLS DCAP libraries are built in Graphene via:
+#   cd graphene/Pal/src/host/Linux-SGX/tools/ra-tls && make dcap
+
 make app dcap files/input.txt
 
 RA_TLS_ALLOW_OUTDATED_TCB_INSECURE=1 ./secret_prov_server_dcap &

--- a/LibOS/shim/test/regression/Makefile
+++ b/LibOS/shim/test/regression/Makefile
@@ -153,7 +153,7 @@ CFLAGS-signal_multithread += -pthread
 CFLAGS-pthread_set_get_affinity += -pthread
 CFLAGS-gettimeofday += -pthread
 
-CFLAGS-attestation += -I$(PALDIR)/../lib/crypto/mbedtls/crypto/include \
+CFLAGS-attestation += -I$(PALDIR)/../lib/crypto/mbedtls/include \
                       -I$(PALDIR)/host/Linux-SGX \
                       -I$(PALDIR)/../include/pal
 LDLIBS-attestation += $(PALDIR)/../lib/crypto/mbedtls/install/lib/libmbedcrypto.a

--- a/Pal/lib/Makefile
+++ b/Pal/lib/Makefile
@@ -15,8 +15,7 @@ CFLAGS += \
 	-I../include/lib \
 	-I../include/pal \
 	-I../src/host/$(PAL_HOST) \
-	-Icrypto/mbedtls/include \
-	-Icrypto/mbedtls/crypto/include
+	-Icrypto/mbedtls/include
 
 CRYPTO_PROVIDER ?= mbedtls
 
@@ -30,22 +29,22 @@ CRYPTO_PROVIDER ?= mbedtls
 # symbols.
 ifeq ($(CRYPTO_PROVIDER),mbedtls)
 crypto_mbedtls_library_objs = \
-	crypto/mbedtls/crypto/library/aes.o \
-	crypto/mbedtls/crypto/library/base64.o \
-	crypto/mbedtls/crypto/library/bignum.o \
-	crypto/mbedtls/crypto/library/cipher.o \
-	crypto/mbedtls/crypto/library/cipher_wrap.o \
-	crypto/mbedtls/crypto/library/cmac.o \
-	crypto/mbedtls/crypto/library/ctr_drbg.o \
-	crypto/mbedtls/crypto/library/dhm.o \
-	crypto/mbedtls/crypto/library/entropy.o \
-	crypto/mbedtls/crypto/library/gcm.o \
-	crypto/mbedtls/crypto/library/md.o \
-	crypto/mbedtls/crypto/library/oid.o \
-	crypto/mbedtls/crypto/library/platform_util.o \
-	crypto/mbedtls/crypto/library/rsa.o \
-	crypto/mbedtls/crypto/library/rsa_internal.o \
-	crypto/mbedtls/crypto/library/sha256.o \
+	crypto/mbedtls/library/aes.o \
+	crypto/mbedtls/library/base64.o \
+	crypto/mbedtls/library/bignum.o \
+	crypto/mbedtls/library/cipher.o \
+	crypto/mbedtls/library/cipher_wrap.o \
+	crypto/mbedtls/library/cmac.o \
+	crypto/mbedtls/library/ctr_drbg.o \
+	crypto/mbedtls/library/dhm.o \
+	crypto/mbedtls/library/entropy.o \
+	crypto/mbedtls/library/gcm.o \
+	crypto/mbedtls/library/md.o \
+	crypto/mbedtls/library/oid.o \
+	crypto/mbedtls/library/platform_util.o \
+	crypto/mbedtls/library/rsa.o \
+	crypto/mbedtls/library/rsa_internal.o \
+	crypto/mbedtls/library/sha256.o \
 	crypto/mbedtls/library/ssl_ciphersuites.o \
 	crypto/mbedtls/library/ssl_cli.o \
 	crypto/mbedtls/library/ssl_msg.o \
@@ -53,32 +52,21 @@ crypto_mbedtls_library_objs = \
 	crypto/mbedtls/library/ssl_tls.o
 ifeq ($(ARCH),x86_64)
 crypto_mbedtls_library_objs += \
-	crypto/mbedtls/crypto/library/aesni.o
+	crypto/mbedtls/library/aesni.o
 endif
 
 objs += $(crypto_mbedtls_library_objs)
 endif
 
-MBEDTLS_VERSION ?= 2.21.0
+MBEDTLS_VERSION ?= 2.26.0
 MBEDTLS_SRC ?= mbedtls-$(MBEDTLS_VERSION).tar.gz
 MBEDTLS_URI ?= \
 	https://github.com/ARMmbed/mbedtls/archive \
 	https://packages.grapheneproject.io/distfiles
-MBEDTLS_CHECKSUM ?= 320e930b7596ade650ae4fc9ba94b510d05e3a7d63520e121d8fdc7a21602db9
-
-# mbedTLS uses a submodule mbedcrypto, need to download it and move under mbedtls/crypto
-MBEDCRYPTO_VERSION ?= 3.1.0
-MBEDCRYPTO_SRC ?= mbedcrypto-$(MBEDCRYPTO_VERSION).tar.gz
-MBEDCRYPTO_URI ?= \
-	https://github.com/ARMmbed/mbed-crypto/archive \
-	https://packages.grapheneproject.io/distfiles
-MBEDCRYPTO_CHECKSUM ?= 7e171df03560031bc712489930831e70ae4b70ff521a609c6361f36bd5f8b76b
+MBEDTLS_CHECKSUM ?= 35d8d87509cd0d002bddbd5508b9d2b931c5e83747d087234cc7ad551d53fe05
 
 crypto/$(MBEDTLS_SRC):
 	../../Scripts/download --output $@ $(foreach mirror,$(MBEDTLS_URI),--url $(mirror)/$(MBEDTLS_SRC)) --sha256 $(MBEDTLS_CHECKSUM)
-
-crypto/$(MBEDCRYPTO_SRC):
-	../../Scripts/download --output $@ $(foreach mirror,$(MBEDCRYPTO_URI),--url $(mirror)/$(MBEDCRYPTO_SRC)) --sha256 $(MBEDCRYPTO_CHECKSUM)
 
 ifeq ($(DEBUG),1)
 MBED_BUILD_TYPE=Debug
@@ -89,26 +77,20 @@ endif
 # First, build mbedtls library against system's glibc and install in ../install. This library is
 # used by, for example, LibOS test cases. Second, prepare mbedtls directory to be used during PAL
 # build. A custom config.h header replaces libc dependencies with PAL-specific alternatives.
-crypto/mbedtls/CMakeLists.txt: crypto/$(MBEDTLS_SRC) crypto/$(MBEDCRYPTO_SRC) crypto/mbedtls-$(MBEDTLS_VERSION).diff
+crypto/mbedtls/CMakeLists.txt: crypto/$(MBEDTLS_SRC) crypto/mbedtls-$(MBEDTLS_VERSION).diff
 	$(RM) -r crypto/mbedtls
 	cd crypto && tar -mxzf $(MBEDTLS_SRC)
-	cd crypto && tar -mxzf $(MBEDCRYPTO_SRC)
 	mv crypto/mbedtls-mbedtls-$(MBEDTLS_VERSION) crypto/mbedtls
-	$(RM) -r crypto/mbedtls/crypto
-	mv crypto/mbed-crypto-mbedcrypto-$(MBEDCRYPTO_VERSION) crypto/mbedtls
-	mv crypto/mbedtls/mbed-crypto-mbedcrypto-3.1.0 crypto/mbedtls/crypto
 	cd crypto/mbedtls && patch -p1 < ../mbedtls-$(MBEDTLS_VERSION).diff || exit 255
 	mkdir crypto/mbedtls/install
 	cd crypto/mbedtls && perl ./scripts/config.pl set MBEDTLS_CMAC_C && $(MAKE) CFLAGS="" SHARED=1 DESTDIR=install install .
 	$(RM) crypto/mbedtls/include/mbedtls/config.h
-	$(RM) crypto/mbedtls/crypto/include/mbedtls/config.h
 
 crypto/mbedtls/include/mbedtls/config.h: crypto/config.h crypto/mbedtls/CMakeLists.txt
-	cp crypto/config.h crypto/mbedtls/crypto/include/mbedtls
 	cp crypto/config.h crypto/mbedtls/include/mbedtls
 
-crypto/mbedtls/crypto/library/aes.c: crypto/mbedtls/CMakeLists.txt crypto/mbedtls/include/mbedtls/config.h
-$(filter-out crypto/mbedtls/crypto/library/aes.c,$(patsubst %.o,%.c,$(crypto_mbedtls_library_objs))): crypto/mbedtls/crypto/library/aes.c
+crypto/mbedtls/library/aes.c: crypto/mbedtls/CMakeLists.txt crypto/mbedtls/include/mbedtls/config.h
+$(filter-out crypto/mbedtls/library/aes.c,$(patsubst %.o,%.c,$(crypto_mbedtls_library_objs))): crypto/mbedtls/library/aes.c
 
 objs += \
 	avl_tree.o \
@@ -133,7 +115,7 @@ objs += \
 	string/utils.o \
 	toml.o
 
-$(addprefix $(target),crypto/adapters/mbedtls_adapter.o crypto/adapters/mbedtls_dh.o crypto/adapters/mbedtls_encoding.o): crypto/mbedtls/crypto/library/aes.c
+$(addprefix $(target),crypto/adapters/mbedtls_adapter.o crypto/adapters/mbedtls_dh.o crypto/adapters/mbedtls_encoding.o): crypto/mbedtls/library/aes.c
 
 ifeq ($(CRYPTO_PROVIDER),mbedtls)
 CFLAGS += -DCRYPTO_USE_MBEDTLS
@@ -195,6 +177,6 @@ clean:
 
 .PHONY: distclean
 distclean: clean
-	$(RM) -r crypto/$(MBEDTLS_SRC) crypto/$(MBEDCRYPTO_SRC) crypto/mbedtls
+	$(RM) -r crypto/$(MBEDTLS_SRC) crypto/mbedtls
 	$(RM) ../include/lib/uthash.h
 	$(RM) ../include/lib/toml.h toml.h toml.c toml.patched

--- a/Pal/lib/crypto/config.h
+++ b/Pal/lib/crypto/config.h
@@ -1,7 +1,9 @@
 /* SPDX-License-Identifier: LGPL-3.0-or-later */
 /* Copyright (C) 2017 Fortanix, Inc.
- * Copyright (C) 2019 Intel Corp.
+ * Copyright (C) 2021 Intel Corp.
  */
+
+/* This mbedTLS config is for v2.26.0 and assumes Intel x86-64 CPU with AESNI and SSE2 support */
 
 #ifndef MBEDTLS_CONFIG_H
 #define MBEDTLS_CONFIG_H
@@ -20,6 +22,7 @@
 #define MBEDTLS_GCM_C
 #define MBEDTLS_GENPRIME
 #define MBEDTLS_HAVE_ASM
+#define MBEDTLS_HAVE_SSE2
 #define MBEDTLS_HAVE_X86_64
 #define MBEDTLS_KEY_EXCHANGE_PSK_ENABLED
 #define MBEDTLS_MD_C

--- a/Pal/lib/crypto/mbedtls-2.26.0.diff
+++ b/Pal/lib/crypto/mbedtls-2.26.0.diff
@@ -2,10 +2,10 @@
 # progress via issue https://github.com/ARMmbed/mbedtls/issues/3141.
 
 diff --git a/library/ssl_tls.c b/library/ssl_tls.c
-index 63bc5c8..a850c36 100644
+index e367fbd9cdd42c81b108a92037b1b16d562a6f55..e9524f66ba4203e7654b1023656c1830c7a01010 100644
 --- a/library/ssl_tls.c
 +++ b/library/ssl_tls.c
-@@ -5951,12 +5951,14 @@ int mbedtls_ssl_context_save( mbedtls_ssl_context *ssl,
+@@ -6235,12 +6235,14 @@ int mbedtls_ssl_context_save( mbedtls_ssl_context *ssl,
          MBEDTLS_SSL_DEBUG_MSG( 1, ( "There is pending outgoing data" ) );
          return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
      }
@@ -20,7 +20,7 @@ index 63bc5c8..a850c36 100644
      /* Version must be 1.2 */
      if( ssl->major_ver != MBEDTLS_SSL_MAJOR_VERSION_3 )
      {
-@@ -6125,6 +6127,16 @@ int mbedtls_ssl_context_save( mbedtls_ssl_context *ssl,
+@@ -6409,6 +6411,16 @@ int mbedtls_ssl_context_save( mbedtls_ssl_context *ssl,
      }
  #endif /* MBEDTLS_SSL_ALPN */
  
@@ -37,7 +37,7 @@ index 63bc5c8..a850c36 100644
      /*
       * Done
       */
-@@ -6135,7 +6147,19 @@ int mbedtls_ssl_context_save( mbedtls_ssl_context *ssl,
+@@ -6419,7 +6431,19 @@ int mbedtls_ssl_context_save( mbedtls_ssl_context *ssl,
  
      MBEDTLS_SSL_DEBUG_BUF( 4, "saved context", buf, used );
  
@@ -57,7 +57,7 @@ index 63bc5c8..a850c36 100644
  }
  
  /*
-@@ -6191,7 +6215,10 @@ static int ssl_context_load( mbedtls_ssl_context *ssl,
+@@ -6475,7 +6499,10 @@ static int ssl_context_load( mbedtls_ssl_context *ssl,
       * We can't check that the config matches the initial one, but we can at
       * least check it matches the requirements for serializing.
       */
@@ -68,7 +68,7 @@ index 63bc5c8..a850c36 100644
          ssl->conf->max_major_ver < MBEDTLS_SSL_MAJOR_VERSION_3 ||
          ssl->conf->min_major_ver > MBEDTLS_SSL_MAJOR_VERSION_3 ||
          ssl->conf->max_minor_ver < MBEDTLS_SSL_MINOR_VERSION_3 ||
-@@ -6203,6 +6230,7 @@ static int ssl_context_load( mbedtls_ssl_context *ssl,
+@@ -6487,6 +6514,7 @@ static int ssl_context_load( mbedtls_ssl_context *ssl,
      {
          return( MBEDTLS_ERR_SSL_BAD_INPUT_DATA );
      }
@@ -76,7 +76,7 @@ index 63bc5c8..a850c36 100644
  
      MBEDTLS_SSL_DEBUG_BUF( 4, "context to load", buf, len );
  
-@@ -6422,6 +6450,15 @@ static int ssl_context_load( mbedtls_ssl_context *ssl,
+@@ -6706,6 +6734,15 @@ static int ssl_context_load( mbedtls_ssl_context *ssl,
      ssl->in_epoch = 1;
  #endif
  

--- a/Pal/src/host/Linux-SGX/Makefile
+++ b/Pal/src/host/Linux-SGX/Makefile
@@ -12,7 +12,6 @@ CFLAGS += \
 	-I../../../include/host/Linux-common \
 	-I../../../include/lib \
 	-I../../../lib/crypto/mbedtls/include \
-	-I../../../lib/crypto/mbedtls/crypto/include \
 	-Iprotected-files
 
 # Some of the code uses alignof on expressions, which is a GNU extension.

--- a/Pal/src/host/Linux-SGX/tools/common/Makefile
+++ b/Pal/src/host/Linux-SGX/tools/common/Makefile
@@ -6,7 +6,6 @@ CFLAGS := $(filter-out -DIN_PAL, $(CFLAGS))
 CFLAGS += -I../.. \
           -I../../../../../include/lib \
           -I../../../../../lib/crypto/mbedtls/install/include \
-          -I../../../../../lib/crypto/mbedtls/crypto/include \
           -I../../protected-files \
           -DCRYPTO_USE_MBEDTLS \
           -D_POSIX_C_SOURCE=200809L \

--- a/Pal/src/host/Linux-SGX/tools/ra-tls/Makefile
+++ b/Pal/src/host/Linux-SGX/tools/ra-tls/Makefile
@@ -3,7 +3,6 @@ include ../../../../../../Scripts/Makefile.configs
 CFLAGS += -I../.. \
           -I../common \
           -I../../../../../lib/crypto/mbedtls/install/include \
-          -I../../../../../lib/crypto/mbedtls/crypto/include \
           -fPIC -fvisibility=hidden
 
 LDFLAGS += -L../../../../../lib/crypto/mbedtls/install/lib -Wl,-rpath,.


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

mbedTLS v2.21.0 was released in February 2020. It is time to update to the latest mbedTLS, which is 2.26.0, released in March 2021.

No changes were required in the Graphene / Examples code. The only non-trivial change is the addition of `MBEDTLS_HAVE_SSE2` config parameter of mbedTLS -- for some reason it was not added previously, even though we explicitly rely on modern-Intel-CPU x86-64 mbedTLS.

## How to test this PR? <!-- (if applicable) -->

All tests must pass. I manually verified that all IPC is still encrypted.