### PR TITLE
[GSC] Exclude deprecated files from trusted files list

### DIFF
--- a/Tools/gsc/finalize_manifest.py
+++ b/Tools/gsc/finalize_manifest.py
@@ -37,6 +37,9 @@ def extract_files_from_user_manifest(manifest):
 def generate_trusted_files(root_dir, already_added_files):
     excluded_paths_regex = (r'^/('
                                 r'boot/.*'
+                                r'|\.dockerenv'
+                                r'|\.dockerinit'
+                                r'|etc/mtab'
                                 r'|dev/.*'
                                 r'|etc/rc(\d|.)\.d/.*'
                                 r'|graphene/python/.*'


### PR DESCRIPTION
Signed-off-by: Veena Saini <veena.saini@intel.com>


## Description of the changes 

While running gsc images as part of Azure Kubernetes Services (AKS) Cluster (kubernetes version 1.19.9), the following errors are showing up:

Could not find size of file: file:/.dockerenv
Failed to load the checksums of trusted files: -9

OR (if previous error is resolved then the next error)

Could not find size of file: file:/.dockerinit
Failed to load the checksums of trusted files: -9

OR

Could not find size of file: file:/etc/mtab
Failed to load the checksums of trusted files: -9

.dockerenv and .dockerinit are considered to be deprecated (https://superuser.com/questions/1021834/what-are-dockerenv-and-dockerinit). 
 
For /etc/mtab file also, there are open issues of broken symlinks (https://github.com/kubernetes/kubernetes/issues/96961).

These 3 files are not used for the gsc-images we tested so far. Hence, we can exclude them from the trusted files list that will be appended inside entrypoint.manifest file. 

As part of the fix, these 3 files are excluded inside finalize_manifest.py.

## How to test this PR?

1. Create a gsc-python image or any other gsc image and deploy it inside AKS cluster (Exact steps described here: https://graphene.readthedocs.io/en/latest/cloud-deployment.html#deploying-a-helloworld-python-application-in-a-confidential-compute-aks-cluster).

2.  First try without the fix: the error will show up.

3.  After putting the fix, the issue resolves.

Note: This issue is observed only with Azure Kubernetes Cluster, with regular docker run the image runs successfully.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2341)
<!-- Reviewable:end -->
