### PR TITLE
[Docs] Add note on adding `/usr/local/bin` to `PATH` envvar

### DIFF
--- a/Documentation/building.rst
+++ b/Documentation/building.rst
@@ -172,6 +172,14 @@ Set ``-Ddirect=`` and ``-Dsgx=`` options to ``enabled`` or ``disabled``
 according to whether you built the corresponding PAL (the snippet assumes you
 built both).
 
+.. note::
+
+   When installing from sources, Graphene executables are placed under
+   ``/usr/local/bin``. Some Linux distributions (notably CentOS) do not search
+   for executables under this path. If your system reports that Graphene
+   programs can not be found, you might need to edit your configuration files so
+   that ``/usr/local/bin`` is in your path (in ``PATH`` environment variable).
+
 Additional build options
 ^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/Documentation/quickstart.rst
+++ b/Documentation/quickstart.rst
@@ -77,6 +77,15 @@ descriptions in :doc:`building`.
       make SGX=1 sgx-tokens
       graphene-sgx helloworld
 
+Troubleshooting
+---------------
+
+When installing from sources, Graphene executables are placed under
+``/usr/local/bin``. Some Linux distributions (notably CentOS) do not search for
+executables under this path. If your system reports that Graphene programs can
+not be found, you might need to edit your configuration files so that
+``/usr/local/bin`` is in your path (in ``PATH`` environment variable).
+
 Running sample applications
 ---------------------------
 


### PR DESCRIPTION

## Description of the changes <!-- (reasons and measures) -->

When installed from sources, Graphene is put under `/usr/local/bin`. However, some Linux distros (notably CentOS) do not allow running apps from this directory, so users must manually add this directory to the `PATH` environment variable.

This PR adds a note on this in our documentation.

## How to test this PR? <!-- (if applicable) -->

N/A.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2509)
<!-- Reviewable:end -->
