### PR TITLE
Strip confidential information from logs on "error" level

### DIFF
--- a/LibOS/shim/src/ipc/shim_ipc.c
+++ b/LibOS/shim/src/ipc/shim_ipc.c
@@ -220,7 +220,8 @@ static int ipc_send_message_to_conn(struct shim_ipc_connection* conn, struct shi
 
     int ret = write_exact(conn->handle, msg,  GET_UNALIGNED(msg->header.size));
     if (ret < 0) {
-        log_error("Failed to send IPC msg to %u: %d\n", conn->vmid, ret);
+        log_error("Failed to send IPC msg\n");
+        log_debug("destination: %u, error: %d\n", conn->vmid, ret);
         unlock(&conn->lock);
         remove_ipc_connection(conn);
         return ret;
@@ -317,7 +318,8 @@ int ipc_response_callback(IDTYPE src, void* data, uint64_t seq) {
     };
     struct avl_tree_node* node = avl_tree_find(&g_msg_waiters_tree, &dummy.node);
     if (!node) {
-        log_error("No thread is waiting for a response with seq: %lu\n", seq);
+        log_error("No thread is waiting for a response\n");
+        log_debug("sequence number: %lu\n", seq);
         ret = -EINVAL;
         goto out_unlock;
     }

--- a/LibOS/shim/src/ipc/shim_ipc_child.c
+++ b/LibOS/shim/src/ipc/shim_ipc_child.c
@@ -19,7 +19,8 @@ void ipc_child_disconnect_callback(IDTYPE vmid) {
      * is not distinguishable from a genuine signal).
      */
     if (mark_child_exited_by_vmid(vmid, /*uid=*/0, /*exit_code=*/0, SIGPWR)) {
-        log_error("Child process (vmid: 0x%x) got disconnected\n", vmid);
+        log_error("Child process got disconnected\n");
+        log_debug("vmid: 0x%x\n", vmid);
     } else {
         log_debug("Unknown process (vmid: 0x%x) disconnected\n", vmid);
     }
@@ -57,14 +58,14 @@ int ipc_cld_exit_callback(IDTYPE src, void* data, uint64_t seq) {
     __UNUSED(seq);
     struct shim_ipc_cld_exit* msgin = (struct shim_ipc_cld_exit*)data;
 
-    log_debug("IPC callback from %u: IPC_MSG_CHILDEXIT(%u, %u, %d, %u)\n", src,
-          msgin->ppid, msgin->pid, msgin->exitcode, msgin->term_signal);
+    log_debug("IPC callback from %u: IPC_MSG_CHILDEXIT(%u, %u, %d, %u)\n", src, msgin->ppid,
+              msgin->pid, msgin->exitcode, msgin->term_signal);
 
     if (mark_child_exited_by_pid(msgin->pid, msgin->uid, msgin->exitcode, msgin->term_signal)) {
         log_debug("Child process (pid: %u) died\n", msgin->pid);
     } else {
-        log_error("Unknown process sent a child-death notification: pid: %d, vmid: %u\n",
-                  msgin->pid, src);
+        log_error("Unknown process sent a child-death notification\n");
+        log_debug("pid: %d, vmid: %u\n", msgin->pid, src);
         return -EINVAL;
     }
 

--- a/LibOS/shim/src/sync/shim_sync_client.c
+++ b/LibOS/shim/src/sync/shim_sync_client.c
@@ -435,7 +435,7 @@ void sync_client_message_callback(int code, uint64_t id, int state, size_t data_
             do_confirm_close(id);
             break;
         default:
-            FATAL("unknown message: %d\n", code);
+            FATAL("unknown message\n");
     }
 }
 

--- a/Pal/src/host/Linux-SGX/db_exception.c
+++ b/Pal/src/host/Linux-SGX/db_exception.c
@@ -166,7 +166,8 @@ static bool handle_ud(sgx_cpu_context_t* uc) {
         /* syscall: LibOS may know how to handle this */
         return false;
     }
-    log_error("Unknown or illegal instruction at RIP 0x%016lx\n", uc->rip);
+    log_error("Unknown or illegal instruction executed\n");
+    log_debug("RIP: 0x%016lx\n", uc->rip);
     return false;
 }
 
@@ -221,18 +222,18 @@ void _DkExceptionHandler(unsigned int exit_info, sgx_cpu_context_t* uc,
         /* event isn't asynchronous (i.e., synchronous exception) */
         event_num != PAL_EVENT_QUIT &&
         event_num != PAL_EVENT_INTERRUPTED) {
-        log_error("*** Unexpected exception occurred inside PAL at RIP = +0x%08lx! ***\n",
-                  uc->rip - (uintptr_t)TEXT_START);
+        log_error("*** Unexpected exception occurred inside PAL ***\n");
+        log_debug("*** RIP: +0x%08lx ***\n", uc->rip - (uintptr_t)TEXT_START);
 
         if (ei.info.valid) {
             /* EXITINFO field: vector = exception number, exit_type = 0x3 for HW / 0x6 for SW */
-            log_error("(SGX HW reported AEX vector 0x%x with exit_type = 0x%x)\n", ei.info.vector,
+            log_debug("(SGX HW reported AEX vector 0x%x with exit_type = 0x%x)\n", ei.info.vector,
                       ei.info.exit_type);
         } else {
-            log_error("(untrusted PAL sent PAL event 0x%x)\n", ei.intval);
+            log_debug("(untrusted PAL sent PAL event 0x%x)\n", ei.intval);
         }
 
-        log_error("rax: 0x%08lx rcx: 0x%08lx rdx: 0x%08lx rbx: 0x%08lx\n"
+        log_debug("rax: 0x%08lx rcx: 0x%08lx rdx: 0x%08lx rbx: 0x%08lx\n"
                   "rsp: 0x%08lx rbp: 0x%08lx rsi: 0x%08lx rdi: 0x%08lx\n"
                   "r8 : 0x%08lx r9 : 0x%08lx r10: 0x%08lx r11: 0x%08lx\n"
                   "r12: 0x%08lx r13: 0x%08lx r14: 0x%08lx r15: 0x%08lx\n"

--- a/Pal/src/host/Linux-SGX/db_files.c
+++ b/Pal/src/host/Linux-SGX/db_files.c
@@ -45,7 +45,7 @@ static int file_open(PAL_HANDLE* handle, const char* type, const char* uri, int 
     char* path = (void*)hdl + HANDLE_SIZE(file);
     int ret;
     if ((ret = get_norm_path(uri, path, &uri_size)) < 0) {
-        log_error("Could not normalize path (%s): %s\n", uri, pal_strerror(ret));
+        log_warning("Could not normalize path (%s): %s\n", uri, pal_strerror(ret));
         free(hdl);
         return ret;
     }
@@ -370,8 +370,8 @@ static int pf_file_map(struct protected_file* pf, PAL_HANDLE handle, void** addr
     if (prot & PAL_PROT_READ) {
         /* we don't check this on writes since file size may be extended then */
         if (offset >= pf_size) {
-            log_error("pf_file_map(PF fd %d): offset (%lu) >= file size (%lu)\n", fd, offset,
-                      pf_size);
+            log_error("pf_file_map(PF fd %d): wrong offset\n", fd);
+            log_debug("offset (%lu) >= file size (%lu)\n", offset, pf_size);
             ret = -PAL_ERROR_INVAL;
             goto out;
         }
@@ -510,8 +510,8 @@ static int64_t pf_file_setlength(struct protected_file* pf, PAL_HANDLE handle, u
 
     pf_status_t pfs = pf_set_size(pf->context, length);
     if (PF_FAILURE(pfs)) {
-        log_error("pf_file_setlength(PF fd %d, %lu): pf_set_size returned %s\n", fd, length,
-                  pf_strerror(pfs));
+        log_error("pf_file_setlength(PF fd %d): pf_set_size returned %s\n", fd, pf_strerror(pfs));
+        log_debug("length: %lu\n", length);
         return -PAL_ERROR_DENIED;
     }
     return length;

--- a/Pal/src/host/Linux-SGX/db_main.c
+++ b/Pal/src/host/Linux-SGX/db_main.c
@@ -395,7 +395,7 @@ static int parse_host_topo_info(struct pal_sec* sec_info) {
 
     if (!IS_IN_RANGE_INCL(sec_info->physical_cores_per_socket, 1, 1 << 13)) {
         log_error("Invalid sec_info.physical_cores_per_socket: %ld\n",
-                sec_info->physical_cores_per_socket);
+                  sec_info->physical_cores_per_socket);
         return -1;
     }
     g_pal_sec.physical_cores_per_socket = sec_info->physical_cores_per_socket;

--- a/Pal/src/host/Linux-SGX/db_misc.c
+++ b/Pal/src/host/Linux-SGX/db_misc.c
@@ -385,8 +385,8 @@ int _DkCpuIdRetrieve(unsigned int leaf, unsigned int subleaf, unsigned int value
 
     return 0;
 fail:
-    log_error("Unrecognized leaf/subleaf in CPUID (EAX=%u, ECX=%u). Exiting...\n", leaf,
-              subleaf);
+    log_error("Unrecognized leaf/subleaf in CPUID. Exiting...\n");
+    log_debug("EAX: %u, ECX: %u\n", leaf, subleaf);
     _DkProcessExit(1);
 }
 

--- a/Pal/src/host/Linux-SGX/db_pipes.c
+++ b/Pal/src/host/Linux-SGX/db_pipes.c
@@ -53,7 +53,8 @@ static int thread_handshake_func(void* param) {
     int ret = _DkStreamSecureInit(handle, handle->pipe.is_server, &handle->pipe.session_key,
                                   (LIB_SSL_CONTEXT**)&handle->pipe.ssl_ctx, NULL, 0);
     if (ret < 0) {
-        log_error("Failed to initialize secure pipe %s: %d\n", handle->pipe.name.str, ret);
+        log_error("Failed to initialize secure pipe\n");
+        log_debug("pipe name: %s, error: %d\n", handle->pipe.name.str, ret);
         _DkProcessExit(1);
     }
 

--- a/Pal/src/host/Linux-SGX/enclave_framework.c
+++ b/Pal/src/host/Linux-SGX/enclave_framework.c
@@ -560,7 +560,7 @@ static int register_trusted_file(const char* uri, const char* checksum_str, bool
 
     size_t uri_len = strlen(uri);
     if (uri_len >= URI_MAX) {
-        log_error("Size of file exceeds maximum %dB: %s\n", URI_MAX, uri);
+        log_error("Size of URI exceeds maximum %dB: %s\n", URI_MAX, uri);
         return -PAL_ERROR_INVAL;
     }
 

--- a/common/include/spinlock.h
+++ b/common/include/spinlock.h
@@ -184,7 +184,8 @@ static inline bool spinlock_is_locked(spinlock_t* lock) {
     }
     unsigned int owner = __atomic_load_n(&lock->owner, __ATOMIC_RELAXED);
     if (owner != get_cur_tid()) {
-        log_error("Unexpected lock ownership: owned by: %d, checked in: %d", owner, get_cur_tid());
+        log_error("Unexpected lock ownership\n");
+        log_debug("owned by: %d, checked in: %d\n", owner, get_cur_tid());
         return false;
     }
     return true;


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

As officially added to the docs in #2454, running with `log_level = "error"` should be secure in production. This PR fixes the places where `log_error()` calls leaked potentially sensitive information.

Things I skipped from censoring:
- error codes: I assume they are not confidential, especially in log_error paths,
- non-SGX Linux PAL altogether,
- paths: they are not encrypted and visible from the host anyways,
- memory page addresses: same as with paths.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2468)
<!-- Reviewable:end -->
