### PR TITLE
[Pal/Linux-SGX] Add `sgx_seal_key_mr{enclave,signer}` manifest options

### DIFF
--- a/Documentation/attestation.rst
+++ b/Documentation/attestation.rst
@@ -179,6 +179,13 @@ use the :program:`quote_dump`, :program:`ias_request` and
 EPID based quote verification) or to use the Intel DCAP libraries and tools (for
 DCAP based quote verification).
 
+The ``/dev/attestation`` pseudo-filesystem also exposes the pseudo-file to set
+the protected files wrap (master) key (see also :doc:`manifest-syntax`):
+
+- ``/dev/attestation/protected_files_key`` pseudo-file can be opened for write
+  access. Typically, it is opened before the actual application runs and filled
+  with they 128-bit key obtained from a remote secret provisioning service.
+
 
 Mid-level RA-TLS interface
 --------------------------
@@ -387,7 +394,9 @@ environment variables if available:
   indicate that the provisioned secret is a protected-files master key. The key
   must be a 32-char null-terminated AES-GCM encryption key in hex format,
   similar to ``sgx.protected_files_key`` manifest option. This environment
-  variable is checked only if ``SECRET_PROVISION_CONSTRUCTOR`` is set.
+  variable is checked only if ``SECRET_PROVISION_CONSTRUCTOR`` is set. The
+  library puts the provisioned key into ``/dev/attestation/protected_files_key``
+  so that Graphene recognizes the provisioned protected-files master key.
 
 - ``SECRET_PROVISION_SERVERS`` (optional) -- a comma, semicolon or space
   separated list of server names with ports to connect to for secret

--- a/Documentation/manifest-syntax.rst
+++ b/Documentation/manifest-syntax.rst
@@ -452,7 +452,7 @@ Protected files
 
 ::
 
-    sgx.protected_files_key = "[16-byte hex value]"
+    sgx.protected_files_key = "sgx_seal_key_mrenclave|sgx_seal_key_mrsigner|[16-byte hex value]"
     sgx.protected_files.[identifier] = "[URI]"
 
 This syntax specifies the files that are encrypted on disk and transparently
@@ -469,9 +469,27 @@ directory are automatically treated as protected.
 Note that path size of a protected file is limited to 512 bytes and filename
 size is limited to 260 bytes.
 
-``sgx.protected_files_key`` specifies the wrap (master) encryption key and must
-be used only for debugging purposes. In production environments, this key must
-be provisioned to the enclave using local/remote attestation.
+``sgx.protected_files_key`` specifies the wrap (master) encryption key:
+
+* ``sgx.protected_files_key = "sgx_seal_key_mrenclave"`` specifies that the key
+  is generated via SGX hardware instruction ``EGETKEY(SEAL_KEY)``, bound to the
+  MRENCLAVE enclave measurement (so that only instances of the same enclave may
+  decrypt protected files). Note that enclave's CPU/ISV/CONFIG SVNs are also
+  used for protected files key derivation.
+
+* ``sgx.protected_files_key = "sgx_seal_key_mrsigner"`` specifies that the key
+  is generated via SGX hardware instruction ``EGETKEY(SEAL_KEY)``, bound to the
+  MRSIGNER enclave measurement (so that only enclaves with the same signer may
+  decrypt protected files). Note that enclave's CPU/ISV/CONFIG SVNs are also
+  used for protected files key derivation.
+
+* ``sgx.protected_files_key = "[16-byte hex value]"`` specifies that the key is
+  hard-coded in the manifest and should be used as-is. *Note:* this option is
+  insecure and must not be used in production environments!
+
+If you want to provision the protected files wrap key using SGX local/remote
+attestation, do *not* specify the ``sgx.protected_files_key`` manifest option at
+all. Instead, use the Secret Provisioning interface (see :doc:`attestation`).
 
 File check policy
 ^^^^^^^^^^^^^^^^^

