### PR TITLE
[LibOS] regression: Use `/dev/zero` host device instead of `/dev/kmsg`

### DIFF
--- a/.ci/lib/config-docker.jenkinsfile
+++ b/.ci/lib/config-docker.jenkinsfile
@@ -2,7 +2,6 @@ env.PREFIX = env.WORKSPACE + '/usr'
 
 // don't mess with PATH before reading this: https://issues.jenkins.io/browse/JENKINS-49076
 env.DOCKER_ARGS_COMMON = """
-    --device=/dev/kmsg:/dev/kmsg
     --env=PATH=${env.PREFIX}/bin:${env.PATH}
 """
 env.DOCKER_ARGS_SGX = '''

--- a/LibOS/shim/test/regression/.gitignore
+++ b/LibOS/shim/test/regression/.gitignore
@@ -17,7 +17,7 @@
 /debug_log_inline
 /debug_regs-x86_64
 /devfs
-/device
+/device_passthrough
 /double_fork
 /env_from_file
 /env_from_host

--- a/LibOS/shim/test/regression/Makefile
+++ b/LibOS/shim/test/regression/Makefile
@@ -15,7 +15,7 @@ c_executables = \
 	bootstrap_static \
 	debug \
 	devfs \
-	device \
+	device_passthrough \
 	double_fork \
 	epoll_epollet \
 	epoll_wait_timeout \
@@ -100,6 +100,7 @@ repo_manifests = \
 	argv_from_file.manifest \
 	debug_log_file.manifest \
 	debug_log_inline.manifest \
+	device_passthrough.manifest \
 	env_from_file.manifest \
 	env_from_host.manifest \
 	file_check_policy_allow_all_but_log.manifest \

--- a/LibOS/shim/test/regression/device_passthrough.c
+++ b/LibOS/shim/test/regression/device_passthrough.c
@@ -7,9 +7,9 @@
 #include <unistd.h>
 
 int main(int argc, char* arvg[]) {
-    int devfd = open("/dev/kmsg", O_RDONLY);
+    int devfd = open("/dev/host-zero", O_RDONLY);
     if (devfd < 0)
-        err(1, "/dev/kmsg open");
+        err(1, "/dev/host-zero open");
 
     off_t offset;
 #if 0
@@ -17,34 +17,34 @@ int main(int argc, char* arvg[]) {
      *        lseek() is not aware of device-specific semantics */
     offset = lseek(devfd, 0, SEEK_CUR);
     if (offset != -1 || errno != EINVAL) {
-        errx(1, "/dev/kmsg lseek(0, SEEK_CUR) didn't return -EINVAL (returned: %ld, errno=%d)",
+        errx(1, "/dev/host-zero lseek(0, SEEK_CUR) didn't return -EINVAL (returned: %ld, errno=%d)",
              offset, errno);
     }
 
     offset = lseek(devfd, 1, SEEK_CUR);
     if (offset != -1 || errno != ESPIPE) {
-        errx(1, "/dev/kmsg lseek(1, SEEK_CUR) didn't return -ESPIPE (returned: %ld, errno=%d)",
+        errx(1, "/dev/host-zero lseek(1, SEEK_CUR) didn't return -ESPIPE (returned: %ld, errno=%d)",
              offset, errno);
     }
 #endif
 
     offset = lseek(devfd, /*offset=*/0, SEEK_SET);
     if (offset < 0)
-        err(1, "/dev/kmsg lseek(0, SEEK_SET)");
+        err(1, "/dev/host-zero lseek(0, SEEK_SET)");
     if (offset > 0)
-        errx(1, "/dev/kmsg lseek(0, SEEK_SET) didn't return 0 (returned: %ld)", offset);
+        errx(1, "/dev/host-zero lseek(0, SEEK_SET) didn't return 0 (returned: %ld)", offset);
 
-    char buf[1024];
-    ssize_t bytes = read(devfd, buf, sizeof(buf) - 1);
+    char buf = 'A';
+    ssize_t bytes = read(devfd, &buf, sizeof(buf));
     if (bytes < 0)
-        err(1, "/dev/kmsg read");
+        err(1, "/dev/host-zero read");
 
-    buf[bytes] = '\0';
-    printf("First line of /dev/kmsg: %s", buf);
+    if (buf != '\0')
+        errx(1, "read from /dev/host-zero didn't return NUL byte");
 
     int ret = close(devfd);
     if (ret < 0)
-        err(1, "/dev/kmsg close");
+        err(1, "/dev/host-zero close");
 
     puts("TEST OK");
     return 0;

--- a/LibOS/shim/test/regression/device_passthrough.manifest.template
+++ b/LibOS/shim/test/regression/device_passthrough.manifest.template
@@ -1,0 +1,18 @@
+loader.preload = "file:{{ graphene.libos }}"
+libos.entrypoint = "device_passthrough"
+loader.env.LD_LIBRARY_PATH = "/lib"
+loader.argv0_override = "device_passthrough"
+
+fs.mount.graphene_lib.type = "chroot"
+fs.mount.graphene_lib.path = "/lib"
+fs.mount.graphene_lib.uri = "file:{{ graphene.runtimedir() }}"
+
+fs.mount.dev.type = "chroot"
+fs.mount.dev.path = "/dev/host-zero"
+fs.mount.dev.uri = "dev:/dev/zero"
+
+sgx.trusted_files.runtime = "file:{{ graphene.runtimedir() }}/"
+
+sgx.trusted_files.entrypoint = "file:device_passthrough"
+
+sgx.nonpie_binary = true

--- a/LibOS/shim/test/regression/manifest.template
+++ b/LibOS/shim/test/regression/manifest.template
@@ -22,10 +22,6 @@ fs.mount.bin.type = "chroot"
 fs.mount.bin.path = "/bin"
 fs.mount.bin.uri = "file:/bin"
 
-fs.mount.devkmsg.type = "chroot"
-fs.mount.devkmsg.path = "/dev/kmsg"
-fs.mount.devkmsg.uri = "dev:/dev/kmsg"
-
 sgx.trusted_files.runtime = "file:{{ graphene.runtimedir() }}/"
 sgx.trusted_files.libgcc_s = "file:{{ arch_libdir }}/libgcc_s.so.1"
 sgx.trusted_files.libstdcxx = "file:/usr{{ arch_libdir }}/libstdc++.so.6"

--- a/LibOS/shim/test/regression/test_libos.py
+++ b/LibOS/shim/test/regression/test_libos.py
@@ -661,8 +661,8 @@ class TC_40_FileSystem(RegressionTestCase):
         self.assertIn('Four bytes from /dev/urandom', stdout)
         self.assertIn('TEST OK', stdout)
 
-    def test_002_device(self):
-        stdout, _ = self.run_binary(['device'])
+    def test_002_device_passthrough(self):
+        stdout, _ = self.run_binary(['device_passthrough'])
         self.assertIn('TEST OK', stdout)
 
     def test_010_path(self):


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Previously, the generic `manifest.template` for all regression tests contained a mount point `/dev/kmsg` (device containing Linux messages). However, recent Ubuntu distros and some other distros (CentOS, RedHat) disallow unprivileged access to this device, and this test failed. This commit fixes this by splitting `/dev/kmsg` test away from the generic manifest file. Additionally, our PyTest script checks if access to `/dev/kmsg` is allowed and skips the `device` test if not.

## How to test this PR? <!-- (if applicable) -->

Try on Ubuntu 21.04 or CentOS 8.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2496)
<!-- Reviewable:end -->
