### PR TITLE
[LibOS,Pal] Reflect memory region used for vDSO in LibOS's initial VMAs

### DIFF
--- a/LibOS/shim/src/bookkeep/shim_vma.c
+++ b/LibOS/shim/src/bookkeep/shim_vma.c
@@ -544,6 +544,15 @@ int init_vma(void) {
             .offset  = 0,
             .comment = "manifest",
         },
+        {
+            .begin   = (uintptr_t)ALLOC_ALIGN_DOWN_PTR(PAL_CB(vdso_preload.start)),
+            .end     = (uintptr_t)ALLOC_ALIGN_UP_PTR(PAL_CB(vdso_preload.end)),
+            .prot    = PROT_NONE,
+            .flags   = MAP_PRIVATE | MAP_ANONYMOUS | VMA_INTERNAL,
+            .file    = NULL,
+            .offset  = 0,
+            .comment = "vDSO",
+        },
     };
 
     spinlock_lock(&vma_tree_lock);

--- a/Pal/include/pal/pal.h
+++ b/Pal/include/pal/pal.h
@@ -156,6 +156,7 @@ typedef struct PAL_CONTROL_ {
     PAL_PTR_RANGE user_address; /*!< The range of user addresses */
 
     PAL_PTR_RANGE manifest_preload; /*!< manifest was preloaded here */
+    PAL_PTR_RANGE vdso_preload;     /*!< vDSO was preloaded here */
 
     /*
      * Host information

--- a/Pal/src/host/Linux/db_rtld.c
+++ b/Pal/src/host/Linux/db_rtld.c
@@ -128,4 +128,10 @@ void setup_vdso_map(ElfW(Addr) addr) {
     sym = do_lookup_map(NULL, gettime, fast_hash, hash, &vdso_map);
     if (sym)
         g_linux_state.vdso_clock_gettime = (void*)(load_offset + sym->st_value);
+
+    if (vdso_start || vdso_end) {
+        /* vDSO occupies some memory region, need to inform the LibOS so it reflects it in VMAs */
+        g_pal_control.vdso_preload.start = (PAL_PTR)vdso_start;
+        g_pal_control.vdso_preload.end   = (PAL_PTR)vdso_end;
+    }
 }


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

When starting the Linux PAL, the Linux host kernel sets up the vDSO region at a random address (the application can read this address via the aux vector AT_SYSINFO_EHDR and parse this ELF for its own needs). The Linux PAL correctly parsed the vDSO ELF and memorized its memory region but forgot to propagate this info to the LibOS VMA component.

This wasn't an issue on older Linux kernels (used in our Ubuntu 18.04 Jenkins pipelines) because those kernels always put vDSO at a high address (above the main-thread stack, such that Graphene never even tries to allocate/overwrite memory there). On the newer Linux kernels (used in our Ubuntu 20.04 Jenkins pipelines), however, vDSO is put at a truly random address (frequently below the main-thread stack). Since this info was not propagated to the LibOS, the LibOS sometimes forcibly overwrote that memory region, and vDSO code segment contained garbage, and the application-under-Graphene segfaulted.

Here is an example of my debug logs on our 20.04 pipeline:
```
error: +++++ setup_vdso_map (PID = 18553, TID = 18553): addr = 0x7f316a262000 +++++
error: +++++ setup_vdso_map (PID = 18553, TID = 18553): load_offset = 0x7f316a262000 +++++
error: +++++ setup_vdso_map (PID = 18553, TID = 18553): vdso_start = 0x7f316a262000 +++++
error: +++++ setup_vdso_map (PID = 18553, TID = 18553): vdso_clock_gettime = 0x7f316a262a30 +++++
error: +++++ pal_linux_main (PID = 18553, TID = 18553): rsp = 0x7ffd1e5fa7d0 +++++
error: *** Unexpected memory fault occurred inside VDSO (PID = 18553, TID = 18553, RIP = +0x00000a30)! ***
```

As you can notice, Linux chose `0x7f3...` address to put the vDSO region. However, the main-thread stack started at `0x7ff...` -- this is the top address at which Graphene will allocate memory. So sometimes Graphene overwrote it.

## How to test this PR? <!-- (if applicable) -->

Let's test 5-10 times on Ubuntu 20.04 in Jenkins.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2329)
<!-- Reviewable:end -->
