### PR TITLE
[CI] Test SGX remote attestation examples on Ubuntu 18.04 and 20.04

### DIFF
--- a/.ci/lib/stage-test-sgx.jenkinsfile
+++ b/.ci/lib/stage-test-sgx.jenkinsfile
@@ -103,9 +103,6 @@ stage('test-sgx') {
     }
     timeout(time: 5, unit: 'MINUTES') {
         sh '''
-            # test SGX remote attestation only on Ubuntu 18.04 to keep internet requests to minimum
-            .ci/isdistro bionic || exit 0
-
             cd Examples/ra-tls-mbedtls
             if [ "${ra_client_spid}" != "" ] && [ "${ra_client_key}" != "" ]; \
             then \
@@ -123,9 +120,6 @@ stage('test-sgx') {
     }
     timeout(time: 5, unit: 'MINUTES') {
         sh '''
-            # test SGX remote attestation only on Ubuntu 18.04 to keep internet requests to minimum
-            .ci/isdistro bionic || exit 0
-
             cd Examples/ra-tls-secret-prov
             if [ "${ra_client_spid}" != "" ] && [ "${ra_client_key}" != "" ]; \
             then \


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Previously, it was tested only on Ubuntu 18.04 (bionic) due to concerns over sending too many EPID requests to the Intel Attestation Service (IAS). This shouldn't be an issue anymore.

## How to test this PR? <!-- (if applicable) -->

Trigger Jenkins several times to be sure.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2534)
<!-- Reviewable:end -->
