### PR TITLE
[LibOS] Change mount semantics

### DIFF
--- a/LibOS/shim/src/fs/shim_fs_hash.c
+++ b/LibOS/shim/src/fs/shim_fs_hash.c
@@ -40,10 +40,14 @@ HASHTYPE hash_name(HASHTYPE parent_hbuf, const char* name) {
 HASHTYPE hash_abs_path(struct shim_dentry* dent) {
     HASHTYPE digest = 0;
 
-    while (dent->parent) {
+    while (true) {
+        struct shim_dentry* up = dentry_up(dent);
+        if (!up)
+            break;
+
         digest += hash_str(qstrgetstr(&dent->name));
         digest *= 9;
-        dent = dent->parent;
+        dent = up;
     }
     return digest;
 }

--- a/LibOS/shim/src/fs/shim_fs_pseudo.c
+++ b/LibOS/shim/src/fs/shim_fs_pseudo.c
@@ -133,7 +133,7 @@ int pseudo_dir_open(struct shim_handle* hdl, const char* name, int flags) {
 
 /*! Generic callback to obtain a mode of an entry in a pseudo-filesystem. */
 int pseudo_mode(struct shim_dentry* dent, mode_t* mode, const struct pseudo_ent* root_ent) {
-    if (dent->state & DENTRY_MOUNTPOINT) {
+    if (!dent->parent) {
         /* root of pseudo-FS */
         return pseudo_dir_mode(/*name=*/NULL, mode);
     }
@@ -162,7 +162,7 @@ out:
 
 /*! Generic callback to check if an entry exists in a pseudo-filesystem (and populate \p dent). */
 int pseudo_lookup(struct shim_dentry* dent, const struct pseudo_ent* root_ent) {
-    if (dent->state & DENTRY_MOUNTPOINT) {
+    if (!dent->parent) {
         /* root of pseudo-FS */
         dent->state |= DENTRY_ISDIRECTORY;
         return 0;
@@ -276,7 +276,7 @@ out:
 
 /*! Generic callback to obtain stat of an entry in a pseudo-filesystem. */
 int pseudo_stat(struct shim_dentry* dent, struct stat* buf, const struct pseudo_ent* root_ent) {
-    if (dent->state & DENTRY_MOUNTPOINT) {
+    if (!dent->parent) {
         /* root of pseudo-FS */
         return pseudo_dir_stat(/*name=*/NULL, buf);
     }

--- a/LibOS/shim/src/fs/tmpfs/fs.c
+++ b/LibOS/shim/src/fs/tmpfs/fs.c
@@ -119,7 +119,7 @@ static int tmpfs_open(struct shim_handle* hdl, struct shim_dentry* dent, int fla
         return ret;
 
     lock(&data->lock);
-    if (dent->state & DENTRY_MOUNTPOINT) {
+    if (!dent->parent) {
         /* root of tmpfs */
         data->type = FILE_DIR;
         dent->perm = PERM_rwxrwxrwx;
@@ -318,7 +318,7 @@ static int query_dentry(struct shim_dentry* dent, mode_t* mode, struct stat* sta
 }
 
 static int tmpfs_mode(struct shim_dentry* dent, mode_t* mode) {
-    if (dent->state & DENTRY_MOUNTPOINT) {
+    if (!dent->parent) {
         /* root of pseudo-FS */
         *mode = PERM_rwx______ | S_IFDIR;
         return 0;
@@ -327,7 +327,7 @@ static int tmpfs_mode(struct shim_dentry* dent, mode_t* mode) {
 }
 
 static int tmpfs_stat(struct shim_dentry* dent, struct stat* statbuf) {
-    if (dent->state & DENTRY_MOUNTPOINT) {
+    if (!dent->parent) {
         /* root of pseudo-FS */
         int ret = pseudo_dir_stat(/*name=*/NULL, statbuf);
         if (ret < 0)
@@ -338,7 +338,7 @@ static int tmpfs_stat(struct shim_dentry* dent, struct stat* statbuf) {
 }
 
 static int tmpfs_lookup(struct shim_dentry* dent) {
-    if (dent->state & DENTRY_MOUNTPOINT) {
+    if (!dent->parent) {
         /* root of pseudo-FS */
         dent->state |= DENTRY_ISDIRECTORY;
         return 0;
@@ -404,7 +404,7 @@ static int tmpfs_mkdir(struct shim_dentry* dir, struct shim_dentry* dent, mode_t
 
 static int tmpfs_hstat(struct shim_handle* hdl, struct stat* stat) {
     assert(hdl->dentry);
-    if (hdl->dentry->state & DENTRY_MOUNTPOINT) {
+    if (!hdl->dentry->parent) {
         /* root of pseudo-FS */
         return pseudo_dir_stat(/*name=*/NULL, stat);
     }

--- a/LibOS/shim/src/sys/shim_pipe.c
+++ b/LibOS/shim/src/sys/shim_pipe.c
@@ -350,7 +350,7 @@ long shim_do_mknodat(int dirfd, const char* pathname, mode_t mode, dev_t dev) {
 
     /* mark pseudo entry in file system as valid and stash FDs in data */
     dent->state &= ~DENTRY_NEGATIVE;
-    dent->state |= DENTRY_VALID | DENTRY_RECENTLY;
+    dent->state |= DENTRY_VALID;
 
     static_assert(sizeof(vfd1) == sizeof(uint32_t) && sizeof(vfd2) == sizeof(uint32_t),
                   "FDs must be 4B in size");

--- a/LibOS/shim/src/sys/shim_socket.c
+++ b/LibOS/shim/src/sys/shim_socket.c
@@ -518,7 +518,7 @@ long shim_do_bind(int sockfd, struct sockaddr* addr, int _addrlen) {
         struct shim_dentry* dent = sock->addr.un.dentry;
 
         dent->state ^= DENTRY_NEGATIVE;
-        dent->state |= DENTRY_VALID | DENTRY_RECENTLY;
+        dent->state |= DENTRY_VALID;
         dent->fs   = &socket_builtin_fs;
         dent->type = S_IFSOCK;
         dent->perm = PERM_rw_______;
@@ -794,7 +794,7 @@ long shim_do_connect(int sockfd, struct sockaddr* addr, int _addrlen) {
         struct shim_dentry* dent = sock->addr.un.dentry;
         lock(&dent->lock);
         dent->state ^= DENTRY_NEGATIVE;
-        dent->state |= DENTRY_VALID | DENTRY_RECENTLY;
+        dent->state |= DENTRY_VALID;
         dent->fs   = &socket_builtin_fs;
         dent->type = S_IFSOCK;
         dent->perm = PERM_rw_______;


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

This changes the mount operation to create and attach new dentry instead of replacing an existing one. See the commit message for details.

## How to test this PR? <!-- (if applicable) -->

I believe the current tests are enough.

Here is an example of the new dentry tree. `M` is a mountpoint dentry, with the actual new filesystem root attached under it.

```
[P67026:T1:busybox] [       V..  3] 040700 drwx M /
[P67026:T1:busybox] [chroot V.. 26] 040700 drwx *   /
[P67026:T1:busybox] [chroot V.S  2] 100000 ---- M     proc
[P67026:T1:busybox] [  proc V..  1] 040555 dr-x *       proc/
[P67026:T1:busybox] [chroot V.S  2] 100000 ---- M     dev
[P67026:T1:busybox] [   dev V..  2] 040555 dr-x *       dev/
[P67026:T1:busybox] [   dev V..  2] 020666 crw- M         tty
[P67026:T1:busybox] [chroot V..  3] 020600 crw- *           tty
[P67026:T1:busybox] [chroot V.S  2] 100000 ---- M     sys
[P67026:T1:busybox] [   sys V..  1] 040555 dr-x *       sys/
[P67026:T1:busybox] [chroot V.S  2] 100000 ---- M     lib
[P67026:T1:busybox] [chroot V..  6] 040700 drwx *       lib/
[P67026:T1:busybox] [chroot V.S  2] 100000 ---- M         x86_64-linux-gnu
[P67026:T1:busybox] [chroot V..  1] 040700 drwx *           x86_64-linux-gnu/
[P67026:T1:busybox] [chroot V..  3] 100700 -rwx           ld-linux-x86-64.so.2
[P67026:T1:busybox] [chroot V..  2] 100700 -rwx           libm.so.6
[P67026:T1:busybox] [chroot V..  2] 100700 -rwx           libresolv.so.2
[P67026:T1:busybox] [chroot V..  2] 100700 -rwx           libc.so.6
[P67026:T1:busybox] [chroot V.S  2] 100000 ---- M     etc
[P67026:T1:busybox] [chroot V..  2] 040700 drwx *       etc/
[P67026:T1:busybox] [chroot V..  1] 000000 ?---  -        ld.so.preload
[P67026:T1:busybox] [chroot V..  2] 100700 -rwx       busybox
[P67026:T1:busybox] [chroot V..  1] 100600 -rw-       .gitignore
[P67026:T1:busybox] [chroot V..  1] 100600 -rw-       busybox.tar.bz2
[P67026:T1:busybox] [chroot V..  1] 100600 -rw-       README.md
[P67026:T1:busybox] [chroot V..  1] 040700 drwx       src/
[P67026:T1:busybox] [chroot V..  1] 100600 -rw-       busybox.manifest
[P67026:T1:busybox] [chroot V..  1] 100600 -rw-       busybox.manifest.template
[P67026:T1:busybox] [chroot V..  1] 100600 -rw-       Makefile
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2403)
<!-- Reviewable:end -->
