### PR TITLE
[LibOS] Convert `libos.entrypoint` to a Graphene path 

### DIFF
--- a/Documentation/manifest-syntax.rst
+++ b/Documentation/manifest-syntax.rst
@@ -71,10 +71,30 @@ Entrypoint
 
 ::
 
-   libos.entrypoint = "URI"
+   libos.entrypoint = "[PATH]"
 
 This specifies the first executable which is to be started when spawning a
-Graphene instance from this manifest file.
+Graphene instance from this manifest file. Needs to be a path inside Graphene
+pointing to a mounted file. Relative paths will be interpreted as starting from
+the current working directory (i.e. from ``/`` by default, or ``fs.start_dir``
+if specified).
+
+The recommended usage is to provide an absolute path, and mount the executable
+at that path. For example:
+
+::
+   libos.entrypoint = "/usr/bin/python3.8"
+
+   fs.mount.python.type = "chroot"
+   fs.mount.python.path = "/usr/bin/python3.8"
+   fs.mount.python.uri = "file:/usr/bin/python3.8"
+   # Or, if using a binary from your local directory:
+   # fs.mount.python.uri = "file:python3.8"
+
+.. note ::
+   Earlier, ``libos.entrypoint`` was a PAL URI. If you used it with a relative
+   path, it's probably enough to remove ``file:`` prefix (convert
+   ``"file:hello"`` to ``"hello"``).
 
 Command-line arguments
 ^^^^^^^^^^^^^^^^^^^^^^
