### PR TITLE
[Pal/Linux-SGX] Perform `SHA256(g_x || g_y)` for SGX local attestation

### DIFF
--- a/Pal/src/host/Linux-SGX/db_process.c
+++ b/Pal/src/host/Linux-SGX/db_process.c
@@ -27,30 +27,69 @@
 #include "protected-files/protected_files.h"
 #include "spinlock.h"
 
-#define LOCAL_ATTESTATION_CHALLENGE_STR "GRAPHENE_LOCAL_ATTESTATION_CHALLENGE"
-
 /*
- * For SGX, the creation of a child process requires a clean enclave and a secure channel
- * between the parent and child processes (enclaves). The establishment of the secure
- * channel must be resilient to a host-level, root-privilege adversary. Such an adversary
- * can either create arbitrary enclaves, or intercept the handshake protocol between the
- * parent and child enclaves to launch a man-in-the-middle attack.
+ * For SGX, the creation of a child process requires a clean enclave and a secure channel between
+ * the parent and child processes (enclaves). The establishment of the secure channel must be
+ * resilient to a host-level, root-privilege adversary. Such an adversary can either create
+ * arbitrary enclaves, or intercept the handshake protocol between the parent and child enclaves to
+ * launch a man-in-the-middle attack.
+ *
+ * The below protocol combines unauthenticated Diffie-Hellman Key Exchange (DHKE) with the SGX local
+ * attestation (this combination provides authenticated DHKE). The protocol is a modified ISO KE
+ * protocol (as described in Section 4 of the "SIGMA: the `SIGn-and-MAc` Approach to Authenticated
+ * Diffie-Hellman and its Use in the IKE Protocols" paper from Hugo Krawczyk). The ISO KE protocol
+ * does not support the "identity protection" feature; this feature is however useless in the SGX
+ * local attestation threat model (malicious host knows identities of all running SGX enclaves
+ * anyway). The ISO KE protocol is proven to be secure and minimal.
+ *
+ * One superficial difference of the below protocol from the original ISO KE protocol is the number
+ * of steps involved. Our protocol uses 5 steps (send DH's g_x, receive DH's g_y, send SGX target
+ * info with identity of enclave A, receive SGX report of enclave B, send SGX report of enclave A).
+ * Note here that SGX report of an enclave contains also the identity of the enclave. The original
+ * ISO KE protocol uses 3 steps (send DH's g_x and identity of A, receive DH's g_y and identity of B
+ * and signature of B over {g_x, g_y, A}, send signature of A over {g_y, g_x, B}). Looking at the
+ * steps, it is clear that our protocol could be optimized to send 3 messages instead of 5 messages
+ * and would result in the original ISO KE protocol. We implement our protocol in 5 steps purely for
+ * readability.
+ *
+ * Another difference of the below protocol from the original ISO KE protocol is the notion of
+ * "identity". In SGX local attestation, identity of an enclave is a combination of its
+ * measurements: mrenclave, attributes, configsvn, etc. This enclave identity is enclosed in the SGX
+ * targetinfo struct as well as in the SGX report. Thus, we use SGX targetinfo and SGX report as
+ * identities.
+ *
+ * One more difference is that instead of calculating SHA256(g_x || g_y) for enclave A and
+ * SHA256(g_y || g_x) for enclave B, our protocol calculates SHA256(K_e || tag1) for enclave A and
+ * SHA256(K_e || tag2) for enclave B. This still introduces assymetry in the protocol (desired to
+ * prevent reflection and interleaving attacks), but is more robust to future modifications.
+ *
+ * Final difference is CMAC used in SGX local attestation for SGX report validation, instead of the
+ * signatures in the original ISO KE protocol. This CMAC however provides the same security
+ * guarantees because it is generated over the SGX report that contains the target identity of the
+ * peer enclave, thus it corresponds to the "directed signature from B to A" in ISO KE.
+ *
+ * Note that Graphene does *not* use the SIGMA-like protocol (used in e.g. Intel SGX SDK). SIGMA
+ * family of protocols is an enhancement over ISO KE to add the "identity protection" feature, which
+ * is irrelevant for SGX local attestation. Thus, Graphene chooses a simpler protocol.
  *
  * Prerequisites of a secure channel:
+ *
  * (1) A session key needs to be shared only between the parent and child enclaves.
  *
- *       See the implementation in _DkStreamKeyExchange().
- *       When initializing an RPC stream, both ends of the stream needs to use
- *       Diffie-Hellman to exchange a session key. The key will be used to both identify
- *       the connection (to prevent man-in-the-middle attack) and for future encryption.
+ *       See the implementation in _DkStreamKeyExchange(). When initializing a secure stream, both
+ *       ends of the stream needs to use Diffie-Hellman to establish a session key. The hashes over
+ *       the established DH session key are used to identify the connection (via SHA256(K_e || tag1)
+ *       for parent enclave A and via SHA256(K_e || tag2) for child enclave B to prevent
+ *       man-in-the-middle/interleaving attacks) as well as to derive other session keys, e.g., to
+ *       encrypt pipes for secure IPC.
  *
  * (2) Both the parent and child enclaves need to be proven by the Intel CPU.
  *
- *       See the implementation in _DkStreamReportRequest() and _DkStreamReportRespond().
- *       The two ends of the RPC stream need to exchange local attestation reports
- *       signed by the Intel CPUs to prove themselves to be running inside enclaves
- *       on the same platform. The local attestation reports contain no secret information
- *       and can be verified cryptographically, and can be sent on an unencrypted channel.
+ *       See the implementation in _DkStreamReportRequest() and _DkStreamReportRespond(). The two
+ *       ends of the stream need to exchange SGX local attestation reports signed by the Intel CPUs
+ *       to prove themselves to be running inside enclaves on the same platform. The local
+ *       attestation reports contain no secret information and can be verified cryptographically,
+ *       and can be sent on an unencrypted channel.
  *
  *       The flow of local attestation is as follows:
  *         - Parent: Send targetinfo(Parent) to Child
@@ -70,51 +109,18 @@
  * (4) The two parties who create the session key need to be the ones proven by the CPU
  *     (for preventing man-in-the-middle attacks).
  *
- *       See the implementation in is_remote_enclave_ok(). The local reports from both sides will
- *       contain a secure hash over the session key. Because the session key is randomly created for
- *       each enclave pair, no report can be reused even from an enclave with the same mr_enclave.
+ *       See the implementation in is_peer_enclave_ok(). The local reports from both sides will
+ *       contain a secure hash over the DH session key: SHA256(K_e || tag1) for parent enclave A and
+ *       SHA256(K_e || tag2) for child enclave B (the different tags are required to prevent
+ *       reflection/interleaving attacks). Because a new DH key exchange protocol is run for each
+ *       enclave pair, no report can be reused even from an enclave with the same MR_ENCLAVE.
  */
 
