### PR TITLE
[LibOS] Handle automatic syscalls restarting where necessary

### DIFF
--- a/LibOS/shim/src/bookkeep/shim_thread.c
+++ b/LibOS/shim/src/bookkeep/shim_thread.c
@@ -192,7 +192,7 @@ static int init_main_thread(void) {
     unlock(&cur_thread->lock);
 
     int ret = DkEventCreate(&cur_thread->scheduler_event, /*init_signaled=*/false,
-                            /*auto_clear=*/false);
+                            /*auto_clear=*/true);
     if (ret < 0) {
         put_thread(cur_thread);
         return pal_to_unix_errno(ret);;
@@ -304,7 +304,7 @@ struct shim_thread* get_new_thread(void) {
     unlock(&cur_thread->lock);
 
     int ret = DkEventCreate(&thread->scheduler_event, /*init_signaled=*/false,
-                            /*auto_clear=*/false);
+                            /*auto_clear=*/true);
     if (ret < 0) {
         put_thread(thread);
         return NULL;
@@ -641,7 +641,7 @@ BEGIN_RS_FUNC(thread) {
     }
 
     int ret = DkEventCreate(&thread->scheduler_event, /*init_signaled=*/false,
-                            /*auto_clear=*/false);
+                            /*auto_clear=*/true);
     if (ret < 0) {
         return pal_to_unix_errno(ret);
     }

--- a/LibOS/shim/src/sys/shim_epoll.c
+++ b/LibOS/shim/src/sys/shim_epoll.c
@@ -414,6 +414,11 @@ long shim_do_epoll_wait(int epfd, struct __kernel_epoll_event* events, int maxev
         if (error && error != -EAGAIN) {
             unlock(&epoll_hdl->lock);
             put_handle(epoll_hdl);
+            if (error == -EINTR) {
+                /* `epoll_wait` and `epoll_pwait` are not restarted after being interrupted by
+                 * a signal handler. */
+                error = -ERESTARTNOHAND;
+            }
             return error;
         } else if (event_handle_update) {
             /* retry if epoll was updated concurrently (similar to Linux semantics) */

--- a/LibOS/shim/src/sys/shim_getrandom.c
+++ b/LibOS/shim/src/sys/shim_getrandom.c
@@ -27,8 +27,13 @@ long shim_do_getrandom(char* buf, size_t count, unsigned int flags) {
      * but this shouldn't be possible in practice, so we don't care.
      */
     int ret = DkRandomBitsRead(buf, count);
-    if (ret < 0)
-        return pal_to_unix_errno(ret);
+    if (ret < 0) {
+        ret = pal_to_unix_errno(ret);
+        if (ret == -EINTR) {
+            ret = -ERESTARTSYS;
+        }
+        return ret;
+    }
 
     return count;
 }

--- a/LibOS/shim/src/sys/shim_ioctl.c
+++ b/LibOS/shim/src/sys/shim_ioctl.c
@@ -115,5 +115,8 @@ long shim_do_ioctl(unsigned int fd, unsigned int cmd, unsigned long arg) {
     }
 
     put_handle(hdl);
+    if (ret == -EINTR) {
+        ret = -ERESTARTSYS;
+    }
     return ret;
 }

--- a/LibOS/shim/src/sys/shim_poll.c
+++ b/LibOS/shim/src/sys/shim_poll.c
@@ -183,6 +183,10 @@ static long _shim_do_poll(struct pollfd* fds, nfds_t nfds, int timeout_ms) {
     if (error == -EAGAIN) {
         /* `poll` returns 0 on timeout. */
         error = 0;
+    } else if (error == -EINTR) {
+        /* `poll`, `ppoll`, `select` and `pselect` are not restarted after being interrupted by
+         * a signal handler. */
+        error = -ERESTARTNOHAND;
     }
     return nrevents ? (long)nrevents : error;
 }

--- a/LibOS/shim/src/sys/shim_wrappers.c
+++ b/LibOS/shim/src/sys/shim_wrappers.c
@@ -59,6 +59,9 @@ long shim_do_readv(int fd, const struct iovec* vec, int vlen) {
     ret = bytes;
 out:
     put_handle(hdl);
+    if (ret == -EINTR) {
+        ret = -ERESTARTSYS;
+    }
     return ret;
 }
 
@@ -121,5 +124,8 @@ long shim_do_writev(int fd, const struct iovec* vec, int vlen) {
     ret = bytes;
 out:
     put_handle(hdl);
+    if (ret == -EINTR) {
+        ret = -ERESTARTSYS;
+    }
     return ret;
 }

--- a/LibOS/shim/test/regression/.gitignore
+++ b/LibOS/shim/test/regression/.gitignore
@@ -94,6 +94,7 @@
 /spinlock
 /stat_invalid_args
 /syscall
+/syscall_restart
 /sysfs_common
 /tcp_ipv6_v6only
 /tcp_msg_peek

--- a/LibOS/shim/test/regression/Makefile
+++ b/LibOS/shim/test/regression/Makefile
@@ -83,6 +83,7 @@ c_executables = \
 	spinlock \
 	stat_invalid_args \
 	syscall \
+	syscall_restart \
 	sysfs_common \
 	tcp_ipv6_v6only \
 	tcp_msg_peek \

--- a/LibOS/shim/test/regression/syscall_restart.c
+++ b/LibOS/shim/test/regression/syscall_restart.c
@@ -1,0 +1,67 @@
+#define _GNU_SOURCE
+#include <err.h>
+#include <stdio.h>
+#include <signal.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+static void child(int fd) {
+    /* We need to wait till parent sleeps on `read`, unfortunately there is no way to check that in
+     * Graphene. Hopyfully 100ms is enough. */
+    if (usleep(100 * 1000) < 0) {
+        err(1, "usleep");
+    }
+
+    if (kill(getppid(), SIGCHLD) < 0) {
+        err(1, "kill");
+    }
+
+    /* Let parent notice the signal. */
+    if (usleep(100 * 1000) < 0) {
+        err(1, "usleep");
+    }
+
+    char c = 'a';
+    if (write(fd, &c, 1) != 1) {
+        err(1, "write");
+    }
+}
+
+int main(int argc, char** argv) {
+    setbuf(stdout, NULL);
+    setbuf(stderr, NULL);
+
+    int pfd[2];
+    if (pipe(pfd) < 0) {
+        err(1, "pipe");
+    }
+
+    pid_t p = fork();
+    if (p < 0) {
+        err(1, "fork");
+    } else if (p == 0) {
+        if (close(pfd[0]) < 0) {
+            err(1, "close");
+        }
+        child(pfd[1]);
+        return 0;
+    }
+
+    char c = 0;
+    if (read(pfd[0], &c, 1) != 1) {
+        err(1, "read");
+    }
+
+    int status = 0;
+    if (waitpid(p, &status, 0) < 0) {
+        err(1, "wait");
+    }
+
+    if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) {
+        errx(1, "child died with: %d", status);
+    }
+
+    puts("TEST OK");
+    return 0;
+}

