### PR TITLE
[LibOS] Remove `shim_dentry.ino`

### DIFF
--- a/LibOS/shim/include/shim_fs.h
+++ b/LibOS/shim/include/shim_fs.h
@@ -57,7 +57,7 @@ struct shim_fs_ops {
     /* Returns 0 on success, -errno on error */
     int (*truncate)(struct shim_handle* hdl, off_t len);
 
-    /* hstat: get status of the file */
+    /* hstat: get status of the file; `st_ino` will be taken from dentry, if there's one */
     int (*hstat)(struct shim_handle* hdl, struct stat* buf);
 
     /* setflags: set flags of the file */
@@ -101,7 +101,6 @@ struct shim_fs_ops {
 //#define DENTRY_REACHABLE    0x0400  /* permission checked to be reachable */
 //#define DENTRY_UNREACHABLE  0x0800  /* permission checked to be unreachable */
 #define DENTRY_LISTED      0x1000 /* children in directory listed */
-#define DENTRY_INO_UPDATED 0x2000 /* ino updated */
 #define DENTRY_SYNTHETIC   0x4000 /* Auto-generated dentry to connect a mount point in the        \
                                    * manifest to the root, when one or more intermediate          \
                                    * directories do not exist on the underlying FS. The semantics \
@@ -129,7 +128,6 @@ struct shim_dentry {
 
     struct shim_mount* mounted;
     void* data;
-    unsigned long ino;
     mode_t type;
     mode_t mode;
 
@@ -166,7 +164,7 @@ struct shim_d_ops {
     /* create a directory inside a directory */
     int (*mkdir)(struct shim_dentry* dir, struct shim_dentry* dent, mode_t mode);
 
-    /* stat: get status of the file */
+    /* stat: get status of the file; `st_ino` will be taken from dentry */
     int (*stat)(struct shim_dentry* dent, struct stat* buf);
 
     /* extracts the symlink name and saves in link */
@@ -536,6 +534,8 @@ int dentry_abs_path_into_qstr(struct shim_dentry* dent, struct shim_qstr* str);
 static inline const char* dentry_get_name(struct shim_dentry* dent) {
     return qstrgetstr(&dent->name);
 }
+
+ino_t dentry_ino(struct shim_dentry* dent);
 
 /*!
  * \brief Allocate and initialize a new dentry

--- a/LibOS/shim/include/shim_handle.h
+++ b/LibOS/shim/include/shim_handle.h
@@ -199,7 +199,6 @@ struct shim_sock_handle {
 
 struct shim_dirent {
     struct shim_dirent* next;
-    unsigned long ino; /* Inode number */
     unsigned char type;
     char name[]; /* File name (null-terminated) */
 };

--- a/LibOS/shim/src/fs/dev/attestation.c
+++ b/LibOS/shim/src/fs/dev/attestation.c
@@ -70,7 +70,6 @@ static int dev_attestation_readonly_stat(const char* name, struct stat* buf) {
     __UNUSED(name);
     memset(buf, 0, sizeof(*buf));
     buf->st_dev  = 1; /* dummy ID of device containing file */
-    buf->st_ino  = 1; /* dummy inode number */
     buf->st_mode = FILE_R_MODE | S_IFREG;
     return 0;
 }
@@ -79,7 +78,6 @@ static int dev_attestation_readwrite_stat(const char* name, struct stat* buf) {
     __UNUSED(name);
     memset(buf, 0, sizeof(*buf));
     buf->st_dev  = 1; /* dummy ID of device containing file */
-    buf->st_ino  = 1; /* dummy inode number */
     buf->st_mode = FILE_RW_MODE | S_IFREG;
     return 0;
 }

--- a/LibOS/shim/src/fs/proc/info.c
+++ b/LibOS/shim/src/fs/proc/info.c
@@ -20,7 +20,6 @@ static int proc_info_stat(const char* name, struct stat* buf) {
     __UNUSED(name);
     memset(buf, 0, sizeof(struct stat));
     buf->st_dev  = 1; /* dummy ID of device containing file */
-    buf->st_ino  = 1; /* dummy inode number */
     buf->st_mode = FILE_R_MODE | S_IFREG;
     return 0;
 }

--- a/LibOS/shim/src/fs/proc/ipc-thread.c
+++ b/LibOS/shim/src/fs/proc/ipc-thread.c
@@ -243,11 +243,11 @@ static int proc_ipc_thread_dir_stat(const char* name, struct stat* buf) {
         for (size_t i = 0; i < pid_status_cache->nstatus; i++)
             if (pid_status_cache->status[i].pid == pid) {
                 memset(buf, 0, sizeof(struct stat));
-                buf->st_dev = buf->st_ino = 1;
-                buf->st_mode              = PERM_r_x______ | S_IFDIR;
-                buf->st_uid               = 0; /* XXX */
-                buf->st_gid               = 0; /* XXX */
-                buf->st_size              = 4096;
+                buf->st_dev  = 1;
+                buf->st_mode = PERM_r_x______ | S_IFDIR;
+                buf->st_uid  = 0; /* XXX */
+                buf->st_gid  = 0; /* XXX */
+                buf->st_size = 4096;
                 unlock(&status_lock);
                 return 0;
             }
@@ -328,7 +328,6 @@ static int proc_list_ipc_thread(const char* name, struct shim_dirent** buf, size
         }
 
         ptr->next      = (void*)(ptr + 1) + l + 1;
-        ptr->ino       = 1;
         ptr->type      = LINUX_DT_DIR;
         ptr->name[l--] = 0;
         for (p = pid; p; p /= 10) {

--- a/LibOS/shim/src/fs/proc/thread.c
+++ b/LibOS/shim/src/fs/proc/thread.c
@@ -176,11 +176,11 @@ static int proc_thread_link_stat(const char* name, struct stat* buf) {
     __UNUSED(name);
     memset(buf, 0, sizeof(*buf));
 
-    buf->st_dev = buf->st_ino = 1;
-    buf->st_mode              = PERM_r________ | S_IFLNK;
-    buf->st_uid               = 0;
-    buf->st_gid               = 0;
-    buf->st_size              = 0;
+    buf->st_dev  = 1;
+    buf->st_mode = PERM_r________ | S_IFLNK;
+    buf->st_uid  = 0;
+    buf->st_gid  = 0;
+    buf->st_size = 0;
 
     return 0;
 }
@@ -292,7 +292,6 @@ static int proc_list_thread_each_fd(const char* name, struct shim_dirent** buf, 
             }
 
             dirent->next      = (void*)(dirent + 1) + l + 1;
-            dirent->ino       = 1;
             dirent->type      = LINUX_DT_LNK;
             dirent->name[0]   = '0';
             dirent->name[l--] = 0;
@@ -502,7 +501,7 @@ static int proc_thread_maps_open(struct shim_handle* hdl, const char* name, int 
     retry_emit_vma:
         if (vma->file) {
             int dev_major = 0, dev_minor = 0;
-            unsigned long ino = vma->file->dentry ? vma->file->dentry->ino : 0;
+            unsigned long ino = vma->file->dentry ? dentry_ino(vma->file->dentry) : 0;
             char* path = NULL;
 
             if (vma->file->dentry)
@@ -578,11 +577,11 @@ static int proc_thread_maps_stat(const char* name, struct stat* buf) {
     __UNUSED(name);
     memset(buf, 0, sizeof(struct stat));
 
-    buf->st_dev = buf->st_ino = 1;
-    buf->st_mode              = PERM_r________ | S_IFREG;
-    buf->st_uid               = 0;
-    buf->st_gid               = 0;
-    buf->st_size              = 0;
+    buf->st_dev  = 1;
+    buf->st_mode = PERM_r________ | S_IFREG;
+    buf->st_uid  = 0;
+    buf->st_gid  = 0;
+    buf->st_size = 0;
 
     return 0;
 }
@@ -642,11 +641,11 @@ static int proc_thread_cmdline_stat(const char* name, struct stat* buf) {
     __UNUSED(name);
     memset(buf, 0, sizeof(*buf));
 
-    buf->st_dev = buf->st_ino = 1;
-    buf->st_mode              = PERM_r________ | S_IFREG;
-    buf->st_uid               = 0;
-    buf->st_gid               = 0;
-    buf->st_size              = 0;
+    buf->st_dev  = 1;
+    buf->st_mode = PERM_r________ | S_IFREG;
+    buf->st_uid  = 0;
+    buf->st_gid  = 0;
+    buf->st_size = 0;
 
     return 0;
 }
@@ -696,8 +695,8 @@ static int proc_thread_dir_stat(const char* name, struct stat* buf) {
         return -ENOENT;
 
     memset(buf, 0, sizeof(struct stat));
-    buf->st_dev = buf->st_ino = 1;
-    buf->st_mode              = PERM_r_x______ | S_IFDIR;
+    buf->st_dev = 1;
+    buf->st_mode = PERM_r_x______ | S_IFDIR;
     lock(&thread->lock);
     buf->st_uid = thread->uid;
     buf->st_gid = thread->gid;
@@ -752,7 +751,6 @@ static int walk_cb(struct shim_thread* thread, void* arg) {
     struct shim_dirent* buf = args->buf;
 
     buf->next      = (void*)(buf + 1) + buflen;
-    buf->ino       = 1;
     buf->type      = LINUX_DT_DIR;
     buf->name[l--] = 0;
     for (p = pid; p; p /= 10) {

--- a/LibOS/shim/src/fs/shim_dcache.c
+++ b/LibOS/shim/src/fs/shim_dcache.c
@@ -244,6 +244,10 @@ bool dentry_is_ancestor(struct shim_dentry* anc, struct shim_dentry* dent) {
     return false;
 }
 
+ino_t dentry_ino(struct shim_dentry* dent) {
+    return hash_abs_path(dent);
+}
+
 static size_t dentry_path_size(struct shim_dentry* dent, bool relative) {
     /* The following code should mirror `dentry_path_into_buf`. */
 
@@ -374,7 +378,6 @@ static void dump_dentry(struct shim_dentry* dent, unsigned int level) {
 
     DUMP_FLAG(DENTRY_VALID, "V", ".");
     DUMP_FLAG(DENTRY_LISTED, "L", ".");
-    DUMP_FLAG(DENTRY_INO_UPDATED, "I", ".");
     DUMP_FLAG(DENTRY_SYNTHETIC, "S", ".");
     buf_printf(&buf, "%3d] ", (int)REF_GET(dent->ref_count));
 

--- a/LibOS/shim/src/fs/shim_namei.c
+++ b/LibOS/shim/src/fs/shim_namei.c
@@ -642,12 +642,9 @@ int list_directory_dentry(struct shim_dentry* dent) {
         }
 
         set_dirent_type(&child->type, d->type);
-        child->ino = d->ino;
         put_dentry(child);
     }
 
-    /* Once DENTRY_LISTED is set, the ino of the newly created file will not be updated, so its
-     * ino needs to be set in create() or open(O_CREAT). */
     dent->state |= DENTRY_LISTED;
     ret = 0;
 

--- a/LibOS/shim/src/fs/sys/fs.c
+++ b/LibOS/shim/src/fs/sys/fs.c
@@ -134,7 +134,6 @@ int sys_list_resource_num(const char* pathname, struct shim_dirent** buf, size_t
 
         memcpy(dirent_in_buf->name, ent_name, name_size);
         dirent_in_buf->next = (void*)dirent_in_buf + dirent_size;
-        dirent_in_buf->ino  = 1;
         dirent_in_buf->type = LINUX_DT_DIR;
         dirent_in_buf = dirent_in_buf->next;
     }
@@ -153,7 +152,6 @@ int sys_info_stat(const char* name, struct stat* buf) {
     __UNUSED(name);
     memset(buf, 0, sizeof(*buf));
     buf->st_dev  = 1;    /* dummy ID of device containing file */
-    buf->st_ino  = 1;    /* dummy inode number */
     buf->st_mode = FILE_R_MODE | S_IFREG;
     return 0;
 }

--- a/LibOS/shim/src/sys/shim_open.c
+++ b/LibOS/shim/src/sys/shim_open.c
@@ -344,7 +344,7 @@ long shim_do_getdents(int fd, struct linux_dirent* buf, size_t count) {
                                                                                          \
         struct linux_dirent_tail* bt = (void*)b + DIRENT_SIZE(len) - sizeof(*bt);        \
                                                                                          \
-        b->d_ino    = (dent)->ino;                                                       \
+        b->d_ino    = dentry_ino(dent);                                                  \
         b->d_off    = ++dirhdl->offset;                                                  \
         b->d_reclen = DIRENT_SIZE(len);                                                  \
                                                                                          \
@@ -445,7 +445,7 @@ long shim_do_getdents64(int fd, struct linux_dirent64* buf, size_t count) {
         if (bytes + DIRENT_SIZE(len) > count) \
             goto done;                        \
                                               \
-        b->d_ino    = (dent)->ino;            \
+        b->d_ino    = dentry_ino(dent);       \
         b->d_off    = ++dirhdl->offset;       \
         b->d_reclen = DIRENT_SIZE(len);       \
         b->d_type   = (type);                 \


### PR DESCRIPTION
This change is in preparation for bigger refactoring: simplifying directory handles, `getdents` and `getdents64`.

This commit removes the `shim_dentry.ino` field, and replaces it with a function computing the dentry hash (which is what we usually did anyway).

This is to simplify the code (the inode number was computed in several places: `readdir`, `stat`, `hstat`), and to ensure that the inode number is always available for a dentry.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2374)
<!-- Reviewable:end -->
