### PR TITLE
[Pal/Linux-SGX]Fix pointer check issues

### DIFF
--- a/Pal/src/db_main.c
+++ b/Pal/src/db_main.c
@@ -111,6 +111,8 @@ static int insert_envs_from_manifest(const char*** envpp) {
     size_t idx = 0;
     for (const char** orig_env = *envpp; *orig_env; orig_env++) {
         char* orig_env_key_end = strchr(*orig_env, '=');
+        if (!orig_env_key_end)
+           return -PAL_ERROR_DENIED;
 
         *orig_env_key_end = '\0';
         toml_raw_t toml_env_raw = toml_raw_in(toml_envs, *orig_env);
@@ -130,7 +132,9 @@ static int insert_envs_from_manifest(const char*** envpp) {
 
     for (ssize_t i = 0; i < toml_envs_cnt; i++) {
         const char* toml_env_key = toml_key_in(toml_envs, i);
-        assert(toml_env_key);
+        if (!toml_env_key)
+           return -PAL_ERROR_DENIED;
+
         toml_raw_t toml_env_value_raw = toml_raw_in(toml_envs, toml_env_key);
         assert(toml_env_value_raw);
 

--- a/Pal/src/host/Linux-SGX/db_misc.c
+++ b/Pal/src/host/Linux-SGX/db_misc.c
@@ -391,6 +391,9 @@ int _DkCpuIdRetrieve(unsigned int leaf, unsigned int subleaf, unsigned int value
         }
     }
 
+    if (!known_leaf)
+       goto fail;
+
     if ((leaf == 0x07 && subleaf != 0 && subleaf != 1) ||
         (leaf == 0x0F && subleaf != 0 && subleaf != 1) ||
         (leaf == 0x10 && subleaf != 0 && subleaf != 1 && subleaf != 2) ||


### PR DESCRIPTION
These issues were flagged by Klocwork

Pointer 'known_leaf' checked for NULL at line 380 may be dereferenced at line 402.
/graphene/Pal/src/host/Linux-SGX/db_misc.c:402 | _DkCpuIdRetrieve()

Null pointer 'known_leaf' that comes from line 372 may be dereferenced at line 402.
/graphene/Pal/src/host/Linux-SGX/db_misc.c:402 | _DkCpuIdRetrieve()

Pointer 'orig_env_key_end' returned from call to function 'strchr' at line 113 may be NULL and will be dereferenced at line 115.
/Pal/src/db_main.c:115 | insert_envs_from_manifest()

Pointer 'toml_env_key' returned from call to function 'toml_key_in' at line 132 may be NULL and may be dereferenced at line 144.
Pal/src/db_main.c:144 | insert_envs_from_manifest()

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2559)
<!-- Reviewable:end -->
