### PR TITLE
[LibOS] Fix deadlock after failed `getdents64`

### DIFF
--- a/LibOS/shim/src/sys/shim_open.c
+++ b/LibOS/shim/src/sys/shim_open.c
@@ -412,13 +412,13 @@ long shim_do_getdents64(int fd, struct linux_dirent64* buf, size_t count) {
 
     if (!hdl->is_dir) {
         ret = -ENOTDIR;
-        goto out;
+        goto out_no_unlock;
     }
 
     /* DEP 3/3/17: Properly handle an unlinked directory */
     if (hdl->dentry->state & DENTRY_NEGATIVE) {
         ret = -ENOENT;
-        goto out;
+        goto out_no_unlock;
     }
 
     lock(&hdl->lock);
@@ -492,8 +492,9 @@ done:
      * hold anything */
     if (bytes == 0 && (dirhdl->dot || dirhdl->dotdot || (dirhdl->ptr && *dirhdl->ptr)))
         ret = -EINVAL;
-    unlock(&hdl->lock);
 out:
+    unlock(&hdl->lock);
+out_no_unlock:
     put_handle(hdl);
     return ret;
 }


### PR DESCRIPTION
A failure inside `getdents64` (for instance in `list_directory_entry`) could return the handle locked. This was fixed in `getdents` but not in `getdents64`.

Triggered while working on #2333. These functions look pretty bad, I don't want to change them yet, but this looks like an obvious fix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2334)
<!-- Reviewable:end -->
