### PR TITLE
[PAL] Fix sysfs numa sanitization when SNC is enabled

### DIFF
--- a/Pal/include/arch/x86_64/pal-arch.h
+++ b/Pal/include/arch/x86_64/pal-arch.h
@@ -322,7 +322,7 @@ typedef struct PAL_NUMA_HUGEPAGE_INFO_ {
 
 typedef struct PAL_NUMA_TOPO_INFO_ {
     char cpumap[PAL_SYSFS_MAP_FILESZ];
-    char distance[PAL_SYSFS_INT_FILESZ];
+    char distance[PAL_SYSFS_BUF_FILESZ];
     PAL_NUMA_HUGEPAGE_INFO hugepages[HUGEPAGES_MAX];
 } PAL_NUMA_TOPO_INFO;
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->
When sanitizing `/sys/devices/system/node/node0/distance` path in graphene we compare the count of distances with number
of nodes present. But when SNC mode is enabled, we run out of the buffer to store the distances which results in incorrect distance count and the comparison fails. This PR increases the buffer size to hold all numa distances even for special cases like SNC.

Signed-off-by: Vijay Dhanraj <vijay.dhanraj@intel.com>

## How to test this PR? <!-- (if applicable) -->
All tests should pass.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2412)
<!-- Reviewable:end -->
