### PR TITLE
Add acknowledgment for fosshost

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -99,3 +99,11 @@ For any questions, please send an email to support@graphene-project.io
 
 For bug reports, post an issue on our GitHub repository:
 https://github.com/oscarlab/graphene/issues.
+
+
+Acknowledgments
+===============
+
+Graphene Project benefits from generous help of `fosshost.org
+<https://fosshost.org>`__: they lend us a VPS, which we use as toolserver and
+package hosting.


### PR DESCRIPTION
Fosshost requires acknowledgement for their help (https://docs.fosshost.org/en/home/what-do-we-expect, pt. 3), which we intended to post on https://grapheneproject.io/, but the webmaster became unresponsive.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2417)
<!-- Reviewable:end -->
