### PR TITLE
[Pal] Flush logging buffers after newline

### DIFF
--- a/Pal/src/host/Linux-SGX/sgx_log.c
+++ b/Pal/src/host/Linux-SGX/sgx_log.c
@@ -55,7 +55,7 @@ static int output_char(void* f, int ch, void* buf_) {
     struct log_buf* buf = (struct log_buf*)buf_;
 
     buf->buf[buf->end++] = ch;
-    if (buf->end == LOG_BUF_SIZE) {
+    if (ch == '\n' || buf->end == LOG_BUF_SIZE) {
         ret = write_all(buf->fd, buf->buf, buf->end);
         buf->end = 0;
     }

--- a/Pal/src/host/Linux-SGX/sgx_log.c
+++ b/Pal/src/host/Linux-SGX/sgx_log.c
@@ -68,7 +68,6 @@ static void print_to_fd(int fd, const char* fmt, va_list ap) {
     buf.fd = fd;
     buf.end = 0;
     vfprintfmt(output_char, NULL, &buf, fmt, ap);
-    write_all(fd, buf.buf, buf.end);
     // No error handling, as `_urts_log` doesn't return errors anyways.
 }
 

--- a/Pal/src/printf.c
+++ b/Pal/src/printf.c
@@ -33,7 +33,7 @@ static int fputch(void* f, int ch, void* buf_) {
     struct printbuf* buf = buf_;
 
     buf->buf[buf->idx++] = ch;
-    if (buf->idx == PRINTBUF_SIZE - 1) {
+    if (ch == '\n' || buf->idx == PRINTBUF_SIZE - 1) {
         _DkPrintConsole(buf->buf, buf->idx);
         buf->idx = 0;
     }


### PR DESCRIPTION
This makes sure the PAL and untrusted SGX PAL logging subsystems always flush the buffer after encountering a newline, same as LibOS.

This minimizes the chance of log lines from different sources interleaving, and makes sure all (full) log lines are flushed before process exit.

Should fix test failures like this one: https://leeroy.cs.unc.edu/job/graphene-sgx-18.04/5067/

```
Send Handle OK
debug: Receive Handle OK
sock_getopt (fd = 7, sockopt addr = 0x7ffe1115e6a0) is not implemented and always returns 0
```

The above output was produced by `pal_printf("Receive Handle OK")` (from inner PAL) and `urts_log_debug("sock_getopt ...")` (from outer PAL).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2304)
<!-- Reviewable:end -->
