### PR TITLE
[Pal] regression: fix make regression without pal_lib=

### DIFF
--- a/.ci/lib/stage-test.jenkinsfile
+++ b/.ci/lib/stage-test.jenkinsfile
@@ -10,18 +10,11 @@ stage('test') {
     timeout(time: 15, unit: 'MINUTES') {
         try {
             sh '''
-                if test -n "$SGX"
-                then
-                    graphene=sgx
-                else
-                    graphene=direct
-                fi
-
                 cd Pal/regression
-                make ${MAKEOPTS} all pal_lib="$GRAPHENE_PKGLIBDIR"/"$graphene"/libpal.so
+                make ${MAKEOPTS} all
                 if test -n "$SGX"
                 then
-                    make ${MAKEOPTS} sgx-tokens pal_lib="$GRAPHENE_PKGLIBDIR"/"$graphene"/libpal.so
+                    make ${MAKEOPTS} sgx-tokens
                 fi
                 python3 -m pytest -v --junit-xml pal-regression.xml test_pal.py
             '''

--- a/Pal/regression/Makefile
+++ b/Pal/regression/Makefile
@@ -72,9 +72,12 @@ target = \
 
 include ../../Scripts/manifest.mk
 graphene_lib = .lib/graphene-lib.a
-pal_lib ?= ../../Runtime/libpal-$(PAL_HOST).so
-
-RUNTIME_DIR = $(CURDIR)/../../Runtime
+ifneq ($(SGX),)
+graphene = sgx
+else
+graphene = direct
+endif
+pal_lib ?= $(shell graphene-manifest -c '{{ graphene.pkglibdir }}')/$(graphene)/libpal.so
 
 .PHONY: all
 all: $(target) $(call expand_target_to_sig,$(target)) \

--- a/python/graphenelibos/manifest.py
+++ b/python/graphenelibos/manifest.py
@@ -73,8 +73,9 @@ class Runtimedir:
 
 def add_globals_from_graphene(env):
     env.globals['graphene'] = {
-        'runtimedir': Runtimedir(),
         'libos': pathlib.Path(_CONFIG_PKGLIBDIR) / 'libsysdb.so',
+        'pkglibdir': pathlib.Path(_CONFIG_PKGLIBDIR),
+        'runtimedir': Runtimedir(),
     }
 
     try:
@@ -114,11 +115,15 @@ def validate_define(_ctx, _param, values):
     return ret
 
 @click.command()
+@click.option('--string', '-c')
 @click.option('--define', '-D', multiple=True, callback=validate_define)
-@click.argument('infile', type=click.File('r'))
+@click.argument('infile', type=click.File('r'), required=False)
 @click.argument('outfile', type=click.File('w'), default='-')
-def main(define, infile, outfile):
-    outfile.write(render(infile.read(), define))
+def main(string, define, infile, outfile):
+    if not bool(string) ^ bool(infile):
+        click.get_current_context().fail('specify exactly one of (infile, -c)')
+    template = infile.read() if infile else string
+    outfile.write(render(template, define))
 
 if __name__ == '__main__':
     main() # pylint: disable=no-value-for-parameter


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Fixes: #2425 (Pal/regression seems broken after 13afef4313b3dfcc3fad73e5ecc685a2c133418f by @jurobystricky)

## How to test this PR? <!-- (if applicable) -->

```sh
cd Pal/regression
make regression
make regression SGX=1
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2428)
<!-- Reviewable:end -->
