### PR TITLE
[Pal/Linux-SGX] tools: add ECDSA signing algo to RA-TLS certs

### DIFF
--- a/Documentation/attestation.rst
+++ b/Documentation/attestation.rst
@@ -254,6 +254,10 @@ The library uses the following environment variables if available:
 - ``RA_TLS_CERT_TIMESTAMP_NOT_AFTER`` -- the generated RA-TLS certificate uses
   this timestamp-not-after value, in the format "20301231235959" (this is also
   the default value if environment variable is not available).
+- ``RA_TLS_CERT_SIGNATURE_ALGO`` -- the generated RA-TLS certificate uses the
+  key pair created by the specified algorithm. The currently available values
+  are ``RSA``, ``ECDSA_SECP256K1``, ``ECDSA_SECP256R1``, ``ECDSA_SECP384R1``,
+  ``ECDSA_SECP521R1``. The default value is ``RSA``.
 
 ``ra_tls_verify_epid.so``
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/Examples/ra-tls-mbedtls/server.manifest.template
+++ b/Examples/ra-tls-mbedtls/server.manifest.template
@@ -8,6 +8,9 @@ loader.log_level = "{{ log_level }}"
 
 loader.env.LD_LIBRARY_PATH = "/lib:/lib/x86_64-linux-gnu:/libs"
 
+# use ECDSA instead of the default RSA for RA-TLS certificate. This is just for testing.
+loader.env.RA_TLS_CERT_SIGNATURE_ALGO = "ECDSA_SECP256K1"
+
 # Read application arguments directly from the command line. Don't use this on production!
 loader.insecure__use_cmdline_argv = 1
 

--- a/Examples/ra-tls-secret-prov/secret_prov_min_client.manifest.template
+++ b/Examples/ra-tls-secret-prov/secret_prov_min_client.manifest.template
@@ -11,6 +11,9 @@ loader.env.LD_LIBRARY_PATH = "/lib:/lib/x86_64-linux-gnu:/libs"
 # Secret Provisioning library (client-side) is preloaded
 loader.env.LD_PRELOAD = "libsecret_prov_attest.so"
 
+# use ECDSA instead of the default RSA for RA-TLS certificate. This is just for testing.
+loader.env.RA_TLS_CERT_SIGNATURE_ALGO = "ECDSA_SECP521R1"
+
 # Read application arguments directly from the command line. Don't use this on production!
 loader.insecure__use_cmdline_argv = 1
 

--- a/Pal/lib/crypto/adapters/mbedtls_adapter.c
+++ b/Pal/lib/crypto/adapters/mbedtls_adapter.c
@@ -11,6 +11,7 @@
 #include "assert.h"
 #include "mbedtls/aes.h"
 #include "mbedtls/cmac.h"
+#include "mbedtls/ecp.h"
 #include "mbedtls/entropy_poll.h"
 #include "mbedtls/error.h"
 #include "mbedtls/gcm.h"
