### PR TITLE
[LTP] fix pread fails when file descriptor refers to a directory

### DIFF
--- a/LibOS/shim/src/sys/shim_open.c
+++ b/LibOS/shim/src/sys/shim_open.c
@@ -263,8 +263,10 @@ long shim_do_pread64(int fd, char* buf, size_t count, loff_t pos) {
     if (!fs->fs_ops->read)
         goto out;
 
-    if (hdl->is_dir)
+    if (hdl->is_dir) {
+        ret = -EISDIR;
         goto out;
+    }
 
     int offset = fs->fs_ops->seek(hdl, 0, SEEK_CUR);
     if (offset < 0) {


### PR DESCRIPTION
Signed-off-by: Sonali Saha <sonali.saha@intel.com>

<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://graphene.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->
fix pread fails when file descriptor refers to a directory.
Fixes #2539 
<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->
Run LTP Test pread03

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2577)
<!-- Reviewable:end -->
