### PR TITLE
[LibOS] Do not update offset on chroot `FILE_DEV` files

### DIFF
--- a/LibOS/shim/src/fs/chroot/fs.c
+++ b/LibOS/shim/src/fs/chroot/fs.c
@@ -577,7 +577,8 @@ static ssize_t chroot_read(struct shim_handle* hdl, void* buf, size_t count) {
     struct shim_file_handle* file = &hdl->info.file;
 
     off_t dummy_off_t;
-    if (file->type != FILE_TTY && __builtin_add_overflow(file->marker, count, &dummy_off_t)) {
+    if (file->type != FILE_TTY && file->type != FILE_DEV &&
+            __builtin_add_overflow(file->marker, count, &dummy_off_t)) {
         ret = -EFBIG;
         goto out;
     }
@@ -588,10 +589,13 @@ static ssize_t chroot_read(struct shim_handle* hdl, void* buf, size_t count) {
     if (ret < 0) {
         ret = pal_to_unix_errno(ret);
     } else {
-        if (__builtin_add_overflow(count, 0, &ret))
+        if (__builtin_add_overflow(count, 0, &ret)) {
             BUG();
-        if (file->type != FILE_TTY && __builtin_add_overflow(file->marker, count, &file->marker))
+        }
+        if (file->type != FILE_TTY && file->type != FILE_DEV &&
+                __builtin_add_overflow(file->marker, count, &file->marker)) {
             BUG();
+        }
     }
 
     unlock(&hdl->lock);
@@ -618,7 +622,8 @@ static ssize_t chroot_write(struct shim_handle* hdl, const void* buf, size_t cou
     struct shim_file_handle* file = &hdl->info.file;
 
     off_t dummy_off_t;
-    if (file->type != FILE_TTY && __builtin_add_overflow(file->marker, count, &dummy_off_t)) {
+    if (file->type != FILE_TTY && file->type != FILE_DEV &&
+            __builtin_add_overflow(file->marker, count, &dummy_off_t)) {
         ret = -EFBIG;
         goto out;
     }
@@ -629,10 +634,13 @@ static ssize_t chroot_write(struct shim_handle* hdl, const void* buf, size_t cou
     if (ret < 0) {
         ret = pal_to_unix_errno(ret);
     } else {
-        if (__builtin_add_overflow(count, 0, &ret))
+        if (__builtin_add_overflow(count, 0, &ret)) {
             BUG();
-        if (file->type != FILE_TTY && __builtin_add_overflow(file->marker, count, &file->marker))
+        }
+        if (file->type != FILE_TTY && file->type != FILE_DEV &&
+                __builtin_add_overflow(file->marker, count, &file->marker)) {
             BUG();
+        }
         if (file->marker > file->size) {
             file->size = file->marker;
             chroot_update_size(hdl, file, FILE_HANDLE_DATA(hdl));


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

There was a bug that LibOS manipulated the offset (`file->marker`) on device files (with type `FILE_DEV`). This led to calls like
`DkStreamRead(.., /*offset=*/10, ..)` which ends up in PAL's device read function that errors out because the offset is not zero (as expected).

Note that this special handling was already implemented for `FILE_TTY` terminal devices, but we forgot about `FILE_DEV` generic devices.

## How to test this PR? <!-- (if applicable) -->

All tests must pass. This was found on a private workload.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2413)
<!-- Reviewable:end -->
