### PR TITLE
[Pal] Add per-thread execution context (in-LibOS or in-PAL)

### DIFF
--- a/LibOS/shim/include/arch/x86_64/shim_entry_api.h
+++ b/LibOS/shim/include/arch/x86_64/shim_entry_api.h
@@ -15,8 +15,8 @@
 #define SHIM_ENTRY_API_H_
 
 /* Offsets for GS register at which entry vectors can be found */
-#define SHIM_SYSCALLDB_OFFSET         32
-#define SHIM_REGISTER_LIBRARY_OFFSET  40
+#define SHIM_SYSCALLDB_OFFSET         40
+#define SHIM_REGISTER_LIBRARY_OFFSET  48
 
 #ifdef __ASSEMBLER__
 

--- a/Pal/src/db_events.c
+++ b/Pal/src/db_events.c
@@ -8,21 +8,43 @@
 #include "pal_internal.h"
 
 int DkEventCreate(PAL_HANDLE* handle, bool init_signaled, bool auto_clear) {
+    assert(current_context_is_libos());
+    current_context_set_pal();
+
     *handle = NULL;
-    return _DkEventCreate(handle, init_signaled, auto_clear);
+    int ret = _DkEventCreate(handle, init_signaled, auto_clear);
+
+    current_context_set_libos();
+    return ret;
 }
 
 void DkEventSet(PAL_HANDLE handle) {
+    assert(current_context_is_libos());
+    current_context_set_pal();
+
     assert(handle && IS_HANDLE_TYPE(handle, event));
     _DkEventSet(handle);
+
+    current_context_set_libos();
 }
 
 void DkEventClear(PAL_HANDLE handle) {
+    assert(current_context_is_libos());
+    current_context_set_pal();
+
     assert(handle && IS_HANDLE_TYPE(handle, event));
     _DkEventClear(handle);
+
+    current_context_set_libos();
 }
 
 int DkEventWait(PAL_HANDLE handle, uint64_t* timeout_us) {
+    assert(current_context_is_libos());
+    current_context_set_pal();
+
     assert(handle && IS_HANDLE_TYPE(handle, event));
-    return _DkEventWait(handle, timeout_us);
+    int ret = _DkEventWait(handle, timeout_us);
+
+    current_context_set_libos();
+    return ret;
 }

--- a/Pal/src/db_exception.c
+++ b/Pal/src/db_exception.c
@@ -22,9 +22,14 @@ PAL_EVENT_HANDLER _DkGetExceptionHandler(PAL_NUM event) {
 }
 
 void DkSetExceptionHandler(PAL_EVENT_HANDLER handler, PAL_NUM event) {
+    assert(current_context_is_libos());
+    current_context_set_pal();
+
     assert(handler && event != 0 && event < ARRAY_SIZE(g_handlers));
 
     __atomic_store_n(&g_handlers[event], handler, __ATOMIC_RELEASE);
+
+    current_context_set_libos();
 }
 
 /* The below function is used by stack protector's __stack_chk_fail(), _FORTIFY_SOURCE's *_chk()

--- a/Pal/src/db_main.c
+++ b/Pal/src/db_main.c
@@ -24,6 +24,7 @@ PAL_CONTROL g_pal_control = {
 };
 
 const PAL_CONTROL* DkGetPalControl(void) {
+    assert(current_context_is_libos()); /* this function is trivial, no need to switch context */
     return &g_pal_control;
 }
 

