### PR TITLE
[LibOS] Fix alignment issued in sysfs implementation and test

### DIFF
--- a/LibOS/shim/src/fs/sys/fs.c
+++ b/LibOS/shim/src/fs/sys/fs.c
@@ -125,7 +125,8 @@ int sys_list_resource_num(const char* pathname, struct shim_dirent** buf, size_t
         char ent_name[42];
         snprintf(ent_name, sizeof(ent_name), "%s%d", filename, i);
         size_t name_size   = strlen(ent_name) + 1;
-        size_t dirent_size = sizeof(struct shim_dirent) + name_size;
+        size_t dirent_size = ALIGN_UP(sizeof(struct shim_dirent) + name_size,
+                                      alignof(struct shim_dirent));
 
         total_size += dirent_size;
         if (total_size > size)

--- a/LibOS/shim/test/regression/sysfs_common.c
+++ b/LibOS/shim/test/regression/sysfs_common.c
@@ -150,7 +150,7 @@ int main(int argc, char** argv) {
         if (strncmp(dirent->d_name, "node", 4) == 0) {
             char* endp;
             unsigned long nr = strtoul(dirent->d_name + 4,  &endp, 10);
-            if (nr != ULONG_MAX && endp != dirent64->d_name + 4 && *endp == '\0')
+            if (nr != ULONG_MAX && endp != dirent->d_name + 4 && *endp == '\0')
                 count++;
         }
     }


### PR DESCRIPTION
This is a split-off from the UBSAN PR.

Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2294)
<!-- Reviewable:end -->
