### PR TITLE
[.dir-locals.el] Use 80 columns for Markdown files

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -7,6 +7,7 @@
  (asm-mode . ((indent-tabs-mode . t)))
  (shell-script-mode . ((indent-tabs-mode . t)))
  ("\.git/COMMIT_EDITMSG" . ((nil . ((fill-column . 80)))))
+ (markdown-mode . ((fill-column . 80)))
  (rst-mode . ((fill-column . 80)))
  ((nil . ((truncate-lines . t)))
           (text-mode . ((eval . ((turn-on-auto-fill)))))))


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

As discussed in #2566, we want README.md files to be wrapped at 80 columns, same as rest of documentation. This adds a directive for Emacs to understand that.

## How to test this PR? <!-- (if applicable) -->

* Open Emacs, install markdown-mode if necessary (`M-x package-install`, `markdown-mode`)
* Open any README.md file in Emacs
* Try to wrap a paragraph with `M-q`. Emacs should wrap it at 80 columns.
* In Emacs 28+: display fill column (`M-x global-display-fill-column-indicator-mode`), it should be displayed at 80 columns in .md files (and at 100 colums for .c files).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2568)
<!-- Reviewable:end -->
