### PR TITLE
[LibOS] Remove IPC port types

### DIFF
--- a/LibOS/shim/include/shim_ipc.h
+++ b/LibOS/shim/include/shim_ipc.h
@@ -28,16 +28,6 @@
 #define MAX_IPC_PORT_FINI_CB 3
 
 enum {
-    IPC_LISTENING,    /* listening port; processes connect to it to create connection ports */
-    IPC_CONNECTION,   /* processes communicate on ports of this type */
-};
-
-enum {
-    IPC_PORT_LISTENING    = 1 << IPC_LISTENING,
-    IPC_PORT_CONNECTION   = 1 << IPC_CONNECTION,
-};
-
-enum {
     IPC_MSG_RESP = 0,
     IPC_MSG_CHILDEXIT,
     IPC_MSG_LEASE,
@@ -76,7 +66,6 @@ struct shim_ipc_info {
 
 struct shim_process_ipc_info {
     IDTYPE vmid;
-    struct shim_ipc_info* self;
     struct shim_ipc_info* parent;
     struct shim_ipc_info* ns;
 };
@@ -116,7 +105,6 @@ struct shim_ipc_port {
 
     port_fini fini[MAX_IPC_PORT_FINI_CB];
 
-    IDTYPE type;
     IDTYPE vmid;
 };
 
@@ -353,11 +341,9 @@ int init_ipc_helper(void);
 struct shim_process_ipc_info* create_process_ipc_info(void);
 void free_process_ipc_info(struct shim_process_ipc_info* process);
 
-struct shim_ipc_info* create_ipc_info_and_port(void);
-
-void add_ipc_port_by_id(IDTYPE vmid, PAL_HANDLE hdl, IDTYPE type, port_fini fini,
+void add_ipc_port_by_id(IDTYPE vmid, PAL_HANDLE hdl, port_fini fini,
                         struct shim_ipc_port** portptr);
-void add_ipc_port(struct shim_ipc_port* port, IDTYPE vmid, IDTYPE type, port_fini fini);
+void add_ipc_port(struct shim_ipc_port* port, IDTYPE vmid, port_fini fini);
 void del_ipc_port_fini(struct shim_ipc_port* port);
 void get_ipc_port(struct shim_ipc_port* port);
 void put_ipc_port(struct shim_ipc_port* port);

--- a/LibOS/shim/src/ipc/shim_ipc_ranges.c
+++ b/LibOS/shim/src/ipc/shim_ipc_ranges.c
@@ -527,7 +527,7 @@ int connect_owner(IDTYPE idx, struct shim_ipc_port** portptr, IDTYPE* owner) {
             goto out;
         }
 
-        add_ipc_port_by_id(range.owner, pal_handle, IPC_PORT_CONNECTION, NULL, &range.port);
+        add_ipc_port_by_id(range.owner, pal_handle, NULL, &range.port);
         assert(range.port);
     }
 
@@ -906,7 +906,7 @@ retry:
             }
 
             if (pal_handle)
-                add_ipc_port_by_id(owner, pal_handle, IPC_PORT_CONNECTION, NULL, &port);
+                add_ipc_port_by_id(owner, pal_handle, NULL, &port);
 
             lock(&range_map_lock);
             LISTP_FOR_EACH_ENTRY(r, list, list) {

--- a/LibOS/shim/src/shim_checkpoint.c
+++ b/LibOS/shim/src/shim_checkpoint.c
@@ -624,8 +624,7 @@ int create_process_and_send_checkpoint(migrate_func_t migrate_func,
     ipc_sublease_send(child_vmid, thread_description->tid);
 
     /* create new IPC port to communicate over pal_process channel with the child process */
-    add_ipc_port_by_id(child_vmid, pal_process, IPC_PORT_CONNECTION, &ipc_port_with_child_fini,
-                       NULL);
+    add_ipc_port_by_id(child_vmid, pal_process, &ipc_port_with_child_fini, NULL);
 
     ret = 0;
 out:

--- a/LibOS/shim/src/sys/shim_semget.c
+++ b/LibOS/shim/src/sys/shim_semget.c
@@ -702,7 +702,7 @@ int submit_sysv_sem(struct shim_sem_handle* sem, struct sembuf* sops, int nsops,
 
     if (client) {
         assert(sendreply);
-        add_ipc_port(client->port, client->vmid, IPC_PORT_CONNECTION, NULL);
+        add_ipc_port(client->port, client->vmid, NULL);
         get_ipc_port(client->port);
         sem_ops->client = *client;
         sem_ops         = NULL;


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->
The only `IPC_PORT_LISTENING` port is the handle listening for new IPC connections (it is unique to the process), rest of ipc ports are describing existing IPC connections.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2281)
<!-- Reviewable:end -->