-static int hash_session_key(const PAL_SESSION_KEY* session_key, sgx_report_data_t* data) {
-    /* use SHA256 to hash the session key between two enclaves into SGX report data */
-    int ret;
-    LIB_SHA256_CONTEXT sha;
-
-    /* SGX report data is 64B in size, but SHA256 hash is only 32B in size, so pad with zeros */
-    memset(data, 0, sizeof(*data));
-
-    ret = lib_SHA256Init(&sha);
-    if (ret < 0)
-        return ret;
-
-    /* newly established session key between two enclaves is the only secure component here */
-    ret = lib_SHA256Update(&sha, (uint8_t*)session_key, sizeof(*session_key));
-    if (ret < 0)
-        return ret;
-
-    /* add a constant tag */
-    ret = lib_SHA256Update(&sha, (uint8_t*)LOCAL_ATTESTATION_CHALLENGE_STR,
-                           sizeof(LOCAL_ATTESTATION_CHALLENGE_STR));
-    if (ret < 0)
-        return ret;
-
-    ret = lib_SHA256Final(&sha, (uint8_t*)data);
-    if (ret < 0)
-        return ret;
-
-    return 0;
-}
-
-bool is_remote_enclave_ok(const PAL_SESSION_KEY* session_key, sgx_measurement_t* mr_enclave,
-                          sgx_report_data_t* remote_data) {
-    sgx_report_data_t calculated_data;
-    int ret = hash_session_key(session_key, &calculated_data);
-    if (ret < 0)
-        return false;
-
-    /* must make sure the signer of the report is also the owner of the key,
-       in order to prevent man-in-the-middle attack */
-    if (memcmp(remote_data, &calculated_data, sizeof(calculated_data)))
+bool is_peer_enclave_ok(sgx_measurement_t* mr_enclave, sgx_report_data_t* expected_data,
+                        sgx_report_data_t* peer_data) {
+    /* must make sure the signer of the report is also the owner of the key, in order to prevent
+     * man-in-the-middle attack */
+    if (memcmp(peer_data, expected_data, sizeof(*expected_data)))
         return false;
 
     /* all Graphene enclaves with same configuration (manifest) should have the same MR_ENCLAVE */
@@ -147,16 +153,14 @@ int _DkProcessCreate(PAL_HANDLE* handle, const char** args) {
     child->process.is_server   = true;
     child->process.ssl_ctx     = NULL;
 
-    ret = _DkStreamKeyExchange(child, &child->process.session_key);
+    __sgx_mem_aligned sgx_report_data_t parent_report_data = {0};
+    __sgx_mem_aligned sgx_report_data_t child_report_data  = {0};
+    ret = _DkStreamKeyExchange(child, &child->process.session_key, &parent_report_data,
+                               &child_report_data);
     if (ret < 0)
         goto failed;
 
-    __sgx_mem_aligned sgx_report_data_t sgx_report_data;
-    ret = hash_session_key(&child->process.session_key, &sgx_report_data);
-    if (ret < 0)
-        goto failed;
-
-    ret = _DkStreamReportRequest(child, &sgx_report_data);
+    ret = _DkStreamReportRequest(child, &parent_report_data, &child_report_data);
     if (ret < 0)
         goto failed;
 
@@ -221,16 +225,14 @@ int init_child_process(PAL_HANDLE* parent_handle, uint64_t* instance_id_ptr) {
     parent->process.is_server   = false;
     parent->process.ssl_ctx     = NULL;
 
-    int ret = _DkStreamKeyExchange(parent, &parent->process.session_key);
+    __sgx_mem_aligned sgx_report_data_t child_report_data  = {0};
+    __sgx_mem_aligned sgx_report_data_t parent_report_data = {0};
+    int ret = _DkStreamKeyExchange(parent, &parent->process.session_key,
+                                   &parent_report_data, &child_report_data);
     if (ret < 0)
         goto out_error;
 
-    __sgx_mem_aligned sgx_report_data_t sgx_report_data;
-    ret = hash_session_key(&parent->process.session_key, &sgx_report_data);
-    if (ret < 0)
-        goto out_error;
-
-    ret = _DkStreamReportRespond(parent, &sgx_report_data);
+    ret = _DkStreamReportRespond(parent, &child_report_data, &parent_report_data);
     if (ret < 0)
         goto out_error;
 

--- a/Pal/src/host/Linux-SGX/enclave_framework.c
+++ b/Pal/src/host/Linux-SGX/enclave_framework.c
@@ -15,6 +15,9 @@
 #include "spinlock.h"
 #include "toml.h"
 
+#define LOCAL_ATTESTATION_TAG_PARENT_STR "GRAPHENE_LOCAL_ATTESTATION_TAG_PARENT"
+#define LOCAL_ATTESTATION_TAG_CHILD_STR "GRAPHENE_LOCAL_ATTESTATION_TAG_CHILD"
+
 void* g_enclave_base;
 void* g_enclave_top;
 
@@ -171,7 +174,7 @@ int sgx_verify_report(sgx_report_t* report) {
                 (uint8_t*)&check_mac, sizeof(check_mac));
 
     // Clear the report key for security
-    memset(&report_key, 0, sizeof(report_key));
+    erase_memory(&report_key, sizeof(report_key));
 
     log_debug("Verify report:");
     print_report(report);
@@ -956,95 +959,129 @@ int init_enclave(void) {
     return 0;
 }
 
-int _DkStreamKeyExchange(PAL_HANDLE stream, PAL_SESSION_KEY* key) {
-    uint8_t pub[DH_SIZE];
-    uint8_t agree[DH_SIZE];
-    PAL_NUM pubsz, agreesz;
+static int hash_over_session_key(const PAL_SESSION_KEY* session_key, const char* tag,
+                                 size_t tag_size, sgx_report_data_t* out_hash) {
+    int ret;
+    LIB_SHA256_CONTEXT sha;
+
+    /* SGX report data is 64B in size, but SHA256 hash is only 32B in size, so pad with zeros */
+    memset(out_hash, 0, sizeof(*out_hash));
+
+    ret = lib_SHA256Init(&sha);
+    if (ret < 0)
+        return ret;
+
+    ret = lib_SHA256Update(&sha, (uint8_t*)session_key, sizeof(*session_key));
+    if (ret < 0)
+        return ret;
+
+    ret = lib_SHA256Update(&sha, (uint8_t*)tag, tag_size);
+    if (ret < 0)
+        return ret;
+
+    return lib_SHA256Final(&sha, (uint8_t*)out_hash);
+}
+
+int _DkStreamKeyExchange(PAL_HANDLE stream, PAL_SESSION_KEY* out_key,
+                         sgx_report_data_t* out_parent_report_data,
+                         sgx_report_data_t* out_child_report_data) {
+    int ret;
     LIB_DH_CONTEXT context;
-    int64_t bytes;
-    int64_t ret;
+
+    uint8_t my_public[DH_SIZE];
+    uint8_t peer_public[DH_SIZE];
+
+    size_t secret_size;
+    uint8_t secret[DH_SIZE];
 
     assert(IS_HANDLE_TYPE(stream, process));
 
+    /* perform unauthenticated DH key exchange to produce two collaterals: the session key K_e and
+     * the assymetric SHA256 hashes over K_e (for later use in SGX report's reportdata) */
     ret = lib_DhInit(&context);
-    if (ret < 0) {
-        log_error("Key Exchange: DH Init failed: %ld", ret);
-        goto out_no_final;
-    }
+    if (ret < 0)
+        return ret;
 
-    pubsz = sizeof(pub);
-    ret = lib_DhCreatePublic(&context, pub, &pubsz);
-    if (ret < 0) {
-        log_error("Key Exchange: DH CreatePublic failed: %ld", ret);
+    ret = lib_DhCreatePublic(&context, my_public, sizeof(my_public));
+    if (ret < 0)
         goto out;
-    }
 
-    assert(pubsz > 0 && pubsz <= DH_SIZE);
-    if (pubsz < DH_SIZE) {
-        /* Insert leading zero bytes if necessary. These values are big-
-         * endian, so we either need to know the length of the bignum or
-         * zero-pad at the beginning instead of the end. This code chooses
-         * to do the latter. */
-        memmove(pub + (DH_SIZE - pubsz), pub, pubsz);
-        memset(pub, 0, DH_SIZE - pubsz);
-    }
-
-    for (bytes = 0, ret = 0; bytes < DH_SIZE; bytes += ret) {
-        ret = _DkStreamWrite(stream, 0, DH_SIZE - bytes, pub + bytes, NULL, 0);
-        if (ret < 0) {
-            if (ret == -PAL_ERROR_INTERRUPTED || ret == -PAL_ERROR_TRYAGAIN) {
-                ret = 0;
+    for (int64_t bytes = 0, total = 0; total < (int64_t)sizeof(my_public); total += bytes) {
+        bytes = _DkStreamWrite(stream, 0, sizeof(my_public) - total, my_public + total, NULL, 0);
+        if (bytes < 0) {
+            if (bytes == -PAL_ERROR_INTERRUPTED || bytes == -PAL_ERROR_TRYAGAIN) {
+                bytes = 0;
                 continue;
             }
-            log_error("Failed to exchange the secret key via RPC: %ld", ret);
+            ret = (int)bytes;
             goto out;
         }
     }
 
-    for (bytes = 0, ret = 0; bytes < DH_SIZE; bytes += ret) {
-        ret = _DkStreamRead(stream, 0, DH_SIZE - bytes, pub + bytes, NULL, 0);
-        if (ret < 0) {
-            if (ret == -PAL_ERROR_INTERRUPTED || ret == -PAL_ERROR_TRYAGAIN) {
-                ret = 0;
+    for (int64_t bytes = 0, total = 0; total < (int64_t)sizeof(peer_public); total += bytes) {
+        bytes = _DkStreamRead(stream, 0, sizeof(peer_public) - total, peer_public + total, NULL, 0);
+        if (bytes < 0) {
+            if (bytes == -PAL_ERROR_INTERRUPTED || bytes == -PAL_ERROR_TRYAGAIN) {
+                bytes = 0;
                 continue;
             }
-            log_error("Failed to exchange the secret key via RPC: %ld", ret);
+            ret = (int)bytes;
+            goto out;
+        }
+        if (bytes == 0) {
+            /* peer enclave closed the connection prematurely */
+            ret = -PAL_ERROR_DENIED;
             goto out;
         }
     }
 
-    agreesz = sizeof(agree);
-    ret = lib_DhCalcSecret(&context, pub, DH_SIZE, agree, &agreesz);
-    if (ret < 0) {
-        log_error("Key Exchange: DH CalcSecret failed: %ld", ret);
+    secret_size = sizeof(secret);
+    ret = lib_DhCalcSecret(&context, peer_public, sizeof(peer_public), secret, &secret_size);
+    if (ret < 0)
         goto out;
-    }
 
-    assert(agreesz > 0 && agreesz <= sizeof(agree));
+    assert(secret_size > 0 && secret_size <= sizeof(secret));
 
-    ret = lib_HKDF_SHA256(agree, agreesz, /*salt=*/NULL, /*salt_size=*/0, /*info=*/NULL,
-                          /*info_size=*/0, (uint8_t*)key, sizeof(*key));
-    if (ret < 0) {
-        log_error("Failed to derive the session key: %ld", ret);
+    /* derive the session key K_e using HKDF-SHA256 */
+    ret = lib_HKDF_SHA256(secret, secret_size, /*salt=*/NULL, /*salt_size=*/0, /*info=*/NULL,
+                          /*info_size=*/0, (uint8_t*)out_key, sizeof(*out_key));
+    if (ret < 0)
         goto out;
-    }
 
-    log_debug("Key exchange succeeded: %s", ALLOCA_BYTES2HEXSTR(*key));
+    /* calculate SHA256(K_e || tag1) / SHA256(K_e || tag2) for use in SGX report's reportdata
+     * -- as a proof of key identity during subsequent SGX local attestation; note that parent
+     *  enclave A uses the hash (K_e || tag1) and child enclave B uses the hash (K_e || tag2) --
+     *  this is to prevent reflection/interleaving attacks */
+    ret = hash_over_session_key(out_key, LOCAL_ATTESTATION_TAG_PARENT_STR,
+                                sizeof(LOCAL_ATTESTATION_TAG_PARENT_STR), out_parent_report_data);
+    if (ret < 0)
+        goto out;
+
+    ret = hash_over_session_key(out_key, LOCAL_ATTESTATION_TAG_CHILD_STR,
+                                sizeof(LOCAL_ATTESTATION_TAG_CHILD_STR), out_child_report_data);
+    if (ret < 0)
+        goto out;
+
+    log_debug("Key exchange succeeded");
     ret = 0;
 out:
+    /* scrub all temporary buffers */
+    erase_memory(&secret, sizeof(secret));
+    erase_memory(&my_public, sizeof(my_public));
+    erase_memory(&peer_public, sizeof(peer_public));
     lib_DhFinal(&context);
-out_no_final:
+
     return ret;
 }
 
 /*
  * Initalize the request of local report exchange.
  *
- * We refer to this enclave as A and to the other enclave as B, e.g., A is this
- * parent enclave and B is the child enclave in the fork case (for more info,
- * see comments in db_process.c).
+ * We refer to this enclave as A and to the other enclave as B, e.g., A is this parent enclave and B
+ * is the child enclave in the fork case (for more info, see comments in db_process.c).
  */
-int _DkStreamReportRequest(PAL_HANDLE stream, sgx_report_data_t* sgx_report_data) {
+int _DkStreamReportRequest(PAL_HANDLE stream, sgx_report_data_t* my_report_data,
+                           sgx_report_data_t* peer_report_data) {
     __sgx_mem_aligned sgx_target_info_t target_info;
     __sgx_mem_aligned sgx_report_t report;
     uint64_t bytes;
@@ -1093,8 +1130,7 @@ int _DkStreamReportRequest(PAL_HANDLE stream, sgx_report_data_t* sgx_report_data
         goto out;
     }
 
-    if (!is_remote_enclave_ok(&stream->process.session_key, &report.body.mr_enclave,
-                              &report.body.report_data)) {
+    if (!is_peer_enclave_ok(&report.body.mr_enclave, peer_report_data, &report.body.report_data)) {
         log_error("Not an allowed enclave (mr_enclave = %s)",
                   ALLOCA_BYTES2HEXSTR(report.body.mr_enclave.m));
         ret = -PAL_ERROR_DENIED;
@@ -1107,7 +1143,7 @@ int _DkStreamReportRequest(PAL_HANDLE stream, sgx_report_data_t* sgx_report_data
     memcpy(&target_info.mr_enclave, &report.body.mr_enclave, sizeof(sgx_measurement_t));
     memcpy(&target_info.attributes, &report.body.attributes, sizeof(sgx_attributes_t));
 
-    ret = sgx_get_report(&target_info, sgx_report_data, &report);
+    ret = sgx_get_report(&target_info, my_report_data, &report);
     if (ret < 0) {
         log_error("Failed to get local report from CPU: %ld", ret);
         goto out;
@@ -1135,11 +1171,11 @@ out:
 /*
  * Respond to the request of local report exchange.
  *
- * We refer to this enclave as B and to the other enclave as A, e.g., B is this
- * child enclave and A is the parent enclave in the fork case (for more info,
- * see comments in db_process.c).
+ * We refer to this enclave as B and to the other enclave as A, e.g., B is this child enclave and A
+ * is the parent enclave in the fork case (for more info, see comments in db_process.c).
  */
-int _DkStreamReportRespond(PAL_HANDLE stream, sgx_report_data_t* sgx_report_data) {
+int _DkStreamReportRespond(PAL_HANDLE stream, sgx_report_data_t* my_report_data,
+                           sgx_report_data_t* peer_report_data) {
     __sgx_mem_aligned sgx_target_info_t target_info;
     __sgx_mem_aligned sgx_report_t report;
     uint64_t bytes;
@@ -1164,7 +1200,7 @@ int _DkStreamReportRespond(PAL_HANDLE stream, sgx_report_data_t* sgx_report_data
     }
 
     /* B -> A: report[B -> A] */
-    ret = sgx_get_report(&target_info, sgx_report_data, &report);
+    ret = sgx_get_report(&target_info, my_report_data, &report);
     if (ret < 0) {
         log_error("Failed to get local report from CPU: %ld", ret);
         goto out;
@@ -1205,8 +1241,7 @@ int _DkStreamReportRespond(PAL_HANDLE stream, sgx_report_data_t* sgx_report_data
         goto out;
     }
 
-    if (!is_remote_enclave_ok(&stream->process.session_key, &report.body.mr_enclave,
-                              &report.body.report_data)) {
+    if (!is_peer_enclave_ok(&report.body.mr_enclave, peer_report_data, &report.body.report_data)) {
         log_error("Not an allowed enclave (mr_enclave = %s)",
                   ALLOCA_BYTES2HEXSTR(report.body.mr_enclave.m));
         ret = -PAL_ERROR_DENIED;

--- a/Pal/src/host/Linux-SGX/protected-files/protected_files.c
+++ b/Pal/src/host/Linux-SGX/protected-files/protected_files.c
@@ -18,18 +18,6 @@
 
 #include "api.h"
 
-/* Function for scrubbing sensitive memory buffers.
- * memset() can be optimized away and memset_s() is not available in PAL.
- * FIXME: this implementation is inefficient (and used in perf-critical functions),
- * replace with a better one.
- * TODO: is this really needed? Intel's implementation uses similar function as "defense in depth".
- */
-static void erase_memory(void* buffer, size_t size) {
-    volatile unsigned char* p = buffer;
-    while (size--)
-        *p++ = 0;
-}
-
 /* Host callbacks */
 static pf_read_f     g_cb_read     = NULL;
 static pf_write_f    g_cb_write    = NULL;

--- a/common/include/api.h
+++ b/common/include/api.h
@@ -443,6 +443,15 @@ int toml_sizestring_in(const toml_table_t* root, const char* key, uint64_t defau
 #define TIME_NS_IN_US 1000ul
 #define TIME_NS_IN_S (TIME_NS_IN_US * TIME_US_IN_S)
 
+/* Scrub sensitive memory bufs (memset can be optimized away and memset_s is not available in PAL).
+ * FIXME: This implementation is inefficient (and used in perf-critical functions).
+ * TODO:  Is this really needed? Intel SGX SDK uses similar function as "defense in depth". */
+static inline void erase_memory(void* buffer, size_t size) {
+    volatile unsigned char* p = buffer;
+    while (size--)
+        *p++ = 0;
+}
+
 #ifdef __x86_64__
 static inline bool __range_not_ok(uintptr_t addr, size_t size) {
     addr += size;

--- a/common/include/crypto.h
+++ b/common/include/crypto.h
@@ -68,7 +68,7 @@ int lib_HKDF_SHA256(const uint8_t* input_key, size_t input_key_size, const uint8
 
 /* Diffie-Hellman Key Exchange */
 int lib_DhInit(LIB_DH_CONTEXT* context);
-int lib_DhCreatePublic(LIB_DH_CONTEXT* context, uint8_t* public, size_t* public_size);
+int lib_DhCreatePublic(LIB_DH_CONTEXT* context, uint8_t* public, size_t public_size);
 int lib_DhCalcSecret(LIB_DH_CONTEXT* context, uint8_t* peer, size_t peer_size, uint8_t* secret,
                      size_t* secret_size);
 void lib_DhFinal(LIB_DH_CONTEXT* context);

--- a/common/src/crypto/adapters/mbedtls_adapter.c
+++ b/common/src/crypto/adapters/mbedtls_adapter.c
@@ -451,20 +451,13 @@ int lib_DhInit(LIB_DH_CONTEXT* context) {
     return 0;
 }
 
-int lib_DhCreatePublic(LIB_DH_CONTEXT* context, uint8_t* public, size_t* public_size) {
-    int ret;
-
-    if (*public_size != DH_SIZE)
+int lib_DhCreatePublic(LIB_DH_CONTEXT* context, uint8_t* public, size_t public_size) {
+    if (public_size != DH_SIZE)
         return -PAL_ERROR_INVAL;
 
-    /* The RNG here is used to generate secret exponent X. */
-    ret = mbedtls_dhm_make_public(context, context->len, public, *public_size, RandomWrapper, NULL);
-    if (ret < 0)
-        return mbedtls_to_pal_error(ret);
-
-    /* mbedtls writes leading zeros in the big-endian output to pad to public_size, so leave
-     * caller's public_size unchanged */
-    return 0;
+    int ret = mbedtls_dhm_make_public(context, context->len, public, public_size, RandomWrapper,
+                                      /*p_rng=*/NULL);
+    return mbedtls_to_pal_error(ret);
 }
 
 int lib_DhCalcSecret(LIB_DH_CONTEXT* context, uint8_t* peer, size_t peer_size, uint8_t* secret,


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Previously, Graphene bound the identity of the peer enclave to the SHA256 hash of generated session key -- `SHA256(K_e)` during Diffie-Hellman key exchange and SGX local attestation. However, the standard ISO KE protocol (after which we model our Graphene protocol) uses DH public keys instead of the session key -- `SIG_B(g_x, g_y, A)` and `SIG_A(g_y, g_x, B)` (notice the reversed order -- this is to deflect interleaving attacks). 

This PR changes Graphene's protocol implementation to more closely follow the ISO KE protocol.

This PR also adds more documentation on Graphene's protocol details.

UPDATE: Added memory scrubbing and reverse order in the SHA256 hashes to conform to the ISO KE protocol. Rebased as I need to change the commit message as well.

## How to test this PR? <!-- (if applicable) -->

All tests must pass. You can manually check (via e.g. `strace`) that all IPC is encrypted.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2452)
<!-- Reviewable:end -->
