### PR TITLE
[LibOS] Make Graphene internal IDs managed by LibOS

### DIFF
--- a/Documentation/pal/porting.rst
+++ b/Documentation/pal/porting.rst
@@ -59,8 +59,6 @@ directory:
    + ``_DkGetAvailableUserAddressRange`` (required): PAL must provide a |~| user
      address range that applications can use. None of these addresses should be
      used by PAL internally.
-   + ``_DkGetProcessId`` (required): Return a unique process ID for each
-     process.
    + ``_DkGetCPUInfo`` (optional): Retrieve CPU information, such as vendor ID,
      model name.
 

--- a/LibOS/shim/include/shim_ipc.h
+++ b/LibOS/shim/include/shim_ipc.h
@@ -19,6 +19,7 @@
 
 enum {
     IPC_MSG_RESP = 0,
+    IPC_MSG_GET_NEW_VMID,       /*!< Request new VMID. */
     IPC_MSG_CHILDEXIT,          /*!< Child exit/death information. */
     IPC_MSG_ALLOC_ID_RANGE,     /*!< Request new IDs range. */
     IPC_MSG_RELEASE_ID_RANGE,   /*!< Release IDs range. */
@@ -42,12 +43,14 @@ enum kill_type { KILL_THREAD, KILL_PROCESS, KILL_PGROUP, KILL_ALL };
 
 enum pid_meta_code { PID_META_CRED, PID_META_EXEC, PID_META_CWD, PID_META_ROOT };
 
+#define STARTING_VMID 1
+
 struct shim_ipc_ids {
+    IDTYPE self_vmid;
     IDTYPE parent_vmid;
     IDTYPE leader_vmid;
 };
 
-extern IDTYPE g_self_vmid;
 extern struct shim_ipc_ids g_process_ipc_ids;
 
 int init_ipc(void);
@@ -141,6 +144,14 @@ int ipc_broadcast(struct shim_ipc_msg* msg, IDTYPE exclude_vmid);
  * free it!
  */
 int ipc_response_callback(IDTYPE src, void* data, uint64_t seq);
+
+/*!
+ * \brief Get a new VMID
+ *
+ * \param[out] vmid contains the new VMID
+ */
+int ipc_get_new_vmid(IDTYPE* vmid);
+int ipc_get_new_vmid_callback(IDTYPE src, void* data, uint64_t seq);
 
 struct shim_ipc_cld_exit {
     IDTYPE ppid, pid;

--- a/LibOS/shim/src/bookkeep/shim_signal.c
+++ b/LibOS/shim/src/bookkeep/shim_signal.c
@@ -311,10 +311,10 @@ static noreturn void internal_fault(const char* errstr, PAL_NUM addr, PAL_CONTEX
 
     if (context_is_libos(context))
         log_error("%s at 0x%08lx (IP = +0x%lx, VMID = %u, TID = %u)", errstr, addr,
-                  (void*)ip - (void*)&__load_address, g_self_vmid, tid);
+                  (void*)ip - (void*)&__load_address, g_process_ipc_ids.self_vmid, tid);
     else
         log_error("%s at 0x%08lx (IP = 0x%08lx, VMID = %u, TID = %u)", errstr, addr,
-                  context ? ip : 0, g_self_vmid, tid);
+                  context ? ip : 0, g_process_ipc_ids.self_vmid, tid);
 
     DEBUG_BREAK_ON_FAILURE();
     DkProcessExit(1);

--- a/LibOS/shim/src/ipc/shim_ipc.c
+++ b/LibOS/shim/src/ipc/shim_ipc.c
@@ -61,7 +61,6 @@ static bool ipc_msg_waiter_cmp(struct avl_tree_node* _a, struct avl_tree_node* _
 static struct avl_tree g_msg_waiters_tree = { .cmp = ipc_msg_waiter_cmp };
 static struct shim_lock g_msg_waiters_tree_lock;
 
-IDTYPE g_self_vmid;
 struct shim_ipc_ids g_process_ipc_ids;
 
 int init_ipc(void) {
@@ -123,7 +122,8 @@ static int ipc_connect(IDTYPE dest, struct shim_ipc_connection** conn_ptr) {
             ret = pal_to_unix_errno(ret);
             goto out;
         }
-        ret = write_exact(conn->handle, &g_self_vmid, sizeof(g_self_vmid));
+        ret = write_exact(conn->handle, &g_process_ipc_ids.self_vmid,
+                          sizeof(g_process_ipc_ids.self_vmid));
         if (ret < 0) {
             goto out;
         }

--- a/LibOS/shim/src/ipc/shim_ipc_pid.c
+++ b/LibOS/shim/src/ipc/shim_ipc_pid.c
@@ -234,7 +234,7 @@ out:
 
 int ipc_alloc_id_range(IDTYPE* out_start, IDTYPE* out_end) {
     if (!g_process_ipc_ids.leader_vmid) {
-        return alloc_id_range(g_self_vmid, out_start, out_end);
+        return alloc_id_range(g_process_ipc_ids.self_vmid, out_start, out_end);
     }
 
     size_t msg_size = get_ipc_msg_size(0);

--- a/LibOS/shim/src/ipc/shim_ipc_sync.c
+++ b/LibOS/shim/src/ipc/shim_ipc_sync.c
@@ -51,7 +51,7 @@ static int sync_msg_send(IDTYPE dest, int code, uint64_t id, int state, size_t d
 
 int ipc_sync_client_send(int code, uint64_t id, int state, size_t data_size, void* data) {
     sync_log("sync client", code, id, state);
-    IDTYPE dest = g_process_ipc_ids.leader_vmid ?: g_self_vmid;
+    IDTYPE dest = g_process_ipc_ids.leader_vmid ?: g_process_ipc_ids.self_vmid;
     return sync_msg_send(dest, code, id, state, data_size, data);
 }
 

--- a/LibOS/shim/src/ipc/shim_ipc_vmid.c
+++ b/LibOS/shim/src/ipc/shim_ipc_vmid.c
@@ -1,0 +1,61 @@
+/* SPDX-License-Identifier: LGPL-3.0-or-later */
+/* Copyright (C) 2021 Intel Corporation
+ *                    Borys Popławski <borysp@invisiblethingslab.com>
+ */
+
+#include "api.h"
+#include "log.h"
+#include "shim_ipc.h"
+#include "shim_types.h"
+#include "shim_utils.h"
+
+static IDTYPE g_last_vmid = STARTING_VMID;
+
+static IDTYPE get_next_vmid(void) {
+    return __atomic_add_fetch(&g_last_vmid, 1, __ATOMIC_RELAXED);
+}
+
+int ipc_get_new_vmid(IDTYPE* vmid) {
+    if (!g_process_ipc_ids.leader_vmid) {
+        *vmid = get_next_vmid();
+        return 0;
+    }
+
+    size_t msg_size = get_ipc_msg_size(0);
+    struct shim_ipc_msg* msg = malloc(msg_size);
+    if (!msg) {
+        return -ENOMEM;
+    }
+    init_ipc_msg(msg, IPC_MSG_GET_NEW_VMID, msg_size);
+
+    log_debug("%s: sending a request", __func__);
+
+    void* resp = NULL;
+    int ret = ipc_send_msg_and_get_response(g_process_ipc_ids.leader_vmid, msg, &resp);
+    if (ret < 0) {
+        goto out;
+    }
+
+    *vmid = *(IDTYPE*)resp;
+    ret = 0;
+    log_debug("%s: got a response: %u", __func__, *vmid);
+
+out:
+    free(resp);
+    free(msg);
+    return ret;
+}
+
+int ipc_get_new_vmid_callback(IDTYPE src, void* data, uint64_t seq) {
+    __UNUSED(data);
+    IDTYPE vmid = get_next_vmid();
+
+    log_debug("%s: %u", __func__, vmid);
+
+    size_t msg_size = get_ipc_msg_size(sizeof(vmid));
+    struct shim_ipc_msg* msg = __alloca(msg_size);
+    init_ipc_response(msg, seq, msg_size);
+    memcpy(&msg->data, &vmid, sizeof(vmid));
+
+    return ipc_send_message(src, msg);
+}

--- a/LibOS/shim/src/ipc/shim_ipc_worker.c
+++ b/LibOS/shim/src/ipc/shim_ipc_worker.c
@@ -46,6 +46,7 @@ static PAL_HANDLE g_self_ipc_handle = NULL;
 typedef int (*ipc_callback)(IDTYPE src, void* data, uint64_t seq);
 static ipc_callback ipc_callbacks[] = {
     [IPC_MSG_RESP]              = ipc_response_callback,
+    [IPC_MSG_GET_NEW_VMID]      = ipc_get_new_vmid_callback,
     [IPC_MSG_CHILDEXIT]         = ipc_cld_exit_callback,
     [IPC_MSG_ALLOC_ID_RANGE]    = ipc_alloc_id_range_callback,
     [IPC_MSG_RELEASE_ID_RANGE]  = ipc_release_id_range_callback,

--- a/LibOS/shim/src/meson.build
+++ b/LibOS/shim/src/meson.build
@@ -48,6 +48,7 @@ libos_sources = files(
     'ipc/shim_ipc_process_info.c',
     'ipc/shim_ipc_signal.c',
     'ipc/shim_ipc_sync.c',
+    'ipc/shim_ipc_vmid.c',
     'ipc/shim_ipc_worker.c',
     'shim_async.c',
     'shim_checkpoint.c',

--- a/LibOS/shim/src/shim_checkpoint.c
+++ b/LibOS/shim/src/shim_checkpoint.c
@@ -499,8 +499,9 @@ int create_process_and_send_checkpoint(migrate_func_t migrate_func,
     }
 
     struct shim_ipc_ids process_ipc_ids = {
-        .parent_vmid = g_self_vmid,
-        .leader_vmid = g_process_ipc_ids.leader_vmid ?: g_self_vmid,
+        .self_vmid = child_process->vmid,
+        .parent_vmid = g_process_ipc_ids.self_vmid,
+        .leader_vmid = g_process_ipc_ids.leader_vmid ?: g_process_ipc_ids.self_vmid,
     };
     va_list ap;
     va_start(ap, thread_description);
@@ -559,9 +560,9 @@ int create_process_and_send_checkpoint(migrate_func_t migrate_func,
     }
     bkeep_remove_tmp_vma(tmp_vma);
 
-    /* wait for final ack from child process (contains VMID of child) */
-    IDTYPE child_vmid = 0;
-    ret = read_exact(pal_process, &child_vmid, sizeof(child_vmid));
+    /* wait for final ack from child process */
+    char dummy_c = 0;
+    ret = read_exact(pal_process, &dummy_c, sizeof(dummy_c));
     if (ret < 0) {
         goto out;
     }
@@ -569,10 +570,9 @@ int create_process_and_send_checkpoint(migrate_func_t migrate_func,
     /* Child creation was successful, now we add it to the children list. Child process should have
      * already connected to us, but is waiting for an acknowledgement, so it will not send any IPC
      * messages yet. */
-    child_process->vmid = child_vmid;
     add_child_process(child_process);
 
-    char dummy_c = 0;
+    dummy_c = 0;
     ret = write_exact(pal_process, &dummy_c, sizeof(dummy_c));
     if (ret < 0) {
         /*
@@ -582,7 +582,7 @@ int create_process_and_send_checkpoint(migrate_func_t migrate_func,
          * after we return from this function.
          */
         log_error("failed to send process creation ack to the child: %d", ret);
-        (void)mark_child_exited_by_vmid(child_vmid, /*uid=*/0, /*exit_code=*/0, SIGPWR);
+        (void)mark_child_exited_by_vmid(child_process->vmid, /*uid=*/0, /*exit_code=*/0, SIGPWR);
     }
 
     ret = 0;

--- a/LibOS/shim/src/sys/shim_clone.c
+++ b/LibOS/shim/src/sys/shim_clone.c
@@ -192,10 +192,11 @@ static long do_clone_new_vm(unsigned long flags, struct shim_thread* thread, uns
     child_process->pid = process_description.pid;
     child_process->child_termination_signal = flags & CSIGNAL;
     child_process->uid = thread->uid;
-    /* `child_process->vmid` is set by the checkpointing function below. */
-
-    long ret = create_process_and_send_checkpoint(&migrate_fork, child_process,
-                                                  &process_description, thread);
+    long ret = ipc_get_new_vmid(&child_process->vmid);
+    if (!ret) {
+        ret = create_process_and_send_checkpoint(&migrate_fork, child_process, &process_description,
+                                                 thread);
+    }
 
     if (parent_stack) {
         pal_context_set_sp(self->shim_tcb->context.regs, parent_stack);
@@ -357,7 +358,7 @@ long shim_do_clone(unsigned long flags, unsigned long user_stack_addr, int* pare
             /* The child process might have already taken the ownership of `tid`, let's change it
              * back (if we still own it, this call will split `tid` from any other range, if it is
              * a part of one)... */
-            int tmp_ret = ipc_change_id_owner(tid, g_self_vmid);
+            int tmp_ret = ipc_change_id_owner(tid, g_process_ipc_ids.self_vmid);
             if (tmp_ret < 0) {
                 log_debug("Failed to change back ID %u owner: %d", tid, tmp_ret);
                 /* No way to recover gracefully. */

--- a/LibOS/shim/src/sys/shim_exit.c
+++ b/LibOS/shim/src/sys/shim_exit.c
@@ -56,10 +56,10 @@ static noreturn void libos_clean_and_exit(int exit_code) {
 
     terminate_ipc_worker();
 
-    log_debug("process %u exited with status %d", g_self_vmid, exit_code);
+    log_debug("process %u exited with status %d", g_process_ipc_ids.self_vmid, exit_code);
 
-    /* TODO: We exit whole libos, but there are some objects that might need cleanup, e.g. we should
-     * release this (last) thread pid. We should do a proper cleanup of everything. */
+    /* TODO: We exit whole libos, but there are some objects that might need cleanup - we should do
+     * a proper cleanup of everything. */
     DkProcessExit(exit_code);
 }
 

--- a/LibOS/shim/src/utils/log.c
+++ b/LibOS/shim/src/utils/log.c
@@ -47,7 +47,7 @@ void log_setprefix(shim_tcb_t* tcb) {
         exec_name = "";
     }
 
-    uint32_t vmid = g_self_vmid;
+    uint32_t vmid = g_process_ipc_ids.self_vmid;
     size_t total_len;
     if (tcb->tp) {
         if (!is_internal(tcb->tp)) {
@@ -63,7 +63,7 @@ void log_setprefix(shim_tcb_t* tcb) {
         total_len = snprintf(tcb->log_prefix, ARRAY_SIZE(tcb->log_prefix), "[P%u::%s] ", vmid,
                              exec_name);
     } else {
-        /* unknown process (must never happen): show exec name */
+        /* unknown process (happens on process init): show exec name */
         total_len = snprintf(tcb->log_prefix, ARRAY_SIZE(tcb->log_prefix), "[::%s] ", exec_name);
     }
     if (total_len > ARRAY_SIZE(tcb->log_prefix) - 1) {

--- a/Pal/include/pal/pal.h
+++ b/Pal/include/pal/pal.h
@@ -127,7 +127,6 @@ typedef struct PAL_MEM_INFO_ {
 /********** PAL APIs **********/
 typedef struct PAL_CONTROL_ {
     PAL_STR host_type;
-    PAL_NUM process_id; /*!< An identifier of current picoprocess */
 
     /*
      * Handles and executables

--- a/Pal/include/pal_internal.h
+++ b/Pal/include/pal_internal.h
@@ -159,7 +159,6 @@ noreturn void pal_main(uint64_t instance_id, PAL_HANDLE parent_process, PAL_HAND
 
 void _DkGetAvailableUserAddressRange(PAL_PTR* start, PAL_PTR* end);
 bool _DkCheckMemoryMappable(const void* addr, size_t size);
-PAL_NUM _DkGetProcessId(void);
 unsigned long _DkMemoryQuota(void);
 unsigned long _DkMemoryAvailableQuota(void);
 // Returns 0 on success, negative PAL code on failure

--- a/Pal/regression/Bootstrap.c
+++ b/Pal/regression/Bootstrap.c
@@ -12,9 +12,6 @@ int main(int argc, char** argv, char** envp) {
         pal_printf("argv[%d] = %s\n", i, argv[i]);
     }
 
-    /* unique process ID */
-    pal_printf("Process ID: %016lx\n", pal_control.process_id);
-
     /* parent process */
     pal_printf("Parent Process: %p\n", pal_control.parent_process);
 

--- a/Pal/src/db_main.c
+++ b/Pal/src/db_main.c
@@ -427,7 +427,6 @@ noreturn void pal_main(uint64_t instance_id,       /* current instance id */
     }
 
     g_pal_control.host_type       = XSTRINGIFY(HOST_TYPE);
-    g_pal_control.process_id      = _DkGetProcessId();
     g_pal_control.manifest_root   = g_pal_state.manifest_root;
     g_pal_control.parent_process  = parent_process;
     g_pal_control.first_thread    = first_thread;

--- a/Pal/src/host/Linux-SGX/db_main.c
+++ b/Pal/src/host/Linux-SGX/db_main.c
@@ -61,10 +61,6 @@ void _DkGetAvailableUserAddressRange(PAL_PTR* start, PAL_PTR* end) {
     }
 }
 
-PAL_NUM _DkGetProcessId(void) {
-    return g_linux_state.process_id;
-}
-
 #include "dynamic_link.h"
 #include "elf-x86_64.h"
 
@@ -632,8 +628,6 @@ noreturn void pal_linux_main(char* uptr_libpal_uri, size_t libpal_uri_len, char*
 
     g_linux_state.uid = g_pal_sec.uid;
     g_linux_state.gid = g_pal_sec.gid;
-    /* TODO: guard this from malicious host. https://github.com/oscarlab/graphene/issues/2087 */
-    g_linux_state.process_id = g_pal_sec.pid;
 
     SET_ENCLAVE_TLS(ready_for_exceptions, 1UL);
 

--- a/Pal/src/host/Linux-SGX/pal_linux.h
+++ b/Pal/src/host/Linux-SGX/pal_linux.h
@@ -29,8 +29,6 @@
 #define IS_UNIX_ERR INTERNAL_SYSCALL_ERRNO_RANGE
 
 extern struct pal_linux_state {
-    PAL_NUM process_id;
-
     const char** host_environ;
 
     /* credentials */

--- a/Pal/src/host/Linux/db_main.c
+++ b/Pal/src/host/Linux/db_main.c
@@ -126,10 +126,6 @@ void _DkGetAvailableUserAddressRange(PAL_PTR* start, PAL_PTR* end) {
     *start = (PAL_PTR)start_addr;
 }
 
-PAL_NUM _DkGetProcessId(void) {
-    return g_linux_state.process_id;
-}
-
 #include "dynamic_link.h"
 
 static struct link_map g_pal_map;
@@ -257,13 +253,10 @@ noreturn void pal_linux_main(void* initial_rsp, void* fini_callback) {
         log_warning("vvar address range not preloaded, is your system missing vvar?!");
     }
 
-    if (!g_pal_sec.process_id)
-        g_pal_sec.process_id = INLINE_SYSCALL(getpid, 0);
-    g_linux_state.pid = g_pal_sec.process_id;
+    g_linux_state.pid = INLINE_SYSCALL(getpid, 0);
 
     g_linux_state.uid = g_uid;
     g_linux_state.gid = g_gid;
-    g_linux_state.process_id = g_linux_state.pid;
 
     PAL_HANDLE parent = NULL;
     char* manifest = NULL;

--- a/Pal/src/host/Linux/db_process.c
+++ b/Pal/src/host/Linux/db_process.c
@@ -211,8 +211,6 @@ int _DkProcessCreate(PAL_HANDLE* handle, const char** args) {
         goto out;
     }
 
-    proc_args->pal_sec.process_id = ret;
-
     /* children unblock async signals by signal_setup() */
     ret = block_async_signals(false);
     if (ret < 0)

--- a/Pal/src/host/Linux/pal_linux.h
+++ b/Pal/src/host/Linux/pal_linux.h
@@ -31,8 +31,6 @@ struct timespec;
 struct timeval;
 
 extern struct pal_linux_state {
-    PAL_NUM         process_id;
-
 #ifdef DEBUG
     bool            in_gdb;
 #endif

--- a/Pal/src/host/Linux/pal_security.h
+++ b/Pal/src/host/Linux/pal_security.h
@@ -11,7 +11,6 @@
 
 extern struct pal_sec {
     /* system variables */
-    unsigned int process_id;
     int random_device;
 } g_pal_sec;
 

--- a/Pal/src/host/Skeleton/db_main.c
+++ b/Pal/src/host/Skeleton/db_main.c
@@ -19,10 +19,6 @@ void _DkGetAvailableUserAddressRange(PAL_PTR* start, PAL_PTR* end) {
     /* needs to be implemented */
 }
 
-PAL_NUM _DkGetProcessId(void) {
-    return 0;
-}
-
 int _DkGetCPUInfo(PAL_CPU_INFO* ci) {
     /* needs to be implemented */
     return 0;


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->
Previously Graphene internal IDs were just equal to host PIDs, which was a security issue on SGX PAL.

Fixes #2087

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2526)
<!-- Reviewable:end -->
