### PR TITLE
Fix filesystem and unskip tests

### DIFF
--- a/.ci/lib/stage-test.jenkinsfile
+++ b/.ci/lib/stage-test.jenkinsfile
@@ -55,9 +55,7 @@ stage('test') {
                 then
                     make ${MAKEOPTS} sgx-tokens
                 fi
-                make test
-                # TODO: after resolving deps problem (or rewriting makefiles):
-#               python3 -m pytest -v --junit-xml fs.xml test_fs.py test_tmpfs.py test_pf.py
+                python3 -m pytest -v --junit-xml fs.xml test_fs.py test_tmpfs.py test_pf.py
             '''
         } finally {
             junit 'LibOS/shim/test/fs/*.xml'

--- a/LibOS/shim/src/fs/chroot/fs.c
+++ b/LibOS/shim/src/fs/chroot/fs.c
@@ -184,6 +184,7 @@ static int create_data(struct shim_dentry* dent, const char* uri, size_t len) {
     assert(mdata);
     data->type = (dent->state & DENTRY_ISDIRECTORY) ? FILE_DIR : mdata->base_type;
     data->mode = NO_MODE;
+    data->queried = false;
 
     if (uri) {
         qstrsetstr(&data->host_uri, uri, len);
@@ -985,6 +986,7 @@ static int chroot_unlink(struct shim_dentry* dir, struct shim_dentry* dent) {
 
     dent->mode = NO_MODE;
     data->mode = 0;
+    data->queried = false;
 
     __atomic_add_fetch(&data->version.counter, 1, __ATOMIC_SEQ_CST);
     __atomic_store_n(&data->size.counter, 0, __ATOMIC_SEQ_CST);
@@ -1062,6 +1064,7 @@ static int chroot_rename(struct shim_dentry* old, struct shim_dentry* new) {
     new->mode = new_data->mode = old_data->mode;
     old->mode = NO_MODE;
     old_data->mode = 0;
+    old_data->queried = false;
 
     new->type = old->type;
 

--- a/LibOS/shim/test/fs/Makefile
+++ b/LibOS/shim/test/fs/Makefile
@@ -21,13 +21,13 @@ execs = \
 	stat \
 	truncate
 
-manifests = $(addsuffix .manifest,$(execs))
+all_manifests = $(addsuffix .manifest,$(execs))
 
 exec_target = $(execs)
 
 target = \
 	$(exec_target) \
-	$(manifests)
+	$(all_manifests)
 
 clean-extra += clean-tmp
 
@@ -85,5 +85,5 @@ pf-test.xml: test_pf.py $(call expand_target_to_token,$(target))
 
 .PHONY: clean-tmp
 clean-tmp:
-	$(RM) -r *.tmp *.cached $(manifests) *.manifest.sgx *~ *.sig *.token *.o \
+	$(RM) -r *.tmp *.cached $(all_manifests) *.manifest.sgx *~ *.sig *.token *.o \
 	         __pycache__ .pytest_cache .cache *.xml bin lib

--- a/Scripts/regression.py
+++ b/Scripts/regression.py
@@ -73,9 +73,9 @@ class RegressionTestCase(unittest.TestCase):
             else self.DEFAULT_TIMEOUT)
 
         if not self.loader_path.exists():
-            self.skipTest('loader ({}) not found'.format(self.loader_path))
+            self.fail('loader ({}) not found'.format(self.loader_path))
         if not self.libpal_path.exists():
-            self.skipTest('libpal ({}) not found'.format(self.libpal_path))
+            self.fail('libpal ({}) not found'.format(self.libpal_path))
 
         if prefix is None:
             prefix = []


### PR DESCRIPTION
Due to an unfortunate accident, the FS tests `LibOS/shim/test/fs` are silently skipped on Jenkins, and filesystem refactor (#2333) got merged with some bugs. This branch fixes these bugs and un-skips the tests.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2377)
<!-- Reviewable:end -->
