### PR TITLE
[Docs,Pal/Linux-SGX] Switch to in-kernel SGX driver as default

### DIFF
--- a/Documentation/quickstart.rst
+++ b/Documentation/quickstart.rst
@@ -30,21 +30,14 @@ Quick start without SGX support
 Quick start with SGX support
 -------------------------------
 
-Graphene-SGX requires that the FSGSBASE feature of recent processors is enabled
-in the Linux kernel. For the ways to enable the FSGSBASE feature, please refer
-to :doc:`building`.
+Graphene requires several features from your system:
 
-Before you run any applications in Graphene-SGX, please make sure that Intel SGX
-SDK and the SGX driver are installed on your system. We recommend using Intel
-SGX SDK and the SGX driver no older than version 1.9 (or the DCAP SGX SDK and
-the driver version 1.4/1.5/1.6).
+- the FSGSBASE feature of recent processors must be enabled in the Linux kernel,
+- the Intel SGX driver must be built in the Linux kernel,
+- Intel SGX SDK/PSW and (optionally) Intel DCAP must be installed.
 
-If Intel SGX SDK and the SGX driver are not installed, please follow the READMEs
-in https://github.com/intel/linux-sgx and
-https://github.com/intel/linux-sgx-driver to download and install them.
-If you want to use the DCAP SDK and driver, please follow the README in
-https://github.com/intel/SGXDataCenterAttestationPrimitives. Please note, that
-the DCAP driver requires Graphene to run as a root user to access it.
+If your system doesn't meet these requirements, please refer to more detailed
+descriptions in :doc:`building`.
 
 #. Ensure that Intel SGX is enabled on your platform::
 
@@ -70,7 +63,7 @@ second command should list the process status of :command:`aesm_service`.
          python3-protobuf libprotobuf-c-dev protobuf-c-compiler python3-pip
       python3 -m pip install toml>=0.10
       make
-      make ISGX_DRIVER_PATH=<path-to-sgx-driver-sources> SGX=1
+      make ISGX_DRIVER_PATH="" SGX=1                  # this assumes Linux 5.11+
       meson build -Ddirect=enabled -Dsgx=enabled
       ninja -C build
       sudo ninja -C build install

--- a/Pal/src/host/Linux-SGX/link-intel-driver.py
+++ b/Pal/src/host/Linux-SGX/link-intel-driver.py
@@ -12,10 +12,11 @@ DRIVER_VERSIONS = {
         'include/uapi/asm/sgx_oot.h': '/dev/sgx/enclave',
         # For DCAP driver 1.10+
         'include/sgx_user.h':         '/dev/sgx/enclave',
-        # For upstreamed in-kernel SGX driver, kernel version 5.11+
-        'include/uapi/asm/sgx.h':     '/dev/sgx_enclave',
-        # By default, using sgx_in_kernel.h in current dir of this script
-        'sgx_in_kernel.h':            '/dev/sgx/enclave',
+        # For custom-built Linux kernels (5.10-) with the Intel SGX driver
+        'include/uapi/asm/sgx.h':     '/dev/sgx/enclave',
+        # By default, using sgx_in_kernel.h in current dir of this script --
+        # this corresponds to the upstreamed in-kernel SGX driver (Linux 5.11+)
+        'sgx_in_kernel.h':            '/dev/sgx_enclave',
 }
 
 def find_intel_sgx_driver(isgx_driver_path):
