### PR TITLE
Ensure dentry type and permissions are always stored

### DIFF
--- a/LibOS/shim/include/shim_fs.h
+++ b/LibOS/shim/include/shim_fs.h
@@ -127,9 +127,14 @@ struct shim_dentry {
     LIST_TYPE(shim_dentry) siblings;
 
     struct shim_mount* mounted;
-    void* data;
+
+    /* file type: S_IFREG, S_IFDIR, S_IFLNK etc. */
     mode_t type;
-    mode_t mode;
+
+    /* file permissions: PERM_rwxrwxrwx, etc. */
+    mode_t perm;
+
+    void* data;
 
     struct shim_lock lock;
     REFTYPE ref_count;
@@ -172,7 +177,7 @@ struct shim_d_ops {
     /* set up symlink name to a dentry */
     int (*set_link)(struct shim_dentry* dent, const char* link);
 
-    /* change the mode or owner of a dentry */
+    /* change the mode or owner of a file; the caller has to update dentry */
     int (*chmod)(struct shim_dentry* dent, mode_t mode);
     int (*chown)(struct shim_dentry* dent, int uid, int gid);
 
@@ -242,8 +247,6 @@ extern struct shim_dentry* g_dentry_root;
 #if 0
 #define MAY_APPEND 010
 #endif
-
-#define NO_MODE ((mode_t)-1)
 
 #define ACC_MODE(x)                                        \
     ((((x) == O_RDONLY || (x) == O_RDWR) ? MAY_READ : 0) | \

--- a/LibOS/shim/include/shim_handle.h
+++ b/LibOS/shim/include/shim_handle.h
@@ -63,7 +63,6 @@ struct shim_file_data {
     struct atomic_int version;
     bool queried;
     enum shim_file_type type;
-    mode_t mode;
     struct atomic_int size;
     struct shim_qstr host_uri;
     unsigned long atime;

--- a/LibOS/shim/src/fs/chroot/fs.c
+++ b/LibOS/shim/src/fs/chroot/fs.c
@@ -183,7 +183,6 @@ static int create_data(struct shim_dentry* dent, const char* uri, size_t len) {
     struct mount_data* mdata = DENTRY_MOUNT_DATA(dent);
     assert(mdata);
     data->type = (dent->state & DENTRY_ISDIRECTORY) ? FILE_DIR : mdata->base_type;
-    data->mode = NO_MODE;
     data->queried = false;
 
     if (uri) {
@@ -215,29 +214,37 @@ static int __query_attr(struct shim_dentry* dent, struct shim_file_data* data,
         return pal_to_unix_errno(ret);
     }
 
+    mode_t type;
     /* need to correct the data type */
-    if (data->type == FILE_UNKNOWN)
-        switch (pal_attr.handle_type) {
-            case pal_type_file:
-                data->type = FILE_REGULAR;
-                if (dent)
-                    dent->type = S_IFREG;
-                break;
-            case pal_type_dir:
-                data->type = FILE_DIR;
-                if (dent)
-                    dent->type = S_IFDIR;
-                break;
-            case pal_type_dev:
+    switch (pal_attr.handle_type) {
+        case pal_type_file:
+            data->type = FILE_REGULAR;
+            type = S_IFREG;
+            break;
+        case pal_type_dir:
+            data->type = FILE_DIR;
+            type = S_IFDIR;
+            break;
+        case pal_type_dev:
+            if (strstartswith(qstrgetstr(&data->host_uri) + static_strlen(URI_PREFIX_DEV), "tty")) {
+                data->type = FILE_TTY;
+            } else {
                 data->type = FILE_DEV;
-                if (dent)
-                    dent->type = S_IFCHR;
-                break;
-        }
+            }
+            type = S_IFCHR;
+            break;
+        default:
+            log_error("unknown PAL handle type: %d\n", pal_attr.handle_type);
+            BUG();
+    }
 
-    data->mode = (pal_attr.readable ? S_IRUSR : 0) |
-                 (pal_attr.writable ? S_IWUSR : 0) |
-                 (pal_attr.runnable ? S_IXUSR : 0);
+    mode_t perm = (pal_attr.readable ? S_IRUSR : 0) |
+                  (pal_attr.writable ? S_IWUSR : 0) |
+                  (pal_attr.runnable ? S_IXUSR : 0);
+    if (dent) {
+        dent->type = type;
+        dent->perm = perm;
+    }
 
     __atomic_store_n(&data->size.counter, pal_attr.pending_size, __ATOMIC_SEQ_CST);
 
@@ -315,35 +322,20 @@ static int query_dentry(struct shim_dentry* dent, PAL_HANDLE pal_handle, mode_t*
     }
 
     if (mode)
-        *mode = data->mode;
+        *mode = dent->type | dent->perm;
 
     if (stat) {
         struct mount_data* mdata = DENTRY_MOUNT_DATA(dent);
 
         memset(stat, 0, sizeof(struct stat));
 
-        stat->st_mode  = (mode_t)data->mode;
+        stat->st_mode  = dent->type | dent->perm;
         stat->st_dev   = (dev_t)mdata->dev;
         stat->st_size  = (off_t)__atomic_load_n(&data->size.counter, __ATOMIC_SEQ_CST);
         stat->st_atime = (time_t)data->atime;
         stat->st_mtime = (time_t)data->mtime;
         stat->st_ctime = (time_t)data->ctime;
         stat->st_nlink = data->nlink;
-
-        switch (data->type) {
-            case FILE_REGULAR:
-                stat->st_mode |= S_IFREG;
-                break;
-            case FILE_DIR:
-                stat->st_mode |= S_IFDIR;
-                break;
-            case FILE_DEV:
-            case FILE_TTY:
-                stat->st_mode |= S_IFCHR;
-                break;
-            default:
-                break;
-        }
     }
 
     unlock(&data->lock);
@@ -422,14 +414,7 @@ static int chroot_open(struct shim_handle* hdl, struct shim_dentry* dent, int fl
     if ((ret = try_create_data(dent, NULL, 0, &data)) < 0)
         return ret;
 
-    if (dent->mode == NO_MODE) {
-        lock(&data->lock);
-        ret = __query_attr(dent, data, NULL);
-        dent->mode = data->mode;
-        unlock(&data->lock);
-    }
-
-    if ((ret = __chroot_open(dent, NULL, flags, dent->mode, hdl, data)) < 0)
+    if ((ret = __chroot_open(dent, NULL, flags, dent->perm, hdl, data)) < 0)
         return ret;
 
     assert(hdl->type == TYPE_FILE);
@@ -984,8 +969,6 @@ static int chroot_unlink(struct shim_dentry* dir, struct shim_dentry* dent) {
         return pal_to_unix_errno(ret);
     }
 
-    dent->mode = NO_MODE;
-    data->mode = 0;
     data->queried = false;
 
     __atomic_add_fetch(&data->version.counter, 1, __ATOMIC_SEQ_CST);
@@ -1061,12 +1044,9 @@ static int chroot_rename(struct shim_dentry* old, struct shim_dentry* new) {
         return pal_to_unix_errno(ret);
     }
 
-    new->mode = new_data->mode = old_data->mode;
-    old->mode = NO_MODE;
-    old_data->mode = 0;
-    old_data->queried = false;
-
+    new->perm = old->perm;
     new->type = old->type;
+    old_data->queried = false;
 
     DkObjectClose(pal_hdl);
 
@@ -1098,8 +1078,6 @@ static int chroot_chmod(struct shim_dentry* dent, mode_t mode) {
     }
 
     DkObjectClose(pal_hdl);
-    dent->mode = data->mode = mode;
-
     return 0;
 }
 

--- a/LibOS/shim/src/fs/proc/thread.c
+++ b/LibOS/shim/src/fs/proc/thread.c
@@ -136,40 +136,10 @@ out:
     return ret;
 }
 
-static int proc_thread_link_open(struct shim_handle* hdl, const char* name, int flags) {
-    struct shim_dentry* dent;
-
-    int ret = find_thread_link(name, NULL, &dent);
-    if (ret < 0)
-        return ret;
-
-    if (!dent->fs || !dent->fs->d_ops || !dent->fs->d_ops->open) {
-        ret = -EACCES;
-        goto out;
-    }
-
-    ret = dent->fs->d_ops->open(hdl, dent, flags);
-out:
-    put_dentry(dent);
-    return 0;
-}
-
 static int proc_thread_link_mode(const char* name, mode_t* mode) {
-    struct shim_dentry* dent;
-
-    int ret = find_thread_link(name, NULL, &dent);
-    if (ret < 0)
-        return ret;
-
-    if (!dent->fs || !dent->fs->d_ops || !dent->fs->d_ops->mode) {
-        ret = -EACCES;
-        goto out;
-    }
-
-    ret = dent->fs->d_ops->mode(dent, mode);
-out:
-    put_dentry(dent);
-    return ret;
+    __UNUSED(name);
+    *mode = PERM_r________ | S_IFLNK;
+    return 0;
 }
 
 static int proc_thread_link_stat(const char* name, struct stat* buf) {
@@ -190,7 +160,6 @@ static int proc_thread_link_follow_link(const char* name, struct shim_qstr* link
 }
 
 static const struct pseudo_fs_ops fs_thread_link = {
-    .open        = &proc_thread_link_open,
     .mode        = &proc_thread_link_mode,
     .stat        = &proc_thread_link_stat,
     .follow_link = &proc_thread_link_follow_link,
@@ -568,7 +537,7 @@ err:
 static int proc_thread_maps_mode(const char* name, mode_t* mode) {
     // Only used by one file
     __UNUSED(name);
-    *mode = PERM_r________;
+    *mode = PERM_r________ | S_IFREG;
     return 0;
 }
 
@@ -632,7 +601,7 @@ static int proc_thread_cmdline_open(struct shim_handle* hdl, const char* name, i
 static int proc_thread_cmdline_mode(const char* name, mode_t* mode) {
     // Only used by one file
     __UNUSED(name);
-    *mode = PERM_r________;
+    *mode = PERM_r________ | S_IFREG;
     return 0;
 }
 
@@ -677,7 +646,7 @@ static int proc_thread_dir_mode(const char* name, mode_t* mode) {
     if (ret < 0)
         return ret;
 
-    *mode = PERM_r_x______;
+    *mode = PERM_r_x______ | S_IFDIR;
     return 0;
 }
 

--- a/LibOS/shim/src/fs/shim_dcache.c
+++ b/LibOS/shim/src/fs/shim_dcache.c
@@ -8,12 +8,14 @@
  */
 
 #include "list.h"
+#include "perm.h"
 #include "shim_checkpoint.h"
 #include "shim_fs.h"
 #include "shim_handle.h"
 #include "shim_internal.h"
 #include "shim_lock.h"
 #include "shim_types.h"
+#include "stat.h"
 
 static struct shim_lock dcache_mgr_lock;
 
@@ -41,7 +43,6 @@ static struct shim_dentry* alloc_dentry(void) {
     memset(dent, 0, sizeof(struct shim_dentry));
 
     REF_SET(dent->ref_count, 1);
-    dent->mode = NO_MODE;
 
     INIT_LISTP(&dent->children);
     INIT_LIST_HEAD(dent, siblings);
@@ -76,6 +77,8 @@ int init_dcache(void) {
 
     /* The root should be a directory too*/
     g_dentry_root->state |= DENTRY_ISDIRECTORY;
+    g_dentry_root->perm = PERM_rwx______;
+    g_dentry_root->type = S_IFDIR;
 
     qstrsetstr(&g_dentry_root->name, "", 0);
 
@@ -367,6 +370,29 @@ static int dump_dentry_write_all(const char* str, size_t size, void* arg) {
     return 0;
 }
 
+static void dump_dentry_mode(struct print_buf* buf, mode_t type, mode_t perm) {
+    buf_printf(buf, "%06o ", type | perm);
+
+    char c;
+    switch (type) {
+        case S_IFSOCK: c = 's'; break;
+        case S_IFLNK: c = 'l'; break;
+        case S_IFREG: c = '-'; break;
+        case S_IFBLK: c = 'b'; break;
+        case S_IFDIR: c = 'd'; break;
+        case S_IFCHR: c = 'c'; break;
+        case S_IFIFO: c = 'f'; break;
+        default: c = '?'; break;
+    }
+    buf_putc(buf, c);
+
+    /* ignore suid/sgid bits; display just user permissions */
+    buf_putc(buf, (perm & 0400) ? 'r' : '-');
+    buf_putc(buf, (perm & 0200) ? 'w' : '-');
+    buf_putc(buf, (perm & 0100) ? 'x' : '-');
+    buf_putc(buf, ' ');
+}
+
 #define DUMP_FLAG(flag, s, empty) buf_puts(&buf, (dent->state & (flag)) ? (s) : (empty))
 
 static void dump_dentry(struct shim_dentry* dent, unsigned int level) {
@@ -380,6 +406,8 @@ static void dump_dentry(struct shim_dentry* dent, unsigned int level) {
     DUMP_FLAG(DENTRY_LISTED, "L", ".");
     DUMP_FLAG(DENTRY_SYNTHETIC, "S", ".");
     buf_printf(&buf, "%3d] ", (int)REF_GET(dent->ref_count));
+
+    dump_dentry_mode(&buf, dent->type, dent->perm);
 
     DUMP_FLAG(DENTRY_MOUNTPOINT, "*", " ");
     DUMP_FLAG(DENTRY_NEGATIVE, "-", " ");

--- a/LibOS/shim/src/fs/shim_fs_pseudo.c
+++ b/LibOS/shim/src/fs/shim_fs_pseudo.c
@@ -196,12 +196,13 @@ int pseudo_mode(struct shim_dentry* dent, mode_t* mode, const struct pseudo_ent*
     if (ret < 0)
         goto out;
 
-    if (!ent->fs_ops || !ent->fs_ops->mode) {
+    if (ent->fs_ops && ent->fs_ops->mode) {
+        ret = ent->fs_ops->mode(rel_path, mode);
+    } else if (ent->dir) {
+        ret = pseudo_dir_mode(rel_path, mode);
+    } else {
         ret = -EACCES;
-        goto out;
     }
-
-    ret = ent->fs_ops->mode(rel_path, mode);
 out:
     free(rel_path);
     return ret;

--- a/LibOS/shim/src/sys/shim_fs.c
+++ b/LibOS/shim/src/sys/shim_fs.c
@@ -186,7 +186,7 @@ long shim_do_fchmodat(int dfd, const char* filename, mode_t mode) {
         dent->state |= DENTRY_PERSIST;
     }
 
-    dent->mode = mode;
+    dent->perm = mode;
 out_dent:
     put_dentry(dent);
 out:
@@ -218,7 +218,7 @@ long shim_do_fchmod(int fd, mode_t mode) {
         dent->state |= DENTRY_PERSIST;
     }
 
-    dent->mode = mode;
+    dent->perm = mode;
 out:
     put_handle(hdl);
     return ret;

--- a/LibOS/shim/src/sys/shim_pipe.c
+++ b/LibOS/shim/src/sys/shim_pipe.c
@@ -294,6 +294,8 @@ long shim_do_mknodat(int dirfd, const char* pathname, mode_t mode, dev_t dev) {
     }
 
     dent->fs = &fifo_builtin_fs;
+    dent->type = mode & S_IFMT;
+    dent->perm = mode & ~S_IFMT;
 
     /* create two pipe ends */
     hdl1 = get_new_handle();

--- a/LibOS/shim/src/sys/shim_socket.c
+++ b/LibOS/shim/src/sys/shim_socket.c
@@ -15,6 +15,7 @@
 #include "hex.h"
 #include "pal.h"
 #include "pal_error.h"
+#include "perm.h"
 #include "shim_checkpoint.h"
 #include "shim_flags_conv.h"
 #include "shim_fs.h"
@@ -25,6 +26,7 @@
 #include "shim_signal.h"
 #include "shim_table.h"
 #include "shim_utils.h"
+#include "stat.h"
 
 /*
  * User-settable options (used with setsockopt).
@@ -519,6 +521,8 @@ long shim_do_bind(int sockfd, struct sockaddr* addr, int _addrlen) {
         dent->state ^= DENTRY_NEGATIVE;
         dent->state |= DENTRY_VALID | DENTRY_RECENTLY;
         dent->fs   = &socket_builtin_fs;
+        dent->type = S_IFSOCK;
+        dent->perm = PERM_rw_______;
         dent->data = NULL;
     }
 
@@ -793,6 +797,8 @@ long shim_do_connect(int sockfd, struct sockaddr* addr, int _addrlen) {
         dent->state ^= DENTRY_NEGATIVE;
         dent->state |= DENTRY_VALID | DENTRY_RECENTLY;
         dent->fs   = &socket_builtin_fs;
+        dent->type = S_IFSOCK;
+        dent->perm = PERM_rw_______;
         dent->data = NULL;
         unlock(&dent->lock);
     }


### PR DESCRIPTION
This change is in preparation for bigger refactoring: simplifying directory handles, `getdents` and `getdents64`. It also unblocks changing the mount semantics (indirectly: there are special files, namely Unix sockets and named pipes, that get super-special treatment in Graphene and having the `type` field will allow me to make that explicit).

In principle, this refactoring could be taken further:
* remove `mode()` callback
* remove `DENTRY_DIRECTORY`, `DENTRY_ISLINK` flags, as they're redundant now
* remove various `type` fields throughout the code

However, when I tried to do any of these, the change snowballed, so I want to make further changes gradually. The important part is that the `type` field is available as part of dentry, because it unblocks many other simplifications in the code.

## How to test this PR? <!-- (if applicable) -->

The existing tests are good enough, but for manual testing/debugging I was also adding `dump_dcache(NULL);` to `shim_exit.c`, and checked if any file type/permissions are missing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2379)
<!-- Reviewable:end -->
