### PR TITLE
[Pal/Linux-SGX] tools: Support upstreamed driver in is_sgx_available

### DIFF
--- a/Pal/src/host/Linux-SGX/tools/is-sgx-available/is_sgx_available.cpp
+++ b/Pal/src/host/Linux-SGX/tools/is-sgx-available/is_sgx_available.cpp
@@ -165,8 +165,9 @@ public:
 };
 
 bool sgx_driver_loaded() {
-    // /dev/isgx is for LKM version, /dev/sgx is for in-kernel support.
-    return file_exists("/dev/isgx") || file_exists("/dev/sgx");
+    return file_exists("/dev/isgx") // LKM version
+        || file_exists("/dev/sgx")  // old in-kernel patchset (<= 5.10) or DCAP drivers
+        || file_exists("/dev/sgx_enclave"); // upstreamed drivers (>= 5.11)
 }
 
 bool psw_installed() {


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Seems we forgot to update this tool after SGX got into the kernel. Kudos to @vans163 for noticing this!

Closes #2427.

## How to test this PR? <!-- (if applicable) -->

Run `is_sgx_available` on a system which uses the upstreamed SGX driver and check if "SGX driver loaded" says "true".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2438)
<!-- Reviewable:end -->