@@ -108,9 +128,11 @@ If you want your application to use commandline arguments you need to either set
 ``loader.argv_src_file`` is intended to point to either a trusted file or a
 protected file. The former allows to securely hardcode arguments (current
 manifest syntax doesn't allow to include them inline), the latter allows the
-arguments to be provided at runtime from an external (trusted) source. *NOTE:*
-Pointing to a protected file is currently not supported, due to the fact that
-PF wrap key provisioning currently happens after setting up arguments.
+arguments to be provided at runtime from an external (trusted) source.
+
+.. note ::
+   Pointing to a protected file is currently not supported, due to the fact that
+   PF wrap key provisioning currently happens after setting up arguments.
 
 Environment variables
 ^^^^^^^^^^^^^^^^^^^^^
@@ -141,9 +163,12 @@ environment, which can be generated using :file:`Tools/argv_serializer`. This
 option is intended to point to either a trusted file or a protected file. The
 former allows to securely hardcode environments (in a more flexible way than
 ``loader.env.[ENVIRON]`` option), the latter allows the environments to be
-provided at runtime from an external (trusted) source. *NOTE:* Pointing to a
-protected file is currently not supported, due to the fact that PF wrap key
-provisioning currently happens after setting up environment variables.
+provided at runtime from an external (trusted) source.
+
+.. note ::
+   Pointing to a protected file is currently not supported, due to the fact that
+   PF wrap key provisioning currently happens after setting up environment
+   variables.
 
 If the same variable is set in both, then ``loader.env.[ENVIRON]`` takes
 precedence.

--- a/Documentation/manpages/graphene-manifest.rst
+++ b/Documentation/manpages/graphene-manifest.rst
@@ -88,7 +88,7 @@ Example
 .. code-block:: jinja
 
    loader.preload = "file:{{ graphene.libos }}"
-   libos.entrypoint = "file:{{ entrypoint }}"
+   libos.entrypoint = "{{ entrypoint }}"
    loader.env.LD_LIBRARY_PATH = "/lib:{{ arch_libdir }}:/usr{{ arch_libdir }}"
 
    [fs.mount.runtime]

--- a/Examples/apache/httpd.manifest.template
+++ b/Examples/apache/httpd.manifest.template
@@ -3,7 +3,7 @@
 # This manifest was prepared and tested on Ubuntu 16.04.
 
 loader.preload = "file:{{ graphene.libos }}"
-libos.entrypoint = "file:{{ install_dir }}/bin/httpd"
+libos.entrypoint = "{{ install_dir }}/bin/httpd"
 loader.argv0_override = "httpd"
 
 # Read application arguments directly from the command line. Don't use this on production!

--- a/Examples/bash/manifest.template
+++ b/Examples/bash/manifest.template
@@ -3,7 +3,7 @@
 #
 # This manifest was prepared and tested on Ubuntu 16.04.
 loader.preload = "file:{{ graphene.libos }}"
-libos.entrypoint = "file:{{ execdir }}/bash"
+libos.entrypoint = "{{ execdir }}/bash"
 
 # Read application arguments directly from the command line. Don't use this on production!
 loader.insecure__use_cmdline_argv = true

--- a/Examples/blender/blender.manifest.template
+++ b/Examples/blender/blender.manifest.template
@@ -11,7 +11,7 @@ sgx.allowed_files.blender_input = "file:{{ data_dir }}/scenes/"
 sgx.allowed_files.blender_output = "file:{{ data_dir }}/images/"
 
 
-libos.entrypoint = "file:{{ blender_dir }}/blender"
+libos.entrypoint = "/blender/blender"
 
 # Read application arguments directly from the command line. Don't use this on production!
 loader.insecure__use_cmdline_argv = true

--- a/Examples/busybox/busybox.manifest.template
+++ b/Examples/busybox/busybox.manifest.template
@@ -5,7 +5,7 @@
 ################################## GRAPHENE ###################################
 
 # The binary to execute.
-libos.entrypoint = "file:busybox"
+libos.entrypoint = "busybox"
 
 # Read application arguments directly from the command line. Don't use this on production!
 loader.insecure__use_cmdline_argv = true

--- a/Examples/capnproto/addressbook.manifest.template
+++ b/Examples/capnproto/addressbook.manifest.template
@@ -3,7 +3,7 @@
 # This manifest was prepared and tested on Ubuntu 16.04 and Ubuntu 18.04.
 
 # The binary to execute.
-libos.entrypoint = "file:addressbook"
+libos.entrypoint = "addressbook"
 
 # LibOS layer library of Graphene (currently only one implementation, libsysdb)
 loader.preload = "file:{{ graphene.libos }}"

--- a/Examples/curl/curl.manifest.template
+++ b/Examples/curl/curl.manifest.template
@@ -2,7 +2,7 @@
 #
 # This manifest was prepared and tested on Ubuntu 16.04.
 
-libos.entrypoint = "file:{{ curl_dir }}/curl"
+libos.entrypoint = "{{ curl_dir }}/curl"
 loader.argv0_override = "curl"
 
 # LibOS layer library of Graphene. There is currently only one implementation,

--- a/Examples/gcc/gcc.manifest.template
+++ b/Examples/gcc/gcc.manifest.template
@@ -2,7 +2,7 @@ loader.preload = "file:{{ graphene.libos }}"
 loader.env.LD_LIBRARY_PATH = "/lib:{{ arch_libdir }}:/usr/lib:/usr/{{ arch_libdir }}"
 loader.env.PATH = "/bin:/usr/bin"
 loader.log_level = "{{ log_level }}"
-libos.entrypoint = "file:/usr/bin/gcc"
+libos.entrypoint = "/usr/bin/gcc"
 
 # Read application arguments directly from the command line. Don't use this on production!
 loader.insecure__use_cmdline_argv = true

--- a/Examples/lighttpd/lighttpd.manifest.template
+++ b/Examples/lighttpd/lighttpd.manifest.template
@@ -7,7 +7,7 @@
 # graphene-direct ./lighttpd <script>
 # graphene-sgx ./lighttpd <script>
 
-libos.entrypoint = "file:{{ install_dir }}/sbin/lighttpd"
+libos.entrypoint = "{{ install_dir }}/sbin/lighttpd"
 
 # Path to the library OS
 loader.preload = "file:{{ graphene.libos }}"

--- a/Examples/memcached/memcached.manifest.template
+++ b/Examples/memcached/memcached.manifest.template
@@ -24,7 +24,7 @@
 loader.preload = "file:{{ graphene.libos }}"
 
 # Binary to run.
-libos.entrypoint = "file:memcached"
+libos.entrypoint = "memcached"
 
 # Verbosity of Graphene debug log (none/error/warning/debug/trace/all). Note
 # that GRAPHENE_LOG_LEVEL macro is expanded in the Makefile as part of the

--- a/Examples/nginx/nginx.manifest.template
+++ b/Examples/nginx/nginx.manifest.template
@@ -2,7 +2,7 @@
 #
 # This manifest was prepared and tested on Ubuntu 18.04.
 
-libos.entrypoint = "file:{{ install_dir }}/sbin/nginx"
+libos.entrypoint = "{{ install_dir }}/sbin/nginx"
 
 # Path to the library OS
 loader.preload = "file:{{ graphene.libos }}"

--- a/Examples/nodejs-express-server/nodejs.manifest.template
+++ b/Examples/nodejs-express-server/nodejs.manifest.template
@@ -2,7 +2,7 @@
 #
 # This manifest was prepared and tested on Ubuntu 18.04. The tested version of Node.js was v13.14.0.
 
-libos.entrypoint = "file:{{ nodejs_dir }}/nodejs"
+libos.entrypoint = "{{ nodejs_dir }}/nodejs"
 
 # LibOS layer library of Graphene. There is currently only one implementation, so it is always set
 # to libsysdb.so.
@@ -27,6 +27,11 @@ loader.env.LD_LIBRARY_PATH = "/lib:{{ arch_libdir }}:/usr/{{ arch_libdir }}"
 
 # Allow for injecting SIGTERM signal from the host.
 sys.enable_sigterm_injection = true
+
+# Mount the nodejs binary
+fs.mount.nodejs.type = "chroot"
+fs.mount.nodejs.path = "{{ nodejs_dir }}/nodejs"
+fs.mount.nodejs.uri = "file:{{ nodejs_dir }}/nodejs"
 
 # Mount host-OS directory to required libraries (in 'uri') into in-Graphene visible directory /lib
 # (in 'path').

--- a/Examples/nodejs/nodejs.manifest.template
+++ b/Examples/nodejs/nodejs.manifest.template
@@ -2,7 +2,7 @@
 #
 # This manifest was prepared and tested on Ubuntu 18.04. The tested version of Node.js was v13.14.0.
 
-libos.entrypoint = "file:{{ nodejs_dir }}/nodejs"
+libos.entrypoint = "{{ nodejs_dir }}/nodejs"
 
 # LibOS layer library of Graphene. There is currently only one implementation,
 # so it is always set to libsysdb.so.
@@ -24,6 +24,11 @@ sys.insecure__allow_eventfd = true
 # applies. Paths must be in-Graphene visible paths, not host-OS paths (i.e.,
 # paths must be taken from fs.mount.xxx.path, not fs.mount.xxx.uri).
 loader.env.LD_LIBRARY_PATH = "/lib:{{ arch_libdir }}:/usr/{{ arch_libdir }}"
+
+# Mount the nodejs binary
+fs.mount.nodejs.type = "chroot"
+fs.mount.nodejs.path = "{{ nodejs_dir }}/nodejs"
+fs.mount.nodejs.uri = "file:{{ nodejs_dir }}/nodejs"
 
 # Mount host-OS directory to required libraries (in 'uri') into in-Graphene
 # visible directory /lib (in 'path').

--- a/Examples/openvino/object_detection_sample_ssd.manifest.template
+++ b/Examples/openvino/object_detection_sample_ssd.manifest.template
@@ -2,7 +2,7 @@
 #
 # This manifest was prepared and tested on Ubuntu 18.04.
 
-libos.entrypoint = "file:{{ openvino_dir }}/bin/intel64/{{ openvino_build }}/object_detection_sample_ssd"
+libos.entrypoint = "{{ openvino_dir }}/bin/intel64/{{ openvino_build }}/object_detection_sample_ssd"
 
 # Path to the library OS
 loader.preload = "file:{{ graphene.libos }}"

--- a/Examples/python/python.manifest.template
+++ b/Examples/python/python.manifest.template
@@ -3,7 +3,7 @@
 # This manifest was prepared and tested on Ubuntu 18.04 and 20.04 and tested with
 # Python 3.6 and 3.8.
 
-libos.entrypoint = "file:{{ entrypoint }}"
+libos.entrypoint = "{{ entrypoint }}"
 
 # Path to the library OS
 loader.preload = "file:{{ graphene.libos }}"

--- a/Examples/pytorch/pytorch.manifest.template
+++ b/Examples/pytorch/pytorch.manifest.template
@@ -2,7 +2,7 @@
 #
 # This manifest was tested on Ubuntu 16.04 and 18.04.
 
-libos.entrypoint = "file:{{ entrypoint }}"
+libos.entrypoint = "{{ entrypoint }}"
 
 # Path to the library OS
 loader.preload = "file:{{ graphene.libos }}"

--- a/Examples/r/R.manifest.template
+++ b/Examples/r/R.manifest.template
@@ -2,7 +2,7 @@
 #
 # This manifest was prepared and tested on Ubuntu 16.04.
 
-libos.entrypoint = "file:{{ r_exec }}"
+libos.entrypoint = "{{ r_exec }}"
 
 # Path to the library OS
 loader.preload = "file:{{ graphene.libos }}"

--- a/Examples/ra-tls-mbedtls/client.manifest.template
+++ b/Examples/ra-tls-mbedtls/client.manifest.template
@@ -2,7 +2,7 @@
 #
 # This manifest was prepared and tested on Ubuntu 18.04.
 
-libos.entrypoint = "file:client"
+libos.entrypoint = "client"
 
 # LibOS layer library of Graphene. There is currently only one implementation,
 # so it is always set to libsysdb.so.

--- a/Examples/ra-tls-mbedtls/server.manifest.template
+++ b/Examples/ra-tls-mbedtls/server.manifest.template
@@ -3,7 +3,7 @@
 # This manifest was prepared and tested on Ubuntu 18.04.
 
 loader.preload = "file:{{ graphene.libos }}"
-libos.entrypoint = "file:server"
+libos.entrypoint = "server"
 loader.log_level = "{{ log_level }}"
 
 loader.env.LD_LIBRARY_PATH = "/lib:/lib/x86_64-linux-gnu:/libs"

--- a/Examples/ra-tls-secret-prov/secret_prov_client.manifest.template
+++ b/Examples/ra-tls-secret-prov/secret_prov_client.manifest.template
@@ -3,7 +3,7 @@
 # This manifest was prepared and tested on Ubuntu 18.04.
 
 loader.preload = "file:{{ graphene.libos }}"
-libos.entrypoint = "file:secret_prov_client"
+libos.entrypoint = "secret_prov_client"
 loader.log_level = "{{ log_level }}"
 
 loader.env.LD_LIBRARY_PATH = "/lib:/lib/x86_64-linux-gnu:/libs"

--- a/Examples/ra-tls-secret-prov/secret_prov_min_client.manifest.template
+++ b/Examples/ra-tls-secret-prov/secret_prov_min_client.manifest.template
@@ -3,7 +3,7 @@
 # This manifest was prepared and tested on Ubuntu 18.04.
 
 loader.preload = "file:{{ graphene.libos }}"
-libos.entrypoint = "file:secret_prov_min_client"
+libos.entrypoint = "secret_prov_min_client"
 loader.log_level = "{{ log_level }}"
 
 loader.env.LD_LIBRARY_PATH = "/lib:/lib/x86_64-linux-gnu:/libs"

--- a/Examples/ra-tls-secret-prov/secret_prov_pf_client.manifest.template
+++ b/Examples/ra-tls-secret-prov/secret_prov_pf_client.manifest.template
@@ -3,7 +3,7 @@
 # This manifest was prepared and tested on Ubuntu 18.04.
 
 loader.preload = "file:{{ graphene.libos }}"
-libos.entrypoint = "file:secret_prov_pf_client"
+libos.entrypoint = "secret_prov_pf_client"
 loader.log_level = "{{ log_level }}"
 
 loader.env.LD_LIBRARY_PATH = "/lib:/lib/x86_64-linux-gnu:/libs"

--- a/Examples/redis/redis-server.manifest.template
+++ b/Examples/redis/redis-server.manifest.template
@@ -9,7 +9,7 @@
 # to relative path to Graphene repository in the Makefile as part of the
 # build process.
 loader.preload = "file:{{ graphene.libos }}"
-libos.entrypoint = "file:redis-server"
+libos.entrypoint = "redis-server"
 
 # Verbosity of Graphene debug log (none/error/warning/debug/trace/all). Note
 # that GRAPHENE_LOG_LEVEL macro is expanded in the Makefile as part of the

--- a/Examples/tensorflow-lite/label_image.manifest.template
+++ b/Examples/tensorflow-lite/label_image.manifest.template
@@ -1,5 +1,5 @@
 loader.preload = "file:{{ graphene.libos }}"
-libos.entrypoint = "file:label_image"
+libos.entrypoint = "label_image"
 loader.env.LD_LIBRARY_PATH = "/lib:."
 loader.env.PATH = "/bin:/usr/bin"
 

--- a/LibOS/shim/include/shim_handle.h
+++ b/LibOS/shim/include/shim_handle.h
@@ -359,6 +359,8 @@ int walk_handle_map(int (*callback)(struct shim_fd_handle*, struct shim_handle_m
 int init_handle(void);
 int init_important_handles(void);
 
+int open_executable(struct shim_handle* hdl, const char* path);
+
 int get_file_size(struct shim_handle* file, uint64_t* size);
 
 int do_handle_read(struct shim_handle* hdl, void* buf, int count);

--- a/LibOS/shim/src/utils/log.c
+++ b/LibOS/shim/src/utils/log.c
@@ -42,16 +42,6 @@ void log_setprefix(shim_tcb_t* tcb) {
     } else if (g_process.exec) {
         if (g_process.exec->dentry) {
             exec_name = qstrgetstr(&g_process.exec->dentry->name);
-        } else if (!qstrempty(&g_process.exec->uri)) {
-            /* TODO: This is possible if `init_exec_handle` does not find the dentry for executable.
-             * Remove this branch after `init_exec_handle` is fixed. */
-            exec_name = qstrgetstr(&g_process.exec->uri);
-            /* Skip everything before ':' and '/' */
-            for (const char* it = exec_name; *it; it++) {
-                if (*it == ':' || *it == '/') {
-                    exec_name = it + 1;
-                }
-            }
         } else {
             /* Unknown executable name */
             exec_name = "?";

--- a/LibOS/shim/test/fs/manifest.template
+++ b/LibOS/shim/test/fs/manifest.template
@@ -1,5 +1,5 @@
 loader.preload = "file:{{ graphene.libos }}"
-libos.entrypoint = "file:{{ entrypoint }}"
+libos.entrypoint = "{{ entrypoint }}"
 loader.env.LD_LIBRARY_PATH = "/lib:{{ arch_libdir }}:/usr/{{ arch_libdir }}"
 loader.insecure__use_cmdline_argv = true
 

--- a/LibOS/shim/test/ltp/manifest.template
+++ b/LibOS/shim/test/ltp/manifest.template
@@ -1,5 +1,5 @@
 loader.preload = "file:{{ graphene.libos }}"
-libos.entrypoint = "file:{{ entrypoint }}"
+libos.entrypoint = "{{ entrypoint }}"
 loader.env.LD_LIBRARY_PATH = "/lib:{{ arch_libdir }}:/usr/lib:/usr/lib64"
 loader.env.PATH = "/bin:/usr/bin:."
 loader.env.LD_PRELOAD = "{{ coreutils_libdir }}/libstdbuf.so"

--- a/LibOS/shim/test/regression/argv_from_file.manifest.template
+++ b/LibOS/shim/test/regression/argv_from_file.manifest.template
@@ -1,5 +1,5 @@
 loader.preload = "file:{{ graphene.libos }}"
-libos.entrypoint = "file:bootstrap"
+libos.entrypoint = "bootstrap"
 loader.argv0_override = "bootstrap"
 
 loader.env.LD_LIBRARY_PATH = "/lib"

--- a/LibOS/shim/test/regression/attestation.manifest.template
+++ b/LibOS/shim/test/regression/attestation.manifest.template
@@ -1,5 +1,5 @@
 loader.preload = "file:{{ graphene.libos }}"
-libos.entrypoint = "file:attestation"
+libos.entrypoint = "attestation"
 loader.argv0_override = "attestation"
 
 loader.env.LD_LIBRARY_PATH = "/lib"

--- a/LibOS/shim/test/regression/bootstrap_cpp.manifest.template
+++ b/LibOS/shim/test/regression/bootstrap_cpp.manifest.template
@@ -1,5 +1,5 @@
 loader.preload = "file:{{ graphene.libos }}"
-libos.entrypoint = "file:bootstrap_cpp"
+libos.entrypoint = "bootstrap_cpp"
 loader.argv0_override = "bootstrap_cpp"
 
 loader.env.LD_LIBRARY_PATH = "/lib:{{ arch_libdir }}:/usr/{{ arch_libdir }}"

--- a/LibOS/shim/test/regression/debug_log_file.manifest.template
+++ b/LibOS/shim/test/regression/debug_log_file.manifest.template
@@ -1,5 +1,5 @@
 loader.preload = "file:{{ graphene.libos }}"
-libos.entrypoint = "file:bootstrap"
+libos.entrypoint = "bootstrap"
 loader.argv0_override = "bootstrap"
 
 loader.env.LD_LIBRARY_PATH = "/lib"

--- a/LibOS/shim/test/regression/debug_log_inline.manifest.template
+++ b/LibOS/shim/test/regression/debug_log_inline.manifest.template
@@ -1,5 +1,5 @@
 loader.preload = "file:{{ graphene.libos }}"
-libos.entrypoint = "file:bootstrap"
+libos.entrypoint = "bootstrap"
 loader.argv0_override = "bootstrap"
 
 loader.env.LD_LIBRARY_PATH = "/lib"

--- a/LibOS/shim/test/regression/env_from_file.manifest.template
+++ b/LibOS/shim/test/regression/env_from_file.manifest.template
@@ -1,5 +1,5 @@
 loader.preload = "file:{{ graphene.libos }}"
-libos.entrypoint = "file:bootstrap"
+libos.entrypoint = "bootstrap"
 loader.argv0_override = "bootstrap"
 loader.env.LD_LIBRARY_PATH = "/lib"
 loader.env_src_file = "file:env_test_input"

--- a/LibOS/shim/test/regression/env_from_host.manifest.template
+++ b/LibOS/shim/test/regression/env_from_host.manifest.template
@@ -1,6 +1,6 @@
 loader.preload = "file:{{ graphene.libos }}"
 loader.argv0_override = "bootstrap"
-libos.entrypoint = "file:bootstrap"
+libos.entrypoint = "bootstrap"
 
 loader.env.LD_LIBRARY_PATH = "/lib"
 loader.insecure__use_host_env = true

--- a/LibOS/shim/test/regression/file_check_policy_allow_all_but_log.manifest.template
+++ b/LibOS/shim/test/regression/file_check_policy_allow_all_but_log.manifest.template
@@ -1,5 +1,5 @@
 loader.preload = "file:{{ graphene.libos }}"
-libos.entrypoint = "file:file_check_policy"
+libos.entrypoint = "file_check_policy"
 loader.argv0_override = "file_check_policy"
 
 loader.env.LD_LIBRARY_PATH = "/lib"

--- a/LibOS/shim/test/regression/file_check_policy_strict.manifest.template
+++ b/LibOS/shim/test/regression/file_check_policy_strict.manifest.template
@@ -1,5 +1,5 @@
 loader.preload = "file:{{ graphene.libos }}"
-libos.entrypoint = "file:file_check_policy"
+libos.entrypoint = "file_check_policy"
 loader.argv0_override = "file_check_policy"
 
 loader.env.LD_LIBRARY_PATH = "/lib"

--- a/LibOS/shim/test/regression/host_root_fs.manifest.template
+++ b/LibOS/shim/test/regression/host_root_fs.manifest.template
@@ -1,5 +1,5 @@
 loader.preload = "file:{{ graphene.libos }}"
-libos.entrypoint = "file:host_root_fs"
+libos.entrypoint = "{{ env.PWD }}/host_root_fs"
 loader.argv0_override = "host_root_fs"
 
 loader.env.LD_LIBRARY_PATH = "/lib"
@@ -13,6 +13,6 @@ fs.mount.graphene_lib.path = "/lib"
 fs.mount.graphene_lib.uri = "file:{{ graphene.runtimedir() }}"
 
 sgx.trusted_files.runtime = "file:{{ graphene.runtimedir() }}/"
-sgx.trusted_files.host_root_fs = "file:host_root_fs"
+sgx.trusted_files.host_root_fs = "file:{{ env.PWD }}/host_root_fs"
 
 sgx.nonpie_binary = true

--- a/LibOS/shim/test/regression/init_fail.manifest.template
+++ b/LibOS/shim/test/regression/init_fail.manifest.template
@@ -1,5 +1,5 @@
 loader.preload = "file:{{ graphene.libos }}"
-libos.entrypoint = "file:init_fail"
+libos.entrypoint = "init_fail"
 loader.argv0_override = "init_fail"
 
 loader.env.LD_LIBRARY_PATH = "/lib"

--- a/LibOS/shim/test/regression/init_fail2.manifest.template
+++ b/LibOS/shim/test/regression/init_fail2.manifest.template
@@ -1,5 +1,5 @@
 loader.preload = "file:{{ graphene.libos }}"
-libos.entrypoint = "file:init_fail"
+libos.entrypoint = "init_fail"
 loader.argv0_override = "init_fail"
 
 loader.env.LD_LIBRARY_PATH = "/lib"

--- a/LibOS/shim/test/regression/large_mmap.manifest.template
+++ b/LibOS/shim/test/regression/large_mmap.manifest.template
@@ -1,5 +1,5 @@
 loader.preload = "file:{{ graphene.libos }}"
-libos.entrypoint = "file:large_mmap"
+libos.entrypoint = "large_mmap"
 loader.argv0_override = "large_mmap"
 
 loader.env.LD_LIBRARY_PATH = "/lib"

--- a/LibOS/shim/test/regression/manifest.template
+++ b/LibOS/shim/test/regression/manifest.template
@@ -1,5 +1,5 @@
 loader.preload = "file:{{ graphene.libos }}"
-libos.entrypoint = "file:{{ entrypoint }}"
+libos.entrypoint = "{{ entrypoint }}"
 loader.env.LD_LIBRARY_PATH = "/lib:{{ arch_libdir }}:/usr/{{ arch_libdir }}"
 loader.insecure__use_cmdline_argv = true
 

--- a/LibOS/shim/test/regression/multi_pthread.manifest.template
+++ b/LibOS/shim/test/regression/multi_pthread.manifest.template
@@ -1,7 +1,7 @@
 loader.preload = "file:{{ graphene.libos }}"
 loader.env.LD_LIBRARY_PATH = "/lib"
 loader.argv0_override = "multi_pthread"
-libos.entrypoint = "file:multi_pthread"
+libos.entrypoint = "multi_pthread"
 
 fs.mount.lib.type = "chroot"
 fs.mount.lib.path = "/lib"

--- a/LibOS/shim/test/regression/multi_pthread_exitless.manifest.template
+++ b/LibOS/shim/test/regression/multi_pthread_exitless.manifest.template
@@ -1,6 +1,6 @@
 loader.preload = "file:{{ graphene.libos }}"
 loader.env.LD_LIBRARY_PATH = "/lib"
-libos.entrypoint = "file:multi_pthread"
+libos.entrypoint = "multi_pthread"
 loader.argv0_override = "multi_pthread"
 
 fs.mount.lib.type = "chroot"

--- a/LibOS/shim/test/regression/openmp.manifest.template
+++ b/LibOS/shim/test/regression/openmp.manifest.template
@@ -1,5 +1,5 @@
 loader.preload = "file:{{ graphene.libos }}"
-libos.entrypoint = "file:openmp"
+libos.entrypoint = "openmp"
 loader.argv0_override = "openmp"
 
 # Graphene optionally provides patched OpenMP runtime library that runs faster inside SGX enclaves

--- a/Tools/gsc/templates/entrypoint.manifest.template
+++ b/Tools/gsc/templates/entrypoint.manifest.template
@@ -1,4 +1,4 @@
-libos.entrypoint = "file:/{{binary}}"
+libos.entrypoint = "/{{binary}}"
 loader.preload = "file:/graphene/Runtime/libsysdb.so"
 
 loader.env.LD_LIBRARY_PATH = "/graphene/Runtime:{{"{{library_paths}}"}}"


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Follow up to #2416. Now `libos.entrypoint` has to point to a mounted executable.

I did keep a fallback: a `file:xxx` URI produces a warning and is handled the same as `xxx` or `/xxx`. Most of the time, this should work, because we mount the current directory by default. If you prefer, I can convert this to an error.

For most of the manifests, it was enough to remove `file:` prefix. I needed to convert the following:

- ``host_root_fs`` test: because we mount `/`, we need to reach the executable through `$PWD`
- ``nodejs`` and ``nodejs-express-server``: added a mount for nodejs binary (``{{ nodejs_dir }}/nodejs``)
- ``blender``: changed entrypoint to ``/blender/blender`` because that's where we mount it at

## How to test this PR? <!-- (if applicable) -->

Most manifests are checked on Jenkins. I manually ran the manifests in Examples folder that are *not* tested on Jenkins, to check if the entry point still executed:

- apache
- busybox
- capnproto
- nodejs, nodejs-express-server (needed updating)
- pytorch

I did not manage to install, but checked the manifests, for the following:
- openvino
- tensorflow-lite

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2421)
<!-- Reviewable:end -->
