### PR TITLE
[Pal/Linux-SGX] Use AES-CMAC for key derivation in Protected Files

### DIFF
--- a/Pal/src/host/Linux-SGX/enclave_pf.c
+++ b/Pal/src/host/Linux-SGX/enclave_pf.c
@@ -102,6 +102,17 @@ static void cb_debug(const char* msg) {
 }
 #endif
 
+static pf_status_t cb_aes_cmac(const pf_key_t* key, const void* input, size_t input_size,
+                               pf_mac_t* mac) {
+    int ret = lib_AESCMAC((const uint8_t*)key, sizeof(*key), input, input_size, (uint8_t*)mac,
+                          sizeof(*mac));
+    if (ret != 0) {
+        log_error("lib_AESCMAC failed: %d\n", ret);
+        return PF_STATUS_CALLBACK_FAILED;
+    }
+    return PF_STATUS_SUCCESS;
+}
+
 static pf_status_t cb_aes_gcm_encrypt(const pf_key_t* key, const pf_iv_t* iv, const void* aad,
                                       size_t aad_size, const void* input, size_t input_size,
                                       void* output, pf_mac_t* mac) {
@@ -467,8 +478,8 @@ int init_protected_files(void) {
     debug_callback = cb_debug;
 #endif
 
-    pf_set_callbacks(cb_read, cb_write, cb_truncate, cb_aes_gcm_encrypt, cb_aes_gcm_decrypt,
-                     cb_random, debug_callback);
+    pf_set_callbacks(cb_read, cb_write, cb_truncate, cb_aes_cmac, cb_aes_gcm_encrypt,
+                     cb_aes_gcm_decrypt, cb_random, debug_callback);
 
     /* if wrap key is not hard-coded in the manifest, assume that it was received from parent or
      * it will be provisioned after local/remote attestation; otherwise read it from manifest */

--- a/Pal/src/host/Linux-SGX/protected-files/protected_files.c
+++ b/Pal/src/host/Linux-SGX/protected-files/protected_files.c
@@ -36,6 +36,7 @@ static pf_write_f    g_cb_write    = NULL;
 static pf_truncate_f g_cb_truncate = NULL;
 static pf_debug_f    g_cb_debug    = NULL;
 
+static pf_aes_cmac_f        g_cb_aes_cmac        = NULL;
 static pf_aes_gcm_encrypt_f g_cb_aes_gcm_encrypt = NULL;
 static pf_aes_gcm_decrypt_f g_cb_aes_gcm_decrypt = NULL;
 static pf_random_f          g_cb_random          = NULL;
@@ -102,8 +103,15 @@ const char* pf_strerror(int err) {
 // The key derivation function follow recommendations from NIST Special Publication 800-108:
 // Recommendation for Key Derivation Using Pseudorandom Functions
 // https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-108.pdf
-
-// derive a metadata key from user key (if restore is false, the derived key is randomized)
+//
+// This function derives a metadata key in two modes:
+//   - restore == false: derives a per-file random key from user_kdk_key using a random nonce, to
+//                       encrypt the metadata block of the protected file; the nonce is stored in
+//                       plaintext part of the metadata block so that the file can be loaded later
+//                       and decrypted using the same key
+//   - restore == true:  derives a key from user_kdk_key + nonce stored in plaintext part of the
+//                       metadata block, to decrypt the encrypted part of the metadata block (and
+//                       thus "restore" access to the whole protected file)
 static bool ipf_import_metadata_key(pf_context_t* pf, bool restore, pf_key_t* output) {
     kdf_input_t buf = {0};
     pf_status_t status;
@@ -125,8 +133,7 @@ static bool ipf_import_metadata_key(pf_context_t* pf, bool restore, pf_key_t* ou
     // length of output (128 bits)
     buf.output_len = 0x80;
 
-    status = g_cb_aes_gcm_encrypt(&pf->user_kdk_key, &g_empty_iv, &buf, sizeof(buf), NULL, 0, NULL,
-                                  output);
+    status = g_cb_aes_cmac(&pf->user_kdk_key, &buf, sizeof(buf), output);
     if (PF_FAILURE(status)) {
         pf->last_error = status;
         return false;
@@ -1205,12 +1212,13 @@ static file_node_t* ipf_read_mht_node(pf_context_t* pf, uint64_t mht_node_number
 // public API
 
 void pf_set_callbacks(pf_read_f read_f, pf_write_f write_f, pf_truncate_f truncate_f,
-                      pf_aes_gcm_encrypt_f aes_gcm_encrypt_f,
+                      pf_aes_cmac_f aes_cmac_f, pf_aes_gcm_encrypt_f aes_gcm_encrypt_f,
                       pf_aes_gcm_decrypt_f aes_gcm_decrypt_f, pf_random_f random_f,
                       pf_debug_f debug_f) {
     g_cb_read            = read_f;
     g_cb_write           = write_f;
     g_cb_truncate        = truncate_f;
+    g_cb_aes_cmac        = aes_cmac_f;
     g_cb_aes_gcm_encrypt = aes_gcm_encrypt_f;
     g_cb_aes_gcm_decrypt = aes_gcm_decrypt_f;
     g_cb_random          = random_f;

--- a/Pal/src/host/Linux-SGX/protected-files/protected_files.h
+++ b/Pal/src/host/Linux-SGX/protected-files/protected_files.h
@@ -105,6 +105,18 @@ typedef pf_status_t (*pf_truncate_f)(pf_handle_t handle, uint64_t size);
 typedef void (*pf_debug_f)(const char* msg);
 
 /*!
+ * \brief AES-CMAC callback used for key derivation
+ *
+ * \param [in] key AES-GCM key
+ * \param [in] input Plaintext data
+ * \param [in] input_size Size of \a input in bytes
+ * \param [out] mac MAC computed for \a input
+ * \return PF status
+ */
+typedef pf_status_t (*pf_aes_cmac_f)(const pf_key_t* key, const void* input, size_t input_size,
+                                     pf_mac_t* mac);
+
+/*!
  * \brief AES-GCM encrypt callback
  *
  * \param [in] key AES-GCM key
@@ -153,6 +165,7 @@ typedef pf_status_t (*pf_random_f)(uint8_t* buffer, size_t size);
  * \param [in] read_f File read callback
  * \param [in] write_f File write callback
  * \param [in] truncate_f File truncate callback
+ * \param [in] aes_cmac_f AES-CMAC callback
  * \param [in] aes_gcm_encrypt_f AES-GCM encrypt callback
  * \param [in] aes_gcm_decrypt_f AES-GCM decrypt callback
  * \param [in] random_f Cryptographic random number generator callback
@@ -161,7 +174,7 @@ typedef pf_status_t (*pf_random_f)(uint8_t* buffer, size_t size);
  * \details Must be called before any actual APIs
  */
 void pf_set_callbacks(pf_read_f read_f, pf_write_f write_f, pf_truncate_f truncate_f,
-                      pf_aes_gcm_encrypt_f aes_gcm_encrypt_f,
+                      pf_aes_cmac_f aes_cmac_f, pf_aes_gcm_encrypt_f aes_gcm_encrypt_f,
                       pf_aes_gcm_decrypt_f aes_gcm_decrypt_f, pf_random_f random_f,
                       pf_debug_f debug_f);
 

--- a/Pal/src/host/Linux-SGX/tools/common/pf_util.h
+++ b/Pal/src/host/Linux-SGX/tools/common/pf_util.h
@@ -32,6 +32,10 @@ int pf_encrypt_files(const char* input_dir, const char* output_dir, const char* 
 int pf_decrypt_files(const char* input_dir, const char* output_dir, bool verify_path,
                      const char* wrap_key_path);
 
+/*! AES-CMAC */
+pf_status_t mbedtls_aes_cmac(const pf_key_t* key, const void* input, size_t input_size,
+                             pf_mac_t* mac);
+
 /*! AES-GCM encrypt */
 pf_status_t mbedtls_aes_gcm_encrypt(const pf_key_t* key, const pf_iv_t* iv, const void* aad,
                                     size_t aad_size, const void* input, size_t input_size,

--- a/Pal/src/host/Linux-SGX/tools/pf_tamper/pf_tamper.c
+++ b/Pal/src/host/Linux-SGX/tools/pf_tamper/pf_tamper.c
@@ -10,6 +10,7 @@
 #include <unistd.h>
 
 #define USE_STDLIB
+#include "api.h"
 #include "pf_util.h"
 #include "protected_files.h"
 #include "protected_files_format.h"
@@ -60,10 +61,10 @@ static void derive_main_key(const pf_key_t* kdk, const pf_keyid_t* key_id, pf_ke
 
     buf.index = 1;
     strncpy(buf.label, METADATA_KEY_NAME, MAX_LABEL_SIZE);
-    memcpy(&buf.nonce, key_id, sizeof(buf.nonce));
+    COPY_ARRAY(buf.nonce, *key_id);
     buf.output_len = 0x80;
 
-    status = mbedtls_aes_gcm_encrypt(kdk, &g_empty_iv, &buf, sizeof(buf), NULL, 0, NULL, out_key);
+    status = mbedtls_aes_cmac(kdk, &buf, sizeof(buf), out_key);
     if (PF_FAILURE(status))
         FATAL("key derivation failed\n");
 }


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Protected FS previously used AES-GCM (with empty output argument, using the MAC as the derived key) as a KDF. This construction lacks any proof of correctness, thus this commit replaces AES-GCM with AES-CMAC as a KDF as per NIST recommendation.

Fixes #2386.

## How to test this PR? <!-- (if applicable) -->

All tests must pass, especially FS tests (`make pf-test`).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2390)
<!-- Reviewable:end -->
