### PR TITLE
[Pal/Linux-SGX] Refactor `file_open` and `load_trusted_file` functions

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -54,21 +54,22 @@ confidence=
 
 enable=*
 disable=
-    bad-option-value,  # for compatibility between different pylint versions
     bad-continuation,
+    bad-option-value,  # for compatibility between different pylint versions
     c-extension-no-member,
+    fixme,
+    invalid-name,
     missing-docstring,
     missing-function-docstring,
     missing-module-docstring,
-    invalid-name,
-    fixme,
+    no-self-use,
     raise-missing-from,
-    too-many-instance-attributes,
-    too-many-branches,
-    too-many-statements,
     too-few-public-methods,
+    too-many-branches,
+    too-many-instance-attributes,
+    too-many-lines,
     too-many-public-methods,
-    no-self-use
+    too-many-statements
 
 
 [REPORTS]

--- a/LibOS/shim/test/regression/.gitignore
+++ b/LibOS/shim/test/regression/.gitignore
@@ -1,6 +1,9 @@
 /*.manifest
 /*.xml
 
+/nonexisting_testfile
+/testfile
+
 /.cache
 /abort
 /abort_multithread
@@ -102,7 +105,6 @@
 /sysfs_common
 /tcp_ipv6_v6only
 /tcp_msg_peek
-/testfile
 /tmp
 /udp
 /unix

--- a/LibOS/shim/test/regression/file_check_policy.c
+++ b/LibOS/shim/test/regression/file_check_policy.c
@@ -1,3 +1,4 @@
+#include <err.h>
 #include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -5,19 +6,29 @@
 
 int main(int argc, char** argv) {
     if (argc != 3) {
-        fprintf(stderr, "Usage: %s read|append <filename>\n", argv[0]);
+        fprintf(stderr, "Usage: %s read|write|append <filename>\n", argv[0]);
         return 1;
     }
 
     /* we use append instead of write simply to not overwrite the file */
-    FILE* fp = fopen(argv[2], argv[1][0] == 'r' ? "r" : "a");
+    const char* mode;
+    if (!strcmp(argv[1], "read")) {
+        mode = "r";
+    } else if (!strcmp(argv[1], "write")) {
+        mode = "r+"; // without file creation
+    } else if (!strcmp(argv[1], "append")) {
+        mode = "a";
+    } else {
+        errx(1, "invalid cmdline argument");
+    }
+    FILE* fp = fopen(argv[2], mode);
     if (!fp) {
         perror("fopen failed");
         return 2;
     }
 
