### PR TITLE
Corrected check for in-kernel driver

### DIFF
--- a/Pal/src/host/Linux-SGX/tools/is-sgx-available/is_sgx_available.cpp
+++ b/Pal/src/host/Linux-SGX/tools/is-sgx-available/is_sgx_available.cpp
@@ -165,8 +165,8 @@ public:
 };
 
 bool sgx_driver_loaded() {
-    // /dev/isgx is for LKM version, /dev/sgx is for in-kernel support.
-    return file_exists("/dev/isgx") || file_exists("/dev/sgx");
+    // /dev/isgx is for LKM version, /dev/sgx_enclave and /dev/sgx_provision are for in-kernel support.
+    return file_exists("/dev/isgx") || (file_exists("/dev/sgx_enclave") && file_exists("/dev/sgx_provision"));
 }
 
 bool psw_installed() {


### PR DESCRIPTION
## Description of the changes

The in-kernel driver by itself doesn't create the /dev/sgx folder any longer.  This is done by the PSW installers now.  So, if the PSW isn't yet installed when running the tool, it will fail the in-kernel driver check.  Modifying the tool to check for /dev/sgx_provision /dev/sgx_enclave which is what the in-kernel driver creates.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2427)
<!-- Reviewable:end -->
