### PR TITLE
[GSC] Fix typo in manifest template `arg0_override` -> `argv0_override`

### DIFF
--- a/Tools/gsc/templates/entrypoint.manifest.template
+++ b/Tools/gsc/templates/entrypoint.manifest.template
@@ -18,7 +18,7 @@ sgx.nonpie_binary = 1
 # !! INSECURE !! Allow passing command-line arguments from the host without validation.
 # Most Docker images rely on runtime arguments and hence, a more general technique is required.
 # The issue is documented at https://github.com/oscarlab/graphene/issues/1520.
-loader.arg0_override = "{{binary}}"
+loader.argv0_override = "{{binary}}"
 loader.insecure__use_cmdline_argv = 1
 {% else %}
 loader.argv_src_file = "file:/trusted_argv"


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

This PR fixes a stupid typo which led to issues like https://github.com/oscarlab/graphene/issues/2261.

## How to test this PR? <!-- (if applicable) -->

All GSC tests must work. Programs that do `execve(<my-own-argv0>)` will work now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2317)
<!-- Reviewable:end -->
