### PR TITLE
[Pal/Linux-SGX] Remove 32-bit limit on buffer size in read/write

### DIFF
--- a/Pal/src/host/Linux-SGX/db_process.c
+++ b/Pal/src/host/Linux-SGX/db_process.c
@@ -291,9 +291,6 @@ static int64_t proc_read(PAL_HANDLE handle, uint64_t offset, uint64_t count, voi
     if (offset)
         return -PAL_ERROR_INVAL;
 
-    if (count != (uint32_t)count)
-        return -PAL_ERROR_INVAL;
-
     ssize_t bytes;
     if (handle->process.ssl_ctx) {
         bytes = _DkStreamSecureRead(handle->process.ssl_ctx, buffer, count,
@@ -308,9 +305,6 @@ static int64_t proc_read(PAL_HANDLE handle, uint64_t offset, uint64_t count, voi
 
 static int64_t proc_write(PAL_HANDLE handle, uint64_t offset, uint64_t count, const void* buffer) {
     if (offset)
-        return -PAL_ERROR_INVAL;
-
-    if (count != (uint32_t)count)
         return -PAL_ERROR_INVAL;
 
     ssize_t bytes;

--- a/Pal/src/host/Linux-SGX/db_sockets.c
+++ b/Pal/src/host/Linux-SGX/db_sockets.c
@@ -410,9 +410,6 @@ static int64_t tcp_read(PAL_HANDLE handle, uint64_t offset, uint64_t len, void* 
     if (handle->sock.fd == PAL_IDX_POISON)
         return 0;
 
-    if (len != (uint32_t)len)
-        return -PAL_ERROR_INVAL;
-
     ssize_t bytes = ocall_recv(handle->sock.fd, buf, len, NULL, NULL, NULL, NULL);
 
     if (bytes < 0)
@@ -431,9 +428,6 @@ static int64_t tcp_write(PAL_HANDLE handle, uint64_t offset, uint64_t len, const
 
     if (handle->sock.fd == PAL_IDX_POISON)
         return -PAL_ERROR_CONNFAILED;
-
-    if (len != (uint32_t)len)
-        return -PAL_ERROR_INVAL;
 
     ssize_t bytes = ocall_send(handle->sock.fd, buf, len, NULL, 0, NULL, 0);
     if (bytes < 0)
@@ -550,9 +544,6 @@ static int64_t udp_receive(PAL_HANDLE handle, uint64_t offset, uint64_t len, voi
     if (handle->sock.fd == PAL_IDX_POISON)
         return -PAL_ERROR_BADHANDLE;
 
-    if (len != (uint32_t)len)
-        return -PAL_ERROR_INVAL;
-
     ssize_t ret = ocall_recv(handle->sock.fd, buf, len, NULL, NULL, NULL, NULL);
     return ret < 0 ? unix_to_pal_error(ret) : ret;
 }
@@ -567,9 +558,6 @@ static int64_t udp_receivebyaddr(PAL_HANDLE handle, uint64_t offset, uint64_t le
 
     if (handle->sock.fd == PAL_IDX_POISON)
         return -PAL_ERROR_BADHANDLE;
-
-    if (len != (uint32_t)len)
-        return -PAL_ERROR_INVAL;
 
     struct sockaddr_storage conn_addr;
     size_t conn_addrlen = sizeof(conn_addr);
@@ -602,9 +590,6 @@ static int64_t udp_send(PAL_HANDLE handle, uint64_t offset, uint64_t len, const 
     if (handle->sock.fd == PAL_IDX_POISON)
         return -PAL_ERROR_BADHANDLE;
 
-    if (len != (uint32_t)len)
-        return -PAL_ERROR_INVAL;
-
     ssize_t bytes = ocall_send(handle->sock.fd, buf, len, NULL, 0, NULL, 0);
     if (bytes < 0)
         return unix_to_pal_error(bytes);
@@ -624,9 +609,6 @@ static int64_t udp_sendbyaddr(PAL_HANDLE handle, uint64_t offset, uint64_t len, 
         return -PAL_ERROR_BADHANDLE;
 
     if (!strstartswith(addr, URI_PREFIX_UDP))
-        return -PAL_ERROR_INVAL;
-
-    if (len != (uint32_t)len)
         return -PAL_ERROR_INVAL;
 
     addr += static_strlen(URI_PREFIX_UDP);


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Long time ago, there was a quirk that OCALLs used 32-bit sizes (e.g., in `ocall_read`/`ocall_write`). This limitation was removed, but the checks for uint32 overflow remained. This led e.g. to failures during fork, when a checkpointed memory region exceeded 4GB and thus was deemed "invalid" to be sent to the child.

Fixes #2388 (probably?).

## How to test this PR? <!-- (if applicable) -->

This PR also adds the case "send >4GB checkpoint" to `large_mmap` regression test. However, since this takes several minutes to execute on wimpy SGX machines, this case is commented out by default.

Uncomment it manually and re-run the regression suite. You'll see that it fails without this PR and succeeds with this PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2414)
<!-- Reviewable:end -->
