### PR TITLE
[LibOS,Pal] Emulate IPV6_V6ONLY both in LibOS and PAL

### DIFF
--- a/LibOS/shim/test/regression/tcp_ipv6_v6only.c
+++ b/LibOS/shim/test/regression/tcp_ipv6_v6only.c
@@ -61,6 +61,19 @@ int main(int argc, char** argv) {
         return 1;
     }
 
+    int ipv6_v6only_value = 42;
+    socklen_t ipv6_v6only_value_len = sizeof(ipv6_v6only_value);
+    if (getsockopt(socket_ipv6, IPPROTO_IPV6, IPV6_V6ONLY, &ipv6_v6only_value,
+                   &ipv6_v6only_value_len) < 0) {
+        perror("getsockopt(IPV6_V6ONLY)");
+        return 1;
+    }
+
+    if (ipv6_v6only_value != 0 || ipv6_v6only_value_len != sizeof(ipv6_v6only_value)) {
+        fprintf(stderr, "getsockopt(IPV6_V6ONLY) returned unexpected value\n");
+        return 1;
+    }
+
     /* we must start listening on IPV6 socket to make it active and kick in Linux rules for bind()
      */
     if (listen(socket_ipv6, 3) < 0) {

--- a/Pal/include/pal/pal.h
+++ b/Pal/include/pal/pal.h
@@ -470,6 +470,7 @@ typedef struct _PAL_STREAM_ATTR {
             PAL_BOL tcp_cork;
             PAL_BOL tcp_keepalive;
             PAL_BOL tcp_nodelay;
+            PAL_BOL ipv6_v6only;
         } socket;
     };
 } PAL_STREAM_ATTR;

--- a/Pal/src/host/Linux-SGX/db_sockets.c
+++ b/Pal/src/host/Linux-SGX/db_sockets.c
@@ -257,6 +257,7 @@ static inline PAL_HANDLE socket_create_handle(int type, int fd, int options,
     hdl->sock.tcp_cork       = sock_options->tcp_cork;
     hdl->sock.tcp_keepalive  = sock_options->tcp_keepalive;
     hdl->sock.tcp_nodelay    = sock_options->tcp_nodelay;
+    hdl->sock.ipv6_v6only    = sock_options->ipv6_v6only;
     return hdl;
 }
 
@@ -284,6 +285,8 @@ static int tcp_listen(PAL_HANDLE* handle, char* uri, int create, int options) {
     sock_options.reuseaddr = 1; /* sockets are always set as reusable in Graphene */
 
     int ipv6_v6only = create & PAL_CREATE_DUALSTACK ? 0 : 1;
+    sock_options.ipv6_v6only = ipv6_v6only;
+
     ret = ocall_listen(bind_addr->sa_family, sock_type(SOCK_STREAM, options), 0, ipv6_v6only,
                        bind_addr, &bind_addrlen, &sock_options);
     if (ret < 0)
@@ -459,6 +462,8 @@ static int udp_bind(PAL_HANDLE* handle, char* uri, int create, int options) {
     sock_options.reuseaddr = 1; /* sockets are always set as reusable in Graphene */
 
     int ipv6_v6only = create & PAL_CREATE_DUALSTACK ? 0 : 1;
+    sock_options.ipv6_v6only = ipv6_v6only;
+
     ret = ocall_listen(bind_addr->sa_family, sock_type(SOCK_DGRAM, options), 0, ipv6_v6only,
                        bind_addr, &bind_addrlen, &sock_options);
     if (ret < 0)
@@ -493,6 +498,8 @@ static int udp_connect(PAL_HANDLE* handle, char* uri, int create, int options) {
     sock_options.reuseaddr = 1; /* sockets are always set as reusable in Graphene */
 
     int ipv6_v6only = create & PAL_CREATE_DUALSTACK ? 0 : 1;
+    sock_options.ipv6_v6only = ipv6_v6only;
+
     ret = ocall_connect(dest_addr ? dest_addr->sa_family : AF_INET, sock_type(SOCK_DGRAM, options),
                         0, ipv6_v6only, dest_addr, dest_addrlen, bind_addr, &bind_addrlen,
                         &sock_options);
@@ -698,6 +705,7 @@ static int socket_attrquerybyhdl(PAL_HANDLE handle, PAL_STREAM_ATTR* attr) {
     attr->socket.tcp_cork       = handle->sock.tcp_cork;
     attr->socket.tcp_keepalive  = handle->sock.tcp_keepalive;
     attr->socket.tcp_nodelay    = handle->sock.tcp_nodelay;
+    attr->socket.ipv6_v6only    = handle->sock.ipv6_v6only;
 
     /* get number of bytes available for reading (doesn't make sense for listening sockets) */
     attr->pending_size = 0;
@@ -733,6 +741,10 @@ static int socket_attrsetbyhdl(PAL_HANDLE handle, PAL_STREAM_ATTR* attr) {
             return unix_to_pal_error(ret);
 
         handle->sock.nonblocking = attr->nonblocking;
+    }
+
+    if (attr->socket.ipv6_v6only != handle->sock.ipv6_v6only) {
+        /* ignore setting v6_only explicitly -- this option is set once during listen/bind */
     }
 
     if (HANDLE_TYPE(handle) != pal_type_tcpsrv) {

--- a/Pal/src/host/Linux-SGX/linux_types.h
+++ b/Pal/src/host/Linux-SGX/linux_types.h
@@ -126,6 +126,7 @@ struct sockopt {
     int tcp_cork : 1;
     int tcp_keepalive : 1;
     int tcp_nodelay : 1;
+    int ipv6_v6only : 1;
 };
 
 /* POSIX.1g specifies this type name for the `sa_family' member.  */

--- a/Pal/src/host/Linux-SGX/pal_host.h
+++ b/Pal/src/host/Linux-SGX/pal_host.h
@@ -109,6 +109,7 @@ typedef struct pal_handle {
             PAL_BOL tcp_cork;
             PAL_BOL tcp_keepalive;
             PAL_BOL tcp_nodelay;
+            PAL_BOL ipv6_v6only;
         } sock;
 
         struct {

--- a/Pal/src/host/Linux/pal_host.h
+++ b/Pal/src/host/Linux/pal_host.h
@@ -95,6 +95,7 @@ typedef struct pal_handle {
             PAL_BOL tcp_cork;
             PAL_BOL tcp_keepalive;
             PAL_BOL tcp_nodelay;
+            PAL_BOL ipv6_v6only;
         } sock;
 
         struct {


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

`IPV6_V6ONLY` socket flag is special in Graphene because it must be set before listen/bind happens (in contrast to other flags that can be applied after these syscalls). This led to special handling of `IPV6_V6ONLY` in LibOS, and this attribute was completely emulated in LibOS and not visible in `PAL_STREAM_ATTR` attributes. This led to corner cases when `getsockopt(IPV6_V6ONLY)` tried to find this flag in `pending_options` of the LibOS shim handle; however, pending options could be already freed which led to a segfault.

This commit makes `IPV6_V6ONLY` less special: this flag is now known to PAL and is handled similarly as other `PAL_STREAM_ATTR` attributes. This change also fixes the segfault caused by `pending_options` user-after-free bug. Also, surrounding code is slightly refactored.

Kudos to Denis Zygann (@dzygann) who found this bug and performed initial analysis.

Fixes #2423.

## How to test this PR? <!-- (if applicable) -->

The LibOS regression test `tcp_ipv6_v6only` is updated. Without this PR, this test fails. With this PR, it passes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/graphene/2495)
<!-- Reviewable:end -->
