### PR TITLE
[LibOS,Pal] Remove malloc_copy and commented-out realloc

### DIFF
--- a/LibOS/shim/include/shim_utils.h
+++ b/LibOS/shim/include/shim_utils.h
@@ -138,7 +138,6 @@ int init_slab(void);
 
 void* malloc(size_t size);
 void free(void* mem);
-void* malloc_copy(const void* mem, size_t size);
 
 /* ELF binary loading */
 int check_elf_object(struct shim_handle* file);

--- a/LibOS/shim/src/ipc/shim_ipc_pid.c
+++ b/LibOS/shim/src/ipc/shim_ipc_pid.c
@@ -245,9 +245,11 @@ int ipc_pid_retstatus_callback(struct shim_ipc_msg* msg, IDTYPE src) {
     struct retstatus_args data = {
         .retval = msgin->nstatus
     };
-    data.status = malloc_copy(msgin->status, sizeof(*data.status) * msgin->nstatus);
+    data.status = malloc(sizeof(*data.status) * msgin->nstatus);
     if (!data.status) {
         data.retval = 0;
+    } else {
+        memcpy(data.status, msgin->status, sizeof(*data.status) * msgin->nstatus);
     }
 
     ipc_msg_response_handle(src, msg->seq, set_msg_retstatus, &data);
@@ -418,9 +420,11 @@ int ipc_pid_retmeta_callback(struct shim_ipc_msg* msg, IDTYPE src) {
         .retval = msgin->datasize,
     };
     if (msgin->datasize) {
-        args.data = malloc_copy(msgin->data, msgin->datasize);
+        args.data = malloc(msgin->datasize);
         if (!args.data) {
             args.retval = 0;
+        } else {
+            memcpy(args.data, msgin->data, msgin->datasize);
         }
     }
 

--- a/LibOS/shim/src/shim_malloc.c
+++ b/LibOS/shim/src/shim_malloc.c
@@ -105,39 +105,6 @@ void* calloc(size_t nmemb, size_t size) {
     return ptr;
 }
 
-#if 0
-void* realloc(void* ptr, size_t new_size) {
-    /* TODO: decide how to deal with migrated-memory case */
-    assert(!memory_migrated(ptr));
-
-    size_t old_size = slab_get_buf_size(slab_mgr, ptr);
-
-    /* TODO: this realloc() implementation follows the Glibc design, which will avoid reallocation
-     *       when the buffer is large enough. Potentially this design can cause memory draining if
-     *       user resizes an extremely large object to much smaller. */
-    if (old_size >= new_size)
-        return ptr;
-
-    void* new_buf = malloc(new_size);
-    if (!new_buf)
-        return NULL;
-
-    /* realloc() does not zero the rest of the object */
-    memcpy(new_buf, ptr, old_size);
-
-    free(ptr);
-    return new_buf;
-}
-#endif
-
-// Copies data from `mem` to a newly allocated buffer of a specified size.
-void* malloc_copy(const void* mem, size_t size) {
-    void* buff = malloc(size);
-    if (buff)
-        memcpy(buff, mem, size);
-    return buff;
-}
-
 void free(void* mem) {
     if (memory_migrated(mem)) {
         return;

--- a/Pal/src/db_main.c
+++ b/Pal/src/db_main.c
@@ -117,12 +117,11 @@ static int insert_envs_from_manifest(const char*** envpp) {
         if (!toml_env_raw) {
             /* this original env is not found in manifest (i.e., not overwritten) */
             *orig_env_key_end = '=';
-            new_envp[idx] = malloc(strlen(*orig_env) + 1);
+            new_envp[idx] = strdup(*orig_env);
             if (!new_envp[idx]) {
                 /* don't care about proper memory cleanup since will terminate anyway */
                 return -PAL_ERROR_NOMEM;
             }
-            memcpy((char*)new_envp[idx], *orig_env, strlen(*orig_env) + 1);
             idx++;
         }
         *orig_env_key_end = '=';

--- a/Pal/src/db_main.c
+++ b/Pal/src/db_main.c
@@ -117,11 +117,12 @@ static int insert_envs_from_manifest(const char*** envpp) {
         if (!toml_env_raw) {
             /* this original env is not found in manifest (i.e., not overwritten) */
             *orig_env_key_end = '=';
-            new_envp[idx] = malloc_copy(*orig_env, strlen(*orig_env) + 1);
+            new_envp[idx] = malloc(strlen(*orig_env) + 1);
             if (!new_envp[idx]) {
                 /* don't care about proper memory cleanup since will terminate anyway */
                 return -PAL_ERROR_NOMEM;
             }
+            memcpy((char*)new_envp[idx], *orig_env, strlen(*orig_env) + 1);
             idx++;
         }
         *orig_env_key_end = '=';

--- a/Pal/src/db_rtld.c
+++ b/Pal/src/db_rtld.c
@@ -59,11 +59,8 @@ struct link_map* new_elf_object(const char* realname, enum object_type type) {
     /* We apparently expect this to be zeroed. */
     memset(new, 0, sizeof(struct link_map));
 
-    new->l_name = realname ? malloc(strlen(realname) + 1) : NULL;
+    new->l_name = realname ? strdup(realname) : NULL;
     new->l_type = type;
-
-    if (new->l_name)
-        memcpy((char*)new->l_name, realname, strlen(realname) + 1);
 
     return new;
 }

--- a/Pal/src/db_streams.c
+++ b/Pal/src/db_streams.c
@@ -117,9 +117,10 @@ static int parse_stream_uri(const char** uri, char** prefix, struct handle_ops**
     *uri = p;
 
     if (prefix) {
-        *prefix = malloc_copy(u, p - u);
+        *prefix = malloc(p - u);
         if (!*prefix)
             return -PAL_ERROR_NOMEM;
+        memcpy(*prefix, u, p - u);
         /* We don't want ':' in prefix, replacing that with nullbyte which also ends the string. */
         (*prefix)[p - 1 - u] = '\0';
     }

--- a/Pal/src/host/Linux-SGX/db_memory.c
+++ b/Pal/src/host/Linux-SGX/db_memory.c
@@ -20,7 +20,9 @@ extern struct atomic_int g_allocated_pages;
 extern size_t g_page_size;
 
 bool _DkCheckMemoryMappable(const void* addr, size_t size) {
-    if (addr < DATA_END && addr + size > TEXT_START) {
+    /* FIXME: This only checks that the memory region doesn't overlap with the PAL text segment.
+     * Ideally, this should check that memory region doesn't overlap with any reserved PAL data. */
+    if (addr < TEXT_END && addr + size > TEXT_START) {
         log_error("Address %p-%p is not mappable\n", addr, addr + size);
         return true;
     }

--- a/Pal/src/host/Linux-SGX/pal_linux.h
+++ b/Pal/src/host/Linux-SGX/pal_linux.h
@@ -70,8 +70,8 @@ void setup_pal_map(struct link_map* map);
 extern char __text_start, __text_end, __data_start, __data_end;
 #define TEXT_START ((void*)(&__text_start))
 #define TEXT_END   ((void*)(&__text_end))
-#define DATA_START ((void*)(&__text_start))
-#define DATA_END   ((void*)(&__text_end))
+#define DATA_START ((void*)(&__data_start))
+#define DATA_END   ((void*)(&__data_end))
 
 typedef struct {
     uint8_t bytes[32];

--- a/Pal/src/host/Linux/db_memory.c
+++ b/Pal/src/host/Linux/db_memory.c
@@ -19,7 +19,9 @@
 #include "pal_linux_error.h"
 
 bool _DkCheckMemoryMappable(const void* addr, size_t size) {
-    return (addr < DATA_END && addr + size > TEXT_START);
+    /* FIXME: This only checks that the memory region doesn't overlap with the PAL text segment.
+     * Ideally, this should check that memory region doesn't overlap with any reserved PAL data. */
+    return (addr < TEXT_END && addr + size > TEXT_START);
 }
 
 int _DkVirtualMemoryAlloc(void** paddr, size_t size, int alloc_type, int prot) {

--- a/Pal/src/host/Linux/pal_linux.h
+++ b/Pal/src/host/Linux/pal_linux.h
@@ -137,8 +137,8 @@ void signal_setup(void);
 extern char __text_start, __text_end, __data_start, __data_end;
 #define TEXT_START ((void*)(&__text_start))
 #define TEXT_END   ((void*)(&__text_end))
-#define DATA_START ((void*)(&__text_start))
-#define DATA_END   ((void*)(&__text_end))
+#define DATA_START ((void*)(&__data_start))
+#define DATA_END   ((void*)(&__data_end))
 
 #define ADDR_IN_PAL_OR_VDSO(addr) \
         (((void*)(addr) > TEXT_START && (void*)(addr) < TEXT_END) || is_in_vdso(addr))

--- a/Pal/src/pal_internal.h
+++ b/Pal/src/pal_internal.h
@@ -259,7 +259,6 @@ int load_elf_object_by_handle(PAL_HANDLE handle, enum object_type type, void** o
 
 void init_slab_mgr(size_t alignment);
 void* malloc(size_t size);
-void* malloc_copy(const void* mem, size_t size);
 void* calloc(size_t nmem, size_t size);
 void free(void* mem);
 

--- a/Pal/src/slab.c
+++ b/Pal/src/slab.c
@@ -136,16 +136,6 @@ void* malloc(size_t size) {
     return ptr;
 }
 
-// Copies data from `mem` to a newly allocated buffer of a specified size.
-void* malloc_copy(const void* mem, size_t size) {
-    void* nmem = malloc(size);
-
-    if (nmem)
-        memcpy(nmem, mem, size);
-
-    return nmem;
-}
-
 void* calloc(size_t nmem, size_t size) {
     void* ptr = malloc(nmem * size);
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Two commits in this PR:

- [LibOS,Pal] Remove `malloc_copy` and commented-out `realloc`
- [Pal/Linux] Fix typo in macros `DATA_START` and `DATA_END`

These are a couple random changes/bug fixes I did while working on a bigger project of "LibOS + PAL + common in one binary". `realloc()` was never used in LibOS and couldn't actually be used, due to the issue of unmovable checkpoint memory. `malloc_copy()` is a weird function not used frequently, so I just re-wrote its usages.

## How to test this PR? <!-- (if applicable) -->

All tests must pass.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2401)
<!-- Reviewable:end -->