-    int reti = fclose(fp);
-    if (reti) {
+    int ret = fclose(fp);
+    if (ret) {
         perror("fclose failed");
         return 3;
     }

--- a/LibOS/shim/test/regression/test_libos.py
+++ b/LibOS/shim/test/regression/test_libos.py
@@ -272,32 +272,78 @@ class TC_03_FileCheckPolicy(RegressionTestCase):
         self.assertIn('file_check_policy succeeded', stdout)
 
     def test_001_strict_fail(self):
-        with self.expect_returncode(2):
+        try:
             self.run_binary(['file_check_policy_strict', 'read', 'unknown_testfile'])
+            self.fail('expected to return nonzero')
+        except subprocess.CalledProcessError as e:
+            self.assertEqual(e.returncode, 2)
+            stderr = e.stderr.decode()
+            self.assertIn('Disallowing access to file \'unknown_testfile\'', stderr)
 
     def test_002_strict_fail_create(self):
-        with self.expect_returncode(2):
+        if os.path.exists('nonexisting_testfile'):
+            os.remove('nonexisting_testfile')
+        try:
             # this tests a previous bug in Graphene that allowed creating unknown files
-            self.run_binary(['file_check_policy_strict', 'append', 'unknown_testfile'])
+            self.run_binary(['file_check_policy_strict', 'append', 'nonexisting_testfile'])
+            self.fail('expected to return nonzero')
+        except subprocess.CalledProcessError as e:
+            self.assertEqual(e.returncode, 2)
+            stderr = e.stderr.decode()
+            self.assertIn('Disallowing access to file \'nonexisting_testfile\'', stderr)
+            if os.path.exists('nonexisting_testfile'):
+                self.fail('test created a file unexpectedly')
 
-    def test_003_allow_all_but_log_unknown(self):
+    def test_003_strict_fail_write(self):
+        try:
+            # writing to trusted files should not be possible
+            self.run_binary(['file_check_policy_strict', 'write', 'trusted_testfile'])
+            self.fail('expected to return nonzero')
+        except subprocess.CalledProcessError as e:
+            self.assertEqual(e.returncode, 2)
+            stderr = e.stderr.decode()
+            self.assertIn('Disallowing create/write/append to a trusted file \'trusted_testfile\'',
+                          stderr)
+
+    def test_004_allow_all_but_log_unknown(self):
         stdout, stderr = self.run_binary(['file_check_policy_allow_all_but_log', 'read',
                                           'unknown_testfile'])
-        self.assertIn('Allowing access to an unknown file due to file_check_policy settings: '
-                      'file:unknown_testfile', stderr)
+        self.assertIn('Allowing access to unknown file \'unknown_testfile\' due to '
+                      'file_check_policy settings.', stderr)
         self.assertIn('file_check_policy succeeded', stdout)
 
-    def test_004_allow_all_but_log_trusted(self):
+    def test_005_allow_all_but_log_trusted(self):
         stdout, stderr = self.run_binary(['file_check_policy_allow_all_but_log', 'read',
                                           'trusted_testfile'])
-        self.assertNotIn('Allowing access to an unknown file due to file_check_policy settings: '
-                         'file:trusted_testfile', stderr)
+        self.assertNotIn('Allowing access to unknown file \'trusted_testfile\' due to '
+                         'file_check_policy settings.', stderr)
         self.assertIn('file_check_policy succeeded', stdout)
 
-    def test_005_allow_all_but_log_trusted_create_fail(self):
-        with self.expect_returncode(2):
+    def test_006_allow_all_but_log_trusted_create_fail(self):
+        try:
             # this fails because modifying trusted files is prohibited
             self.run_binary(['file_check_policy_allow_all_but_log', 'append', 'trusted_testfile'])
+            self.fail('expected to return nonzero')
+        except subprocess.CalledProcessError as e:
+            self.assertEqual(e.returncode, 2)
+            stderr = e.stderr.decode()
+            self.assertIn('Disallowing create/write/append to a trusted file \'trusted_testfile\'',
+                          stderr)
+
+    def test_007_allow_all_but_log_unknown_create(self):
+        if os.path.exists('nonexisting_testfile'):
+            os.remove('nonexisting_testfile')
+        try:
+            stdout, stderr = self.run_binary(['file_check_policy_allow_all_but_log', 'append',
+                                              'nonexisting_testfile'])
+            self.assertIn('Allowing access to unknown file \'nonexisting_testfile\' due to '
+                          'file_check_policy settings.', stderr)
+            self.assertIn('file_check_policy succeeded', stdout)
+            if not os.path.exists('nonexisting_testfile'):
+                self.fail('test did not create a file')
+        finally:
+            os.remove('nonexisting_testfile')
+
 
 @unittest.skipUnless(HAS_SGX,
     'These tests are only meaningful on SGX PAL because only SGX supports attestation.')

--- a/Pal/regression/File.manifest
+++ b/Pal/regression/File.manifest
@@ -6,7 +6,7 @@ fs.mount.root.uri = "file:"
 
 sgx.nonpie_binary = true
 
-sgx.trusted_files.tmp1 = "file:File"
-sgx.trusted_files.tmp2 = "file:../regression/File"
+sgx.allowed_files.tmp1 = "file:File"
+sgx.allowed_files.tmp2 = "file:../regression/File"
 sgx.allowed_files.tmp3 = "file:file_nonexist.tmp"
 sgx.allowed_files.tmp4 = "file:file_delete.tmp"

--- a/Pal/regression/normalize_path.c
+++ b/Pal/regression/normalize_path.c
@@ -54,8 +54,8 @@ static int run_test(void) {
             return 1;
         }
 
-        if (strlen(buf) != size) {
-            print_err(func_name, i, "returned wrong size: %zu\n", size);
+        if (size != strlen(buf) + 1) {
+            print_err(func_name, i, "returned wrong size: %lu\n", size);
             return 1;
         }
 

--- a/Pal/src/host/Linux-SGX/db_main.c
+++ b/Pal/src/host/Linux-SGX/db_main.c
@@ -19,6 +19,8 @@
 #include "ecall_types.h"
 #include "elf/elf.h"
 #include "enclave_pages.h"
+#include "enclave_pf.h"
+#include "enclave_tf.h"
 #include "pal.h"
 #include "pal_defs.h"
 #include "pal_error.h"

--- a/Pal/src/host/Linux-SGX/db_misc.c
+++ b/Pal/src/host/Linux-SGX/db_misc.c
@@ -11,6 +11,7 @@
 
 #include "api.h"
 #include "cpu.h"
+#include "enclave_pf.h"
 #include "gsgx.h"
 #include "hex.h"
 #include "linux_utils.h"

--- a/Pal/src/host/Linux-SGX/db_streams.c
+++ b/Pal/src/host/Linux-SGX/db_streams.c
@@ -19,6 +19,7 @@
 #include "api.h"
 #include "crypto.h"
 #include "enclave_pages.h"
+#include "enclave_pf.h"
 #include "pal.h"
 #include "pal_defs.h"
 #include "pal_error.h"

--- a/Pal/src/host/Linux-SGX/enclave_pf.c
+++ b/Pal/src/host/Linux-SGX/enclave_pf.c
@@ -6,6 +6,7 @@
 #include <linux/fs.h>
 
 #include "crypto.h"
+#include "enclave_pf.h"
 #include "hex.h"
 #include "pal_internal.h"
 #include "pal_linux.h"
@@ -348,12 +349,12 @@ static int register_protected_path(const char* path, struct protected_file** new
     int ret = -PAL_ERROR_NOMEM;
     struct protected_file* new = NULL;
 
-    char* normpath = malloc(URI_MAX);
+    size_t normpath_size = strlen(path) + 1;
+    char* normpath = malloc(normpath_size);
     if (!normpath)
         goto out;
 
-    size_t len = URI_MAX;
-    ret = get_norm_path(path, normpath, &len);
+    ret = get_norm_path(path, normpath, &normpath_size);
     if (ret < 0) {
         log_warning("Couldn't normalize path (%s): %s", path, pal_strerror(ret));
         goto out;

--- a/Pal/src/host/Linux-SGX/enclave_pf.h
+++ b/Pal/src/host/Linux-SGX/enclave_pf.h
@@ -1,0 +1,101 @@
+/* SPDX-License-Identifier: LGPL-3.0-or-later */
+/* Copyright (C) 2019-2020 Invisible Things Lab
+ *                         Rafal Wojdyla <omeg@invisiblethingslab.com>
+ * Copyright (C) 2021      Intel Corporation */
+
+/* Protected files (PF) are encrypted on disk and transparently decrypted when accessed by Graphene
+ * or by app running inside Graphene. Internal protected file format was ported from Intel SGX SDK,
+ * https://github.com/intel/linux-sgx/tree/1eaa4551d4b02677eec505684412dc288e6d6361/sdk/protected_fs
+ *
+ * Features:
+ * - Data is encrypted (confidentiality) and integrity protected (tamper resistance).
+ * - File swap protection (a PF can only be accessed when in a specific path).
+ * - Transparency (Graphene app sees PFs as regular files, no need to modify the app).
+ *
+ * Limitations:
+ * - Metadata currently limits PF path size to 512 bytes and filename size to 260 bytes.
+ * - Truncating protected files is not yet implemented.
+ * - The recovery file feature is disabled (present in Intel SGX SDK).
+ */
+
+#ifndef ENCLAVE_PF_H_
+#define ENCLAVE_PF_H_
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "api.h"
+#include "pal.h"
+#include "pal_internal.h"
+#include "protected_files.h"
+
+/* Used to track map buffers for protected files */
+DEFINE_LIST(pf_map);
+struct pf_map {
+    LIST_TYPE(pf_map) list;
+    struct protected_file* pf;
+    void* buffer;
+    uint64_t size;
+    uint64_t offset; /* offset in PF, needed for write buffers when flushing to the PF */
+};
+DEFINE_LISTP(pf_map);
+
+/* List of PF map buffers; this list is traversed on PF flush (on file close) */
+extern LISTP_TYPE(pf_map) g_pf_map_list;
+
+/* Data of a protected file */
+struct protected_file {
+    UT_hash_handle hh;
+    size_t path_len;
+    char* path;
+    pf_context_t* context; /* NULL until PF is opened */
+    int64_t refcount; /* used for deciding when to call unload_protected_file() */
+    int writable_fd; /* fd of underlying file for writable PF, -1 if no writable handles are open */
+};
+
+/* Take ownership of the global PF lock */
+void pf_lock(void);
+
+/* Release ownership of the global PF lock */
+void pf_unlock(void);
+
+/* Set new wrap key for protected files (e.g., provisioned by remote user) */
+int set_protected_files_key(const char* pf_key_hex);
+
+/* Return a registered PF that matches specified path
+   (or the path is contained in a registered PF directory) */
+struct protected_file* get_protected_file(const char* path);
+
+/* Load and initialize a PF (must be called before any I/O operations)
+ *
+ * path:   normalized host path
+ * fd:     pointer to an opened file descriptor (must point to a valid value for the whole time PF
+ *         is being accessed)
+ * size:   underlying file size (in bytes)
+ * mode:   access mode
+ * create: if true, the PF is being created/truncated
+ * pf:     (optional) PF pointer if already known
+ */
+struct protected_file* load_protected_file(const char* path, int* fd, size_t size,
+                                           pf_file_mode_t mode, bool create,
+                                           struct protected_file* pf);
+
+/* Flush PF map buffers and optionally remove and free them.
+   If pf is NULL, process all maps containing given buffer.
+   If buffer is NULL, process all maps for given pf. */
+int flush_pf_maps(struct protected_file* pf, void* buffer, bool remove);
+
+/* Flush map buffers and unload/close the PF */
+int unload_protected_file(struct protected_file* pf);
+
+/* Find registered PF by path (exact match) */
+struct protected_file* find_protected_file(const char* path);
+
+/* Find protected file by handle (uses handle's path to call find_protected_file) */
+struct protected_file* find_protected_file_handle(PAL_HANDLE handle);
+
+/* Initialize the PF library, register PFs from the manifest */
+int init_protected_files(void);
+
+#endif /* ENCLAVE_PF_H_ */

--- a/Pal/src/host/Linux-SGX/enclave_tf.h
+++ b/Pal/src/host/Linux-SGX/enclave_tf.h
@@ -1,0 +1,109 @@
+/* SPDX-License-Identifier: LGPL-3.0-or-later */
+/* Copyright (C) 2021 Intel Corporation */
+
+/* Trusted files (TF) are integrity protected and transparently verified when accessed by Graphene
+ * or by app running inside Graphene. For each file that requires authentication (specified in the
+ * manifest as "sgx.trusted_files"), a SHA256 hash is generated and stored in the manifest, signed
+ * and verified as part of the enclave's crypto measurement. When user opens such a file, Graphene
+ * loads the whole file, calculates its SHA256 hash, and checks against the corresponding hash in
+ * the manifest. If the hashes do not match, the file access will be rejected.
+ *
+ * During the generation of the SHA256 hash, a 128-bit hash (truncated SHA256) is also generated for
+ * each chunk (of size TRUSTED_CHUNK_SIZE) in the file. The per-chunk hashes are used for partial
+ * verification in future reads, to avoid re-verifying the whole file again or the need of caching
+ * file contents.
+ *
+ * Perhaps confusingly, `struct trusted_file` describes not only "sgx.trusted_files" but also
+ * "sgx.allowed_files". For allowed files, `allowed = true`, `chunk_hashes = NULL`, and `uri` can be
+ * not only a file but also a directory. TODO: Perhaps split "allowed_files" into a separate struct?
+ */
+
+/* TODO: Move trusted/allowed files implementation into a separate file (`enclave_tf.c`?) */
+
+#ifndef ENCLAVE_TF_H_
+#define ENCLAVE_TF_H_
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <sys/types.h>
+
+#include "api.h"
+#include "pal.h"
+
+enum {
+    FILE_CHECK_POLICY_STRICT = 0,
+    FILE_CHECK_POLICY_ALLOW_ALL_BUT_LOG,
+};
+
+int init_file_check_policy(void);
+
+int get_file_check_policy(void);
+
+typedef struct {
+    uint8_t bytes[32];
+} sgx_file_hash_t;
+
+typedef struct {
+    uint8_t bytes[16];
+} sgx_chunk_hash_t;
+
+DEFINE_LIST(trusted_file);
+struct trusted_file {
+    LIST_TYPE(trusted_file) list;
+    uint64_t size;
+    bool allowed;
+    sgx_file_hash_t file_hash;      /* hash over the whole file, retrieved from the manifest */
+    sgx_chunk_hash_t* chunk_hashes; /* array of hashes over separate file chunks */
+    size_t uri_len;
+    char uri[]; /* must be NULL-terminated */
+};
+
+/*!
+ * \brief Get trusted/allowed file struct, if corresponding path entry exists in the manifest
+ *
+ * \param path  Normalized path to search for trusted/allowed files
+ *
+ * \return trusted/allowed file struct if found, NULL otherwise
+ */
+struct trusted_file* get_trusted_or_allowed_file(const char* path);
+
+/*!
+ * \brief Open the file as trusted or allowed, according to the manifest
+ *
+ * \param tf                trusted file struct corresponding to this file
+ * \param file              file handle to be opened
+ * \param create            whether this file is newly created
+ * \param out_chunk_hashes  array of hashes over file chunks
+ * \param out_size          returns size of opened file
+ * \param out_umem          untrusted memory address at which the file was loaded
+ *
+ * \return 0 on success, negative error code on failure
+ */
+int load_trusted_or_allowed_file(struct trusted_file* tf, PAL_HANDLE file, bool create,
+                                 sgx_chunk_hash_t** out_chunk_hashes, uint64_t* out_size,
+                                 void** out_umem);
+
+/*!
+ * \brief Copy and check file contents from untrusted outside buffer to in-enclave buffer
+ *
+ * \param path            file path (currently only for a log message)
+ * \param buf             in-enclave buffer where contents of the file are copied
+ * \param umem            start of untrusted file memory mapped outside the enclave
+ * \param aligned_offset  offset into file contents to copy, aligned to TRUSTED_CHUNK_SIZE
+ * \param aligned_end     end of file contents to copy, aligned to TRUSTED_CHUNK_SIZE
+ * \param offset          unaligned offset into file contents to copy
+ * \param end             unaligned end of file contents to copy
+ * \param chunk_hashes    array of hashes of all file chunks
+ * \param file_size       total size of the file
+ *
+ * \return 0 on success, negative error code on failure
+ */
+int copy_and_verify_trusted_file(const char* path, uint8_t* buf, const void* umem,
+                                 off_t aligned_offset, off_t aligned_end, off_t offset, off_t end,
+                                 sgx_chunk_hash_t* chunk_hashes, size_t file_size);
+
+int init_trusted_files(void);
+int init_allowed_files(void);
+
+#endif /* ENCLAVE_TF_H_ */

--- a/common/include/api.h
+++ b/common/include/api.h
@@ -330,8 +330,8 @@ extern const char* const* sys_errlist_internal;
 
 /* Graphene functions */
 
-int get_norm_path(const char* path, char* buf, size_t* size);
-int get_base_name(const char* path, char* buf, size_t* size);
+int get_norm_path(const char* path, char* buf, size_t* inout_size);
+int get_base_name(const char* path, char* buf, size_t* inout_size);
 
 /*!
  * \brief Parse a size (number with optional "G"/"M"/"K" suffix) into an unsigned long.

--- a/common/src/path.c
+++ b/common/src/path.c
@@ -49,16 +49,16 @@ static inline bool find_prev_slash_offset(const char* path, size_t* offset) {
 }
 
 /*
- * Before calling this function *size_ptr should hold the size of buf.
- * After returning it holds number of bytes actually written to it (excluding the ending '\0'). This
+ * Before calling this function *inout_size should hold the size of buf.
+ * After returning it holds number of bytes actually written to it (including the ending '\0'). This
  * number is never greater than the size of the input path.
  */
-int get_norm_path(const char* path, char* buf, size_t* size_ptr) {
-    assert(path && buf && size_ptr);
+int get_norm_path(const char* path, char* buf, size_t* inout_size) {
+    assert(path && buf && inout_size);
     size_t path_size = strlen(path) + 1;
     __UNUSED(path_size);  // used only for an assert at the end
 
-    size_t size = *size_ptr;
+    size_t size = *inout_size;
     if (!size) {
         return -PAL_ERROR_INVAL;
     }
@@ -130,8 +130,8 @@ int get_norm_path(const char* path, char* buf, size_t* size_ptr) {
 
     buf[offset] = '\0';
 
-    *size_ptr = ret_size + offset;
-    assert(*size_ptr <= path_size);
+    *inout_size = ret_size + offset + 1;
+    assert(*inout_size <= path_size);
 
     return 0;
 }
@@ -139,10 +139,10 @@ int get_norm_path(const char* path, char* buf, size_t* size_ptr) {
 /*
  * Returns the part after the last '/' (so `path` should probably be normalized).
  * Before calling this function *size should hold the size of buf.
- * After returning it holds number of bytes actually written to it (excluding the trailing '\0').
+ * After returning it holds number of bytes actually written to it (including the trailing '\0').
  */
-int get_base_name(const char* path, char* buf, size_t* size) {
-    if (!path || !buf || !size) {
+int get_base_name(const char* path, char* buf, size_t* inout_size) {
+    if (!path || !buf || !inout_size) {
         return -PAL_ERROR_INVAL;
     }
 
@@ -152,14 +152,14 @@ int get_base_name(const char* path, char* buf, size_t* size) {
     }
 
     size_t result = (size_t)(end - path);
-    if (result + 1 > *size) {
+    if (result + 1 > *inout_size) {
         return -PAL_ERROR_TOOLONG;
     }
 
     memcpy(buf, path, result);
     buf[result] = '\0';
 
-    *size = result;
+    *inout_size = result + 1;
 
     return 0;
 }


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

This PR moves all possible checks (file must be in a set of protected, trusted, allowed files from the manifest; trusted files cannot be created; etc.) before actual opening of the file in `file_open`. As a side effect, this fixes a bug when app wants to open an unknown file for write/append -- previously, Graphene would open such file, possibly truncate it and only then return error.

Also, this PR refactors `load_trusted_file` into `get_trusted_or_allowed_file` and `load_trusted_or_allowed_file`.

~~Must be rebased on top of #2446.~~

Originally found by @mkow.

## How to test this PR? <!-- (if applicable) -->

All tests must succeed. Especially `file_check_policy` LibOS regression tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2450)
<!-- Reviewable:end -->
