### PR TITLE
[Pal/Linux-SGX] Remove TODO on fetching SigRLs from IAS in RA-TLS

### DIFF
--- a/Pal/src/host/Linux-SGX/tools/ra-tls/ra_tls_verify_epid.c
+++ b/Pal/src/host/Linux-SGX/tools/ra-tls/ra_tls_verify_epid.c
@@ -209,9 +209,6 @@ int ra_tls_verify_callback(void* data, mbedtls_x509_crt* crt, int depth, uint32_
     assert(sig_data[sig_data_size - 1] == '\0');
     sig_data_size--;
 
-    /* TODO: obtain cert revocation lists via ias_get_sigrl(); currently they are not used during
-     *       IAS attestation report verification, so we don't obtain them */
-
     /* verify the received IAS attestation report */
     bool allow_outdated_tcb;
     ret = getenv_allow_outdated_tcb(&allow_outdated_tcb);
@@ -224,6 +221,9 @@ int ra_tls_verify_callback(void* data, mbedtls_x509_crt* crt, int depth, uint32_
     if (ret < 0)
         goto out;
 
+    /* below function verifies `isvEnclaveQuoteStatus` returned in the IAS attestation report; it
+     * fails if the SGX quote is invalid or if the EPID group/private key/signature is revoked (see
+     * also https://api.trustedservices.intel.com/documents/IAS-API-Spec-rev-5.0.pdf) */
     ret = verify_ias_report_extract_quote((uint8_t*)report_data, report_data_size,
                                           (uint8_t*)sig_data, sig_data_size,
                                           allow_outdated_tcb, nonce,


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

SigRLs are Signature Revocation Lists that can be separately fetched from Intel Attestation Service (IAS), to verify that the EPID private key of the user was revoked. Previously, we had a TODO comment to fetch these SigRLs and verify against them. However, this is not needed because the "verify attestation evidence" request to IAS (issued by RA-TLS) already forces IAS to check the EPID key against SigRLs. Thus, fetching SigRLs separately is just an optimization and not needed to be enforced in RA-TLS.

Please check https://api.trustedservices.intel.com/documents/IAS-API-Spec-rev-5.0.pdf, Section 3.2 for the details of "verify attestation evidence" end-point of IAS. There is an example of a revoked EPID group in Section 3.2.3.7. Similarly, the IAS attestation report will return `"isvEnclaveQuoteStatus": "SIGNATURE_REVOKED"` if the EPID signature was revoked, see Section 4.2.1.

Finally, notice that our RA-TLS code errors out on any `isvEnclaveQuoteStatus` that is not `OK` or `GROUP_OUT_OF_DATE`/`CONFIGURATION_NEEDED`/`SW_HARDENING_NEEDED`/`CONFIGURATION_AND_SW_HARDENING_NEEDED`: https://github.com/oscarlab/graphene/blob/d4602cee8c76e4d8fb8002777009e2fc016ba077/Pal/src/host/Linux-SGX/tools/common/attestation.c#L221-L237

In other words, `isvEnclaveQuoteStatus == SIGNATURE_REVOKED` will fail RA-TLS verification. No additional step of fetching SigRLs is thus needed.

## How to test this PR? <!-- (if applicable) -->

N/A.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2575)
<!-- Reviewable:end -->
