### PR TITLE
[Common,Pal,LibOS] Move logging functionality to the common library

### DIFF
--- a/LibOS/shim/include/shim_internal.h
+++ b/LibOS/shim/include/shim_internal.h
@@ -11,6 +11,7 @@
 #include "api.h"
 #include "assert.h"
 #include "atomic.h"
+#include "log.h"
 #include "pal.h"
 #include "pal_error.h"
 #include "shim_defs.h"
@@ -34,17 +35,7 @@ extern const PAL_CONTROL* g_pal_control;
 
 // TODO(mkow): We should make it cross-object-inlinable, ideally by enabling LTO, less ideally by
 // pasting it here and making `inline`, but our current linker scripts prevent both.
-void _log(int level, const char* fmt, ...) __attribute__((format(printf, 2, 3)));
-/* This function emits logs regardless of log_level setting and doesn't prefix the output. */
-void log_always(const char* fmt, ...) __attribute__((format(printf, 1, 2)));
-
-#define log_error(fmt...)    _log(PAL_LOG_ERROR, fmt)
-#define log_warning(fmt...)  _log(PAL_LOG_WARNING, fmt)
-#define log_debug(fmt...)    _log(PAL_LOG_DEBUG, fmt)
-#define log_trace(fmt...)    _log(PAL_LOG_TRACE, fmt)
-
-/* TODO: Replace debug() calls with log_*() at the appropriate levels, and remove this macro. */
-#define debug(fmt...)        _log(PAL_LOG_WARNING, fmt)
+void shim_log(int level, const char* fmt, ...) __attribute__((format(printf, 2, 3)));
 
 #if 0
 #define DEBUG_BREAK_ON_FAILURE() DEBUG_BREAK()

