### PR TITLE
Clean up shim_handle types

### DIFF
--- a/LibOS/shim/include/shim_handle.h
+++ b/LibOS/shim/include/shim_handle.h
@@ -15,6 +15,7 @@
 #include <linux/shm.h>
 #include <linux/un.h>
 #include <stdalign.h>
+#include <stdbool.h>
 #include <stdint.h>
 
 #include "atomic.h"  // TODO: migrate to stdatomic.h
@@ -24,20 +25,25 @@
 #include "shim_sysv.h"
 #include "shim_types.h"
 
-/* start definition of shim handle */
+/* Handle types. Many of these are used by a single filesystem. */
 enum shim_handle_type {
-    TYPE_FILE,
-    TYPE_DEV,
-    TYPE_PIPE,
-    TYPE_SOCK,
-    TYPE_DIR,
-    TYPE_SHM,
-    TYPE_SEM,
-    TYPE_MSG,
-    TYPE_FUTEX,
-    TYPE_STR,
-    TYPE_EPOLL,
-    TYPE_EVENTFD
+    /* Files: */
+    TYPE_FILE,       /* host files, used by `chroot` filesystem */
+    TYPE_DEV,        /* emulated devices, used by `dev` filesystem */
+    TYPE_STR,        /* string-based files, handled by `str_*` functions, used by several
+                      * filesystems */
+    TYPE_PSEUDO,     /* pseudo nodes (currently directories), handled by `pseudo_*` functions, used
+                      * by several filesystems */
+
+    /* Pipes and sockets: */
+    TYPE_PIPE,       /* pipes, used by `pipe` filesystem */
+    TYPE_SOCK,       /* sockets, used by `socket` filesystem */
+
+    /* Special handles: */
+    TYPE_SEM,        /* System V semaphores, see `shim_semget.c` */
+    TYPE_MSG,        /* System V messages, see `shim_msgget.c` */
+    TYPE_EPOLL,      /* epoll handles, see `shim_epoll.c` */
+    TYPE_EVENTFD,    /* eventfd handles, used by `eventfd` filesystem */
 };
 
 struct shim_handle;
@@ -212,11 +218,6 @@ struct shim_dir_handle {
     struct shim_dentry** ptr;
 };
 
-struct shim_shm_handle {
-    /* XXX: need to implement */
-    void* __reserved;
-};
-
 struct msg_type;
 struct msg_item;
 struct msg_client;
