### PR TITLE
Convert seek offsets to `file_off_t`

### DIFF
--- a/Documentation/devel/coding-style.rst
+++ b/Documentation/devel/coding-style.rst
@@ -143,7 +143,7 @@ Conventions and high-level style
 #. Types:
 
     #. All in-memory sizes and array indexes should be stored using ``size_t``.
-    #. All file offsets and sizes should be stored using ``uint64_t``.
+    #. All file offsets and sizes should be stored using ``file_off_t``.
     #. In general, C99 types should be used where possible (although some code
        is "grandfathered" in, it should also be changed as time allows).
 

--- a/LibOS/shim/include/shim_fs.h
+++ b/LibOS/shim/include/shim_fs.h
@@ -47,14 +47,14 @@ struct shim_fs_ops {
     int (*flush)(struct shim_handle* hdl);
 
     /* seek: the content from the file opened as handle */
-    off_t (*seek)(struct shim_handle* hdl, off_t offset, int whence);
+    file_off_t (*seek)(struct shim_handle* hdl, file_off_t offset, int whence);
 
     /* move, copy: rename or duplicate the file */
     int (*move)(const char* trim_old_name, const char* trim_new_name);
     int (*copy)(const char* trim_old_name, const char* trim_new_name);
 
     /* Returns 0 on success, -errno on error */
-    int (*truncate)(struct shim_handle* hdl, off_t len);
+    int (*truncate)(struct shim_handle* hdl, file_off_t len);
 
     /* hstat: get status of the file; `st_ino` will be taken from dentry, if there's one */
     int (*hstat)(struct shim_handle* hdl, struct stat* buf);
@@ -693,9 +693,24 @@ int str_dput(struct shim_dentry* dent);
 int str_close(struct shim_handle* hdl);
 ssize_t str_read(struct shim_handle* hdl, void* buf, size_t count);
 ssize_t str_write(struct shim_handle* hdl, const void* buf, size_t count);
-off_t str_seek(struct shim_handle* hdl, off_t offset, int whence);
+file_off_t str_seek(struct shim_handle* hdl, file_off_t offset, int whence);
 int str_flush(struct shim_handle* hdl);
-int str_truncate(struct shim_handle* hdl, off_t len);
+int str_truncate(struct shim_handle* hdl, file_off_t len);
 int str_poll(struct shim_handle* hdl, int poll_type);
+
+/*!
+ * \brief Compute file position for `seek`
+ *
+ * \param pos current file position (non-negative)
+ * \param size file size (non-negative)
+ * \param offset desired offset
+ * \param origin `seek` origin parameter (SEEK_SET, SEEK_CUR, SEEK_END)
+ * \param[out] out_pos on success, contains new file position
+ *
+ * Computes new file position according to `seek` semantics. The new position will be non-negative,
+ * although it can be larger than file size.
+ */
+int generic_seek(file_off_t pos, file_off_t size, file_off_t offset, int origin,
+                 file_off_t* out_pos);
 
 #endif /* _SHIM_FS_H_ */

--- a/LibOS/shim/include/shim_fs.h
+++ b/LibOS/shim/include/shim_fs.h
@@ -24,7 +24,6 @@ struct shim_handle;
 #define FS_POLL_RD 0x01
 #define FS_POLL_WR 0x02
 #define FS_POLL_ER 0x04
-#define FS_POLL_SZ 0x08
 
 struct shim_fs_ops {
     /* mount: mount an uri to the certain location */
@@ -79,10 +78,7 @@ struct shim_fs_ops {
     int (*checkin)(struct shim_handle* hdl);
 
     /* poll a single handle */
-    /* POLL_RD|POLL_WR: return POLL_RD|POLL_WR for readable|writable,
-       POLL_ER for failure, -EAGAIN for unknown. */
-    /* POLL_SZ: return total size */
-    off_t (*poll)(struct shim_handle* hdl, int poll_type);
+    int (*poll)(struct shim_handle* hdl, int poll_type);
 
     /* checkpoint/migrate the file system */
     ssize_t (*checkpoint)(void** checkpoint, void* mount_data);
@@ -703,6 +699,6 @@ ssize_t str_write(struct shim_handle* hdl, const void* buf, size_t count);
 off_t str_seek(struct shim_handle* hdl, off_t offset, int whence);
 int str_flush(struct shim_handle* hdl);
 int str_truncate(struct shim_handle* hdl, off_t len);
-off_t str_poll(struct shim_handle* hdl, int poll_type);
+int str_poll(struct shim_handle* hdl, int poll_type);
 
 #endif /* _SHIM_FS_H_ */

--- a/LibOS/shim/include/shim_fs.h
+++ b/LibOS/shim/include/shim_fs.h
@@ -178,9 +178,6 @@ struct shim_d_ops {
      */
     int (*lookup)(struct shim_dentry* dent);
 
-    /* this is to check file type and access, returning the stat.st_mode */
-    int (*mode)(struct shim_dentry* dent, mode_t* mode);
-
     /* detach internal data from dentry */
     int (*dput)(struct shim_dentry* dent);
 

--- a/LibOS/shim/include/shim_handle.h
+++ b/LibOS/shim/include/shim_handle.h
@@ -74,8 +74,8 @@ struct shim_file_handle {
     struct shim_file_data* data;
 
     enum shim_file_type type;
-    off_t size;
-    off_t marker;
+    file_off_t size;
+    file_off_t marker;
 
     struct sync_handle* sync;
 };
@@ -171,7 +171,7 @@ struct shim_dir_handle {
 struct shim_str_data {
     REFTYPE ref_count;
     char* str;
-    off_t len;
+    file_off_t len;
     size_t buf_size;
     bool dirty;
     int (*update)(struct shim_handle* hdl);

--- a/LibOS/shim/include/shim_types.h
+++ b/LibOS/shim/include/shim_types.h
@@ -342,6 +342,9 @@ typedef uint16_t FDTYPE;
 #define FDTYPE_MAX UINT16_MAX
 typedef uint64_t HASHTYPE;
 
+#define FILE_OFF_MAX INT64_MAX
+typedef int64_t file_off_t;
+
 typedef struct atomic_int REFTYPE;
 
 struct shim_lock {

--- a/LibOS/shim/src/bookkeep/shim_handle.c
+++ b/LibOS/shim/src/bookkeep/shim_handle.c
@@ -517,15 +517,6 @@ int get_file_size(struct shim_handle* hdl, uint64_t* size) {
     if (!hdl->fs || !hdl->fs->fs_ops)
         return -EINVAL;
 
-    if (hdl->fs->fs_ops->poll) {
-        off_t x = hdl->fs->fs_ops->poll(hdl, FS_POLL_SZ);
-        if (x < 0) {
-            return -EINVAL;
-        }
-        *size = (uint64_t)x;
-        return 0;
-    }
-
     if (hdl->fs->fs_ops->hstat) {
         struct stat stat;
         int ret = hdl->fs->fs_ops->hstat(hdl, &stat);

--- a/LibOS/shim/src/fs/chroot/fs.c
+++ b/LibOS/shim/src/fs/chroot/fs.c
@@ -943,16 +943,13 @@ static int chroot_unlink(struct shim_dentry* dir, struct shim_dentry* dent) {
     return 0;
 }
 
-static off_t chroot_poll(struct shim_handle* hdl, int poll_type) {
+static int chroot_poll(struct shim_handle* hdl, int poll_type) {
     int ret;
     if (NEED_RECREATE(hdl) && (ret = chroot_recreate(hdl)) < 0)
         return ret;
 
     struct shim_file_data* data = FILE_HANDLE_DATA(hdl);
     off_t size = __atomic_load_n(&data->size.counter, __ATOMIC_SEQ_CST);
-
-    if (poll_type == FS_POLL_SZ)
-        return size;
 
     struct shim_file_handle* file = &hdl->info.file;
     lock(&hdl->lock);

--- a/LibOS/shim/src/fs/chroot/fs.c
+++ b/LibOS/shim/src/fs/chroot/fs.c
@@ -313,8 +313,7 @@ static inline int try_create_data(struct shim_dentry* dent, const char* uri, siz
     return 0;
 }
 
-static int query_dentry(struct shim_dentry* dent, PAL_HANDLE pal_handle, mode_t* mode,
-                        struct stat* stat) {
+static int query_dentry(struct shim_dentry* dent, PAL_HANDLE pal_handle, struct stat* stat) {
     int ret = 0;
 
     struct shim_file_data* data;
@@ -327,9 +326,6 @@ static int query_dentry(struct shim_dentry* dent, PAL_HANDLE pal_handle, mode_t*
         unlock(&data->lock);
         return ret;
     }
-
-    if (mode)
-        *mode = dent->type | dent->perm;
 
     if (stat) {
         struct mount_data* mdata = DENTRY_MOUNT_DATA(dent);
@@ -349,16 +345,12 @@ static int query_dentry(struct shim_dentry* dent, PAL_HANDLE pal_handle, mode_t*
     return 0;
 }
 
-static int chroot_mode(struct shim_dentry* dent, mode_t* mode) {
-    return query_dentry(dent, NULL, mode, NULL);
-}
-
 static int chroot_stat(struct shim_dentry* dent, struct stat* statbuf) {
-    return query_dentry(dent, NULL, NULL, statbuf);
+    return query_dentry(dent, NULL, statbuf);
 }
 
 static int chroot_lookup(struct shim_dentry* dent) {
-    return query_dentry(dent, NULL, NULL, NULL);
+    return query_dentry(dent, NULL, NULL);
 }
 
 static int __chroot_open(struct shim_dentry* dent, const char* uri, int flags, mode_t mode,
@@ -577,7 +569,7 @@ static int chroot_hstat(struct shim_handle* hdl, struct stat* stat) {
         return 0;
     }
 
-    return query_dentry(hdl->dentry, hdl->pal_handle, NULL, stat);
+    return query_dentry(hdl->dentry, hdl->pal_handle, stat);
 }
 
 static int chroot_flush(struct shim_handle* hdl) {
@@ -1057,7 +1049,6 @@ struct shim_fs_ops chroot_fs_ops = {
 
 struct shim_d_ops chroot_d_ops = {
     .open    = &chroot_open,
-    .mode    = &chroot_mode,
     .lookup  = &chroot_lookup,
     .creat   = &chroot_creat,
     .mkdir   = &chroot_mkdir,

--- a/LibOS/shim/src/fs/eventfd/fs.c
+++ b/LibOS/shim/src/fs/eventfd/fs.c
@@ -46,8 +46,8 @@ static ssize_t eventfd_write(struct shim_handle* hdl, const void* buf, size_t co
     return (ssize_t)count;
 }
 
-static off_t eventfd_poll(struct shim_handle* hdl, int poll_type) {
-    off_t ret = 0;
+static int eventfd_poll(struct shim_handle* hdl, int poll_type) {
+    int ret = 0;
 
     lock(&hdl->lock);
 
@@ -60,11 +60,6 @@ static off_t eventfd_poll(struct shim_handle* hdl, int poll_type) {
     int query_ret = DkStreamAttributesQueryByHandle(hdl->pal_handle, &attr);
     if (query_ret < 0) {
         ret = pal_to_unix_errno(query_ret);
-        goto out;
-    }
-
-    if (poll_type == FS_POLL_SZ) {
-        ret = attr.pending_size;
         goto out;
     }
 

--- a/LibOS/shim/src/fs/pipe/fs.c
+++ b/LibOS/shim/src/fs/pipe/fs.c
@@ -93,8 +93,8 @@ static int pipe_hstat(struct shim_handle* hdl, struct stat* stat) {
     return 0;
 }
 
-static off_t pipe_poll(struct shim_handle* hdl, int poll_type) {
-    off_t ret = 0;
+static int pipe_poll(struct shim_handle* hdl, int poll_type) {
+    int ret = 0;
 
     assert(hdl->type == TYPE_PIPE);
     if (!hdl->info.pipe.ready_for_ops)
@@ -111,11 +111,6 @@ static off_t pipe_poll(struct shim_handle* hdl, int poll_type) {
     int query_ret = DkStreamAttributesQueryByHandle(hdl->pal_handle, &attr);
     if (query_ret < 0) {
         ret = pal_to_unix_errno(query_ret);
-        goto out;
-    }
-
-    if (poll_type == FS_POLL_SZ) {
-        ret = attr.pending_size;
         goto out;
     }
 

--- a/LibOS/shim/src/fs/shim_fs_pseudo.c
+++ b/LibOS/shim/src/fs/shim_fs_pseudo.c
@@ -196,11 +196,6 @@ static int pseudo_lookup(struct shim_dentry* dent) {
     return 0;
 }
 
-static int pseudo_mode(struct shim_dentry* dent, mode_t* mode) {
-    *mode = dent->type | dent->perm;
-    return 0;
-}
-
 static int count_nlink(const char* name, void* arg) {
     __UNUSED(name);
     size_t* nlink = arg;
@@ -547,7 +542,6 @@ struct shim_fs_ops pseudo_fs_ops = {
 struct shim_d_ops pseudo_d_ops = {
     .open        = &pseudo_open,
     .lookup      = &pseudo_lookup,
-    .mode        = &pseudo_mode,
     .readdir     = &pseudo_readdir,
     .stat        = &pseudo_stat,
     .follow_link = &pseudo_follow_link,

--- a/LibOS/shim/src/fs/shim_fs_pseudo.c
+++ b/LibOS/shim/src/fs/shim_fs_pseudo.c
@@ -442,17 +442,14 @@ static int pseudo_close(struct shim_handle* hdl) {
     }
 }
 
-static off_t pseudo_poll(struct shim_handle* hdl, int poll_type) {
+static int pseudo_poll(struct shim_handle* hdl, int poll_type) {
     assert(hdl->dentry);
     struct pseudo_node* node = pseudo_find(hdl->dentry);
     if (!node)
         return -ENOENT;
     switch (node->type) {
         case PSEUDO_DEV: {
-            if (poll_type == FS_POLL_SZ)
-                return 0;
-
-            off_t ret = 0;
+            int ret = 0;
             if ((poll_type & FS_POLL_RD) && node->dev.dev_ops.read)
                 ret |= FS_POLL_RD;
             if ((poll_type & FS_POLL_WR) && node->dev.dev_ops.write)

--- a/LibOS/shim/src/fs/shim_fs_pseudo.c
+++ b/LibOS/shim/src/fs/shim_fs_pseudo.c
@@ -339,7 +339,7 @@ static ssize_t pseudo_write(struct shim_handle* hdl, const void* buf, size_t siz
     }
 }
 
-static off_t pseudo_seek(struct shim_handle* hdl, off_t offset, int whence) {
+static file_off_t pseudo_seek(struct shim_handle* hdl, file_off_t offset, int whence) {
     assert(hdl->dentry);
     struct pseudo_node* node = pseudo_find(hdl->dentry);
     if (!node)
@@ -358,7 +358,7 @@ static off_t pseudo_seek(struct shim_handle* hdl, off_t offset, int whence) {
     }
 }
 
-static int pseudo_truncate(struct shim_handle* hdl, off_t size) {
+static int pseudo_truncate(struct shim_handle* hdl, file_off_t size) {
     assert(hdl->dentry);
     struct pseudo_node* node = pseudo_find(hdl->dentry);
     if (!node)

--- a/LibOS/shim/src/fs/shim_fs_util.c
+++ b/LibOS/shim/src/fs/shim_fs_util.c
@@ -1,0 +1,39 @@
+/* SPDX-License-Identifier: LGPL-3.0-or-later */
+/* Copyright (C) 2021 Intel Corporation
+ *                    Paweł Marczewski <pawel@invisiblethingslab.com>
+ */
+
+#include <stdint.h>
+
+#include "shim_fs.h"
+
+int generic_seek(file_off_t pos, file_off_t size, file_off_t offset, int origin,
+                 file_off_t* out_pos) {
+    assert(pos >= 0);
+    assert(size >= 0);
+
+    switch (origin) {
+        case SEEK_SET:
+            pos = offset;
+            break;
+
+        case SEEK_CUR:
+            if (__builtin_add_overflow(pos, offset, &pos))
+                return -EOVERFLOW;
+            break;
+
+        case SEEK_END:
+            if (__builtin_add_overflow(size, offset, &pos))
+                return -EOVERFLOW;
+            break;
+
+        default:
+            return -EINVAL;
+    }
+
+    if (pos < 0)
+        return -EINVAL;
+
+    *out_pos = pos;
+    return 0;
+}

--- a/LibOS/shim/src/fs/shim_namei.c
+++ b/LibOS/shim/src/fs/shim_namei.c
@@ -102,20 +102,7 @@ static int validate_dentry(struct shim_dentry* dent) {
     int ret = dent->fs->d_ops->lookup(dent);
 
     if (ret == 0) {
-        /*
-         * Lookup succeeded. Now, ensure `dent->perm` and `dent->type` are valid.
-         *
-         * TODO: remove `mode()` as a separate operation, and make sure this is always done by
-         * `lookup()`.
-         */
-        assert(dent->fs->d_ops->mode);
-        mode_t mode;
-        ret = dent->fs->d_ops->mode(dent, &mode);
-        if (ret < 0) {
-            return ret;
-        }
-        dent->perm = mode & ~S_IFMT;
-        dent->type = mode & S_IFMT;
+        /* Lookup succeeded. */
         dent->state |= DENTRY_VALID;
         return 0;
     } else if (ret == -ENOENT) {

--- a/LibOS/shim/src/fs/socket/fs.c
+++ b/LibOS/shim/src/fs/socket/fs.c
@@ -129,10 +129,10 @@ static int socket_hstat(struct shim_handle* hdl, struct stat* stat) {
     return 0;
 }
 
-static off_t socket_poll(struct shim_handle* hdl, int poll_type) {
+static int socket_poll(struct shim_handle* hdl, int poll_type) {
     assert(hdl->type == TYPE_SOCK);
     struct shim_sock_handle* sock = &hdl->info.sock;
-    off_t ret = 0;
+    int ret = 0;
 
     lock(&hdl->lock);
 
@@ -178,11 +178,6 @@ static off_t socket_poll(struct shim_handle* hdl, int poll_type) {
         goto out;
     }
 
-    if (poll_type == FS_POLL_SZ) {
-        ret = attr.pending_size;
-        goto out;
-    }
-
     ret = 0;
     if (attr.disconnected)
         ret |= FS_POLL_ER;
@@ -193,7 +188,7 @@ static off_t socket_poll(struct shim_handle* hdl, int poll_type) {
 
 out:
     if (ret < 0) {
-        log_error("socket_poll failed (%ld)", ret);
+        log_error("socket_poll failed (%d)", ret);
         sock->error = -ret;
     }
 

--- a/LibOS/shim/src/fs/str/fs.c
+++ b/LibOS/shim/src/fs/str/fs.c
@@ -258,17 +258,14 @@ int str_truncate(struct shim_handle* hdl, off_t len) {
     return ret;
 }
 
-off_t str_poll(struct shim_handle* hdl, int poll_type) {
+int str_poll(struct shim_handle* hdl, int poll_type) {
     assert(hdl->type == TYPE_STR);
 
     struct shim_str_handle* strhdl = &hdl->info.str;
     struct shim_str_data* data = strhdl->data;
     assert(data);
 
-    if (poll_type == FS_POLL_SZ)
-        return data->len;
-
-    off_t ret = 0;
+    int ret = 0;
     if (poll_type & FS_POLL_RD) {
         if (data->len > 0) {
             assert(data->str);

--- a/LibOS/shim/src/fs/tmpfs/fs.c
+++ b/LibOS/shim/src/fs/tmpfs/fs.c
@@ -260,7 +260,7 @@ static int tmpfs_mmap(struct shim_handle* hdl, void** addr, size_t size, int pro
     return -ENOSYS;
 }
 
-static off_t tmpfs_seek(struct shim_handle* hdl, off_t offset, int whence) {
+static file_off_t tmpfs_seek(struct shim_handle* hdl, file_off_t offset, int whence) {
     return str_seek(hdl, offset, whence);
 }
 
@@ -390,7 +390,7 @@ static int tmpfs_hstat(struct shim_handle* hdl, struct stat* stat) {
     return query_dentry(hdl->dentry, stat);
 }
 
-static int tmpfs_truncate(struct shim_handle* hdl, off_t len) {
+static int tmpfs_truncate(struct shim_handle* hdl, file_off_t len) {
     int ret = 0;
     lock(&hdl->lock);
     ret = str_truncate(hdl, len);

--- a/LibOS/shim/src/fs/tmpfs/fs.c
+++ b/LibOS/shim/src/fs/tmpfs/fs.c
@@ -464,14 +464,9 @@ static int tmpfs_unlink(struct shim_dentry* dir, struct shim_dentry* dent) {
     return 0;
 }
 
-static off_t tmpfs_poll(struct shim_handle* hdl, int poll_type) {
-    assert(hdl->type == TYPE_STR);
-    struct shim_str_data* data = hdl->info.str.data;
-    off_t size = data ? data->len : 0;
-
-    if (poll_type == FS_POLL_SZ)
-        return size;
-
+static int tmpfs_poll(struct shim_handle* hdl, int poll_type) {
+    __UNUSED(hdl);
+    __UNUSED(poll_type);
     return -EAGAIN;
 }
 

--- a/LibOS/shim/src/meson.build
+++ b/LibOS/shim/src/meson.build
@@ -33,6 +33,7 @@ libos_sources = files(
     'fs/shim_fs_hash.c',
     'fs/shim_fs_lock.c',
     'fs/shim_fs_pseudo.c',
+    'fs/shim_fs_util.c',
     'fs/shim_namei.c',
     'fs/socket/fs.c',
     'fs/str/fs.c',

--- a/LibOS/shim/src/shim_rtld.c
+++ b/LibOS/shim/src/shim_rtld.c
@@ -750,12 +750,6 @@ static int __load_interp_object(struct link_map* exec_map) {
             return ret;
         }
 
-        if (fs->d_ops->mode) {
-            mode_t mode;
-            if ((ret = fs->d_ops->mode(dent, &mode)) < 0)
-                goto err;
-        }
-
         struct shim_handle* interp = NULL;
 
         if (!(interp = get_new_handle())) {

--- a/LibOS/shim/src/sys/shim_fcntl.c
+++ b/LibOS/shim/src/sys/shim_fcntl.c
@@ -78,7 +78,7 @@ static int flock_to_posix_lock(struct flock* fl, struct shim_handle* hdl, struct
             if (!fs->fs_ops->seek)
                 return -EINVAL;
 
-            off_t pos = fs->fs_ops->seek(hdl, 0, SEEK_CUR);
+            file_off_t pos = fs->fs_ops->seek(hdl, 0, SEEK_CUR);
             if (pos < 0)
                 return pos;
             origin = pos;

--- a/LibOS/shim/src/sys/shim_file.c
+++ b/LibOS/shim/src/sys/shim_file.c
@@ -407,7 +407,7 @@ long shim_do_sendfile(int out_fd, int in_fd, off_t* offset, size_t count) {
         goto out;
     }
 
-    off_t old_offset = 0;
+    file_off_t old_offset = 0;
 
     if (offset) {
         if (!in_hdl->fs->fs_ops->seek) {

--- a/LibOS/shim/test/ltp/ltp.cfg
+++ b/LibOS/shim/test/ltp/ltp.cfg
@@ -15,6 +15,10 @@ timeout = 30
 [accept02]
 skip = yes
 
+# relies on shared mmap (see tst_test.c:setup_ipc)
+[accept4_01]
+skip = yes
+
 # utimensat
 [access01]
 skip = yes
@@ -1839,8 +1843,9 @@ skip = yes
 [sched_setscheduler03]
 skip = yes
 
+# relies on shared mmap (see tst_test.c:setup_ipc)
 [select04]
-timeout = 40
+skip = yes
 
 [semctl*]
 skip = yes
@@ -2162,6 +2167,10 @@ skip = yes
 skip = yes
 
 [signalfd4_02]
+skip = yes
+
+# relies on shared mmap (see tst_test.c:setup_ipc)
+[sigpending02]
 skip = yes
 
 [socket01]


### PR DESCRIPTION
**EDIT**: We introduce our own type, `file_off_t`, instead of using `loff_t`; see discussion.

## Description of the changes <!-- (reasons and measures) -->

This converts all internal `off_t` to `loff_t` (plus a few related changes, see commits). 

I'm planning bigger changes to FS regarding file position and size after that (currently we keep it in far too many places), but I want to have the right type first.

Note that this does not make us fully 32-bit ready: we would (at least) need to implement syscalls like `llseek` and `stat64`, because `lseek` and `stat` use `off_t`.

### Why `loff_t`?

This is apparently what Linux uses internally everywhere, for both file size and offset, and I think they have good reasons:

* Initially I wanted to have an usigned type such as `uint64_t`, but it's much easier to check/assert if size or offset is >= 0, than worry about the conversions other way around. With an usigned value, you could end up storing offsets that are too large to be presented to the user (and could be silently converted to negative if we're not careful).
* We talked about using `int64_t`, but `loff_t` is also guaranteed to be 64-bit, and carries more meaning (you know that the variable is for file size/position specifically).

## How to test this PR? <!-- (if applicable) -->

Not much to check, because there should be no difference on 64-bit systems.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2574)
<!-- Reviewable:end -->