--- a/LibOS/shim/src/shim_async.c
+++ b/LibOS/shim/src/shim_async.c
@@ -287,7 +287,7 @@ static void shim_async_worker(void* arg) {
         ret = DkStreamsWaitEvents(pals_cnt + 1, pals, pal_events, ret_events, sleep_time);
         if (ret < 0 && ret != -PAL_ERROR_INTERRUPTED && ret != -PAL_ERROR_TRYAGAIN) {
             ret = pal_to_unix_errno(ret);
-            debug("Async worker: DkStreamsWaitEvents failed: %d\n", ret);
+            log_error("DkStreamsWaitEvents failed with: %d\n", ret);
             goto out_err;
         }
         PAL_BOL polled = ret == 0;

--- a/LibOS/shim/src/shim_parser.c
+++ b/LibOS/shim/src/shim_parser.c
@@ -1558,7 +1558,7 @@ static int buf_write_all(const char* str, size_t size, void* arg) {
 }
 
 void debug_print_syscall_before(unsigned long sysno, ...) {
-    if (g_log_level < PAL_LOG_TRACE)
+    if (g_log_level < LOG_LEVEL_TRACE)
         return;
 
     struct parser_table* parser = &syscall_parser_table[sysno];
@@ -1592,7 +1592,7 @@ void debug_print_syscall_before(unsigned long sysno, ...) {
 }
 
 void debug_print_syscall_after(unsigned long sysno, ...) {
-    if (g_log_level < PAL_LOG_TRACE)
+    if (g_log_level < LOG_LEVEL_TRACE)
         return;
 
     struct parser_table* parser = &syscall_parser_table[sysno];

--- a/LibOS/shim/src/utils/log.c
+++ b/LibOS/shim/src/utils/log.c
@@ -14,19 +14,20 @@
 #include "shim_internal.h"
 #include "shim_ipc.h"
 
-int g_log_level = PAL_LOG_NONE;
+int g_log_level = LOG_LEVEL_NONE;
 
+/* NOTE: We could add "libos" prefix to the below strings for more fine-grained log info */
 static const char* log_level_to_prefix[] = {
-    [PAL_LOG_NONE]    = "", // not a valid entry actually (no public wrapper uses this log level)
-    [PAL_LOG_ERROR]   = "error: ",
-    [PAL_LOG_WARNING] = "warning: ",
-    [PAL_LOG_DEBUG]   = "debug: ",
-    [PAL_LOG_TRACE]   = "trace: ",
-    [PAL_LOG_ALL]     = "", // same as for PAL_LOG_NONE
+    [LOG_LEVEL_NONE]    = "",
+    [LOG_LEVEL_ERROR]   = "error: ",
+    [LOG_LEVEL_WARNING] = "warning: ",
+    [LOG_LEVEL_DEBUG]   = "debug: ",
+    [LOG_LEVEL_TRACE]   = "trace: ",
+    [LOG_LEVEL_ALL]     = "", // same as for LOG_LEVEL_NONE
 };
 
 void log_setprefix(shim_tcb_t* tcb) {
-    if (g_log_level <= PAL_LOG_NONE)
+    if (g_log_level <= LOG_LEVEL_NONE)
         return;
 
     const char* exec = g_pal_control->executable;
@@ -68,7 +69,7 @@ static int buf_write_all(const char* str, size_t size, void* arg) {
     return 0;
 }
 
-void _log(int level, const char* fmt, ...) {
+void shim_log(int level, const char* fmt, ...) {
     if (level <= g_log_level) {
         struct print_buf buf = INIT_PRINT_BUF(buf_write_all);
 
@@ -82,17 +83,4 @@ void _log(int level, const char* fmt, ...) {
 
         buf_flush(&buf);
     }
-}
-
-void log_always(const char* fmt, ...) {
-    struct print_buf buf = INIT_PRINT_BUF(buf_write_all);
-
-    buf_puts(&buf, shim_get_tcb()->log_prefix);
-
-    va_list ap;
-    va_start(ap, fmt);
-    buf_vprintf(&buf, fmt, ap);
-    va_end(ap);
-
-    buf_flush(&buf);
 }

--- a/Pal/include/pal/pal.h
+++ b/Pal/include/pal/pal.h
@@ -91,16 +91,6 @@ typedef union pal_handle {
 
 #include "pal-arch.h"
 
-/*! Log level */
-enum {
-    PAL_LOG_NONE    = 0,
-    PAL_LOG_ERROR   = 1,
-    PAL_LOG_WARNING = 2,
-    PAL_LOG_DEBUG   = 3,
-    PAL_LOG_TRACE   = 4,
-    PAL_LOG_ALL     = 5,
-};
-
 /********** PAL TYPE DEFINITIONS **********/
 enum {
     pal_type_file,
@@ -830,10 +820,6 @@ int DkSetProtectedFilesKey(PAL_PTR pf_key_hex);
  */
 int DkCpuIdRetrieve(PAL_IDX leaf, PAL_IDX subleaf, PAL_IDX values[CPUID_WORD_NUM]);
 #endif
-
-// TODO: Replace this with log_* everywhere
-void pal_printf(const char* fmt, ...) __attribute__((format(printf, 1, 2)));
-void pal_vprintf(const char* fmt, va_list ap) __attribute__((format(printf, 1, 0)));
 
 void DkDebugMapAdd(PAL_STR uri, PAL_PTR start_addr);
 void DkDebugMapRemove(PAL_PTR start_addr);

--- a/Pal/regression/pal_regression.h
+++ b/Pal/regression/pal_regression.h
@@ -8,4 +8,7 @@
 
 #define pal_control (*DkGetPalControl())
 
+void __attribute__((format(printf, 1, 2))) pal_printf(const char* fmt, ...);
+void __attribute__((format(printf, 2, 3))) _log(int level, const char* fmt, ...);
+
 #endif /* PAL_REGRESSION_H */

--- a/Pal/regression/utils.c
+++ b/Pal/regression/utils.c
@@ -1,5 +1,6 @@
 #include "api.h"
 #include "pal.h"
+#include "pal_regression.h"
 
 // pal_printf() is required by PAL regression tests.
 static int buf_write_all(const char* str, size_t size, void* arg) {
@@ -14,7 +15,7 @@ static void log_vprintf(const char* fmt, va_list ap) {
     buf_flush(&buf);
 }
 
-void __attribute__((format(printf, 1, 2))) pal_printf(const char* fmt, ...) {
+void pal_printf(const char* fmt, ...) {
     va_list ap;
     va_start(ap, fmt);
     log_vprintf(fmt, ap);
@@ -24,7 +25,8 @@ void __attribute__((format(printf, 1, 2))) pal_printf(const char* fmt, ...) {
 /* The below two functions are used by stack protector's __stack_chk_fail(), _FORTIFY_SOURCE's
  * *_chk() functions and by assert.h's assert() defined in the common library. Thus they might be
  * called by any execution context, including these PAL tests. */
-void __attribute__((format(printf, 1, 2))) log_always(const char* fmt, ...) {
+void _log(int level, const char* fmt, ...) {
+    (void)level; /* PAL regression always prints log messages */
     va_list ap;
     va_start(ap, fmt);
     log_vprintf(fmt, ap);

--- a/Pal/src/db_main.c
+++ b/Pal/src/db_main.c
@@ -173,17 +173,17 @@ static void configure_logging(void) {
 
     if (log_level_str) {
         if (!strcmp(log_level_str, "none")) {
-            log_level = PAL_LOG_NONE;
+            log_level = LOG_LEVEL_NONE;
         } else if (!strcmp(log_level_str, "error")) {
-            log_level = PAL_LOG_ERROR;
+            log_level = LOG_LEVEL_ERROR;
         } else if (!strcmp(log_level_str, "warning")) {
-            log_level = PAL_LOG_WARNING;
+            log_level = LOG_LEVEL_WARNING;
         } else if (!strcmp(log_level_str, "debug")) {
-            log_level = PAL_LOG_DEBUG;
+            log_level = LOG_LEVEL_DEBUG;
         } else if (!strcmp(log_level_str, "trace")) {
-            log_level = PAL_LOG_TRACE;
+            log_level = LOG_LEVEL_TRACE;
         } else if (!strcmp(log_level_str, "all")) {
-            log_level = PAL_LOG_ALL;
+            log_level = LOG_LEVEL_ALL;
         } else {
             INIT_FAIL_MANIFEST(PAL_ERROR_DENIED, "Unknown 'loader.log_level'");
         }
@@ -195,7 +195,7 @@ static void configure_logging(void) {
     if (ret < 0)
         INIT_FAIL_MANIFEST(PAL_ERROR_DENIED, "Cannot parse 'loader.log_file'");
 
-    if (log_file && log_level > PAL_LOG_NONE) {
+    if (log_file && log_level > LOG_LEVEL_NONE) {
         ret = _DkInitDebugStream(log_file);
 
         if (ret < 0)

--- a/Pal/src/host/Linux-SGX/pal_linux.h
+++ b/Pal/src/host/Linux-SGX/pal_linux.h
@@ -12,6 +12,7 @@
 #include "crypto.h"
 #include "enclave_ocalls.h"
 #include "linux_types.h"
+#include "log.h"
 #include "pal.h"
 #include "pal_defs.h"
 #include "pal_internal.h"

--- a/Pal/src/host/Linux-SGX/sgx_log.c
+++ b/Pal/src/host/Linux-SGX/sgx_log.c
@@ -12,13 +12,14 @@
 #include "perm.h"
 #include "sgx_log.h"
 
+/* NOTE: We could add "untrusted-pal" prefix to the below strings for more fine-grained log info */
 static const char* log_level_to_prefix[] = {
-    [PAL_LOG_NONE]    = "", // not a valid entry actually (no public wrapper uses this log level)
-    [PAL_LOG_ERROR]   = "error: ",
-    [PAL_LOG_WARNING] = "warning: ",
-    [PAL_LOG_DEBUG]   = "debug: ",
-    [PAL_LOG_TRACE]   = "trace: ",
-    [PAL_LOG_ALL]     = "", // same as for PAL_LOG_NONE
+    [LOG_LEVEL_NONE]    = "",
+    [LOG_LEVEL_ERROR]   = "error: ",
+    [LOG_LEVEL_WARNING] = "warning: ",
+    [LOG_LEVEL_DEBUG]   = "debug: ",
+    [LOG_LEVEL_TRACE]   = "trace: ",
+    [LOG_LEVEL_ALL]     = "", // same as for LOG_LEVEL_NONE
 };
 
 int g_urts_log_level = PAL_LOG_DEFAULT_LEVEL;
@@ -56,16 +57,7 @@ static void print_to_fd(int fd, const char* prefix, const char* fmt, va_list ap)
     // No error handling, as `_urts_log` doesn't return errors anyways.
 }
 
-// TODO: Remove this and always use log_*.
-void pal_printf(const char* fmt, ...) {
-    va_list ap;
-
-    va_start(ap, fmt);
-    print_to_fd(g_urts_log_fd, /*prefix=*/NULL, fmt, ap);
-    va_end(ap);
-}
-
-void _urts_log(int level, const char* fmt, ...) {
+void pal_log(int level, const char* fmt, ...) {
     if (level <= g_urts_log_level) {
         va_list ap;
         va_start(ap, fmt);
@@ -73,21 +65,4 @@ void _urts_log(int level, const char* fmt, ...) {
         print_to_fd(g_urts_log_fd, log_level_to_prefix[level], fmt, ap);
         va_end(ap);
     }
-}
-
-void urts_log_always(const char* fmt, ...) {
-    va_list ap;
-    va_start(ap, fmt);
-    print_to_fd(g_urts_log_fd, /*prefix=*/NULL, fmt, ap);
-    va_end(ap);
-}
-
-/* The below function is used by stack protector's __stack_chk_fail(), _FORTIFY_SOURCE's *_chk()
- * functions and by assert.h's assert() defined in the common library. Do not use this function in
- * untrusted-PAL code, instead use urts_log_always() for readability! */
-void pal_log_always(const char* fmt, ...) {
-    va_list ap;
-    va_start(ap, fmt);
-    print_to_fd(g_urts_log_fd, /*prefix=*/NULL, fmt, ap);
-    va_end(ap);
 }

--- a/Pal/src/host/Linux-SGX/sgx_log.h
+++ b/Pal/src/host/Linux-SGX/sgx_log.h
@@ -21,13 +21,13 @@ int urts_log_printf(const char* fmt, ...) __attribute__((format(printf, 1, 2)));
 
 // TODO(mkow): We should make it cross-object-inlinable, ideally by enabling LTO, less ideally by
 // pasting it here and making `inline`, but our current linker scripts prevent both.
-void _urts_log(int level, const char* fmt, ...) __attribute__((format(printf, 2, 3)));
-/* This function emits logs regardless of log_level setting and doesn't prefix the output. */
-void urts_log_always(const char* fmt, ...) __attribute__((format(printf, 1, 2)));
+void pal_log(int level, const char* fmt, ...) __attribute__((format(printf, 2, 3)));
 
-#define urts_log_error(fmt...)    _urts_log(PAL_LOG_ERROR, fmt)
-#define urts_log_warning(fmt...)  _urts_log(PAL_LOG_WARNING, fmt)
-#define urts_log_debug(fmt...)    _urts_log(PAL_LOG_DEBUG, fmt)
-#define urts_log_trace(fmt...)    _urts_log(PAL_LOG_TRACE, fmt)
+/* NOTE: these macros are identical to log_error, log_warning, etc. but defined for readability */
+#define urts_log_always(fmt...)   pal_log(LOG_LEVEL_NONE, fmt)
+#define urts_log_error(fmt...)    pal_log(LOG_LEVEL_ERROR, fmt)
+#define urts_log_warning(fmt...)  pal_log(LOG_LEVEL_WARNING, fmt)
+#define urts_log_debug(fmt...)    pal_log(LOG_LEVEL_DEBUG, fmt)
+#define urts_log_trace(fmt...)    pal_log(LOG_LEVEL_TRACE, fmt)
 
 #endif /* SGX_LOG_H_ */

--- a/Pal/src/host/Linux-SGX/sgx_main.c
+++ b/Pal/src/host/Linux-SGX/sgx_main.c
@@ -847,17 +847,17 @@ static int parse_loader_config(char* manifest, struct pal_enclave* enclave_info)
     }
     if (log_level_str) {
         if (!strcmp(log_level_str, "none")) {
-            log_level = PAL_LOG_NONE;
+            log_level = LOG_LEVEL_NONE;
         } else if (!strcmp(log_level_str, "error")) {
-            log_level = PAL_LOG_ERROR;
+            log_level = LOG_LEVEL_ERROR;
         } else if (!strcmp(log_level_str, "warning")) {
-            log_level = PAL_LOG_WARNING;
+            log_level = LOG_LEVEL_WARNING;
         } else if (!strcmp(log_level_str, "debug")) {
-            log_level = PAL_LOG_DEBUG;
+            log_level = LOG_LEVEL_DEBUG;
         } else if (!strcmp(log_level_str, "trace")) {
-            log_level = PAL_LOG_TRACE;
+            log_level = LOG_LEVEL_TRACE;
         } else if (!strcmp(log_level_str, "all")) {
-            log_level = PAL_LOG_ALL;
+            log_level = LOG_LEVEL_ALL;
         } else {
             urts_log_error("Unknown 'loader.log_level'\n");
             ret = -EINVAL;
@@ -873,7 +873,7 @@ static int parse_loader_config(char* manifest, struct pal_enclave* enclave_info)
         ret = -EINVAL;
         goto out;
     }
-    if (log_level > PAL_LOG_NONE && log_file) {
+    if (log_level > LOG_LEVEL_NONE && log_file) {
         ret = urts_log_init(log_file);
 
         if (ret < 0) {

--- a/Pal/src/pal_internal.h
+++ b/Pal/src/pal_internal.h
@@ -11,6 +11,8 @@
 #include <stdarg.h>
 #include <stdbool.h>
 
+#include "api.h"
+#include "log.h"
 #include "pal.h"
 #include "pal_defs.h"
 #include "pal_error.h"
@@ -277,17 +279,10 @@ int _DkDebugLog(const void* buf, size_t size);
 
 // TODO(mkow): We should make it cross-object-inlinable, ideally by enabling LTO, less ideally by
 // pasting it here and making `inline`, but our current linker scripts prevent both.
-void _log(int level, const char* fmt, ...) __attribute__((format(printf, 2, 3)));
-/* This function emits logs regardless of log_level setting and doesn't prefix the output. */
-void log_always(const char* fmt, ...) __attribute__((format(printf, 1, 2)));
+void pal_log(int level, const char* fmt, ...) __attribute__((format(printf, 2, 3)));
 
-#define PAL_LOG_DEFAULT_LEVEL  PAL_LOG_ERROR
+#define PAL_LOG_DEFAULT_LEVEL  LOG_LEVEL_ERROR
 #define PAL_LOG_DEFAULT_FD     2
-
-#define log_error(fmt...)    _log(PAL_LOG_ERROR, fmt)
-#define log_warning(fmt...)  _log(PAL_LOG_WARNING, fmt)
-#define log_debug(fmt...)    _log(PAL_LOG_DEBUG, fmt)
-#define log_trace(fmt...)    _log(PAL_LOG_TRACE, fmt)
 
 #define uthash_fatal(msg)                      \
     do {                                       \

--- a/Pal/src/printf.c
+++ b/Pal/src/printf.c
@@ -6,13 +6,14 @@
 #include "pal.h"
 #include "pal_internal.h"
 
+/* NOTE: We could add "pal" prefix to the below strings for more fine-grained log info */
 static const char* log_level_to_prefix[] = {
-    [PAL_LOG_NONE]    = "", // not a valid entry actually (no public wrapper uses this log level)
-    [PAL_LOG_ERROR]   = "error: ",
-    [PAL_LOG_WARNING] = "warning: ",
-    [PAL_LOG_DEBUG]   = "debug: ",
-    [PAL_LOG_TRACE]   = "trace: ",
-    [PAL_LOG_ALL]     = "", // same as for PAL_LOG_NONE
+    [LOG_LEVEL_NONE]    = "",
+    [LOG_LEVEL_ERROR]   = "error: ",
+    [LOG_LEVEL_WARNING] = "warning: ",
+    [LOG_LEVEL_DEBUG]   = "debug: ",
+    [LOG_LEVEL_TRACE]   = "trace: ",
+    [LOG_LEVEL_ALL]     = "", // same as for LOG_LEVEL_NONE
 };
 
 static int buf_write_all(const char* str, size_t size, void* arg) {
@@ -30,21 +31,7 @@ static void log_vprintf(const char* prefix, const char* fmt, va_list ap) {
     buf_flush(&buf);
 }
 
-// TODO: Replace this with log_* everywhere
-void pal_printf(const char* fmt, ...) {
-    va_list ap;
-
-    va_start(ap, fmt);
-    log_vprintf(/*prefix=*/NULL, fmt, ap);
-    va_end(ap);
-}
-
-// TODO: Replace this with log_* everywhere
-void pal_vprintf(const char* fmt, va_list ap) {
-    return log_vprintf(/*prefix=*/NULL, fmt, ap);
-}
-
-void _log(int level, const char* fmt, ...) {
+void pal_log(int level, const char* fmt, ...) {
     if (level <= g_pal_control.log_level) {
         va_list ap;
         va_start(ap, fmt);
@@ -52,11 +39,4 @@ void _log(int level, const char* fmt, ...) {
         log_vprintf(log_level_to_prefix[level], fmt, ap);
         va_end(ap);
     }
-}
-
-void log_always(const char* fmt, ...) {
-    va_list ap;
-    va_start(ap, fmt);
-    log_vprintf(/*prefix=*/NULL, fmt, ap);
-    va_end(ap);
 }

--- a/common/include/assert.h
+++ b/common/include/assert.h
@@ -1,3 +1,6 @@
+/* SPDX-License-Identifier: LGPL-3.0-or-later */
+/* Copyright (C) 2021 Intel Corporation */
+
 /*
  * Define a common interface for assertions that builds for both the PAL and libOS.
  */
@@ -8,6 +11,7 @@
 #include <stdnoreturn.h>
 
 #include "callbacks.h"
+#include "log.h"
 
 #define static_assert _Static_assert
 

--- a/common/include/callbacks.h
+++ b/common/include/callbacks.h
@@ -1,3 +1,6 @@
+/* SPDX-License-Identifier: LGPL-3.0-or-later */
+/* Copyright (C) 2021 Intel Corporation */
+
 /*
  * Defines a set of callbacks that the common library expects from environment it is linked into.
  * Currently, the common library expects `shim_`-prefixed callbacks from LibOS, `pal_`-prefixed
@@ -12,7 +15,7 @@
  *
  * All environments should implement the following callbacks:
  *
- * - log_always(), prints a non-optional debug message
+ * - _log(), prints a debug message (at different log levels)
  * - abort(), terminates the process
  *
  */
@@ -23,19 +26,19 @@
 #include <stdnoreturn.h>
 
 #ifdef IN_SHIM
-void shim_log_always(const char* format, ...) __attribute__((format(printf, 1, 2)));
+void shim_log(int level, const char* fmt, ...) __attribute__((format(printf, 2, 3)));
 noreturn void shim_abort(void);
-#define log_always(format...) shim_log_always(format)
+#define _log(level, format...) shim_log(level, format)
 #define abort() shim_abort()
 
 #elif IN_PAL
-void pal_log_always(const char* format, ...) __attribute__((format(printf, 1, 2)));
+void pal_log(int level, const char* fmt, ...) __attribute__((format(printf, 2, 3)));
 noreturn void pal_abort(void);
-#define log_always(format...) pal_log_always(format)
+#define _log(level, format...) pal_log(level, format)
 #define abort() pal_abort()
 
 #else
-void log_always(const char* format, ...) __attribute__((format(printf, 1, 2)));
+void _log(int level, const char* fmt, ...) __attribute__((format(printf, 2, 3)));
 noreturn void abort(void);
 #endif
 

--- a/common/include/log.h
+++ b/common/include/log.h
@@ -1,0 +1,24 @@
+/* SPDX-License-Identifier: LGPL-3.0-or-later */
+/* Copyright (C) 2021 Intel Corporation */
+
+#ifndef COMMON_LOG_H
+#define COMMON_LOG_H
+
+#include "callbacks.h"
+
+enum {
+    LOG_LEVEL_NONE    = 0,
+    LOG_LEVEL_ERROR   = 1,
+    LOG_LEVEL_WARNING = 2,
+    LOG_LEVEL_DEBUG   = 3,
+    LOG_LEVEL_TRACE   = 4,
+    LOG_LEVEL_ALL     = 5,
+};
+
+#define log_always(fmt...)   _log(LOG_LEVEL_NONE, fmt)
+#define log_error(fmt...)    _log(LOG_LEVEL_ERROR, fmt)
+#define log_warning(fmt...)  _log(LOG_LEVEL_WARNING, fmt)
+#define log_debug(fmt...)    _log(LOG_LEVEL_DEBUG, fmt)
+#define log_trace(fmt...)    _log(LOG_LEVEL_TRACE, fmt)
+
+#endif /* COMMON_LOG_H */

--- a/common/include/slabmgr.h
+++ b/common/include/slabmgr.h
@@ -14,6 +14,7 @@
 #include "api.h"
 #include "assert.h"
 #include "list.h"
+#include "log.h"
 
 // Before calling any of `system_malloc` and `system_free` this library will
 // acquire `SYSTEM_LOCK` (the system_* implementation must not do it).

--- a/common/include/spinlock.h
+++ b/common/include/spinlock.h
@@ -9,6 +9,7 @@
 
 #include "api.h"
 #include "cpu.h"
+#include "log.h"
 
 #ifdef DEBUG
 #define DEBUG_SPINLOCKS
@@ -183,7 +184,7 @@ static inline bool spinlock_is_locked(spinlock_t* lock) {
     }
     unsigned int owner = __atomic_load_n(&lock->owner, __ATOMIC_RELAXED);
     if (owner != get_cur_tid()) {
-        debug("Unexpected lock ownership: owned by: %d, checked in: %d", owner, get_cur_tid());
+        log_error("Unexpected lock ownership: owned by: %d, checked in: %d", owner, get_cur_tid());
         return false;
     }
     return true;

--- a/common/src/stack_protector.c
+++ b/common/src/stack_protector.c
@@ -3,7 +3,10 @@
  *                    Borys Popławski <borysp@invisiblethingslab.com>
  */
 
-#include "assert.h"
+#include <stdnoreturn.h>
+
+#include "callbacks.h"
+#include "log.h"
 
 /* declare here to silence GCC's "error: no previous prototype" */
 noreturn void __stack_chk_fail(void);

--- a/common/src/stdlib/printfmt.c
+++ b/common/src/stdlib/printfmt.c
@@ -8,6 +8,7 @@
 
 #include "assert.h"
 #include "api.h"
+#include "log.h"
 
 #undef vsnprintf
 #undef snprintf

--- a/common/src/string/memcpy.c
+++ b/common/src/string/memcpy.c
@@ -4,6 +4,7 @@
 
 #include "api.h"
 #include "assert.h"
+#include "log.h"
 
 #undef memcpy
 #undef memmove

--- a/common/src/string/memset.c
+++ b/common/src/string/memset.c
@@ -7,6 +7,7 @@
 
 #include "api.h"
 #include "assert.h"
+#include "log.h"
 
 #undef memset
 


### PR DESCRIPTION

## Description of the changes <!-- (reasons and measures) -->

Logging macros are used in the common library, LibOS and PAL. Thus, logging must be defined in the common library, with a callback defined in the corresponding Graphene component. This enables the common library functions to also use logging macros. This PR also removes unused `pal_printf()`, `pal_vprintf()` and `debug()`.

## How to test this PR? <!-- (if applicable) -->

All tests must pass.