### PR TITLE
Enable _FORTIFY_SOURCE

### DIFF
--- a/LibOS/Makefile
+++ b/LibOS/Makefile
@@ -45,7 +45,7 @@ endif
 GLIBC_TARGET = $(addprefix $(BUILD_DIR)/, $(GLIBC_LIBS))
 GLIBC_RUNTIME = $(addprefix $(RUNTIME_DIR)/, $(notdir $(GLIBC_TARGET)))
 
-GLIBC_CFLAGS = -O2 -Wp,-U_FORTIFY_SOURCE -Wno-unused-value
+GLIBC_CFLAGS = -O2 -Wno-unused-value
 ifeq ($(DEBUG),1)
 	GLIBC_CFLAGS += -g
 endif

--- a/LibOS/shim/include/shim_checkpoint.h
+++ b/LibOS/shim/include/shim_checkpoint.h
@@ -19,7 +19,7 @@
 
 #define __attribute_migratable __attribute__((section(".migratable")))
 
-extern char __migratable;
+extern char __migratable[];
 extern char __migratable_end;
 
 /* FIXME: Checkpointing must be de-macroed and simplified */

--- a/LibOS/shim/src/fs/sys/fs.c
+++ b/LibOS/shim/src/fs/sys/fs.c
@@ -122,7 +122,7 @@ int sys_list_resource_num(const char* pathname, struct shim_dirent** buf, size_t
 
     size_t total_size = 0;
     for (int i = 0; i < totalcnt; i++) {
-        char ent_name[32];
+        char ent_name[42];
         snprintf(ent_name, sizeof(ent_name), "%s%d", filename, i);
         size_t name_size   = strlen(ent_name) + 1;
         size_t dirent_size = sizeof(struct shim_dirent) + name_size;

--- a/LibOS/shim/src/shim_checkpoint.c
+++ b/LibOS/shim/src/shim_checkpoint.c
@@ -166,9 +166,9 @@ BEGIN_CP_FUNC(migratable) {
     __UNUSED(size);
     __UNUSED(objp);
 
-    size_t len = &__migratable_end - &__migratable;
+    size_t len = &__migratable_end - &__migratable[0];
     size_t off = ADD_CP_OFFSET(len);
-    memcpy((char*)base + off, &__migratable, len);
+    memcpy((char*)base + off, &__migratable[0], len);
     ADD_CP_FUNC_ENTRY(off);
 }
 END_CP_FUNC(migratable)
@@ -178,7 +178,7 @@ BEGIN_RS_FUNC(migratable) {
     __UNUSED(rebase);
 
     const char* data = (char*)base + GET_CP_FUNC_ENTRY();
-    memcpy(&__migratable, data, &__migratable_end - &__migratable);
+    memcpy(&__migratable[0], data, &__migratable_end - &__migratable[0]);
 }
 END_RS_FUNC(migratable)
 

--- a/LibOS/shim/test/regression/spinlock.c
+++ b/LibOS/shim/test/regression/spinlock.c
@@ -1,9 +1,10 @@
 /* Poor man's spinlock test */
-#include "spinlock.h"
-
 #include <pthread.h>
 #include <stdio.h>
 #include <stdlib.h>
+
+#define USE_STDLIB
+#include "spinlock.h"
 
 #define TEST_TIMES 1000
 

--- a/Pal/include/lib/api.h
+++ b/Pal/include/lib/api.h
@@ -135,6 +135,16 @@ typedef ptrdiff_t ssize_t;
 /* LibC functions */
 
 /* LibC string functions */
+
+/* Undefine macros for compatibility with glibc headers: glibc 2.23 string.h defines these names as
+ * macros, and while we shouldn't mix this file with glibc headers, we still do that in a few places
+ * (e.g. for standalone tools.) */
+#undef strchr
+#undef strstr
+#undef strspn
+#undef strcmp
+#undef strncmp
+
 size_t strnlen(const char* str, size_t maxlen);
 size_t strlen(const char* str);
 int strncmp(const char* lhs, const char* rhs, size_t maxlen);
@@ -165,6 +175,11 @@ void* memcpy(void* restrict dest, const void* restrict src, size_t count);
 void* memmove(void* dest, const void* src, size_t count);
 void* memset(void* dest, int ch, size_t count);
 int memcmp(const void* lhs, const void* rhs, size_t count);
+
+/* Used by _FORTIFY_SOURCE */
+void* __memcpy_chk(void* restrict dest, const void* restrict src, size_t count, size_t dest_count);
+void* __memmove_chk(void* dest, const void* src, size_t count, size_t dest_count);
+void* __memset_chk(void* dest, int ch, size_t count, size_t dest_count);
 
 bool strstartswith(const char* str, const char* prefix);
 bool strendswith(const char* str, const char* suffix);
@@ -221,6 +236,12 @@ void vfprintfmt(int (*_fputch)(void*, int, void*), void* f, void* put_data, cons
 int vsnprintf(char* buf, size_t buf_size, const char* fmt, va_list ap);
 int snprintf(char* buf, size_t buf_size, const char* fmt, ...)
     __attribute__((format(printf, 3, 4)));
+
+/* Used by _FORTIFY_SOURCE */
+int __vsnprintf_chk(char* buf, size_t buf_size, int flag, size_t real_size, const char* fmt,
+                    va_list ap);
+int __snprintf_chk(char* buf, size_t buf_size, int flag, size_t real_size, const char* fmt, ...)
+    __attribute__((format(printf, 5, 6)));
 
 /* Miscelleneous */
 
@@ -335,5 +356,9 @@ static inline bool access_ok(const volatile void* addr, size_t size) {
 #else
 #error "Unsupported architecture"
 #endif /* __x86_64__ */
+
+#if !defined(USE_STDLIB) && __USE_FORTIFY_LEVEL > 0
+# include "api_fortified.h"
+#endif
 
 #endif /* API_H */

--- a/Pal/include/lib/api_fortified.h
+++ b/Pal/include/lib/api_fortified.h
@@ -1,0 +1,53 @@
+/* SPDX-License-Identifier: LGPL-3.0-or-later */
+/* Copyright (C) 2021 Intel Corporation
+ *                    Paweł Marczewski <pawel@invisiblethingslab.com>
+ */
+
+/*
+ * Fortified version of standard functions, used when _FORTIFY_SOURCE is enabled. We use compiler
+ * builtins (e.g. __builtin___memcpy_chk), which, depending on their argument, call either the
+ * normal version (memcpy) or the version with runtime check (__memcpy_chk).
+ *
+ * For more information, see:
+ * - 'man feature_test_macros' and _FORTIFY_SOURCE
+ * - https://gcc.gnu.org/onlinedocs/gcc/Object-Size-Checking.html
+ * - glibc sources: string_fortified.h, stdio2.h
+ *
+ * This file will conflict with regular glibc headers (e.g. stdio.h, string.h). You should not use
+ * these headers in no-stdlib context, but if necessary, you can disable this file by defining
+ * USE_STDLIB before including api.h:
+ *
+ *     #include <stdio.h>
+ *     #include <string.h>
+ *
+ *     #define USE_STDLIB
+ *     #include "api.h"
+ */
+
+#ifndef _API_FORTIFIED_H_
+#define _API_FORTIFIED_H_
+
+#ifndef API_H
+# error This file should only be included inside api.h.
+#endif
+
+#define __api_bos0(ptr) __builtin_object_size(ptr, 0)
+#define __api_bos(ptr) __builtin_object_size(ptr, __USE_FORTIFY_LEVEL > 1)
+
+#define memcpy(dest, src, count) \
+    __builtin___memcpy_chk(dest, src, count, __api_bos0(dest))
+
+#define memmove(dest, src, count) \
+    __builtin___memmove_chk(dest, src, count, __api_bos0(dest))
+
+#define memset(dest, ch, count) \
+    __builtin___memset_chk(dest, ch, count, __api_bos0(dest))
+
+#define vsnprintf(buf, buf_size, fmt, ap) \
+    __builtin___vsnprintf_chk(buf, buf_size, __USE_FORTIFY_LEVEL - 1, __api_bos(buf), fmt, ap)
+
+#define snprintf(buf, buf_size, fmt...) \
+    __builtin___snprintf_chk(buf, buf_size, __USE_FORTIFY_LEVEL - 1, __api_bos(buf), fmt)
+
+
+#endif /* _API_FORTIFIED_H_ */

--- a/Pal/lib/stdlib/printfmt.c
+++ b/Pal/lib/stdlib/printfmt.c
@@ -6,7 +6,11 @@
 #include <stdarg.h>
 #include <stdint.h>
 
+#include "assert.h"
 #include "api.h"
+
+#undef vsnprintf
+#undef snprintf
 
 // Print a number (base <= 16) in reverse order,
 // using specified fputch function and associated pointer put_data.
@@ -269,7 +273,34 @@ int vsnprintf(char* buf, size_t n, const char* fmt, va_list ap) {
     return b.cnt;
 }
 
+int __vsnprintf_chk(char* buf, size_t n, int flag, size_t real_size, const char* fmt,
+                    va_list ap) {
+    __UNUSED(flag);
+    if (n > real_size) {
+        warn("vsnprintf() check failed\n");
+        __abort();
+    }
+    return vsnprintf(buf, n, fmt, ap);
+}
+
 int snprintf(char* buf, size_t n, const char* fmt, ...) {
+    va_list ap;
+    int rc;
+
+    va_start(ap, fmt);
+    rc = vsnprintf(buf, n, fmt, ap);
+    va_end(ap);
+
+    return rc;
+}
+
+int __snprintf_chk(char* buf, size_t n, int flag, size_t real_size, const char* fmt, ...) {
+    __UNUSED(flag);
+    if (n > real_size) {
+        warn("vsnprintf() check failed\n");
+        __abort();
+    }
+
     va_list ap;
     int rc;
 

--- a/Pal/lib/string/memcpy.c
+++ b/Pal/lib/string/memcpy.c
@@ -3,6 +3,10 @@
 #include <stdint.h>
 
 #include "api.h"
+#include "assert.h"
+
+#undef memcpy
+#undef memmove
 
 void* memcpy(void* restrict dest, const void* restrict src, size_t count) {
     char* d = dest;
@@ -24,6 +28,14 @@ void* memcpy(void* restrict dest, const void* restrict src, size_t count) {
     return dest;
 }
 
+void* __memcpy_chk(void* restrict dest, const void* restrict src, size_t count, size_t dest_count) {
+    if (count > dest_count) {
+        warn("memcpy() check failed\n");
+        __abort();
+    }
+    return memcpy(dest, src, count);
+}
+
 void* memmove(void* dest, const void* src, size_t count) {
     char* d = dest;
     const char* s = src;
@@ -42,4 +54,12 @@ void* memmove(void* dest, const void* src, size_t count) {
             d[count] = s[count];
     }
     return dest;
+}
+
+void* __memmove_chk(void* restrict dest, const void* restrict src, size_t count, size_t dest_count) {
+    if (count > dest_count) {
+        warn("memmove() check failed\n");
+        __abort();
+    }
+    return memmove(dest, src, count);
 }

--- a/Pal/lib/string/memset.c
+++ b/Pal/lib/string/memset.c
@@ -6,6 +6,9 @@
 #include <stdint.h>
 
 #include "api.h"
+#include "assert.h"
+
+#undef memset
 
 void* memset(void* dest, int ch, size_t count) {
     char* d = dest;
@@ -21,4 +24,12 @@ void* memset(void* dest, int ch, size_t count) {
         *d++ = ch;
 #endif
     return dest;
+}
+
+void* __memset_chk(void* dest, int ch, size_t count, size_t dest_count) {
+    if (count > dest_count) {
+        warn("memset() check failed\n");
+        __abort();
+    }
+    return memset(dest, ch, count);
 }

--- a/Pal/regression/Hex.c
+++ b/Pal/regression/Hex.c
@@ -1,6 +1,5 @@
 #include <assert.h>
 
-#include "api.h"
 #include "hex.h"
 #include "pal.h"
 #include "pal_debug.h"
@@ -10,11 +9,6 @@ char y[] = {0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd, 0xcd};
 
 static_assert(sizeof(x) <= sizeof(y), "array x is longer than array y");
 char hex_buf[sizeof(y) * 2 + 1];
-
-noreturn void __abort(void) {
-    // ENOTRECOVERABLE = 131
-    DkProcessExit(131);
-}
 
 int main(void) {
     pal_printf("Hex test 1 is %s\n", BYTES2HEXSTR(x, hex_buf, sizeof(hex_buf)));

--- a/Pal/regression/Makefile
+++ b/Pal/regression/Makefile
@@ -1,7 +1,7 @@
 include ../../Scripts/Makefile.configs
 include ../../Scripts/Makefile.rules
 
-CFLAGS	+= -Wp,-U_FORTIFY_SOURCE -fno-stack-protector -fno-builtin -nostdlib \
+CFLAGS	+= -fno-stack-protector -fno-builtin -nostdlib \
 	  -I../src \
 	  -I../include \
 	  -I../include/pal \
@@ -98,16 +98,18 @@ crt_init-recurse:
 CFLAGS-Pie = -fPIC -pie
 CFLAGS-AttestationReport = -I../src/host/Linux-SGX
 
+abort.o: CFLAGS += -fPIC
+
 # workaround: File.manifest.template has strange reference
 # to ../regression/File
 ../regression/File: | File
 	@true
 
-LDLIBS-preloads = ../crt_init/user_shared_start.o $(graphene_lib) $(pal_lib)
+LDLIBS-preloads = ../crt_init/user_shared_start.o $(graphene_lib) $(pal_lib) abort.o
 $(preloads): %.so: %.c $(LDLIBS-preloads)
 	$(call cmd,csingle) -shared -fPIC $(LDLIBS-preloads)
 
-LDLIBS-executables = ../crt_init/user_start.o $(graphene_lib) $(pal_lib) $(preloads)
+LDLIBS-executables = ../crt_init/user_start.o $(graphene_lib) $(pal_lib) $(preloads) abort.o
 $(executables): %: %.c $(LDLIBS-executables)
 	$(call cmd,csingle) -no-pie $(LDLIBS-executables)
 
@@ -132,7 +134,7 @@ pal-regression.xml: test_pal.py $(target) $(call expand_target_to_sig,$(target))
 .PHONY: clean
 clean:
 	$(RM) -r $(executables) $(preloads) $(gen_manifests) *.tmp .lib *.cached *.sig .*.sig *.d .*.d \
-	         .output.* *.token .*.token *.manifest.sgx .*.manifest.sgx __pycache__ .cache \
+	         *.o .output.* *.token .*.token *.manifest.sgx .*.manifest.sgx __pycache__ .cache \
 	         pal-regression.xml pal_loader
 
 .PHONY: distclean

--- a/Pal/regression/Process4.c
+++ b/Pal/regression/Process4.c
@@ -36,8 +36,8 @@ int main(int argc, char** argv) {
         if (count < 100) {
             count++;
 
-            char count_arg[8];
-            snprintf(count_arg, 8, "%d", count);
+            char count_arg[12];
+            snprintf(count_arg, 12, "%d", count);
             const char* newargs[4] = {"Process4", count_arg, argv[2], NULL};
 
             PAL_HANDLE proc = NULL;

--- a/Pal/regression/abort.c
+++ b/Pal/regression/abort.c
@@ -1,0 +1,9 @@
+#include "api.h"
+#include "pal.h"
+
+// Required by asserts and _FORTIFY_SOURCE.
+noreturn void __abort(void) {
+    warn("ABORTED\n");
+    // ENOTRECOVERABLE = 131
+    DkProcessExit(131);
+}

--- a/Pal/regression/avl_tree_test.c
+++ b/Pal/regression/avl_tree_test.c
@@ -9,11 +9,6 @@
 #include "pal.h"
 #include "pal_debug.h"
 
-noreturn void __abort(void) {
-    warn("ABORTED\n");
-    DkProcessExit(1);
-}
-
 #define EXIT_UNBALANCED()                                 \
     do {                                                  \
         pal_printf("Unbalanced tree at: %u\n", __LINE__); \

--- a/Pal/regression/normalize_path.c
+++ b/Pal/regression/normalize_path.c
@@ -3,12 +3,6 @@
 #include "pal_defs.h"
 #include "pal_error.h"
 
-// Required for asserts inside get_norm_path().
-noreturn void __abort(void) {
-    warn("ABORTED\n");
-    DkProcessExit(1);
-}
-
 static const char* get_norm_path_cases[][2] = {
     {"/", "/"},
     {"/a/b/c", "/a/b/c"},

--- a/Pal/src/host/Linux-SGX/Makefile.am
+++ b/Pal/src/host/Linux-SGX/Makefile.am
@@ -1,6 +1,6 @@
 # Add host-specific compilation rules here
 
-CFLAGS += -fPIC -maes -Wp,-U_FORTIFY_SOURCE -fno-builtin $(call cc-option,-Wtrampolines)
+CFLAGS += -fPIC -maes -fno-builtin $(call cc-option,-Wtrampolines)
 
 CFLAGS += -Wextra $(call cc-option,-Wnull-dereference)
 

--- a/Pal/src/host/Linux-SGX/enclave_framework.c
+++ b/Pal/src/host/Linux-SGX/enclave_framework.c
@@ -808,7 +808,7 @@ int init_trusted_files(void) {
 
     if (preload_str) {
         int npreload = 0;
-        char key[10];
+        char key[20];
         const char* start;
         const char* end;
         size_t len = strlen(preload_str);
@@ -820,7 +820,7 @@ int init_trusted_files(void) {
                 char uri[end - start + 1];
                 memcpy(uri, start, end - start);
                 uri[end - start] = 0;
-                snprintf(key, 10, "preload%d", npreload++);
+                snprintf(key, 20, "preload%d", npreload++);
 
                 ret = init_trusted_file(key, uri);
                 if (ret < 0) {

--- a/Pal/src/host/Linux-SGX/protected-files/lru_cache.c
+++ b/Pal/src/host/Linux-SGX/protected-files/lru_cache.c
@@ -6,7 +6,6 @@
 
 /* TODO: add regression tests for this */
 
-#include "api.h"
 #include "lru_cache.h"
 #include "list.h"
 

--- a/Pal/src/host/Linux-SGX/protected-files/protected_files.c
+++ b/Pal/src/host/Linux-SGX/protected-files/protected_files.c
@@ -4,16 +4,18 @@
  * Copyright (C) 2011-2019 Intel Corporation
  */
 
-#include "api.h"
-#include "protected_files.h"
-#include "protected_files_format.h"
-#include "protected_files_internal.h"
-
 #ifndef IN_PAL
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#define USE_STDLIB
 #endif
+
+#include "protected_files.h"
+#include "protected_files_format.h"
+#include "protected_files_internal.h"
+
+#include "api.h"
 
 /* Function for scrubbing sensitive memory buffers.
  * memset() can be optimized away and memset_s() is not available in PAL.

--- a/Pal/src/host/Linux-SGX/sgx_internal.h
+++ b/Pal/src/host/Linux-SGX/sgx_internal.h
@@ -19,9 +19,6 @@
 #define IS_ERR_P INTERNAL_SYSCALL_ERROR_P
 #define ERRNO_P  INTERNAL_SYSCALL_ERRNO_P
 
-int printf(const char* fmt, ...) __attribute__((format(printf, 1, 2)));
-int snprintf(char* str, size_t size, const char* fmt, ...) __attribute__((format(printf, 3, 4)));
-
 /* constants and macros to help rounding addresses to page
    boundaries */
 extern size_t g_page_size;

--- a/Pal/src/host/Linux-SGX/tools/common/pf_util.c
+++ b/Pal/src/host/Linux-SGX/tools/common/pf_util.c
@@ -20,6 +20,7 @@
 #include <sys/types.h>
 #include <unistd.h>
 
+#define USE_STDLIB
 #include "api.h"
 #include "perm.h"
 #include "util.h"

--- a/Pal/src/host/Linux/Makefile.am
+++ b/Pal/src/host/Linux/Makefile.am
@@ -1,5 +1,5 @@
 # Add host-specific compilation rules here
-CFLAGS += -fPIC -Wp,-U_FORTIFY_SOURCE -fno-builtin $(call cc-option,-Wtrampolines)
+CFLAGS += -fPIC -fno-builtin $(call cc-option,-Wtrampolines)
 
 CFLAGS += -Wextra $(call cc-option,-Wnull-dereference)
 

--- a/Pal/src/host/Skeleton/Makefile.am
+++ b/Pal/src/host/Skeleton/Makefile.am
@@ -1,7 +1,6 @@
 # Add host-specific compilation rules here
 
-CFLAGS += -fPIC -Wp,-U_FORTIFY_SOURCE \
-         -fno-stack-protector -fno-builtin
+CFLAGS += -fPIC -fno-stack-protector -fno-builtin
 
 CFLAGS += -Wextra -Wno-unused-parameter -Wno-sign-compare $(call cc-option,-Wnull-dereference)
 


### PR DESCRIPTION
Following the discussion #2277, I'm adding support for `_FORTIFY_SOURCE`. Apart from runtime checks, this actually added some compile-time warnings related to `snprintf` buffer size.

This is on top of #2277 and will be rebased later.

By the way, does anyone know why we also disable `_FORTIFY_SOURCE` within glibc itself?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2282)
<!-- Reviewable:end -->