--- a/Pal/src/db_memory.c
+++ b/Pal/src/db_memory.c
@@ -12,50 +12,76 @@
 #include "pal_internal.h"
 
 int DkVirtualMemoryAlloc(PAL_PTR* addr, PAL_NUM size, PAL_FLG alloc_type, PAL_FLG prot) {
+    assert(current_context_is_libos());
+    current_context_set_pal();
+
     assert(addr);
     void* map_addr = *addr;
 
     if ((map_addr && !IS_ALLOC_ALIGNED_PTR(map_addr)) || !size || !IS_ALLOC_ALIGNED(size)) {
+        current_context_set_libos();
         return -PAL_ERROR_INVAL;
     }
 
     if (map_addr && _DkCheckMemoryMappable(map_addr, size)) {
+        current_context_set_libos();
         return -PAL_ERROR_DENIED;
     }
 
-    return _DkVirtualMemoryAlloc(addr, size, alloc_type, prot);
+    int ret = _DkVirtualMemoryAlloc(addr, size, alloc_type, prot);
+
+    current_context_set_libos();
+    return ret;
 }
 
 int DkVirtualMemoryFree(PAL_PTR addr, PAL_NUM size) {
+    assert(current_context_is_libos());
+    current_context_set_pal();
+
     if (!addr || !size) {
+        current_context_set_libos();
         return -PAL_ERROR_INVAL;
     }
 
     if (!IS_ALLOC_ALIGNED_PTR(addr) || !IS_ALLOC_ALIGNED(size)) {
+        current_context_set_libos();
         return -PAL_ERROR_INVAL;
     }
 
     if (_DkCheckMemoryMappable((void*)addr, size)) {
+        current_context_set_libos();
         return -PAL_ERROR_DENIED;
     }
 
-    return _DkVirtualMemoryFree((void*)addr, size);
+    int ret = _DkVirtualMemoryFree((void*)addr, size);
+
+    current_context_set_libos();
+    return ret;
 }
 
 int DkVirtualMemoryProtect(PAL_PTR addr, PAL_NUM size, PAL_FLG prot) {
+    assert(current_context_is_libos());
+    current_context_set_pal();
+
     if (!addr || !size) {
+        current_context_set_libos();
         return -PAL_ERROR_INVAL;
     }
 
     if (!IS_ALLOC_ALIGNED_PTR(addr) || !IS_ALLOC_ALIGNED(size)) {
+        current_context_set_libos();
         return -PAL_ERROR_INVAL;
     }
 
     if (_DkCheckMemoryMappable((void*)addr, size)) {
+        current_context_set_libos();
         return -PAL_ERROR_DENIED;
     }
 
-    return _DkVirtualMemoryProtect((void*)addr, size, prot);
+    int ret = _DkVirtualMemoryProtect((void*)addr, size, prot);
+
+    current_context_set_libos();
+    return ret;
 }
 
 int add_preloaded_range(uintptr_t start, uintptr_t end, const char* comment) {

--- a/Pal/src/db_misc.c
+++ b/Pal/src/db_misc.c
@@ -12,35 +12,69 @@
 #include "pal_internal.h"
 
 int DkSystemTimeQuery(PAL_NUM* time) {
-    return _DkSystemTimeQuery(time);
+    assert(current_context_is_libos());
+    current_context_set_pal();
+
+    int ret = _DkSystemTimeQuery(time);
+
+    current_context_set_libos();
+    return ret;
 }
 
 int DkRandomBitsRead(PAL_PTR buffer, PAL_NUM size) {
-    return _DkRandomBitsRead((void*)buffer, size);
+    assert(current_context_is_libos());
+    current_context_set_pal();
+
+    int ret = _DkRandomBitsRead((void*)buffer, size);
+
+    current_context_set_libos();
+    return ret;
 }
 
 #if defined(__x86_64__)
 int DkSegmentRegisterGet(PAL_FLG reg, PAL_PTR* addr) {
-    return _DkSegmentRegisterGet(reg, addr);
+    assert(current_context_is_libos());
+    current_context_set_pal();
+
+    int ret = _DkSegmentRegisterGet(reg, addr);
+
+    current_context_set_libos();
+    return ret;
 }
 
 int DkSegmentRegisterSet(PAL_FLG reg, PAL_PTR addr) {
-    return _DkSegmentRegisterSet(reg, addr);
+    assert(current_context_is_libos());
+    current_context_set_pal();
+
+    int ret = _DkSegmentRegisterSet(reg, addr);
+
+    current_context_set_libos();
+    return ret;
 }
 #endif
 
 PAL_NUM DkMemoryAvailableQuota(void) {
+    assert(current_context_is_libos());
+    current_context_set_pal();
+
     long quota = _DkMemoryAvailableQuota();
     if (quota < 0)
         quota = 0;
 
-    return (PAL_NUM)quota;
+    PAL_NUM ret = (PAL_NUM)quota;
+
+    current_context_set_libos();
+    return ret;
 }
 
 int DkCpuIdRetrieve(PAL_IDX leaf, PAL_IDX subleaf, PAL_IDX values[4]) {
+    assert(current_context_is_libos());
+    current_context_set_pal();
+
     unsigned int vals[4];
     int ret = _DkCpuIdRetrieve(leaf, subleaf, vals);
     if (ret < 0) {
+        current_context_set_libos();
         return ret;
     }
 
@@ -49,21 +83,40 @@ int DkCpuIdRetrieve(PAL_IDX leaf, PAL_IDX subleaf, PAL_IDX values[4]) {
     values[2] = vals[2];
     values[3] = vals[3];
 
+    current_context_set_libos();
     return 0;
 }
 
 int DkAttestationReport(PAL_PTR user_report_data, PAL_NUM* user_report_data_size,
                         PAL_PTR target_info, PAL_NUM* target_info_size, PAL_PTR report,
                         PAL_NUM* report_size) {
-    return _DkAttestationReport(user_report_data, user_report_data_size, target_info,
-                                target_info_size, report, report_size);
+    assert(current_context_is_libos());
+    current_context_set_pal();
+
+    int ret = _DkAttestationReport(user_report_data, user_report_data_size, target_info,
+                                   target_info_size, report, report_size);
+
+    current_context_set_libos();
+    return ret;
 }
 
 int DkAttestationQuote(PAL_PTR user_report_data, PAL_NUM user_report_data_size, PAL_PTR quote,
                        PAL_NUM* quote_size) {
-    return _DkAttestationQuote(user_report_data, user_report_data_size, quote, quote_size);
+    assert(current_context_is_libos());
+    current_context_set_pal();
+
+    int ret = _DkAttestationQuote(user_report_data, user_report_data_size, quote, quote_size);
+
+    current_context_set_libos();
+    return ret;
 }
 
 int DkSetProtectedFilesKey(PAL_PTR pf_key_hex) {
-    return _DkSetProtectedFilesKey(pf_key_hex);
+    assert(current_context_is_libos());
+    current_context_set_pal();
+
+    int ret = _DkSetProtectedFilesKey(pf_key_hex);
+
+    current_context_set_libos();
+    return ret;
 }

--- a/Pal/src/db_object.c
+++ b/Pal/src/db_object.c
@@ -42,9 +42,14 @@ int _DkObjectClose(PAL_HANDLE objectHandle) {
  */
 /* PAL call DkObjectClose: Close the given object handle. */
 void DkObjectClose(PAL_HANDLE objectHandle) {
+    assert(current_context_is_libos());
+    current_context_set_pal();
+
     assert(objectHandle);
 
     _DkObjectClose(objectHandle);
+
+    current_context_set_libos();
 }
 
 /* Wait for user-specified events of handles in the handle array. The wait can be timed out, unless
@@ -52,11 +57,18 @@ void DkObjectClose(PAL_HANDLE objectHandle) {
  * error code otherwise. */
 int DkStreamsWaitEvents(PAL_NUM count, PAL_HANDLE* handle_array, PAL_FLG* events,
                         PAL_FLG* ret_events, PAL_NUM timeout_us) {
+    assert(current_context_is_libos());
+    current_context_set_pal();
+
     for (PAL_NUM i = 0; i < count; i++) {
         if (UNKNOWN_HANDLE(handle_array[i])) {
+            current_context_set_libos();
             return -PAL_ERROR_INVAL;
         }
     }
 
-    return _DkStreamsWaitEvents(count, handle_array, events, ret_events, timeout_us);
+    int ret = _DkStreamsWaitEvents(count, handle_array, events, ret_events, timeout_us);
+
+    current_context_set_libos();
+    return ret;
 }

--- a/Pal/src/db_process.c
+++ b/Pal/src/db_process.c
@@ -16,13 +16,22 @@
 #include "pal_internal.h"
 
 int DkProcessCreate(PAL_STR exec_uri, PAL_STR* args, PAL_HANDLE* handle) {
+    assert(current_context_is_libos());
+    current_context_set_pal();
+
     assert(exec_uri);
 
     *handle = NULL;
-    return _DkProcessCreate(handle, exec_uri, args);
+    int ret = _DkProcessCreate(handle, exec_uri, args);
+
+    current_context_set_libos();
+    return ret;
 }
 
 noreturn void DkProcessExit(PAL_NUM exitcode) {
+    assert(current_context_is_libos());
+    current_context_set_pal();
+
     _DkProcessExit(exitcode);
     die_or_inf_loop();
 }

--- a/Pal/src/db_streams.c
+++ b/Pal/src/db_streams.c
@@ -161,8 +161,14 @@ int _DkStreamOpen(PAL_HANDLE* handle, const char* uri, int access, int share, in
  */
 int DkStreamOpen(PAL_STR uri, PAL_FLG access, PAL_FLG share, PAL_FLG create, PAL_FLG options,
                  PAL_HANDLE* handle) {
+    assert(current_context_is_libos());
+    current_context_set_pal();
+
     *handle = NULL;
-    return _DkStreamOpen(handle, uri, access, share, create, options);
+    int ret = _DkStreamOpen(handle, uri, access, share, create, options);
+
+    current_context_set_libos();
+    return ret;
 }
 
 static int _DkStreamWaitForClient(PAL_HANDLE handle, PAL_HANDLE* client) {
@@ -180,8 +186,14 @@ static int _DkStreamWaitForClient(PAL_HANDLE handle, PAL_HANDLE* client) {
 }
 
 int DkStreamWaitForClient(PAL_HANDLE handle, PAL_HANDLE* client) {
+    assert(current_context_is_libos());
+    current_context_set_pal();
+
     *client = NULL;
-    return _DkStreamWaitForClient(handle, client);
+    int ret = _DkStreamWaitForClient(handle, client);
+
+    current_context_set_libos();
+    return ret;
 }
 
 /* _DkStreamDelete for internal use. This function will explicit delete
@@ -202,11 +214,18 @@ int _DkStreamDelete(PAL_HANDLE handle, int access) {
 }
 
 int DkStreamDelete(PAL_HANDLE handle, PAL_FLG access) {
+    assert(current_context_is_libos());
+    current_context_set_pal();
+
     if (!handle) {
+        current_context_set_libos();
         return -PAL_ERROR_INVAL;
     }
 
-    return _DkStreamDelete(handle, access);
+    int ret = _DkStreamDelete(handle, access);
+
+    current_context_set_libos();
+    return ret;
 }
 
 /* _DkStreamRead for internal use. Read from stream as absolute offset.
@@ -237,7 +256,11 @@ int64_t _DkStreamRead(PAL_HANDLE handle, uint64_t offset, uint64_t count, void* 
 
 int DkStreamRead(PAL_HANDLE handle, PAL_NUM offset, PAL_NUM* count, PAL_PTR buffer, PAL_PTR source,
                  PAL_NUM size) {
+    assert(current_context_is_libos());
+    current_context_set_pal();
+
     if (!handle || !buffer) {
+        current_context_set_libos();
         return -PAL_ERROR_INVAL;
     }
 
@@ -245,10 +268,13 @@ int DkStreamRead(PAL_HANDLE handle, PAL_NUM offset, PAL_NUM* count, PAL_PTR buff
                                 source ? size : 0);
 
     if (ret < 0) {
+        current_context_set_libos();
         return ret;
     }
 
     *count = ret;
+
+    current_context_set_libos();
     return 0;
 }
 
@@ -279,7 +305,11 @@ int64_t _DkStreamWrite(PAL_HANDLE handle, uint64_t offset, uint64_t count, const
 }
 
 int DkStreamWrite(PAL_HANDLE handle, PAL_NUM offset, PAL_NUM* count, PAL_PTR buffer, PAL_STR dest) {
+    assert(current_context_is_libos());
+    current_context_set_pal();
+
     if (!handle || !buffer) {
+        current_context_set_libos();
         return -PAL_ERROR_INVAL;
     }
 
@@ -287,10 +317,13 @@ int DkStreamWrite(PAL_HANDLE handle, PAL_NUM offset, PAL_NUM* count, PAL_PTR buf
                                  dest ? strlen(dest) : 0);
 
     if (ret < 0) {
+        current_context_set_libos();
         return ret;
     }
 
     *count = ret;
+
+    current_context_set_libos();
     return 0;
 }
 
@@ -314,7 +347,11 @@ int _DkStreamAttributesQuery(const char* uri, PAL_STREAM_ATTR* attr) {
 }
 
 int DkStreamAttributesQuery(PAL_STR uri, PAL_STREAM_ATTR* attr) {
+    assert(current_context_is_libos());
+    current_context_set_pal();
+
     if (!uri || !attr) {
+        current_context_set_libos();
         return -PAL_ERROR_INVAL;
     }
 
@@ -323,10 +360,13 @@ int DkStreamAttributesQuery(PAL_STR uri, PAL_STREAM_ATTR* attr) {
     int ret = _DkStreamAttributesQuery(uri, &attr_buf);
 
     if (ret < 0) {
+        current_context_set_libos();
         return ret;
     }
 
     memcpy(attr, &attr_buf, sizeof(PAL_STREAM_ATTR));
+
+    current_context_set_libos();
     return 0;
 }
 
@@ -345,28 +385,44 @@ int _DkStreamAttributesQueryByHandle(PAL_HANDLE hdl, PAL_STREAM_ATTR* attr) {
 }
 
 int DkStreamAttributesQueryByHandle(PAL_HANDLE handle, PAL_STREAM_ATTR* attr) {
+    assert(current_context_is_libos());
+    current_context_set_pal();
+
     if (!handle || !attr) {
+        current_context_set_libos();
         return -PAL_ERROR_INVAL;
     }
 
-    return _DkStreamAttributesQueryByHandle(handle, attr);
+    int ret = _DkStreamAttributesQueryByHandle(handle, attr);
+
+    current_context_set_libos();
+    return ret;
 }
 
 int DkStreamAttributesSetByHandle(PAL_HANDLE handle, PAL_STREAM_ATTR* attr) {
+    assert(current_context_is_libos());
+    current_context_set_pal();
+
     if (!handle || !attr) {
+        current_context_set_libos();
         return -PAL_ERROR_INVAL;
     }
 
     const struct handle_ops* ops = HANDLE_OPS(handle);
     if (!ops) {
+        current_context_set_libos();
         return -PAL_ERROR_BADHANDLE;
     }
 
     if (!ops->attrsetbyhdl) {
+        current_context_set_libos();
         return -PAL_ERROR_NOTSUPPORT;
     }
 
-    return ops->attrsetbyhdl(handle, attr);
+    int ret = ops->attrsetbyhdl(handle, attr);
+
+    current_context_set_libos();
+    return ret;
 }
 
 int _DkStreamGetName(PAL_HANDLE handle, char* buffer, size_t size) {
@@ -388,11 +444,18 @@ int _DkStreamGetName(PAL_HANDLE handle, char* buffer, size_t size) {
 }
 
 int DkStreamGetName(PAL_HANDLE handle, PAL_PTR buffer, PAL_NUM size) {
+    assert(current_context_is_libos());
+    current_context_set_pal();
+
     if (!handle || !buffer || !size) {
+        current_context_set_libos();
         return -PAL_ERROR_INVAL;
     }
 
-    return _DkStreamGetName(handle, (void*)buffer, size);
+    int ret = _DkStreamGetName(handle, (void*)buffer, size);
+
+    current_context_set_libos();
+    return ret;
 }
 
 /* _DkStreamMap for internal use. Map specific handle to certain memory,
@@ -419,37 +482,55 @@ int _DkStreamMap(PAL_HANDLE handle, void** paddr, int prot, uint64_t offset, uin
 }
 
 int DkStreamMap(PAL_HANDLE handle, PAL_PTR* addr, PAL_FLG prot, PAL_NUM offset, PAL_NUM size) {
+    assert(current_context_is_libos());
+    current_context_set_pal();
+
     assert(addr);
     void* map_addr = *addr;
 
     if (!handle) {
+        current_context_set_libos();
         return -PAL_ERROR_INVAL;
     }
 
     if (map_addr && !IS_ALLOC_ALIGNED_PTR(map_addr)) {
+        current_context_set_libos();
         return -PAL_ERROR_INVAL;
     }
     if (!size || !IS_ALLOC_ALIGNED(size) || !IS_ALLOC_ALIGNED(offset)) {
+        current_context_set_libos();
         return -PAL_ERROR_INVAL;
     }
 
     if (map_addr && _DkCheckMemoryMappable(map_addr, size)) {
+        current_context_set_libos();
         return -PAL_ERROR_DENIED;
     }
 
-    return _DkStreamMap(handle, addr, prot, offset, size);
+    int ret = _DkStreamMap(handle, addr, prot, offset, size);
+
+    current_context_set_libos();
+    return ret;
 }
 
 int DkStreamUnmap(PAL_PTR addr, PAL_NUM size) {
+    assert(current_context_is_libos());
+    current_context_set_pal();
+
     if (!addr || !IS_ALLOC_ALIGNED_PTR(addr) || !size || !IS_ALLOC_ALIGNED(size)) {
+        current_context_set_libos();
         return -PAL_ERROR_INVAL;
     }
 
     if (_DkCheckMemoryMappable((void*)addr, size)) {
+        current_context_set_libos();
         return -PAL_ERROR_DENIED;
     }
 
-    return _DkStreamUnmap((void*)addr, size);
+    int ret = _DkStreamUnmap((void*)addr, size);
+
+    current_context_set_libos();
+    return ret;
 }
 
 /* _DkStreamSetLength for internal use. This function truncate the stream
@@ -467,17 +548,23 @@ int64_t _DkStreamSetLength(PAL_HANDLE handle, uint64_t length) {
 }
 
 int DkStreamSetLength(PAL_HANDLE handle, PAL_NUM length) {
+    assert(current_context_is_libos());
+    current_context_set_pal();
+
     if (!handle) {
+        current_context_set_libos();
         return -PAL_ERROR_INVAL;
     }
 
     int64_t ret = _DkStreamSetLength(handle, length);
 
     if (ret < 0) {
+        current_context_set_libos();
         return ret;
     }
 
     assert((uint64_t)ret == length);
+    current_context_set_libos();
     return 0;
 }
 
@@ -499,33 +586,57 @@ int _DkStreamFlush(PAL_HANDLE handle) {
 }
 
 int DkStreamFlush(PAL_HANDLE handle) {
+    assert(current_context_is_libos());
+    current_context_set_pal();
+
     if (!handle) {
+        current_context_set_libos();
         return -PAL_ERROR_INVAL;
     }
 
-    return _DkStreamFlush(handle);
+    int ret = _DkStreamFlush(handle);
+
+    current_context_set_libos();
+    return ret;
 }
 
 int DkSendHandle(PAL_HANDLE handle, PAL_HANDLE cargo) {
+    assert(current_context_is_libos());
+    current_context_set_pal();
+
     // Return error if any of the handle is NULL
     if (!handle || !cargo) {
+        current_context_set_libos();
         return -PAL_ERROR_INVAL;
     }
 
-    return _DkSendHandle(handle, cargo);
+    int ret = _DkSendHandle(handle, cargo);
+
+    current_context_set_libos();
+    return ret;
 }
 
 int DkReceiveHandle(PAL_HANDLE handle, PAL_HANDLE* cargo) {
+    assert(current_context_is_libos());
+    current_context_set_pal();
+
     // return error if any of the handle is NULL
     if (!handle) {
+        current_context_set_libos();
         return -PAL_ERROR_INVAL;
     }
 
     *cargo = NULL;
-    return _DkReceiveHandle(handle, cargo);
+    int ret = _DkReceiveHandle(handle, cargo);
+
+    current_context_set_libos();
+    return ret;
 }
 
 int DkStreamChangeName(PAL_HANDLE hdl, PAL_STR uri) {
+    assert(current_context_is_libos());
+    current_context_set_pal();
+
     struct handle_ops* ops = NULL;
     char* type             = NULL;
     int ret;
@@ -534,6 +645,7 @@ int DkStreamChangeName(PAL_HANDLE hdl, PAL_STR uri) {
         ret = parse_stream_uri(&uri, &type, &ops);
 
         if (ret < 0) {
+            current_context_set_libos();
             return ret;
         }
     }
@@ -542,11 +654,14 @@ int DkStreamChangeName(PAL_HANDLE hdl, PAL_STR uri) {
 
     if (!hops || !hops->rename || (ops && hops != ops)) {
         free(type);
+        current_context_set_libos();
         return -PAL_ERROR_NOTSUPPORT;
     }
 
     ret = hops->rename(hdl, type, uri);
     free(type);
+
+    current_context_set_libos();
     return ret;
 }
 
@@ -562,5 +677,11 @@ const char* _DkStreamRealpath(PAL_HANDLE hdl) {
 }
 
 int DkDebugLog(PAL_PTR buffer, PAL_NUM size) {
-    return _DkDebugLog(buffer, size);
+    assert(current_context_is_libos());
+    current_context_set_pal();
+
+    int ret = _DkDebugLog(buffer, size);
+
+    current_context_set_libos();
+    return ret;
 }

--- a/Pal/src/db_threading.c
+++ b/Pal/src/db_threading.c
@@ -13,34 +13,67 @@
 
 /* PAL call DkThreadCreate: create a thread inside the current process */
 int DkThreadCreate(PAL_PTR addr, PAL_PTR param, PAL_HANDLE* handle) {
+    assert(current_context_is_libos());
+    current_context_set_pal();
+
     *handle = NULL;
-    return _DkThreadCreate(handle, (int (*)(void*))addr, (const void*)param);
+    int ret = _DkThreadCreate(handle, (int (*)(void*))addr, (const void*)param);
+
+    current_context_set_libos();
+    return ret;
 }
 
 /* PAL call DkThreadYieldExecution. Yield the execution of the current thread. */
 void DkThreadYieldExecution(void) {
+    assert(current_context_is_libos());
+    current_context_set_pal();
+
     _DkThreadYieldExecution();
+
+    current_context_set_libos();
 }
 
 /* PAL call DkThreadExit: simply exit the current thread no matter what */
 noreturn void DkThreadExit(PAL_PTR clear_child_tid) {
+    assert(current_context_is_libos());
+    current_context_set_pal();
+
     _DkThreadExit((int*)clear_child_tid);
     /* UNREACHABLE */
 }
 
 /* PAL call DkThreadResume: resume the execution of a thread which is delayed before */
 int DkThreadResume(PAL_HANDLE threadHandle) {
+    assert(current_context_is_libos());
+    current_context_set_pal();
+
     if (!threadHandle || !IS_HANDLE_TYPE(threadHandle, thread)) {
+        current_context_set_libos();
         return -PAL_ERROR_INVAL;
     }
 
-    return _DkThreadResume(threadHandle);
+    int ret = _DkThreadResume(threadHandle);
+
+    current_context_set_libos();
+    return ret;
 }
 
 int DkThreadSetCpuAffinity(PAL_HANDLE thread, PAL_NUM cpumask_size, PAL_PTR cpu_mask) {
-    return _DkThreadSetCpuAffinity(thread, cpumask_size, cpu_mask);
+    assert(current_context_is_libos());
+    current_context_set_pal();
+
+    int ret = _DkThreadSetCpuAffinity(thread, cpumask_size, cpu_mask);
+
+    current_context_set_libos();
+    return ret;
 }
 
 int DkThreadGetCpuAffinity(PAL_HANDLE thread, PAL_NUM cpumask_size, PAL_PTR cpu_mask) {
-    return _DkThreadGetCpuAffinity(thread, cpumask_size, cpu_mask);
+    assert(current_context_is_libos());
+    current_context_set_pal();
+
+    int ret = _DkThreadGetCpuAffinity(thread, cpumask_size, cpu_mask);
+
+    current_context_set_libos();
+    return ret;
 }

--- a/Pal/src/host/Linux-SGX/db_threading.c
+++ b/Pal/src/host/Linux-SGX/db_threading.c
@@ -87,7 +87,12 @@ __attribute__((__optimize__("-fno-stack-protector"))) void pal_start_thread(void
     pal_set_tcb_stack_canary(stack_protector_canary);
     PAL_TCB* pal_tcb = pal_get_tcb();
     memset(&pal_tcb->libos_tcb, 0, sizeof(pal_tcb->libos_tcb));
+
+    assert(current_context_is_pal());
+    current_context_set_libos();
     callback((void*)param);
+    current_context_set_pal();
+
     _DkThreadExit(/*clear_child_tid=*/NULL);
     /* UNREACHABLE */
 }

--- a/Pal/src/host/Linux-SGX/enclave_ecalls.c
+++ b/Pal/src/host/Linux-SGX/enclave_ecalls.c
@@ -77,6 +77,7 @@ void handle_ecall(long ecall_index, void* ecall_args, void* exit_target, void* e
     SET_ENCLAVE_TLS(ustack_top,      ursp);
     SET_ENCLAVE_TLS(clear_child_tid, NULL);
     SET_ENCLAVE_TLS(untrusted_area_cache.in_use, 0UL);
+    SET_ENCLAVE_TLS(common.current_context, 0UL);
 
     int64_t t = 0;
     if (__atomic_compare_exchange_n(&g_enclave_start_called.counter, &t, 1, /*weak=*/false,

--- a/Pal/src/host/Linux/db_threading.c
+++ b/Pal/src/host/Linux/db_threading.c
@@ -110,8 +110,13 @@ __attribute__((__optimize__("-fno-stack-protector"))) int pal_thread_init(void* 
             return ret;
     }
 
-    if (tcb->callback)
-        return (*tcb->callback)(tcb->param);
+    if (tcb->callback) {
+        assert(current_context_is_pal());
+        current_context_set_libos();
+        ret = (*tcb->callback)(tcb->param);
+        current_context_set_pal();
+        return ret;
+    }
 
     return 0;
 }


### PR DESCRIPTION

## Description of the changes <!-- (reasons and measures) -->

With this PR, at every moment in time each thread can be queried to determine whether it executes in LibOS context or in PAL context. For this, a 64-bit variable is introduced in the common PAL_TCB block. Each bit in this variable denotes PAL context (bit == 0) or LibOS context (bit == 1). To support nested exceptions, each of 64 bits represents a nested level (bit 0 is normal execution, bit 1 is first exception level, etc).

This per-thread execution context is not used currently. Future commits will use it to dynamically choose between LibOS/PAL callbacks for malloc/free/log/abort in the common library. This paves a way to statically link LibOS, PAL and the common library in one binary.

## How to test this PR? <!-- (if applicable) -->

All tests must pass.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2397)
<!-- Reviewable:end -->
