### PR TITLE
[LibOS] Rename `async helper` to `async worker`

### DIFF
--- a/LibOS/shim/include/shim_utils.h
+++ b/LibOS/shim/include/shim_utils.h
@@ -159,10 +159,10 @@ int create_pipe(char* name, char* uri, size_t size, PAL_HANDLE* hdl, struct shim
                 bool use_vmid_for_name);
 
 /* Asynchronous event support */
-int init_async(void);
+int init_async_worker(void);
 int64_t install_async_event(PAL_HANDLE object, unsigned long time,
                             void (*callback)(IDTYPE caller, void* arg), void* arg);
-struct shim_thread* terminate_async_helper(void);
+struct shim_thread* terminate_async_worker(void);
 
 extern const toml_table_t* g_manifest_root;
 

--- a/LibOS/shim/src/bookkeep/shim_thread.c
+++ b/LibOS/shim/src/bookkeep/shim_thread.c
@@ -460,8 +460,8 @@ bool check_last_thread(bool mark_self_dead) {
     return ret;
 }
 
-/* This function is called by Async Helper thread to wait on thread->clear_child_tid_pal to be
- * zeroed (PAL does it when thread finally exits). Since it is a callback to Async Helper thread,
+/* This function is called by async worker thread to wait on thread->clear_child_tid_pal to be
+ * zeroed (PAL does it when thread finally exits). Since it is a callback to async worker thread,
  * this function must follow the `void (*callback) (IDTYPE caller, void* arg)` signature. */
 void cleanup_thread(IDTYPE caller, void* arg) {
     __UNUSED(caller);

--- a/LibOS/shim/src/shim_async.c
+++ b/LibOS/shim/src/shim_async.c
@@ -28,20 +28,20 @@ struct async_event {
 DEFINE_LISTP(async_event);
 static LISTP_TYPE(async_event) async_list;
 
-/* Should be accessed with async_helper_lock held. */
-static enum { HELPER_NOTALIVE, HELPER_ALIVE } async_helper_state;
+/* Should be accessed with async_worker_lock held. */
+static enum { WORKER_NOTALIVE, WORKER_ALIVE } async_worker_state;
 
-static struct shim_thread* async_helper_thread;
-static struct shim_lock async_helper_lock;
+static struct shim_thread* async_worker_thread;
+static struct shim_lock async_worker_lock;
 
 static AEVENTTYPE install_new_event;
 
-static int create_async_helper(void);
+static int create_async_worker(void);
 
 /* Threads register async events like alarm(), setitimer(), ioctl(FIOASYNC)
  * using this function. These events are enqueued in async_list and delivered
- * to Async Helper thread by triggering install_new_event. When event is
- * triggered in Async Helper thread, the corresponding event's callback with
+ * to async worker thread by triggering install_new_event. When event is
+ * triggered in async worker thread, the corresponding event's callback with
  * arguments `arg` is called. This callback typically sends a signal to the
  * thread which registered the event (saved in `event->caller`).
  *
@@ -77,7 +77,7 @@ int64_t install_async_event(PAL_HANDLE object, uint64_t time,
     event->object      = object;
     event->expire_time = time ? now + time : 0;
 
-    lock(&async_helper_lock);
+    lock(&async_worker_lock);
 
     if (callback != &cleanup_thread && !object) {
         /* This is alarm() or setitimer() emulation, treat both according to
@@ -99,7 +99,7 @@ int64_t install_async_event(PAL_HANDLE object, uint64_t time,
             /* This is alarm(0), we cancelled all pending alarms/timers
              * and user doesn't want to set a new alarm: we are done. */
             free(event);
-            unlock(&async_helper_lock);
+            unlock(&async_worker_lock);
             return max_prev_expire_time - now;
         }
     }
