### PR TITLE
[LTP] Fix path for `libstdbuf.so` on CentOS/Fedora

### DIFF
--- a/LibOS/shim/test/ltp/manifest.template
+++ b/LibOS/shim/test/ltp/manifest.template
@@ -39,6 +39,6 @@ sgx.trusted_files.libdl = "file:{{ graphene.runtimedir() }}/libdl.so.2"
 sgx.trusted_files.libm = "file:{{ graphene.runtimedir() }}/libm.so.6"
 sgx.trusted_files.libpthread = "file:{{ graphene.runtimedir() }}/libpthread.so.0"
 sgx.trusted_files.librt = "file:{{ graphene.runtimedir() }}/librt.so.1"
-sgx.trusted_files.libstdbuf = "file:/usr/{{ arch_libdir }}/coreutils/libstdbuf.so"
+sgx.trusted_files.libstdbuf = "file:{{ coreutils_libdir }}/libstdbuf.so"
 
 sgx.allowed_files.tmp = "file:/tmp"


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Commit ee5acd1 from Stefan Berger fixed running LTP tests on CentOS/Fedora by identifying a correct path for coreutils' libstdbuf library. However, this commit missed one place in the manifest file (because Stefan doesn't test SGX-related options in the manifest).

For context, see https://github.com/oscarlab/graphene/pull/1617.

Fixes #2475.

## How to test this PR? <!-- (if applicable) -->

Test LTP on CentOS.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2555)
<!-- Reviewable:end -->
