### PR TITLE
[Pal/Linux-SGX] Restrict Untrusted RSP to point outside the enclave

### DIFF
--- a/Pal/src/host/Linux-SGX/enclave_entry.S
+++ b/Pal/src/host/Linux-SGX/enclave_entry.S
@@ -169,8 +169,23 @@ enclave_entry:
 1:
 
 	movq %gs:SGX_GPR, %rbx
-
 	movq %rdi, %rsi
+
+	# note that g_enclave_base/g_enclave_top are initialized only after the first ENCLAVE_START
+	# ecall, and below check always fails before this initialization is done -- this limitation is
+	# fine because we don't expect exceptions until the enclave is actually started
+	movq SGX_GPR_URSP(%rbx), %rdi
+	movq g_enclave_base(%rip), %rax
+	cmpq %rax, %rdi
+	jb 1f
+	movq g_enclave_top(%rip), %rax
+	cmpq %rax, %rdi
+	ja 1f
+
+	# detected malicious Untrusted RSP (g_enclave_base <= ursp && ursp <= g_enclave_top)
+	FAIL_LOOP
+1:
+
 	xorq %rdi, %rdi
 	movl SGX_GPR_EXITINFO(%rbx), %edi
 	testl $0x80000000, %edi

--- a/Pal/src/host/Linux-SGX/generated-offsets.c
+++ b/Pal/src/host/Linux-SGX/generated-offsets.c
@@ -50,6 +50,7 @@ __attribute__((__used__)) static void dummy(void) {
     OFFSET_T(SGX_GPR_R15, sgx_pal_gpr_t, r15);
     OFFSET_T(SGX_GPR_RFLAGS, sgx_pal_gpr_t, rflags);
     OFFSET_T(SGX_GPR_RIP, sgx_pal_gpr_t, rip);
+    OFFSET_T(SGX_GPR_URSP, sgx_pal_gpr_t, ursp);
     OFFSET_T(SGX_GPR_EXITINFO, sgx_pal_gpr_t, exitinfo);
     DEFINE(SGX_GPR_SIZE, sizeof(sgx_pal_gpr_t));
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Untrusted RSP value (`SSA[0].ursp`) is not sanitized by the SGX hardware upon EENTER/ERESUME and may be controlled by the attacker. To prevent any possibility of tampering with this value, we simply disallow it to point inside the SGX enclave.

## How to test this PR? <!-- (if applicable) -->

All tests must pass.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2546)
<!-- Reviewable:end -->
