### PR TITLE
[Pal/Linux-SGX] Fix pointer check issues flagged by Klocwork

### DIFF
--- a/common/src/crypto/adapters/mbedtls_adapter.c
+++ b/common/src/crypto/adapters/mbedtls_adapter.c
@@ -211,7 +211,7 @@ int lib_AESCMAC(const uint8_t* key, size_t key_size, const uint8_t* input, size_
 
     const mbedtls_cipher_info_t* cipher_info = mbedtls_cipher_info_from_type(cipher);
 
-    if (mac_size < cipher_info->block_size) {
+    if (!cipher_info || mac_size < cipher_info->block_size) {
         return -PAL_ERROR_INVAL;
     }
 
@@ -254,7 +254,7 @@ int lib_AESCMACFinish(LIB_AESCMAC_CONTEXT* context, uint8_t* mac, size_t mac_siz
     const mbedtls_cipher_info_t* cipher_info = mbedtls_cipher_info_from_type(context->cipher);
 
     int ret = -PAL_ERROR_INVAL;
-    if (mac_size < cipher_info->block_size)
+    if (!cipher_info || mac_size < cipher_info->block_size)
         goto exit;
 
     ret = mbedtls_cipher_cmac_finish(&context->ctx, mac);


### PR DESCRIPTION
This PR fixes the following issues flagged by Klockwork scan of graphene repo

 Pointer 'cipher_info' returned from call to function 'mbedtls_cipher_info_from_type' at line 254 may be NULL and will be dereferenced at line 257.
/home/intel/graphene_klockwork/graphene/common/src/crypto/adapters/mbedtls_adapter.c:257 | lib_AESCMACFinish()

Pointer 'cipher_info' returned from call to function 'mbedtls_cipher_info_from_type' at line 212 may be NULL and will be dereferenced at line 214.
/home/intel/graphene_klockwork/graphene/common/src/crypto/adapters/mbedtls_adapter.c:214 | lib_AESCMAC()

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2483)
<!-- Reviewable:end -->
