### PR TITLE
[LibOS] Send PID alongside TID in tgkill IPC message

### DIFF
--- a/LibOS/shim/include/shim_ipc.h
+++ b/LibOS/shim/include/shim_ipc.h
@@ -205,13 +205,13 @@ int ipc_change_id_owner_callback(IDTYPE src, void* data, uint64_t seq);
 int ipc_get_id_owner(IDTYPE id, IDTYPE* out_owner);
 int ipc_get_id_owner_callback(IDTYPE src, void* data, uint64_t seq);
 
-/* PID_KILL: send signal to certain pid */
 struct shim_ipc_pid_kill {
     IDTYPE sender;
-    enum kill_type type;
+    IDTYPE pid;
     IDTYPE id;
     int signum;
-} __attribute__((packed));
+    enum kill_type type;
+};
 
 int ipc_kill_process(IDTYPE sender, IDTYPE target, int sig);
 int ipc_kill_thread(IDTYPE sender, IDTYPE dest_pid, IDTYPE target, int sig);


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->
Previously Graphene (incorrectly) assumed that a `tgkill` IPC message is always sent to a process which PID matches the killed TGID (which could be false if TGID was incorrect).

Fixes #2488

## How to test this PR? <!-- (if applicable) -->
`tgkill03` from LTP

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2490)
<!-- Reviewable:end -->
