### PR TITLE
[LibOS] Checkpoint `g_dentry_root`

### DIFF
--- a/LibOS/shim/include/shim_fs.h
+++ b/LibOS/shim/include/shim_fs.h
@@ -267,9 +267,6 @@ struct shim_mount {
     LIST_TYPE(shim_mount) list;
 };
 
-/* TODO: This actually does not get migrated after a fork. We migrate `g_process.root`, which is
- * enough for Graphene to function, but leaves `g_dentry_root` in child process pointing to an empty
- * directory. */
 extern struct shim_dentry* g_dentry_root;
 
 #define F_OK 0

--- a/LibOS/shim/src/sys/shim_clone.c
+++ b/LibOS/shim/src/sys/shim_clone.c
@@ -107,6 +107,7 @@ static BEGIN_MIGRATION_DEF(fork, struct shim_process* process_description,
                            struct shim_thread* thread_description,
                            struct shim_ipc_ids* process_ipc_ids) {
     DEFINE_MIGRATE(process_ipc_ids, process_ipc_ids, sizeof(*process_ipc_ids));
+    DEFINE_MIGRATE(dentry_root, NULL, 0);
     DEFINE_MIGRATE(all_mounts, NULL, 0);
     DEFINE_MIGRATE(all_vmas, NULL, 0);
     DEFINE_MIGRATE(process_description, process_description, sizeof(*process_description));


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://graphene.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

Previously, the child process initialized `g_dentry_root` but restored all other dentries from a checkpoint. As a result, `g_dentry_root` was an isolated dentry. This worked only because the rest of the code used `g_process.root` which was checkpointed.

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->

As mentioned above, this should not be noticeable from outside. However, if you do `dump_dcache(NULL)`, on this branch it will display the dentry tree copied from parent, and on `master` it will display an empty dentry tree.

You can also take a look at `g_dentry_root` in GDB: it should have `attached_mount`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2561)
<!-- Reviewable:end -->
