### PR TITLE
[Docs] building.rst: Mention --buildtype

### DIFF
--- a/Documentation/building.rst
+++ b/Documentation/building.rst
@@ -164,7 +164,7 @@ and EINITTOKENs (``.token`` files).
 
 Then install Graphene (recall that "direct" means non-SGX version)::
 
-   meson build -Ddirect=enabled -Dsgx=enabled
+   meson build --buildtype=release -Ddirect=enabled -Dsgx=enabled
    ninja -C build
    sudo ninja -C build install
 
@@ -175,12 +175,12 @@ built both).
 Additional build options
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-- To create a debug build, run :command:`make DEBUG=1`. This adds debug symbols
-  in all Graphene components, builds them without optimizations, and enables
-  detailed debug logs in Graphene.
+- To create a debug build, run :command:`make DEBUG=1` and :command:`meson
+  --buildtype=debug`. This adds debug symbols in all Graphene components, builds
+  them without optimizations, and enables detailed debug logs in Graphene.
 
 - To create a debug build that does not disable optimizations, run
-  :command:`make DEBUGOPT=1`.
+  :command:`make DEBUGOPT=1` and :command:`meson --buildtype=debugoptimized`.
 
   *Note:* this is generally *not* recommended, because optimized builds lose
   some debugging information, and may cause GDB to display confusing tracebacks

--- a/Documentation/cloud-deployment.rst
+++ b/Documentation/cloud-deployment.rst
@@ -54,7 +54,7 @@ Building
 #. Build Graphene::
 
        make ISGX_DRIVER_PATH=/usr/src/linux-headers-`uname -r`/arch/x86/ SGX=1
-       meson build -Dsgx=enabled -Ddirect=disabled
+       meson build --buildtype=release -Dsgx=enabled -Ddirect=disabled
        ninja -C build
        sudo ninja -C build install
 

--- a/Documentation/devel/debugging.rst
+++ b/Documentation/devel/debugging.rst
@@ -16,7 +16,7 @@ To build Graphene with debug symbols, the source code needs to be compiled with
 
     make clean
     make DEBUG=1
-    meson build -Ddirect=enabled
+    meson build --buildtype=debug -Ddirect=enabled
     ninja -C build
     sudo ninja -C build install
 
@@ -41,7 +41,7 @@ To build Graphene with debug symbols, the source code needs to be compiled with
 
     make SGX=1 clean
     make SGX=1 DEBUG=1
-    meson build -Dsgx=enabled
+    meson build --buildtype=debug -Dsgx=enabled
     ninja -C build
     sudo ninja -C build install
 

--- a/Documentation/quickstart.rst
+++ b/Documentation/quickstart.rst
@@ -15,7 +15,7 @@ Quick start without SGX support
       sudo apt-get install -y build-essential autoconf gawk bison wget python3
       cd graphene
       make
-      meson build -Ddirect=enabled -Dsgx=disabled
+      meson build --buildtype=release -Ddirect=enabled -Dsgx=disabled
       ninja -C build
       sudo ninja -C build install
 
@@ -59,7 +59,7 @@ descriptions in :doc:`building`.
       python3 -m pip install toml>=0.10
       make
       make ISGX_DRIVER_PATH="" SGX=1                  # this assumes Linux 5.11+
-      meson build -Ddirect=enabled -Dsgx=enabled
+      meson build --buildtype=release -Ddirect=enabled -Dsgx=enabled
       ninja -C build
       sudo ninja -C build install
 


### PR DESCRIPTION

## Description of the changes <!-- (reasons and measures) -->

Meson by default has --buildtype=debug, so currently, with two stacked
build systems and without explicit setting, half of the build was
non-debug (make) and the other half was debug (meson).

## How to test this PR? <!-- (if applicable) -->

Execute the changed instruction. Ensure that the build is either fully debug or fully non-debug

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2492)
<!-- Reviewable:end -->
