### PR TITLE
[LibOS] Error out on messages containing ancillary data

### DIFF
--- a/LibOS/shim/src/sys/shim_socket.c
+++ b/LibOS/shim/src/sys/shim_socket.c
@@ -1212,6 +1212,11 @@ static int check_msghdr(struct msghdr* msg, bool is_recv) {
         }
     }
 
+    if (msg->msg_controllen != 0) {
+        log_warning("\"struct msghdr\" ancillary data is not supported");
+        return -ENOSYS;
+    }
+
     return 0;
 }
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->
Previously if there was some ancillary data in `struct msghdr` e.g. sent via `sendmsg`, Graphene would silently ignore it and move on. Now it explicitly errors out with a warning (ancillary data is not yet supported).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2557)
<!-- Reviewable:end -->
