### PR TITLE
[LibOS] Always close child PAL handle

### DIFF
--- a/LibOS/shim/src/bookkeep/shim_process.c
+++ b/LibOS/shim/src/bookkeep/shim_process.c
@@ -181,6 +181,7 @@ static bool mark_child_exited(child_cmp_t child_cmp, unsigned long arg, IDTYPE c
          * gets inlined). */
         COMPILER_BARRIER();
         thread_wakeup(thread);
+        put_thread(thread);
         wait_queue = next;
     }
 

--- a/LibOS/shim/src/shim_checkpoint.c
+++ b/LibOS/shim/src/shim_checkpoint.c
@@ -590,9 +590,10 @@ int create_process_and_send_checkpoint(migrate_func_t migrate_func,
 
     ret = 0;
 out:
+    if (pal_process)
+        DkObjectClose(pal_process);
+
     if (ret < 0) {
-        if (pal_process)
-            DkObjectClose(pal_process);
         log_error("process creation failed\n");
     }
 


### PR DESCRIPTION

## Description of the changes <!-- (reasons and measures) -->
Currently PAL handle used to communicate with the child process (e.g. to send checkpoint) is not needed after successful process creation and needs to be destroyed correctly.

This commit also adds missing `get_thread` and `put_thread` in `wait*` syscalls routines.

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->
Run a couple of fork()+wait() and check list of host-OS fds (`/proc/[pid]/fd/`). Without this patch there will be 1 fd leaked per child process.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2404)
<!-- Reviewable:end -->
