### PR TITLE
[Examples] Fix Out-of-memory in PAL

### DIFF
--- a/Examples/pytorch/pytorch.manifest.template
+++ b/Examples/pytorch/pytorch.manifest.template
@@ -19,6 +19,9 @@ loader.insecure__use_host_env = true
 # Overwrite some environment variables
 loader.env.LD_LIBRARY_PATH = "/lib:/usr/lib:{{ arch_libdir }}:/usr/{{ arch_libdir }}"
 
+# Set Graphene internal metadata size
+loader.pal_internal_mem_size = "128M"
+
 # Default glibc files, mounted from the Runtime directory in GRAPHENEDIR
 fs.mount.lib.type = "chroot"
 fs.mount.lib.path = "/lib"


### PR DESCRIPTION
Signed-off-by: Przystawski <sebastian.przystawski@intel.com>

Without specifying Graphene metadata size this pytorch sample application
was not able to run because of "Out-of-memory in PAL" error.
Specifying "loader.pal_internal_mem_size" in manifest fix that issue.

 Changes to be committed:
	modified:   Examples/pytorch/pytorch.manifest.template

## Description of the changes
Added loader.pal_internal_mem_size = "128M" to pytorch manifest.template

## How to test this PR?
Buld and run pytorch example according to the instructions
in https://github.com/sprzysta/graphene/blob/master/Examples/pytorch/README.md.
Example application should run without error

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2512)
<!-- Reviewable:end -->
