### PR TITLE
[Examples] Fix SQLite command invocation in README

### DIFF
--- a/Examples/sqlite/README.md
+++ b/Examples/sqlite/README.md
@@ -25,16 +25,16 @@ Here's an example of running SQLite under Graphene:
 
 Without SGX:
 ```
-graphene-direct sqlite scripts/testdir/test.db < scripts/create.sql
-graphene-direct sqlite scripts/testdir/test.db < scripts/update.sql
-graphene-direct sqlite scripts/testdir/test.db < scripts/select.sql
+graphene-direct sqlite3 scripts/testdir/test.db < scripts/create.sql
+graphene-direct sqlite3 scripts/testdir/test.db < scripts/update.sql
+graphene-direct sqlite3 scripts/testdir/test.db < scripts/select.sql
 ```
 
 With SGX:
 ```
-graphene-sgx sqlite scripts/testdir/test.db < scripts/create.sql
-graphene-sgx sqlite scripts/testdir/test.db < scripts/update.sql
-graphene-sgx sqlite scripts/testdir/test.db < scripts/select.sql
+graphene-sgx sqlite3 scripts/testdir/test.db < scripts/create.sql
+graphene-sgx sqlite3 scripts/testdir/test.db < scripts/update.sql
+graphene-sgx sqlite3 scripts/testdir/test.db < scripts/select.sql
 ```
 
 # Note about concurrency


### PR DESCRIPTION
This PR adds the missing `3` to the sqlite command. Otherwise, the readme works perfectly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2579)
<!-- Reviewable:end -->
