### PR TITLE
[Pal/Linux-SGX] Add `sgx.protected_mr{enclave,signer}_files` manifest options

### DIFF
--- a/Documentation/manifest-syntax.rst
+++ b/Documentation/manifest-syntax.rst
@@ -505,7 +505,18 @@ Protected files
 ::
 
     sgx.protected_files_key = "[16-byte hex value]"
+
     sgx.protected_files = [
+      "[URI]",
+      "[URI]",
+    ]
+
+    sgx.protected_mrenclave_files = [
+      "[URI]",
+      "[URI]",
+    ]
+
+    sgx.protected_mrsigner_files = [
       "[URI]",
       "[URI]",
     ]
@@ -534,6 +545,16 @@ be used only for debugging purposes.
    attestation, thus you should not specify the ``sgx.protected_files_key``
    manifest option at all. Instead, use the Secret Provisioning interface (see
    :doc:`attestation`).
+
+``sgx.protected_files`` are encrypted using the wrap (master) encryption key;
+they are well-suited for input files encrypted by the user and sent to the
+deployment platform as well as for output files sent back to the user and
+decrypted at the user side. ``sgx.protected_mrenclave_files`` are encrypted
+using the SGX sealing key based on the MRENCLAVE identity of the enclave; they
+are useful to allow only the same enclave (on the same platform) to unseal
+files. ``sgx.protected_mrsigner_files`` are encrypted using the SGX sealing key
+based on the MRSIGNER identity of the enclave; they are useful to allow all
+enclaves signed with the same key (and on the same platform) to unseal files.
 
 File check policy
 ^^^^^^^^^^^^^^^^^

--- a/LibOS/shim/test/regression/.gitignore
+++ b/LibOS/shim/test/regression/.gitignore
@@ -2,6 +2,7 @@
 /*.xml
 
 /nonexisting_testfile
+/sealed_file.dat
 /testfile
 /trusted_testfile
 
@@ -83,6 +84,7 @@
 /proc_common
 /proc_cpuinfo
 /proc_path
+/protected_file
 /pselect
 /pthread_set_get_affinity
 /rdtsc

--- a/LibOS/shim/test/regression/Makefile
+++ b/LibOS/shim/test/regression/Makefile
@@ -70,6 +70,7 @@ c_executables = \
 	proc_common \
 	proc_cpuinfo \
 	proc_path \
+	protected_file \
 	pselect \
 	pthread_set_get_affinity \
 	readdir \
@@ -193,6 +194,7 @@ clean-tmp:
 		*.sig \
 		*.tmp \
 		*.token \
+		*.dat \
 		*~ \
 		.cache \
 		.pytest_cache \

--- a/LibOS/shim/test/regression/manifest.template
+++ b/LibOS/shim/test/regression/manifest.template
@@ -38,3 +38,8 @@ sgx.trusted_files = [
   "file:{{ entrypoint }}",
   "file:exec_victim",
 ]
+
+# for sealed_file test
+sgx.protected_mrenclave_files = [
+  "file:sealed_file.dat",
+]

--- a/LibOS/shim/test/regression/protected_file.c
+++ b/LibOS/shim/test/regression/protected_file.c
@@ -1,0 +1,99 @@
+#include <assert.h>
+#include <err.h>
+#include <errno.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#define SECRETSTRING "Secret string\n"
+
+static ssize_t rw_file(const char* path, char* buf, size_t bytes, bool do_write) {
+    size_t rv = 0;
+    size_t ret = 0;
+
+    FILE* f = fopen(path, do_write ? "w" : "r");
+    if (!f) {
+        fprintf(stderr, "opening %s failed\n", path);
+        return -1;
+    }
+
+    while (bytes > rv) {
+        if (do_write)
+            ret = fwrite(buf + rv, /*size=*/1, /*nmemb=*/bytes - rv, f);
+        else
+            ret = fread(buf + rv, /*size=*/1, /*nmemb=*/bytes - rv, f);
+
+        if (ret > 0) {
+            rv += ret;
+        } else {
+            if (feof(f)) {
+                if (rv) {
+                    /* read some bytes from file, success */
+                    break;
+                }
+                assert(rv == 0);
+                fprintf(stderr, "%s failed: unexpected end of file\n", do_write ? "write" : "read");
+                fclose(f);
+                return -1;
+            }
+
+            assert(ferror(f));
+
+            if (errno == EAGAIN || errno == EINTR) {
+                continue;
+            }
+
+            fprintf(stderr, "%s failed: %s\n", do_write ? "write" : "read", strerror(errno));
+            fclose(f);
+            return -1;
+        }
+    }
+
+    int close_ret = fclose(f);
+    if (close_ret) {
+        fprintf(stderr, "closing %s failed\n", path);
+        return -1;
+    }
+    return rv;
+}
+
+
+int main(int argc, char** argv) {
+    int ret;
+    ssize_t bytes;
+
+    if (argc != 2)
+        errx(EXIT_FAILURE, "Usage: %s <protected file to create/validate>", argv[0]);
+
+    ret = access(argv[1], F_OK);
+    if (ret < 0) {
+        if (errno == ENOENT) {
+            /* file is not yet created, create with secret string */
+            bytes = rw_file(argv[1], SECRETSTRING, sizeof(SECRETSTRING), /*do_write=*/true);
+            if (bytes != sizeof(SECRETSTRING)) {
+                /* error is already printed by rw_file_f() */
+                return EXIT_FAILURE;
+            }
+            printf("CREATION OK\n");
+            return 0;
+        }
+        err(EXIT_FAILURE, "access failed");
+    }
+
+    char buf[128];
+    bytes = rw_file(argv[1], buf, sizeof(buf), /*do_write=*/false);
+    if (bytes <= 0) {
+        /* error is already printed by rw_file_f() */
+        return EXIT_FAILURE;
+    }
+    buf[bytes - 1] = '\0';
+
+    size_t size_to_cmp = sizeof(SECRETSTRING) < bytes ? sizeof(SECRETSTRING) : bytes;
+    if (strncmp(SECRETSTRING, buf, size_to_cmp))
+        errx(EXIT_FAILURE, "Expected '%s' but read '%s'\n", SECRETSTRING, buf);
+
+    printf("TEST OK\n");
+    return 0;
+}

