### PR TITLE
[LibOS] Partial implementation of `getcpu` syscall

### DIFF
--- a/LibOS/shim/src/sys/shim_sched.c
+++ b/LibOS/shim/src/sys/shim_sched.c
@@ -156,13 +156,6 @@ long shim_do_sched_setaffinity(pid_t pid, unsigned int cpumask_size, unsigned lo
     if (pid == 0)
         get_thread(thread);
 
-    /* Internal graphene threads are not affinitized; if we hit an internal thread here, this is
-       some bug in user app. */
-    if (is_internal(thread)) {
-        put_thread(thread);
-        return -ESRCH;
-    }
-
     ret = DkThreadSetCpuAffinity(thread->pal_handle, cpumask_size, user_mask_ptr);
     if (ret < 0) {
         put_thread(thread);
@@ -202,13 +195,6 @@ long shim_do_sched_getaffinity(pid_t pid, unsigned int cpumask_size, unsigned lo
        get_cur_thread(). */
     if (pid == 0)
         get_thread(thread);
-
-    /* Internal graphene threads are not affinitized; if we hit an internal thread here, this is
-       some bug in user app. */
-    if (is_internal(thread)) {
-        put_thread(thread);
-        return -ESRCH;
-    }
 
     memset(user_mask_ptr, 0, cpumask_size);
     ret = DkThreadGetCpuAffinity(thread->pal_handle, bitmask_size_in_bytes, user_mask_ptr);

--- a/LibOS/shim/src/sys/shim_sched.c
+++ b/LibOS/shim/src/sys/shim_sched.c
@@ -222,23 +222,78 @@ long shim_do_sched_getaffinity(pid_t pid, unsigned int cpumask_size, unsigned lo
     return bitmask_size_in_bytes;
 }
 
-/* dummy implementation: always return cpu0  */
+/* Approx. implementation that returns a random bit that is set from the cpu affinity mask
+ * associated with the current calling thread */
 long shim_do_getcpu(unsigned* cpu, unsigned* node, struct getcpu_cache* unused) {
     __UNUSED(unused);
 
-    if (cpu) {
-        if (!is_user_memory_writable(cpu, sizeof(*cpu))) {
-            return -EFAULT;
-        }
-        *cpu = 0;
+    int ret = 0;
+    if (cpu && !is_user_memory_writable(cpu, sizeof(*cpu)))
+        return -EFAULT;
+
+    if (node && !is_user_memory_writable(node, sizeof(*node)))
+        return -EFAULT;
+
+    size_t cpu_cnt = g_pal_control->cpu_info.online_logical_cores;
+
+    /* Allocate memory to hold the thread's cpu affinity mask. */
+    size_t max_cpu_bitmask = BITS_TO_LONGS(cpu_cnt);
+    size_t bitmask_size_in_bytes = max_cpu_bitmask * sizeof(unsigned long);
+    unsigned long* mask = malloc(bitmask_size_in_bytes);
+    if (!mask)
+        return -ENOMEM;
+
+    struct shim_thread* thread = get_cur_thread();
+    ret = DkThreadGetCpuAffinity(thread->pal_handle, bitmask_size_in_bytes, mask);
+    if (ret < 0) {
+        ret = pal_to_unix_errno(ret);
+        goto out;
     }
 
-    if (node) {
-        if (!is_user_memory_writable(node, sizeof(*node))) {
-            return -EFAULT;
-        }
-        *node = 0;
+    /* CPU affinity mask is basically an array of unsigned long(s). Below logic finds the first
+     * non-empty unsigned long and returns a random bit that is set to the user. */
+    unsigned int num_bits = 0;
+    unsigned int idx = 0;
+    while (idx < max_cpu_bitmask) {
+        num_bits = count_ulong_bits_set(mask[idx]);
+        if (num_bits)
+            break;
+        idx++;
     }
 
-    return 0;
+    /* There should be at least one bit set as part of the cpu affinity mask otherwise host is
+       malicious. */
+    if (num_bits == 0) {
+        ret = -EINVAL;
+        goto out;
+    }
+
+    /* Generate a random number and use it to find a random bit set in the first non-empty
+     * unsigned long of the cpu affinity mask. */
+    unsigned long rand_num = 0;
+    ret = DkRandomBitsRead(&rand_num, sizeof(rand_num));
+    if (ret < 0) {
+        ret = pal_to_unix_errno(ret);
+        goto out;
+    }
+
+    unsigned int nth_setbit = rand_num % num_bits;
+    unsigned long cpumask = mask[idx];
+    for (unsigned int j = 0; j < nth_setbit; j++) {
+        /* At each iteration, find the lowest bit set in cpumask and unset it; this will bring
+         * us to the nth_setbit after nth_setbit iterations. */
+        cpumask = cpumask & ~(1UL << __builtin_ctzl(cpumask));
+    }
+
+    unsigned int cpu_current = __builtin_ctzl(cpumask) + BITS_IN_TYPE(unsigned long) * idx;
+
+    if (cpu)
+        *cpu = cpu_current;
+
+    if (node)
+        *node = g_pal_control->topo_info.core_topology[cpu_current].node;
+
+out:
+    free(mask);
+    return ret;
 }

--- a/LibOS/shim/test/ltp/ltp.cfg
+++ b/LibOS/shim/test/ltp/ltp.cfg
@@ -643,10 +643,6 @@ skip = yes
 [get_robust_list01]
 skip = yes
 
-# getcpu() always returns cpu0
-[getcpu01]
-skip = yes
-
 # no symlink()
 [getcwd03]
 skip = yes

--- a/LibOS/shim/test/regression/pthread_set_get_affinity.c
+++ b/LibOS/shim/test/regression/pthread_set_get_affinity.c
@@ -32,7 +32,7 @@ static void* dowork(void* args) {
         iterations--;
 
     unsigned int cpu, node;
-    int ret =  syscall(SYS_getcpu, &cpu, &node);
+    int ret = syscall(SYS_getcpu, &cpu, &node);
     if (ret < 0)
         err(EXIT_FAILURE, "sched_getcpu failed!");
 

--- a/LibOS/shim/test/regression/pthread_set_get_affinity.c
+++ b/LibOS/shim/test/regression/pthread_set_get_affinity.c
@@ -9,6 +9,7 @@
 #include <err.h>
 #include <errno.h>
 #include <pthread.h>
+#include <sched.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -30,7 +31,14 @@ static void* dowork(void* args) {
     while (iterations != 0)
         iterations--;
 
-    int ret = pthread_barrier_wait(&barrier);
+    unsigned int cpu, node;
+    int ret =  syscall(SYS_getcpu, &cpu, &node);
+    if (ret < 0) {
+        err(EXIT_FAILURE, "sched_getcpu failed!");
+
+    printf("Thread %ld is running on cpu: %d, node: %d\n", syscall(SYS_gettid), cpu, node);
+
+    ret = pthread_barrier_wait(&barrier);
     if (ret != 0 && ret != PTHREAD_BARRIER_SERIAL_THREAD) {
         errx(EXIT_FAILURE, "Child did not wait on barrier!");
     }

--- a/LibOS/shim/test/regression/pthread_set_get_affinity.c
+++ b/LibOS/shim/test/regression/pthread_set_get_affinity.c
@@ -33,7 +33,7 @@ static void* dowork(void* args) {
 
     unsigned int cpu, node;
     int ret =  syscall(SYS_getcpu, &cpu, &node);
-    if (ret < 0) {
+    if (ret < 0)
         err(EXIT_FAILURE, "sched_getcpu failed!");
 
     printf("Thread %ld is running on cpu: %d, node: %d\n", syscall(SYS_gettid), cpu, node);

--- a/Pal/include/arch/x86_64/pal-arch.h
+++ b/Pal/include/arch/x86_64/pal-arch.h
@@ -313,6 +313,7 @@ typedef struct PAL_CORE_TOPO_INFO_ {
     char core_id[PAL_SYSFS_INT_FILESZ];
     char core_siblings[PAL_SYSFS_MAP_FILESZ];
     char thread_siblings[PAL_SYSFS_MAP_FILESZ];
+    unsigned int node; /* numa node closest to the core */
     PAL_CORE_CACHE_INFO* cache; /* Array of size num_cache_index, owned by this struct */
 } PAL_CORE_TOPO_INFO;
 

--- a/Pal/src/host/Linux-SGX/db_main.c
+++ b/Pal/src/host/Linux-SGX/db_main.c
@@ -343,14 +343,17 @@ static int sanitize_numa_topology_info(PAL_NUMA_TOPO_INFO* numa_topology, int64_
     if (num_nodes == 0 || num_cores == 0)
         return -ENOENT;
 
+    int64_t cpumap;
     for (int64_t idx = 0; idx < num_nodes; idx++) {
-        int64_t cpumap = count_bits_set_from_resource_map(numa_topology[idx].cpumap);
-        if (!IS_IN_RANGE_INCL(cpumap, 1, num_cores))
-            return -EINVAL;
+        cpumap =+ count_bits_set_from_resource_map(numa_topology[idx].cpumap);
 
         if (num_nodes != sanitize_hw_resource_count(numa_topology[idx].distance, /*ordered=*/false))
             return -EINVAL;
     }
+    /* TODO: Ensure each NUMA has unique set of cores and there is no overlap */
+    if (!IS_IN_RANGE_INCL(cpumap, 1, num_cores))
+        return -EINVAL;
+
     return 0;
 }
 

--- a/Pal/src/host/Linux-SGX/db_main.c
+++ b/Pal/src/host/Linux-SGX/db_main.c
@@ -350,7 +350,8 @@ static int sanitize_numa_topology_info(PAL_NUMA_TOPO_INFO* numa_topology, int64_
         if (num_nodes != sanitize_hw_resource_count(numa_topology[idx].distance, /*ordered=*/false))
             return -EINVAL;
     }
-    /* TODO: Ensure each NUMA has unique set of cores and there is no overlap */
+
+    /* TODO: Ensure each NUMA node has unique set of cores and there is no overlap */
     if (!IS_IN_RANGE_INCL(num_bits_in_cpumap, 1, num_cores))
         return -EINVAL;
 

--- a/Pal/src/host/Linux-SGX/db_main.c
+++ b/Pal/src/host/Linux-SGX/db_main.c
@@ -343,15 +343,15 @@ static int sanitize_numa_topology_info(PAL_NUMA_TOPO_INFO* numa_topology, int64_
     if (num_nodes == 0 || num_cores == 0)
         return -ENOENT;
 
-    int64_t cpumap;
+    int64_t num_bits_in_cpumap = 0;
     for (int64_t idx = 0; idx < num_nodes; idx++) {
-        cpumap =+ count_bits_set_from_resource_map(numa_topology[idx].cpumap);
+        num_bits_in_cpumap += count_bits_set_from_resource_map(numa_topology[idx].cpumap);
 
         if (num_nodes != sanitize_hw_resource_count(numa_topology[idx].distance, /*ordered=*/false))
             return -EINVAL;
     }
     /* TODO: Ensure each NUMA has unique set of cores and there is no overlap */
-    if (!IS_IN_RANGE_INCL(cpumap, 1, num_cores))
+    if (!IS_IN_RANGE_INCL(num_bits_in_cpumap, 1, num_cores))
         return -EINVAL;
 
     return 0;

--- a/Pal/src/host/Linux-common/topo_info.c
+++ b/Pal/src/host/Linux-common/topo_info.c
@@ -292,12 +292,18 @@ static int extract_cpu_node_mapping(unsigned int node, const char* cpumap,
 
         for (int pos = 0; bitmap; pos++) {
             if (bitmap & 1U) {
-                /* Ensure that number of cores represented by cpumap doesn't exceed the total number
-                 * of cores present in the system. */
+                /* Number of cores represented by cpumap of each NUMA node should not exceed the
+                 * total number of cores present in the system. */
                 total_online_cores++;
                 if (total_online_cores > online_logical_cores)
                     return -EINVAL;
+
+                /* `cpu` extracted from cpumap cannot be greater than or equal to total number of
+                 * cores. `cpu` value ranges from 0 to number of cores in system - 1. */
                 int cpu = (num_bitmaps - 1) * BITS_IN_TYPE(int) + pos;
+                if (cpu >= online_logical_cores)
+                    return -EINVAL;
+
                 core_topology[cpu].node = node;
             }
             bitmap = bitmap >> 1;

--- a/Pal/src/host/Linux-common/topo_info.c
+++ b/Pal/src/host/Linux-common/topo_info.c
@@ -207,6 +207,10 @@ static int get_core_topo_info(PAL_TOPO_INFO* topo_info) {
 
     char filename[128];
     for (int idx = 0; idx < online_logical_cores; idx++) {
+        /* Initialize all cores to be part of node 0. We later update this when reading NUMA
+         * topology, see get_numa_topo_info() */
+        core_topology[idx].node = 0;
+
         /* cpu0 is always online and thus the "online" file is not present. */
         if (idx != 0) {
             snprintf(filename, sizeof(filename), "/sys/devices/system/cpu/cpu%d/online", idx);
@@ -240,6 +244,63 @@ out:
     return ret;
 }
 
+static int extract_cpu_node_mapping(unsigned int node, const char* cpumap,
+                                    PAL_CORE_TOPO_INFO* core_topology) {
+    int possible_logical_cores = get_hw_resource("/sys/devices/system/cpu/possible",
+                                                 /*count=*/true);
+    if (possible_logical_cores < 0)
+        return possible_logical_cores;
+
+    int num_bitmaps = BITS_TO_INTS(possible_logical_cores);
+    const char* p = cpumap;
+    while (*p) {
+        while (*p == ' ' || *p == '\t' || *p == ',' || *p == '\n')
+            p++;
+
+        if (*p == '\0')
+            break;
+
+        const char* end = NULL;
+        unsigned long bitmap;
+        bool overflowed = str_to_ulong(p, 16, &bitmap, &end);
+        if (end == p || overflowed)
+            return -EINVAL;
+
+        /* cpumap is represented by comma seperated unsigned 32-bit integers ranging upto the total
+         * processors present in the system. `bitmap` represents each unsigned 32-bit value. So any
+         * value above this range is considered malicious and we fail. */
+        if (bitmap > UINT32_MAX)
+            return -EINVAL;
+
+        if (*end != '\0' && *end != ',' && *end != '\n')
+            return -EINVAL;
+        p = end;
+
+        /* Number of 32-bit unsigned `bitmap` to represent `cpumap` exceeds the number of cores
+         * present in the system. */
+        if (num_bitmaps < 1)
+            return -EINVAL;
+
+        for (int pos = 0; bitmap; pos++) {
+            if (bitmap & 1U) {
+                /* Since bitmap cannot be greater than UINT32_MAX, `pos` will be less than or equal
+                 * to 31 */
+                int cpu = (num_bitmaps - 1) * BITS_IN_TYPE(int) + pos;
+                core_topology[cpu].node = node;
+            }
+            bitmap = bitmap >> 1;
+        }
+        num_bitmaps--;
+    }
+
+    /* We have an inconsistency between the node cpumap and the total cores present in the system.
+     * cpumap should be able to encompass all cores present in the system. */
+    if (num_bitmaps != 0)
+        return -EINVAL;
+
+    return 0;
+}
+
 /* Get NUMA topology-related info */
 static int get_numa_topo_info(PAL_TOPO_INFO* topo_info) {
     int ret;
@@ -260,6 +321,11 @@ static int get_numa_topo_info(PAL_TOPO_INFO* topo_info) {
     for (int idx = 0; idx < num_nodes; idx++) {
         snprintf(filename, sizeof(filename), "/sys/devices/system/node/node%d/cpumap", idx);
         READ_FILE_BUFFER(filename, numa_topology[idx].cpumap, /*failure_label=*/out_topology);
+
+        /* Extract cpu<->node info from cpumap and update core_topology struct */
+        ret = extract_cpu_node_mapping(idx, numa_topology[idx].cpumap, topo_info->core_topology);
+        if (ret < 0)
+            goto out_topology;
 
         snprintf(filename, sizeof(filename), "/sys/devices/system/node/node%d/distance", idx);
         READ_FILE_BUFFER(filename, numa_topology[idx].distance, /*failure_label=*/out_topology);

--- a/common/include/api.h
+++ b/common/include/api.h
@@ -81,6 +81,7 @@ typedef ptrdiff_t ssize_t;
 
 #define BITS_IN_BYTE                    8
 #define BITS_IN_TYPE(type)              (sizeof(type) * BITS_IN_BYTE)
+#define BITS_TO_INTS(nr)                DIV_ROUND_UP(nr, BITS_IN_TYPE(int))
 #define BITS_TO_LONGS(nr)               DIV_ROUND_UP(nr, BITS_IN_TYPE(long))
 /* Note: This macro is not intended for use when nbits == BITS_IN_TYPE(type) */
 #define SET_HIGHEST_N_BITS(type, nbits) (~(((uint64_t)1 << (BITS_IN_TYPE(type) - (nbits))) - 1))


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

This patch adds a partial implementation of `getcpu` syscall that returns a random set bit from the first non-empty cpu affinity mask. `pthread_set_get_affinity` regression test is extended to validate this implementation. This patch also enables the `getcpu01` ltp test for non-SGX case.

## How to test this PR? <!-- (if applicable) -->
Please run `pthread_set_get_affinity` regression test to validate this PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/graphene/2331)
<!-- Reviewable:end -->
