### PR TITLE
[Pal/Linux-SGX] Improve info and error messages in Protected Files

### DIFF
--- a/Pal/src/host/Linux-SGX/db_files.c
+++ b/Pal/src/host/Linux-SGX/db_files.c
@@ -164,7 +164,7 @@ static int64_t pf_file_read(struct protected_file* pf, PAL_HANDLE handle, uint64
     pf_status_t pfs = pf_read(pf->context, offset, count, buffer, &bytes_read);
 
     if (PF_FAILURE(pfs)) {
-        log_error("pf_file_read(PF fd %d): pf_read failed: %d\n", fd, pfs);
+        log_error("pf_file_read(PF fd %d): pf_read failed: %s\n", fd, pf_strerror(pfs));
         return -PAL_ERROR_DENIED;
     }
 
@@ -224,7 +224,7 @@ static int64_t pf_file_write(struct protected_file* pf, PAL_HANDLE handle, uint6
     pf_status_t pf_ret = pf_write(pf->context, offset, count, buffer);
 
     if (PF_FAILURE(pf_ret)) {
-        log_error("pf_file_write(PF fd %d): pf_write failed: %d\n", fd, pf_ret);
+        log_error("pf_file_write(PF fd %d): pf_write failed: %s\n", fd, pf_strerror(pf_ret));
         return -PAL_ERROR_DENIED;
     }
 
@@ -386,7 +386,7 @@ static int pf_file_map(struct protected_file* pf, PAL_HANDLE handle, void** addr
             pf_ret = PF_STATUS_CORRUPTED;
         }
         if (PF_FAILURE(pf_ret)) {
-            log_error("pf_file_map(PF fd %d): pf_read failed: %d\n", fd, pf_ret);
+            log_error("pf_file_map(PF fd %d): pf_read failed: %s\n", fd, pf_strerror(pf_ret));
             ret = -PAL_ERROR_DENIED;
             goto out;
         }
@@ -517,8 +517,8 @@ static int64_t pf_file_setlength(struct protected_file* pf, PAL_HANDLE handle, u
 
     pf_status_t pfs = pf_set_size(pf->context, length);
     if (PF_FAILURE(pfs)) {
-        log_error("pf_file_setlength(PF fd %d, %lu): pf_set_size returned %d\n", fd, length,
-                  pfs);
+        log_error("pf_file_setlength(PF fd %d, %lu): pf_set_size returned %s\n", fd, length,
+                  pf_strerror(pfs));
         return -PAL_ERROR_DENIED;
     }
     return length;
@@ -545,12 +545,12 @@ static int file_flush(PAL_HANDLE handle) {
     if (pf) {
         int ret = flush_pf_maps(pf, /*buffer=*/NULL, /*remove=*/false);
         if (ret < 0) {
-            log_error("file_flush(PF fd %d): flush_pf_maps returned %d\n", fd, ret);
+            log_error("file_flush(PF fd %d): flush_pf_maps returned %s\n", fd, pal_strerror(ret));
             return ret;
         }
         pf_status_t pfs = pf_flush(pf->context);
         if (PF_FAILURE(pfs)) {
-            log_error("file_flush(PF fd %d): pf_flush returned %d\n", fd, pfs);
+            log_error("file_flush(PF fd %d): pf_flush returned %s\n", fd, pf_strerror(pfs));
             return -PAL_ERROR_DENIED;
         }
     } else {

--- a/Pal/src/host/Linux-SGX/enclave_pf.c
+++ b/Pal/src/host/Linux-SGX/enclave_pf.c
@@ -521,7 +521,7 @@ static int open_protected_file(const char* path, struct protected_file* pf, pf_h
     pf_status_t pfs;
     pfs = pf_open(handle, path, size, mode, create, &g_pf_wrap_key, &pf->context);
     if (PF_FAILURE(pfs)) {
-        log_error("pf_open(%d, %s) failed: %d\n", *(int*)handle, path, pfs);
+        log_error("pf_open(%d, %s) failed: %s\n", *(int*)handle, path, pf_strerror(pfs));
         return -PAL_ERROR_DENIED;
     }
     return 0;
@@ -585,7 +585,7 @@ int flush_pf_maps(struct protected_file* pf, void* buffer, bool remove) {
         if (map_size > 0) {
             pfs = pf_write(map_pf->context, map->offset, map_size, map->buffer);
             if (PF_FAILURE(pfs)) {
-                log_error("flush_pf_maps: pf_write failed: %d\n", pfs);
+                log_error("flush_pf_maps: pf_write failed: %s\n", pf_strerror(pfs));
                 pf_unlock();
                 return -PAL_ERROR_INVAL;
             }
@@ -609,7 +609,7 @@ int unload_protected_file(struct protected_file* pf) {
         return ret;
     pf_status_t pfs = pf_close(pf->context);
     if (PF_FAILURE(pfs)) {
-        log_error("unload_protected_file(%p) failed: %d\n", pf, pfs);
+        log_error("unload_protected_file(%p) failed: %s\n", pf, pf_strerror(pfs));
     }
 
     pf->context = NULL;

--- a/Pal/src/host/Linux-SGX/protected-files/protected_files.h
+++ b/Pal/src/host/Linux-SGX/protected-files/protected_files.h
@@ -171,6 +171,14 @@ typedef struct pf_context pf_context_t;
 /* Public API */
 
 /*!
+ * \brief Convert error code to error message
+ *
+ * \param [in] err Error code
+ * \return Error message
+ */
+const char* pf_strerror(int err);
+
+/*!
  * \brief Open a protected file
  *
  * \param [in] handle Open underlying file handle

--- a/Pal/src/host/Linux-SGX/tools/pf_crypt/pf_crypt.c
+++ b/Pal/src/host/Linux-SGX/tools/pf_crypt/pf_crypt.c
@@ -40,6 +40,10 @@ static void usage(void) {
     INFO("  --output, -o PATH       Single file or directory to write output files to\n");
     INFO("  --wrap-key, -w PATH     Path to wrap key file, must exist\n");
     INFO("  --verify, -V            (optional) Verify that input path matches PF's allowed paths\n");
+    INFO("\n");
+    INFO("NOTE: Files encrypted using the 'encrypt' mode embed the output path string, exactly\n");
+    INFO("      as specified in '-o PATH'. Therefore, the Graphene manifest must specify this\n");
+    INFO("      exact path in sgx.protected_files.xyz = \"PATH\".\n");
 }
 
 int main(int argc, char* argv[]) {


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

The `pf_crypt` utility now highlights that the encrypted-file path must be specified exactly in the Graphene manifest (otherwise there will be a mismatch in the metadata header of the encrypted file: the embedded relative path will not match the `sgx.protected_files` path). Also, error messages are printed now instead of raw error codes.

## How to test this PR? <!-- (if applicable) -->

All tests must pass, only cosmetic changes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2362)
<!-- Reviewable:end -->