--- a/LibOS/shim/test/regression/test_libos.py
+++ b/LibOS/shim/test/regression/test_libos.py
@@ -830,6 +830,16 @@ class TC_40_FileSystem(RegressionTestCase):
             self.assertIn(f'{node}/hugepages/hugepages-2048kB/nr_hugepages: file', lines)
             self.assertIn(f'{node}/hugepages/hugepages-1048576kB/nr_hugepages: file', lines)
 
+    def test_060_sealed_file(self):
+        pf_path = 'sealed_file.dat'
+        if os.path.exists(pf_path):
+            os.remove(pf_path)
+
+        stdout, _ = self.run_binary(['protected_file', pf_path])
+        self.assertIn('CREATION OK', stdout)
+        stdout, _ = self.run_binary(['protected_file', pf_path])
+        self.assertIn('TEST OK', stdout)
+
 
 class TC_50_GDB(RegressionTestCase):
     def setUp(self):

--- a/Pal/src/host/Linux-SGX/enclave_framework.c
+++ b/Pal/src/host/Linux-SGX/enclave_framework.c
@@ -185,6 +185,41 @@ int sgx_verify_report(sgx_report_t* report) {
     return 0;
 }
 
+int sgx_get_seal_key(uint16_t key_policy, sgx_key_128bit_t* seal_key) {
+    assert(key_policy == KEYPOLICY_MRENCLAVE || key_policy == KEYPOLICY_MRSIGNER);
+
+    /* get our own SGX report to obtain this enclave's isv_svn, cpu_svn, config_svn */
+    __sgx_mem_aligned sgx_target_info_t empty_target_info = {0};
+    __sgx_mem_aligned sgx_report_data_t empty_report_data = {0};
+    __sgx_mem_aligned sgx_report_t our_sgx_report = {0};
+    int ret = sgx_get_report(&empty_target_info, &empty_report_data, &our_sgx_report);
+    if (ret) {
+        log_error("Failed to get our own enclave report\n");
+        return -PAL_ERROR_DENIED;
+    }
+
+    /* The keyrequest struct dictates the key derivation material used to generate the sealing key.
+     * It includes MRENCLAVE/MRSIGNER key policy (to allow secret migration/sealing between
+     * instances of the same enclave or between different enclaves of the same author/signer), and
+     * CPU/ISV/CONFIG SVNs (to prevent secret migration to older vulnerable versions of the
+     * enclave). The rest of the keyrequest fields are currently zeros -- CET attributes, enclave
+     * ATTRIBUTES, enclave MISCSELECT bits are *not* included in key derivation. KEYID is also zero,
+     * to generate the same sealing key in different instances of the same enclave/same signer. */
+    __sgx_mem_aligned sgx_key_request_t key_request = {0};
+    key_request.key_name   = SEAL_KEY;
+    key_request.key_policy = key_policy;
+    memcpy(&key_request.cpu_svn, &our_sgx_report.body.cpu_svn, sizeof(sgx_cpu_svn_t));
+    memcpy(&key_request.isv_svn, &our_sgx_report.body.isv_svn, sizeof(sgx_isv_svn_t));
+    memcpy(&key_request.config_svn, &our_sgx_report.body.config_svn, sizeof(sgx_config_svn_t));
+
+    ret = sgx_getkey(&key_request, seal_key);
+    if (ret) {
+        log_error("Failed to generate sealing key using SGX EGETKEY\n");
+        return -PAL_ERROR_DENIED;
+    }
+    return 0;
+}
+
 DEFINE_LISTP(trusted_file);
 static LISTP_TYPE(trusted_file) g_trusted_file_list = LISTP_INIT;
 static spinlock_t g_trusted_file_lock = INIT_SPINLOCK_UNLOCKED;

