### PR TITLE
[LibOS] Use a lock in `shim_debug`

### DIFF
--- a/LibOS/shim/include/shim_utils.h
+++ b/LibOS/shim/include/shim_utils.h
@@ -148,6 +148,7 @@ noreturn void execute_elf_object(struct shim_handle* exec, void* argp, elf_auxv_
 int remove_loaded_libraries(void);
 
 /* gdb debugging support */
+int init_r_debug(void);
 void remove_r_debug(void* addr);
 void append_r_debug(const char* uri, void* addr);
 void clean_link_map_list(void);

--- a/LibOS/shim/src/shim_debug.c
+++ b/LibOS/shim/src/shim_debug.c
@@ -2,20 +2,25 @@
 /* Copyright (C) 2014 Stony Brook University */
 
 /*
- * This file contains code for registering libraries to GDB.
+ * This file contains code for registering libraries for debugger integration. We report the
+ * libraries to PAL using `DkDebugMapAdd`/`DkDebugMapRemove`.
+ *
+ * We also keep our own list of reported libraries, so that we can copy them to the child process,
+ * or remove them all (in case of `exec`).
  */
 
+#include "list.h"
 #include "pal.h"
-#include "pal_error.h"
 #include "shim_checkpoint.h"
-#include "shim_fs.h"
-#include "shim_handle.h"
-#include "shim_internal.h"
-#include "shim_ipc.h"
-#include "shim_tcb.h"
-#include "shim_vma.h"
+#include "shim_lock.h"
+#include "shim_types.h"
+#include "shim_utils.h"
 
 #ifndef DEBUG
+
+int init_r_debug(void) {
+    return 0;
+}
 
 void clean_link_map_list(void) {
     /* do nothing */
@@ -34,136 +39,124 @@ void append_r_debug(const char* uri, void* addr) {
 
 #else /* !DEBUG */
 
+DEFINE_LISTP(gdb_link_map);
+DEFINE_LIST(gdb_link_map);
 struct gdb_link_map {
     void* l_addr;
     char* l_name;
-    struct gdb_link_map *l_next, *l_prev;
+
+    LIST_TYPE(gdb_link_map) list;
 };
 
-/* XXX: What lock protects this?  vma_list_lock? */
-static struct gdb_link_map* link_map_list = NULL;
+static LISTP_TYPE(gdb_link_map) g_link_map_list = LISTP_INIT;
+static struct shim_lock g_link_map_list_lock;
+
+int init_r_debug(void) {
+    return create_lock(&g_link_map_list_lock);
+}
 
 void clean_link_map_list(void) {
-    if (!link_map_list)
-        return;
+    lock(&g_link_map_list_lock);
 
-    if (link_map_list->l_prev)
-        link_map_list->l_prev->l_next = NULL;
-
-    struct gdb_link_map* m = link_map_list;
-    struct gdb_link_map* next;
-    for (; m; m = next) {
+    struct gdb_link_map* m;
+    struct gdb_link_map* tmp;
+    LISTP_FOR_EACH_ENTRY_SAFE(m, tmp, &g_link_map_list, list) {
+        LISTP_DEL(m, &g_link_map_list, list);
         DkDebugMapRemove(m->l_addr);
-        next = m->l_next;
         free(m);
     }
 
-    link_map_list = NULL;
+    unlock(&g_link_map_list_lock);
 }
 
 void remove_r_debug(void* addr) {
-    struct gdb_link_map* m = link_map_list;
+    lock(&g_link_map_list_lock);
 
-    for (; m; m = m->l_next)
-        if (m->l_addr == addr)
+    struct gdb_link_map* m;
+    bool found = false;
+    LISTP_FOR_EACH_ENTRY(m, &g_link_map_list, list) {
+        if (m->l_addr == addr) {
+            found = true;
             break;
-
-    if (!m)
-        return;
-
-    log_debug("removing a library for gdb: %s", m->l_name);
-
-    if (m->l_prev) {
-        m->l_prev->l_next = m->l_next;
-    } else {
-        link_map_list = m->l_next;
+        }
     }
 
-    if (m->l_next) {
-        m->l_next->l_prev = m->l_prev;
+    if (!found) {
+        /* No map found. This is normal because we call remove_r_debug() on every munmap
+         * operation. */
+        goto out;
     }
 
+    log_debug("%s: removing %s at %p", __func__, m->l_name, addr);
+    LISTP_DEL(m, &g_link_map_list, list);
     DkDebugMapRemove(addr);
     free(m);
+
+out:
+    unlock(&g_link_map_list_lock);
 }
 
 void append_r_debug(const char* uri, void* addr) {
+    lock(&g_link_map_list_lock);
+
     struct gdb_link_map* new = malloc(sizeof(struct gdb_link_map));
-    if (!new)
-        return;
+    if (!new) {
+        log_warning("%s: couldn't allocate map", __func__);
+        goto out;
+    }
 
     char* new_uri = strdup(uri);
     if (!new_uri) {
-        free(new);
-        return;
+        log_warning("%s: couldn't allocate uri", __func__);
+        goto out;
     }
 
     new->l_addr = addr;
     new->l_name = new_uri;
 
-    struct gdb_link_map* prev  = NULL;
-    struct gdb_link_map** tail = &link_map_list;
-
-    while (*tail) {
-        prev = *tail;
-        tail = &(*tail)->l_next;
-    }
-
-    log_debug("adding a library for gdb: %s", uri);
-
-    new->l_prev = prev;
-    new->l_next = NULL;
-    *tail       = new;
-
+    log_debug("%s: adding %s at %p", __func__, uri, addr);
+    LISTP_ADD_TAIL(new, &g_link_map_list, list);
     DkDebugMapAdd(uri, addr);
+
+out:
+    unlock(&g_link_map_list_lock);
 }
 
 BEGIN_CP_FUNC(gdb_map) {
     __UNUSED(obj);
     __UNUSED(size);
     __UNUSED(objp);
-    struct gdb_link_map* m    = link_map_list;
-    struct gdb_link_map* newm = NULL;
 
-    while (m) {
+    lock(&g_link_map_list_lock);
+
+    struct gdb_link_map* m;
+    LISTP_FOR_EACH_ENTRY(m, &g_link_map_list, list) {
         size_t off = ADD_CP_OFFSET(sizeof(struct gdb_link_map));
-        newm       = (struct gdb_link_map*)(base + off);
+        struct gdb_link_map* newm = (struct gdb_link_map*)(base + off);
 
-        *newm = *m;
-        newm->l_prev = newm->l_next = NULL;
+        newm->l_addr = m->l_addr;
 
-        size_t len   = strlen(newm->l_name);
+        size_t len   = strlen(m->l_name);
         newm->l_name = (char*)(base + ADD_CP_OFFSET(len + 1));
         memcpy(newm->l_name, m->l_name, len + 1);
 
+        INIT_LIST_HEAD(newm, list);
+
         ADD_CP_FUNC_ENTRY(off);
-        m = m->l_next;
     }
+
+    unlock(&g_link_map_list_lock);
 }
 END_CP_FUNC(gdb_map)
 
 BEGIN_RS_FUNC(gdb_map) {
     __UNUSED(offset);
-    struct gdb_link_map* map = (void*)(base + GET_CP_FUNC_ENTRY());
+    struct gdb_link_map* m = (void*)(base + GET_CP_FUNC_ENTRY());
 
-    CP_REBASE(map->l_name);
-    CP_REBASE(map->l_prev);
-    CP_REBASE(map->l_next);
+    CP_REBASE(m->l_name);
 
-    struct gdb_link_map* prev  = NULL;
-    struct gdb_link_map** tail = &link_map_list;
-
-    while (*tail) {
-        prev = *tail;
-        tail = &(*tail)->l_next;
-    }
-
-    map->l_prev = prev;
-    *tail       = map;
-
-    DkDebugMapAdd(map->l_name, map->l_addr);
-
-    DEBUG_RS("base=%p,name=%s", map->l_addr, map->l_name);
+    LISTP_ADD_TAIL(m, &g_link_map_list, list);
+    DkDebugMapAdd(m->l_name, m->l_addr);
 }
 END_RS_FUNC(gdb_map)
 

--- a/LibOS/shim/src/shim_init.c
+++ b/LibOS/shim/src/shim_init.c
@@ -411,6 +411,7 @@ noreturn void* shim_init(int argc, void* args) {
     RUN_INIT(init_fs_lock);
     RUN_INIT(init_dcache);
     RUN_INIT(init_handle);
+    RUN_INIT(init_r_debug);
 
     log_debug("Shim loaded at %p, ready to initialize", &__load_address);
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

This solves a small TODO: the global debug map list was not protected by any lock. I'm not sure if that ever caused problems, but now it should be correct.

In addition, I took the opportunity to convert the global variable name to `g_*`, and use standard `list.h` instead of ad-hoc lists.

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->

Existing tests should be enough: they include GDB integration, as well as various fork and exec scenarios.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2560)
<!-- Reviewable:end -->
