### PR TITLE
[meson] Install symlinks with -f

### DIFF
--- a/Runtime/meson.build
+++ b/Runtime/meson.build
@@ -11,7 +11,7 @@ if direct
         install_dir: join_paths(pkglibdir, 'direct/gdb_integration/common'),
         strip_directory: true)
     meson.add_install_script('/bin/sh', '-c',
-        'ln -s libpal.so "$MESON_INSTALL_DESTDIR_PREFIX"/@0@'.format(
+        'ln -sf libpal.so "$MESON_INSTALL_DESTDIR_PREFIX"/@0@'.format(
             join_paths(pkglibdir, 'direct', 'loader')))
 
     hostpalpath_direct = join_paths(prefix, pkglibdir, 'direct')
@@ -45,7 +45,7 @@ if sgx
         strip_directory: true)
 
     meson.add_install_script('/bin/sh', '-c',
-        'ln -s pal-sgx "$MESON_INSTALL_DESTDIR_PREFIX"/@0@'.format(
+        'ln -sf pal-sgx "$MESON_INSTALL_DESTDIR_PREFIX"/@0@'.format(
             join_paths(pkglibdir, 'sgx', 'loader')))
 
     hostpalpath_linux_sgx = join_paths(prefix, pkglibdir, 'sgx')


### PR DESCRIPTION

## Description of the changes <!-- (reasons and measures) -->

```
Running custom install script '/bin/sh -c ln -s libpal.so "$MESON_INSTALL_DESTDIR_PREFIX"/lib/x86_64-linux-gnu/graphene/direct/loader'
ln: failed to create symbolic link '/usr/local/lib/x86_64-linux-gnu/graphene/direct/loader': File exists
FAILED: meson-install
```

## How to test this PR? <!-- (if applicable) -->

```sh
make && make SGX=1 ISGX_DRIVER_PATH=...
meson build --prefix=... -Ddirect=enabled -Dsgx=enabled
ninja -C build
ninja -C build install
ninja -C build install # second install should not fail
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2349)
<!-- Reviewable:end -->
