### PR TITLE
[LTP] Disable `recvmsg01` because of the non-fatal crash

### DIFF
--- a/LibOS/shim/test/ltp/ltp.cfg
+++ b/LibOS/shim/test/ltp/ltp.cfg
@@ -1640,13 +1640,11 @@ must-pass =
 #            broken, the child uses a dangling pointer (hdl->info.sock.addr.un.dentry; actually
 #            pointing to the parent's address space) and crashes in __do_accept which tries to do
 #            get_dentry(sock->addr.un.dentry).
+#
+# NOTE: Previously we had `must-pass = 1 2 5 6 7`, but given that subtest 8 loudly crashes the child
+#       process, it is better to disable this test completely until a proper fix is implemented.
 [recvmsg01]
-must-pass =
-    1
-    2
-    5
-    6
-    7
+skip = yes
 
 [recvmsg02]
 skip = yes


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Previously, `recvmsg01` was enabled with only a handful of subtests required to pass. In this test, one of the subtests spawns a child process that crashes loudly (because of the bug in Graphene). It is better to completely disable this test than to have only "partially working" test in our CI.

Fixes #2265 

## How to test this PR? <!-- (if applicable) -->

N/A.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2513)
<!-- Reviewable:end -->
