### PR TITLE
[LibOS] Remove internal threads IDs

### DIFF
--- a/LibOS/shim/include/shim_internal.h
+++ b/LibOS/shim/include/shim_internal.h
@@ -23,12 +23,6 @@ void* shim_init(int argc, void* args);
 
 /* important macros and static inline functions */
 
-#define INTERNAL_TID_BASE ((IDTYPE)1 << (sizeof(IDTYPE) * 8 - 1))
-
-static inline bool is_internal_tid(unsigned int tid) {
-    return tid >= INTERNAL_TID_BASE;
-}
-
 extern int g_log_level;
 
 extern const PAL_CONTROL* g_pal_control;

--- a/LibOS/shim/include/shim_thread.h
+++ b/LibOS/shim/include/shim_thread.h
@@ -136,7 +136,7 @@ struct shim_thread_queue {
 int init_threading(void);
 
 static inline bool is_internal(struct shim_thread* thread) {
-    return thread->tid >= INTERNAL_TID_BASE;
+    return thread->tid == 0;
 }
 
 void free_signal_queue(struct shim_signal_queue* queue);

--- a/LibOS/shim/src/bookkeep/shim_signal.c
+++ b/LibOS/shim/src/bookkeep/shim_signal.c
@@ -311,10 +311,10 @@ static noreturn void internal_fault(const char* errstr, PAL_NUM addr, PAL_CONTEX
 
     if (context_is_libos(context))
         log_error("%s at 0x%08lx (IP = +0x%lx, VMID = %u, TID = %u)\n", errstr, addr,
-                  (void*)ip - (void*)&__load_address, g_self_vmid, is_internal_tid(tid) ? 0 : tid);
+                  (void*)ip - (void*)&__load_address, g_self_vmid, tid);
     else
         log_error("%s at 0x%08lx (IP = 0x%08lx, VMID = %u, TID = %u)\n", errstr, addr,
-                  context ? ip : 0, g_self_vmid, is_internal_tid(tid) ? 0 : tid);
+                  context ? ip : 0, g_self_vmid, tid);
 
     DEBUG_BREAK_ON_FAILURE();
     DkProcessExit(1);
@@ -325,7 +325,7 @@ static void arithmetic_error_upcall(bool is_in_pal, PAL_NUM addr, PAL_CONTEXT* c
     assert(!is_in_pal);
     assert(context);
 
-    if (is_internal_tid(get_cur_tid()) || context_is_libos(context)) {
+    if (is_internal(get_cur_thread()) || context_is_libos(context)) {
         internal_fault("Internal arithmetic fault", addr, context);
     } else {
         log_debug("arithmetic fault at 0x%08lx\n", pal_context_get_ip(context));
@@ -344,7 +344,7 @@ static void memfault_upcall(bool is_in_pal, PAL_NUM addr, PAL_CONTEXT* context) 
     assert(!is_in_pal);
     assert(context);
 
-    if (is_internal_tid(get_cur_tid()) || context_is_libos(context)) {
+    if (is_internal(get_cur_thread()) || context_is_libos(context)) {
         internal_fault("Internal memory fault", addr, context);
     }
 

--- a/LibOS/shim/src/bookkeep/shim_thread.c
+++ b/LibOS/shim/src/bookkeep/shim_thread.c
@@ -31,8 +31,6 @@ static IDTYPE g_tid_alloc_idx = 0;
 static LISTP_TYPE(shim_thread) g_thread_list = LISTP_INIT;
 struct shim_lock g_thread_list_lock;
 
-static IDTYPE g_internal_tid_alloc_idx = INTERNAL_TID_BASE;
-
 //#define DEBUG_REF
 
 #ifdef DEBUG_REF
@@ -244,14 +242,6 @@ struct shim_thread* lookup_thread(IDTYPE tid) {
     return thread;
 }
 
-static IDTYPE get_new_internal_tid(void) {
-    IDTYPE idx = __atomic_add_fetch(&g_internal_tid_alloc_idx, 1, __ATOMIC_RELAXED);
-    if (!is_internal_tid(idx)) {
-        return 0;
-    }
-    return idx;
-}
-
 struct shim_thread* get_new_thread(void) {
     struct shim_thread* thread = alloc_new_thread();
     if (!thread) {
@@ -314,18 +304,7 @@ struct shim_thread* get_new_thread(void) {
 }
 
 struct shim_thread* get_new_internal_thread(void) {
-    struct shim_thread* thread = alloc_new_thread();
-    if (!thread) {
-        return NULL;
-    }
-
-    thread->tid = get_new_internal_tid();
-    if (!thread->tid) {
-        put_thread(thread);
-        return NULL;
-    }
-
-    return thread;
+    return alloc_new_thread();
 }
 
 void get_signal_dispositions(struct shim_signal_dispositions* dispositions) {


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->
Internal threads do not need IDs at all and now have `0` set as the thread ID.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2458)
<!-- Reviewable:end -->
