### PR TITLE
[Pal/Linux-SGX] Do not include `api.h` in stdlib builds of Protected FS

### DIFF
--- a/Pal/src/host/Linux-SGX/protected-files/protected_files.c
+++ b/Pal/src/host/Linux-SGX/protected-files/protected_files.c
@@ -188,6 +188,9 @@ static pf_context_t* ipf_open(const char* path, pf_file_mode_t mode, bool create
     // for new file, this value will later be saved in the meta data plain part (init_new_file)
     // for existing file, we will later compare this value with the value from the file
     // (init_existing_file)
+    static_assert(__builtin_types_compatible_p(__typeof__(pf->user_kdk_key), __typeof__(*kdk_key)),
+                  "nonmatching kdk key types");
+    static_assert(sizeof(pf->user_kdk_key) == sizeof(*kdk_key), "nonmatching kdk key sizes");
     memcpy(pf->user_kdk_key, *kdk_key, sizeof(pf->user_kdk_key));
 
     // omeg: we require a canonical full path to file, so no stripping path to filename only

--- a/Pal/src/host/Linux-SGX/protected-files/protected_files.h
+++ b/Pal/src/host/Linux-SGX/protected-files/protected_files.h
@@ -13,6 +13,16 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#ifndef MIN
+#define MIN(a, b)               \
+    ({                          \
+        __typeof__(a) _a = (a); \
+        __typeof__(b) _b = (b); \
+        _a < _b ? _a : _b;      \
+    })
+#endif
+
+
 /*! Size of the AES-GCM encryption key */
 #define PF_KEY_SIZE 16
 

--- a/Pal/src/host/Linux-SGX/protected-files/protected_files_format.h
+++ b/Pal/src/host/Linux-SGX/protected-files/protected_files_format.h
@@ -133,7 +133,12 @@ typedef struct {
     uint32_t output_len; // in bits
 } kdf_input_t;
 
+static_assert(__builtin_types_compatible_p(__typeof__(((kdf_input_t*)0)->nonce),
+                                           __typeof__(((metadata_plain_t*)0)->metadata_key_id)),
+              "nonmatching struct fields' types");
+static_assert(sizeof(((kdf_input_t*)0)->nonce) == sizeof(((metadata_plain_t*)0)->metadata_key_id),
+              "nonmatching struct fields");
+
 #pragma pack(pop)
 
 #endif /* PROTECTED_FILES_FORMAT_H_ */
-

--- a/Pal/src/host/Linux-SGX/tools/common/pf_util.c
+++ b/Pal/src/host/Linux-SGX/tools/common/pf_util.c
@@ -20,8 +20,6 @@
 #include <sys/types.h>
 #include <unistd.h>
 
-#define USE_STDLIB
-#include "api.h"
 #include "perm.h"
 #include "util.h"
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Some files that implement Protected FS feature are built both in Graphene mode (without stdlib, instead using a subset of stdlib
functions provided in Graphene-internal `api.h`) and in normal stdlib mode. If stdlib headers and the `api.h` header are included together, this may lead to mismatches in function declarations, e.g., in `string.h` functions.

This PR fixes Protected-FS files to always use either `api.h` or stdlib `string.h` header but not two simultaneously.

## How to test this PR? <!-- (if applicable) -->

All tests (especially `make pf-test`) must pass.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2357)
<!-- Reviewable:end -->
