### PR TITLE
[Docs] Fix invalid `ninja` invocation in cloud-deployment.rst

### DIFF
--- a/Documentation/cloud-deployment.rst
+++ b/Documentation/cloud-deployment.rst
@@ -56,7 +56,7 @@ Building
        make ISGX_DRIVER_PATH=/usr/src/linux-headers-`uname -r`/arch/x86/ SGX=1
        meson build -Dsgx=enabled -Ddirect=disabled
        ninja -C build
-       sudo ninja -C install
+       sudo ninja -C build install
 
 #. Build and run :program:`helloworld`::
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Seems that one of the invocations was wrong. Originally noticed by @codingwithblackcoffee, thanks!

Closes #2462.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2480)
<!-- Reviewable:end -->