--- a/LibOS/shim/test/regression/.gitignore
+++ b/LibOS/shim/test/regression/.gitignore
@@ -1,6 +1,9 @@
 /*.manifest
 /*.xml
 
+/protected_file.dat
+/testfile
+
 !argv_from_file.manifest
 !debug_log_file.manifest
 !debug_log_inline.manifest
@@ -89,6 +92,7 @@
 /proc_common
 /proc_cpuinfo
 /proc_path
+/protected_file
 /pselect
 /pthread_set_get_affinity
 /rdtsc
@@ -111,7 +115,6 @@
 /sysfs_common
 /tcp_ipv6_v6only
 /tcp_msg_peek
-/testfile
 /tmp
 /udp
 /unix

--- a/LibOS/shim/test/regression/Makefile
+++ b/LibOS/shim/test/regression/Makefile
@@ -66,6 +66,7 @@ c_executables = \
 	proc_common \
 	proc_cpuinfo \
 	proc_path \
+	protected_file \
 	pselect \
 	pthread_set_get_affinity \
 	readdir \

--- a/LibOS/shim/test/regression/Makefile
+++ b/LibOS/shim/test/regression/Makefile
@@ -185,6 +185,7 @@ clean-tmp:
 		*.sig \
 		*.tmp \
 		*.token \
+		*.dat \
 		*~ \
 		.cache \
 		.pytest_cache \

--- a/LibOS/shim/test/regression/manifest.template
+++ b/LibOS/shim/test/regression/manifest.template
@@ -37,6 +37,10 @@ sgx.allowed_files.tmp_dir = "file:tmp/"
 sgx.allowed_files.root = "file:root" # for getdents test
 sgx.allowed_files.testfile = "file:testfile" # for mmap_file test
 
+# for protected_file test
+sgx.protected_files_key = "sgx_seal_key_mrenclave"
+sgx.protected_files.pffile = "file:protected_file.dat"
+
 sgx.thread_num = 16
 
 sgx.nonpie_binary = 1

--- a/LibOS/shim/test/regression/protected_file.c
+++ b/LibOS/shim/test/regression/protected_file.c
@@ -1,0 +1,99 @@
+#include <assert.h>
+#include <err.h>
+#include <errno.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#define SECRETSTRING "Secret string\n"
+
+static ssize_t rw_file(const char* path, char* buf, size_t bytes, bool do_write) {
+    size_t rv = 0;
+    size_t ret = 0;
+
+    FILE* f = fopen(path, do_write ? "w" : "r");
+    if (!f) {
+        fprintf(stderr, "opening %s failed\n", path);
+        return -1;
+    }
+
+    while (bytes > rv) {
+        if (do_write)
+            ret = fwrite(buf + rv, /*size=*/1, /*nmemb=*/bytes - rv, f);
+        else
+            ret = fread(buf + rv, /*size=*/1, /*nmemb=*/bytes - rv, f);
+
+        if (ret > 0) {
+            rv += ret;
+        } else {
+            if (feof(f)) {
+                if (rv) {
+                    /* read some bytes from file, success */
+                    break;
+                }
+                assert(rv == 0);
+                fprintf(stderr, "%s failed: unexpected end of file\n", do_write ? "write" : "read");
+                fclose(f);
+                return -1;
+            }
+
+            assert(ferror(f));
+
+            if (errno == EAGAIN || errno == EINTR) {
+                continue;
+            }
+
+            fprintf(stderr, "%s failed: %s\n", do_write ? "write" : "read", strerror(errno));
+            fclose(f);
+            return -1;
+        }
+    }
+
+    int close_ret = fclose(f);
+    if (close_ret) {
+        fprintf(stderr, "closing %s failed\n", path);
+        return -1;
+    }
+    return rv;
+}
+
+
+int main(int argc, char** argv) {
+    int ret;
+    ssize_t bytes;
+
+    if (argc != 2)
+        errx(EXIT_FAILURE, "Usage: %s <protected file to create/validate>", argv[0]);
+
+    ret = access(argv[1], F_OK);
+    if (ret < 0) {
+        if (errno == ENOENT) {
+            /* file is not yet created, create with secret string */
+            bytes = rw_file(argv[1], SECRETSTRING, sizeof(SECRETSTRING), /*do_write=*/true);
+            if (bytes != sizeof(SECRETSTRING)) {
+                /* error is already printed by rw_file_f() */
+                return EXIT_FAILURE;
+            }
+            printf("CREATION OK\n");
+            return 0;
+        }
+        err(EXIT_FAILURE, "access failed");
+    }
+
+    char buf[128];
+    bytes = rw_file(argv[1], buf, sizeof(buf), /*do_write=*/false);
+    if (bytes <= 0) {
+        /* error is already printed by rw_file_f() */
+        return EXIT_FAILURE;
+    }
+    buf[bytes - 1] = '\0';
+
+    size_t size_to_cmp = sizeof(SECRETSTRING) < bytes ? sizeof(SECRETSTRING) : bytes;
+    if (strncmp(SECRETSTRING, buf, size_to_cmp))
+        errx(EXIT_FAILURE, "Expected '%s' but read '%s'\n", SECRETSTRING, buf);
+
+    printf("TEST OK\n");
+    return 0;
+}