--- a/Pal/src/host/Linux-SGX/enclave_pf.h
+++ b/Pal/src/host/Linux-SGX/enclave_pf.h
@@ -44,6 +44,12 @@ DEFINE_LISTP(pf_map);
 /* List of PF map buffers; this list is traversed on PF flush (on file close) */
 extern LISTP_TYPE(pf_map) g_pf_map_list;
 
+enum {
+    PROTECTED_FILE_KEY_WRAP = 0,
+    PROTECTED_FILE_KEY_MRENCLAVE,
+    PROTECTED_FILE_KEY_MRSIGNER,
+};
+
 /* Data of a protected file */
 struct protected_file {
     UT_hash_handle hh;
@@ -52,6 +58,7 @@ struct protected_file {
     pf_context_t* context; /* NULL until PF is opened */
     int64_t refcount; /* used for deciding when to call unload_protected_file() */
     int writable_fd; /* fd of underlying file for writable PF, -1 if no writable handles are open */
+    int key_type; /* one of KEY_WRAP (provisioned key), KEY_MRENCLAVE, KEY_MRSIGNER */
 };
 
 /* Take ownership of the global PF lock */

--- a/Pal/src/host/Linux-SGX/pal_linux.h
+++ b/Pal/src/host/Linux-SGX/pal_linux.h
@@ -129,6 +129,18 @@ int sgx_get_report(const sgx_target_info_t* target_info, const sgx_report_data_t
                    sgx_report_t* report);
 
 /*!
+ * \brief Obtain an enclave/signer-specific key via EGETKEY(SEAL_KEY) for secret migration/sealing
+ * of files.
+ *
+ * \param[in]  key_policy  Must be KEYPOLICY_MRENCLAVE or KEYPOLICY_MRSIGNER. Binds the sealing key
+ *                         to MRENCLAVE (only the same enclave can unseal secrets) or to MRSIGNER
+ *                         (all enclaves from the same signer can unseal secrets).
+ * \param[out] seal_key    Output buffer to store the sealing key.
+ * \return 0 on success, negative error code otherwise.
+ */
+int sgx_get_seal_key(uint16_t key_policy, sgx_key_128bit_t* seal_key);
+
+/*!
  * \brief Verify the remote enclave during SGX local attestation.
  *
  * Verifies that the MR_ENCLAVE of the remote enclave is the same as ours (all Graphene enclaves

--- a/Pal/src/host/Linux-SGX/protected-files/protected_files.h
+++ b/Pal/src/host/Linux-SGX/protected-files/protected_files.h
@@ -27,6 +27,8 @@ typedef uint8_t pf_mac_t[PF_MAC_SIZE];
 typedef uint8_t pf_key_t[PF_KEY_SIZE];
 typedef uint8_t pf_keyid_t[32]; /* key derivation material */
 
+extern pf_key_t g_pf_mrenclave_key;
+extern pf_key_t g_pf_mrsigner_key;
 extern pf_key_t g_pf_wrap_key;
 extern bool g_pf_wrap_key_set;
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Previously, only `sgx.protected_files` were available in the manifest. This kind of protected files needs a provisioned master (wrap) key. But sometimes it is enough to seal files on the same platform for later usage by the same enclave or by enclaves of the same signer: this is the SGX sealing feature.

This PR adds two more options to support SGX sealing: `sgx.protected_mrenclave_files` and `sgx.protected_mrsigner_files`.
Similarly to `sgx.protected_files`, these new options specify lists of files that are encrypted by the SGX key generated via SGX instruction `EGETKEY(SEAL_KEY)`, bound to the MRENCLAVE/MRSIGNER enclave measurement (so that only instances of the same enclave/only enclaves with the same signer may decrypt protected files). 

This is a reincarnation of #2328 but with a different user interface (and more flexible -- now we have three keys at the same time).

Closes #2328.

## How to test this PR? <!-- (if applicable) -->

A corresponding LibOS test is added and documentation is updated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/graphene/2484)
<!-- Reviewable:end -->
