### PR TITLE
[LibOS] Fix lseek with large offsets

### DIFF
--- a/LibOS/shim/src/sys/shim_open.c
+++ b/LibOS/shim/src/sys/shim_open.c
@@ -218,7 +218,7 @@ long shim_do_lseek(int fd, off_t offset, int origin) {
     if (!hdl)
         return -EBADF;
 
-    int ret = 0;
+    off_t ret = 0;
     if (hdl->is_dir) {
         ret = do_lseek_dir(hdl, offset, origin);
         goto out;

--- a/LibOS/shim/test/regression/.gitignore
+++ b/LibOS/shim/test/regression/.gitignore
@@ -58,6 +58,7 @@
 /init_fail2
 /kill_all
 /large_dir_read
+/large_file
 /large_mmap
 /madvise
 /mkfifo

--- a/LibOS/shim/test/regression/Makefile
+++ b/LibOS/shim/test/regression/Makefile
@@ -49,8 +49,9 @@ c_executables = \
 	host_root_fs \
 	init_fail \
 	kill_all \
-	large_mmap \
 	large_dir_read \
+	large_file \
+	large_mmap \
 	madvise \
 	mkfifo \
 	mmap_file \

--- a/LibOS/shim/test/regression/large_file.c
+++ b/LibOS/shim/test/regression/large_file.c
@@ -1,0 +1,96 @@
+/* SPDX-License-Identifier: LGPL-3.0-or-later */
+/* Copyright (C) 2021 Intel Corporation
+ *                    Paweł Marczewski <pawel@invisiblethingslab.com>
+ */
+
+/* This test checks large file sizes and offsets that overflow 32-bit integers. */
+
+#define _GNU_SOURCE /* ftruncate */
+#include <assert.h>
+#include <err.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#define TEST_FILE "tmp/large_file"
+
+static_assert(sizeof(off_t) == 8, "this test is for 64-bit off_t");
+
+static off_t test_lengths[] = {
+    // around 2 GB (limit of 32-bit signed int)
+    0x7FFFFFFF,
+    0x80000000,
+    0x80000001,
+    // around 4 GB (limit of 32-bit unsigned int)
+    0xFFFFFFFF,
+    0x100000000,
+    0x100000001,
+    0,
+};
+
+static void try_seek(int fd, off_t offset, int whence, off_t expected) {
+    off_t result = lseek(fd, offset, whence);
+    if (result == -1)
+        err(1, "lseek(fd, %ld, %d) returned -1", offset, whence);
+    if (result != expected)
+        errx(1, "lseek(fd, %ld, %d) returned %ld (0x%lx), expected %ld (0x%lx)", offset, whence,
+             result, result, expected, expected);
+}
+
+int main(void) {
+    setbuf(stdout, NULL);
+
+    int fd = open(TEST_FILE, O_CREAT | O_TRUNC | O_RDWR, 0600);
+    if (fd < 0)
+        err(1, "open");
+
+    int ret;
+
+    for (unsigned int i = 0; test_lengths[i] != 0; i++) {
+        off_t length = test_lengths[i];
+        printf("testing length 0x%lx\n", length);
+
+        /* Resize the file */
+        ret = ftruncate(fd, length);
+        if (ret < 0)
+            err(1, "ftruncate");
+
+        /* Check file size */
+        struct stat st;
+        if (stat(TEST_FILE, &st) < 0)
+            err(1, "stat");
+        if (st.st_size != length)
+            errx(1, "stat: got 0x%lx, expected 0x%lx", st.st_size, length);
+
+        /* Seek to end - 1 */
+        try_seek(fd, -1, SEEK_END, length - 1);
+
+        /* Read a single byte, check position */
+        char c;
+        ssize_t n;
+        do {
+            n = read(fd, &c, 1);
+        } while (n == -1 && errno == -EINTR);
+        if (n == -1)
+            err(1, "read");
+        if (n != 1)
+            errx(1, "read %ld bytes, expected %d", n, 1);
+        if (c != 0)
+            errx(1, "read byte %d, expected %d", (int)c, 0);
+        try_seek(fd, 0, SEEK_CUR, length);
+
+        /* Seek to 0 and then back to length by providing large offsets */
+        try_seek(fd, -length, SEEK_END, 0);
+        try_seek(fd, length, SEEK_SET, length);
+    }
+
+    if (close(fd) < 0)
+        err(1, "close");
+
+    printf("TEST OK\n");
+    return 0;
+}

--- a/LibOS/shim/test/regression/test_libos.py
+++ b/LibOS/shim/test/regression/test_libos.py
@@ -400,7 +400,11 @@ class TC_30_Syscall(RegressionTestCase):
         self.assertIn('getdents64 2: file4', stdout)
         self.assertIn('getdents64 2: file5', stdout)
 
-    def test_022_host_root_fs(self):
+    def test_023_readdir(self):
+        stdout, _ = self.run_binary(['readdir'])
+        self.assertIn('test completed successfully', stdout)
+
+    def test_024_host_root_fs(self):
         stdout, _ = self.run_binary(['host_root_fs'])
         self.assertIn('Test was successful', stdout)
 
@@ -412,13 +416,18 @@ class TC_30_Syscall(RegressionTestCase):
         # fopen corner cases
         self.assertIn('Successfully read from file: Hello World', stdout)
 
-    def test_031_readdir(self):
-        stdout, _ = self.run_binary(['readdir'])
-        self.assertIn('test completed successfully', stdout)
-
-    def test_032_file_size(self):
+    def test_031_file_size(self):
         stdout, _ = self.run_binary(['file_size'])
         self.assertIn('test completed successfully', stdout)
+
+    def test_032_large_file(self):
+        try:
+            stdout, _ = self.run_binary(['large_file'])
+        finally:
+            # This test generates a 4 GB file, don't leave it in FS.
+            os.remove('tmp/large_file')
+
+        self.assertIn('TEST OK', stdout)
 
     def test_040_futex_bitset(self):
         stdout, _ = self.run_binary(['futex_bitset'])


### PR DESCRIPTION
See recent issue #2478 (to be confirmed).

## Description of the changes <!-- (reasons and measures) -->

`lseek` used an int, I fixed it and added a test.

(We're planning to stop using `off_t` internally, but it's unrelated to the current bug).

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->

There is a new regression test, `large_file`. Before the fix, it displayed:

```
testing length 0x7fffffff
testing length 0x80000001
large_file: lseek(fd, -1, 2) = -2147483648 (ffffffff80000000): Success
```

And it looks like the length `0xffffffff` actually causes `lseek` to return something resembling an error code, because I get:
```
testing length 0xffffffff
large_file: lseek(fd, -1, 2) = -1 (ffffffffffffffff): No such file or directory
```

(The test passes now).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2485)
<!-- Reviewable:end -->
