### PR TITLE
[Pal/Linux-SGX] Add handling for all reserved and unrecognized CPUID leaves

### DIFF
--- a/LibOS/shim/test/regression/cpuid.c
+++ b/LibOS/shim/test/regression/cpuid.c
@@ -1,5 +1,6 @@
 /* Sanity checks on values returned by CPUID. */
 
+#include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -10,7 +11,25 @@ struct regs {
     uint32_t ebx;
     uint32_t ecx;
     uint32_t edx;
-} __attribute__((packed));
+};
+
+static void clear_regs(struct regs* r) {
+    r->eax = 0x0;
+    r->ebx = 0x0;
+    r->ecx = 0x0;
+    r->edx = 0x0;
+}
+
+static void set_dummy_regs(struct regs* r) {
+    r->eax = 0xdead;
+    r->ebx = 0xbeef;
+    r->ecx = 0xdeaf;
+    r->edx = 0xbabe;
+}
+
+static bool are_dummy_regs(struct regs* r) {
+    return r->eax == 0xdead && r->ebx == 0xbeef && r->ecx == 0xdeaf && r->edx == 0xbabe;
+}
 
 static void cpuid(uint32_t leaf, uint32_t subleaf, struct regs* r) {
     __asm__ volatile("cpuid"
@@ -35,57 +54,82 @@ static void test_cpuid_leaf_0xd(void) {
     cpuid(leaf, AVX, &r);
     if (!(r.eax == extension_unavailable || r.eax == extension_sizes_bytes[AVX]))
         abort();
-    memset(&r, 0, sizeof(r));
+    clear_regs(&r);
 
     cpuid(leaf, MPX_1, &r);
     if (!(r.eax == extension_unavailable || r.eax == extension_sizes_bytes[MPX_1]))
         abort();
-    memset(&r, 0, sizeof(r));
+    clear_regs(&r);
 
     cpuid(leaf, MPX_2, &r);
     if (!(r.eax == extension_unavailable || r.eax == extension_sizes_bytes[MPX_2]))
         abort();
-    memset(&r, 0, sizeof(r));
+    clear_regs(&r);
 
     cpuid(leaf, AVX512_1, &r);
     if (!(r.eax == extension_unavailable || r.eax == extension_sizes_bytes[AVX512_1]))
         abort();
-    memset(&r, 0, sizeof(r));
+    clear_regs(&r);
 
     cpuid(leaf, AVX512_2, &r);
     if (!(r.eax == extension_unavailable || r.eax == extension_sizes_bytes[AVX512_2]))
         abort();
-    memset(&r, 0, sizeof(r));
+    clear_regs(&r);
 
     cpuid(leaf, AVX512_3, &r);
     if (!(r.eax == extension_unavailable || r.eax == extension_sizes_bytes[AVX512_3]))
         abort();
-    memset(&r, 0, sizeof(r));
+    clear_regs(&r);
 
     cpuid(leaf, PKRU, &r);
     if (!(r.eax == extension_unavailable || r.eax == extension_sizes_bytes[PKRU]))
         abort();
-    memset(&r, 0, sizeof(r));
 }
 
+static void test_cpuid_leaf_reserved(void) {
+    /* Graphene returns all zeros for reserved CPUID leaves */
+    struct regs r;
+    set_dummy_regs(&r);
 
-static void test_cpuid_leaf_invalid(void) {
-    /* Graphene returns all zeros for CPUID leaves 0x40000000 - 0x4FFFFFFF ("no virtualization") */
-    struct regs r = {0, };
-
-    cpuid(0x40000000, 0x00, &r); /* subleaf value doesn't matter */
+    cpuid(0x8, 0x0, &r); /* subleaf value doesn't matter */
     if (r.eax || r.ebx || r.ecx || r.edx)
         abort();
-    memset(&r, 0, sizeof(r));
+    set_dummy_regs(&r);
 
-    cpuid(0x4FFFFFFF, 0x42, &r); /* subleaf value doesn't matter */
+    cpuid(0xE, 0x42, &r); /* subleaf value doesn't matter */
     if (r.eax || r.ebx || r.ecx || r.edx)
+        abort();
+}
+
+static void test_cpuid_leaf_not_recognized(void) {
+    /* in case of unrecognized leaves, Graphene returns info for highest basic information leaf */
+    struct regs r;
+    set_dummy_regs(&r);
+
+    cpuid(0x1b, 0x0, &r);
+    /* return values may be anything (including all-zeros), so just check that it's not dummy */
+    if (are_dummy_regs(&r))
+        abort();
+    set_dummy_regs(&r);
+
+    /* range 0x40000000 - 0x4FFFFFFF is called "invalid" in Intel SDM, but in reality these leaves
+     * are treated same as unrecognized leaves */
+    cpuid(0x40000000, 0x0, &r);
+    /* return values may be anything (including all-zeros), so just check that it's not dummy */
+    if (are_dummy_regs(&r))
+        abort();
+    set_dummy_regs(&r);
+
+    cpuid(0x4FFFFFFF, 0x0, &r);
+    /* return values may be anything (including all-zeros), so just check that it's not dummy */
+    if (are_dummy_regs(&r))
         abort();
 }
 
 int main(int argc, char** argv, char** envp) {
     test_cpuid_leaf_0xd();
-    test_cpuid_leaf_invalid();
+    test_cpuid_leaf_reserved();
+    test_cpuid_leaf_not_recognized();
     printf("CPUID test passed.\n");
     return 0;
 }


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Previously, Linux-SGX PAL failed on all CPUID leaves not mentioned in our internal CPUID table. This is not how the actual Intel CPUID instruction behaves: some CPUID leaves are explicitly reserved and always return zeros, and the rest CPUID leaves return the info as if they are the "highest basic information leaf".

This PR adds such handling to make our CPUID logic exactly the same as in the latest Intel SDM documentation.

Fixes #2439 .

## How to test this PR? <!-- (if applicable) -->

Added more testing to the `cpuid` LibOS regression test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2440)
<!-- Reviewable:end -->
