### PR TITLE
[GSC] Add dockerfile and manifest file for ra-tls-secret-prov sample's gsc image

### DIFF
--- a/Examples/ra-tls-secret-prov/Makefile
+++ b/Examples/ra-tls-secret-prov/Makefile
@@ -29,6 +29,9 @@ endif
 
 include ../../Scripts/Makefile.configs
 
+.PHONY: clients
+clients: secret_prov_min_client secret_prov_client secret_prov_pf_client
+
 .PHONY: all
 all: app epid  # by default, only build EPID because it doesn't rely on additional (DCAP) libs
 

--- a/Tools/gsc/test/ubuntu18.04-ra-tls-secret-prov.dockerfile
+++ b/Tools/gsc/test/ubuntu18.04-ra-tls-secret-prov.dockerfile
@@ -1,0 +1,61 @@
+FROM ubuntu:18.04
+
+RUN apt-get update \
+    && env DEBIAN_FRONTEND=noninteractive apt-get install -y wget \
+    build-essential \
+    python3 \
+    libcurl3-gnutls \
+    gnupg2
+
+# Installing DCAP and EPID-specific libraries
+
+RUN echo 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu bionic main' \
+    > /etc/apt/sources.list.d/intel-sgx.list \
+    && wget https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key \
+    && apt-key add intel-sgx-deb.key
+
+RUN apt-get update \
+    && apt-get install -y libsgx-urts \
+    libsgx-dcap-ql \
+    libsgx-epid
+
+# Build environment of this Dockerfile should point to the root of Graphene directory
+
+RUN mkdir -p /graphene/Scripts \
+    && mkdir -p /graphene/Pal/src/host/Linux-SGX/tools/pf_crypt \
+    && mkdir -p /graphene/Pal/src/host/Linux-SGX/tools/common \
+    && mkdir -p /graphene/Pal/src/host/Linux-SGX/tools/ra-tls \
+    && mkdir -p /graphene/Examples/ra-tls-secret-prov
+
+# The below files are copied to satisfy Makefile dependencies of graphene/Examples/ra-tls-secret-prov
+
+COPY Scripts/Makefile.configs  /graphene/Scripts/
+COPY Scripts/Makefile.Host  /graphene/Scripts/
+COPY Scripts/download  /graphene/Scripts/
+
+COPY Pal/src/host/Linux-SGX/tools/pf_crypt/pf_crypt /graphene/Pal/src/host/Linux-SGX/tools/pf_crypt/
+COPY Pal/src/host/Linux-SGX/tools/common/libsgx_util.so /graphene/Pal/src/host/Linux-SGX/tools/common/
+
+# make sure RA-TLS DCAP libraries are built in host Graphene via:
+# cd graphene/Pal/src/host/Linux-SGX/tools/ra-tls && make dcap
+
+COPY Pal/src/host/Linux-SGX/tools/ra-tls/libsecret_prov_attest.so /graphene/Pal/src/host/Linux-SGX/tools/ra-tls/
+COPY Pal/src/host/Linux-SGX/tools/ra-tls/libsecret_prov_verify_dcap.so /graphene/Pal/src/host/Linux-SGX/tools/ra-tls/
+COPY Pal/src/host/Linux-SGX/tools/ra-tls/libsecret_prov_verify_epid.so /graphene/Pal/src/host/Linux-SGX/tools/ra-tls/
+COPY Pal/src/host/Linux-SGX/tools/ra-tls/secret_prov.h /graphene/Pal/src/host/Linux-SGX/tools/ra-tls/
+
+# If user doesn't want to copy above files, then she can build the ra-tls-secret-prov sample locally
+# and copy the entire directory with executables
+
+COPY Examples/ra-tls-secret-prov /graphene/Examples/ra-tls-secret-prov
+
+WORKDIR /graphene/Examples/ra-tls-secret-prov
+
+RUN make clean \
+    && make clients epid dcap files/input.txt
+
+ENV LD_LIBRARY_PATH = "${LD_LIBRARY_PATH}:./libs"
+
+ENV PATH = "${PATH}:/graphene/Examples/ra-tls-secret-prov"
+
+ENTRYPOINT ["/graphene/Examples/ra-tls-secret-prov/secret_prov_client"]

