### PR TITLE
[Pal/Linux-SGX] Update Diffie-Hellman parameters to use modp3072 group

### DIFF
--- a/Pal/src/host/Linux-SGX/enclave_framework.c
+++ b/Pal/src/host/Linux-SGX/enclave_framework.c
@@ -905,8 +905,8 @@ int init_enclave(void) {
 }
 
 int _DkStreamKeyExchange(PAL_HANDLE stream, PAL_SESSION_KEY* key) {
-    uint8_t pub[DH_SIZE]   __attribute__((aligned(DH_SIZE)));
-    uint8_t agree[DH_SIZE] __attribute__((aligned(DH_SIZE)));
+    uint8_t pub[DH_SIZE];
+    uint8_t agree[DH_SIZE];
     PAL_NUM pubsz, agreesz;
     LIB_DH_CONTEXT context;
     int64_t bytes;

--- a/common/include/crypto.h
+++ b/common/include/crypto.h
@@ -16,7 +16,7 @@
 #include <unistd.h>
 
 #define SHA256_DIGEST_LEN 32
-#define DH_SIZE           256 /* DH_SIZE is tied to the choice of parameters in mbedtls_dh.c */
+#define DH_SIZE           384 /* DH_SIZE is tied to the choice of parameters in mbedtls_adapter.c */
 
 #ifdef CRYPTO_USE_MBEDTLS
 #define CRYPTO_PROVIDER_SPECIFIED

--- a/common/src/crypto/adapters/mbedtls_adapter.c
+++ b/common/src/crypto/adapters/mbedtls_adapter.c
@@ -435,11 +435,11 @@ int lib_DhInit(LIB_DH_CONTEXT* context) {
     /* Configure parameters. Note that custom Diffie-Hellman parameters are considered more secure,
      * but require more data be exchanged between the two parties to establish the parameters, so we
      * haven't implemented that yet. */
-    ret = mbedtls_mpi_read_string(&context->P, 16 /* radix */, MBEDTLS_DHM_RFC3526_MODP_2048_P);
+    ret = mbedtls_mpi_read_string(&context->P, 16 /* radix */, MBEDTLS_DHM_RFC3526_MODP_3072_P);
     if (ret < 0)
         return mbedtls_to_pal_error(ret);
 
-    ret = mbedtls_mpi_read_string(&context->G, 16 /* radix */, MBEDTLS_DHM_RFC3526_MODP_2048_G);
+    ret = mbedtls_mpi_read_string(&context->G, 16 /* radix */, MBEDTLS_DHM_RFC3526_MODP_3072_G);
     if (ret < 0)
         return mbedtls_to_pal_error(ret);
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

It was recommended to us to update from modp2048 Diffie-Hellman group (group 14) to modp3072 group (group 15). It is a trivial update.

## How to test this PR? <!-- (if applicable) -->

All tests should pass.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2429)
<!-- Reviewable:end -->
