### PR TITLE
LibOS: Compile and run bootstrap_cpp only on x86_64

### DIFF
--- a/LibOS/shim/test/regression/Makefile
+++ b/LibOS/shim/test/regression/Makefile
@@ -91,7 +91,7 @@ c_executables = \
 	vfork_and_exec \
 	$(c_executables-$(ARCH))
 
-cxx_executables = bootstrap_cpp
+cxx_executables-x86_64 = bootstrap_cpp
 
 repo_manifests = \
 	argv_from_file.manifest \
@@ -111,12 +111,12 @@ repo_manifests = \
 # Empty rule to prevent overriding them using "%.manifest: manifest.template" rule.
 $(repo_manifests): ;
 
-gen_manifests = $(filter-out $(repo_manifests),$(addsuffix .manifest,$(c_executables) $(cxx_executables)))
+gen_manifests = $(filter-out $(repo_manifests),$(addsuffix .manifest,$(c_executables) $(cxx_executables-$(ARCH))))
 all_manifests = $(repo_manifests) $(gen_manifests)
 
 exec_target = \
 	$(c_executables) \
-	$(cxx_executables)
+	$(cxx_executables-$(ARCH))
 
 # repo_manifests needs to be included here to generate .manifest.sgx on SGX also for them.
 target = \

--- a/LibOS/shim/test/regression/test_libos.py
+++ b/LibOS/shim/test/regression/test_libos.py
@@ -102,6 +102,7 @@ class TC_01_Bootstrap(RegressionTestCase):
         self.assertIn('Local Address in Executable: 0x', stdout)
         self.assertIn('argv[0] = bootstrap_pie', stdout)
 
+    @unittest.skipUnless(ON_X86, "x86-specific")
     def test_110_basic_bootstrapping_cpp(self):
         stdout, _ = self.run_binary(['bootstrap_cpp'])
         self.assertIn('User Program Started', stdout)


### PR DESCRIPTION
Signed-off-by: Stefan Berger <stefanb@linux.ibm.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2295)
<!-- Reviewable:end -->