@@ -27,10 +28,10 @@ def find_intel_sgx_driver(isgx_driver_path):
         (https://github.com/intel/SGXDataCenterAttestationPrimitives)
       - include/sgx_user.h for DCAP 1.10+ version of the driver
         (https://github.com/intel/SGXDataCenterAttestationPrimitives)
-      - include/uapi/asm/sgx.h for upstreamed SGX in-kernel driver from mainline kernel version 5.11
-        (https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git)
-      - default sgx_in_kernel.h for in-kernel 32+ version of the driver
+      - include/uapi/asm/sgx.h for in-kernel (but not upstreamed) version of the driver
         (https://lore.kernel.org/linux-sgx/20200716135303.276442-1-jarkko.sakkinen@linux.intel.com)
+      - default sgx_in_kernel.h for upstreamed in-kernel driver from mainline Linux kernel 5.11+
+        (https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git)
 
     This function returns the required header from the SGX driver.
     '''
@@ -72,9 +73,9 @@ def main(args=None):
     except KeyError:
         print(
             'ISGX_DRIVER_PATH environment variable is undefined. You can define\n'
-            'ISGX_DRIVER_PATH="" to use the in-kernel driver\'s C header from version\n'
-            '32 (bundled with Graphene but NOT upstreamed). For upstreamed\n'
-            'in-kernel driver (if you are using Linux kernel 5.11+), define\n'
+            'ISGX_DRIVER_PATH="" to use the upstreamed in-kernel driver (if you\n'
+            'are using Linux kernel 5.11+). For a custom-built Linux kernel\n'
+            '(versions 5.10-), specify a complete path to SGX driver headers:\n'
             'ISGX_DRIVER_PATH="/usr/src/linux-headers-$(uname -r)/arch/x86"\n',
             file=sys.stderr)
         sys.exit(1)

--- a/Tools/gsc/config.yaml.template
+++ b/Tools/gsc/config.yaml.template
@@ -11,7 +11,9 @@ Graphene:
 # Specify the Intel SGX driver installed on your machine (more specifically, on the machine where
 # the graphenized Docker container will run); there are several variants of the SGX driver:
 #
-#   - legacy out-of-tree driver: use the defaults below, but adjust the branch name
+#   - legacy out-of-tree driver: use something like the below values, but adjust the branch name
+#         Repository: "https://github.com/01org/linux-sgx-driver.git"
+#         Branch:     "sgx_driver_1.9"
 #
 #   - DCAP out-of-tree driver: use something like the below values
 #         Repository: "https://github.com/intel/SGXDataCenterAttestationPrimitives.git"
@@ -22,5 +24,5 @@ Graphene:
 #         Branch:     ""
 #
 SGXDriver:
-    Repository: "https://github.com/01org/linux-sgx-driver.git"
-    Branch:     "sgx_driver_1.9"
+    Repository: ""
+    Branch:     ""

--- a/Tools/gsc/test/Makefile
+++ b/Tools/gsc/test/Makefile
@@ -6,8 +6,11 @@ TESTS = $(foreach D,$(DISTRIBUTIONS),$(foreach T,$(TESTCASES),$D-$T))
 
 GRAPHENE_REPO ?= https://github.com/oscarlab/graphene.git
 GRAPHENE_BRANCH ?= master
-SGXDRIVER_REPO ?= https://github.com/01org/linux-sgx-driver.git
-SGXDRIVER_BRANCH ?= sgx_driver_1.9
+
+# the below default values assume Linux 5.11+ with built-in SGX driver; see ../config.yaml.template
+# for different options (legacy driver, out-of-tree DCAP driver, in-kernel driver)
+SGXDRIVER_REPO ?=
+SGXDRIVER_BRANCH ?=
 
 DOCKER_BUILD_FLAGS ?= --rm --no-cache
 GSC_BUILD_FLAGS ?= --rm --no-cache
@@ -16,9 +19,9 @@ ENV_VARS ?=
 IMAGE_SUFFIX ?=
 
 # use "isgx" for legacy driver, "sgx/enclave" for DCAP driver, "sgx_enclave" for in-kernel driver
-INTEL_SGX_DEVICE ?= isgx
-# "gsgx" is needed on Linux before v5.9 (before FSGSBASE was merged), otherwise leave empty
-ADDITIONAL_DEVICES ?= --device=/dev/gsgx
+INTEL_SGX_DEVICE ?= sgx_enclave
+# use "--device=/dev/gsgx" on Linux 5.8- (before FSGSBASE was merged), otherwise leave empty
+ADDITIONAL_DEVICES ?=
 # use if AESM daemon from the host is needed (e.g. for remote attestation), otherwise leave empty
 ADDITIONAL_VOLUMES ?= --volume /var/run/aesmd/aesm.socket:/var/run/aesmd/aesm.socket
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Now `ISGX_DRIVER_PATH=""` correctly implies the in-kernel SGX driver `/dev/sgx_enclave` as used in Linux versions 5.11+. Documentation and GSC are updated correspondingly (to assume Linux 5.11+ by default).

## How to test this PR? <!-- (if applicable) -->

Try building and installing on a Linux 5.11 machine. The rest works as usual.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2387)
<!-- Reviewable:end -->
