### PR TITLE
Simplify getdents/getdents64

### DIFF
--- a/LibOS/shim/include/shim_handle.h
+++ b/LibOS/shim/include/shim_handle.h
@@ -196,24 +196,11 @@ struct shim_sock_handle {
     }* peek_buffer;
 };
 
-struct shim_dirent {
-    struct shim_dirent* next;
-    unsigned char type;
-    char name[]; /* File name (null-terminated) */
-};
-
-#define SHIM_DIRENT_SIZE      offsetof(struct shim_dirent, name)
-#define SHIM_DIRENT_ALIGNMENT alignof(struct shim_dirent)
-/* Size of struct shim_dirent instance together with alignment,
- * which might be different depending on the length of the name field */
-#define SHIM_DIRENT_ALIGNED_SIZE(len) ALIGN_UP(SHIM_DIRENT_SIZE + (len), SHIM_DIRENT_ALIGNMENT)
-
 struct shim_dir_handle {
-    int offset;
-    struct shim_dentry* dotdot;
-    struct shim_dentry* dot;
-    struct shim_dentry** buf;
-    struct shim_dentry** ptr;
+    /* The first two dentries are always "." and ".." */
+    struct shim_dentry** dents;
+    size_t count;
+    size_t pos;
 };
 
 struct msg_type;

--- a/LibOS/shim/include/shim_table.h
+++ b/LibOS/shim/include/shim_table.h
@@ -100,7 +100,7 @@ long shim_do_fsync(int fd);
 long shim_do_fdatasync(int fd);
 long shim_do_truncate(const char* path, loff_t length);
 long shim_do_ftruncate(int fd, loff_t length);
-long shim_do_getdents(int fd, struct linux_dirent* buf, size_t count);
+long shim_do_getdents(int fd, struct linux_dirent* buf, unsigned int count);
 long shim_do_getcwd(char* buf, size_t size);
 long shim_do_chdir(const char* filename);
 long shim_do_fchdir(int fd);

--- a/LibOS/shim/src/fs/dev/fs.c
+++ b/LibOS/shim/src/fs/dev/fs.c
@@ -79,8 +79,8 @@ static int dev_mode(struct shim_dentry* dent, mode_t* mode) {
     return pseudo_mode(dent, mode, &dev_root_ent);
 }
 
