### PR TITLE
Fix compilation under Clang

### DIFF
--- a/LibOS/shim/src/bookkeep/shim_process.c
+++ b/LibOS/shim/src/bookkeep/shim_process.c
@@ -151,14 +151,10 @@ static bool mark_child_exited(child_cmp_t child_cmp, unsigned long arg, IDTYPE c
     /* We send signal to our process while still holding the lock, so that no thread is able to
      * see 0 pending signals but still get an exited child info. */
     if (parent_signal) {
-        siginfo_t info = {
-            .si_signo = parent_signal,
-            .si_pid = child_pid,
-            .si_uid = child_uid,
-            /* These 2 fields are not supported in Graphene. */
-            .si_utime = 0,
-            .si_stime = 0,
-        };
+        siginfo_t info = {0};
+        info.si_signo = parent_signal;
+        info.si_pid = child_pid;
+        info.si_uid = child_uid;
         fill_siginfo_code_and_status(&info, signal, exit_code);
         int x = kill_current_proc(&info);
         if (x < 0) {

--- a/LibOS/shim/src/fs/shim_namei.c
+++ b/LibOS/shim/src/fs/shim_namei.c
@@ -19,14 +19,6 @@
 #include "shim_utils.h"
 #include "stat.h"
 
-/* Advances a char pointer (string) past any repeated slashes and returns the result.
- * Must be a null-terminated string. */
-static inline const char* eat_slashes(const char* string) {
-    while (*string == '/')
-        string++;
-    return string;
-}
-
 int check_permissions(struct shim_dentry* dent, mode_t mask) {
     assert(locked(&g_dcache_lock));
     assert(dent->state & DENTRY_VALID);

--- a/Pal/include/arch/x86_64/Linux/pal_host-arch.h
+++ b/Pal/include/arch/x86_64/Linux/pal_host-arch.h
@@ -15,11 +15,13 @@
 #include <asm/prctl.h>
 #endif
 
+#include "api.h"
 #include "sysdep-arch.h"
 
 /* Graphene uses GCC's stack protector that looks for canary at gs:[0x8], but this function changes
  * the GS register value, so we disable stack protector here (even though it is mostly inlined) */
-__attribute__((__optimize__("-fno-stack-protector"))) static inline int pal_set_tcb(PAL_TCB* tcb) {
+__attribute_no_stack_protector
+static inline int pal_set_tcb(PAL_TCB* tcb) {
     return INLINE_SYSCALL(arch_prctl, 2, ARCH_SET_GS, tcb);
 }
 

--- a/Pal/include/arch/x86_64/pal-arch.h
+++ b/Pal/include/arch/x86_64/pal-arch.h
@@ -47,7 +47,7 @@ typedef struct pal_tcb {
     /* data private to PAL implementation follows this struct. */
 } PAL_TCB;
 
-__attribute__((__optimize__("-fno-stack-protector")))
+__attribute_no_stack_protector
 static inline void pal_tcb_arch_set_stack_canary(PAL_TCB* tcb, uint64_t canary) {
     tcb->stack_protector_canary = canary;
 }

--- a/Pal/src/host/Linux-SGX/Makefile
+++ b/Pal/src/host/Linux-SGX/Makefile
@@ -17,7 +17,7 @@ CFLAGS += \
 
 # Some of the code uses alignof on expressions, which is a GNU extension.
 # Silence Clang - it complains but does support it.
-CFLAGS += $(cc-option,-Wno-gnu-alignof-expression)
+CFLAGS += $(call cc-option,-Wno-gnu-alignof-expression)
 
 ASFLAGS += \
 	-I. \

--- a/Pal/src/host/Linux-SGX/db_main.c
+++ b/Pal/src/host/Linux-SGX/db_main.c
@@ -513,7 +513,7 @@ extern void* g_enclave_top;
 
 /* Graphene uses GCC's stack protector that looks for a canary at gs:[0x8], but this function starts
  * with a default canary and then updates it to a random one, so we disable stack protector here */
-__attribute__((__optimize__("-fno-stack-protector")))
+__attribute_no_stack_protector
 noreturn void pal_linux_main(char* uptr_libpal_uri, size_t libpal_uri_len, char* uptr_args,
                              size_t args_size, char* uptr_env, size_t env_size,
                              struct pal_sec* uptr_sec_info) {

--- a/Pal/src/host/Linux-SGX/db_threading.c
+++ b/Pal/src/host/Linux-SGX/db_threading.c
@@ -51,7 +51,8 @@ static PAL_IDX pal_assign_tid(void) {
  * g_thread_list, initializes its TCB/TLS, and jumps into the callback-to-run. Graphene uses GCC's
  * stack protector that looks for a canary at gs:[0x8], but this function starts with a default
  * canary and then updates it to a random one, so we disable stack protector here. */
-__attribute__((__optimize__("-fno-stack-protector"))) void pal_start_thread(void) {
+__attribute_no_stack_protector
+void pal_start_thread(void) {
     struct pal_handle_thread *new_thread = NULL, *tmp;
 
     spinlock_lock(&g_thread_list_lock);

--- a/Pal/src/host/Linux-SGX/sgx_tls.h
+++ b/Pal/src/host/Linux-SGX/sgx_tls.h
@@ -83,7 +83,7 @@ static inline struct enclave_tls* get_tcb_trts(void) {
     } while (0)
 
 
-__attribute__((__optimize__("-fno-stack-protector")))
+__attribute_no_stack_protector
 static inline void pal_set_tcb_stack_canary(uint64_t canary) {
     ((char*)&canary)[0] = 0; /* prevent C-string-based stack leaks from exposing the cookie */
     SET_ENCLAVE_TLS(common.stack_protector_canary, canary);

--- a/Pal/src/host/Linux/db_main.c
+++ b/Pal/src/host/Linux/db_main.c
@@ -144,7 +144,7 @@ noreturn static void print_usage_and_exit(const char* argv_0) {
 
 /* Graphene uses GCC's stack protector that looks for a canary at gs:[0x8], but this function starts
  * with no TCB in the GS register, so we disable stack protector here */
-__attribute__((__optimize__("-fno-stack-protector")))
+__attribute_no_stack_protector
 noreturn void pal_linux_main(void* initial_rsp, void* fini_callback) {
     __UNUSED(fini_callback);  // TODO: We should call `fini_callback` at the end.
     int ret;

--- a/Pal/src/host/Linux/db_threading.c
+++ b/Pal/src/host/Linux/db_threading.c
@@ -78,7 +78,8 @@ out:
  * accepts a TCB pointer to be set to the GS register (on x86-64) of the thread. The rest of the TCB
  * is used as the alternate stack for signal handling. Since Graphene uses GCC's stack protector,
  * and this function modifies the stack protector's GS register, we disable stack protector here. */
-__attribute__((__optimize__("-fno-stack-protector"))) int pal_thread_init(void* tcbptr) {
+__attribute_no_stack_protector
+int pal_thread_init(void* tcbptr) {
     PAL_TCB_LINUX* tcb = tcbptr;
     int ret;
 

--- a/Pal/src/host/Linux/pal_linux.h
+++ b/Pal/src/host/Linux/pal_linux.h
@@ -170,7 +170,7 @@ static inline PAL_TCB_LINUX* get_tcb_linux(void) {
     return (PAL_TCB_LINUX*)pal_get_tcb();
 }
 
-__attribute__((__optimize__("-fno-stack-protector")))
+__attribute_no_stack_protector
 static inline void pal_tcb_set_stack_canary(PAL_TCB* tcb, uint64_t canary) {
     ((char*)&canary)[0] = 0; /* prevent C-string-based stack leaks from exposing the cookie */
     pal_tcb_arch_set_stack_canary(tcb, canary);

--- a/common/include/api.h
+++ b/common/include/api.h
@@ -138,6 +138,14 @@ typedef ptrdiff_t ssize_t;
 
 #define __alloca __builtin_alloca
 
+/* Clang has different syntax than GCC for no-stack-protector, see:
+ * https://reviews.llvm.org/D46300 */
+#ifdef __clang__
+#define __attribute_no_stack_protector __attribute((no_stack_protector))
+#else
+#define __attribute_no_stack_protector __attribute__((__optimize__("-fno-stack-protector")))
+#endif
+
 #define XSTRINGIFY(x) STRINGIFY(x)
 #define STRINGIFY(x)  #x
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

This fixes a few things that broke recently under Clang. We need to run Clang on Jenkins, but I think that can wait until the end of Meson migration.

## How to test this PR? <!-- (if applicable) -->

Build (run `make` and `ninja`) with `CC=clang CXX=clang++ AS=clang`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2570)
<!-- Reviewable:end -->