@@ -313,6 +314,7 @@ struct shim_dentry;
  */
 struct shim_handle {
     enum shim_handle_type type;
+    bool is_dir;
 
     REFTYPE ref_count;
 
@@ -330,16 +332,21 @@ struct shim_handle {
 
     PAL_HANDLE pal_handle;
 
+    /* Type-specific fields: when accessing, ensure that `type` field is appropriate first (at least
+     * by using assert()) */
     union {
-        struct shim_file_handle file;
-        struct shim_dev_handle dev;
-        struct shim_pipe_handle pipe;
-        struct shim_sock_handle sock;
-        struct shim_shm_handle shm;
-        struct shim_msg_handle msg;
-        struct shim_sem_handle sem;
-        struct shim_str_handle str;
-        struct shim_epoll_handle epoll;
+        struct shim_file_handle file;    /* TYPE_FILE */
+        struct shim_dev_handle dev;      /* TYPE_DEV */
+        struct shim_str_handle str;      /* TYPE_STR */
+        /* (no data) */                  /* TYPE_PSEUDO */
+
+        struct shim_pipe_handle pipe;    /* TYPE_PIPE */
+        struct shim_sock_handle sock;    /* TYPE_SOCK */
+
+        struct shim_sem_handle sem;      /* TYPE_SEM */
+        struct shim_msg_handle msg;      /* TYPE_MSG */
+        struct shim_epoll_handle epoll;  /* TYPE_EPOLL */
+        /* (no data) */                  /* TYPE_EVENTFD */
     } info;
 
     struct shim_dir_handle dir_info;

--- a/LibOS/shim/src/bookkeep/shim_handle.c
+++ b/LibOS/shim/src/bookkeep/shim_handle.c
@@ -420,7 +420,7 @@ void put_handle(struct shim_handle* hdl) {
     if (!ref_count) {
         delete_from_epoll_handles(hdl);
 
-        if (hdl->type == TYPE_DIR) {
+        if (hdl->is_dir) {
             struct shim_dir_handle* dir = &hdl->dir_info;
 
             if (dir->dot) {
@@ -440,14 +440,14 @@ void put_handle(struct shim_handle* hdl) {
                     *(dir->ptr++) = NULL;
                 }
             }
-        } else {
-            if (hdl->fs && hdl->fs->fs_ops && hdl->fs->fs_ops->close)
-                hdl->fs->fs_ops->close(hdl);
+        }
 
-            if (hdl->type == TYPE_SOCK && hdl->info.sock.peek_buffer) {
-                free(hdl->info.sock.peek_buffer);
-                hdl->info.sock.peek_buffer = NULL;
-            }
+        if (hdl->fs && hdl->fs->fs_ops && hdl->fs->fs_ops->close)
+            hdl->fs->fs_ops->close(hdl);
+
+        if (hdl->type == TYPE_SOCK && hdl->info.sock.peek_buffer) {
+            free(hdl->info.sock.peek_buffer);
+            hdl->info.sock.peek_buffer = NULL;
         }
 
         if (hdl->fs && hdl->fs->fs_ops && hdl->fs->fs_ops->hput)

--- a/LibOS/shim/src/fs/dev/attestation.c
+++ b/LibOS/shim/src/fs/dev/attestation.c
@@ -88,6 +88,7 @@ static int dev_attestation_readwrite_stat(const char* name, struct stat* buf) {
  * global `g_user_report_data` struct on file close */
 static int user_report_data_modify(struct shim_handle* hdl) {
     assert(g_user_report_data_size);
+    assert(hdl->type == TYPE_STR);
     memcpy(&g_user_report_data, hdl->info.str.data->str, g_user_report_data_size);
     return 0;
 }
@@ -96,6 +97,7 @@ static int user_report_data_modify(struct shim_handle* hdl) {
  * `g_target_info` struct on file close */
 static int target_info_modify(struct shim_handle* hdl) {
     assert(g_target_info_size);
+    assert(hdl->type == TYPE_STR);
     memcpy(&g_target_info, hdl->info.str.data->str, g_target_info_size);
     return 0;
 }
@@ -431,6 +433,7 @@ out:
 /* callback for str FS; copies contents of `/dev/attestation/protected_files_key` file in the
  * global `g_pf_key_hex` string on file close and applies new PF key */
 static int pfkey_modify(struct shim_handle* hdl) {
+    assert(hdl->type == TYPE_STR);
     memcpy(&g_pf_key_hex, hdl->info.str.data->str, sizeof(g_pf_key_hex));
     g_pf_key_hex[sizeof(g_pf_key_hex) - 1] = '\0';
 

--- a/LibOS/shim/src/fs/dev/fs.c
+++ b/LibOS/shim/src/fs/dev/fs.c
@@ -156,6 +156,11 @@ static int dev_close(struct shim_handle* hdl) {
         return str_close(hdl);
     }
 
+    if (hdl->type == TYPE_PSEUDO) {
+        /* e.g. a directory */
+        return 0;
+    }
+
     assert(hdl->type == TYPE_DEV);
     if (!hdl->info.dev.dev_ops.close)
         return 0;
@@ -165,6 +170,8 @@ static int dev_close(struct shim_handle* hdl) {
 static off_t dev_poll(struct shim_handle* hdl, int poll_type) {
     if (poll_type == FS_POLL_SZ)
         return 0;
+
+    assert(hdl->type == TYPE_DEV);
 
     off_t ret = 0;
     if ((poll_type & FS_POLL_RD) && hdl->info.dev.dev_ops.read)

--- a/LibOS/shim/src/fs/dev/null.c
+++ b/LibOS/shim/src/fs/dev/null.c
@@ -74,6 +74,7 @@ static int dev_null_open(struct shim_handle* hdl, const char* name, int flags) {
                                .stat     = &dev_null_stat,
                                .hstat    = &dev_null_hstat};
 
+    hdl->type = TYPE_DEV;
     hdl->info.dev.dev_ops = ops;
     return 0;
 }
@@ -108,6 +109,7 @@ static int dev_tty_open(struct shim_handle* hdl, const char* name, int flags) {
                                .stat     = &dev_tty_stat,
                                .hstat    = &dev_tty_hstat};
 
+    hdl->type = TYPE_DEV;
     hdl->info.dev.dev_ops = ops;
     return 0;
 }

--- a/LibOS/shim/src/fs/dev/random.c
+++ b/LibOS/shim/src/fs/dev/random.c
@@ -64,6 +64,7 @@ static int dev_random_open(struct shim_handle* hdl, const char* name, int flags)
                                .stat  = &dev_random_stat,
                                .hstat = &dev_random_hstat};
 
+    hdl->type = TYPE_DEV;
     hdl->info.dev.dev_ops = ops;
     return 0;
 }

--- a/LibOS/shim/src/fs/dev/zero.c
+++ b/LibOS/shim/src/fs/dev/zero.c
@@ -67,6 +67,7 @@ static int dev_zero_open(struct shim_handle* hdl, const char* name, int flags) {
                                .stat     = &dev_zero_stat,
                                .hstat    = &dev_zero_hstat};
 
+    hdl->type = TYPE_DEV;
     hdl->info.dev.dev_ops = ops;
     return 0;
 }

--- a/LibOS/shim/src/fs/pipe/fs.c
+++ b/LibOS/shim/src/fs/pipe/fs.c
@@ -25,6 +25,7 @@
 #include "stat.h"
 
 static ssize_t pipe_read(struct shim_handle* hdl, void* buf, size_t count) {
+    assert(hdl->type == TYPE_PIPE);
     if (!hdl->info.pipe.ready_for_ops)
         return -EACCES;
 
@@ -37,6 +38,7 @@ static ssize_t pipe_read(struct shim_handle* hdl, void* buf, size_t count) {
 }
 
 static ssize_t pipe_write(struct shim_handle* hdl, const void* buf, size_t count) {
+    assert(hdl->type == TYPE_PIPE);
     if (!hdl->info.pipe.ready_for_ops)
         return -EACCES;
 
@@ -95,6 +97,7 @@ static int pipe_checkout(struct shim_handle* hdl) {
 static off_t pipe_poll(struct shim_handle* hdl, int poll_type) {
     off_t ret = 0;
 
+    assert(hdl->type == TYPE_PIPE);
     if (!hdl->info.pipe.ready_for_ops)
         return -EACCES;
 
@@ -213,6 +216,8 @@ static int fifo_open(struct shim_handle* hdl, struct shim_dentry* dent, int flag
     }
 
     /* rewire new hdl to contents of intermediate FIFO hdl */
+    assert(fifo_hdl->type == TYPE_PIPE);
+
     hdl->type       = fifo_hdl->type;
     hdl->acc_mode   = fifo_hdl->acc_mode;
     hdl->owner      = fifo_hdl->owner;

--- a/LibOS/shim/src/fs/proc/fs.c
+++ b/LibOS/shim/src/fs/proc/fs.c
@@ -81,10 +81,19 @@ static int proc_follow_link(struct shim_dentry* dent, struct shim_qstr* link) {
     return pseudo_follow_link(dent, link, &proc_root_ent);
 }
 
+static int proc_close(struct shim_handle* hdl) {
+    if (hdl->type == TYPE_PSEUDO) {
+        /* e.g. a directory */
+        return 0;
+    }
+    assert(hdl->type == TYPE_STR);
+    return str_close(hdl);
+}
+
 struct shim_fs_ops proc_fs_ops = {
     .mount   = &pseudo_mount,
     .unmount = &pseudo_unmount,
-    .close   = &str_close,
+    .close   = &proc_close,
     .read    = &str_read,
     .write   = &str_write,
     .seek    = &str_seek,

--- a/LibOS/shim/src/fs/shim_fs_pseudo.c
+++ b/LibOS/shim/src/fs/shim_fs_pseudo.c
@@ -173,8 +173,9 @@ int pseudo_dir_open(struct shim_handle* hdl, const char* name, int flags) {
     }
 
     if (*name == '\0') {
-        hdl->type     = TYPE_DIR;
-        hdl->flags    = flags & ~O_ACCMODE;
+        hdl->is_dir = true;
+        hdl->type = TYPE_PSEUDO;
+        hdl->flags = flags & ~O_ACCMODE;
         hdl->acc_mode = 0;
     }
 
@@ -240,8 +241,10 @@ int pseudo_open(struct shim_handle* hdl, struct shim_dentry* dent, int flags,
     if (!ent->fs_ops || !ent->fs_ops->open)
         return -EACCES;
 
-    hdl->type     = ent->dir ? TYPE_DIR : (ent->type == LINUX_DT_CHR ? TYPE_DEV : TYPE_FILE);
-    hdl->flags    = flags & ~O_ACCMODE;
+    hdl->is_dir = !!ent->dir;
+    /* Initialize as an empty TYPE_PSEUDO handle, fs_ops->open may override that */
+    hdl->type = TYPE_PSEUDO;
+    hdl->flags = flags & ~O_ACCMODE;
     hdl->acc_mode = ACC_MODE(flags & O_ACCMODE);
 
     return ent->fs_ops->open(hdl, rel_path, flags);

--- a/LibOS/shim/src/fs/shim_namei.c
+++ b/LibOS/shim/src/fs/shim_namei.c
@@ -622,7 +622,7 @@ int dentry_open(struct shim_handle* hdl, struct shim_dentry* dent, int flags) {
     // XXX: Having a type on the handle seems a little redundant if we have a
     // dentry too.
     if (dent->state & DENTRY_ISDIRECTORY) {
-        hdl->type = TYPE_DIR;
+        hdl->is_dir = true;
         memcpy(hdl->fs_type, fs->type, sizeof(fs->type));
 
         // Set dot and dot dot for some reason
@@ -843,7 +843,7 @@ int get_dirfd_dentry(int dirfd, struct shim_dentry** dir) {
         return -EBADF;
     }
 
-    if (hdl->type != TYPE_DIR) {
+    if (!hdl->is_dir) {
         put_handle(hdl);
         return -ENOTDIR;
     }

--- a/LibOS/shim/src/fs/socket/fs.c
+++ b/LibOS/shim/src/fs/socket/fs.c
@@ -27,6 +27,7 @@ static int socket_close(struct shim_handle* hdl) {
 }
 
 static ssize_t socket_read(struct shim_handle* hdl, void* buf, size_t count) {
+    assert(hdl->type == TYPE_SOCK);
     struct shim_sock_handle* sock = &hdl->info.sock;
 
     lock(&hdl->lock);
@@ -60,6 +61,7 @@ static ssize_t socket_read(struct shim_handle* hdl, void* buf, size_t count) {
 }
 
 static ssize_t socket_write(struct shim_handle* hdl, const void* buf, size_t count) {
+    assert(hdl->type == TYPE_SOCK);
     struct shim_sock_handle* sock = &hdl->info.sock;
 
     lock(&hdl->lock);
@@ -130,6 +132,7 @@ static int socket_checkout(struct shim_handle* hdl) {
 }
 
 static off_t socket_poll(struct shim_handle* hdl, int poll_type) {
+    assert(hdl->type == TYPE_SOCK);
     struct shim_sock_handle* sock = &hdl->info.sock;
     off_t ret = 0;
 

--- a/LibOS/shim/src/fs/str/fs.c
+++ b/LibOS/shim/src/fs/str/fs.c
@@ -2,7 +2,8 @@
 /* Copyright (C) 2014 Stony Brook University */
 
 /*
- * This file contains code for implementation of 'str' filesystem.
+ * This file contains code for implementation of 'str' filesystem. It is used by pseudo filesystems
+ * (/proc, /dev, /sys) and by tmpfs.
  */
 
 #include <asm/fcntl.h>
@@ -25,8 +26,17 @@ int str_open(struct shim_handle* hdl, struct shim_dentry* dent, int flags) {
 
     REF_INC(data->ref_count);
 
+    hdl->type = TYPE_STR;
+
+    /* note that if file was just created, then `str` and `len` are guaranteed to be NULL
+     * and zero */
+    hdl->info.str.data = data;
+    hdl->info.str.ptr = data->str;
+    if (flags & O_APPEND)
+        hdl->info.str.ptr += data->len;
+
     hdl->dentry = dent;
-    hdl->flags  = flags;
+    hdl->flags = flags;
 
     return 0;
 }
@@ -51,6 +61,8 @@ int str_dput(struct shim_dentry* dent) {
 }
 
 int str_close(struct shim_handle* hdl) {
+    assert(hdl->type == TYPE_STR);
+
     if (hdl->flags & (O_WRONLY | O_RDWR)) {
         int ret = str_flush(hdl);
 
@@ -77,6 +89,7 @@ ssize_t str_read(struct shim_handle* hdl, void* buf, size_t count) {
         goto out;
     }
 
+    assert(hdl->type == TYPE_STR);
     struct shim_str_handle* strhdl = &hdl->info.str;
 
     assert(hdl->dentry);

--- a/LibOS/shim/src/fs/sys/fs.c
+++ b/LibOS/shim/src/fs/sys/fs.c
@@ -252,10 +252,19 @@ static int sys_hstat(struct shim_handle* hdl, struct stat* buf) {
     return pseudo_hstat(hdl, buf, &sys_root_ent);
 }
 
+static int sys_close(struct shim_handle* hdl) {
+    if (hdl->type == TYPE_PSEUDO) {
+        /* e.g. a directory */
+        return 0;
+    }
+    assert(hdl->type == TYPE_STR);
+    return str_close(hdl);
+}
+
 struct shim_fs_ops sys_fs_ops = {
     .mount   = &pseudo_mount,
     .unmount = &pseudo_unmount,
-    .close   = &str_close,
+    .close   = &sys_close,
     .read    = &str_read,
     .seek    = &str_seek,
     .hstat   = &sys_hstat,

--- a/LibOS/shim/src/sys/shim_msgget.c
+++ b/LibOS/shim/src/sys/shim_msgget.c
@@ -75,9 +75,10 @@ static int __add_msg_handle(unsigned long key, IDTYPE msqid, bool owned,
     if (!hdl)
         return -ENOMEM;
 
+    hdl->type = TYPE_MSG;
+
     struct shim_msg_handle* msgq = &hdl->info.msg;
 
-    hdl->type         = TYPE_MSG;
     msgq->msqkey      = key;
     msgq->msqid       = msqid;
     msgq->owned       = owned;

--- a/LibOS/shim/src/sys/shim_open.c
+++ b/LibOS/shim/src/sys/shim_open.c
@@ -32,7 +32,7 @@ int do_handle_read(struct shim_handle* hdl, void* buf, int count) {
     if (!fs->fs_ops->read)
         return -EBADF;
 
-    if (hdl->type == TYPE_DIR)
+    if (hdl->is_dir)
         return -EISDIR;
 
     return fs->fs_ops->read(hdl, buf, count);
@@ -67,7 +67,7 @@ int do_handle_write(struct shim_handle* hdl, const void* buf, int count) {
     if (!fs->fs_ops->write)
         return -EBADF;
 
-    if (hdl->type == TYPE_DIR)
+    if (hdl->is_dir)
         return -EISDIR;
 
     return fs->fs_ops->write(hdl, buf, count);
@@ -159,7 +159,7 @@ long shim_do_lseek(int fd, off_t offset, int origin) {
         goto out;
     }
 
-    if (hdl->type == TYPE_DIR) {
+    if (hdl->is_dir) {
         /* TODO: handle lseek'ing of directories */
         ret = -ENOSYS;
         goto out;
@@ -196,7 +196,7 @@ long shim_do_pread64(int fd, char* buf, size_t count, loff_t pos) {
     if (!fs->fs_ops->read)
         goto out;
 
-    if (hdl->type == TYPE_DIR)
+    if (hdl->is_dir)
         goto out;
 
     int offset = fs->fs_ops->seek(hdl, 0, SEEK_CUR);
@@ -246,7 +246,7 @@ long shim_do_pwrite64(int fd, char* buf, size_t count, loff_t pos) {
     if (!fs->fs_ops->write)
         goto out;
 
-    if (hdl->type == TYPE_DIR)
+    if (hdl->is_dir)
         goto out;
 
     int offset = fs->fs_ops->seek(hdl, 0, SEEK_CUR);
@@ -302,7 +302,7 @@ long shim_do_getdents(int fd, struct linux_dirent* buf, size_t count) {
 
     int ret = -EACCES;
 
-    if (hdl->type != TYPE_DIR) {
+    if (!hdl->is_dir) {
         ret = -ENOTDIR;
         goto out_no_unlock;
     }
@@ -410,7 +410,7 @@ long shim_do_getdents64(int fd, struct linux_dirent64* buf, size_t count) {
 
     int ret = -EACCES;
 
-    if (hdl->type != TYPE_DIR) {
+    if (!hdl->is_dir) {
         ret = -ENOTDIR;
         goto out;
     }
@@ -509,7 +509,7 @@ long shim_do_fsync(int fd) {
     if (!fs || !fs->fs_ops)
         goto out;
 
-    if (hdl->type == TYPE_DIR)
+    if (hdl->is_dir)
         goto out;
 
     if (!fs->fs_ops->flush) {
@@ -587,7 +587,7 @@ long shim_do_ftruncate(int fd, loff_t length) {
     if (!fs || !fs->fs_ops)
         goto out;
 
-    if (hdl->type == TYPE_DIR || !fs->fs_ops->truncate)
+    if (hdl->is_dir || !fs->fs_ops->truncate)
         goto out;
 
     ret = fs->fs_ops->truncate(hdl, length);

--- a/LibOS/shim/src/sys/shim_pipe.c
+++ b/LibOS/shim/src/sys/shim_pipe.c
@@ -186,13 +186,13 @@ long shim_do_socketpair(int domain, int type, int protocol, int* sv) {
         goto out;
     }
 
-    struct shim_sock_handle* sock1 = &hdl1->info.sock;
-    struct shim_sock_handle* sock2 = &hdl2->info.sock;
 
     hdl1->type = TYPE_SOCK;
     set_handle_fs(hdl1, &socket_builtin_fs);
     hdl1->flags       = O_RDONLY;
     hdl1->acc_mode    = MAY_READ | MAY_WRITE;
+
+    struct shim_sock_handle* sock1 = &hdl1->info.sock;
     sock1->domain     = domain;
     sock1->sock_type  = type & ~(SOCK_NONBLOCK | SOCK_CLOEXEC);
     sock1->protocol   = protocol;
@@ -202,6 +202,8 @@ long shim_do_socketpair(int domain, int type, int protocol, int* sv) {
     set_handle_fs(hdl2, &socket_builtin_fs);
     hdl2->flags       = O_WRONLY;
     hdl2->acc_mode    = MAY_READ | MAY_WRITE;
+
+    struct shim_sock_handle* sock2 = &hdl2->info.sock;
     sock2->domain     = domain;
     sock2->sock_type  = type & ~(SOCK_NONBLOCK | SOCK_CLOEXEC);
     sock2->protocol   = protocol;

--- a/LibOS/shim/src/sys/shim_semget.c
+++ b/LibOS/shim/src/sys/shim_semget.c
@@ -67,11 +67,13 @@ static int __add_sem_handle(unsigned long key, IDTYPE semid, int nsems, bool own
     if (!hdl)
         return -ENOMEM;
 
-    tmp         = &hdl->info.sem;
-    hdl->type   = TYPE_SEM;
+    hdl->type = TYPE_SEM;
+    tmp = &hdl->info.sem;
+
     tmp->semkey = key;
     tmp->semid  = semid;
     tmp->owned  = owned;
+
     ret = DkNotificationEventCreate(PAL_FALSE, &tmp->event);
     if (ret < 0) {
         ret = pal_to_unix_errno(ret);


### PR DESCRIPTION
It looks like there was an assumption that `shim_handle.info` is controlled by `shim_handle.type`, and at some point it broke down because of `TYPE_DIR`. See also #810 (which adds a workaround by extracting `info.dir` outside of union) and #836 (which proposes to clean up that workaround).

This change restores that assumption and ensures it's explicit in the code. Now directories have `is_dir == true`, and are `TYPE_FILE` (in case of chroot), `TYPE_STR` (in case of tmpfs) or `TYPE_PSEUDO` (in case of pseudo FSes).

As a next step, I would like to rename `TYPE_FILE` to `TYPE_CHROOT` and `shim_file_handle` to `shim_chroot_handle` - these are specific to the "chroot" (host) filesystem, and it's not obvious because of the generic name, which causes some incorrect usages.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2302)
<!-- Reviewable:end -->
