### PR TITLE
[Examples] Add https://packages.grapheneproject.io/ mirror

### DIFF
--- a/Examples/apache/Makefile
+++ b/Examples/apache/Makefile
@@ -18,10 +18,11 @@ HTTPD_CHECKSUM ?= 44b759ce932dc090c0e75c0210b4485ebf6983466fb8ca1b446c8168e1a1ae
 
 # Mirros for downloading the Apache source code
 HTTPD_MIRRORS ?= \
-	https://www-eu.apache.org/dist/ \
-	https://www-us.apache.org/dist/ \
-	https://ftp.fau.de/apache/ \
-	https://archive.apache.org/dist/
+    https://www-eu.apache.org/dist/httpd \
+    https://www-us.apache.org/dist/httpd \
+    https://ftp.fau.de/apache/httpd \
+    https://archive.apache.org/dist/httpd \
+    https://packages.grapheneproject.io/distfiles
 
 # Address and port for the Apache server to listen
 LISTEN_HOST ?= 127.0.0.1
@@ -62,7 +63,8 @@ $(HTTPD_SRC)/configure: $(HTTPD_SRC).tar.gz
 	cd $(HTTPD_SRC) && patch -p1 -l < ../apache_makefile.patch
 
 $(HTTPD_SRC).tar.gz:
-	$(GRAPHENEDIR)/Scripts/download --output $@ --sha256 $(HTTPD_CHECKSUM) $(foreach mirror,$(HTTPD_MIRRORS),--url $(mirror)httpd/$(HTTPD_SRC).tar.gz)
+	$(GRAPHENEDIR)/Scripts/download --output $@ --sha256 $(HTTPD_CHECKSUM) \
+	    $(foreach mirror,$(HTTPD_MIRRORS),--url $(mirror)/$(HTTPD_SRC).tar.gz)
 
 $(INSTALL_DIR)/conf/httpd.conf: $(INSTALL_DIR)/bin/httpd
 $(INSTALL_DIR)/conf/extra/httpd-ssl.conf: $(INSTALL_DIR)/bin/httpd

--- a/Examples/blender/Makefile
+++ b/Examples/blender/Makefile
@@ -5,7 +5,10 @@ GRAPHENE_DIR = $(PWD)/../..
 SGX_SIGNER_KEY ?= $(GRAPHENE_DIR)/Pal/src/host/Linux-SGX/signer/enclave-key.pem
 
 BLENDER_DIR = $(PWD)/blender_dir
-BLENDER_URL ?= https://ftp.nluug.nl/pub/graphics/blender/release/Blender2.82/blender-2.82-linux64.tar.xz
+BLENDER_SRC ?= blender-2.82-linux64.tar.xz
+BLENDER_MIRRORS ?= \
+    https://ftp.nluug.nl/pub/graphics/blender/release/Blender2.82 \
+    https://packages.grapheneproject.io/distfiles
 BLENDER_SHA256 ?= b13600fa2ca23ea1bba511e3a6599b6792acde80b180707c3ea75db592a9b916
 BLENDER_VER = 2.82
 
@@ -37,8 +40,8 @@ endif
 include ../../Scripts/Makefile.configs
 
 $(BLENDER_DIR)/blender:
-	$(GRAPHENE_DIR)/Scripts/download --output blender.tar.xz \
-		--sha256 $(BLENDER_SHA256) --url $(BLENDER_URL)
+	$(GRAPHENE_DIR)/Scripts/download --output blender.tar.xz --sha256 $(BLENDER_SHA256) \
+	    $(foreach mirror,$(BLENDER_MIRRORS),--url $(mirror)/$(BLENDER_SRC))
 	mkdir $(BLENDER_DIR)
 	tar -C $(BLENDER_DIR) --strip-components=1 -xf blender.tar.xz
 

--- a/Examples/lighttpd/Makefile
+++ b/Examples/lighttpd/Makefile
@@ -6,7 +6,8 @@ LIGHTTPD_SRC ?= $(THIS_DIR)lighttpd-1.4.54
 LIGHTTPD_HASH ?= 5151d38cb7c4c40effa13710e77ebdbef899f945b062cf32befc02d128ac424c
 
 LIGHTTPD_MIRRORS ?= \
-	https://download.lighttpd.net/lighttpd/releases-1.4.x/
+    https://download.lighttpd.net/lighttpd/releases-1.4.x \
+    https://packages.grapheneproject.io/distfiles
 
 # Host and port on which lighttpd listens
 HOST ?= 127.0.0.1
