### PR TITLE
[Pal/Linux-SGX] Do not use Exitless for clone OCALL

### DIFF
--- a/Pal/src/host/Linux-SGX/enclave_ocalls.c
+++ b/Pal/src/host/Linux-SGX/enclave_ocalls.c
@@ -854,9 +854,12 @@ int ocall_resume_thread(void* tcs) {
 int ocall_clone_thread(void) {
     int retval = 0;
     void* dummy = NULL;
+    /* FIXME: if there was an EINTR, there may be an untrusted thread left over */
     do {
-        /* FIXME: if there was an EINTR, there may be an untrusted thread left over */
-        retval = sgx_exitless_ocall(OCALL_CLONE_THREAD, dummy);
+        /* clone must happen in the context of current (enclave) thread, cannot use exitless;
+         * in particular, the new (enclave) thread must have the same signal mask as the current
+         * enclave thread (and NOT signal mask of the RPC thread) */
+        retval = sgx_ocall(OCALL_CLONE_THREAD, dummy);
     } while (retval == -EINTR);
     return retval;
 }


### PR DESCRIPTION

## Description of the changes <!-- (reasons and measures) -->

Exitless feature distinguishes between normal enclave threads and untrusted RPC threads (the latter submit syscall requests on behalf of the former). Enclave threads catch all sync and async signals from the host, including SIGILL. RPC threads block all sync and async signals other than SIGUSR2.

This PR fixes a bug that clone OCALL was considered suitable for Exitless, which meant that the new enclave thread was created on behalf of the RPC tread, and thus inherited its signal mask. Thus, the new enclave thread couldn't handle e.g. SIGILL exceptions (which can happen on legit CPUID and RDTSC instructions), and Graphene terminated the whole process.


## How to test this PR? <!-- (if applicable) -->

All tests must pass. This bug was found on our Redis example with Exitless enabled.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2384)
<!-- Reviewable:end -->