@@ -93,6 +94,29 @@ int mbedtls_to_pal_error(int error) {
 
         case MBEDTLS_ERR_RSA_RNG_FAILED:
             return -PAL_ERROR_CRYPTO_RNG_FAILED;
+
+        case MBEDTLS_ERR_ECP_BAD_INPUT_DATA:
+            return -PAL_ERROR_CRYPTO_BAD_INPUT_DATA;
+
+        case MBEDTLS_ERR_ECP_FEATURE_UNAVAILABLE:
+            return -PAL_ERROR_CRYPTO_FEATURE_UNAVAILABLE;
+
+        case MBEDTLS_ERR_ECP_VERIFY_FAILED:
+            return -PAL_ERROR_CRYPTO_VERIFY_FAILED;
+
+        case MBEDTLS_ERR_ECP_BUFFER_TOO_SMALL:
+        case MBEDTLS_ERR_ECP_ALLOC_FAILED:
+            return -PAL_ERROR_NOMEM;
+
+        case MBEDTLS_ERR_ECP_RANDOM_FAILED:
+            return -PAL_ERROR_CRYPTO_RNG_FAILED;
+
+        case MBEDTLS_ERR_ECP_INVALID_KEY:
+        case MBEDTLS_ERR_ECP_SIG_LEN_MISMATCH:
+            return -PAL_ERROR_CRYPTO_INVALID_KEY;
+
+        case MBEDTLS_ERR_ECP_IN_PROGRESS:
+            return -PAL_ERROR_TRYAGAIN;
 
         case MBEDTLS_ERR_SSL_WANT_READ:
         case MBEDTLS_ERR_SSL_WANT_WRITE:

--- a/Pal/src/host/Linux-SGX/tools/ra-tls/ra_tls_attest.c
+++ b/Pal/src/host/Linux-SGX/tools/ra-tls/ra_tls_attest.c
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: LGPL-3.0-or-later */
-/* Copyright (C) 2018-2020 Intel Labs */
+/* Copyright (C) 2018-2021 Intel Labs */
 
 /*!
  * \file
@@ -8,6 +8,11 @@
  * functions to create a self-signed RA-TLS certificate with an SGX quote embedded in it. It works
  * with both EPID-based (quote v2) and ECDSA-based (quote v3 or DCAP) SGX quotes (in fact, it is
  * agnostic to the format of the SGX quote).
+ *
+ * The self-signed RA-TLS certificate is signed by an ephemeral keypair generated and kept inside
+ * the enclave. The keypair is either RSA or ECDSA (for ECDSA, the available curves are SECP256K1,
+ * SECP256R1, SECP384R1, SECP521R1). By default, the keypair is RSA but can be configured via the
+ * envvar RA_TLS_CERT_SIGNATURE_ALGO.
  *
  * This file is part of the RA-TLS attestation library which is typically linked into server
  * applications. This library is *not* thread-safe.
@@ -25,6 +30,7 @@
 #include <unistd.h>
 
 #include <mbedtls/ctr_drbg.h>
+#include <mbedtls/ecp.h>
 #include <mbedtls/entropy.h>
 #include <mbedtls/pk.h>
 #include <mbedtls/rsa.h>
@@ -154,13 +160,69 @@ static int sha256_over_pk(mbedtls_pk_context* pk, uint8_t* sha) {
 
     /* below function writes data at the end of the buffer */
     int pk_der_size_byte = mbedtls_pk_write_pubkey_der(pk, pk_der, PUB_KEY_SIZE_MAX);
-    if (pk_der_size_byte != RSA_PUB_3072_KEY_DER_LEN)
+    if (pk_der_size_byte <= 0)
         return MBEDTLS_ERR_PK_INVALID_PUBKEY;
 
     /* move the data to the beginning of the buffer, to avoid pointer arithmetic later */
     memmove(pk_der, pk_der + PUB_KEY_SIZE_MAX - pk_der_size_byte, pk_der_size_byte);
 
     return mbedtls_sha256_ret(pk_der, pk_der_size_byte, sha, /*is224=*/0);
+}
+
+/*! create keypair \p pk: can be RSA or ECDSA depending on RA-TLS envvars */
+static int create_key(mbedtls_ctr_drbg_context* ctr_drbg, mbedtls_pk_context* pk) {
+    int ret;
+    char* key_algo = NULL;
+
+    key_algo = strdup(getenv(RA_TLS_CERT_SIGNATURE_ALGO) ? : RA_TLS_CERT_SIGNATURE_ALGO_DEFAULT);
+    if (!key_algo) {
+        ret = MBEDTLS_ERR_X509_ALLOC_FAILED;
+        goto out;
+    }
+
+    if (!strcmp(key_algo, RA_TLS_CERT_SIGNATURE_ALGO_RSA)) {
+        /* RSA pk generation is requested by the user of RA-TLS */
+        ret = mbedtls_pk_setup(pk, mbedtls_pk_info_from_type(MBEDTLS_PK_RSA));
+        if (ret < 0)
+            goto out;
+
+        mbedtls_rsa_init((mbedtls_rsa_context*)pk->pk_ctx, MBEDTLS_RSA_PKCS_V15, /*hash_id=*/0);
+
+        ret = mbedtls_rsa_gen_key((mbedtls_rsa_context*)pk->pk_ctx, mbedtls_ctr_drbg_random,
+                                  ctr_drbg, RSA_PUB_3072_KEY_LEN, RSA_PUB_EXPONENT);
+        if (ret < 0)
+            goto out;
+    } else {
+        /* ECDSA pk generation is requested by the user of RA-TLS (actually, via EC key API) */
+        ret = mbedtls_pk_setup(pk, mbedtls_pk_info_from_type(MBEDTLS_PK_ECKEY));
+        if (ret < 0)
+            goto out;
+
+        int elliptic_curve_group_id = 0;
+        if (!strcmp(key_algo, RA_TLS_CERT_SIGNATURE_ALGO_ECDSA_SECP256K1)) {
+            elliptic_curve_group_id = MBEDTLS_ECP_DP_SECP256K1;
+        } else if (!strcmp(key_algo, RA_TLS_CERT_SIGNATURE_ALGO_ECDSA_SECP256R1)) {
+            elliptic_curve_group_id = MBEDTLS_ECP_DP_SECP256R1;
+        } else if (!strcmp(key_algo, RA_TLS_CERT_SIGNATURE_ALGO_ECDSA_SECP384R1)) {
+            elliptic_curve_group_id = MBEDTLS_ECP_DP_SECP384R1;
+        } else if (!strcmp(key_algo, RA_TLS_CERT_SIGNATURE_ALGO_ECDSA_SECP521R1)) {
+            elliptic_curve_group_id = MBEDTLS_ECP_DP_SECP521R1;
+        } else {
+            /* unrecognized ECDSA curve */
+            ret = MBEDTLS_ERR_X509_FATAL_ERROR;
+            goto out;
+        }
+
+        ret = mbedtls_ecp_gen_key(elliptic_curve_group_id, mbedtls_pk_ec(*pk),
+                                  mbedtls_ctr_drbg_random, ctr_drbg);
+        if (ret < 0)
+            goto out;
+    }
+
+    ret = 0;
+out:
+    free(key_algo);
+    return ret;
 }
 
 /*! given public key \p pk, generate an RA-TLS certificate \p writecrt */
