### PR TITLE
[LibOS] Make POSIX locks interruptible

### DIFF
--- a/LibOS/shim/include/shim_fs_lock.h
+++ b/LibOS/shim/include/shim_fs_lock.h
@@ -111,7 +111,23 @@ int posix_lock_clear_pid(IDTYPE pid);
  * to add a lock (-EAGAIN, -ENOMEM etc.) will be sent in the response instead.
  */
 int posix_lock_set_from_ipc(const char* path, struct posix_lock* pl, bool wait, IDTYPE vmid,
-                            unsigned long seq);
+                            uint64_t seq);
+
+/*!
+ * \brief Cancel a lock request (IPC handler)
+ *
+ * \param path absolute path for a file
+ * \param vmid target process for IPC response
+ * \param seq sequence number for IPC response
+ *
+ * Cancels the request previously added by `posix_lock_set_from_ipc`: if the request with given
+ * `vmid` and `seq` parameters is still unresolved, it is removed and a response with -EINTR is
+ * sent. If the request has been resolved in the meantime, nothing happens.
+ *
+ * This function should be called if the wait for IPC response has been interrupted. It ensures that
+ * a response will be sent immediately.
+ */
+int posix_lock_cancel_from_ipc(const char* path, IDTYPE vmid, uint64_t seq);
 
 /*!
  * \brief Check for conflicting locks on a file (IPC handler)

--- a/LibOS/shim/include/shim_fs_lock.h
+++ b/LibOS/shim/include/shim_fs_lock.h
@@ -34,7 +34,6 @@ int init_fs_lock(void);
  * - The main process has to be able to look up the same file, so locking will not work for files in
  *   local-process-only filesystems (tmpfs).
  * - There is no deadlock detection (EDEADLK).
- * - The lock requests cannot be interrupted (EINTR).
  * - The locks work only on files that have a dentry (no pipes, sockets etc.)
  */
 

--- a/LibOS/shim/src/ipc/shim_ipc_worker.c
+++ b/LibOS/shim/src/ipc/shim_ipc_worker.c
@@ -62,6 +62,7 @@ static ipc_callback ipc_callbacks[] = {
     [IPC_MSG_SYNC_CONFIRM_CLOSE]     = ipc_sync_confirm_close_callback,
 
     [IPC_MSG_POSIX_LOCK_SET]       = ipc_posix_lock_set_callback,
+    [IPC_MSG_POSIX_LOCK_CANCEL]    = ipc_posix_lock_cancel_callback,
     [IPC_MSG_POSIX_LOCK_GET]       = ipc_posix_lock_get_callback,
     [IPC_MSG_POSIX_LOCK_CLEAR_PID] = ipc_posix_lock_clear_pid_callback,
 };

--- a/LibOS/shim/src/shim_parser.c
+++ b/LibOS/shim/src/shim_parser.c
@@ -203,7 +203,7 @@ struct parser_table {
                      parse_pointer_arg, parse_pointer_arg, parse_long_arg, parse_integer_arg}},
     [__NR_msgctl] = {.slow = true, .name = "msgctl", .parser = {parse_long_arg, parse_integer_arg,
                      parse_integer_arg, parse_pointer_arg}},
-    [__NR_fcntl] = {.slow = false, .name = "fcntl", .parser = {parse_long_arg, parse_integer_arg,
+    [__NR_fcntl] = {.slow = true, .name = "fcntl", .parser = {parse_long_arg, parse_integer_arg,
                     parse_fcntlop, parse_pointer_arg}},
     [__NR_flock] = {.slow = false, .name = "flock", .parser = {NULL}},
     [__NR_fsync] = {.slow = false, .name = "fsync", .parser = {parse_long_arg, parse_integer_arg}},

--- a/LibOS/shim/test/ltp/ltp.cfg
+++ b/LibOS/shim/test/ltp/ltp.cfg
@@ -369,13 +369,6 @@ timeout = 60
 [fcntl14_64]
 timeout = 60
 
-# depends on POSIX locks returning EINTR after signal, which we don't support
-[fcntl16]
-skip = yes
-
-[fcntl16_64]
-skip = yes
-
 # no deadlock detection for POSIX locks
 [fcntl17]
 skip = yes


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

This makes it possible for POSIX locks (`F_SETLKW`) to return `-EINTR` when interrupted, e.g. after receiving a signal from `alarm()`. See #2517 for design discussion. 

Fixes #2510.

## How to test this PR? <!-- (if applicable) -->

* I added some test cases to `fcntl_lock`
* The `stress-ng` lockf test should no longer hang (see #2510)
* LTP `fcntl16` test is reenabled (the test depends on being able to interrupt a lock request, unfortunately it's racy and the interrupt is not always necessary)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2522)
<!-- Reviewable:end -->
