### PR TITLE
[LTP] Enable LTP tests that PASS but marked as skipped in ltp.cfg

### DIFF
--- a/LibOS/shim/test/ltp/ltp.cfg
+++ b/LibOS/shim/test/ltp/ltp.cfg
@@ -640,16 +640,8 @@ skip = yes
 [fstat03_64]
 skip = yes
 
-# no fstatfs()
-[fstatfs*]
-skip = yes
-
 # tries to mount a filesystem
 [fsync01]
-skip = yes
-
-# no tstatfs()
-[fsync02]
 skip = yes
 
 # 1. fsync() on a pipe returns EROFS, not EINVAL
@@ -1158,15 +1150,7 @@ skip = yes
 [mmap01]
 skip = yes
 
-# uses siglongjmp() from exception handler back into normal execution; not supported by Graphene
-[mmap05]
-skip = yes
-
 [mmap12]
-skip = yes
-
-# uses siglongjmp() from exception handler back into normal execution; not supported by Graphene
-[mmap13]
 skip = yes
 
 [mmap14]
@@ -1221,10 +1205,6 @@ skip = yes
 [mprotect01]
 must-pass =
     2
-
-# uses siglongjmp() from exception handler back into normal execution; not supported by Graphene
-[mprotect04]
-skip = yes
 
 [mq_notify01]
 skip = yes
@@ -1342,15 +1322,19 @@ skip = yes
 [msgstress04]
 skip = yes
 
-[msync01]
-skip = yes
-
+# uses MS_INVALIDATE flag which is not supported in Graphene
 [msync02]
 skip = yes
 
+# 2 sub-tests fail with MS_INVALIDATE and MS_SYNC unsupported flag
 [msync03]
-skip = yes
+must-pass =
+    2
+    3
+    4
+    5
 
+# uses MS_SYNC flag which is not supported in Graphene
 [msync04]
 skip = yes
 
@@ -1697,14 +1681,15 @@ skip = yes
 [pwritev202_64]
 skip = yes
 
+# one sub-test fails MS_SYNC unsupported msync flag
 [qmm01]
-skip = yes
+must-pass =
+    1
+    2
+    4
 
 # no quotactl()
 [quotactl*]
-skip = yes
-
-[read02]
 skip = yes
 
 [read03]
@@ -1973,9 +1958,6 @@ skip = yes
 [semctl05]
 skip = yes
 
-[semctl06]
-skip = yes
-
 [semctl07]
 skip = yes
 
@@ -2058,9 +2040,6 @@ skip = yes
 skip = yes
 
 [sendmsg01]
-skip = yes
-
-[sendmsg02]
 skip = yes
 
 # opens /proc/sys/kernel/tainted
@@ -2398,12 +2377,22 @@ skip = yes
 [stat04_64]
 skip = yes
 
-# no statfs()
-[statfs*]
+# no symlink()
+[statfs02]
 skip = yes
 
-# no statvfs()
-[statvfs*]
+# no symlink()
+[statfs02_64]
+skip = yes
+
+[statfs03]
+skip = yes
+
+[statfs03_64]
+skip = yes
+
+# no symlink()
+[statvfs02]
 skip = yes
 
 [statx01]


### PR DESCRIPTION

<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://graphene.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->
With multiple features and bug-fixes that have been pushed to Graphene, multiple of the LTP tests have been passing with Graphene non-SGX. This PR is enabling such tests and removing the skip label from ltp.cfg.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2301)
<!-- Reviewable:end -->