@@ -47,7 +48,8 @@ $(LIGHTTPD_SRC)/configure: $(LIGHTTPD_SRC).tar.gz
 	touch $(LIGHTTPD_SRC)/configure
 
 $(LIGHTTPD_SRC).tar.gz:
-	$(GRAPHENEDIR)/Scripts/download --output $@ --sha256 $(LIGHTTPD_HASH) $(foreach mirror,$(LIGHTTPD_MIRRORS),--url $(mirror)/$(LIGHTTPD_SRC).tar.gz)
+	$(GRAPHENEDIR)/Scripts/download --output $@ --sha256 $(LIGHTTPD_HASH) \
+	    $(foreach mirror,$(LIGHTTPD_MIRRORS),--url $(mirror)/$(LIGHTTPD_SRC).tar.gz)
 
 lighttpd.manifest: lighttpd.manifest.template
 	sed -e 's|$$(GRAPHENEDIR)|'"$(GRAPHENEDIR)"'|g' \

--- a/Examples/memcached/Makefile
+++ b/Examples/memcached/Makefile
@@ -16,7 +16,11 @@ GRAPHENEDIR = ../..
 SGX_SIGNER_KEY ?= $(GRAPHENEDIR)/Pal/src/host/Linux-SGX/signer/enclave-key.pem
 
 SRCDIR = src
-MEMCACHED_URL ?= https://memcached.org/files/memcached-1.5.21.tar.gz
+MEMCACHED_SRC ?= memcached-1.5.21.tar.gz
+MEMCACHED_MIRRORS ?= \
+    https://memcached.org/files \
+    https://packages.grapheneproject.io/distfiles
+
 MEMCACHED_SHA256 ?= e3d10c06db755b220f43d26d3b68d15ebf737a69c7663529b504ab047efe92f4
 
 UBUNTU_VER = $(shell lsb_release --short --id)$(shell lsb_release --short --release)
@@ -48,8 +52,8 @@ include ../../Scripts/Makefile.configs
 # the final executable "src/memcached".
 
 $(SRCDIR)/configure:
-	$(GRAPHENEDIR)/Scripts/download --output memcached.tar.gz \
-		--sha256 $(MEMCACHED_SHA256) --url $(MEMCACHED_URL)
+	$(GRAPHENEDIR)/Scripts/download --output memcached.tar.gz --sha256 $(MEMCACHED_SHA256) \
+	    $(foreach mirror,$(MEMCACHED_MIRRORS),--url $(mirror)/$(MEMCACHED_SRC))
 	mkdir $(SRCDIR)
 	tar -C $(SRCDIR) --strip-components=1 -xf memcached.tar.gz
 

--- a/Examples/nginx/Makefile
+++ b/Examples/nginx/Makefile
@@ -18,7 +18,8 @@ NGINX_SHA256 ?= f11c2a6dd1d3515736f0324857957db2de98be862461b5a542a3ac6188dbe32b
 
 # Mirrors for downloading the Nginx source code
 NGINX_MIRRORS ?= \
-	http://nginx.org/download/
+    http://nginx.org/download \
+    https://packages.grapheneproject.io/distfiles
 
 # Address and port for the Nginx server to listen
 LISTEN_HOST ?= 127.0.0.1
@@ -61,7 +62,8 @@ $(NGINX_SRC)/configure: $(NGINX_SRC).tar.gz
 	tar --touch -xzf $<
 
 $(NGINX_SRC).tar.gz:
-	$(GRAPHENEDIR)/Scripts/download --output $@ --sha256 $(NGINX_SHA256) $(foreach mirror,$(NGINX_MIRRORS),--url $(mirror)/$(NGINX_SRC).tar.gz)
+	$(GRAPHENEDIR)/Scripts/download --output $@ --sha256 $(NGINX_SHA256) \
+	    $(foreach mirror,$(NGINX_MIRRORS),--url $(mirror)/$(NGINX_SRC).tar.gz)
 
 nginx.manifest: nginx.manifest.template
 	sed -e 's|$$(GRAPHENEDIR)|'"$(GRAPHENEDIR)"'|g' \


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

We have our own mirror for projects used in Graphene examples: https://packages.grapheneproject.io/distfiles/.

However, not all example Makefiles knew about this mirror. This PR adds this mirror to the places which didn't know.

## How to test this PR? <!-- (if applicable) -->

There should be no more failed downloads in Jenkins.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2280)
<!-- Reviewable:end -->
