### PR TITLE
[LibOS] Rewrite path lookup functions

### DIFF
--- a/LibOS/shim/include/shim_fs.h
+++ b/LibOS/shim/include/shim_fs.h
@@ -102,7 +102,7 @@ struct shim_fs_ops {
 //#define DENTRY_UNREACHABLE  0x0800  /* permission checked to be unreachable */
 #define DENTRY_LISTED      0x1000 /* children in directory listed */
 #define DENTRY_INO_UPDATED 0x2000 /* ino updated */
-#define DENTRY_ANCESTOR    0x4000 /* Auto-generated dentry to connect a mount point in the        \
+#define DENTRY_SYNTHETIC   0x4000 /* Auto-generated dentry to connect a mount point in the        \
                                    * manifest to the root, when one or more intermediate          \
                                    * directories do not exist on the underlying FS. The semantics \
                                    * of subsequent changes to such directories (or attempts to    \
@@ -217,12 +217,10 @@ struct shim_mount {
     LIST_TYPE(shim_mount) list;
 };
 
+/* TODO: This actually does not get migrated after a fork. We migrate `g_process.root`, which is
+ * enough for Graphene to function, but leaves `g_dentry_root` in child process pointing to an empty
+ * directory. */
 extern struct shim_dentry* g_dentry_root;
-
-#define LOOKUP_FOLLOW    001
-#define LOOKUP_DIRECTORY 002
-#define LOOKUP_CONTINUE  004  // No longer needed
-#define LOOKUP_PARENT    010  // Not sure we need this
 
 #define F_OK 0
 // XXX: Duplicate definition; should probably weed out includes of host system
@@ -242,28 +240,6 @@ extern struct shim_dentry* g_dentry_root;
 #define ACC_MODE(x)                                        \
     ((((x) == O_RDONLY || (x) == O_RDWR) ? MAY_READ : 0) | \
      (((x) == O_WRONLY || (x) == O_RDWR) ? MAY_WRITE : 0))
-
-#define LOOKUP_OPEN   0100  // Appears to be ignored
-#define LOOKUP_CREATE 0200
-#define LOOKUP_ACCESS 0400  // Appears to be ignored
-#define LOOKUP_SYNC   (LOOKUP_OPEN | LOOKUP_CREATE | LOOKUP_ACCESS)
-
-enum lookup_type {
-    LAST_NORM,
-    LAST_ROOT,
-    LAST_DOT,
-    LAST_DOTDOT,
-    LAST_BIND
-};
-
-struct lookup {
-    struct shim_dentry* dentry;
-    struct shim_mount* mount;
-    const char* last;
-    int depth;
-    int flags;
-    enum lookup_type last_type;
-};
 
 /* initialization for fs and mounts */
 int init_fs(void);
@@ -297,41 +273,99 @@ int init_dcache(void);
 
 extern struct shim_lock g_dcache_lock;
 
-/* Checks permission (specified by mask) of a dentry. If force is not set, permission is considered
- * granted on invalid dentries.
- * Assumes that caller has acquired g_dcache_lock. */
-int __permission(struct shim_dentry* dent, mode_t mask);
-
-/* This function looks up a single dentry based on its parent dentry pointer and the name. `namelen`
- * is the length of char* name. The dentry is returned in pointer *new.
+/*!
+ * \brief Dump dentry cache
  *
- * The caller should hold the g_dcache_lock.
+ * \param dent the starting dentry, or NULL (will default to dentry root)
+ *
+ * Dumps the dentry cache using `log_always`, starting from the provided dentry. Intended for
+ * debugging the filesystem - just add it manually to the code.
  */
-int lookup_dentry(struct shim_dentry* parent, const char* name, int namelen,
-                  struct shim_dentry** new, struct shim_mount* fs);
+void dump_dcache(struct shim_dentry* dent);
 
-/* Looks up path under start dentry. Saves in dent.
+/*!
+ * \brief Check file permissions, similar to Unix access
  *
- * Assumes g_dcache_lock is held; main difference from path_lookupat is that g_dcache_lock is not
- * released on return.
+ * \param dentry the dentry to check
+ * \param mask mask, same as for Unix access
  *
- * The refcount is raised by one on the returned dentry.
+ * Checks permissions for a dentry. Because Graphene currently has no notion of users, this will
+ * always use the "user" part of file mode.
  *
- * The make_ancestor flag creates pseudo-dentries for any parent paths that are not in cache and do
- * not exist on the underlying file system. This is intended for use only in setting up the
- * file system view specified in the manifest.
+ * The caller should hold `g_dcache_lock`.
  *
- * If the file isnt' found, returns -ENOENT.
- *
- * If the LOOKUP_DIRECTORY flag is set, and the found file isn't a directory, returns -ENOTDIR.
+ * `dentry` should be a valid dentry, but can be negative (in which case the function will return
+ * -ENOENT).
  */
-int __path_lookupat(struct shim_dentry* start, const char* path, int flags,
-                    struct shim_dentry** dent, int link_depth, struct shim_mount* fs,
-                    bool make_ancestor);
+int check_permissions(struct shim_dentry* dent, mode_t mask);
 
-/* Just wraps __path_lookupat, but also acquires and releases the g_dcache_lock. */
-int path_lookupat(struct shim_dentry* start, const char* name, int flags, struct shim_dentry** dent,
-                  struct shim_mount* fs);
+/*
+ * Flags for `path_lookupat`.
+ *
+ * Note that, opposite to user-level O_NOFOLLOW, we define LOOKUP_FOLLOW as a positive flag, and add
+ * LOOKUP_NO_FOLLOW as a pseudo-flag for readability.
+ *
+ * This is modeled after Linux and BSD codebases, which define a positive FOLLOW flag, and a
+ * negative pseudo-flag was introduced by FreeBSD.
+ */
+#define LOOKUP_NO_FOLLOW       0
+#define LOOKUP_FOLLOW          0x1
+#define LOOKUP_CREATE          0x2
+#define LOOKUP_DIRECTORY       0x4
+#define LOOKUP_MAKE_SYNTHETIC  0x8
+
+/* Maximum number of nested symlinks that `path_lookupat` and related functions will follow */
+#define MAX_LINK_DEPTH 8
+
+/*!
+ * \brief Look up a path, retrieving a dentry
+ *
+ * \param start the start dentry for relative paths, or NULL (in which case it will default to
+ * process' cwd)
+ * \param path the path to look up
+ * \param flags lookup flags (see description below)
+ * \param[out] found pointer to retrieved dentry
+ *
+ * The caller should hold `g_dcache_lock`.
+ *
+ * On success, returns 0, and puts the retrieved dentry in `*found`. The reference count of the
+ * dentry will be increased by one.
+ *
+ * The retrieved dentry is always valid, and can only be negative if LOOKUP_CREATE is set.
+ *
+ * On failure, returns a negative error code, and sets `*found` to NULL.
+ *
+ * Supports the following flags:
+ *
+ * - LOOKUP_FOLLOW: if `path` refers to a symbolic link, follow it (the default is to return the
+ *   dentry to the link). Note that symbolic links for intermediate path segments are always
+ *   followed.
+ *
+ * - LOOKUP_NO_FOLLOW: this is a pseudo-flag defined as 0. You can use it to indicate to the reader
+ *   that symbolic links are intentionally not being followed.
+ *
+ * - LOOKUP_CREATE: if the file under `path` does not exist, but can be created (i.e. the parent
+ *   directory exists), the function will succeed and a negative dentry will be put in `*found`. If
+ *   the parent directory also does not exist, the function will still fail with -ENOENT.
+ *
+ * - LOOKUP_DIRECTORY: expect the file under `path` to be a directory, and fail with -ENOTDIR
+ *   otherwise
+ *
+ * - LOOKUP_MAKE_SYNTHETIC: create pseudo-files (DENTRY_SYNTHETIC) for any components on the path
+ *   that do not exist. This is intended for use when creating mountpoints specified in manifest.
+ *
+ * Note that a path with trailing slash is always treated as a directory, and LOOKUP_FOLLOW /
+ * LOOKUP_CREATE do not apply.
+ *
+ * TODO: This function doesn't check any permissions. It should return -EACCES on inaccessible
+ * directories.
+ */
+int _path_lookupat(struct shim_dentry* start, const char* path, int flags,
+                   struct shim_dentry** found);
+
+/* Same as path_lookupat, but also acquires and releases  `g_dcache_lock`. */
+int path_lookupat(struct shim_dentry* start, const char* path, int flags,
+                  struct shim_dentry** found);
 
 /*
  * This function returns a dentry (in *dir) from a handle corresponding to dirfd.
@@ -343,24 +377,53 @@ int path_lookupat(struct shim_dentry* start, const char* name, int flags, struct
  */
 int get_dirfd_dentry(int dirfd, struct shim_dentry** dir);
 
-/* Open path with given flags, in mode, similar to Unix open.
+/*
+ * \brief Open a file under a given path, similar to Unix open
  *
- * The start dentry specifies where to begin the search.
- * `hdl` is an optional argument; if passed in, it is initialized to refer to the opened path.
+ * \param[out] hdl handle to associate with dentry, can be NULL
+ * \param start the start dentry for relative paths, or NULL (in which case it will default to
+ * process' cwd)
+ * \param path the path to look up
+ * \param flags Unix open flags (see below)
+ * \param mode Unix file mode, used when creating a new file/directory
+ * \param[out] found pointer to retrieved dentry, can be NULL
  *
- * The result is stored in `dent`.
+ * If `hdl` is provided, on success it will be associated with the dentry. Otherwise, the file will
+ * just be retrieved or created.
+ *
+ * If `found` is provided, on success it will be set to the file's dentry (and its reference count
+ * will be increased), and on failure it will be set to NULL.
+ *
+ * Similar to Unix open, `flags` must include one of O_RDONLY, O_WRONLY or O_RDWR. In addition,
+ * the following flags are supported by this function:
+ * - O_CREAT: create a new file if one does not exist
+ * - O_EXCL: fail if the file already exists
+ * - O_DIRECTORY: expect/create a directory instead of regular file
+ * - O_NOFOLLOW: don't follow symbolic links when resolving a path
+ * - O_TRUNC: truncate the file after opening
+ *
+ * The flags (including any not listed above), as well as file mode, are passed to the underlying
+ * filesystem.
+ *
+ * TODO: This function checks permissions of the opened file (if it exists) and parent directory (if
+ * the file is being created), but not permissions for the whole path. That check probably should be
+ * added to `path_lookupat`.
  */
-
 int open_namei(struct shim_handle* hdl, struct shim_dentry* start, const char* path, int flags,
-               int mode, struct shim_dentry** dent);
+               int mode, struct shim_dentry** found);
 
-/* This function calls the low-level file system to do the work of opening file indicated by dent,
- * and initializing it in hdl. Flags are standard open flags.
+/*
+ * \brief Open an already retrieved dentry, and associate a handle with it
  *
- * If O_TRUNC is specified, this function is responsible for calling the underlying truncate
- * function.
+ * \param[out] hdl handle to associate with dentry
+ * \param dent the dentry to open
+ * \param flags Unix open flags
+ *
+ * The dentry has to already correspond to a file (i.e. has to be valid and non-negative).
+ *
+ * The `flags` parameter will be passed to the underlying filesystem's `open` function. If O_TRUNC
+ * flag is specified, the filesystem's `truncate` function will also be called.
  */
-
 int dentry_open(struct shim_handle* hdl, struct shim_dentry* dent, int flags);
 
 /* This function enumerates a directory and caches the results in the dentry.
@@ -471,7 +534,7 @@ struct shim_dentry* get_new_dentry(struct shim_mount* fs, struct shim_dentry* pa
  * \param name name of searched dentry
  * \param name_len length of the name
  *
- * \returns the new dentry, or NULL if not found
+ * \returns the dentry, or NULL if not found
  *
  * The caller should hold `g_dcache_lock`.
  *

--- a/LibOS/shim/src/bookkeep/shim_handle.c
+++ b/LibOS/shim/src/bookkeep/shim_handle.c
@@ -38,7 +38,7 @@ static int init_tty_handle(struct shim_handle* hdl, bool write) {
     hdl->flags = write ? (O_WRONLY | O_APPEND) : O_RDONLY;
 
     struct shim_dentry* dent = NULL;
-    if ((ret = path_lookupat(NULL, "/dev/tty", LOOKUP_OPEN, &dent, NULL)) < 0)
+    if ((ret = path_lookupat(/*start=*/NULL, "/dev/tty", LOOKUP_FOLLOW, &dent)) < 0)
         return ret;
 
     ret = dent->fs->d_ops->open(hdl, dent, hdl->flags);