--- a/LibOS/shim/test/regression/test_libos.py
+++ b/LibOS/shim/test/regression/test_libos.py
@@ -623,6 +623,16 @@ class TC_40_FileSystem(RegressionTestCase):
         stdout, _ = self.run_binary(['sysfs_common'])
         self.assertIn('TEST OK', stdout)
 
+    def test_060_protected_file(self):
+        pf_path = 'protected_file.dat'
+        if os.path.exists(pf_path):
+            os.remove(pf_path)
+
+        stdout, _ = self.run_binary(['protected_file', pf_path])
+        self.assertIn('CREATION OK', stdout)
+        stdout, _ = self.run_binary(['protected_file', pf_path])
+        self.assertIn('TEST OK', stdout)
+
 
 class TC_50_GDB(RegressionTestCase):
     def setUp(self):

--- a/Pal/src/host/Linux-SGX/enclave_framework.c
+++ b/Pal/src/host/Linux-SGX/enclave_framework.c
@@ -204,6 +204,41 @@ int sgx_verify_report(sgx_report_t* report) {
     return 0;
 }
 
+int sgx_get_seal_key(uint16_t key_policy, sgx_key_128bit_t* seal_key) {
+    assert(key_policy == KEYPOLICY_MRENCLAVE || key_policy == KEYPOLICY_MRSIGNER);
+
+    /* get our own SGX report to obtain this enclave's isv_svn, cpu_svn, config_svn */
+    __sgx_mem_aligned sgx_target_info_t empty_target_info = {0};
+    __sgx_mem_aligned sgx_report_data_t empty_report_data = {0};
+    __sgx_mem_aligned sgx_report_t our_sgx_report = {0};
+    int ret = sgx_get_report(&empty_target_info, &empty_report_data, &our_sgx_report);
+    if (ret) {
+        log_error("Failed to get our own enclave report\n");
+        return -PAL_ERROR_DENIED;
+    }
+
+    /* The keyrequest struct dictates the key derivation material used to generate the sealing key.
+     * It includes MRENCLAVE/MRSIGNER key policy (to allow secret migration/sealing between
+     * instances of the same enclave or between different enclaves of the same author/signer), and
+     * CPU/ISV/CONFIG SVNs (to prevent secret migration to older vulnerable versions of the
+     * enclave). The rest of the keyrequest fields are currently zeros -- CET attributes, enclave
+     * ATTRIBUTES, enclave MISCSELECT bits are *not* included in key derivation. KEYID is also zero,
+     * to generate the same sealing key in different instances of the same enclave/same signer. */
+    __sgx_mem_aligned sgx_key_request_t key_request = {0};
+    key_request.key_name   = SEAL_KEY;
+    key_request.key_policy = key_policy;
+    memcpy(&key_request.cpu_svn, &our_sgx_report.body.cpu_svn, sizeof(sgx_cpu_svn_t));
+    memcpy(&key_request.isv_svn, &our_sgx_report.body.isv_svn, sizeof(sgx_isv_svn_t));
+    memcpy(&key_request.config_svn, &our_sgx_report.body.config_svn, sizeof(sgx_config_svn_t));
+
+    ret = sgx_getkey(&key_request, seal_key);
+    if (ret) {
+        log_error("Failed to generate sealing key using SGX EGETKEY\n");
+        return -PAL_ERROR_DENIED;
+    }
+    return 0;
+}
+
 int init_enclave_key(void) {
     __sgx_mem_aligned sgx_key_request_t keyrequest;
     memset(&keyrequest, 0, sizeof(sgx_key_request_t));

--- a/Pal/src/host/Linux-SGX/pal_linux.h
+++ b/Pal/src/host/Linux-SGX/pal_linux.h
@@ -253,6 +253,18 @@ int sgx_verify_report(sgx_report_t* report);
 int sgx_get_report(const sgx_target_info_t* target_info, const sgx_report_data_t* data,
                    sgx_report_t* report);
 
+/*!
+ * \brief Obtain an enclave/signer-specific key via EGETKEY(SEAL_KEY) for secret migration/sealing
+ * of files.
+ *
+ * \param[in]  key_policy  Must be KEYPOLICY_MRENCLAVE or KEYPOLICY_MRSIGNER. Binds the sealing key
+ *                         to MRENCLAVE (only the same enclave can unseal secrets) or to MRSIGNER
+ *                         (all enclaves from the same signer can unseal secrets).
+ * \param[out] seal_key    Output buffer to store the sealing key.
+ * \return                 0 on success, negative error code otherwise.
+ */
+int sgx_get_seal_key(uint16_t key_policy, sgx_key_128bit_t* seal_key);
+
 typedef bool (*mr_enclave_check_t)(PAL_HANDLE, sgx_measurement_t*, struct pal_enclave_state*);
 
 /*

--- a/Pal/src/host/Linux-SGX/protected-files/README.rst
+++ b/Pal/src/host/Linux-SGX/protected-files/README.rst
@@ -2,9 +2,9 @@
 Protected Files
 ===============
 
-Protected files (PF) are a new type of files that can be specified in the manifest (SGX only).
-They are encrypted on disk and transparently decrypted when accessed by Graphene or by application
-running inside Graphene.
+Protected files (PF) are a type of files that can be specified in the manifest (SGX only). They are
+encrypted on disk and transparently decrypted when accessed by Graphene or by application running
+inside Graphene.
 
 Features
 ========
@@ -12,12 +12,6 @@ Features
 - Data is encrypted (confidentiality) and integrity protected (tamper resistance).
 - File swap protection (a PF can only be accessed when in a specific path).
 - Transparency (Graphene application sees PFs as regular files, no need to modify the application).
-
-The following new manifest elements are added::
-
-   sgx.protected_files_key = "<16-byte hex value>"
-   sgx.protected_files.<name> = "file:<host path>"
-
 
 Example
 -------
@@ -41,9 +35,6 @@ Metadata currently limits PF path size to 512 bytes and filename size to 260 byt
 NOTE
 ----
 
-``sgx.protected_files_key`` specifies the encryption key and is only a temporary implementation.
-This key should be provisioned to the enclave with local/remote attestation in the future.
-
 The ``tools`` directory contains the ``pf_crypt`` utility that converts files to/from the protected
 format.
 
@@ -53,8 +44,7 @@ Internal protected file format in this version was ported from the `SGX SDK
 Tests
 =====
 
-Tests in ``LibOS/shim/test/fs`` now contain PF tests too (target is still ``test``).
-Target to run just non-PF tests is ``fs-test``.
+Tests in ``LibOS/shim/test/fs`` contain PF tests (target is ``pf-test``).
 
 TODO
 ====

--- a/Pal/src/host/Linux/db_main.c
+++ b/Pal/src/host/Linux/db_main.c
@@ -258,6 +258,9 @@ noreturn void pal_linux_main(void* initial_rsp, void* fini_callback) {
 
     g_pal_state.raw_manifest_data = manifest;
 
+    log_error("+++++ pal_linux_main (PID = %ld, TID = %ld): rsp = %p +++++\n",
+           INLINE_SYSCALL(getpid, 0), INLINE_SYSCALL(gettid, 0), initial_rsp);
+
     char errbuf[256];
     g_pal_state.manifest_root = toml_parse(manifest, errbuf, sizeof(errbuf));
     if (!g_pal_state.manifest_root)

--- a/Pal/src/host/Linux/db_rtld.c
+++ b/Pal/src/host/Linux/db_rtld.c
@@ -101,6 +101,8 @@ void setup_vdso_map(ElfW(Addr) addr) {
         switch(dyn->d_tag) {
             case DT_STRTAB:
             case DT_SYMTAB:
+                if (ndyn > 3)
+                    log_error("+++++ setup_vdso_map: buffer overflow of local_dyn 1 +++++\n");
                 local_dyn[ndyn] = *dyn;
                 local_dyn[ndyn].d_un.d_ptr += load_offset;
                 vdso_map.l_info[dyn->d_tag] = &local_dyn[ndyn++];
@@ -114,6 +116,8 @@ void setup_vdso_map(ElfW(Addr) addr) {
             }
             case DT_VERSYM:
             case DT_VERDEF:
+                if (ndyn > 3)
+                    log_error("+++++ setup_vdso_map: buffer overflow of local_dyn 2 +++++\n");
                 local_dyn[ndyn] = *dyn;
                 local_dyn[ndyn].d_un.d_ptr += load_offset;
                 vdso_map.l_info[VERSYMIDX(dyn->d_tag)] = &local_dyn[ndyn++];
@@ -128,4 +132,13 @@ void setup_vdso_map(ElfW(Addr) addr) {
     sym = do_lookup_map(NULL, gettime, fast_hash, hash, &vdso_map);
     if (sym)
         g_linux_state.vdso_clock_gettime = (void*)(load_offset + sym->st_value);
+
+    log_error("+++++ setup_vdso_map (PID = %ld, TID = %ld): addr = %p +++++\n",
+            INLINE_SYSCALL(getpid, 0), INLINE_SYSCALL(gettid, 0), (void*)addr);
+    log_error("+++++ setup_vdso_map (PID = %ld, TID = %ld): load_offset = %p +++++\n",
+            INLINE_SYSCALL(getpid, 0), INLINE_SYSCALL(gettid, 0), (void*)load_offset);
+    log_error("+++++ setup_vdso_map (PID = %ld, TID = %ld): vdso_start = %p +++++\n",
+            INLINE_SYSCALL(getpid, 0), INLINE_SYSCALL(gettid, 0), (void*)vdso_start);
+    log_error("+++++ setup_vdso_map (PID = %ld, TID = %ld): vdso_clock_gettime = %p +++++\n",
+            INLINE_SYSCALL(getpid, 0), INLINE_SYSCALL(gettid, 0), g_linux_state.vdso_clock_gettime);
 }


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Previously, only `sgx.protected_files_key = "[16-byte hex value]"` was allowed in the manifest (i.e., hard-coding the master key for protected-files encryption). This could only be used for debugging purposes and never in production.

This PR adds two more options to this manifest config: `"sgx_seal_key_mrenclave"` and `"sgx_seal_key_mrsigner"`. They specify that the key is generated via SGX instruction `EGETKEY(SEAL_KEY)`, bound to the MRENCLAVE/MRSIGNER enclave measurement (so that only instances of the same enclave/only enclaves with the same signer may decrypt protected files). This allows to seal data files.

A corresponding LibOS test is added and documentation is updated to reflect this. Also, internal doc on Protected Files was updated (unrelated, so in a separate commit).

This PR is partially related to https://github.com/oscarlab/graphene/pull/2000. Kudos to @llly who submitted that PR (though that particular change turned out to be unneeded).

## How to test this PR? <!-- (if applicable) -->

A corresponding LibOS test is added.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2328)
<!-- Reviewable:end -->
