### PR TITLE
Erase memory on `free()` in debug builds

### DIFF
--- a/LibOS/shim/src/bookkeep/shim_process.c
+++ b/LibOS/shim/src/bookkeep/shim_process.c
@@ -135,7 +135,7 @@ static bool mark_child_exited(child_cmp_t child_cmp, unsigned long arg, IDTYPE c
             child->term_signal = signal;
             child->uid = child_uid;
 
-            LISTP_DEL_INIT(child, &g_process.children, list);
+            LISTP_DEL(child, &g_process.children, list);
             /* TODO: if SIGCHLD is ignored or has SA_NOCLDWAIT flag set, then the child should not
              * become a zombie. */
             LISTP_ADD(child, &g_process.zombies, list);

--- a/LibOS/shim/src/shim_debug.c
+++ b/LibOS/shim/src/shim_debug.c
@@ -51,8 +51,10 @@ void clean_link_map_list(void) {
         link_map_list->l_prev->l_next = NULL;
 
     struct gdb_link_map* m = link_map_list;
-    for (; m; m = m->l_next) {
+    struct gdb_link_map* next;
+    for (; m; m = next) {
         DkDebugMapRemove(m->l_addr);
+        next = m->l_next;
         free(m);
     }
 

--- a/common/include/memmgr.h
+++ b/common/include/memmgr.h
@@ -227,6 +227,9 @@ static inline void free_mem_obj_to_mgr(MEM_MGR mgr, OBJ_TYPE* obj) {
     }
 
     MEM_OBJ mobj = container_of(obj, MEM_OBJ_TYPE, obj);
+#ifdef DEBUG
+    memset(obj, 0xCC, sizeof(*obj));
+#endif
 
     SYSTEM_LOCK();
     INIT_LIST_HEAD(mobj, __list);

--- a/common/include/slabmgr.h
+++ b/common/include/slabmgr.h
@@ -378,6 +378,9 @@ static inline void slab_free(SLAB_MGR mgr, void* obj) {
 
     if (level == (unsigned char)-1) {
         LARGE_MEM_OBJ mem = RAW_TO_OBJ(obj, LARGE_MEM_OBJ_TYPE);
+#ifdef DEBUG
+        memset(obj, 0xCC, mem->size);
+#endif
         system_free(mem, mem->size + sizeof(LARGE_MEM_OBJ_TYPE));
         return;
     }
@@ -401,6 +404,9 @@ static inline void slab_free(SLAB_MGR mgr, void* obj) {
 #endif
 
     SLAB_OBJ mobj = RAW_TO_OBJ(obj, SLAB_OBJ_TYPE);
+#ifdef DEBUG
+    memset(obj, 0xCC, slab_levels[level]);
+#endif
 
     SYSTEM_LOCK();
     INIT_LIST_HEAD(mobj, __list);


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Seems we finally can do this, some time ago everything exploded after doing so :) Now it found only one use-after-free bug, which is also fixed in this PR.

## How to test this PR? <!-- (if applicable) -->

CI in debug mode.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2470)
<!-- Reviewable:end -->