--- a/LibOS/shim/test/regression/test_libos.py
+++ b/LibOS/shim/test/regression/test_libos.py
@@ -543,16 +543,22 @@ class TC_30_Syscall(RegressionTestCase):
         stdout, _ = self.run_binary(['gettimeofday'])
         self.assertIn('TEST OK', stdout)
 
-@unittest.skipUnless(HAS_SGX,
-    'This test is only meaningful on SGX PAL because only SGX catches raw '
-    'syscalls and redirects to Graphene\'s LibOS. If we will add seccomp to '
-    'Linux PAL, then we should allow this test on Linux PAL as well.')
-class TC_31_SyscallSGX(RegressionTestCase):
+class TC_31_Syscall(RegressionTestCase):
+    @unittest.skipUnless(HAS_SGX,
+        'This test is only meaningful on SGX PAL because only SGX catches raw '
+        'syscalls and redirects to Graphene\'s LibOS. If we will add seccomp to '
+        'Linux PAL, then we should allow this test on Linux PAL as well.')
     def test_000_syscall_redirect(self):
         stdout, _ = self.run_binary(['syscall'])
 
         # Syscall Instruction Redirection
         self.assertIn('Hello world', stdout)
+
+    @unittest.skipIf(HAS_SGX, 'currently broken on SGX due to pipe encryption '
+        'layer translating EINTR to EAGAIN')
+    def test_010_syscall_restart(self):
+        stdout, _ = self.run_binary(['syscall_restart'])
+        self.assertIn('TEST OK', stdout)
 
 class TC_40_FileSystem(RegressionTestCase):
     def test_000_proc(self):


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->
Add rest of missing `ERESTART*` returns.

## How to test this PR? <!-- (if applicable) -->
Added new regression tests, which fails on the current master.
Unfortunately it fails on SGX even with this PR due to pipe encryption layer translating `EINTR` to `EAGAIN` (https://github.com/oscarlab/graphene/blob/master/common/src/crypto/adapters/mbedtls_adapter.c#L314).