@@ -107,25 +107,25 @@ int64_t install_async_event(PAL_HANDLE object, uint64_t time,
     INIT_LIST_HEAD(event, list);
     LISTP_ADD_TAIL(event, &async_list, list);
 
-    if (async_helper_state == HELPER_NOTALIVE) {
-        int ret = create_async_helper();
+    if (async_worker_state == WORKER_NOTALIVE) {
+        int ret = create_async_worker();
         if (ret < 0) {
-            unlock(&async_helper_lock);
+            unlock(&async_worker_lock);
             return ret;
         }
     }
 
-    unlock(&async_helper_lock);
+    unlock(&async_worker_lock);
 
     log_debug("Installed async event at %lu\n", now);
     set_event(&install_new_event, 1);
     return max_prev_expire_time - now;
 }
 
-int init_async(void) {
+int init_async_worker(void) {
     /* early enough in init, can write global vars without the lock */
-    async_helper_state = HELPER_NOTALIVE;
-    if (!create_lock(&async_helper_lock)) {
+    async_worker_state = WORKER_NOTALIVE;
+    if (!create_lock(&async_worker_lock)) {
         return -ENOMEM;
     }
     int ret = create_event(&install_new_event);
@@ -139,7 +139,7 @@ int init_async(void) {
     return 0;
 }
 
-static void shim_async_helper(void* arg) {
+static void shim_async_worker(void* arg) {
     struct shim_thread* self = (struct shim_thread*)arg;
     if (!arg)
         return;
@@ -149,9 +149,9 @@ static void shim_async_helper(void* arg) {
 
     log_setprefix(shim_get_tcb());
 
-    lock(&async_helper_lock);
-    bool notme = (self != async_helper_thread);
-    unlock(&async_helper_lock);
+    lock(&async_worker_lock);
+    bool notme = (self != async_worker_thread);
+    unlock(&async_worker_lock);
 
     if (notme) {
         put_thread(self);
@@ -159,12 +159,12 @@ static void shim_async_helper(void* arg) {
         /* UNREACHABLE */
     }
 
-    /* Assume async helper thread will not drain the stack that PAL provides,
+    /* Assume async worker thread will not drain the stack that PAL provides,
      * so for efficiency we don't swap the stack. */
-    log_debug("Async helper thread started\n");
+    log_debug("Async worker thread started\n");
 
     /* Simple heuristic to not burn cycles when no async events are installed:
-     * async helper thread sleeps IDLE_SLEEP_TIME for MAX_IDLE_CYCLES and
+     * async worker thread sleeps IDLE_SLEEP_TIME for MAX_IDLE_CYCLES and
      * if nothing happens, dies. It will be re-spawned if some thread wants
      * to install a new event. */
     uint64_t idle_cycles = 0;
@@ -199,10 +199,10 @@ static void shim_async_helper(void* arg) {
             goto out_err;
         }
 
-        lock(&async_helper_lock);
-        if (async_helper_state != HELPER_ALIVE) {
-            async_helper_thread = NULL;
-            unlock(&async_helper_lock);
+        lock(&async_worker_lock);
+        if (async_worker_state != WORKER_ALIVE) {
+            async_worker_thread = NULL;
+            unlock(&async_worker_lock);
             break;
         }
 
@@ -275,19 +275,19 @@ static void shim_async_helper(void* arg) {
         }
 
         if (idle_cycles == MAX_IDLE_CYCLES) {
-            async_helper_state  = HELPER_NOTALIVE;
-            async_helper_thread = NULL;
-            unlock(&async_helper_lock);
-            log_debug("Async helper thread has been idle for some time; stopping it\n");
+            async_worker_state  = WORKER_NOTALIVE;
+            async_worker_thread = NULL;
+            unlock(&async_worker_lock);
+            log_debug("Async worker thread has been idle for some time; stopping it\n");
             break;
         }
-        unlock(&async_helper_lock);
+        unlock(&async_worker_lock);
 
         /* wait on async IO events + install_new_event + next expiring alarm/timer */
         ret = DkStreamsWaitEvents(pals_cnt + 1, pals, pal_events, ret_events, sleep_time);
         if (ret < 0 && ret != -PAL_ERROR_INTERRUPTED && ret != -PAL_ERROR_TRYAGAIN) {
             ret = pal_to_unix_errno(ret);
-            debug("Async helper: DkStreamsWaitEvents failed: %d\n", ret);
+            debug("Async worker: DkStreamsWaitEvents failed: %d\n", ret);
             goto out_err;
         }
         PAL_BOL polled = ret == 0;
@@ -303,7 +303,7 @@ static void shim_async_helper(void* arg) {
         INIT_LISTP(&triggered);
 
         /* acquire lock because we read/modify async_list below */
-        lock(&async_helper_lock);
+        lock(&async_worker_lock);
 
         for (size_t i = 0; polled && i < pals_cnt + 1; i++) {
             if (ret_events[i]) {
@@ -338,7 +338,7 @@ static void shim_async_helper(void* arg) {
             }
         }
 
-        unlock(&async_helper_lock);
+        unlock(&async_worker_lock);
 
         /* call callbacks for all triggered events */
         if (!LISTP_EMPTY(&triggered)) {
@@ -354,7 +354,7 @@ static void shim_async_helper(void* arg) {
     }
 
     put_thread(self);
-    log_debug("Async helper thread terminated\n");
+    log_debug("Async worker thread terminated\n");
 
     free(pals);
     free(pal_events);
@@ -363,33 +363,33 @@ static void shim_async_helper(void* arg) {
     /* UNREACHABLE */
 
 out_err_unlock:
-    unlock(&async_helper_lock);
+    unlock(&async_worker_lock);
 out_err:
-    log_error("Terminating the process due to a fatal error in async helper\n");
+    log_error("Terminating the process due to a fatal error in async worker\n");
     put_thread(self);
     DkProcessExit(1);
 }
 
-/* this should be called with the async_helper_lock held */
-static int create_async_helper(void) {
-    assert(locked(&async_helper_lock));
+/* this should be called with the async_worker_lock held */
+static int create_async_worker(void) {
+    assert(locked(&async_worker_lock));
 
-    if (async_helper_state == HELPER_ALIVE)
+    if (async_worker_state == WORKER_ALIVE)
         return 0;
 
     struct shim_thread* new = get_new_internal_thread();
     if (!new)
         return -ENOMEM;
 
-    async_helper_thread = new;
-    async_helper_state  = HELPER_ALIVE;
+    async_worker_thread = new;
+    async_worker_state  = WORKER_ALIVE;
 
     PAL_HANDLE handle = NULL;
-    int ret = DkThreadCreate(shim_async_helper, new, &handle);
+    int ret = DkThreadCreate(shim_async_worker, new, &handle);
 
     if (ret < 0) {
-        async_helper_thread = NULL;
-        async_helper_state  = HELPER_NOTALIVE;
+        async_worker_thread = NULL;
+        async_worker_state  = WORKER_NOTALIVE;
         put_thread(new);
         return pal_to_unix_errno(ret);
     }
@@ -398,26 +398,26 @@ static int create_async_helper(void) {
     return 0;
 }
 
-/* On success, the reference to async helper thread is returned with refcount
- * incremented. It is the responsibility of caller to wait for async helper's
+/* On success, the reference to async worker thread is returned with refcount
+ * incremented. It is the responsibility of caller to wait for async worker's
  * exit and then release the final reference to free related resources (it is
  * problematic for the thread itself to release its own resources e.g. stack).
  */
-struct shim_thread* terminate_async_helper(void) {
-    lock(&async_helper_lock);
+struct shim_thread* terminate_async_worker(void) {
+    lock(&async_worker_lock);
 
-    if (async_helper_state != HELPER_ALIVE) {
-        unlock(&async_helper_lock);
+    if (async_worker_state != WORKER_ALIVE) {
+        unlock(&async_worker_lock);
         return NULL;
     }
 
-    struct shim_thread* ret = async_helper_thread;
+    struct shim_thread* ret = async_worker_thread;
     if (ret)
         get_thread(ret);
-    async_helper_state = HELPER_NOTALIVE;
-    unlock(&async_helper_lock);
+    async_worker_state = WORKER_NOTALIVE;
+    unlock(&async_worker_lock);
 
-    /* force wake up of async helper thread so that it exits */
+    /* force wake up of async worker thread so that it exits */
     set_event(&install_new_event, 1);
     return ret;
 }

--- a/LibOS/shim/src/shim_init.c
+++ b/LibOS/shim/src/shim_init.c
@@ -451,7 +451,7 @@ noreturn void* shim_init(int argc, void* args) {
     RUN_INIT(init_threading);
     RUN_INIT(init_mount);
     RUN_INIT(init_important_handles);
-    RUN_INIT(init_async);
+    RUN_INIT(init_async_worker);
 
     const char** new_argp;
     elf_auxv_t* new_auxv;

--- a/LibOS/shim/src/sys/shim_exit.c
+++ b/LibOS/shim/src/sys/shim_exit.c
@@ -25,7 +25,7 @@ static noreturn void libos_clean_and_exit(int exit_code) {
      * 2) wait for them to exit here, before we terminate the IPC helper
      */
 
-    struct shim_thread* async_thread = terminate_async_helper();
+    struct shim_thread* async_thread = terminate_async_worker();
     if (async_thread) {
         /* TODO: wait for the thread to exit in host.
          * This is tracked by the following issue.
@@ -48,7 +48,7 @@ noreturn void thread_exit(int error_code, int term_signal) {
     if (!check_last_thread(/*mark_self_dead=*/true)) {
         struct shim_thread* cur_thread = get_cur_thread();
 
-        /* ask Async Helper thread to cleanup this thread */
+        /* ask async worker thread to cleanup this thread */
         cur_thread->clear_child_tid_pal = 1; /* any non-zero value suffices */
         /* We pass this ownership to `cleanup_thread`. */
         get_thread(cur_thread);

--- a/Pal/src/host/Linux-SGX/enclave_entry.S
+++ b/Pal/src/host/Linux-SGX/enclave_entry.S
@@ -131,7 +131,7 @@ enclave_entry:
 
 	# At this point, the thread has completely exited from the point of view
 	# of LibOS. We can now set *clear_child_tid to 0, which will trigger
-	# async helper thread in LibOS, which will wake up parent thread if any.
+	# async worker thread in LibOS, which will wake up parent thread if any.
 	cmpq $0, %gs:SGX_CLEAR_CHILD_TID
 	je 1f
 	movq %gs:SGX_CLEAR_CHILD_TID, %rbx

--- a/Pal/src/host/Linux/db_threading.c
+++ b/Pal/src/host/Linux/db_threading.c
@@ -246,7 +246,7 @@ noreturn void _DkThreadExit(int* clear_child_tid) {
     /* To make sure the compiler doesn't touch the stack after it was freed, need inline asm:
      *   1. Unlock g_thread_stack_lock (so that other threads can start re-using this stack)
      *   2. Set *clear_child_tid = 0 if clear_child_tid != NULL
-     *      (we thus inform LibOS, where async helper thread is waiting on this to wake up parent)
+     *      (we thus inform LibOS, where async worker thread is waiting on this to wake up parent)
      *   3. Exit thread */
     static_assert(sizeof(g_thread_stack_lock.lock) == 4,
                   "unexpected g_thread_stack_lock.lock size");


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->
To be consistent with recent IPC worker rename.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2318)
<!-- Reviewable:end -->
