### PR TITLE
[Make] Add DEBUGOPT=1 option for optimized debug builds

### DIFF
--- a/Documentation/building.rst
+++ b/Documentation/building.rst
@@ -205,6 +205,14 @@ Additional build options
   in all Graphene components, builds them without optimizations, and enables
   detailed debug logs in Graphene.
 
+- To create a debug build that does not disable optimizations, run
+  :command:`make DEBUGOPT=1`.
+
+  *Note:* this is generally *not* recommended, because optimized builds lose
+  some debugging information, and may cause GDB to display confusing tracebacks
+  or garbage data. You should use ``DEBUGOPT=1`` only if you have a good reason
+  (e.g. for profiling).
+
 - To build with ``-Werror``, run :command:`make WERROR=1`.
 
 - To specify custom mirrors for downloading the Glibc source, use :command:`make

--- a/Documentation/devel/debugging.rst
+++ b/Documentation/devel/debugging.rst
@@ -55,3 +55,18 @@ To run Graphene with GDB, use the Graphene loader (``pal_loader``) and specify
 ``GDB=1``::
 
     GDB=1 SGX=1 [Graphene Directory]/Runtime/pal_loader [application] [arguments]
+
+Compiling with optimizations enabled
+------------------------------------
+
+Building Graphene with ``DEBUG=1`` enables debug symbols and GDB integration,
+but disables optimizations. This is usually the right thing to do: optimized
+builds are harder to debug, as they may cause GDB to display confusing
+tracebacks or garbage data.
+
+However, in some cases an optimized debug build might be desirable: for example,
+``_FORTIFY_SOURCE`` runtime checks work only when optimizations are enabled, and
+profiling optimized code will give you more accurate results.
+
+To build Graphene with debug symbols, and with optimizations still enabled, run
+``make DEBUGOPT=1``.

--- a/Documentation/devel/performance.rst
+++ b/Documentation/devel/performance.rst
@@ -531,7 +531,10 @@ SGX profiling
 There is support for profiling the code inside the SGX enclave. Here is how to
 use it:
 
-#. Compile Graphene with ``SGX=1 DEBUG=1``.
+#. Compile Graphene with ``SGX=1 DEBUGOPT=1``.
+
+   You can also use ``SGX=1 DEBUG=1``, but ``DEBUGOPT=1`` (optimizations
+   enabled) makes Graphene performance more similar to release build.
 
 #. Add ``sgx.profile.enable = "main"`` to manifest (to collect data for the main
    process), or ``sgx.profile.enable = "all"`` (to collect data for all

--- a/Documentation/manifest-syntax.rst
+++ b/Documentation/manifest-syntax.rst
@@ -563,7 +563,8 @@ SGX profiling
     (Default: "none")
 
 This syntax specifies whether to enable SGX profiling. Graphene must be compiled
-with ``DEBUG=1`` for this option to work.
+with ``DEBUG=1`` or ``DEBUGOPT=1`` for this option to work (the latter is
+advised).
 
 If this option is set to ``main``, the main process will collect IP samples and
 save them as ``sgx-perf.data``. If it is set to ``all``, all processes will

--- a/Scripts/Makefile.configs
+++ b/Scripts/Makefile.configs
@@ -45,7 +45,15 @@ endif
 ARCH_LONG := $(SYS)
 
 DEBUG ?=
+OPTIMIZE ?= $(if $(DEBUG),,1)
+
+ifeq ($(DEBUGOPT),1)
+DEBUG = 1
+OPTIMIZE = 1
+endif
+
 export DEBUG
+export OPTIMIZE
 
 CFLAGS += -Wall -std=c11 -Wmissing-prototypes
 CXXFLAGS += -Wall -std=c++14
@@ -59,7 +67,7 @@ ASFLAGS += -DDEBUG
 CXXFLAGS += -DDEBUG
 endif
 
-ifeq ($(DEBUG),)
+ifeq ($(OPTIMIZE),1)
 CFLAGS += -O2
 CXXFLAGS += -O2
 endif


### PR DESCRIPTION
This should be useful for more reliable profiling, and is necessary for debugging _FORTIFY_SOURCE runtime failures, because they are enabled only in optimized builds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2283)
<!-- Reviewable:end -->
