### PR TITLE
[LibOS] Split `shim_mount` and `shim_fs`

### DIFF
--- a/LibOS/shim/include/shim_handle.h
+++ b/LibOS/shim/include/shim_handle.h
@@ -291,7 +291,7 @@ struct shim_epoll_handle {
     LISTP_TYPE(shim_epoll_item) fds;
 };
 
-struct shim_mount;
+struct shim_fs;
 struct shim_qstr;
 struct shim_dentry;
 
@@ -303,8 +303,7 @@ struct shim_handle {
 
     REFTYPE ref_count;
 
-    char fs_type[8];
-    struct shim_mount* fs;
+    struct shim_fs* fs;
     struct shim_dentry* dentry;
 
     /* If this handle is registered for any epoll handle, this list contains

--- a/LibOS/shim/src/bookkeep/shim_handle.c
+++ b/LibOS/shim/src/bookkeep/shim_handle.c
@@ -45,7 +45,7 @@ static int init_tty_handle(struct shim_handle* hdl, bool write) {
     if (ret < 0)
         return ret;
 
-    set_handle_fs(hdl, dent->fs);
+    hdl->fs = dent->fs;
     hdl->dentry = dent;
     return 0;
 }
@@ -73,15 +73,27 @@ static inline int init_exec_handle(void) {
     exec->flags    = O_RDONLY;
     exec->acc_mode = MAY_READ;
 
-    struct shim_mount* fs = find_mount_from_uri(g_pal_control->executable);
-    if (fs) {
-        const char* p = g_pal_control->executable + fs->uri.len;
+    /*
+     * Find a mounted filesystem for an executable, and initialize the handle (dentry and fs).
+     *
+     * TODO: The below code is broken, and should be rewritten:
+     *
+     * - Instead of manually constructing the handle, use the proper function for opening a file
+     *   (`open_namei`).
+     *
+     * - The treatment of relative paths is wrong, and really only makes sense for the default case
+     *   when the root mount is "file:." and executable is "file:<executable>". We should probably
+     *   convert both of these to absolute paths first.
+     */
+    struct shim_mount* mount = find_mount_from_uri(g_pal_control->executable);
+    if (mount) {
+        const char* p = g_pal_control->executable + mount->uri.len;
         /* Lookup for `g_pal_control->executable` needs to be done under a given mount point which
          * requires a relative path name. OTOH the one in manifest file can be absolute path. */
         while (*p == '/') {
             p++;
         }
-        int ret = path_lookupat(fs->mount_point, p, LOOKUP_FOLLOW, &exec->dentry);
+        int ret = path_lookupat(mount->mount_point, p, LOOKUP_FOLLOW, &exec->dentry);
         if (ret < 0) {
             log_error("init_exec_handle: cannot find executable in filesystem: %d\n", ret);
             return ret;
@@ -91,15 +103,20 @@ static inline int init_exec_handle(void) {
             log_error("init_exec_handle: executable is not a regular file\n");
             return -EINVAL;
         }
-        if (exec->dentry->fs != fs) {
+        if (exec->dentry->mount != mount) {
             log_error("init_exec_handle: cannot find executable in filesystem, "
                       "it seems to be shadowed by a mount\n");
             return -EINVAL;
         }
-        set_handle_fs(exec, fs);
-        put_mount(fs);
+        exec->fs = mount->fs;
+        put_mount(mount);
     } else {
-        set_handle_fs(exec, &chroot_builtin_fs);
+        /*
+         * TODO: This is for cases where the above lookup fails, e.g. `host_root_fs` regression test
+         * (which mounts "file:/" as root). We construct a dentry-less handle in such cases, but
+         * once the lookup is fixed, we should return an error instead.
+         */
+        exec->fs = &chroot_builtin_fs;
     }
 
     lock(&g_process.fs_lock);
@@ -396,8 +413,8 @@ static inline __attribute__((unused)) const char* __handle_name(struct shim_hand
         return qstrgetstr(&hdl->uri);
     if (hdl->dentry && !qstrempty(&hdl->dentry->name))
         return qstrgetstr(&hdl->dentry->name);
-    if (hdl->fs_type[0])
-        return hdl->fs_type;
+    if (hdl->fs)
+        return hdl->fs->name;
     return "(unknown)";
 }
 
@@ -454,9 +471,6 @@ void put_handle(struct shim_handle* hdl) {
 
         if (hdl->dentry)
             put_dentry(hdl->dentry);
-
-        if (hdl->fs)
-            put_mount(hdl->fs);
 
         destroy_handle(hdl);
     }
@@ -655,23 +669,18 @@ BEGIN_CP_FUNC(handle) {
         new_hdl = (struct shim_handle*)(base + off);
 
         lock(&hdl->lock);
-        struct shim_mount* fs = hdl->fs;
-        *new_hdl              = *hdl;
+        *new_hdl = *hdl;
 
-        if (fs && fs->fs_ops && fs->fs_ops->checkout)
-            fs->fs_ops->checkout(new_hdl);
+        if (hdl->fs && hdl->fs->fs_ops && hdl->fs->fs_ops->checkout)
+            hdl->fs->fs_ops->checkout(new_hdl);
 
         new_hdl->dentry = NULL;
         REF_SET(new_hdl->ref_count, 0);
         clear_lock(&new_hdl->lock);
 
-        DO_CP_IN_MEMBER(qstr, new_hdl, uri);
+        DO_CP(fs, hdl->fs, &new_hdl->fs);
 
-        if (fs && fs != &fifo_builtin_fs && hdl->dentry) {
-            DO_CP_MEMBER(mount, hdl, new_hdl, fs);
-        } else {
-            new_hdl->fs = NULL;
-        }
+        DO_CP_IN_MEMBER(qstr, new_hdl, uri);
 
         if (hdl->dentry) {
             if (hdl->dentry->state & DENTRY_ISDIRECTORY) {
@@ -732,17 +741,6 @@ BEGIN_RS_FUNC(handle) {
 
     if (!create_lock(&hdl->lock)) {
         return -ENOMEM;
-    }
-
-    if (!hdl->fs) {
-        assert(hdl->fs_type);
-        search_builtin_fs(hdl->fs_type, &hdl->fs);
-        if (!hdl->fs) {
-            destroy_lock(&hdl->lock);
-            return -EINVAL;
-        }
-    } else {
-        get_mount(hdl->fs);
     }
 
     if (hdl->dentry) {

--- a/LibOS/shim/src/bookkeep/shim_vma.c
+++ b/LibOS/shim/src/bookkeep/shim_vma.c
@@ -1294,7 +1294,7 @@ BEGIN_RS_FUNC(vma) {
 
     if (!(vma->flags & VMA_UNMAPPED)) {
         if (vma->file) {
-            struct shim_mount* fs = vma->file->fs;
+            struct shim_fs* fs = vma->file->fs;
             get_handle(vma->file);
 
             if (need_mapped < vma->addr + vma->length) {

--- a/LibOS/shim/src/fs/chroot/fs.c
+++ b/LibOS/shim/src/fs/chroot/fs.c
@@ -31,8 +31,7 @@ struct mount_data {
     char root_uri[];
 };
 
-#define HANDLE_MOUNT_DATA(h) ((struct mount_data*)(h)->fs->data)
-#define DENTRY_MOUNT_DATA(d) ((struct mount_data*)(d)->fs->data)
+#define DENTRY_MOUNT_DATA(d) ((struct mount_data*)(d)->mount->data)
 
 static int chroot_mount(const char* uri, void** mount_data) {
     enum shim_file_type type;
@@ -830,9 +829,6 @@ out:
 }
 
 static int chroot_checkout(struct shim_handle* hdl) {
-    if (hdl->fs == &chroot_builtin_fs)
-        hdl->fs = NULL;
-
     if (hdl->type == TYPE_FILE) {
         struct shim_file_data* data = FILE_HANDLE_DATA(hdl);
         if (data)
@@ -1027,14 +1023,8 @@ struct shim_d_ops chroot_d_ops = {
     .chmod   = &chroot_chmod,
 };
 
-struct mount_data chroot_data = {
-    .root_uri_len = 5,
-    .root_uri     = URI_PREFIX_FILE,
-};
-
-struct shim_mount chroot_builtin_fs = {
-    .type   = "chroot",
+struct shim_fs chroot_builtin_fs = {
+    .name   = "chroot",
     .fs_ops = &chroot_fs_ops,
     .d_ops  = &chroot_d_ops,
-    .data   = &chroot_data,
 };

--- a/LibOS/shim/src/fs/dev/fs.c
+++ b/LibOS/shim/src/fs/dev/fs.c
@@ -211,3 +211,9 @@ struct shim_d_ops dev_d_ops = {
     .stat        = &dev_stat,
     .follow_link = &dev_follow_link,
 };
+
+struct shim_fs dev_builtin_fs = {
+    .name   = "dev",
+    .fs_ops = &dev_fs_ops,
+    .d_ops  = &dev_d_ops,
+};

--- a/LibOS/shim/src/fs/eventfd/fs.c
+++ b/LibOS/shim/src/fs/eventfd/fs.c
@@ -87,7 +87,7 @@ struct shim_fs_ops eventfd_fs_ops = {
     .poll  = &eventfd_poll,
 };
 
-struct shim_mount eventfd_builtin_fs = {
-    .type   = URI_TYPE_EVENTFD,
+struct shim_fs eventfd_builtin_fs = {
+    .name   = "eventfd",
     .fs_ops = &eventfd_fs_ops,
 };

--- a/LibOS/shim/src/fs/pipe/fs.c
+++ b/LibOS/shim/src/fs/pipe/fs.c
@@ -93,11 +93,6 @@ static int pipe_hstat(struct shim_handle* hdl, struct stat* stat) {
     return 0;
 }
 
-static int pipe_checkout(struct shim_handle* hdl) {
-    hdl->fs = NULL;
-    return 0;
-}
-
 static off_t pipe_poll(struct shim_handle* hdl, int poll_type) {
     off_t ret = 0;
 
@@ -183,7 +178,7 @@ static int fifo_open(struct shim_handle* hdl, struct shim_dentry* dent, int flag
          * one end (read or write) in our emulation, so we treat such FIFOs as read-only. This
          * covers most apps seen in the wild (in particular, LTP apps). */
         log_warning("FIFO (named pipe) '%s' cannot be opened in read-write mode in Graphene. "
-                    "Treating it as read-only.\n", qstrgetstr(&dent->fs->path));
+                    "Treating it as read-only.\n", qstrgetstr(&dent->mount->path));
         flags = O_RDONLY;
     }
 
@@ -245,7 +240,6 @@ static struct shim_fs_ops pipe_fs_ops = {
     .read     = &pipe_read,
     .write    = &pipe_write,
     .hstat    = &pipe_hstat,
-    .checkout = &pipe_checkout,
     .poll     = &pipe_poll,
     .setflags = &pipe_setflags,
 };
@@ -261,13 +255,13 @@ static struct shim_d_ops fifo_d_ops = {
     .open = &fifo_open,
 };
 
-struct shim_mount pipe_builtin_fs = {
-    .type   = URI_TYPE_PIPE,
+struct shim_fs pipe_builtin_fs = {
+    .name   = "pipe",
     .fs_ops = &pipe_fs_ops,
 };
 
-struct shim_mount fifo_builtin_fs = {
-    .type   = "fifo",
+struct shim_fs fifo_builtin_fs = {
+    .name   = "fifo",
     .fs_ops = &fifo_fs_ops,
     .d_ops  = &fifo_d_ops,
 };

--- a/LibOS/shim/src/fs/proc/fs.c
+++ b/LibOS/shim/src/fs/proc/fs.c
@@ -109,3 +109,9 @@ struct shim_d_ops proc_d_ops = {
     .follow_link = &proc_follow_link,
     .readdir     = &proc_readdir,
 };
+
+struct shim_fs proc_builtin_fs = {
+    .name   = "proc",
+    .fs_ops = &proc_fs_ops,
+    .d_ops  = &proc_d_ops,
+};

--- a/LibOS/shim/src/fs/shim_namei.c
+++ b/LibOS/shim/src/fs/shim_namei.c
@@ -74,7 +74,7 @@ static int lookup_dentry(struct shim_dentry* parent, const char* name, size_t na
 
     struct shim_dentry* dent = lookup_dcache(parent, name, name_len);
     if (!dent) {
-        dent = get_new_dentry(parent->fs, parent, name, name_len);
+        dent = get_new_dentry(parent->mount, parent, name, name_len);
         if (!dent) {
             ret = -ENOMEM;
             goto err;
@@ -341,7 +341,7 @@ static inline int open_flags_to_lookup_flags(int flags) {
 }
 
 static void assoc_handle_with_dentry(struct shim_handle* hdl, struct shim_dentry* dent, int flags) {
-    set_handle_fs(hdl, dent->fs);
+    hdl->fs = dent->fs;
     get_dentry(dent);
     hdl->dentry = dent;
     hdl->flags = flags;
@@ -353,7 +353,7 @@ int dentry_open(struct shim_handle* hdl, struct shim_dentry* dent, int flags) {
     assert(!hdl->dentry);
 
     int ret = 0;
-    struct shim_mount* fs = dent->fs;
+    struct shim_fs* fs = dent->fs;
 
     if (!(fs->d_ops && fs->d_ops->open)) {
         ret = -EINVAL;
@@ -369,7 +369,6 @@ int dentry_open(struct shim_handle* hdl, struct shim_dentry* dent, int flags) {
     if (dent->state & DENTRY_ISDIRECTORY) {
         /* Initialize directory handle */
         hdl->is_dir = true;
-        memcpy(hdl->fs_type, fs->type, sizeof(fs->type));
 
         hdl->dir_info.dents = NULL;
     }

--- a/LibOS/shim/src/fs/socket/fs.c
+++ b/LibOS/shim/src/fs/socket/fs.c
@@ -129,11 +129,6 @@ static int socket_hstat(struct shim_handle* hdl, struct stat* stat) {
     return 0;
 }
 
-static int socket_checkout(struct shim_handle* hdl) {
-    hdl->fs = NULL;
-    return 0;
-}
-
 static off_t socket_poll(struct shim_handle* hdl, int poll_type) {
     assert(hdl->type == TYPE_SOCK);
     struct shim_sock_handle* sock = &hdl->info.sock;
@@ -242,12 +237,11 @@ struct shim_fs_ops socket_fs_ops = {
     .read     = &socket_read,
     .write    = &socket_write,
     .hstat    = &socket_hstat,
-    .checkout = &socket_checkout,
     .poll     = &socket_poll,
     .setflags = &socket_setflags,
 };
 
-struct shim_mount socket_builtin_fs = {
-    .type   = "socket",
+struct shim_fs socket_builtin_fs = {
+    .name   = "socket",
     .fs_ops = &socket_fs_ops,
 };

--- a/LibOS/shim/src/fs/sys/fs.c
+++ b/LibOS/shim/src/fs/sys/fs.c
@@ -262,3 +262,9 @@ struct shim_d_ops sys_d_ops = {
     .lookup  = &sys_lookup,
     .readdir = &sys_readdir,
 };
+
+struct shim_fs sys_builtin_fs = {
+    .name   = "sys",
+    .fs_ops = &sys_fs_ops,
+    .d_ops  = &sys_d_ops,
+};

--- a/LibOS/shim/src/fs/tmpfs/fs.c
+++ b/LibOS/shim/src/fs/tmpfs/fs.c
@@ -555,3 +555,9 @@ struct shim_d_ops tmp_d_ops = {
     .rename  = &tmpfs_rename,
     .chmod   = &tmpfs_chmod,
 };
+
+struct shim_fs tmp_builtin_fs = {
+    .name   = "tmpfs",
+    .fs_ops = &tmp_fs_ops,
+    .d_ops  = &tmp_d_ops,
+};

--- a/LibOS/shim/src/shim_rtld.c
+++ b/LibOS/shim/src/shim_rtld.c
@@ -740,7 +740,7 @@ static int __load_interp_object(struct link_map* exec_map) {
             dent->state & DENTRY_NEGATIVE)
             continue;
 
-        struct shim_mount* fs = dent->fs;
+        struct shim_fs* fs = dent->fs;
         get_dentry(dent);
 
         if (!fs->d_ops->open) {
@@ -763,8 +763,8 @@ static int __load_interp_object(struct link_map* exec_map) {
             goto err;
         }
 
-        set_handle_fs(interp, fs);
-        interp->flags    = O_RDONLY;
+        interp->fs = fs;
+        interp->flags = O_RDONLY;
         interp->acc_mode = MAY_READ;
 
         if ((ret = fs->d_ops->open(interp, dent, O_RDONLY)) < 0) {

--- a/LibOS/shim/src/sys/shim_epoll.c
+++ b/LibOS/shim/src/sys/shim_epoll.c
@@ -32,7 +32,7 @@
 /* TODO: 1024 handles/FDs is a small number for high-load servers (e.g., Linux has ~3M) */
 #define MAX_EPOLL_HANDLES 1024
 
-struct shim_mount epoll_builtin_fs;
+struct shim_fs epoll_builtin_fs;
 
 long shim_do_epoll_create1(int flags) {
     if ((flags & ~EPOLL_CLOEXEC))
@@ -43,7 +43,7 @@ long shim_do_epoll_create1(int flags) {
         return -ENOMEM;
 
     hdl->type = TYPE_EPOLL;
-    set_handle_fs(hdl, &epoll_builtin_fs);
+    hdl->fs = &epoll_builtin_fs;
 
     struct shim_epoll_handle* epoll = &hdl->info.epoll;
     epoll->fds_count = 0;
@@ -499,8 +499,8 @@ struct shim_fs_ops epoll_fs_ops = {
     .close = &epoll_close,
 };
 
-struct shim_mount epoll_builtin_fs = {
-    .type   = "epoll",
+struct shim_fs epoll_builtin_fs = {
+    .name   = "epoll",
     .fs_ops = &epoll_fs_ops,
 };
 

--- a/LibOS/shim/src/sys/shim_eventfd.c
+++ b/LibOS/shim/src/sys/shim_eventfd.c
@@ -66,8 +66,8 @@ long shim_do_eventfd2(unsigned int count, int flags) {
     }
 
     hdl->type = TYPE_EVENTFD;
-    set_handle_fs(hdl, &eventfd_builtin_fs);
-    hdl->flags    = O_RDWR;
+    hdl->fs = &eventfd_builtin_fs;
+    hdl->flags = O_RDWR;
     hdl->acc_mode = MAY_READ | MAY_WRITE;
 
     if ((ret = create_eventfd(&hdl->pal_handle, count, flags)) < 0)

--- a/LibOS/shim/src/sys/shim_exec.c
+++ b/LibOS/shim/src/sys/shim_exec.c
@@ -185,7 +185,7 @@ reopen:
     if ((ret = path_lookupat(/*start=*/NULL, file, LOOKUP_FOLLOW, &dent)) < 0)
         return ret;
 
-    struct shim_mount* fs = dent->fs;
+    struct shim_fs* fs = dent->fs;
 
     if (!fs->d_ops->open) {
         ret = -EACCES;
@@ -212,8 +212,8 @@ reopen:
         goto err;
     }
 
-    set_handle_fs(exec, fs);
-    exec->flags    = O_RDONLY;
+    exec->fs = fs;
+    exec->flags = O_RDONLY;
     exec->acc_mode = MAY_READ;
 
     get_dentry(dent);

--- a/LibOS/shim/src/sys/shim_file.c
+++ b/LibOS/shim/src/sys/shim_file.c
@@ -264,8 +264,8 @@ long shim_do_fchown(int fd, uid_t uid, gid_t gid) {
  *       statement to distinguish between "map input", "map output", "map both", "map none" */
 static ssize_t handle_copy(struct shim_handle* hdli, off_t* offseti, struct shim_handle* hdlo,
                            off_t* offseto, ssize_t count) {
-    struct shim_mount* fsi = hdli->fs;
-    struct shim_mount* fso = hdlo->fs;
+    struct shim_fs* fsi = hdli->fs;
+    struct shim_fs* fso = hdlo->fs;
 
     if (!count)
         return 0;

--- a/LibOS/shim/src/sys/shim_ioctl.c
+++ b/LibOS/shim/src/sys/shim_ioctl.c
@@ -74,7 +74,7 @@ long shim_do_ioctl(unsigned int fd, unsigned int cmd, unsigned long arg) {
                 break;
             }
 
-            struct shim_mount* fs = hdl->fs;
+            struct shim_fs* fs = hdl->fs;
             if (!fs || !fs->fs_ops) {
                 ret = -EACCES;
                 break;

--- a/LibOS/shim/src/sys/shim_open.c
+++ b/LibOS/shim/src/sys/shim_open.c
@@ -29,7 +29,7 @@ int do_handle_read(struct shim_handle* hdl, void* buf, int count) {
     if (!(hdl->acc_mode & MAY_READ))
         return -EACCES;
 
-    struct shim_mount* fs = hdl->fs;
+    struct shim_fs* fs = hdl->fs;
     assert(fs && fs->fs_ops);
 
     if (!fs->fs_ops->read)
@@ -67,7 +67,7 @@ int do_handle_write(struct shim_handle* hdl, const void* buf, int count) {
     if (!(hdl->acc_mode & MAY_WRITE))
         return -EACCES;
 
-    struct shim_mount* fs = hdl->fs;
+    struct shim_fs* fs = hdl->fs;
     assert(fs && fs->fs_ops);
 
     if (!fs->fs_ops->write)
@@ -224,7 +224,7 @@ long shim_do_lseek(int fd, off_t offset, int origin) {
         goto out;
     }
 
-    struct shim_mount* fs = hdl->fs;
+    struct shim_fs* fs = hdl->fs;
     assert(fs && fs->fs_ops);
 
     if (!fs->fs_ops->seek) {
@@ -249,7 +249,7 @@ long shim_do_pread64(int fd, char* buf, size_t count, loff_t pos) {
     if (!hdl)
         return -EBADF;
 
-    struct shim_mount* fs = hdl->fs;
+    struct shim_fs* fs = hdl->fs;
     ssize_t ret = -EACCES;
 
     if (!fs || !fs->fs_ops)
@@ -299,7 +299,7 @@ long shim_do_pwrite64(int fd, char* buf, size_t count, loff_t pos) {
     if (!hdl)
         return -EBADF;
 
-    struct shim_mount* fs = hdl->fs;
+    struct shim_fs* fs = hdl->fs;
     ssize_t ret = -EACCES;
 
     if (!fs || !fs->fs_ops)
@@ -487,7 +487,7 @@ long shim_do_fsync(int fd) {
         return -EBADF;
 
     int ret = -EACCES;
-    struct shim_mount* fs = hdl->fs;
+    struct shim_fs* fs = hdl->fs;
 
     if (!fs || !fs->fs_ops)
         goto out;
@@ -525,7 +525,7 @@ long shim_do_truncate(const char* path, loff_t length) {
     if ((ret = path_lookupat(/*start=*/NULL, path, LOOKUP_FOLLOW, &dent)) < 0)
         return ret;
 
-    struct shim_mount* fs = dent->fs;
+    struct shim_fs* fs = dent->fs;
 
     if (!fs || !fs->d_ops || !fs->d_ops->open) {
         ret = -EBADF;
@@ -564,7 +564,7 @@ long shim_do_ftruncate(int fd, loff_t length) {
     if (!hdl)
         return -EBADF;
 
-    struct shim_mount* fs = hdl->fs;
+    struct shim_fs* fs = hdl->fs;
     int ret = -EINVAL;
 
     if (!fs || !fs->fs_ops)

--- a/LibOS/shim/src/sys/shim_pipe.c
+++ b/LibOS/shim/src/sys/shim_pipe.c
@@ -112,13 +112,13 @@ long shim_do_pipe2(int* filedes, int flags) {
     }
 
     hdl1->type = TYPE_PIPE;
-    set_handle_fs(hdl1, &pipe_builtin_fs);
-    hdl1->flags    = O_RDONLY;
+    hdl1->fs = &pipe_builtin_fs;
+    hdl1->flags = O_RDONLY;
     hdl1->acc_mode = MAY_READ;
 
     hdl2->type = TYPE_PIPE;
-    set_handle_fs(hdl2, &pipe_builtin_fs);
-    hdl2->flags    = O_WRONLY;
+    hdl2->fs = &pipe_builtin_fs;
+    hdl2->flags = O_WRONLY;
     hdl2->acc_mode = MAY_WRITE;
 
     hdl1->info.pipe.ready_for_ops = true;
@@ -188,9 +188,9 @@ long shim_do_socketpair(int domain, int type, int protocol, int* sv) {
 
 
     hdl1->type = TYPE_SOCK;
-    set_handle_fs(hdl1, &socket_builtin_fs);
-    hdl1->flags       = O_RDONLY;
-    hdl1->acc_mode    = MAY_READ | MAY_WRITE;
+    hdl1->fs = &socket_builtin_fs;
+    hdl1->flags = O_RDONLY;
+    hdl1->acc_mode = MAY_READ | MAY_WRITE;
 
     struct shim_sock_handle* sock1 = &hdl1->info.sock;
     sock1->domain     = domain;
@@ -199,9 +199,9 @@ long shim_do_socketpair(int domain, int type, int protocol, int* sv) {
     sock1->sock_state = SOCK_ACCEPTED;
 
     hdl2->type = TYPE_SOCK;
-    set_handle_fs(hdl2, &socket_builtin_fs);
-    hdl2->flags       = O_WRONLY;
-    hdl2->acc_mode    = MAY_READ | MAY_WRITE;
+    hdl2->fs = &socket_builtin_fs;
+    hdl2->flags = O_WRONLY;
+    hdl2->acc_mode = MAY_READ | MAY_WRITE;
 
     struct shim_sock_handle* sock2 = &hdl2->info.sock;
     sock2->domain     = domain;
@@ -307,15 +307,15 @@ long shim_do_mknodat(int dirfd, const char* pathname, mode_t mode, dev_t dev) {
     }
 
     hdl1->type = TYPE_PIPE;
-    set_handle_fs(hdl1, &fifo_builtin_fs);
-    hdl1->flags    = O_RDONLY;
+    hdl1->fs =  &fifo_builtin_fs;
+    hdl1->flags = O_RDONLY;
     hdl1->acc_mode = MAY_READ;
     get_dentry(dent);
     hdl1->dentry = dent;
 
     hdl2->type = TYPE_PIPE;
-    set_handle_fs(hdl2, &fifo_builtin_fs);
-    hdl2->flags    = O_WRONLY;
+    hdl2->fs = &fifo_builtin_fs;
+    hdl2->flags = O_WRONLY;
     hdl2->acc_mode = MAY_WRITE;
     get_dentry(dent);
     hdl2->dentry = dent;

--- a/LibOS/shim/src/sys/shim_socket.c
+++ b/LibOS/shim/src/sys/shim_socket.c
@@ -70,7 +70,7 @@ long shim_do_socket(int family, int type, int protocol) {
         return -ENOMEM;
 
     hdl->type = TYPE_SOCK;
-    set_handle_fs(hdl, &socket_builtin_fs);
+    hdl->fs = &socket_builtin_fs;
     hdl->flags = type & SOCK_NONBLOCK ? O_NONBLOCK : 0;
     hdl->acc_mode = 0;
 
@@ -744,7 +744,7 @@ long shim_do_connect(int sockfd, struct sockaddr* addr, int _addrlen) {
             goto out;
         }
 
-        if (!(dent->state & DENTRY_NEGATIVE) && dent->fs != &socket_builtin_fs) {
+        if (!(dent->state & DENTRY_NEGATIVE) && dent->type != S_IFSOCK) {
             ret = -ECONNREFUSED;
             put_dentry(dent);
             goto out;
@@ -926,11 +926,11 @@ static int __do_accept(struct shim_handle* hdl, int flags, struct sockaddr* addr
 
 
     cli->type = TYPE_SOCK;
-    set_handle_fs(cli, &socket_builtin_fs);
-    cli->acc_mode   = MAY_READ | MAY_WRITE;
-    cli->flags      = O_RDWR | flags;
+    cli->fs = &socket_builtin_fs;
+    cli->acc_mode = MAY_READ | MAY_WRITE;
+    cli->flags = O_RDWR | flags;
     cli->pal_handle = accepted;
-    accepted        = NULL;
+    accepted = NULL;
 
     struct shim_sock_handle* cli_sock = &cli->info.sock;
     cli_sock->domain     = sock->domain;


### PR DESCRIPTION
(I think this finally unblocks the "mount semantics" refactoring! I'm checking that right now, but it's going to be a separate PR.)

This change replaces most usages of `shim_mount` with `shim_fs`. Graphene uses the `shim_mount` structure to represent a mounted filesystem, but in most cases we're only interested in the function table.

The main reason for this change is special treatment of sockets and FIFOs: before, we replaced the `fs` field (actually `shim_mount`) for their dentries, so that they are served by a different filesystem. However, that loses information about which part of the tree the dentry actually is in.

The new solution is to store both `shim_mount` and `shim_fs` for a dentry. This follows Linux, which stores both `super_block` and `inode_iperations` for an inode, and replaces the latter in case of sockets and FIFOs. This will allow me to refactor the way mounted filesystems are represented.

As a bonus, this change removes some hacks like unwarranted usage of `*_builtin_fs` and storing filesystem type separately for checkpointing purposes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2402)
<!-- Reviewable:end -->