@@ -82,7 +82,7 @@ static inline int init_exec_handle(void) {
         while (*p == '/') {
             p++;
         }
-        path_lookupat(fs->root, p, 0, &exec->dentry, fs);
+        path_lookupat(fs->root, p, LOOKUP_FOLLOW, &exec->dentry);
         set_handle_fs(exec, fs);
         if (exec->dentry)
             dentry_get_path_into_qstr(exec->dentry, &exec->path);

--- a/LibOS/shim/src/bookkeep/shim_process.c
+++ b/LibOS/shim/src/bookkeep/shim_process.c
@@ -46,7 +46,7 @@ int init_process(int argc, const char** argv) {
     g_process.umask = 0;
 
     struct shim_dentry* dent = NULL;
-    int ret = path_lookupat(NULL, "/", 0, &dent, NULL);
+    int ret = path_lookupat(/*start=*/NULL, "/", LOOKUP_FOLLOW | LOOKUP_DIRECTORY, &dent);
     if (ret < 0) {
         log_error("Could not set up dentry for \"/\", something is seriously broken.\n");
         return ret;

--- a/LibOS/shim/src/fs/proc/ipc-thread.c
+++ b/LibOS/shim/src/fs/proc/ipc-thread.c
@@ -98,12 +98,6 @@ do_ipc:
     if (dentptr) {
         /* XXX: Not sure how to handle this case yet */
         __abort();
-        ret = path_lookupat(NULL, (char*)ipc_data, 0, &dent, NULL);
-        if (ret < 0)
-            goto out;
-
-        get_dentry(dent);
-        *dentptr = dent;
     }
 
 out:

--- a/LibOS/shim/src/fs/proc/thread.c
+++ b/LibOS/shim/src/fs/proc/thread.c
@@ -110,7 +110,7 @@ static int find_thread_link(const char* name, struct shim_qstr* link,
     if (nextnext) {
         struct shim_dentry* next_dent = NULL;
 
-        ret = path_lookupat(dent, nextnext, 0, &next_dent, dent->fs);
+        ret = path_lookupat(dent, nextnext, LOOKUP_FOLLOW, &next_dent);
         if (ret < 0)
             goto out;
 
@@ -344,7 +344,7 @@ static int find_thread_each_fd(const char* name, struct shim_qstr* link,
     if (rest) {
         struct shim_dentry* next_dent = NULL;
 
-        ret = path_lookupat(dent, rest, 0, &next_dent, dent->fs);
+        ret = path_lookupat(dent, rest, LOOKUP_NO_FOLLOW, &next_dent);
         if (ret < 0)
             goto out;
 

--- a/LibOS/shim/src/fs/shim_dcache.c
+++ b/LibOS/shim/src/fs/shim_dcache.c
@@ -250,6 +250,56 @@ bool dentry_is_ancestor(struct shim_dentry* anc, struct shim_dentry* dent) {
     return false;
 }
 
+static int dump_dentry_write_all(const char* str, size_t size, void* arg) {
+    __UNUSED(arg);
+    log_always("%.*s\n", (int)size, str);
+    return 0;
+}
+
+#define DUMP_FLAG(flag, s, empty) buf_puts(&buf, (dent->state & (flag)) ? (s) : (empty))
+
+static void dump_dentry(struct shim_dentry* dent, unsigned int level) {
+    assert(locked(&g_dcache_lock));
+
+    struct print_buf buf = INIT_PRINT_BUF(dump_dentry_write_all);
+
+    buf_printf(&buf, "[%6.6s ", dent->fs ? dent->fs->type : "");
+
+    DUMP_FLAG(DENTRY_VALID, "V", ".");
+    DUMP_FLAG(DENTRY_LISTED, "L", ".");
+    DUMP_FLAG(DENTRY_INO_UPDATED, "I", ".");
+    DUMP_FLAG(DENTRY_SYNTHETIC, "S", ".");
+    buf_printf(&buf, "%3d] ", (int)REF_GET(dent->ref_count));
+
+    DUMP_FLAG(DENTRY_MOUNTPOINT, "*", " ");
+    DUMP_FLAG(DENTRY_NEGATIVE, "-", " ");
+
+    for (unsigned int i = 0; i < level; i++)
+        buf_puts(&buf, "  ");
+
+    buf_puts(&buf, qstrgetstr(&dent->name));
+    DUMP_FLAG(DENTRY_ISDIRECTORY, "/", "");
+    DUMP_FLAG(DENTRY_ISLINK, " -> ", "");
+    buf_flush(&buf);
+
+    struct shim_dentry* child;
+    LISTP_FOR_EACH_ENTRY(child, &dent->children, siblings) {
+        dump_dentry(child, level + 1);
+    }
+}
+
+#undef DUMP_FLAG
+
+void dump_dcache(struct shim_dentry* dent) {
+    lock(&g_dcache_lock);
+
+    if (!dent)
+        dent = g_dentry_root;
+
+    dump_dentry(dent, 0);
+    unlock(&g_dcache_lock);
+}
+
 BEGIN_CP_FUNC(dentry) {
     __UNUSED(size);
     assert(size == sizeof(struct shim_dentry));

--- a/LibOS/shim/src/fs/shim_namei.c
+++ b/LibOS/shim/src/fs/shim_namei.c
@@ -26,53 +26,27 @@ static inline const char* eat_slashes(const char* string) {
     return string;
 }
 
-static inline int __lookup_flags(int flags) {
-    int retval = LOOKUP_FOLLOW;
-
-    if (flags & O_NOFOLLOW)
-        retval &= ~LOOKUP_FOLLOW;
-
-    if ((flags & (O_CREAT | O_EXCL)) == (O_CREAT | O_EXCL))
-        retval &= ~LOOKUP_FOLLOW;
-
-    if (flags & O_DIRECTORY)
-        retval |= LOOKUP_DIRECTORY;
-
-    return retval;
-}
-
-/* check permission (specified by mask) of a dentry. If force is not set,
- * permission is considered granted on invalid dentries
- *
- * mask is the same as mode in the manual for access(2): F_OK, R_OK, W_OK,
- * X_OK
- *
- * Returns 0 on success, negative on failure.
- */
-/* Assume caller has acquired g_dcache_lock */
-int __permission(struct shim_dentry* dent, mode_t mask) {
+int check_permissions(struct shim_dentry* dent, mode_t mask) {
     assert(locked(&g_dcache_lock));
-
-    mode_t mode = 0;
-
-    /* Pseudo dentries don't really have permssions.  I wonder if
-     * we could tighten up the range of allowed calls.
-     */
-    if (dent->state & DENTRY_ANCESTOR)
-        return 0;
+    assert(dent->state & DENTRY_VALID);
 
     if (dent->state & DENTRY_NEGATIVE)
         return -ENOENT;
 
-    /* At this point, we can just return zero if we are only
-     * checking F_OK (the dentry isn't negative). */
+    /* If we only check if the file exists, at this point we know that */
     if (mask == F_OK)
         return 0;
 
-    /* A dentry may not have the mode stored.  The original code
-     * used both NO_MODE and !DENTRY_VALID; let's try to consolidate to
-     * just NO_MODE.
+    /*
+     * Synthetic directories don't really have permissions.
+     *
+     * TODO: current mount operation marks the mount root as synthetic. Once that's fixed, we'll be
+     * able to disallow W_OK here.
      */
+    if (dent->state & DENTRY_SYNTHETIC)
+        return 0;
+
+    /* A dentry may not have the mode stored yet. Query the underlying filesystem. */
     if (dent->mode == NO_MODE) {
         assert(dent->fs);
         if (!dent->fs->d_ops || !dent->fs->d_ops->mode) {
@@ -81,6 +55,7 @@ int __permission(struct shim_dentry* dent, mode_t mask) {
         }
 
         /* Fall back to the low-level file system */
+        mode_t mode = 0;
         int err = dent->fs->d_ops->mode(dent, &mode);
 
         /*
@@ -95,534 +70,324 @@ int __permission(struct shim_dentry* dent, mode_t mask) {
         dent->mode = mode;
     }
 
-    mode = dent->mode;
-
-    if (((mode >> 6) & mask) == mask)
+    /* Check the "user" part of mode against mask */
+    if (((dent->mode >> 6) & mask) == mask)
         return 0;
 
     return -EACCES;
 }
 
-/*
- * This function looks up a single dentry based on its parent dentry pointer
- * and the name.  Namelen is the length of char * name.
- * The dentry is returned in pointer *new.  The refcount of new is incremented
- * by one.
+/*!
+ * \brief Search for a child of a dentry, querying the filesystem if necessary
  *
- * The fs argument specifies the file system type to use on a miss; typically,
- * this will be parent->fs.
+ * \param parent dentry to look in
+ * \param name file name
+ * \param name_len length of the name
+ * \param[out] found pointer to retrieved dentry
  *
- * This function checks the dcache first, and then, on a miss, falls back
- * to the low-level file system.
+ * This function works like `lookup_dcache`, but if the dentry is not in cache, it queries the
+ * underlying filesystem.
  *
- * XXX: The original code returned whether the process can exec the task?
- *       Not clear this is needed; try not doing this.
+ * The caller should hold `g_dcache_lock`.
  *
- * Returns zero if the file is found; -ENOENT if it doesn't exist,
- * possibly other errors.
+ * On success, returns 0 and sets `*new` to the found dentry (whose reference count is increased). A
+ * negative filesystem lookup (ENOENT) is also considered a success, and `*new` is set to a negative
+ * dentry. The dentry is always valid.
  *
- * The caller should hold the g_dcache_lock.
+ * On failure (including lookup failing with any other error than ENOENT) returns the negative error
+ * code, and sets `*new` to NULL.
  */
-int lookup_dentry(struct shim_dentry* parent, const char* name, int namelen,
-                  struct shim_dentry** new, struct shim_mount* fs) {
+static int lookup_dentry(struct shim_dentry* parent, const char* name, size_t name_len,
+                         struct shim_dentry** found) {
     assert(locked(&g_dcache_lock));
     assert(parent);
 
-    struct shim_dentry* dent = NULL;
-    int do_fs_lookup = 0;
-    int err = 0;
+    int ret = 0;
 
-    /* Look up the name in the dcache first, one atom at a time. */
-    dent = lookup_dcache(parent, name, namelen);
-
+    struct shim_dentry* dent = lookup_dcache(parent, name, name_len);
     if (!dent) {
-        if (parent) {
-            /* Newly created dentry's relative path will be a concatenation of parent
-             * + name strings (see get_new_dentry), make sure it fits into qstr */
-            if (parent->rel_path.len + 1 + namelen >= STR_SIZE) { /* +1 for '/' */
-                log_error("Relative path exceeds the limit %d\n", STR_SIZE);
-                err = -ENAMETOOLONG;
-                goto out;
-            }
+        /* Make sure newly created dentry's relative path will fit into qstr. */
+        if (parent->rel_path.len + 1 + name_len >= STR_SIZE) { /* +1 for '/' */
+            log_error("Relative path exceeds the limit %d\n", STR_SIZE);
+            ret = -ENAMETOOLONG;
+            goto err;
         }
 
-        dent = get_new_dentry(fs, parent, name, namelen);
+        dent = get_new_dentry(parent->fs, parent, name, name_len);
         if (!dent) {
-            err = -ENOMEM;
-            goto out;
+            ret = -ENOMEM;
+            goto err;
         }
-        do_fs_lookup = 1;
-    } else {
-        if (!(dent->state & DENTRY_VALID))
-            do_fs_lookup = 1;
+
+        assert(!(dent->state & DENTRY_VALID));
     }
 
-    if (do_fs_lookup) {
-        // This doesn't make any sense if there isn't a low-level
-        // lookup function.
+    if (!(dent->state & DENTRY_VALID)) {
+        /* This is an invalid dentry: either we just created it, or it got left over from a previous
+         * failed lookup. Perform the lookup. */
         assert(dent->fs);
         assert(dent->fs->d_ops);
         assert(dent->fs->d_ops->lookup);
-        err = dent->fs->d_ops->lookup(dent);
+        ret = dent->fs->d_ops->lookup(dent);
 
-        /* XXX: On an error, it seems like we should probably destroy
-         * the dentry, rather than keep some malformed dentry lying around.
-         * Not done in original code, so leaving for now.
-         */
-        if (err) {
-            if (err == -ENOENT || err == -EACCES) {
-                /* Non-existing files and inaccessible files are marked as
-                 * negative dentries, so they can still be cached */
-                dent->state |= DENTRY_NEGATIVE;
-            } else {
-                goto out;
-            }
+        if (ret == 0) {
+            /* Lookup succeeded */
+            dent->state |= DENTRY_VALID;
+        } else if (ret == -ENOENT) {
+            /* File not found, we will return a negative dentry */
+            dent->state |= DENTRY_VALID | DENTRY_NEGATIVE;
+        } else {
+            /* Lookup failed, keep dentry as invalid (and don't return it to user) */
+            goto err;
         }
-        dent->state |= DENTRY_VALID;
     }
 
-    /* I think we can assume we have a valid dent at this point */
-    assert(dent);
-    assert(dent->state & DENTRY_VALID);
+    *found = dent;
+    return 0;
 
-    // Set the err is ENOENT if negative
-    if (dent->state & DENTRY_NEGATIVE)
-        err = -ENOENT;
+err:
+    if (dent)
+        put_dentry(dent);
+    *found = NULL;
+    return ret;
+}
 
-    if (new) {
-        get_dentry(dent);
-        *new = dent;
-    }
+static int do_path_lookupat(struct shim_dentry* start, const char* path, int flags,
+                            struct shim_dentry** found, unsigned int link_depth);
+
+
+/* Helper function that follows a symbolic link, performing a nested call to `do_path_lookupat`  */
+static int path_lookupat_follow(struct shim_dentry* parent, struct shim_dentry* link, int flags,
+                                struct shim_dentry** found, unsigned int link_depth) {
+    int ret;
+    struct shim_qstr link_target = QSTR_INIT;
+
+    assert(locked(&g_dcache_lock));
+
+    assert(link->fs);
+    assert(link->fs->d_ops);
+    assert(link->fs->d_ops->follow_link);
+    ret = link->fs->d_ops->follow_link(link, &link_target);
+    if (ret < 0)
+        goto out;
+
+    ret = do_path_lookupat(parent, qstrgetstr(&link_target), flags, found, link_depth);
 
 out:
-    if (dent) {
-        put_dentry(dent);
-    }
-
-    return err;
+    qstrfree(&link_target);
+    return ret;
 }
 
 /*
- * Looks up path under start dentry.  Saves in dent (if specified; dent may be
- * NULL).  Start is a hint, and may be null; in this case, we use the first
- * char of the path to infer whether the path is relative or absolute.
- *
- * Primarily to support bootstrapping, this function takes a fs parameter,
- * that specifies a mount point. Typically, this would be start->fs, but there
- * are cases where start may be absent (e.g., in bootstrapping).  Fs can be
- * null only if the current thread is defined.
- *
- * Assumes g_dcache_lock is held; main difference from path_lookupat is that
- * g_dcache_lock is acquired/released.
- *
- * We assume the caller has incremented the reference count on start and its
- * associated file system mount by one
- *
- * The refcount is raised by one on the returned dentry and associated mount.
- *
- * The make_ancestor flag creates pseudo-dentries for any parent paths that
- * are not in cache and do not exist on the underlying file system.  This is
- * intended for use only in setting up the file system view specified in the
- * manifest.
- *
- * If the file isn't found, returns -ENOENT.
- * FIXME: path_lookupat() abuses -ENOENT for two cases:
- *        - actual failure: one of the subdirs was not found, i.e., the file
- *          cannot be created at all (and then dent is set to NULL);
- *        - benign failure: all subdirs are found but the file doesn't exist,
- *          i.e., the file can be created (and then dent is set to object).
- *        This is terrible semantics and must be fixed when FS is re-worked.
- *
- * If the LOOKUP_DIRECTORY flag is set, and the found file isn't a directory,
- *  returns -ENOTDIR.
+ * This implementation is mostly iterative, but uses recursion to follow symlinks (which is why the
+ * link depth is limited to MAX_LINK_DEPTH).
  */
-int __path_lookupat(struct shim_dentry* start, const char* path, int flags,
-                    struct shim_dentry** dent, int link_depth, struct shim_mount* fs,
-                    bool make_ancestor) {
+static int do_path_lookupat(struct shim_dentry* start, const char* path, int flags,
+                            struct shim_dentry** found, unsigned int link_depth) {
     assert(locked(&g_dcache_lock));
-    // Basic idea: recursively iterate over path, peeling off one atom at a
-    // time.
-    /* Chia-Che 12/5/2014:
-     * XXX I am not a big fan of recursion. I am giving a pass to this code
-     * for now, but eventually someone (probably me) should rewrite it. */
-    const char* my_path;
-    int my_pathlen = 0;
-    int err = 0;
-    struct shim_dentry* my_dent = NULL;
-    struct shim_qstr link_target = QSTR_INIT;
-    bool leaf_case = false; // Leaf call in case of recursion
-    bool no_start = false; // start not passed
-    bool no_fs = false; // fs not passed
+
+    struct shim_dentry* dent = NULL;
+    struct shim_dentry* next_dent = NULL;
+    int ret = 0;
+
+    /* Empty path is invalid in POSIX */
+    if (*path == '\0') {
+        ret = -ENOENT;
+        goto err;
+    }
 
     if (*path == '/') {
-        /*
-         * Allow (start != NULL, absolute path) for *at() system calls.
-         * which are common case as normal namei path resolution.
-         */
+        /* Absolute path, use process root even if `start` was provided (can happen for *at() system
+         * calls) */
         lock(&g_process.fs_lock);
-        if (g_process.root) {
-            start = g_process.root;
-            get_dentry(start);
-            no_start = true;
-            fs = NULL;
+        start = g_process.root;
+        if (!start) {
+            /* Can happen during LibOS initialization */
+            start = g_dentry_root;
         }
         unlock(&g_process.fs_lock);
-    }
-    if (!start) {
+    } else if (!start) {
+        /* Relative part with no start dentry provided, use process current working directory */
         lock(&g_process.fs_lock);
         start = g_process.cwd;
         if (!start) {
-            /* Start at the global root if we have no fs and no start dentry.
-             * This should only happen as part of initialization.
-             */
+            /* Can happen during LibOS initialization */
             start = g_dentry_root;
         }
-        get_dentry(start);
         unlock(&g_process.fs_lock);
-        no_start = true;
-        assert(fs == NULL);
     }
 
     assert(start);
-    if (!fs) {
-        no_fs = true;
-        fs = start->fs;
-        // refcount should only be incremented if the caller didn't do it
-        get_mount(fs);
-    }
+    dent = start;
+    get_dentry(dent);
 
-    assert(fs);
+    const char* name = path;
+    while (*name == '/')
+        name++;
 
-    if (!(start->state & DENTRY_ISDIRECTORY)) {
-        err = -ENOTDIR;
-        goto out;
-    }
+    while (*name != '\0') {
+        assert(*name != '/');
 
-    // Peel off any preceeding slashes
-    path = eat_slashes(path);
+        const char* name_end = name;
+        while (*name_end != '\0' && *name_end != '/')
+            name_end++;
+        size_t name_len = name_end - name;
 
-    // Check that we didn't hit the leaf case
-    if (*path == '\0') {
-        // We'll return start since this is the last path element
-        my_dent = start;
-        // Increment refcount of the found entry
-        get_dentry(my_dent);
-        leaf_case = true;
-    } else {
-        my_path = path;
-        // Find the length of the path
-        while (*my_path != '/' && *my_path != '\0') {
-            my_path++;
-            my_pathlen++;
+        const char* next_name = name_end;
+        while (*next_name == '/')
+            next_name++;
+
+        /* Check if this is the final component, but treat paths ending with slash specially. */
+        bool is_final = (*next_name == '\0');
+        bool has_slash = (*name_end == '/');
+
+        if (name_len > MAX_FILENAME) {
+            ret = -ENAMETOOLONG;
+            goto err;
         }
 
-        if (my_pathlen > MAX_FILENAME) {
-            err = -ENAMETOOLONG;
-            goto out;
-        }
-
-        /* Handle . */
-        if (my_pathlen == 1 && *path == '.') {
-            /* For the recursion to work, we need to do the following:
-             * Bump the ref count, set my_dent to start
-             */
-            my_dent = start;
-            get_dentry(my_dent);
-        } else if (my_pathlen == 2 && path[0] == '.' && path[1] == '.') {
-            if (start->parent) {
-                my_dent = start->parent;
-            } else {
-                // Root
-                my_dent = start;
-            }
-            get_dentry(my_dent);
-
+        if (name_len == 1 && name[0] == '.') {
+            next_dent = dent;
+            get_dentry(next_dent);
+        } else if (name_len == 2 && name[0] == '.' && name[1] == '.') {
+            next_dent = dent->parent ? dent->parent : dent;
+            get_dentry(next_dent);
         } else {
-            // Once we have an atom, look it up and update start
-            err = lookup_dentry(start, path, my_pathlen, &my_dent, fs);
-            // my_dent's refcount is incremented after this, consistent with cases above
+            ret = lookup_dentry(dent, name, name_len, &next_dent);
+            if (ret)
+                goto err;
 
-            // Allow a negative dentry to move forward
-            if (err < 0 && err != -ENOENT)
-                goto out;
-
-            // Drop any trailing slashes from the path
-            my_path = eat_slashes(my_path);
-
-            // If the LOOKUP_FOLLOW flag is set, check if we hit a symlink
-            if ((flags & LOOKUP_FOLLOW) && (my_dent->state & DENTRY_ISLINK)) {
-                // Keep from following too many links
-                if (link_depth > 80) {
-                    err = -ELOOP;
-                    goto out;
-                }
-                link_depth++;
-
-                assert(my_dent->fs->d_ops && my_dent->fs->d_ops->follow_link);
-
-                if ((err = my_dent->fs->d_ops->follow_link(my_dent, &link_target)) < 0)
-                    goto out;
-
-                /* let's re-start lookup & recursion with the link's target */
-                my_path = qstrgetstr(&link_target);
-
-                if (my_path) {
-                    /* symlink name starts with a slash, restart lookup at root */
-                    if (*my_path == '/') {
-                        /*XXX: Check out path_reacquire here? */
-                        // my_dent's refcount was incremented by lookup_dentry above,
-                        // we need to not leak it here
-                        put_dentry(my_dent);
-                        lock(&g_process.fs_lock);
-                        my_dent = g_process.root;
-                        // not sure how to deal with this case if `g_process.root` isn't defined
-                        assert(my_dent);
-                        get_dentry(my_dent);
-                        unlock(&g_process.fs_lock);
-                    } else {
-                        // Relative path, stay in this dir
-                        put_dentry(my_dent);
-                        my_dent = start;
-                        get_dentry(my_dent);
+            if (!(next_dent->state & DENTRY_NEGATIVE) && (next_dent->state & DENTRY_ISLINK)) {
+                /* Traverse the symbolic link. This applies to all intermediate segments, final
+                 * segments ending with slash, and to all final segments if LOOKUP_FOLLOW is set. */
+                if (!is_final || has_slash || (flags & LOOKUP_FOLLOW)) {
+                    if (link_depth >= MAX_LINK_DEPTH) {
+                        ret = -ELOOP;
+                        goto err;
                     }
+
+                    /* If this is not the final segment (without slash), the nested lookup has
+                     * different options: it always follows symlinks, needs to always find the
+                     * target, and the target has to be a directory. */
+                    int sub_flags = flags;
+                    if (!is_final || has_slash) {
+                        sub_flags |= LOOKUP_FOLLOW | LOOKUP_DIRECTORY;
+                        sub_flags &= ~LOOKUP_CREATE;
+                    }
+
+                    struct shim_dentry* target_dent;
+                    ret = path_lookupat_follow(dent, next_dent, sub_flags, &target_dent,
+                                               link_depth + 1);
+                    if (ret < 0)
+                        goto err;
+
+                    put_dentry(next_dent);
+                    next_dent = target_dent;
+                }
+            }
+
+            if (next_dent->state & DENTRY_NEGATIVE) {
+                if ((!is_final || has_slash) && (flags & LOOKUP_MAKE_SYNTHETIC)) {
+                    /* Create a synthetic directory */
+                    next_dent->state &= ~DENTRY_NEGATIVE;
+                    next_dent->state |= DENTRY_VALID | DENTRY_SYNTHETIC | DENTRY_ISDIRECTORY;
+                } else if (!(is_final && (flags & LOOKUP_CREATE))) {
+                    ret = -ENOENT;
+                    goto err;
+                }
+            } else if (!(next_dent->state & DENTRY_ISDIRECTORY)) {
+                if (!is_final || has_slash || (flags & LOOKUP_DIRECTORY)) {
+                    ret = -ENOTDIR;
+                    goto err;
                 }
             }
         }
 
-        // Drop any trailing slashes from the path
-        my_path = eat_slashes(my_path);
-
-        // If we found something, and there is more, recur
-        if (*my_path != '\0') {
-            /* If we have more to look up, but got a negative DENTRY,
-             * we need to fail or (unlikely) create an ancestor dentry.*/
-            if (my_dent->state & DENTRY_NEGATIVE) {
-                if (make_ancestor) {
-                    my_dent->state |= DENTRY_ANCESTOR;
-                    my_dent->state |= DENTRY_ISDIRECTORY;
-                    my_dent->state &= ~DENTRY_NEGATIVE;
-                } else {
-                    err = -ENOENT;
-                    goto out;
-                }
-            }
-
-            /* Although this is slight over-kill, let's just always increment the
-             * mount ref count on a recursion, for easier bookkeeping */
-            get_mount(my_dent->fs);
-            err = __path_lookupat(my_dent, my_path, flags, dent, link_depth, my_dent->fs,
-                                  make_ancestor);
-            put_mount(my_dent->fs);
-            if (err < 0)
-                goto out;
-        } else {
-            /* If make_ancestor is set, we also need to handle the case here */
-            if (make_ancestor && (my_dent->state & DENTRY_NEGATIVE)) {
-                my_dent->state |= DENTRY_ANCESTOR;
-                my_dent->state |= DENTRY_ISDIRECTORY;
-                my_dent->state &= ~DENTRY_NEGATIVE;
-                if (err == -ENOENT)
-                    err = 0;
-            }
-            leaf_case = true;
-        }
+        put_dentry(dent);
+        dent = next_dent;
+        next_dent = NULL;
+        name = next_name;
     }
 
-    /* Base case.  Set dent and return. */
-    if (leaf_case) {
-        if (dent) {
-            get_dentry(my_dent);
-            *dent = my_dent;
-        }
+    assert(dent->state & DENTRY_VALID);
+    assert(!next_dent);
+    *found = dent;
+    return 0;
 
-        // Enforce LOOKUP_CREATE flag at a higher level
-        if (my_dent->state & DENTRY_NEGATIVE) {
-            err = -ENOENT;
-            goto out;
-        }
-
-        // Enforce the LOOKUP_DIRECTORY flag
-        if ((flags & LOOKUP_DIRECTORY) && !(my_dent->state & DENTRY_ISDIRECTORY))
-            err = -ENOTDIR;
-    }
-
-out:
-    if (my_dent) {
-        put_dentry(my_dent);
-    }
-
-    /* If we didn't have a start dentry, decrement the ref count here */
-    if (no_start)
-        put_dentry(start);
-
-    if (no_fs)
-        put_mount(fs);
-
-    qstrfree(&link_target);
-    return err;
+err:
+    if (dent)
+        put_dentry(dent);
+    if (next_dent)
+        put_dentry(next_dent);
+    *found = NULL;
+    return ret;
 }
 
-/* Just wraps __path_lookupat, but also acquires and releases the g_dcache_lock.
- */
-int path_lookupat(struct shim_dentry* start, const char* name, int flags, struct shim_dentry** dent,
-                  struct shim_mount* fs) {
-    int ret = 0;
+int _path_lookupat(struct shim_dentry* start, const char* path, int flags,
+                   struct shim_dentry** found) {
+    return do_path_lookupat(start, path, flags, found, /*link_depth=*/0);
+}
+
+int path_lookupat(struct shim_dentry* start, const char* path, int flags,
+                   struct shim_dentry** found) {
     lock(&g_dcache_lock);
-    ret = __path_lookupat(start, name, flags, dent, 0, fs, 0);
+    int ret = do_path_lookupat(start, path, flags, found, /*link_depth=*/0);
     unlock(&g_dcache_lock);
     return ret;
 }
 
-/* Open path with given flags, in mode, similar to Unix open.
- *
- * The start dentry specifies where to begin the search, and can be null. If
- * specified, we assume the caller has incremented the ref count on the start,
- * but not the associated mount (probably using get_dirfd_dentry)
- *
- * hdl is an optional argument; if passed in, it is initialized to
- *   refer to the opened path.
- *
- * We assume the caller has not increased
- *
- * The result is stored in dent.
- */
+static inline int open_flags_to_lookup_flags(int flags) {
+    int retval = LOOKUP_FOLLOW;
 
-int open_namei(struct shim_handle* hdl, struct shim_dentry* start, const char* path, int flags,
-               int mode, struct shim_dentry** dent) {
-    int lookup_flags = __lookup_flags(flags);
-    mode_t acc_mode = ACC_MODE(flags & O_ACCMODE);
-    int err = 0, newly_created = 0;
-    struct shim_dentry* mydent = NULL;
+    if (flags & O_NOFOLLOW)
+        retval &= ~LOOKUP_FOLLOW;
 
-    if (*path == '\0') {
-        /* corner case: trying to open with empty filename */
-        return -ENOENT;
-    }
+    if (flags & O_CREAT)
+        retval |= LOOKUP_CREATE;
 
-    lock(&g_dcache_lock);
+    /*
+     * See `man 2 open`:
+     *
+     * "When these two flags [O_CREAT and O_EXCL] are specified, symbolic links are not followed: if
+     * pathname is a symbolic link, then open() fails regardless of where the symbolic link points."
+     */
+    if ((flags & (O_CREAT | O_EXCL)) == (O_CREAT | O_EXCL))
+        retval &= ~LOOKUP_FOLLOW;
 
-    // lookup the path from start, passing flags
-    err = __path_lookupat(start, path, lookup_flags, &mydent, 0, NULL, 0);
+    if (flags & O_DIRECTORY)
+        retval |= LOOKUP_DIRECTORY;
 
-    if (mydent && (mydent->state & DENTRY_ISDIRECTORY)) {
-        if (flags & O_WRONLY || flags & O_RDWR) {
-            err = -EISDIR;
-            goto out;
-        }
-    }
-
-    // Deal with O_CREAT, O_EXCL, but only if we actually got a valid prefix
-    // of directories.
-    if (mydent && err == -ENOENT && (flags & O_CREAT)) {
-        // Create the file
-        struct shim_dentry* dir = mydent->parent;
-
-        if (!dir) {
-            err = -ENOENT;
-            goto out;
-        }
-
-        // Check the parent permission first
-        err = __permission(dir, MAY_WRITE | MAY_EXEC);
-        if (err)  goto out;
-
-        // Try EINVAL when creat isn't an option
-        if (!dir->fs->d_ops || !dir->fs->d_ops->creat) {
-            err = -EINVAL;
-            goto out;
-        }
-
-        // Differentiate directory and file creation;
-        // Seems like overloading functionality that could probably be more
-        // cleanly pushed into shim_do_mkdir
-        if (flags & O_DIRECTORY) {
-            err = dir->fs->d_ops->mkdir(dir, mydent, mode);
-        } else {
-            err = dir->fs->d_ops->creat(hdl, dir, mydent, flags, mode);
-        }
-        if (err)
-            goto out;
-
-        newly_created = 1;
-
-        // If we didn't get an error and made a directory, set the dcache dir flag
-        if (flags & O_DIRECTORY) {
-            mydent->state |= DENTRY_ISDIRECTORY;
-            mydent->type = S_IFDIR;
-        }
-
-        // Once the dentry is creat-ed, drop the negative flag
-        mydent->state &= ~DENTRY_NEGATIVE;
-
-        // Set err back to zero and fall through
-        err = 0;
-    } else if (err == 0 && ((flags & (O_CREAT | O_EXCL)) == (O_CREAT | O_EXCL))) {
-        err = -EEXIST;
-    }
-
-    if (err < 0) {
-        goto out;
-    }
-
-    // Check permission, but only if we didn't create the file.
-    // creat/O_CREAT have idiosyncratic semantics about opening a
-    // newly-created, read-only file for writing, but only the first time.
-    if (!newly_created) {
-        if ((err = __permission(mydent, acc_mode)) < 0)
-            goto out;
-    }
-
-    // Set up the file handle, if provided
-    if (hdl)
-        err = dentry_open(hdl, mydent, flags);
-
-out:
-    if (dent && !err) {
-        *dent = mydent;
-    } else if (mydent) {
-        put_dentry(mydent);
-    }
-
-    unlock(&g_dcache_lock);
-
-    return err;
+    return retval;
 }
 
-/* This function calls the low-level file system to do the work
- * of opening file indicated by dent, and initializing it in hdl.
- * Flags are standard open flags.
- *
- * If O_TRUNC is specified, this function is responsible for calling
- * the underlying truncate function.
- */
-
 int dentry_open(struct shim_handle* hdl, struct shim_dentry* dent, int flags) {
+    assert(dent->state & DENTRY_VALID);
+    assert(!(dent->state & DENTRY_NEGATIVE));
+    assert(!hdl->dentry);
+
     int ret = 0;
     struct shim_mount* fs = dent->fs;
 
-    /* I think missing functionality should be treated as EINVAL, or maybe
-     * ENOSYS?*/
-    if (!fs->d_ops || !fs->d_ops->open) {
+    if (!(fs->d_ops && fs->d_ops->open)) {
         ret = -EINVAL;
-        goto out;
+        goto err;
     }
 
-    if ((ret = fs->d_ops->open(hdl, dent, flags)) < 0)
-        goto out;
+    ret = fs->d_ops->open(hdl, dent, flags);
+    if (ret < 0)
+        goto err;
 
     set_handle_fs(hdl, fs);
     get_dentry(dent);
     hdl->dentry = dent;
     hdl->flags = flags;
-    // Set the type of the handle if we have a directory.  The original code
-    // had a special case for this.
-    // XXX: Having a type on the handle seems a little redundant if we have a
-    // dentry too.
+
     if (dent->state & DENTRY_ISDIRECTORY) {
+        /* Initialize directory handle */
         hdl->is_dir = true;
         memcpy(hdl->fs_type, fs->type, sizeof(fs->type));
 
-        // Set dot and dot dot for some reason
+        /* Set `dot` and `dotdot` so that we later know to list them */
         get_dentry(dent);
         hdl->dir_info.dot = dent;
 
@@ -641,23 +406,146 @@ int dentry_open(struct shim_handle* hdl, struct shim_dentry* dent, int flags) {
 
     if (!dentry_get_path_into_qstr(dent, &hdl->path)) {
         ret = -ENOMEM;
-        goto out;
+        goto err;
     }
 
     /* truncate regular writable file if O_TRUNC is given */
-    if ((flags & O_TRUNC) &&
-            ((flags & O_RDWR) | (flags & O_WRONLY)) &&
-            !(dent->state & DENTRY_ISDIRECTORY) &&
-            !(dent->state & DENTRY_MOUNTPOINT) &&
-            !(dent->state & DENTRY_ISLINK)) {
-        if (!fs->fs_ops->truncate) {
+    if ((flags & O_TRUNC) && ((flags & O_RDWR) | (flags & O_WRONLY))
+            && !(dent->state & DENTRY_ISDIRECTORY)
+            && !(dent->state & DENTRY_MOUNTPOINT)
+            && !(dent->state & DENTRY_ISLINK)) {
+
+        if (!(fs->fs_ops && fs->fs_ops->truncate)) {
             ret = -EINVAL;
-            goto out;
+            goto err;
         }
         ret = fs->fs_ops->truncate(hdl, 0);
+        if (ret < 0)
+            goto err;
     }
 
-out:
+    return 0;
+
+err:
+    /* If we failed after calling `open`, undo it */
+    if (hdl->dentry) {
+        if (fs->fs_ops && fs->fs_ops->hput)
+            fs->fs_ops->hput(hdl);
+
+        hdl->dentry = NULL;
+        put_dentry(dent);
+    }
+    return ret;
+}
+
+int open_namei(struct shim_handle* hdl, struct shim_dentry* start, const char* path, int flags,
+               int mode, struct shim_dentry** found) {
+    int lookup_flags = open_flags_to_lookup_flags(flags);
+    mode_t acc_mode = ACC_MODE(flags & O_ACCMODE);
+    int ret = 0;
+    struct shim_dentry* dent = NULL;
+
+    if (hdl)
+        assert(!hdl->dentry);
+
+    lock(&g_dcache_lock);
+
+    ret = _path_lookupat(start, path, lookup_flags, &dent);
+    if (ret < 0)
+        goto err;
+
+    assert(dent->state & DENTRY_VALID);
+
+    if (dent->state & DENTRY_ISDIRECTORY) {
+        if (flags & O_WRONLY || flags & O_RDWR) {
+            ret = -EISDIR;
+            goto err;
+        }
+    }
+
+    if (dent->state & DENTRY_ISLINK) {
+        /* Can happen if user specified O_NOFOLLOW, or O_TRUNC | O_EXCL. Posix requires us to fail
+         * with -ELOOP when trying to open a symlink. */
+        ret = -ELOOP;
+        goto err;
+    }
+
+    if (dent->state & DENTRY_NEGATIVE) {
+        if (!(flags & O_CREAT)) {
+            ret = -ENOENT;
+            goto err;
+        }
+
+        /* The root always exists, so if we got here, the dentry should have a parent */
+        struct shim_dentry* dir = dent->parent;
+        assert(dir);
+        assert(dir->fs);
+        assert(dir->fs->d_ops);
+
+        /* Check the parent permission first */
+        ret = check_permissions(dir, MAY_WRITE | MAY_EXEC);
+        if (ret < 0)
+            goto err;
+
+        /* Create directory or file, depending on O_DIRECTORY. Return -EINVAL if the operation is
+         * not supported for this filesystem. */
+        if (flags & O_DIRECTORY) {
+            if (!dir->fs->d_ops->mkdir) {
+                ret = -EINVAL;
+                goto err;
+            }
+            ret = dir->fs->d_ops->mkdir(dir, dent, mode);
+            if (ret < 0)
+                goto err;
+            dent->state &= ~DENTRY_NEGATIVE;
+            dent->state |= DENTRY_ISDIRECTORY;
+            dent->type = S_IFDIR;
+        } else {
+            if (!dir->fs->d_ops->creat) {
+                ret = -EINVAL;
+                goto err;
+            }
+            ret = dir->fs->d_ops->creat(hdl, dir, dent, flags, mode);
+            if (ret < 0)
+                goto err;
+            dent->state &= ~DENTRY_NEGATIVE;
+        }
+    } else {
+        /* The file exists. This is not permitted if both O_CREAT and O_EXCL are set. */
+        if ((flags & O_CREAT) && (flags & O_EXCL)) {
+            ret = -EEXIST;
+            goto err;
+        }
+
+        /* Check permissions. Note that we do it only if the file already exists: a newly created
+         * file is allowed to have a mode that's incompatible with `acc_mode`. */
+        ret = check_permissions(dent, acc_mode);
+        if (ret < 0)
+            goto err;
+    }
+
+    if (hdl) {
+        ret = dentry_open(hdl, dent, flags);
+        if (ret < 0)
+            goto err;
+    }
+
+    if (found) {
+        *found = dent;
+    } else {
+        put_dentry(dent);
+    }
+    unlock(&g_dcache_lock);
+    return 0;
+
+err:
+    if (dent)
+        put_dentry(dent);
+
+    if (found)
+        *found = NULL;
+
+    unlock(&g_dcache_lock);
     return ret;
 }
 
@@ -736,11 +624,16 @@ int list_directory_dentry(struct shim_dentry* dent) {
     struct shim_dirent* d = dirent;
     for (; d; d = d->next) {
         struct shim_dentry* child;
-        if ((ret = lookup_dentry(dent, d->name, strlen(d->name), &child, fs)) < 0) {
-            if (ret != -ENOENT) {
-                /* if the file is recently deleted or inaccessible, ignore it */
-                goto done_read;
-            }
+        if ((ret = lookup_dentry(dent, d->name, strlen(d->name), &child)) < 0) {
+            /* -ENOENT from underlying lookup should be handled as DENTRY_NEGATIVE */
+            assert(ret != -ENOENT);
+
+            /* Ignore inaccessible files */
+            if (ret == -EACCES)
+                continue;
+
+            /* Other errors fail the lookup */
+            goto done_read;
         }
 
         if (child->state & DENTRY_NEGATIVE) {

--- a/LibOS/shim/src/shim_rtld.c
+++ b/LibOS/shim/src/shim_rtld.c
@@ -736,7 +736,7 @@ static int __load_interp_object(struct link_map* exec_map) {
         struct shim_dentry* dent = NULL;
         int ret = 0;
 
-        if ((ret = path_lookupat(NULL, interp_path, LOOKUP_OPEN, &dent, NULL)) < 0 ||
+        if ((ret = path_lookupat(/*start=*/NULL, interp_path, LOOKUP_FOLLOW, &dent)) < 0 ||
             dent->state & DENTRY_NEGATIVE)
             continue;
 

--- a/LibOS/shim/src/sys/shim_access.c
+++ b/LibOS/shim/src/sys/shim_access.c
@@ -37,11 +37,11 @@ long shim_do_faccessat(int dfd, const char* filename, mode_t mode) {
 
     lock(&g_dcache_lock);
 
-    ret = __path_lookupat(dir, filename, LOOKUP_ACCESS | LOOKUP_FOLLOW, &dent, 0, NULL, false);
+    ret = _path_lookupat(dir, filename, LOOKUP_FOLLOW, &dent);
     if (ret < 0)
         goto out;
 
-    ret = __permission(dent, mode);
+    ret = check_permissions(dent, mode);
 
 out:
     unlock(&g_dcache_lock);

--- a/LibOS/shim/src/sys/shim_exec.c
+++ b/LibOS/shim/src/sys/shim_exec.c
@@ -182,7 +182,7 @@ long shim_do_execve(const char* file, const char** argv, const char** envp) {
 reopen:
 
     /* XXX: Not sure what to do here yet */
-    if ((ret = path_lookupat(NULL, file, LOOKUP_OPEN, &dent, NULL)) < 0)
+    if ((ret = path_lookupat(/*start=*/NULL, file, LOOKUP_FOLLOW, &dent)) < 0)
         return ret;
 
     struct shim_mount* fs = dent->fs;

--- a/LibOS/shim/src/sys/shim_getcwd.c
+++ b/LibOS/shim/src/sys/shim_getcwd.c
@@ -63,18 +63,11 @@ long shim_do_chdir(const char* filename) {
     if (strnlen(filename, MAX_PATH + 1) == MAX_PATH + 1)
         return -ENAMETOOLONG;
 
-    if ((ret = path_lookupat(NULL, filename, LOOKUP_OPEN, &dent, NULL)) < 0)
+    if ((ret = path_lookupat(/*start=*/NULL, filename, LOOKUP_FOLLOW | LOOKUP_DIRECTORY, &dent)) < 0)
         return ret;
 
     if (!dent)
         return -ENOENT;
-
-    if (!(dent->state & DENTRY_ISDIRECTORY)) {
-        char buffer[dentry_get_path_size(dent)];
-        log_debug("%s is not a directory\n", dentry_get_path(dent, buffer));
-        put_dentry(dent);
-        return -ENOTDIR;
-    }
 
     lock(&g_process.fs_lock);
     put_dentry(g_process.cwd);

--- a/LibOS/shim/src/sys/shim_open.c
+++ b/LibOS/shim/src/sys/shim_open.c
@@ -540,7 +540,7 @@ long shim_do_truncate(const char* path, loff_t length) {
     if (!path || test_user_string(path))
         return -EFAULT;
 
-    if ((ret = path_lookupat(NULL, path, 0, &dent, NULL)) < 0)
+    if ((ret = path_lookupat(/*start=*/NULL, path, LOOKUP_FOLLOW, &dent)) < 0)
         return ret;
 
     struct shim_mount* fs = dent->fs;

--- a/LibOS/shim/src/sys/shim_pipe.c
+++ b/LibOS/shim/src/sys/shim_pipe.c
@@ -283,17 +283,12 @@ long shim_do_mknodat(int dirfd, const char* pathname, mode_t mode, dev_t dev) {
     if (*pathname != '/' && (ret = get_dirfd_dentry(dirfd, &dir)) < 0)
         goto out;
 
-    ret = path_lookupat(dir, pathname, LOOKUP_CREATE, &dent, NULL);
-    if (ret < 0 && ret != -ENOENT) {
+    ret = path_lookupat(dir, pathname, LOOKUP_NO_FOLLOW | LOOKUP_CREATE, &dent);
+    if (ret < 0) {
         goto out;
     }
 
-    if (!dent) {
-        ret = -ENOENT; /* impossible path, file cannot be created, mknod must return ENOENT */
-        goto out;
-    }
-
-    if (dent->state & DENTRY_VALID && !(dent->state & DENTRY_NEGATIVE)) {
+    if (!(dent->state & DENTRY_NEGATIVE)) {
         ret = -EEXIST;
         goto out;
     }


### PR DESCRIPTION
This is the next step in FS rewrite, after #2324 (the first commit should disappear after merging #2324).

See also the issue for dentry cleanup (#2321).

Initially, I wanted to reverse the "follow symlinks" semantics (`LOOKUP_FOLLOW` -> `LOOKUP_NO_FOLLOW`). I decided against that after seeing Linux and BSD have a flag like that, but found that FreeBSD has a convention to *also* use `NOFOLLOW` (defined as zero) to make the code clearer.

Apart from that (and general cleanup), the most important change is `LOOKUP_CREATE` and not returning `-ENOENT` when the file can be created.

Next step: rewrite `mount_fs` and make mount semantics more sane (as mentioned in #2324).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2333)
<!-- Reviewable:end -->
