### PR TITLE
[LibOS] Fix a crash after reusing dentry touched by `mknod`

### DIFF
--- a/LibOS/shim/test/regression/mkfifo.c
+++ b/LibOS/shim/test/regression/mkfifo.c
@@ -9,7 +9,7 @@
 #include <sys/wait.h>
 #include <unistd.h>
 
-#define FIFO_PATH "fifo123"
+#define FIFO_PATH "tmp/fifo"
 
 int main(int argc, char** argv) {
     int fd;
@@ -93,6 +93,23 @@ int main(int argc, char** argv) {
             perror("[parent] unlink error");
             return 1;
         }
+
+        /* Check if we can create a normal file with the same name. */
+        fd = open(FIFO_PATH, O_CREAT | O_TRUNC, 0600);
+        if (fd < 0) {
+            perror("[parent] open error");
+            return 1;
+        }
+        if (close(fd) < 0) {
+            perror("[parent] close error");
+            return 1;
+        }
+        if (unlink(FIFO_PATH) < 0) {
+            perror("[parent] unlink error");
+            return 1;
+        }
+
+        printf("[parent] TEST OK\n");
     }
 
     return 0;

--- a/LibOS/shim/test/regression/test_libos.py
+++ b/LibOS/shim/test/regression/test_libos.py
@@ -874,8 +874,13 @@ class TC_80_Socket(RegressionTestCase):
         self.assertIn('TEST OK', stdout)
 
     def test_095_mkfifo(self):
-        stdout, _ = self.run_binary(['mkfifo'], timeout=60)
+        try:
+            stdout, _ = self.run_binary(['mkfifo'], timeout=60)
+        finally:
+            if os.path.exists('tmp/fifo'):
+                os.remove('tmp/fifo')
         self.assertIn('read on FIFO: Hello from write end of FIFO!', stdout)
+        self.assertIn('[parent] TEST OK', stdout)
 
     def test_100_socket_unix(self):
         stdout, _ = self.run_binary(['unix'])


### PR DESCRIPTION
Found while investigating #2419. I tried to make a proper fix in PR #2499, but that seems to be blocked by conflict with tmpfs/strfs code. Merging #2499 would probably make an existing memory leak worse, so I would like to take care of tmpfs and strfs first. In the mean time, here is the workaround for the actual crash.

I ticketed the proper fix as #2507 and intend to work on it.

<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://graphene.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

This fixes a crash where we create a named pipe, remove it, and then try to create a normal file with the same name. Unfortunately, fixing the underlying problem (dentry reuse) is more problematic, so this is only a workaround for that specific case.

## How to test this PR? <!-- (if applicable) -->

* Should fix the mknod crash in #2419 
   * Note that the mknod stress test still fails, because our mknod doesn't create sockets, and (when these failures are ignored) hits EMFILE from host on creating too many named pipes. However, it should not cause Graphene to crash anymore.
* I added a short snippet to the end of `mkfifo` that crashes in same manner on master.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2505)
<!-- Reviewable:end -->
