### PR TITLE
[meson] Detect corner case of Python's platlib path

### DIFF
--- a/.ci/lib/config.jenkinsfile
+++ b/.ci/lib/config.jenkinsfile
@@ -1,10 +1,7 @@
 env.WERROR = '1'
 env.MAKEOPTS = '-j8'
 
-python_platlib = sh(returnStdout: true, script: '''python3 -c "
-import os, sysconfig
-print(sysconfig.get_path('platlib', vars={'platbase': os.environ['PREFIX']}))
-"''').trim()
+python_platlib = sh(returnStdout: true, script: 'python3 Scripts/get-python-platlib.py "$PREFIX"')
 env.PYTHONPATH = python_platlib + ':' + env.WORKSPACE + '/Scripts'
 
 env.RA_TLS_ALLOW_OUTDATED_TCB_INSECURE = '1'

--- a/.pylintrc
+++ b/.pylintrc
@@ -229,7 +229,7 @@ spelling-store-unknown-words=no
 expected-line-ending-format=LF
 
 # Regexp for a line that is allowed to be longer than the limit.
-ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+ignore-long-lines=^\s*(# )?(- )?<?https?://\S+>?$
 
 # Number of spaces of indent required inside a hanging or continued line.
 indent-after-paren=4

--- a/Scripts/get-python-platlib.py
+++ b/Scripts/get-python-platlib.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-3.0-or-later
+# Copyright (c) 2021 Intel Corporation
+#                    Wojtek Porczyk <woju@invisiblethingslab.com>
+#
+
+'''
+Statement of the problem
+========================
+
+Debian. The problem is Debian.
+
+No, for real
+------------
+
+The problem is that Debian (and by induction, Ubuntu), change the install paths,
+and also ``sys.path`` using ``site`` module.
+
+Things that don't work
+----------------------
+
+- ``sysconfig`` - Debian doesn't touch this, so it returns wrong values
+- ``import('python')`` or ``import('python3')`` in Meson - uses ``sysconfig``
+  python module, so doesn't work for exactly the same reason
+- ``distutils.sysconfig`` - haha no, but close: it has only major python version
+  in path, but ``sys.path`` has ``major.minor``
+- some functions from ``site`` - should work, right? isn't it the place where
+  this change happens? not even close, you'd be condemned to sift through lists
+  with traps like `/usr/local/local/*`
+
+Solution
+========
+
+``distutils.command.install.INSTALL_SCHEMES`` and detection of corner case.
+
+Things that can/will bite us, now or in the future
+--------------------------------------------------
+
+- ``site`` gates adding to path on ``os.path.exists``, so when reproducing, make
+  sure to ``mkdir -p`` all suspected paths; that's also why we can't ``assert``
+  that result is in ``sys.path``.
+- PEP-632 deprecates ``distutils`` package (3.10-3.11 ``DeprecationWarning``,
+  not installed in 3.12).
+
+References
+==========
+
+- https://www.python.org/dev/peps/pep-0632/
+- https://discuss.python.org/t/pep-632-deprecate-distutils-module/5134/122
+  - https://salsa.debian.org/cpython-team/python3-stdlib/blob/master/debian/patches/3.8/distutils-install-layout.diff
+  - https://github.com/fedora-python/cpython/commit/acba1a24b6ad5b894b4d6ef3223c2d174e225d21
+- https://fedoraproject.org/wiki/Changes/Making_sudo_pip_safe
+'''
+
+import argparse
+import distutils.command.install
+import distutils.sysconfig
+import distutils.util
+import pathlib
+import sys
+
+
+def get_platlib(prefix):
+    is_debian = 'deb_system' in distutils.command.install.INSTALL_SCHEMES
+
+    # this takes care of `/` at the end, though not `/usr/../usr/local`
+    is_usr_local = pathlib.PurePosixPath(prefix).as_posix() == '/usr/local'
+
+    if is_debian and is_usr_local:
+        # we have to compensate for Debian
+        return distutils.util.subst_vars(
+            distutils.command.install.INSTALL_SCHEMES['unix_local']['platlib'],
+            {
+                'platbase': '/usr',
+                'py_version_short': '.'.join(map(str, sys.version_info[:2])),
+            })
+
+    return distutils.sysconfig.get_python_lib(plat_specific=True, prefix=prefix)
+
+
+argparser = argparse.ArgumentParser()
+argparser.add_argument('prefix')
+
+def main(args=None):
+    args = argparser.parse_args(args)
+    print(get_platlib(args.prefix), end='')
+
+if __name__ == '__main__':
+    main()

--- a/Scripts/meson.build
+++ b/Scripts/meson.build
@@ -1,0 +1,6 @@
+foreach script : [
+    'get-python-platlib.py',
+]
+    set_variable('@0@_prog'.format(script.split('.')[0].underscorify()),
+        find_program(script))
+endforeach

--- a/meson.build
+++ b/meson.build
@@ -27,6 +27,8 @@ sgx = get_option('sgx') == 'enabled'
 python3mod = import('python3')
 python3 = python3mod.find_python()
 
+subdir('Scripts')
+
 subdir('LibOS')
 subdir('Runtime')
 subdir('python')

--- a/python/graphenelibos/meson.build
+++ b/python/graphenelibos/meson.build
@@ -9,7 +9,9 @@ init_py = configure_file(
     configuration: conf,
 )
 
-python3_pkgdir = join_paths(python3mod.sysconfig_path('platlib'), 'graphenelibos')
+python3_platlib = run_command(
+    python3, get_python_platlib_prog, get_option('prefix')).stdout()
+python3_pkgdir = join_paths(python3_platlib, 'graphenelibos')
 
 install_data([
     init_py,


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://graphene.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

See docstring in the committed script.

## How to test this PR? <!-- (if applicable) -->

1. Install graphene using default `--prefix` of `/usr/local` (i.e., don't specify `--prefix` at all) on different distros. `graphene-manifest` should work without munging neither `$PATH` nor `$PYTHONPATH`.
2. Install graphene using `--prefix=/usr`. Also should work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2353)
<!-- Reviewable:end -->
