### PR TITLE
[meson] Move clang-format from make

### DIFF
--- a/Documentation/devel/coding-style.rst
+++ b/Documentation/devel/coding-style.rst
@@ -16,11 +16,11 @@ setup it this way:
 
    sudo apt-get install clang-format
 
-Usage: (assuming you're in the project's top directory)
+Usage: (assuming you've configured your build into ``build`` directory)
 
 .. code-block:: sh
 
-   make format
+   ninja -C build clang-format
 
 This :command:`make` target **reformats all source files in-place**, so we
 recommend you first commit them (or add to `git index

--- a/LibOS/Makefile
+++ b/LibOS/Makefile
@@ -216,10 +216,6 @@ clean:
 distclean: clean
 endif
 
-.PHONY: format
-format:
-	$(MAKE) -C $(SHIM_DIR) format
-
 .PHONY: test
 test:
 	$(MAKE) -C $(SHIM_DIR) test

--- a/LibOS/shim/Makefile
+++ b/LibOS/shim/Makefile
@@ -19,7 +19,3 @@ clean_targets = clean distclean
 $(clean_targets):
 	$(MAKE) -C src $@
 	$(MAKE) -C test $@
-
-.PHONY: format
-format:
-	clang-format -i $(shell find . -path ./test/ltp -prune -o \( -name '*.h' -o -name '*.c' \) -print)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 include Scripts/Makefile.configs
 
-targets = all clean format test sgx-tokens distclean
+targets = all clean test sgx-tokens distclean
 
 ifneq ($(filter sgx-tokens,$(MAKECMDGOALS)),)
 ifneq ($(SGX),1)

--- a/Pal/Makefile
+++ b/Pal/Makefile
@@ -22,14 +22,5 @@ test:
 sgx-tokens:
 	$(MAKE) -C regression sgx-tokens
 
-.PHONY: format
-format:
-	clang-format -i $(shell find . -path ./lib/crypto/mbedtls -prune -o \
-	                               -path ./src/host/Linux-SGX/tools/common/cJSON.c -prune -o \
-	                               -path ./src/host/Linux-SGX/tools/common/cJSON.h -prune -o \
-	                               -path ./src/host/Linux-SGX/tools/common/cJSON-*/cJSON.c -prune -o \
-	                               -path ./src/host/Linux-SGX/tools/common/cJSON-*/cJSON.h -prune -o \
-	                               \( -name '*.h' -o -name '*.c' \) -print)
-
 .PHONY: distclean
 distclean: clean

--- a/Runtime/Makefile
+++ b/Runtime/Makefile
@@ -8,9 +8,6 @@ clean:
 .PHONY: distclean
 distclean: clean
 
-.PHONY: format
-format:
-
 .PHONY: test
 test:
 

--- a/Scripts/Makefile
+++ b/Scripts/Makefile
@@ -8,9 +8,6 @@ clean:
 .PHONY: distclean
 distclean: clean
 
-.PHONY: format
-format: ;
-
 .PHONY: test
 test: ;
 

--- a/Scripts/meson-clang-format.sh
+++ b/Scripts/meson-clang-format.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+set -e
+
+if test x"$1" = x-d
+then
+    # debug mode: just print, and developer is responsible for running in source root
+    FINDACTION="-print"
+else
+    test -n "$MESON_SOURCE_ROOT"
+    cd "$MESON_SOURCE_ROOT"
+    FINDACTION="-exec clang-format -i {} +"
+fi
+
+find Pal LibOS Tools \
+    -path Pal/lib/crypto/mbedtls -prune -o \
+    -path Pal/src/host/Linux-SGX/tools/common/cJSON.c -prune -o \
+    -path Pal/src/host/Linux-SGX/tools/common/cJSON.h -prune -o \
+    -path Pal/src/host/Linux-SGX/tools/common/cJSON-\*/cJSON.c -prune -o \
+    -path Pal/src/host/Linux-SGX/tools/common/cJSON-\*/cJSON.h -prune -o \
+    -path LibOS/shim/test/ltp -prune -o \
+    -path LibOS/glibc\* -prune -o \
+    \( -name \*.c -o -name \*.h \) \
+    $FINDACTION

--- a/Scripts/meson.build
+++ b/Scripts/meson.build
@@ -1,5 +1,6 @@
 foreach script : [
     'get-python-platlib.py',
+    'meson-clang-format.sh',
 ]
     set_variable('@0@_prog'.format(script.split('.')[0].underscorify()),
         find_program(script))

--- a/Tools/Makefile
+++ b/Tools/Makefile
@@ -7,10 +7,6 @@ all: argv_serializer
 .PHONY: test sgx-tokens
 test sgx-tokens:
 
-.PHONY: format
-format:
-	clang-format -i $(shell find . \( -name '*.h' -o -name '*.c' \) -print)
-
 %: %.c
 	$(call cmd,csingle)
 

--- a/meson.build
+++ b/meson.build
@@ -32,3 +32,5 @@ subdir('Scripts')
 subdir('LibOS')
 subdir('Runtime')
 subdir('python')
+
+run_target('clang-format', command: [meson_clang_format_prog])


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

This is another thing to move from make to meson.

## How to test this PR? <!-- (if applicable) -->

Follow the new new reformat procedure, according to the change in documentation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2373)
<!-- Reviewable:end -->