--- a/Tools/gsc/test/ubuntu18.04-ra-tls-secret-prov.manifest
+++ b/Tools/gsc/test/ubuntu18.04-ra-tls-secret-prov.manifest
@@ -1,0 +1,52 @@
+# Steps to create ra-tls-secret-prov GSC image:
+#
+# STEP 1: Make sure RA-TLS DCAP libraries are built in Graphene via:
+#         $ cd graphene/Pal/src/host/Linux-SGX/tools/ra-tls && make dcap
+#
+# STEP 2: Create base ra-tls-secret-prov image
+#         $ cd graphene
+#         $ docker build -t <base-secret-prov-img> \
+#           -f Tools/gsc/test/ubuntu18.04-ra-tls-secret-prov.dockerfile .
+#
+# STEP 3: Create gsc-unsigned and gsc-signed images
+#         $ cd graphene/Tools/gsc
+#         $ ./gsc build <base-secret-prov-img> test/ubuntu18.04-ra-tls-secret-prov.manifest
+#         $ ./gsc sign-image <base-secret-prov-img> \
+#           ../../Pal/src/host/Linux-SGX/signer/enclave-key.pem
+#
+# STEP 4: Start ra-tls-secret-prov server [Note: Here the server will run on localhost:4433]
+#         $ cd graphene/Examples/ra-tls-secret-prov
+#         $ make dcap
+#         $ export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:./libs
+#         $ ./secret_prov_server_dcap &
+#
+# STEP 5: Run the gsc-<base-secret-prov-img>-signed image created at STEP 3
+#         $ docker run --net=host --device=/dev/sgx/enclave \
+#           -v /var/run/aesmd/aesm.socket:/var/run/aesmd/aesm.socket \
+#           gsc-<base-secret-prov-img>
+
+# Secret Provisioning library (client-side) is preloaded
+loader.env.LD_PRELOAD = "libs/libsecret_prov_attest.so"
+
+# Uncomment below lines for secret_prov_min_client and secret_prov_pf_client
+#
+#loader.env.SECRET_PROVISION_CONSTRUCTOR = "1"
+#loader.env.SECRET_PROVISION_SET_PF_KEY = "1"
+#loader.env.SECRET_PROVISION_CA_CHAIN_PATH = "certs/test-ca-sha256.crt"
+#loader.env.SECRET_PROVISION_SERVERS = "dummyserver:80;localhost:4433;anotherdummy:4433"
+
+# Request remote attestation functionality from Graphene
+sgx.remote_attestation = 1
+
+# Uncomment below lines for epid-based attestation
+#
+# Specify your SPID and linkable/unlinkable attestation policy
+#sgx.ra_client_spid = "1234567891234567891234567891234567"
+#sgx.ra_client_linkable = 0
+
+sgx.allowed_files.etchostname = "file:/etc/hostname"
+sgx.allowed_files.hosts = "file:/etc/hosts"
+sgx.allowed_files.resolv = "file:/etc/resolv.conf"
+
+# Uncomment for secret_prov_pf_client
+# sgx.protected_files.input = "file:files/input.txt"


### PR DESCRIPTION

Signed-off-by: Veena Saini <veena.saini@intel.com>
## Description of the changes 
This PR adds dockerifle and manifest file for ra-tls-secret-prov sample inside gsc/test folder. In addition to these two files, there is a docker-entrypoint.sh file provided in the gsc/test folder itself. Also, there is a small extra PHONY included inside /Examples/ra-tls-secret-prov/Makefile.

The objective of this PR is to provide a sample implementation of how a remote client running as part of docker container can provide it's sgx-based attestation report to a verifier/server entity.

## How to test this PR?
Step 0.  make sure RA-TLS DCAP libraries are built in Graphene via:
            $ cd graphene/Pal/src/host/Linux-SGX/tools/ra-tls && make dcap

Step 1. $ cd graphene
            $ docker build -t my_ra-tls-secret-prov:0.1 -f ~/graphene/Tools/gsc/test/ubuntu18.04-ra-tls-secret-prov.dockerfile .
            // Here "my_ra-tls-secret-prov:0.1" is the name of base ra-tls-secret-prov image.
            // ubuntu18.04-ra-tls-secret-prov.dockerfile is the dockerfile added as part of this PR.

Step 2. $  cd graphene/Tools/gsc
            $ ./gsc build  --insecure-args my_ra-tls-secret-prov:0.1 test/ubuntu18.04-ra-tls-secret-prov.manifest
            //  ubuntu18.04-ra-tls-secret-prov.manifest is the manifest added as part of this PR.

Step 3. ./gsc sign-image my_ra-tls-secret-prov:0.1  ~/graphene/Pal/src/host/Linux-SGX/signer/enclave-key.pem
             // Now we will have signed gsc image gsc-my_ra-tls-secret-prov:0.1

Step 4. Start the server
            $ cd graphene/Examples/ra-tls-secret-prov
            $  make dcap
            $ export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:./libs
            $ RA_TLS_ALLOW_OUTDATED_TCB_INSECURE=1 ./secret_prov_server_dcap &
            // Press ctrl +c , the server will be running in background

Step 5. docker run --net=host --device=/dev/sgx/enclave    -v /var/run/aesmd/aesm.socket:/var/run/aesmd/aesm.socket gsc- my_ra-tls-secret-prov:0.1
// Output will look something like:
send secret1, send secret 2
received secret1, received secret 2

Note 1: By default the above steps are for DCAP attestation. For EPID attestation please uncomment "sgx.ra_client_spid" and "sgx.ra_client_linkable" inside ubuntu18.04-ra-tls-secret-prov.manifest. Also, please start EPID based server at the localhost.

Note 2: There are 3 clients implemented as part of Examples/ra-tls-secret-prov sample. The above steps will show output for secret_prov_client only. This binary is defined inside Tools/gsc/test/ra-tls-secret-prov-docker-entrypoint.sh. User can change the binary name inside this entrypoint.sh file, and also can uncomment client specific flags inside ubuntu18.04-ra-tls-secret-prov.manifest.

Note 3: In order to build client binaries in non-graphene / non-graphene-sgx mode, I have added a phony target "clients" inside graphene/Examples/ra-tls-secret-prov/Makefile. 

Note 4: This sample assumes the server is running on localhost:4433, so --net=host command will allow docker to connect to the localhost server. In real scenario, the server will be a remote entity.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2305)
<!-- Reviewable:end -->
