### PR TITLE
[CI] Add a timeout to running the LTP tests step

### DIFF
--- a/.ci/lib/stage-test-direct.jenkinsfile
+++ b/.ci/lib/stage-test-direct.jenkinsfile
@@ -1,10 +1,12 @@
 stage('test-direct') {
     try {
-        sh '''
-            cd LibOS/shim/test/ltp
-            make ${MAKEOPTS} all
-            make ltp.xml
-        '''
+        timeout(time: 20, unit: 'MINUTES') {
+            sh '''
+                cd LibOS/shim/test/ltp
+                make ${MAKEOPTS} all
+                make ltp.xml
+            '''
+        }
     } finally {
         archiveArtifacts 'LibOS/shim/test/ltp/ltp.xml'
         junit 'LibOS/shim/test/ltp/ltp.xml'


### PR DESCRIPTION

## Description of the changes <!-- (reasons and measures) -->
I've seen some pipelines getting deadlocked due to lack of timeout on LTP tests. No idea how was that possible (since there should be a per test timeout in LTP).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2330)
<!-- Reviewable:end -->