@@ -223,14 +285,8 @@ static int create_key_and_crt(mbedtls_pk_context* key, mbedtls_x509_crt* crt, ui
     if (ret < 0)
         goto out;
 
-    ret = mbedtls_pk_setup(key, mbedtls_pk_info_from_type(MBEDTLS_PK_RSA));
-    if (ret < 0)
-        goto out;
 
-    mbedtls_rsa_init((mbedtls_rsa_context*)key->pk_ctx, MBEDTLS_RSA_PKCS_V15, /*hash_id=*/0);
-
-    ret = mbedtls_rsa_gen_key((mbedtls_rsa_context*)key->pk_ctx, mbedtls_ctr_drbg_random, &ctr_drbg,
-                              RSA_PUB_3072_KEY_LEN, RSA_PUB_EXPONENT);
+    ret = create_key(&ctr_drbg, key);
     if (ret < 0)
         goto out;
 
@@ -292,7 +348,7 @@ int ra_tls_create_key_and_crt_der(uint8_t** der_key, size_t* der_key_size, uint8
 
     uint8_t* der_key_buf   = NULL;
     uint8_t* output_buf    = NULL;
-    size_t output_buf_size = 1024; /* enough for any public key */
+    size_t output_buf_size = PUB_KEY_SIZE_MAX; /* enough for any public key */
 
     output_buf = malloc(output_buf_size);
     if (!output_buf) {

--- a/Pal/src/host/Linux-SGX/tools/ra-tls/ra_tls_verify_common.c
+++ b/Pal/src/host/Linux-SGX/tools/ra-tls/ra_tls_verify_common.c
@@ -151,7 +151,7 @@ static int sha256_over_crt_pk(mbedtls_x509_crt* crt, uint8_t* sha) {
 
     /* below function writes data at the end of the buffer */
     int pk_der_size_byte = mbedtls_pk_write_pubkey_der(&crt->pk, pk_der, PUB_KEY_SIZE_MAX);
-    if (pk_der_size_byte != RSA_PUB_3072_KEY_DER_LEN)
+    if (pk_der_size_byte <= 0)
         return MBEDTLS_ERR_PK_INVALID_PUBKEY;
 
     /* move the data to the beginning of the buffer, to avoid pointer arithmetic later */


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Previously, RA-TLS generated only RSA keypairs (and signed self-signed RA-TLS X.509 certificates with these RSA keys). This PR adds the ability to choose between RSA and ECDSA (four popular curves are currently supported for ECDSA: SECP256K1, SECP256R1, SECP384R1, SECP521R1). A new envvar for RA-TLS is added to choose signing algo: `RA_TLS_CERT_SIGNATURE_ALGO`.

Fixes #2266.

## How to test this PR? <!-- (if applicable) -->

I added `loader.env.RA_TLS_CERT_SIGNATURE_ALGO = "ECDSA_SECP256K1"` to two examples: `ra-tls-mbedtls` and `ra-tls-secret-prov`.

Without this PR (or without this new envvar), `ra-tls-mbedtls` example prints something like this:
```
<h2>mbed TLS Test Server</h2>
<p>Successful connection using: TLS-ECDHE-RSA-WITH-CHACHA20-POLY1305-SHA256</p>
```

With this PR (and with this new envvar etting), it prints something like this:
```
<h2>mbed TLS Test Server</h2>
<p>Successful connection using: TLS-ECDHE-ECDSA-WITH-CHACHA20-POLY1305-SHA256</p>
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/graphene/2314)
<!-- Reviewable:end -->
