### PR TITLE
[LibOS] Do not build memusagestat Glibc utility

### DIFF
--- a/LibOS/Makefile
+++ b/LibOS/Makefile
@@ -77,6 +77,7 @@ $(BUILD_DIR)/Makefile: $(GLIBC_SRC)/.configured
 	CFLAGS=$$GLIBC_CFLAGS CPPFLAGS=$$GLIBC_CPPFLAGS \
 	../$(GLIBC_SRC)/configure --prefix=$(RUNTIME_DIR) \
 		--with-tls \
+		--without-gd \
 		--without-selinux \
 		--disable-test \
 		--disable-nscd \


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

This utility has a bug of linking against the host's libraries, which may mismatch from the internal Graphene Glibc version and lead to Glibc build errors. Also, this utility is useless for Graphene.

Some details:
- http://www.linuxfromscratch.org/lfs/view/6.2/chapter05/glibc.html
- https://elixir.bootlin.com/glibc/glibc-2.33.9000/source/NEWS
- https://elixir.bootlin.com/glibc/glibc-2.27/source/malloc/memusagestat.c (proof that our oldest support Glibc version also has this utility and configuration flag)

This led to build errors in #2306, see it for details.

Fixes #2306 .

## How to test this PR? <!-- (if applicable) -->

Glibc build must succeed. You can check the `LibOS/build.log` that there is no `memusagestat` program being built now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2308)
<!-- Reviewable:end -->