-static int dev_readdir(struct shim_dentry* dent, struct shim_dirent** dirent) {
-    return pseudo_readdir(dent, dirent, &dev_root_ent);
+static int dev_readdir(struct shim_dentry* dent, readdir_callback_t callback, void* arg) {
+    return pseudo_readdir(dent, callback, arg, &dev_root_ent);
 }
 
 static int dev_stat(struct shim_dentry* dent, struct stat* buf) {

--- a/LibOS/shim/src/fs/proc/fs.c
+++ b/LibOS/shim/src/fs/proc/fs.c
@@ -65,8 +65,8 @@ static int proc_open(struct shim_handle* hdl, struct shim_dentry* dent, int flag
     return pseudo_open(hdl, dent, flags, &proc_root_ent);
 }
 
-static int proc_readdir(struct shim_dentry* dent, struct shim_dirent** dirent) {
-    return pseudo_readdir(dent, dirent, &proc_root_ent);
+static int proc_readdir(struct shim_dentry* dent, readdir_callback_t callback, void* arg) {
+    return pseudo_readdir(dent, callback, arg, &proc_root_ent);
 }
 
 static int proc_stat(struct shim_dentry* dent, struct stat* buf) {

--- a/LibOS/shim/src/fs/proc/ipc-thread.c
+++ b/LibOS/shim/src/fs/proc/ipc-thread.c
@@ -220,7 +220,7 @@ static int proc_ipc_thread_dir_stat(const char* name, struct stat* buf) {
     return -ENOENT;
 }
 
-static int proc_list_ipc_thread(const char* name, struct shim_dirent** buf, size_t size) {
+static int proc_list_ipc_thread(const char* name, readdir_callback_t callback, void* arg) {
     // Only one valid name
     __UNUSED(name);
     struct pid_status_cache* status = NULL;
@@ -274,34 +274,17 @@ static int proc_list_ipc_thread(const char* name, struct shim_dirent** buf, size
     if (!status->nstatus)
         goto success;
 
-    struct shim_dirent* ptr = (*buf);
-    void* buf_end           = (void*)ptr + size;
-
     for (size_t i = 0; i < status->nstatus; i++) {
         if (status->status[i].pid != status->status[i].tgid)
             continue;
 
         IDTYPE pid = status->status[i].pid;
-        int p = pid, l = 0;
-        for (; p; p /= 10, l++)
-            ;
-
-        if ((void*)(ptr + 1) + l + 1 > buf_end) {
-            ret = -ENOMEM;
+        char name[11];
+        snprintf(name, sizeof(name), "%u", pid);
+        if ((ret = callback(name, arg)) < 0)
             goto err;
-        }
-
-        ptr->next      = (void*)(ptr + 1) + l + 1;
-        ptr->type      = LINUX_DT_DIR;
-        ptr->name[l--] = 0;
-        for (p = pid; p; p /= 10) {
-            ptr->name[l--] = p % 10 + '0';
-        }
-
-        ptr = ptr->next;
     }
 
-    *buf = ptr;
 success:
     lock(&status_lock);
     status->dirty = true;

--- a/LibOS/shim/src/fs/shim_dcache.c
+++ b/LibOS/shim/src/fs/shim_dcache.c
@@ -168,14 +168,20 @@ struct shim_dentry* get_new_dentry(struct shim_mount* fs, struct shim_dentry* pa
     if (!dent)
         return NULL;
 
-    if (fs) {
-        get_mount(fs);
-        dent->fs = fs;
-    }
-
     if (!qstrsetstr(&dent->name, name, name_len)) {
         free_dentry(dent);
         return NULL;
+    }
+
+    if (parent->nchildren >= DENTRY_MAX_CHILDREN) {
+        log_warning("get_new_dentry: nchildren limit reached\n");
+        free_dentry(dent);
+        return NULL;
+    }
+
+    if (fs) {
+        get_mount(fs);
+        dent->fs = fs;
     }
 
     if (parent) {

--- a/LibOS/shim/src/fs/shim_namei.c
+++ b/LibOS/shim/src/fs/shim_namei.c
@@ -371,21 +371,7 @@ int dentry_open(struct shim_handle* hdl, struct shim_dentry* dent, int flags) {
         hdl->is_dir = true;
         memcpy(hdl->fs_type, fs->type, sizeof(fs->type));
 
-        /* Set `dot` and `dotdot` so that we later know to list them */
-        get_dentry(dent);
-        hdl->dir_info.dot = dent;
-
-        if (dent->parent) {
-            get_dentry(dent->parent);
-            hdl->dir_info.dotdot = dent->parent;
-        } else {
-            hdl->dir_info.dotdot = NULL;
-        }
-
-        // Let's defer setting the DENTRY_LISTED flag until we need it
-        // Use -1 to indicate that the buf/ptr isn't initialized
-        hdl->dir_info.buf = (void*)-1;
-        hdl->dir_info.ptr = (void*)-1;
+        hdl->dir_info.dents = NULL;
     }
 
     /* truncate regular writable file if O_TRUNC is given */
@@ -539,139 +525,138 @@ err:
     return ret;
 }
 
-/* This function enumerates a directory and caches the results in the cache.
+/* A list for `populate_directory` to hold file names from `readdir`. */
+DEFINE_LIST(temp_dirent);
+DEFINE_LISTP(temp_dirent);
+struct temp_dirent {
+    LIST_TYPE(temp_dirent) list;
+
+    size_t name_len;
+    char name[];
+};
+
+static int add_name(const char* name, void* arg) {
+    LISTP_TYPE(temp_dirent)* ents = arg;
+
+    size_t name_len = strlen(name);
+    struct temp_dirent* ent = malloc(sizeof(*ent) + name_len + 1);
+    if (!ent)
+        return -ENOMEM;
+
+    memcpy(&ent->name, name, name_len + 1);
+    ent->name_len = name_len;
+    LISTP_ADD(ent, ents, list);
+    return 0;
+}
+
+/*
+ * Ensure that a directory has a complete list of dentries, by calling `readdir` and then
+ * `lookup_dentry` on every name.
  *
- * Input: A dentry for a directory in the DENTRY_ISDIRECTORY and not in the
- * DENTRY_LISTED state.  The dentry DENTRY_LISTED flag is set upon success.
- *
- * Return value: 0 on success, <0 on error
- *
- * DEP 7/9/17: This work was once done as part of open, but, since getdents*
- * have no consistency semantics, we can apply the principle of laziness and
- * not do the work until we are sure we really need to.
+ * While `readdir` is callback-based, we don't look up the names inside of callback, but first
+ * finish `readdir`. Otherwise, the two filesystem operations (`readdir` and `lookup`) might
+ * deadlock.
  */
-int list_directory_dentry(struct shim_dentry* dent) {
-    int ret = 0;
-    struct shim_mount* fs = dent->fs;
-    lock(&g_dcache_lock);
+static int populate_directory(struct shim_dentry* dent) {
+    assert(locked(&g_dcache_lock));
 
-    /* DEP 8/4/17: Another process could list this directory
-     * while we are waiting on the dcache lock.  This is ok,
-     * no need to blow an assert.
-     */
-    if (dent->state & DENTRY_LISTED) {
-        unlock(&g_dcache_lock);
-        return 0;
-    }
+    if (dent->state & DENTRY_NEGATIVE)
+        return -ENOENT;
 
-    // DEP 7/9/17: In yet another strange turn of events in POSIX-land,
-    // you can do a readdir on a rmdir-ed directory handle.  What you
-    // expect to learn is beyond me, but be careful with blowing assert
-    // and tell the program something to keep it moving.
-    if (dent->state & DENTRY_NEGATIVE) {
-        unlock(&g_dcache_lock);
-        return 0;
-    }
+    if (!dent->fs || !dent->fs->d_ops || !dent->fs->d_ops->readdir)
+        return -EINVAL;
 
-    assert(dent->state & DENTRY_ISDIRECTORY);
+    LISTP_TYPE(temp_dirent) ents = LISTP_INIT;
+    int ret = dent->fs->d_ops->readdir(dent, &add_name, &ents);
+    if (ret < 0)
+        log_error("readdir error: %d\n", ret);
 
-    struct shim_dirent* dirent = NULL;
+    struct temp_dirent* ent;
+    struct temp_dirent* tmp;
 
-    if ((ret = fs->d_ops->readdir(dent, &dirent)) < 0 || !dirent) {
-        dirent = NULL;
-        goto done_read;
-    }
-
-    struct shim_dirent* d = dirent;
-    for (; d; d = d->next) {
+    LISTP_FOR_EACH_ENTRY(ent, &ents, list) {
         struct shim_dentry* child;
-        if ((ret = lookup_dentry(dent, d->name, strlen(d->name), &child)) < 0) {
-            /* -ENOENT from underlying lookup should be handled as DENTRY_NEGATIVE */
-            assert(ret != -ENOENT);
-
-            /* Ignore inaccessible files: the underlying lookup can fail with -EACCES, for example
-             * for host symlinks pointing to inaccessible target (since the "chroot" filesystem
-             * transparently follows symlinks instead of reporting them to Graphene). */
-            if (ret == -EACCES)
-                continue;
-
-            /* Other errors fail the lookup */
-            goto done_read;
-        }
-
-        if (child->state & DENTRY_NEGATIVE) {
+        ret = lookup_dentry(dent, ent->name, ent->name_len, &child);
+        if (ret == 0) {
             put_dentry(child);
-            continue;
+        } else if (ret != -EACCES) {
+            /* Fail on underlying lookup errors, except -EACCES (for which we will just ignore the
+             * file). The lookup might fail with -EACCES for host symlinks pointing to inaccessible
+             * target, since the "chroot" filesystem transparently follows symlinks instead of
+             * reporting them to Graphene. */
+            goto out;
         }
-
-        if (!(child->state & DENTRY_VALID)) {
-            child->state |= DENTRY_VALID | DENTRY_RECENTLY;
-        }
-
-        put_dentry(child);
     }
 
-    dent->state |= DENTRY_LISTED;
     ret = 0;
-
-done_read:
-    unlock(&g_dcache_lock);
-    free(dirent);
+out:
+    LISTP_FOR_EACH_ENTRY_SAFE(ent, tmp, &ents, list) {
+        LISTP_DEL(ent, &ents, list);
+        free(ent);
+    }
     return ret;
 }
 
-/* This function caches the contents of a directory (dent), already
- * in the listed state, in a buffer associated with a handle (hdl).
- *
- * This function should only be called once on a handle.
- *
- * Returns 0 on success, <0 on failure.
- */
-int list_directory_handle(struct shim_dentry* dent, struct shim_handle* hdl) {
-    struct shim_dentry** children = NULL;
+int populate_directory_handle(struct shim_handle* hdl) {
+    struct shim_dir_handle* dirhdl = &hdl->dir_info;
 
-    int nchildren = dent->nchildren, count = 0;
-    struct shim_dentry* child;
-    struct shim_dentry* tmp;
+    assert(locked(&hdl->lock));
+    assert(locked(&g_dcache_lock));
+    assert(hdl->dentry);
 
-    assert(hdl->dir_info.buf == (void*)-1);
-    assert(hdl->dir_info.ptr == (void*)-1);
+    int ret;
 
-    // Handle the case where the handle is on a rmdir-ed directory
-    // Handle is already locked by caller, so these values shouldn't change
-    // after dcache lock is acquired
-    if (dent->state & DENTRY_NEGATIVE) {
-        hdl->dir_info.buf = NULL;
-        hdl->dir_info.ptr = NULL;
+    if (dirhdl->dents)
         return 0;
+
+    if ((ret = populate_directory(hdl->dentry)) < 0)
+        goto err;
+
+    size_t capacity = hdl->dentry->nchildren + 2; // +2 for ".", ".."
+
+    dirhdl->dents = malloc(sizeof(struct shim_dentry) * capacity);
+    if (!dirhdl->dents) {
+        ret = -ENOMEM;
+        goto err;
     }
+    dirhdl->count = 0;
 
-    children = malloc(sizeof(struct shim_dentry*) * (nchildren + 1));
-    if (!children)
-        return -ENOMEM;
+    struct shim_dentry* dot = hdl->dentry;
+    get_dentry(dot);
+    dirhdl->dents[dirhdl->count++] = dot;
 
-    lock(&g_dcache_lock);
-    LISTP_FOR_EACH_ENTRY_SAFE(child, tmp, &dent->children, siblings) {
-        if (count >= nchildren)
-            break;
+    struct shim_dentry* dotdot = hdl->dentry->parent ?: hdl->dentry;
+    get_dentry(dotdot);
+    dirhdl->dents[dirhdl->count++] = dotdot;
 
-        struct shim_dentry* c = child;
-
-        if (c->state & DENTRY_VALID) {
-            get_dentry(c);
-            children[count++] = c;
+    struct shim_dentry* tmp;
+    struct shim_dentry* dent;
+    LISTP_FOR_EACH_ENTRY_SAFE(dent, tmp, &hdl->dentry->children, siblings) {
+        if ((dent->state & DENTRY_VALID) && !(dent->state & DENTRY_NEGATIVE)) {
+            get_dentry(dent);
+            assert(dirhdl->count < capacity);
+            dirhdl->dents[dirhdl->count++] = dent;
         }
-
-        dentry_gc(child);
+        dentry_gc(dent);
     }
-    children[count] = NULL;
-
-    hdl->dir_info.buf = children;
-    hdl->dir_info.ptr = children;
-
-    unlock(&g_dcache_lock);
 
     return 0;
+
+err:
+    clear_directory_handle(hdl);
+    return ret;
+}
+
+void clear_directory_handle(struct shim_handle* hdl) {
+    struct shim_dir_handle* dirhdl = &hdl->dir_info;
+    if (!dirhdl->dents)
+        return;
+
+    for (size_t i = 0; i < dirhdl->count; i++)
+        put_dentry(dirhdl->dents[i]);
+    free(dirhdl->dents);
+    dirhdl->dents = NULL;
+    dirhdl->count = 0;
 }
 
 int get_dirfd_dentry(int dirfd, struct shim_dentry** dir) {

--- a/LibOS/shim/src/sys/shim_open.c
+++ b/LibOS/shim/src/sys/shim_open.c
@@ -6,8 +6,11 @@
  * "pread64", "pwrite64", "getdents", "getdents64", "fsync", "truncate" and "ftruncate".
  */
 
+#define _POSIX_C_SOURCE 200809L  /* for SSIZE_MAX */
+
 #include <dirent.h>
 #include <errno.h>
+#include <limits.h>
 #include <linux/fcntl.h>
 #include <stdalign.h>
 
@@ -282,7 +285,7 @@ out:
     return ret;
 }
 
-static inline int get_dirent_type(mode_t type) {
+static int get_dirent_type(mode_t type) {
     switch (type) {
         case S_IFLNK:
             return LINUX_DT_LNK;
@@ -303,211 +306,126 @@ static inline int get_dirent_type(mode_t type) {
     }
 }
 
-long shim_do_getdents(int fd, struct linux_dirent* buf, size_t count) {
-    if (test_user_memory(buf, count, true))
+static ssize_t do_getdents(int fd, uint8_t* buf, size_t buf_size, bool is_getdents64) {
+    if (test_user_memory(buf, buf_size, true))
         return -EFAULT;
 
     struct shim_handle* hdl = get_fd_handle(fd, NULL, NULL);
     if (!hdl)
         return -EBADF;
 
-    int ret = -EACCES;
+    ssize_t ret;
 
     if (!hdl->is_dir) {
         ret = -ENOTDIR;
         goto out_no_unlock;
     }
 
-    /* DEP 3/3/17: Properly handle an unlinked directory */
     if (hdl->dentry->state & DENTRY_NEGATIVE) {
         ret = -ENOENT;
         goto out_no_unlock;
     }
 
-    /* we are grabbing the lock because the handle content is actually
-       updated */
+    lock(&g_dcache_lock);
     lock(&hdl->lock);
 
     struct shim_dir_handle* dirhdl = &hdl->dir_info;
-    struct shim_dentry* dent = hdl->dentry;
-    struct linux_dirent* b = buf;
-    int bytes = 0;
+    if ((ret = populate_directory_handle(hdl)) < 0)
+        goto out;
 
-    /* If we haven't listed the directory, do this first */
-    if (!(dent->state & DENTRY_LISTED)) {
-        ret = list_directory_dentry(dent);
-        if (ret < 0)
-            goto out;
+    size_t buf_pos = 0;
+    while (dirhdl->pos < dirhdl->count) {
+        struct shim_dentry* dent = dirhdl->dents[dirhdl->pos];
+        const char* name;
+        size_t name_len;
+
+        if (dirhdl->pos == 0) {
+            name = ".";
+            name_len = 1;
+        } else if (dirhdl->pos == 1) {
+            name = "..";
+            name_len = 2;
+        } else {
+            name = qstrgetstr(&dent->name);
+            name_len = dent->name.len;
+        }
+
+        uint64_t d_ino = dentry_ino(dent);
+        char d_type = get_dirent_type(dent->type);
+
+        size_t ent_size;
+
+        if (is_getdents64) {
+            ent_size = ALIGN_UP(sizeof(struct linux_dirent64) + name_len + 1,
+                                alignof(struct linux_dirent64));
+            if (buf_pos + ent_size > buf_size)
+                break;
+
+            struct linux_dirent64* ent = (struct linux_dirent64*)(buf + buf_pos);
+            memset(ent, 0, ent_size); // this ensures `name` will be null-terminated
+
+            ent->d_ino = d_ino;
+            ent->d_off = dirhdl->pos;
+            ent->d_reclen = ent_size;
+            ent->d_type = d_type;
+            memcpy(&ent->d_name, name, name_len);
+        } else {
+            /* Note that `struct linux_dirent_tail` starts with a zero padding byte, so we don't
+             * need to account for extra null byte at the end of `name`. */
+            ent_size = ALIGN_UP(
+                sizeof(struct linux_dirent) + sizeof(struct linux_dirent_tail) + name_len,
+                alignof(struct linux_dirent)
+            );
+            if (buf_pos + ent_size > buf_size)
+                break;
+
+            struct linux_dirent* ent = (struct linux_dirent*)(buf + buf_pos);
+            struct linux_dirent_tail* tail =
+                (struct linux_dirent_tail*)(buf + buf_pos + ent_size - sizeof(*tail));
+            memset(ent, 0, ent_size); // this ensures `name` will be null-terminated
+
+            ent->d_ino = d_ino;
+            ent->d_off = dirhdl->pos;
+            ent->d_reclen = ent_size;
+            memcpy(&ent->d_name, name, name_len);
+            tail->d_type = d_type;
+        }
+
+        buf_pos += ent_size;
+        dirhdl->pos++;
     }
 
-/* Size calculation for dirent considering alignment restrictions for b->d_ino */
-// TODO: This "+ 1" below is most likely not needed (NULL byte is already included in
-//       linux_dirent_tail).
-#define DIRENT_SIZE(len) \
-    ALIGN_UP(sizeof(struct linux_dirent) + sizeof(struct linux_dirent_tail) + (len) + 1, \
-             alignof(struct linux_dirent))
-
-#define ASSIGN_DIRENT(dent, name, type)                                                  \
-    do {                                                                                 \
-        int len = strlen(name);                                                          \
-        if (bytes + DIRENT_SIZE(len) > count)                                            \
-            goto done;                                                                   \
-                                                                                         \
-        struct linux_dirent_tail* bt = (void*)b + DIRENT_SIZE(len) - sizeof(*bt);        \
-                                                                                         \
-        b->d_ino    = dentry_ino(dent);                                                  \
-        b->d_off    = ++dirhdl->offset;                                                  \
-        b->d_reclen = DIRENT_SIZE(len);                                                  \
-                                                                                         \
-        memcpy(b->d_name, name, len + 1);                                                \
-                                                                                         \
-        bt->pad    = 0;                                                                  \
-        bt->d_type = (type);                                                             \
-                                                                                         \
-        bytes += b->d_reclen;                                                            \
-        b = (void*)b + b->d_reclen;                                                      \
-    } while (0)
-
-    if (dirhdl->dot) {
-        ASSIGN_DIRENT(dirhdl->dot, ".", LINUX_DT_DIR);
-        put_dentry(dirhdl->dot);
-        dirhdl->dot = NULL;
-    }
-
-    if (dirhdl->dotdot) {
-        ASSIGN_DIRENT(dirhdl->dotdot, "..", LINUX_DT_DIR);
-        put_dentry(dirhdl->dotdot);
-        dirhdl->dotdot = NULL;
-    }
-
-    if (dirhdl->ptr == (void*)-1) {
-        ret = list_directory_handle(dent, hdl);
-        if (ret < 0)
-            goto out;
-    }
-
-    while (dirhdl->ptr && *dirhdl->ptr) {
-        dent = *dirhdl->ptr;
-        /* DEP 3/3/17: We need to filter negative dentries */
-        if (!(dent->state & DENTRY_NEGATIVE))
-            ASSIGN_DIRENT(dent, dentry_get_name(dent), get_dirent_type(dent->type));
-        put_dentry(dent);
-        *(dirhdl->ptr++) = NULL;
-    }
-
-#undef DIRENT_SIZE
-#undef ASSIGN_DIRENT
-
-done:
-    ret = bytes;
-    /* DEP 3/3/17: Properly detect EINVAL case, where buffer is too small to
-     * hold anything */
-    if (bytes == 0 && (dirhdl->dot || dirhdl->dotdot || (dirhdl->ptr && *dirhdl->ptr)))
+    /* Guard against overflow */
+    size_t limit = is_getdents64 ? (size_t)LONG_MAX : (size_t)SSIZE_MAX;
+    if (buf_pos > limit) {
         ret = -EINVAL;
+        goto out;
+    }
+
+    /* Return EINVAL if buffer is too small to hold anything */
+    if (buf_pos == 0 && dirhdl->pos < dirhdl->count) {
+        ret = -EINVAL;
+        goto out;
+    }
+
+    ret = buf_pos;
 out:
     unlock(&hdl->lock);
+    unlock(&g_dcache_lock);
 out_no_unlock:
     put_handle(hdl);
     return ret;
 }
 
+static_assert(sizeof(long) <= sizeof(ssize_t),
+              "return type of do_getdents() is too small for getdents32");
+
+long shim_do_getdents(int fd, struct linux_dirent* buf, unsigned int count) {
+    return do_getdents(fd, (uint8_t*)buf, count, /*is_getdents64=*/false);
+}
+
 long shim_do_getdents64(int fd, struct linux_dirent64* buf, size_t count) {
-    if (test_user_memory(buf, count, true))
-        return -EFAULT;
-
-    struct shim_handle* hdl = get_fd_handle(fd, NULL, NULL);
-    if (!hdl)
-        return -EBADF;
-
-    int ret = -EACCES;
-
-    if (!hdl->is_dir) {
-        ret = -ENOTDIR;
-        goto out_no_unlock;
-    }
-
-    /* DEP 3/3/17: Properly handle an unlinked directory */
-    if (hdl->dentry->state & DENTRY_NEGATIVE) {
-        ret = -ENOENT;
-        goto out_no_unlock;
-    }
-
-    lock(&hdl->lock);
-
-    struct shim_dir_handle* dirhdl = &hdl->dir_info;
-    struct shim_dentry* dent = hdl->dentry;
-    struct linux_dirent64* b = buf;
-    int bytes = 0;
-
-    /* If we haven't listed the directory, do this first */
-    if (!(dent->state & DENTRY_LISTED)) {
-        ret = list_directory_dentry(dent);
-        if (ret)
-            goto out;
-    }
-
-/* Size calculation for dirent considering alignment restrictions for b->d_ino */
-#define DIRENT_SIZE(len) ALIGN_UP(sizeof(struct linux_dirent64) + (len) + 1, \
-                                  alignof(struct linux_dirent64))
-
-#define ASSIGN_DIRENT(dent, name, type)       \
-    do {                                      \
-        int len = strlen(name);               \
-        if (bytes + DIRENT_SIZE(len) > count) \
-            goto done;                        \
-                                              \
-        b->d_ino    = dentry_ino(dent);       \
-        b->d_off    = ++dirhdl->offset;       \
-        b->d_reclen = DIRENT_SIZE(len);       \
-        b->d_type   = (type);                 \
-                                              \
-        memcpy(b->d_name, name, len + 1);     \
-                                              \
-        bytes += b->d_reclen;                 \
-        b = (void*)b + b->d_reclen;           \
-    } while (0)
-
-    if (dirhdl->dot) {
-        ASSIGN_DIRENT(dirhdl->dot, ".", LINUX_DT_DIR);
-        put_dentry(dirhdl->dot);
-        dirhdl->dot = NULL;
-    }
-
-    if (dirhdl->dotdot) {
-        ASSIGN_DIRENT(dirhdl->dotdot, "..", LINUX_DT_DIR);
-        put_dentry(dirhdl->dotdot);
-        dirhdl->dotdot = NULL;
-    }
-
-    if (dirhdl->ptr == (void*)-1) {
-        ret = list_directory_handle(dent, hdl);
-        if (ret)
-            goto out;
-    }
-
-    while (dirhdl->ptr && *dirhdl->ptr) {
-        dent = *dirhdl->ptr;
-        /* DEP 3/3/17: We need to filter negative dentries */
-        if (!(dent->state & DENTRY_NEGATIVE))
-            ASSIGN_DIRENT(dent, dentry_get_name(dent), get_dirent_type(dent->type));
-        put_dentry(dent);
-        *(dirhdl->ptr++) = NULL;
-    }
-
-#undef DIRENT_SIZE
-#undef ASSIGN_DIRENT
-
-done:
-    ret = bytes;
-    /* DEP 3/3/17: Properly detect EINVAL case, where buffer is too small to
-     * hold anything */
-    if (bytes == 0 && (dirhdl->dot || dirhdl->dotdot || (dirhdl->ptr && *dirhdl->ptr)))
-        ret = -EINVAL;
-out:
-    unlock(&hdl->lock);
-out_no_unlock:
-    put_handle(hdl);
-    return ret;
+    return do_getdents(fd, (uint8_t*)buf, count, /*is_getdents64=*/true);
 }
 
 long shim_do_fsync(int fd) {

--- a/LibOS/shim/test/regression/getdents.c
+++ b/LibOS/shim/test/regression/getdents.c
@@ -5,6 +5,7 @@
 #include <stdio.h>
 #include <sys/stat.h>
 #include <sys/syscall.h>
+#include <sys/wait.h>
 #include <unistd.h>
 
 struct linux_dirent {
@@ -23,11 +24,45 @@ struct linux_dirent64 {
 };
 
 #define BUF_SIZE 512
+#define BUF_SIZE_SMALL 64
+
+static int do_getdents(const char* name, int fd, size_t buf_size) {
+    char buf[buf_size];
+
+    int count = syscall(SYS_getdents, fd, buf, buf_size);
+    if (count < 0) {
+        perror(name);
+        return -1;
+    }
+    for (size_t offs = 0; offs < count;) {
+        struct linux_dirent* d32 = (struct linux_dirent*)(buf + offs);
+        char d_type = *(buf + offs + d32->d_reclen - 1);
+        printf("%s: %s [0x%x]\n", name, d32->d_name, d_type);
+        offs += d32->d_reclen;
+    }
+    return count;
+}
+
+static int do_getdents64(const char* name, int fd, size_t buf_size) {
+    char buf[buf_size];
+
+    int count = syscall(SYS_getdents64, fd, buf, buf_size);
+    if (count < 0) {
+        perror(name);
+        return -1;
+    }
+
+    for (size_t offs = 0; offs < count;) {
+        struct linux_dirent64* d64 = (struct linux_dirent64*)(buf + offs);
+        printf("%s: %s [0x%x]\n", name, d64->d_name, d64->d_type);
+        offs += d64->d_reclen;
+    }
+    return count;
+}
 
 int main(void) {
-    int rv, fd, offs;
+    int rv, fd, count;
     const mode_t perm = S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH;
-    char buf[BUF_SIZE];
 
     // setup
     // We test a directory one level below root so ".." is also present in SGX.
@@ -78,21 +113,12 @@ int main(void) {
         return 1;
     }
 
-    while (1) {
-        int count = syscall(SYS_getdents, fd, buf, BUF_SIZE);
-        if (count < 0) {
-            perror("getdents32");
+    do {
+        count = do_getdents("getdents32", fd, BUF_SIZE);
+        if (count < 0)
             return 1;
-        }
-        if (count == 0)
-            break;
-        for (offs = 0; offs < count;) {
-            struct linux_dirent* d32 = (struct linux_dirent*)(buf + offs);
-            char d_type              = *(buf + offs + d32->d_reclen - 1);
-            printf("getdents32: %s [0x%x]\n", d32->d_name, d_type);
-            offs += d32->d_reclen;
-        }
-    }
+    } while (count > 0);
+
     rv = close(fd);
     if (rv) {
         perror("close 1");
@@ -106,31 +132,75 @@ int main(void) {
         return 1;
     }
 
-    while (1) {
-        int count = syscall(SYS_getdents64, fd, buf, BUF_SIZE);
-        if (count < 0) {
-            perror("getdents64");
+    do {
+        count = do_getdents64("getdents64", fd, BUF_SIZE);
+        if (count < 0)
             return 1;
-        }
-        if (count == 0)
-            break;
-        for (offs = 0; offs < count;) {
-            struct linux_dirent64* d64 = (struct linux_dirent64*)(buf + offs);
-            printf("getdents64: %s [0x%x]\n", d64->d_name, d64->d_type);
-            offs += d64->d_reclen;
-        }
-    }
+    } while (count > 0);
+
     rv = close(fd);
     if (rv) {
         perror("close 2");
         return 1;
     }
 
-    // cleanup
-    remove("root/testdir/file1");
-    remove("root/testdir/file2");
-    remove("root/testdir/dir3");
-    remove("root/testdir");
-    remove("root");
+    /*
+     * Check if dir handle works across fork: call getdents64 once before fork, then once after fork
+     * by both parent and child, with a buffer size small enough so that all three calls return
+     * something (if the buffer is too big, the call before fork might retrieve all the entries, and
+     * subsequent calls will return 0).
+     *
+     * Note that we currently do not synchronize handle state between parent and child in Graphene,
+     * so both calls after fork will return the same entries.
+     */
+    fd = open("root/testdir", O_RDONLY | O_DIRECTORY);
+
+    count = do_getdents64("getdents64 before fork", fd, BUF_SIZE_SMALL);
+    if (count < 0)
+        return 1;
+
+    fflush(stdout);
+
+    pid_t pid = fork();
+    if (pid < 0) {
+        perror("fork");
+        return 1;
+    }
+
+    const char* process = pid ? "parent getdents64" : "child getdents64";
+    count = do_getdents64(process, fd, BUF_SIZE_SMALL);
+    if (count < 0)
+        return 1;
+    if (count == 0) {
+        fprintf(stderr, "%s: handle empty too soon\n", process);
+        return 1;
+    }
+
+    rv = close(fd);
+    if (rv) {
+        perror("close after fork");
+        return 1;
+    }
+
+    if (pid) {
+        // wait for child
+        int status;
+        rv = waitpid(pid, &status, 0);
+        if (rv < 0) {
+            perror("waitpid");
+            return 1;
+        }
+        if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) {
+            fprintf(stderr, "waitpid: got %d\n", status);
+            return 1;
+        }
+
+        // cleanup
+        remove("root/testdir/file1");
+        remove("root/testdir/file2");
+        remove("root/testdir/dir3");
+        remove("root/testdir");
+        remove("root");
+    }
     return 0;
 }

--- a/LibOS/shim/test/regression/test_libos.py
+++ b/LibOS/shim/test/regression/test_libos.py
@@ -354,6 +354,12 @@ class TC_30_Syscall(RegressionTestCase):
         self.assertIn('getdents64: file2 [0x8]', stdout)
         self.assertIn('getdents64: dir3 [0x4]', stdout)
 
+        # Directory listing across fork (we don't guarantee the exact names, just that there be at
+        # least one of each)
+        self.assertIn('getdents64 before fork:', stdout)
+        self.assertIn('parent getdents64:', stdout)
+        self.assertIn('child getdents64:', stdout)
+
     def test_021_getdents_large_dir(self):
         if os.path.exists("tmp/large_dir"):
             shutil.rmtree("tmp/large_dir")


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://graphene.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

This changes the filesystem `readdir` operation so that it only needs to call a callback. This is a big simplification for underlying filesystems: a lot of code was responsible for dynamically allocating the right amount of memory.

Additionally, the only piece of information required from `readdir` is a name, not file type or inode number. We perform a lookup on the underlying dentries anyway, so this prevents code duplication.

The directory handle stores an array of dentries, along with size and position in that array, instead of special `dot` and `dotdot` pointers. This simplifies the implementation of `getdents/getdents64` system calls, and also should allow for easier implementation of `lseek` on directory handles. 

(@dimakuv you asked about this recently - this commit does not implement `lseek`, but it makes it relatively simple to do so)

## How to test this PR? <!-- (if applicable) -->

Existing tests (regression and fs) should be enough here.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2383)
<!-- Reviewable:end -->
