### PR TITLE
`libos.entrypoint` parsing fixes

### DIFF
--- a/LibOS/shim/src/shim_rtld.c
+++ b/LibOS/shim/src/shim_rtld.c
@@ -865,9 +865,9 @@ int init_loader(void) {
         ret = load_elf_object(exec);
         if (ret < 0) {
             // TODO: Actually verify that the non-PIE-ness was the real cause of loading failure.
-            log_error("ERROR: Failed to load %s. This may be caused by the binary being non-PIE, "
-                      "in which case Graphene requires a specially-crafted memory layout. You can "
-                      "enable it by adding 'sgx.nonpie_binary = 1' to the manifest.\n",
+            log_error("Failed to load %s. This may be caused by the binary being non-PIE, in which "
+                      "case Graphene requires a specially-crafted memory layout. You can enable it "
+                      "by adding 'sgx.nonpie_binary = 1' to the manifest.\n",
                       qstrgetstr(&exec->path));
             goto out;
         }

--- a/Pal/include/lib/api.h
+++ b/Pal/include/lib/api.h
@@ -223,16 +223,16 @@ void* calloc(size_t nmemb, size_t size);
 int vfprintfmt(int (*_fputc)(char c, void* arg), void* arg, const char* fmt, va_list ap)
     __attribute__((format(printf, 3, 0)));
 
-int vsnprintf(char* str, size_t size, const char* fmt, va_list ap)
+int vsnprintf(char* buf, size_t buf_size, const char* fmt, va_list ap)
     __attribute__((format(printf, 3, 0)));
-int snprintf(char* str, size_t size, const char* fmt, ...)
+int snprintf(char* buf, size_t buf_size, const char* fmt, ...)
     __attribute__((format(printf, 3, 4)));
 
 /* Used by _FORTIFY_SOURCE */
-int __vsnprintf_chk(char* str, size_t size, int flag, size_t real_size, const char* fmt,
+int __vsnprintf_chk(char* buf, size_t buf_size, int flag, size_t real_size, const char* fmt,
                     va_list ap)
     __attribute__((format(printf, 5, 0)));
-int __snprintf_chk(char* str, size_t size, int flag, size_t real_size, const char* fmt, ...)
+int __snprintf_chk(char* buf, size_t buf_size, int flag, size_t real_size, const char* fmt, ...)
     __attribute__((format(printf, 5, 6)));
 
 /*

--- a/Pal/src/db_main.c
+++ b/Pal/src/db_main.c
@@ -418,6 +418,8 @@ noreturn void pal_main(PAL_NUM instance_id,        /* current instance id */
     if (ret < 0)
         INIT_FAIL_MANIFEST(PAL_ERROR_INVAL, "Cannot parse 'pal.entrypoint'");
     if (entrypoint) {
+        if (!strstartswith(entrypoint, URI_PREFIX_FILE))
+            INIT_FAIL(PAL_ERROR_INVAL, "'pal.entrypoint' is missing 'file:' prefix\n");
         // Temporary hack: Assume we're in PAL regression test suite and load the test binary
         // directly, without LibOS.
         exec_uri = entrypoint;

--- a/Pal/src/host/Linux-SGX/sgx_main.c
+++ b/Pal/src/host/Linux-SGX/sgx_main.c
@@ -597,6 +597,10 @@ static int parse_loader_config(char* manifest, struct pal_enclave* enclave_info)
             ret = -EINVAL;
             goto out;
         }
+    } else if (!strstartswith(entrypoint, URI_PREFIX_FILE)) {
+        urts_log_error("'libos.entrypoint' is missing 'file:' prefix\n");
+        ret = -EINVAL;
+        goto out;
     }
     enclave_info->entrypoint_uri = entrypoint;
 

--- a/Pal/src/host/Linux/db_main.c
+++ b/Pal/src/host/Linux/db_main.c
@@ -276,6 +276,8 @@ noreturn void pal_linux_main(void* initial_rsp, void* fini_callback) {
             if (!pal_entrypoint)
                 INIT_FAIL(PAL_ERROR_INVAL,
                           "'libos.entrypoint' must be specified in the manifest\n");
+        } else if (!strstartswith(exec_uri, URI_PREFIX_FILE)) {
+            INIT_FAIL(PAL_ERROR_INVAL, "'libos.entrypoint' is missing 'file:' prefix\n");
         }
     }
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

This fixes a bunch of issues around `libos.entrypoint` handling:
- Due to our old and incorrect implementation of `snprintf`, long exec names resulted in an unterminated C-strings in some places.
- Even after fixing the above, our logging didn't handle this case nicely - `] ` suffix was missing.
- Seems that one `error: ERROR: ` survived the last logging cleanup.
- `libos.entrypoint` was silently assumed to start with `file:`. So, it if wasn't a proper URI (e.g. due to a user error) it got trimmed: e.g. `my_binary` was stripped to `nary`.

## How to test this PR? <!-- (if applicable) -->

Set `libos.entrypoint` to some funny things and check whether anything still blows up :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2322)
<!-- Reviewable:end -->
