### PR TITLE
[LibOS] Do not reuse dentries after removing a file (fixes mknod crash)

### DIFF
--- a/LibOS/shim/include/shim_fs.h
+++ b/LibOS/shim/include/shim_fs.h
@@ -169,10 +169,7 @@ struct shim_d_ops {
     /* this is to check file type and access, returning the stat.st_mode */
     int (*mode)(struct shim_dentry* dent, mode_t* mode);
 
-    /*
-     * Detach internal data from dentry. Called before the dentry is destroyed.
-     * TODO: some filesystems (`str`, `tmpfs`) abuse this callback for reference counting.
-     */
+    /* detach internal data from dentry */
     int (*dput)(struct shim_dentry* dent);
 
     /* create a dentry inside a directory */

--- a/LibOS/shim/include/shim_fs.h
+++ b/LibOS/shim/include/shim_fs.h
@@ -169,7 +169,10 @@ struct shim_d_ops {
     /* this is to check file type and access, returning the stat.st_mode */
     int (*mode)(struct shim_dentry* dent, mode_t* mode);
 
-    /* detach internal data from dentry */
+    /*
+     * Detach internal data from dentry. Called before the dentry is destroyed.
+     * TODO: some filesystems (`str`, `tmpfs`) abuse this callback for reference counting.
+     */
     int (*dput)(struct shim_dentry* dent);
 
     /* create a dentry inside a directory */

--- a/LibOS/shim/src/fs/shim_dcache.c
+++ b/LibOS/shim/src/fs/shim_dcache.c
@@ -100,12 +100,6 @@ void get_dentry(struct shim_dentry* dent) {
 }
 
 static void free_dentry(struct shim_dentry* dent) {
-    if (dent->fs && dent->fs->d_ops && dent->fs->d_ops->dput) {
-        int ret = dent->fs->d_ops->dput(dent);
-        if (ret < 0)
-            log_warning("dput() failed on %s: %d", qstrgetstr(&dent->name), ret);
-    }
-
     if (dent->mount) {
         put_mount(dent->mount);
     }
@@ -123,6 +117,9 @@ static void free_dentry(struct shim_dentry* dent) {
     if (dent->attached_mount) {
         put_mount(dent->attached_mount);
     }
+
+    /* XXX: We are leaking `data` field here. This field seems to have different meaning for
+     * different dentries and how to free it is a mystery to me. */
 
     destroy_lock(&dent->lock);
 

--- a/LibOS/shim/src/fs/str/fs.c
+++ b/LibOS/shim/src/fs/str/fs.c
@@ -44,7 +44,7 @@ int str_open(struct shim_handle* hdl, struct shim_dentry* dent, int flags) {
 int str_dput(struct shim_dentry* dent) {
     struct shim_str_data* data = dent->data;
 
-    if (!data || REF_DEC(data->ref_count) > 1)
+    if (!data || REF_DEC(data->ref_count) > 0)
         return 0;
 
     if (data->str) {

--- a/LibOS/shim/src/fs/tmpfs/fs.c
+++ b/LibOS/shim/src/fs/tmpfs/fs.c
@@ -172,7 +172,7 @@ static int tmpfs_dput(struct shim_dentry* dent) {
     lock(&dent->lock);
     struct shim_tmpfs_data* tmpfs_data = dent->data;
 
-    if (!tmpfs_data || REF_DEC(tmpfs_data->str_data.ref_count) > 1) {
+    if (!tmpfs_data || REF_DEC(tmpfs_data->str_data.ref_count) > 0) {
         unlock(&dent->lock);
         return 0;
     }

--- a/LibOS/shim/src/sys/shim_file.c
+++ b/LibOS/shim/src/sys/shim_file.c
@@ -36,7 +36,7 @@ long shim_do_unlinkat(int dfd, const char* pathname, int flag) {
 
     struct shim_dentry* dir = NULL;
     struct shim_dentry* dent = NULL;
-    int ret = 0;
+    int ret;
 
     if (*pathname != '/' && (ret = get_dirfd_dentry(dfd, &dir)) < 0)
         return ret;

--- a/LibOS/shim/test/regression/mkfifo.c
+++ b/LibOS/shim/test/regression/mkfifo.c
@@ -93,6 +93,21 @@ int main(int argc, char** argv) {
             perror("[parent] unlink error");
             return 1;
         }
+
+        /* Check if we can create a normal file with the same name. */
+        fd = open(FIFO_PATH, O_CREAT | O_TRUNC, 0600);
+        if (fd < 0) {
+            perror("[parent] open error");
+            return 1;
+        }
+        if (close(fd) < 0) {
+            perror("[parent] close error");
+            return 1;
+        }
+        if (unlink(FIFO_PATH) < 0) {
+            perror("[parent] unlink error");
+            return 1;
+        }
     }
 
     return 0;

--- a/LibOS/shim/test/regression/mkfifo.c
+++ b/LibOS/shim/test/regression/mkfifo.c
@@ -108,6 +108,8 @@ int main(int argc, char** argv) {
             perror("[parent] unlink error");
             return 1;
         }
+
+        printf("[parent] TEST OK\n");
     }
 
     return 0;

--- a/LibOS/shim/test/regression/test_libos.py
+++ b/LibOS/shim/test/regression/test_libos.py
@@ -865,6 +865,7 @@ class TC_80_Socket(RegressionTestCase):
     def test_095_mkfifo(self):
         stdout, _ = self.run_binary(['mkfifo'], timeout=60)
         self.assertIn('read on FIFO: Hello from write end of FIFO!', stdout)
+        self.assertIn('[parent] TEST OK', stdout)
 
     def test_100_socket_unix(self):
         stdout, _ = self.run_binary(['unix'])


### PR DESCRIPTION
Found while investigating #2419.

## Description of the changes <!-- (reasons and measures) -->

This change ensures that dentries for removed files are not reused. Instead of marking a dentry as negative, we mark it as invalid, and make sure that a new one is created during next lookup.

This fixes a crash where we create a named pipe, remove it, and then reuse the same object for a normal file. More generally, it ensures that filesystems always receive a dentry in a consistent state.

Several unused dentry flags are also removed.
<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->

* Should fix the mknod crash in #2419 
   * Note that the mknod stress test still fails, because our mknod doesn't create sockets, and hit EMFILE from hst on creating too many named pipes). However, it should not crash anymore.
* I added a short snippet to the end of `mkfifo` that crashes in same manner on master.
* To verify the operations on dentries (e.g. an entry is invalidated and removed later), I added `dump_dcache(NULL);` to `shim_exit.c`, and ran a few sanity checks with `graphene-direct python -c "<script>"`:
  * `import os; open('x', 'w').close(); os.unlink('x')` (should show an invalid dentry)
  * `...; os.path.exists('x')` (should show a new, negative dentry, with no mode etc. set)
  * `...; os.readdir(".")` (should show no dentry, due to lookup triggering `dentry_gc()`)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2499)
<!-- Reviewable:end -->
