### PR TITLE
[Pal/Linux-SGX] `is_sgx_available`: report whether AESMD is installed

### DIFF
--- a/Documentation/manpages/is_sgx_available.rst
+++ b/Documentation/manpages/is_sgx_available.rst
@@ -39,4 +39,4 @@ Exit status
    SGX Platform Software (:term:`PSW`) is not installed
 
 4
-   The ``aesmd`` :term:`PSW` daemon is not running
+   The ``aesmd`` :term:`PSW` daemon is not installed

--- a/Pal/src/host/Linux-SGX/tools/README.rst
+++ b/Pal/src/host/Linux-SGX/tools/README.rst
@@ -18,8 +18,8 @@ Example output::
     Max enclave size (64-bit): 0x1000000000
     EPC size: 0x5d80000
     SGX driver loaded: true
+    AESMD installed: true
     SGX PSW/libsgx installed: true
-    AESMD running: false
 
 The program terminates successfully if all SGX1 components are detected and running, otherwise
 the program exits with an error code (see the source code for possible values).

--- a/Pal/src/host/Linux-SGX/tools/is-sgx-available/is_sgx_available.cpp
+++ b/Pal/src/host/Linux-SGX/tools/is-sgx-available/is_sgx_available.cpp
@@ -15,8 +15,7 @@ enum ExitCodes {
     NO_CPU_SUPPORT = 1,
     NO_BIOS_SUPPORT = 2,
     PSW_NOT_INSTALLED = 3,
-    AESMD_NOT_RUNNING = 4 // This is a separate exit code, because AESMD tends
-                          // to die spontaneously.
+    AESMD_NOT_INSTALLED = 4
 };
 
 bool file_exists(const char* path) {
@@ -175,7 +174,7 @@ bool psw_installed() {
     return sgx_driver_loaded() && aesmd_installed;
 }
 
-bool aesmd_running() {
+bool aesmd_installed() {
     return file_exists("/var/run/aesmd/aesm.socket");
 }
 
@@ -209,8 +208,8 @@ void print_detailed_info(const SgxCpuChecker& cpu_checker) {
     printf("Max enclave size (64-bit): 0x%" PRIx64 "\n", cpu_checker.maximum_enclave_size_x64());
     printf("EPC size: 0x%" PRIx64 "\n", cpu_checker.epc_region_size());
     printf("SGX driver loaded: %s\n", bool2str(sgx_driver_loaded()));
+    printf("AESMD installed: %s\n", bool2str(aesmd_installed()));
     printf("SGX PSW/libsgx installed: %s\n", bool2str(psw_installed()));
-    printf("AESMD running: %s\n", bool2str(aesmd_running()));
 }
 
 int main(int argc, char* argv[]) {
@@ -231,7 +230,7 @@ int main(int argc, char* argv[]) {
         return ExitCodes::NO_BIOS_SUPPORT;
     if (!psw_installed())
         return ExitCodes::PSW_NOT_INSTALLED;
-    if (!aesmd_running())
-        return ExitCodes::AESMD_NOT_RUNNING;
+    if (!aesmd_installed())
+        return ExitCodes::AESMD_NOT_INSTALLED;
     return ExitCodes::SUCCESS;
 }


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Previously, `is_sgx_available` reported whether AESMD is *running* based on existence of the socket `/var/run/aesmd/aesm.socket`. In reality, the existence of this socket doesn't mean that AESMD is actually running but that it is only installed on the machine.

See https://github.com/oscarlab/graphene/issues/1998 for context. I went with the approach number 3 in here: https://github.com/oscarlab/graphene/issues/1998#issuecomment-736333951.

Fixes #1998.

## How to test this PR? <!-- (if applicable) -->

Run `is_sgx_available` on any machine, including CentOS.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2573)
<!-- Reviewable:end -->
