### PR TITLE
[LibOS] Fix sendfile syscall with negative offsets

### DIFF
--- a/LibOS/shim/src/sys/shim_file.c
+++ b/LibOS/shim/src/sys/shim_file.c
@@ -622,6 +622,9 @@ long shim_do_sendfile(int ofd, int ifd, off_t* offset, size_t count) {
     ret = -EACCES;
 
     if (offset) {
+        if (*offset < 0)
+            return -EINVAL;
+
         if (!hdli->fs || !hdli->fs->fs_ops || !hdli->fs->fs_ops->seek)
             goto out;
 

--- a/LibOS/shim/test/ltp/ltp-sgx.cfg
+++ b/LibOS/shim/test/ltp/ltp-sgx.cfg
@@ -594,12 +594,6 @@ skip = yes
 [sendfile03_64]
 timeout = 60
 
-[sendfile05]
-skip = yes
-
-[sendfile05_64]
-skip = yes
-
 [sendto01]
 skip = yes
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->
This commit handles negative offset passed to sendfile syscall by returning `-EINVAL`. Negative offsets maybe valid for some special files like `/dev/(k)mem` and `/proc/<pid>/mem` which can have large file offsets. But in graphene, these files are not emulated so it will be safe to return `-EINVAL` for negative offsets.

Also, this patch enables 2 `sendfile` ltp tests.

Signed-off-by: Vijay Dhanraj <vijay.dhanraj@intel.com>

Fixes #2364

## How to test this PR? <!-- (if applicable) -->
Please run ltp-sgx tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2501)
<!-- Reviewable:end -->
