### PR TITLE
[LibOS] Do not print errors on last TID release failure

### DIFF
--- a/LibOS/shim/src/bookkeep/shim_pid.c
+++ b/LibOS/shim/src/bookkeep/shim_pid.c
@@ -168,8 +168,11 @@ void release_id(IDTYPE id) {
 
             int ret = ipc_release_id_range(range->start, range->end);
             if (ret < 0) {
-                log_error("IPC pid release failed");
-                die_or_inf_loop();
+                /* TODO: this is a fatal error, unfortunately it can happen if the IPC leader exits
+                 * without fully waiting for this process to end. For more information check
+                 * "LibOS/shim/src/sys/shim_exit.c". Change to `log_error` + `die` after fixing. */
+                log_warning("IPC pid release failed");
+                DkProcessExit(1);
             }
             free(range);
             return;


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->
Check the commit message and comment in code.

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->
Hopefully fixes PR #2504

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2508)
<!-- Reviewable:end -->
