### PR TITLE
[Pal/Linux] Honor `loader.pal_internal_mem_size` limit

### DIFF
--- a/LibOS/shim/src/sys/shim_file.c
+++ b/LibOS/shim/src/sys/shim_file.c
@@ -362,6 +362,8 @@ static ssize_t handle_copy(struct shim_handle* hdli, off_t* offseti, struct shim
         if (do_mapi && !bufi) {
             boffi = offi - ALLOC_ALIGN_DOWN(offi);
 
+            /* TODO: mmap below invokes DkStreamMap() with NULL address; this is wrong -- we need
+             *       VMA bookkeeping; see also comment in DkStreamMap() implementation */
             if (fsi->fs_ops->mmap(hdli, &bufi, ALLOC_ALIGN_UP(bufsize + boffi), PROT_READ, MAP_FILE,
                                   offi - boffi) < 0) {
                 do_mapi = false;
@@ -381,6 +383,8 @@ static ssize_t handle_copy(struct shim_handle* hdli, off_t* offseti, struct shim
         if (do_mapo && !bufo) {
             boffo = offo - ALLOC_ALIGN_DOWN(offo);
 
+            /* TODO: mmap below invokes DkStreamMap() with NULL address; this is wrong -- we need
+             *       VMA bookkeeping; see also comment in DkStreamMap() implementation */
             if (fso->fs_ops->mmap(hdlo, &bufo, ALLOC_ALIGN_UP(bufsize + boffo), PROT_WRITE,
                                   MAP_FILE, offo - boffo) < 0) {
                 do_mapo = false;

--- a/Pal/include/pal_internal.h
+++ b/Pal/include/pal_internal.h
@@ -156,9 +156,6 @@ noreturn void pal_main(PAL_NUM instance_id, PAL_HANDLE parent_process, PAL_HANDL
 
 /* For initialization */
 
-/* Called very early, its implementation should have no dependencies. */
-unsigned long _DkGetAllocationAlignment(void);
-
 void _DkGetAvailableUserAddressRange(PAL_PTR* start, PAL_PTR* end);
 bool _DkCheckMemoryMappable(const void* addr, size_t size);
 PAL_NUM _DkGetProcessId(void);

--- a/Pal/regression/AttestationReport.c
+++ b/Pal/regression/AttestationReport.c
@@ -40,24 +40,24 @@ int main(int argc, char** argv) {
                user_report_data_size, target_info_size, report_size);
 
     void* user_report_data = NULL;
-    ret = DkVirtualMemoryAlloc(&user_report_data, ALLOC_ALIGN_UP(user_report_data_size), 0,
-                               PAL_PROT_READ | PAL_PROT_WRITE);
+    ret = DkVirtualMemoryAlloc(&user_report_data, ALLOC_ALIGN_UP(user_report_data_size),
+                               PAL_ALLOC_INTERNAL, PAL_PROT_READ | PAL_PROT_WRITE);
     if (ret < 0) {
         pal_printf("ERROR: Cannot allocate memory for user_report_data\n");
         return -1;
     }
 
     void* target_info = NULL;
-    ret = DkVirtualMemoryAlloc(&target_info, ALLOC_ALIGN_UP(target_info_size), 0,
-                               PAL_PROT_READ | PAL_PROT_WRITE);
+    ret = DkVirtualMemoryAlloc(&target_info, ALLOC_ALIGN_UP(target_info_size),
+                               PAL_ALLOC_INTERNAL, PAL_PROT_READ | PAL_PROT_WRITE);
     if (ret < 0) {
         pal_printf("ERROR: Cannot allocate memory for target_info\n");
         return -1;
     }
 
     void* report = NULL;
-    ret = DkVirtualMemoryAlloc(&report, ALLOC_ALIGN_UP(report_size), 0,
-                               PAL_PROT_READ | PAL_PROT_WRITE);
+    ret = DkVirtualMemoryAlloc(&report, ALLOC_ALIGN_UP(report_size),
+                               PAL_ALLOC_INTERNAL, PAL_PROT_READ | PAL_PROT_WRITE);
     if (ret < 0) {
         pal_printf("ERROR: Cannot allocate memory for report\n");
         return -1;

--- a/Pal/regression/File.c
+++ b/Pal/regression/File.c
@@ -59,7 +59,7 @@ int main(int argc, char** argv, char** envp) {
 
         /* test file map */
 
-        void* mem1 = NULL;
+        void* mem1 = (void*)pal_control.user_address.start;
         ret = DkStreamMap(file1, &mem1, PAL_PROT_READ | PAL_PROT_WRITECOPY, 0, PAGE_SIZE);
         if (ret >= 0 && mem1) {
             memcpy(buffer1, mem1, 40);

--- a/Pal/regression/Memory.c
+++ b/Pal/regression/Memory.c
@@ -1,4 +1,5 @@
-/* XXX: What on earth is this supposed to be, an attempt to fit most UBs in one file? */
+/* XXX: What on earth is this supposed to be, an attempt to fit most UBs in one file?
+ * XXX: +1, please someone rm rf this file. */
 
 #include <stdbool.h>
 
@@ -30,13 +31,15 @@ int main(int argc, char** argv, char** envp) {
     DkSetExceptionHandler(handler, PAL_EVENT_MEMFAULT);
 
     void* mem1 = NULL;
-    int ret = DkVirtualMemoryAlloc(&mem1, UNIT * 4, 0, PAL_PROT_READ | PAL_PROT_WRITE);
+    int ret = DkVirtualMemoryAlloc(&mem1, UNIT * 4, PAL_ALLOC_INTERNAL,
+                                   PAL_PROT_READ | PAL_PROT_WRITE);
 
     if (!ret && mem1)
         pal_printf("Memory Allocation OK\n");
 
     void* mem2 = NULL;
-    ret = DkVirtualMemoryAlloc(&mem2, UNIT, 0, PAL_PROT_READ | PAL_PROT_WRITE);
+    ret = DkVirtualMemoryAlloc(&mem2, UNIT, PAL_ALLOC_INTERNAL,
+                               PAL_PROT_READ | PAL_PROT_WRITE);
 
     if (!ret && mem2) {
         c                    = count;

--- a/Pal/regression/manifest.template
+++ b/Pal/regression/manifest.template
@@ -2,6 +2,10 @@ pal.entrypoint = "file:{{ entrypoint }}"
 loader.log_level = "debug"
 loader.insecure__use_cmdline_argv = true
 
+# PAL tests use `DkVirtualMemoryAlloc(PAL_ALLOC_INTERNAL)` which must allocate in the PAL-internal
+# part of the Graphene memory
+loader.pal_internal_mem_size = "64M"
+
 fs.mount.root.uri = "file:"
 sgx.trusted_files.entrypoint = "file:{{ entrypoint }}"
 sgx.nonpie_binary = true # all tests are currently non-PIE unless overridden

--- a/Pal/src/db_memory.c
+++ b/Pal/src/db_memory.c
@@ -23,6 +23,14 @@ int DkVirtualMemoryAlloc(PAL_PTR* addr, PAL_NUM size, PAL_FLG alloc_type, PAL_FL
         return -PAL_ERROR_DENIED;
     }
 
+    if ((alloc_type & PAL_ALLOC_INTERNAL) && map_addr) {
+        return -PAL_ERROR_INVAL;
+    }
+
+    if (!(alloc_type & PAL_ALLOC_INTERNAL) && !map_addr) {
+        return -PAL_ERROR_INVAL;
+    }
+
     return _DkVirtualMemoryAlloc(addr, size, alloc_type, prot);
 }
 

--- a/Pal/src/db_streams.c
+++ b/Pal/src/db_streams.c
@@ -423,6 +423,9 @@ int DkStreamMap(PAL_HANDLE handle, PAL_PTR* addr, PAL_FLG prot, PAL_NUM offset, 
     assert(addr);
     void* map_addr = *addr;
 
+    /* TODO: we must not allow NULL addresses here, but sendfile() in LibOS does it -- it must be
+     *       re-written and then this function should enforce `map_addr != NULL` */
+
     if (!handle) {
         return -PAL_ERROR_INVAL;
     }

--- a/Pal/src/host/Linux-SGX/db_main.c
+++ b/Pal/src/host/Linux-SGX/db_main.c
@@ -43,11 +43,7 @@ PAL_SESSION_KEY g_master_key = {0};
  * limited by the variable below */
 size_t g_pal_internal_mem_size = 0;
 
-size_t g_page_size = PRESET_PAGESIZE;
-
-unsigned long _DkGetAllocationAlignment(void) {
-    return g_page_size;
-}
+const size_t g_page_size = PRESET_PAGESIZE;
 
 void _DkGetAvailableUserAddressRange(PAL_PTR* start, PAL_PTR* end) {
     *start = (PAL_PTR)g_pal_sec.heap_min;
@@ -535,7 +531,7 @@ noreturn void pal_linux_main(char* uptr_libpal_uri, size_t libpal_uri_len, char*
     }
 
     /* Initialize alloc_align as early as possible, a lot of PAL APIs depend on this being set. */
-    g_pal_state.alloc_align = _DkGetAllocationAlignment();
+    g_pal_state.alloc_align = g_page_size;
     assert(IS_POWER_OF_2(g_pal_state.alloc_align));
 
     struct pal_sec sec_info;

--- a/Pal/src/host/Linux-SGX/db_memory.c
+++ b/Pal/src/host/Linux-SGX/db_memory.c
@@ -42,11 +42,6 @@ int _DkVirtualMemoryAlloc(void** paddr, uint64_t size, int alloc_type, int prot)
 
     void* addr = *paddr;
 
-    if ((alloc_type & PAL_ALLOC_INTERNAL) && addr) {
-        /* internal-PAL memory allocation never uses fixed addresses */
-        return -PAL_ERROR_INVAL;
-    }
-
     void* mem = get_enclave_pages(addr, size, alloc_type & PAL_ALLOC_INTERNAL);
     if (!mem)
         return addr ? -PAL_ERROR_DENIED : -PAL_ERROR_NOMEM;

--- a/Pal/src/host/Linux-SGX/db_memory.c
+++ b/Pal/src/host/Linux-SGX/db_memory.c
@@ -17,7 +17,6 @@
 #include "pal_security.h"
 
 extern struct atomic_int g_allocated_pages;
-extern size_t g_page_size;
 
 bool _DkCheckMemoryMappable(const void* addr, size_t size) {
     if (addr < DATA_END && addr + size > TEXT_START) {

--- a/Pal/src/host/Linux-SGX/enclave_pages.c
+++ b/Pal/src/host/Linux-SGX/enclave_pages.c
@@ -10,7 +10,6 @@
 
 struct atomic_int g_allocated_pages;
 
-static size_t g_page_size = PRESET_PAGESIZE;
 static void* g_heap_bottom;
 static void* g_heap_top;
 

--- a/Pal/src/host/Linux-SGX/enclave_untrusted.c
+++ b/Pal/src/host/Linux-SGX/enclave_untrusted.c
@@ -5,11 +5,11 @@
 #include "enclave_ocalls.h"
 #include "pal_error.h"
 #include "pal_internal.h"
+#include "pal_linux.h"
 #include "pal_security.h"
 #include "spinlock.h"
 
 static spinlock_t g_malloc_lock = INIT_SPINLOCK_UNLOCKED;
-static size_t g_page_size = PRESET_PAGESIZE;
 
 #define SYSTEM_LOCK()   spinlock_lock(&g_malloc_lock)
 #define SYSTEM_UNLOCK() spinlock_unlock(&g_malloc_lock)

--- a/Pal/src/host/Linux-SGX/pal_linux.h
+++ b/Pal/src/host/Linux-SGX/pal_linux.h
@@ -72,8 +72,8 @@ void setup_pal_map(struct link_map* map);
 extern char __text_start, __text_end, __data_start, __data_end;
 #define TEXT_START ((void*)(&__text_start))
 #define TEXT_END   ((void*)(&__text_end))
-#define DATA_START ((void*)(&__text_start))
-#define DATA_END   ((void*)(&__text_end))
+#define DATA_START ((void*)(&__data_start))
+#define DATA_END   ((void*)(&__data_end))
 
 typedef struct {
     uint8_t bytes[32];

--- a/Pal/src/host/Linux-SGX/pal_linux.h
+++ b/Pal/src/host/Linux-SGX/pal_linux.h
@@ -58,6 +58,7 @@ int init_child_process(PAL_HANDLE* parent);
 
 #ifdef IN_ENCLAVE
 
+extern const size_t g_page_size;
 extern size_t g_pal_internal_mem_size;
 
 struct pal_sec;

--- a/Pal/src/host/Linux-SGX/sgx_internal.h
+++ b/Pal/src/host/Linux-SGX/sgx_internal.h
@@ -19,9 +19,7 @@
 #define IS_ERR_P INTERNAL_SYSCALL_ERROR_P
 #define ERRNO_P  INTERNAL_SYSCALL_ERRNO_P
 
-/* constants and macros to help rounding addresses to page
-   boundaries */
-extern size_t g_page_size;
+extern const size_t g_page_size;
 
 #undef IS_ALLOC_ALIGNED
 #undef IS_ALLOC_ALIGNED_PTR

--- a/Pal/src/host/Linux-SGX/sgx_main.c
+++ b/Pal/src/host/Linux-SGX/sgx_main.c
@@ -40,7 +40,7 @@
 
 #include "sysdeps/generic/ldsodefs.h"
 
-size_t g_page_size = PRESET_PAGESIZE;
+const size_t g_page_size = PRESET_PAGESIZE;
 
 char* g_pal_loader_path = NULL;
 char* g_libpal_path = NULL;

--- a/Pal/src/host/Linux/pal_linux.h
+++ b/Pal/src/host/Linux/pal_linux.h
@@ -103,7 +103,7 @@ int clone(int (*__fn)(void* __arg), void* __child_stack, int __flags, const void
 /* PAL main function */
 noreturn void pal_linux_main(void* initial_rsp, void* fini_callback);
 
-extern size_t g_page_size;
+extern const size_t g_page_size;
 extern char* g_pal_internal_mem_addr;
 extern size_t g_pal_internal_mem_size;
 

--- a/Pal/src/host/Linux/pal_linux.h
+++ b/Pal/src/host/Linux/pal_linux.h
@@ -103,6 +103,10 @@ int clone(int (*__fn)(void* __arg), void* __child_stack, int __flags, const void
 /* PAL main function */
 noreturn void pal_linux_main(void* initial_rsp, void* fini_callback);
 
+extern size_t g_page_size;
+extern char* g_pal_internal_mem_addr;
+extern size_t g_pal_internal_mem_size;
+
 extern uintptr_t g_vdso_start;
 extern uintptr_t g_vdso_end;
 bool is_in_vdso(uintptr_t addr);
@@ -136,8 +140,8 @@ void signal_setup(void);
 extern char __text_start, __text_end, __data_start, __data_end;
 #define TEXT_START ((void*)(&__text_start))
 #define TEXT_END   ((void*)(&__text_end))
-#define DATA_START ((void*)(&__text_start))
-#define DATA_END   ((void*)(&__text_end))
+#define DATA_START ((void*)(&__data_start))
+#define DATA_END   ((void*)(&__data_end))
 
 #define ADDR_IN_PAL_OR_VDSO(addr) \
         (((void*)(addr) > TEXT_START && (void*)(addr) < TEXT_END) || is_in_vdso(addr))

--- a/Pal/src/host/Skeleton/db_main.c
+++ b/Pal/src/host/Skeleton/db_main.c
@@ -15,10 +15,6 @@
 /* must implement "pal_start", and call "pal_main" inside */
 void pal_start(void);
 
-unsigned long _DkGetAllocationAlignment(void) {
-    return 0;
-}
-
 void _DkGetAvailableUserAddressRange(PAL_PTR* start, PAL_PTR* end) {
     /* needs to be implemented */
 }


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Previously, only the Linux-SGX PAL honored the manifest option `loader.pal_internal_mem_size`. The Linux PAL simply performed
`mmap(/*addr=*/NULL, ..)` when 64MB of the pre-allocated memory pool depleted, which led to memory corruptions (since LibOS was unaware of this PAL-internal mmap and could overwrite it, and vice versa).

This commit fixes Linux PAL's allocator to honor this limit. The whole virtual space of the process is split into two parts: the lower part is for LibOS consumption, the upper part is for internal PAL consumption, so there is no possibility for memory corruptions any more.

As part of this fix, PAL memory allocation routines have stricter checks on allocation arguments. As a side effect, PAL regression tests are modified to always use fixed memory addresses.

## How to test this PR? <!-- (if applicable) -->

This was found on a huge Java workload (which allocated more than 1000 threads in parallel!). One can manually test with smth like this:
```
diff --git a/LibOS/shim/test/regression/multi_pthread.c b/LibOS/shim/test/regression/multi_pthread.c
-#define CONC_THREAD_NUM 4
+#define CONC_THREAD_NUM 1024

 static void* inc(void* arg) {
+        sleep(1);
     counter++;
     return NULL;
 }

diff --git a/LibOS/shim/test/regression/multi_pthread.manifest.template b/LibOS/shim/test/regression/multi_pthread.manifest.te
mplate
@@ -7,6 +7,8 @@ fs.mount.lib.type = "chroot"

+loader.pal_internal_mem_size = "256M"
+
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2444)
<!-- Reviewable:end -->
