### PR TITLE
[Pal/Linux-SGX] Force CPUID values of unused XSAVE features to zero

### DIFF
--- a/Pal/src/host/Linux-SGX/db_misc.c
+++ b/Pal/src/host/Linux-SGX/db_misc.c
@@ -270,15 +270,18 @@ static void sanity_check_cpuid(uint32_t leaf, uint32_t subleaf, uint32_t values[
             case AVX512_3:
             case PKRU:
                 if (extension_enabled(xfrm, subleaf)) {
-                    if (values[EAX] != extension_sizes_bytes[subleaf]) {
+                    if (values[EAX] != extension_sizes_bytes[subleaf] ||
+                            values[EBX] != extension_offset_bytes[subleaf]) {
                         log_error("Unexpected value in host CPUID. Exiting...\n");
                         _DkProcessExit(1);
                     }
                 } else {
-                    if (values[EAX] != 0) {
-                        log_error("Unexpected value in host CPUID. Exiting...\n");
-                        _DkProcessExit(1);
-                    }
+                    /* SGX enclave doesn't use this CPU extension, pretend it doesn't exist by
+                     * forcing EAX ("size in bytes of the save area for an extended state feature")
+                     * and EBX ("offset in bytes of this extended state component's save area from
+                     * the beginning of the XSAVE/XRSTOR area") to zero */
+                    values[EAX] = 0;
+                    values[EBX] = 0;
                 }
                 break;
         }


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Previously, if the SGX enclave didn't use an XSAVE feature (by unsetting the bit in the SECS.ATTRIBUTES.XFRM mask), the sanity check failed if the XSAVE feature was available on the CPU. This check doesn't make sense: the SGX enclave may want to "hide" some CPU features, but this doesn't mean the enclave execution must be stopped.

This PR removes this incorrect check and instead forces the corresponding CPUID return values to zero.

For more information, please consult the Intel SDM. In particular, the `CPUID` instruction description (leaf `Processor Extended State Enumeration Sub-leaves (EAX = 0DH, ECX = n, n > 1)`), and SGX sections 37.7.1 and 41.7.

Fixes #2408.

## How to test this PR? <!-- (if applicable) -->

All tests must pass.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2409)
<!-- Reviewable:end -->
