### PR TITLE
[LibOS] Simplify low-level dentry functions

### DIFF
--- a/LibOS/shim/include/shim_types.h
+++ b/LibOS/shim/include/shim_types.h
@@ -365,7 +365,6 @@ struct shim_str {
 /* Use qstr for names. This has fixed size string + string object
  * if len > SHIM_QSTR_SIZE then use overflow string */
 struct shim_qstr {
-    HASHTYPE hash;
     size_t len;
     char name[QSTR_SIZE];
     struct shim_str* oflow;

--- a/LibOS/shim/include/shim_utils.h
+++ b/LibOS/shim/include/shim_utils.h
@@ -123,7 +123,6 @@ static inline int qstrempty(const struct shim_qstr* qstr) {
 
 static inline void qstrcopy(struct shim_qstr* to, const struct shim_qstr* from) {
     qstrsetstr(to, qstrgetstr(from), from->len);
-    to->hash = from->hash;
 }
 
 static inline int qstrcmpstr(const struct shim_qstr* qstr, const char* str, size_t len) {

--- a/LibOS/shim/src/bookkeep/shim_handle.c
+++ b/LibOS/shim/src/bookkeep/shim_handle.c
@@ -465,7 +465,7 @@ void put_handle(struct shim_handle* hdl) {
         }
 
         if (hdl->dentry)
-            put_dentry_maybe_delete(hdl->dentry);
+            put_dentry(hdl->dentry);
 
         if (hdl->fs)
             put_mount(hdl->fs);

--- a/LibOS/shim/src/fs/shim_dcache.c
+++ b/LibOS/shim/src/fs/shim_dcache.c
@@ -26,15 +26,11 @@ static struct shim_lock dcache_mgr_lock;
 #define OBJ_TYPE struct shim_dentry
 #include "memmgr.h"
 
-struct shim_lock dcache_lock;
+struct shim_lock g_dcache_lock;
 
 static MEM_MGR dentry_mgr = NULL;
 
-struct shim_dentry* dentry_root = NULL;
-
-static inline HASHTYPE hash_dentry(struct shim_dentry* start, const char* path, int len) {
-    return rehash_path(start ? start->rel_path.hash : 0, path, len);
-}
+struct shim_dentry* g_dentry_root = NULL;
 
 static struct shim_dentry* alloc_dentry(void) {
     struct shim_dentry* dent =
@@ -59,30 +55,30 @@ static struct shim_dentry* alloc_dentry(void) {
 }
 
 int init_dcache(void) {
-    if (!create_lock(&dcache_mgr_lock) || !create_lock(&dcache_lock)) {
+    if (!create_lock(&dcache_mgr_lock) || !create_lock(&g_dcache_lock)) {
         return -ENOMEM;
     }
 
     dentry_mgr = create_mem_mgr(init_align_up(DCACHE_MGR_ALLOC));
 
-    dentry_root = alloc_dentry();
-    if (!dentry_root) {
+    g_dentry_root = alloc_dentry();
+    if (!g_dentry_root) {
         return -ENOMEM;
     }
 
     /* The root is special; we assume it won't change or be freed, so we artificially increase its
      * refcount by 1. */
-    get_dentry(dentry_root);
+    get_dentry(g_dentry_root);
 
     /* Initialize the root to a valid state, as a low-level lookup
      *  will fail. */
-    dentry_root->state |= DENTRY_VALID;
+    g_dentry_root->state |= DENTRY_VALID;
 
     /* The root should be a directory too*/
-    dentry_root->state |= DENTRY_ISDIRECTORY;
+    g_dentry_root->state |= DENTRY_ISDIRECTORY;
 
-    qstrsetstr(&dentry_root->name, "", 0);
-    qstrsetstr(&dentry_root->rel_path, "", 0);
+    qstrsetstr(&g_dentry_root->name, "", 0);
+    qstrsetstr(&g_dentry_root->rel_path, "", 0);
 
     return 0;
 }
@@ -90,9 +86,9 @@ int init_dcache(void) {
 /* Increment the reference count for a dentry */
 void get_dentry(struct shim_dentry* dent) {
 #ifdef DEBUG_REF
-    int count = REF_INC(dent->ref_count);
+    int64_t count = REF_INC(dent->ref_count);
 
-    log_debug("get dentry %p(%s/%s) (ref_count = %d)\n", dent,
+    log_debug("get dentry %p(%s/%s) (ref_count = %lld)\n", dent,
               dent->fs ? qstrgetstr(&dent->fs->path) : "", qstrgetstr(&dent->rel_path), count);
 #else
     REF_INC(dent->ref_count);
@@ -127,189 +123,93 @@ static void free_dentry(struct shim_dentry* dent) {
     free_mem_obj_to_mgr(dentry_mgr, dent);
 }
 
-/*
- * Decrement the reference count on dent.
- *
- * If we notice that dentry is negative and there are only 2 references left (ours and 1 for
- * parent's children list) we try to free this dentry - try, because somebody could get another
- * reference asynchronously.
- */
-void put_dentry_maybe_delete(struct shim_dentry* dent) {
-    long count = REF_GET(dent->ref_count);
-    assert(count >= 0);
-
-    /* First try without the lock. This check is racy - in some cases dentry might be left alive,
-     * but this is a opportunistic free anyway. */
-    if (count == 2) {
-        lock(&dcache_lock);
-
-        count = REF_GET(dent->ref_count);
-        /* If the dentry does not exist on fs anymore, let's delete it. */
-        if (count == 2 && dent->state & DENTRY_NEGATIVE && dent->parent) {
-            LISTP_DEL_INIT(dent, &dent->parent->children, siblings);
-            put_dentry(dent);
-        }
-
-        unlock(&dcache_lock);
-    }
-
-    /* This might free `dent`. */
-    put_dentry(dent);
-}
-
 void put_dentry(struct shim_dentry* dent) {
-    int count = REF_DEC(dent->ref_count);
+    int64_t count = REF_DEC(dent->ref_count);
+#ifdef DEBUG_REF
+    log_debug("put dentry %p(%s/%s) (ref_count = %lld)\n", dent,
+              dent->fs ? qstrgetstr(&dent->fs->path) : "", qstrgetstr(&dent->rel_path), count);
+#endif
     assert(count >= 0);
+
     if (count == 0) {
         assert(LIST_EMPTY(dent, siblings));
+        assert(LISTP_EMPTY(&dent->children));
         free_dentry(dent);
     }
 }
 
-/* Allocate and initialize a new dentry for path name, under
- * parent.  Return the dentry.
- *
- * mount is the mountpoint the dentry is under; this is typically
- * the parent->fs, but is passed explicitly for initializing
- * the dentry of a mountpoint.
- *
- * If hashptr is passed (as an optimization), this is a hash
- * of the name.
- *
- * If parent is non-null, the ref count is 2; else it is 1.
- *
- * This function also sets up both a name and a relative path
- */
-struct shim_dentry* get_new_dentry(struct shim_mount* mount, struct shim_dentry* parent,
-                                   const char* name, int namelen, HASHTYPE* hashptr) {
-    assert(locked(&dcache_lock));
+void dentry_gc(struct shim_dentry* dent) {
+    assert(locked(&g_dcache_lock));
+    assert(dent->parent);
+
+    if (REF_GET(dent->ref_count) != 1)
+        return;
+
+    if ((dent->state & DENTRY_VALID) && !(dent->state & DENTRY_NEGATIVE))
+        return;
+
+    LISTP_DEL_INIT(dent, &dent->parent->children, siblings);
+    dent->parent->nchildren--;
+    /* This should delete `dent` */
+    put_dentry(dent);
+}
+
+struct shim_dentry* get_new_dentry(struct shim_mount* fs, struct shim_dentry* parent,
+                                   const char* name, size_t name_len) {
+    assert(locked(&g_dcache_lock));
 
     struct shim_dentry* dent = alloc_dentry();
-    HASHTYPE hash;
 
     if (!dent)
         return NULL;
 
-    if (hashptr) {
-#ifdef DEBUG
-        // For debug builds, assert that the hash passed in is correct.
-        assert(*hashptr == hash_dentry(parent, name, namelen));
-#endif
-        hash = *hashptr;
-    } else {
-        hash = hash_dentry(parent, name, namelen);
+    if (fs) {
+        get_mount(fs);
+        dent->fs = fs;
     }
 
-    qstrsetstr(&dent->name, name, namelen);
-    dent->rel_path.hash = hash;
-    /* DEP 6/16/17: Not sure this flag is strictly necessary.
-     * But keeping it for now.
-     */
-    dent->state |= DENTRY_HASHED;
-
-    if (mount) {
-        get_mount(mount);
-        dent->fs = mount;
-    }
+    qstrsetstr(&dent->name, name, name_len);
 
     if (parent) {
-        // Increment both dentries' ref counts once they are linked
         get_dentry(parent);
+        dent->parent = parent;
+
         get_dentry(dent);
         LISTP_ADD_TAIL(dent, &parent->children, siblings);
-        dent->parent = parent;
         parent->nchildren++;
 
         if (!qstrempty(&parent->rel_path)) {
             const char* strs[] = {qstrgetstr(&parent->rel_path), "/", name};
-            size_t lens[]      = {parent->rel_path.len, 1, namelen};
+            size_t lens[]      = {parent->rel_path.len, 1, name_len};
             assert(lens[0] + lens[1] + lens[2] < STR_SIZE);
             qstrsetstrs(&dent->rel_path, 3, strs, lens);
         } else {
-            qstrsetstr(&dent->rel_path, name, namelen);
+            qstrsetstr(&dent->rel_path, name, name_len);
         }
     } else {
-        qstrsetstr(&dent->rel_path, name, namelen);
+        qstrsetstr(&dent->rel_path, name, name_len);
     }
 
     return dent;
 }
 
-/* This function searches for name/namelen (as the relative path) under
- * the parent directory (start).
- *
- * If requested, the expected hash of the dentry is returned in hashptr,
- * primarily so that the hashing can be reused to add the dentry later.
- *
- * The reference count on the found dentry is incremented by one.
- *
- * Used only by shim_namei.c
- */
-struct shim_dentry* __lookup_dcache(struct shim_dentry* start, const char* name, int namelen,
-                                    HASHTYPE* hashptr) {
-    assert(locked(&dcache_lock));
+struct shim_dentry* lookup_dcache(struct shim_dentry* parent, const char* name, size_t name_len) {
+    assert(locked(&g_dcache_lock));
 
-    /* In this implementation, we just look at the children
-     * under the parent and see if there are matches.  It so,
-     * return it; if not, don't.
-     *
-     * To minimize disruption (and possibly for future optimization)
-     * we are keeping hashes, so let's start with that for a marginally
-     * faster comparison
-     */
-    HASHTYPE hash = hash_dentry(start, name, namelen);
-    struct shim_dentry *dent, *found = NULL;
+    assert(parent);
+    assert(name_len > 0);
 
-    /* If start is NULL, there will be no hit in the cache.
-     * This mainly happens when boostrapping; in general, we assume the
-     * caller will use the current root or cwd.
-     */
-    if (!start)
-        return NULL;
-
-    /* If we are looking up an empty string, return start */
-    if (namelen == 0) {
-        get_dentry(start);
-        found = start;
-        goto out;
+    struct shim_dentry* tmp;
+    struct shim_dentry* dent;
+    LISTP_FOR_EACH_ENTRY_SAFE(dent, tmp, &parent->children, siblings) {
+        if (qstrcmpstr(&dent->name, name, name_len) == 0) {
+            get_dentry(dent);
+            return dent;
+        }
+        dentry_gc(dent);
     }
 
-    LISTP_FOR_EACH_ENTRY(dent, &start->children, siblings) {
-        /* DEP 6/20/XX: The old code skipped mountpoints; I don't see any good
-         * reason for mount point lookup to fail, at least in this code.
-         * Keeping a note just in case.  That is why you always leave a note.
-         */
-        // if (dent->state & DENTRY_MOUNTPOINT)
-        //     continue;
-
-        // Check for memory corruption
-        assert((dent->state & DENTRY_INVALID_FLAGS) == 0);
-
-        /* Compare the hash first */
-        if (dent->rel_path.hash != hash)
-            continue;
-
-        /* I think comparing the relative path is adequate; with a global
-         * hash table, a full path comparison may be needed, but I think
-         * we can assume a parent has children with unique names */
-        const char* filename = get_file_name(name, namelen);
-        const char* dname    = dentry_get_name(dent);
-        int dname_len        = strlen(dname);
-        int fname_len        = name + namelen - filename;
-        if (dname_len != fname_len || memcmp(dname, filename, fname_len))
-            continue;
-
-        /* If we get this far, we have a match */
-        get_dentry(dent);
-        found = dent;
-        break;
-    }
-
-out:
-    if (hashptr)
-        *hashptr = hash;
-
-    return found;
+    return NULL;
 }
 
 /* This function recursively removes children and drops the reference count
@@ -322,7 +222,7 @@ out:
  * structure on the heap to track progress.
  */
 int __del_dentry_tree(struct shim_dentry* root) {
-    assert(locked(&dcache_lock));
+    assert(locked(&g_dcache_lock));
 
     struct shim_dentry *cursor, *n;
 
@@ -334,9 +234,6 @@ int __del_dentry_tree(struct shim_dentry* root) {
         LISTP_DEL_INIT(cursor, &root->children, siblings);
         cursor->parent = NULL;
         root->nchildren--;
-        // Clear the hashed flag, in case there is any vestigial code based
-        //  on this state machine (where hased == valid).
-        cursor->state &= ~DENTRY_HASHED;
         put_dentry(cursor);
     }
 
@@ -445,7 +342,7 @@ BEGIN_RS_FUNC(dentry) {
 #if DEBUG_RESUME == 1
     char buffer[dentry_get_path_size(dent)];
 #endif
-    DEBUG_RS("hash=%08lx,path=%s,fs=%s", dent->rel_path.hash, dentry_get_path(dent, buffer),
+    DEBUG_RS("path=%s,fs=%s", dentry_get_path(dent, buffer),
              dent->fs ? qstrgetstr(&dent->fs->path) : NULL);
 }
 END_RS_FUNC(dentry)

--- a/LibOS/shim/src/sys/shim_access.c
+++ b/LibOS/shim/src/sys/shim_access.c
@@ -35,7 +35,7 @@ long shim_do_faccessat(int dfd, const char* filename, mode_t mode) {
     if (*filename != '/' && (ret = get_dirfd_dentry(dfd, &dir)) < 0)
         return ret;
 
-    lock(&dcache_lock);
+    lock(&g_dcache_lock);
 
     ret = __path_lookupat(dir, filename, LOOKUP_ACCESS | LOOKUP_FOLLOW, &dent, 0, NULL, false);
     if (ret < 0)
@@ -44,7 +44,7 @@ long shim_do_faccessat(int dfd, const char* filename, mode_t mode) {
     ret = __permission(dent, mode);
 
 out:
-    unlock(&dcache_lock);
+    unlock(&g_dcache_lock);
 
     if (dir)
         put_dentry(dir);

--- a/LibOS/shim/src/sys/shim_fs.c
+++ b/LibOS/shim/src/sys/shim_fs.c
@@ -80,7 +80,7 @@ out:
     if (dir)
         put_dentry(dir);
     if (dent) {
-        put_dentry_maybe_delete(dent);
+        put_dentry(dent);
     }
     return ret;
 }

--- a/LibOS/shim/src/sys/shim_socket.c
+++ b/LibOS/shim/src/sys/shim_socket.c
@@ -424,12 +424,23 @@ static bool __socket_is_ipv6_v6only(struct shim_handle* hdl) {
     return false;
 }
 
-static int hash_to_hex_string(HASHTYPE hash, char* buf, size_t size) {
+static int hash_dentry_path(struct shim_dentry* dent, char* buf, size_t size) {
+    HASHTYPE hash;
     static_assert(sizeof(hash) == 8, "Unsupported HASHTYPE size");
     char hashbytes[8];
 
     if (size < sizeof(hashbytes) * 2 + 1)
         return -ENOMEM;
+
+    size_t path_size = dentry_get_path_size(dent);
+    char* buffer = malloc(path_size);
+
+    if (!buffer)
+        return -ENOMEM;
+
+    char* path = dentry_get_path(dent, buffer);
+    hash = hash_path(path, strlen(path));
+    free(buffer);
 
     memcpy(hashbytes, &hash, sizeof(hash));
     BYTES2HEXSTR(hashbytes, buf, size);
@@ -485,8 +496,7 @@ long shim_do_bind(int sockfd, struct sockaddr* addr, int _addrlen) {
 
         /* instead of user-specified sun_path of UNIX socket, use its deterministic hash as name
          * (deterministic so that independent parent and child connect to the same socket) */
-        ret = hash_to_hex_string(dent->rel_path.hash, sock->addr.un.name,
-                                 sizeof(sock->addr.un.name));
+        ret = hash_dentry_path(dent, sock->addr.un.name, sizeof(sock->addr.un.name));
         if (ret < 0)
             goto out;
 
@@ -760,8 +770,7 @@ long shim_do_connect(int sockfd, struct sockaddr* addr, int _addrlen) {
 
         /* instead of user-specified sun_path of UNIX socket, use its deterministic hash as name
          * (deterministic so that independent parent and child connect to the same socket) */
-        ret = hash_to_hex_string(dent->rel_path.hash, sock->addr.un.name,
-                                 sizeof(sock->addr.un.name));
+        ret = hash_dentry_path(dent, sock->addr.un.name, sizeof(sock->addr.un.name));
         if (ret < 0) {
             put_dentry(dent);
             goto out;


### PR DESCRIPTION
Related to issue #2321 (dentry cleanup)

See the commit message for full list.

This takes care of some low hanging fruit in the dentry cache system - the things that, hopefully, do not cascade to a bigger change.

Next steps are going to be a bit bigger:
- Rewrite `mount_fs`. The current mount semantics are pretty weird: `DENTRY_ANCESTOR` synthetic entries, confusion between parent and child filesystem dentry, deleting old dentries under a mountpoint, mountpoints are invisible in listings (`readdir("/")` doesn't contain `"proc"` even though listing `/proc` works), etc.
  - Fun fact: the regression tests contain a `dev` binary which somehow gets mounted under `/dev`, alongside (???) the dev filesystem
- Rewrite `path_lookupat` / `open_namei` functions, as outlined in #2321 (saner semantics around files that do not exist, and following links); unfortunately this means rewriting all of the call sites, so I want to do it in a separate PR
- Get serious about reference counting and debug whatever is happening there; probably I'll write some nice function to dump the full dentry tree

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2324)
<!-- Reviewable:end -->
