### PR TITLE
[GSC] Fix Graphene version in GSC config file to last working commit

### DIFF
--- a/Documentation/manpages/gsc.rst
+++ b/Documentation/manpages/gsc.rst
@@ -9,6 +9,13 @@
     see `issue #1520 <https://github.com/oscarlab/graphene/issues/1520>`__ for a
     description of missing features and security caveats.
 
+.. warning::
+    GSC is currently set to a version of Graphene from 26. May, 2021 (commit
+    2e737e69f076c60918f87d6829bb769925e75fec). This means that GSC does *not*
+    track the latest Graphene and does not incorporate the latest changes and
+    bug fixes. This is a temporary limitation and will be fixed around July
+    2021.
+
 Synopsis
 ========
 

--- a/Tools/gsc/config.yaml.template
+++ b/Tools/gsc/config.yaml.template
@@ -6,7 +6,7 @@ Distro: "ubuntu18.04"
 # below; typically, you want to keep the default values though
 Graphene:
     Repository: "https://github.com/oscarlab/graphene.git"
-    Branch:     "master"
+    Branch:     "2e737e69f076c60918f87d6829bb769925e75fec" # last working commit
 
 # Specify the Intel SGX driver installed on your machine (more specifically, on the machine where
 # the graphenized Docker container will run); there are several variants of the SGX driver:

--- a/Tools/gsc/templates/entrypoint.manifest.template
+++ b/Tools/gsc/templates/entrypoint.manifest.template
@@ -1,4 +1,4 @@
-libos.entrypoint = "/{{binary}}"
+libos.entrypoint = "file:/{{binary}}"
 loader.preload = "file:/graphene/Runtime/libsysdb.so"
 
 loader.env.LD_LIBRARY_PATH = "/graphene/Runtime:{{"{{library_paths}}"}}"
@@ -12,14 +12,14 @@ fs.root.uri = "file:/"
 # Graphene's default working dir is '/', so change the working directory to the desired one
 fs.start_dir = "{{working_dir}}"
 
-sgx.nonpie_binary = true
+sgx.nonpie_binary = 1
 
 {% if insecure_args %}
 # !! INSECURE !! Allow passing command-line arguments from the host without validation.
 # Most Docker images rely on runtime arguments and hence, a more general technique is required.
 # The issue is documented at https://github.com/oscarlab/graphene/issues/1520.
 loader.argv0_override = "{{binary}}"
-loader.insecure__use_cmdline_argv = true
+loader.insecure__use_cmdline_argv = 1
 {% else %}
 loader.argv_src_file = "file:/trusted_argv"
 sgx.trusted_files.trusted_argv = "file:/trusted_argv"

--- a/Tools/gsc/test/Makefile
+++ b/Tools/gsc/test/Makefile
@@ -5,7 +5,7 @@ MAXTESTNUM ?= 11
 TESTS = $(foreach D,$(DISTRIBUTIONS),$(foreach T,$(TESTCASES),$D-$T))
 
 GRAPHENE_REPO ?= https://github.com/oscarlab/graphene.git
-GRAPHENE_BRANCH ?= master
+GRAPHENE_BRANCH ?= "2e737e69f076c60918f87d6829bb769925e75fec" # last working commit
 
 # the below default values assume Linux 5.11+ with built-in SGX driver; see ../config.yaml.template
 # for different options (legacy driver, out-of-tree DCAP driver, in-kernel driver)

--- a/Tools/gsc/test/ubuntu18.04-ra-tls-secret-prov.manifest
+++ b/Tools/gsc/test/ubuntu18.04-ra-tls-secret-prov.manifest
@@ -36,13 +36,13 @@ loader.env.LD_PRELOAD = "libs/libsecret_prov_attest.so"
 #loader.env.SECRET_PROVISION_SERVERS = "dummyserver:80;localhost:4433;anotherdummy:4433"
 
 # Request remote attestation functionality from Graphene
-sgx.remote_attestation = true
+sgx.remote_attestation = 1
 
 # Uncomment below lines for epid-based attestation
 #
 # Specify your SPID and linkable/unlinkable attestation policy
 #sgx.ra_client_spid = "1234567891234567891234567891234567"
-#sgx.ra_client_linkable = false
+#sgx.ra_client_linkable = 0
 
 sgx.allowed_files.etchostname = "file:/etc/hostname"
 sgx.allowed_files.hosts = "file:/etc/hosts"


### PR DESCRIPTION

## Description of the changes <!-- (reasons and measures) -->

Recently, our changes to the build system (moving to Meson, renaming tools, deprecating Makefiles) break GSC when it tries to use the latest master commits. Let's make GSC work again by fixing its config to the last known working commit (and reverting some GSC-related changes from the newer commits).

After this PR, no changes to core Graphene should touch GSC files!

## How to test this PR? <!-- (if applicable) -->

Manually test GSC.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2457)
<!-- Reviewable:end -->
