### PR TITLE
[Examples] Decouple all examples from the core Graphene repo

### DIFF
--- a/Examples/apache/Makefile
+++ b/Examples/apache/Makefile
@@ -1,5 +1,7 @@
 THIS_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 
+ARCH_LIBDIR ?= /lib/$(shell $(CC) -dumpmachine)
+
 INSTALL_DIR ?= $(THIS_DIR)install
 HTTPD_SRC ?= $(THIS_DIR)httpd-2.4.46
 HTTPD_CHECKSUM ?= 44b759ce932dc090c0e75c0210b4485ebf6983466fb8ca1b446c8168e1a1aec2
@@ -15,8 +17,7 @@ HTTPD_MIRRORS ?= \
 LISTEN_HOST ?= 127.0.0.1
 LISTEN_PORT ?= 8001
 
-GRAPHENEDIR ?= $(THIS_DIR)../..
-SGX_SIGNER_KEY ?= $(GRAPHENEDIR)/Pal/src/host/Linux-SGX/signer/enclave-key.pem
+SGX_SIGNER_KEY ?= ../../Pal/src/host/Linux-SGX/signer/enclave-key.pem
 
 ifeq ($(DEBUG),1)
 GRAPHENE_LOG_LEVEL = debug
@@ -29,8 +30,6 @@ all: $(INSTALL_DIR)/bin/httpd httpd.manifest config testdata ssldata
 ifeq ($(SGX),1)
 all: httpd.manifest.sgx httpd.sig httpd.token
 endif
-
-include ../../Scripts/Makefile.configs
 
 $(INSTALL_DIR)/bin/httpd: $(HTTPD_SRC)/configure
 	cd $(HTTPD_SRC) && ./configure --prefix=$(abspath $(INSTALL_DIR)) \
@@ -46,7 +45,7 @@ $(HTTPD_SRC)/configure: $(HTTPD_SRC).tar.gz
 	cd $(HTTPD_SRC) && patch -p1 -l < ../apache_makefile.patch
 
 $(HTTPD_SRC).tar.gz:
-	$(GRAPHENEDIR)/Scripts/download --output $@ --sha256 $(HTTPD_CHECKSUM) \
+	../common_tools/download --output $@ --sha256 $(HTTPD_CHECKSUM) \
 		$(foreach mirror,$(HTTPD_MIRRORS),--url $(mirror)/$(HTTPD_SRC).tar.gz)
 
 $(INSTALL_DIR)/conf/httpd.conf: $(INSTALL_DIR)/bin/httpd
@@ -74,6 +73,8 @@ httpd.manifest.sgx: httpd.manifest $(INSTALL_DIR)/bin/httpd \
 		$(INSTALL_DIR)/conf/extra/httpd-ssl-graphene.conf \
 		$(TEST_DATA) \
 		$(INSTALL_DIR)/conf/server.crt
+	@test -s $(SGX_SIGNER_KEY) || \
+	    { echo "SGX signer private key was not found, please specify SGX_SIGNER_KEY!"; exit 1; }
 	graphene-sgx-sign \
 		--key $(SGX_SIGNER_KEY) \
 		--manifest httpd.manifest \

--- a/Examples/bash/Makefile
+++ b/Examples/bash/Makefile
@@ -1,5 +1,6 @@
-GRAPHENEDIR ?= ../..
-SGX_SIGNER_KEY ?= $(GRAPHENEDIR)/Pal/src/host/Linux-SGX/signer/enclave-key.pem
+SGX_SIGNER_KEY ?= ../../Pal/src/host/Linux-SGX/signer/enclave-key.pem
+
+ARCH_LIBDIR ?= /lib/$(shell $(CC) -dumpmachine)
 
 ifeq ($(DEBUG),1)
 GRAPHENE_LOG_LEVEL = debug
@@ -13,8 +14,6 @@ ifeq ($(SGX),1)
 all: bash.manifest.sgx bash.sig bash.token
 endif
 
-include ../../Scripts/Makefile.configs
-
 bash.manifest: manifest.template
 	graphene-manifest \
 		-Dlog_level=$(GRAPHENE_LOG_LEVEL) \
@@ -23,6 +22,8 @@ bash.manifest: manifest.template
 		$< >$@
 
 bash.manifest.sgx: bash.manifest
+	@test -s $(SGX_SIGNER_KEY) || \
+	    { echo "SGX signer private key was not found, please specify SGX_SIGNER_KEY!"; exit 1; }
 	graphene-sgx-sign \
 		--key $(SGX_SIGNER_KEY) \
 		--manifest bash.manifest \

--- a/Examples/blender/Makefile
+++ b/Examples/blender/Makefile
@@ -1,8 +1,9 @@
 # assumes this makefile lies in cwd
 PWD := $(shell pwd)
 
-GRAPHENE_DIR = $(PWD)/../..
-SGX_SIGNER_KEY ?= $(GRAPHENE_DIR)/Pal/src/host/Linux-SGX/signer/enclave-key.pem
+ARCH_LIBDIR ?= /lib/$(shell $(CC) -dumpmachine)
+
+SGX_SIGNER_KEY ?= ../../Pal/src/host/Linux-SGX/signer/enclave-key.pem
 
 BLENDER_DIR = $(PWD)/blender_dir
 BLENDER_SRC ?= blender-2.82-linux64.tar.xz
@@ -30,10 +31,8 @@ ifeq ($(SGX),1)
 all: blender.manifest.sgx blender.sig blender.token
 endif
 
-include ../../Scripts/Makefile.configs
-
 $(BLENDER_DIR)/blender:
-	$(GRAPHENE_DIR)/Scripts/download --output blender.tar.xz --sha256 $(BLENDER_SHA256) \
+	../common_tools/download --output blender.tar.xz --sha256 $(BLENDER_SHA256) \
 		$(foreach mirror,$(BLENDER_MIRRORS),--url $(mirror)/$(BLENDER_SRC))
 	mkdir $(BLENDER_DIR)
 	tar -C $(BLENDER_DIR) --strip-components=1 -xf blender.tar.xz
@@ -57,6 +56,8 @@ blender.sig blender.manifest.sgx: sgx_outputs
 
 .INTERMEDIATE: sgx_outputs
 sgx_outputs: $(BLENDER_DIR)/blender blender.manifest | $(RUN_DIR)
+	@test -s $(SGX_SIGNER_KEY) || \
+	    { echo "SGX signer private key was not found, please specify SGX_SIGNER_KEY!"; exit 1; }
 	graphene-sgx-sign \
 		--output blender.manifest.sgx \
 		--key $(SGX_SIGNER_KEY) \

--- a/Examples/busybox/Makefile
+++ b/Examples/busybox/Makefile
@@ -1,5 +1,6 @@
-GRAPHENEDIR = ../..
-SGX_SIGNER_KEY ?= $(GRAPHENEDIR)/Pal/src/host/Linux-SGX/signer/enclave-key.pem
+SGX_SIGNER_KEY ?= ../../Pal/src/host/Linux-SGX/signer/enclave-key.pem
+
+ARCH_LIBDIR ?= /lib/$(shell $(CC) -dumpmachine)
 
 SRCDIR = src
 BUSYBOX_URL ?= https://busybox.net/downloads/busybox-1.32.0.tar.bz2
@@ -18,10 +19,8 @@ ifeq ($(SGX),1)
 all: busybox.manifest.sgx busybox.sig busybox.token
 endif
 
-include ../../Scripts/Makefile.configs
-
 $(SRCDIR)/Makefile:
-	$(GRAPHENEDIR)/Scripts/download --output busybox.tar.bz2 \
+	../common_tools/download --output busybox.tar.bz2 \
 		--sha256 $(BUSYBOX_SHA256) --url $(BUSYBOX_URL)
 	mkdir $(SRCDIR)
 	tar -C $(SRCDIR) --strip-components=1 -xf busybox.tar.bz2
@@ -47,6 +46,8 @@ busybox.manifest: busybox.manifest.template
 		$< > $@
 
 busybox.manifest.sgx: busybox.manifest busybox
+	@test -s $(SGX_SIGNER_KEY) || \
+	    { echo "SGX signer private key was not found, please specify SGX_SIGNER_KEY!"; exit 1; }
 	graphene-sgx-sign \
 		--key $(SGX_SIGNER_KEY) \
 		--manifest $< \

--- a/Examples/common_tools/download
+++ b/Examples/common_tools/download
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+declare -a urls
+
+usage() {
+    echo "Usage: download --url https://example.org/test --url https://mirror.example/blah --output test.tar --sha256 1234..abc"
+    exit "${1:-0}"
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --url)
+            urls+=("$2")
+            shift
+            ;;
+        --output)
+            output="$2"
+            shift
+            ;;
+        --sha256)
+            sha256="$2"
+            shift
+            ;;
+        --help|-h)
+            usage
+            ;;
+        *)
+            usage 1
+            ;;
+    esac
+    shift
+done
+
+if [ -z "${output:-}" ] || [ -z "${sha256:-}" ] || [ -z "${urls[*]}" ]; then
+    usage 1
+fi
+
+if [ -n "${DL_CACHE:-}" ]; then
+    if [ -f "$DL_CACHE/$sha256" ]; then
+        echo "download: Found '$output' (${sha256:0:8}...) in cache."
+        cp "$DL_CACHE/$sha256" "$output"
+        exit 0
+    fi
+fi
+
+if [ "${DL_OFFLINE:-}" == "true" ]; then
+    echo "download: ERROR: File '$output' (${sha256:0:8}...) not found in cache and offline mode is active!"
+    exit 1
+fi
+
+tmpd="$(mktemp -d -p "${DL_CACHE:-.}")"
+cleanup() {
+    rm -rf "$tmpd"
+}
+trap cleanup EXIT
+
+for url in "${urls[@]}"; do
+    echo "download: Trying to fetch $url"
+    wget --timeout=10 -O "$tmpd/unverified" "$url" || true
+    sha256_received="$(sha256sum "$tmpd/unverified" | cut -d ' ' -f 1)"
+    if [ "$sha256" != "$sha256_received" ]; then
+        echo "download: WARNING: Hash mismatch: Expected $sha256 but received $sha256_received"
+        continue
+    fi
+    echo "download: Fetched '$output' (${sha256:0:8}...) successfully."
+    if [ -n "${DL_CACHE:-}" ]; then
+        mv "$tmpd/unverified" "$DL_CACHE/$sha256"
+        cp "$DL_CACHE/$sha256" "$output"
+        exit 0
+    fi
+    mv "$tmpd/unverified" "$output"
+    exit 0
+done
+
+echo "download: ERROR: Failed to download '$output' (${sha256:0:8}...)! No URLs left to try."
+exit 1

--- a/Examples/curl/Makefile
+++ b/Examples/curl/Makefile
@@ -1,8 +1,9 @@
 THIS_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 CURL_DIR ?= /usr/bin
 
-GRAPHENEDIR ?= ../..
-SGX_SIGNER_KEY ?= $(GRAPHENEDIR)/Pal/src/host/Linux-SGX/signer/enclave-key.pem
+ARCH_LIBDIR ?= /lib/$(shell $(CC) -dumpmachine)
+
+SGX_SIGNER_KEY ?= ../../Pal/src/host/Linux-SGX/signer/enclave-key.pem
 
 ifeq ($(DEBUG),1)
 GRAPHENE_LOG_LEVEL = debug
@@ -16,8 +17,6 @@ ifeq ($(SGX),1)
 all: curl.manifest.sgx curl.sig curl.token
 endif
 
-include ../../Scripts/Makefile.configs
-
 curl.manifest: curl.manifest.template
 	graphene-manifest \
 		-Dlog_level=$(GRAPHENE_LOG_LEVEL) \
@@ -27,6 +26,8 @@ curl.manifest: curl.manifest.template
 		$< >$@
 
 curl.manifest.sgx: curl.manifest
+	@test -s $(SGX_SIGNER_KEY) || \
+	    { echo "SGX signer private key was not found, please specify SGX_SIGNER_KEY!"; exit 1; }
 	graphene-sgx-sign \
 		--key $(SGX_SIGNER_KEY) \
 		--manifest curl.manifest \

--- a/Examples/gcc/Makefile
+++ b/Examples/gcc/Makefile
@@ -1,7 +1,10 @@
 THIS_DIR := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
 
-GRAPHENEDIR ?= $(THIS_DIR)/../..
-SGX_SIGNER_KEY ?= $(GRAPHENEDIR)/Pal/src/host/Linux-SGX/signer/enclave-key.pem
+ARCH_LONG ?= $(shell $(CC) -dumpmachine)
+ARCH_LIBDIR ?= /lib/$(shell $(CC) -dumpmachine)
+
+SGX_SIGNER_KEY ?= ../../Pal/src/host/Linux-SGX/signer/enclave-key.pem
+
 BZIP2_MIRRORS ?= \
 	https://people.csail.mit.edu/smcc/projects/single-file-programs/bzip2.c \
 	https://packages.grapheneproject.io/distfiles/single-file-programs/bzip2.c
@@ -16,8 +19,6 @@ GRAPHENE_LOG_LEVEL = debug
 else
 GRAPHENE_LOG_LEVEL = error
 endif
-
-include ../../Scripts/Makefile.configs
 
 # awk '{print $NF}' ...  print last field.
 BINUTILS_VERSION ?= $(shell ld -v | awk '{print $$NF}')
@@ -45,6 +46,8 @@ gcc.sig gcc.manifest.sgx: sgx_outputs
 
 .INTERMEDIATE: sgx_outputs
 sgx_outputs: gcc.manifest
+	@test -s $(SGX_SIGNER_KEY) || \
+	    { echo "SGX signer private key was not found, please specify SGX_SIGNER_KEY!"; exit 1; }
 	graphene-sgx-sign \
 		--key $(SGX_SIGNER_KEY) \
 		--manifest gcc.manifest \
@@ -54,11 +57,11 @@ sgx_outputs: gcc.manifest
 	graphene-sgx-get-token --output $@ --sig $<
 
 test_files/bzip2.c:
-	$(GRAPHENEDIR)/Scripts/download --output $@ --sha256 $(BZIP2_HASH) $(foreach mirror,$(BZIP2_MIRRORS),--url $(mirror))
+	../common_tools/download --output $@ --sha256 $(BZIP2_HASH) $(foreach mirror,$(BZIP2_MIRRORS),--url $(mirror))
 
 # the file hosted by the authors doesn't compile...
 test_files/gzip_broken.c:
-	$(GRAPHENEDIR)/Scripts/download --output $@ --sha256 $(GZIP_HASH) $(foreach mirror,$(GZIP_MIRRORS),--url $(mirror))
+	../common_tools/download --output $@ --sha256 $(GZIP_HASH) $(foreach mirror,$(GZIP_MIRRORS),--url $(mirror))
 
 test_files/gzip.c: test_files/gzip_broken.c test_files/gzip.patch
 	patch test_files/gzip_broken.c -i test_files/gzip.patch -o $@

--- a/Examples/lighttpd/Makefile
+++ b/Examples/lighttpd/Makefile
@@ -1,5 +1,7 @@
 THIS_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 
+ARCH_LIBDIR ?= /lib/$(shell $(CC) -dumpmachine)
+
 INSTALL_DIR ?= $(THIS_DIR)install
 
 LIGHTTPD_SRC ?= $(THIS_DIR)lighttpd-1.4.59
@@ -12,8 +14,7 @@ LIGHTTPD_MIRRORS ?= \
 HOST ?= 127.0.0.1
 PORT ?= 8003
 
-GRAPHENEDIR ?= $(THIS_DIR)../..
-SGX_SIGNER_KEY ?= $(GRAPHENEDIR)/Pal/src/host/Linux-SGX/signer/enclave-key.pem
+SGX_SIGNER_KEY ?= ../../Pal/src/host/Linux-SGX/signer/enclave-key.pem
 
 ifeq ($(DEBUG),1)
 GRAPHENE_LOG_LEVEL = debug
@@ -29,8 +30,6 @@ ifeq ($(SGX),1)
 all: lighttpd.manifest.sgx lighttpd.sig lighttpd.token
 endif
 
-include ../../Scripts/Makefile.configs
-
 $(INSTALL_DIR)/sbin/lighttpd: $(LIGHTTPD_SRC)/configure
 	cd $(LIGHTTPD_SRC) && ./configure --prefix=$(abspath $(INSTALL_DIR)) \
 		--without-openssl --without-pcre --without-bzip2
@@ -44,7 +43,7 @@ $(LIGHTTPD_SRC)/configure: $(LIGHTTPD_SRC).tar.gz
 	touch $(LIGHTTPD_SRC)/configure
 
 $(LIGHTTPD_SRC).tar.gz:
-	$(GRAPHENEDIR)/Scripts/download --output $@ --sha256 $(LIGHTTPD_HASH) \
+	../common_tools/download --output $@ --sha256 $(LIGHTTPD_HASH) \
 		$(foreach mirror,$(LIGHTTPD_MIRRORS),--url $(mirror)/$(LIGHTTPD_SRC).tar.gz)
 
 lighttpd.manifest: lighttpd.manifest.template
@@ -56,6 +55,8 @@ lighttpd.manifest: lighttpd.manifest.template
 		$< >$@
 
 lighttpd.manifest.sgx: lighttpd.manifest $(INSTALL_DIR)/sbin/lighttpd
+	@test -s $(SGX_SIGNER_KEY) || \
+	    { echo "SGX signer private key was not found, please specify SGX_SIGNER_KEY!"; exit 1; }
 	graphene-sgx-sign \
 		--key $(SGX_SIGNER_KEY) \
 		--manifest lighttpd.manifest \

--- a/Examples/memcached/Makefile
+++ b/Examples/memcached/Makefile
@@ -1,5 +1,6 @@
-GRAPHENEDIR = ../..
-SGX_SIGNER_KEY ?= $(GRAPHENEDIR)/Pal/src/host/Linux-SGX/signer/enclave-key.pem
+ARCH_LIBDIR ?= /lib/$(shell $(CC) -dumpmachine)
+
+SGX_SIGNER_KEY ?= ../../Pal/src/host/Linux-SGX/signer/enclave-key.pem
 
 SRCDIR = src
 MEMCACHED_SRC ?= memcached-1.5.21.tar.gz
@@ -23,10 +24,8 @@ ifeq ($(SGX),1)
 all: memcached.manifest.sgx memcached.sig memcached.token
 endif
 
-include ../../Scripts/Makefile.configs
-
 $(SRCDIR)/configure:
-	$(GRAPHENEDIR)/Scripts/download --output memcached.tar.gz --sha256 $(MEMCACHED_SHA256) \
+	../common_tools/download --output memcached.tar.gz --sha256 $(MEMCACHED_SHA256) \
 		$(foreach mirror,$(MEMCACHED_MIRRORS),--url $(mirror)/$(MEMCACHED_SRC))
 	mkdir $(SRCDIR)
 	tar -C $(SRCDIR) --strip-components=1 -xf memcached.tar.gz
@@ -42,6 +41,8 @@ memcached.manifest: memcached.manifest.template
 		$< > $@
 
 memcached.manifest.sgx: memcached.manifest memcached
+	@test -s $(SGX_SIGNER_KEY) || \
+	    { echo "SGX signer private key was not found, please specify SGX_SIGNER_KEY!"; exit 1; }
 	graphene-sgx-sign \
 		--key $(SGX_SIGNER_KEY) \
 		--manifest $< \

--- a/Examples/nginx/Makefile
+++ b/Examples/nginx/Makefile
@@ -1,5 +1,7 @@
 THIS_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 
+ARCH_LIBDIR ?= /lib/$(shell $(CC) -dumpmachine)
+
 INSTALL_DIR ?= $(THIS_DIR)install
 NGINX_SRC ?= $(THIS_DIR)nginx-1.16.1
 NGINX_SHA256 ?= f11c2a6dd1d3515736f0324857957db2de98be862461b5a542a3ac6188dbe32b
@@ -12,8 +14,7 @@ LISTEN_HOST ?= 127.0.0.1
 LISTEN_PORT ?= 8002
 LISTEN_SSL_PORT ?= 8444
 
-GRAPHENEDIR ?= $(THIS_DIR)../..
-SGX_SIGNER_KEY ?= $(GRAPHENEDIR)/Pal/src/host/Linux-SGX/signer/enclave-key.pem
+SGX_SIGNER_KEY ?= ../../Pal/src/host/Linux-SGX/signer/enclave-key.pem
 
 ifeq ($(DEBUG),1)
 GRAPHENE_LOG_LEVEL = debug
@@ -45,7 +46,7 @@ $(NGINX_SRC)/configure: $(NGINX_SRC).tar.gz
 	tar --touch -xzf $<
 
 $(NGINX_SRC).tar.gz:
-	$(GRAPHENEDIR)/Scripts/download --output $@ --sha256 $(NGINX_SHA256) \
+	../common_tools/download --output $@ --sha256 $(NGINX_SHA256) \
 		$(foreach mirror,$(NGINX_MIRRORS),--url $(mirror)/$(NGINX_SRC).tar.gz)
 
 nginx.manifest: nginx.manifest.template
@@ -60,6 +61,8 @@ nginx.manifest.sgx: nginx.manifest $(INSTALL_DIR)/sbin/nginx \
 		$(INSTALL_DIR)/conf/nginx-graphene.conf \
 		$(TEST_DATA) \
 		$(INSTALL_DIR)/conf/server.crt
+	@test -s $(SGX_SIGNER_KEY) || \
+	    { echo "SGX signer private key was not found, please specify SGX_SIGNER_KEY!"; exit 1; }
 	graphene-sgx-sign \
 		--key $(SGX_SIGNER_KEY) \
 		--manifest $< \

--- a/Examples/nodejs/Makefile
+++ b/Examples/nodejs/Makefile
@@ -1,8 +1,9 @@
 THIS_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 NODEJS_DIR ?= /usr/bin
 
-GRAPHENEDIR ?= ../..
-SGX_SIGNER_KEY ?= $(GRAPHENEDIR)/Pal/src/host/Linux-SGX/signer/enclave-key.pem
+ARCH_LIBDIR ?= /lib/$(shell $(CC) -dumpmachine)
+
+SGX_SIGNER_KEY ?= ../../Pal/src/host/Linux-SGX/signer/enclave-key.pem
 
 ifeq ($(DEBUG),1)
 GRAPHENE_LOG_LEVEL = debug
@@ -16,8 +17,6 @@ ifeq ($(SGX),1)
 all: nodejs.manifest.sgx nodejs.sig nodejs.token
 endif
 
-include ../../Scripts/Makefile.configs
-
 nodejs.manifest: nodejs.manifest.template
 	graphene-manifest \
 		-Dlog_level=$(GRAPHENE_LOG_LEVEL) \
@@ -26,6 +25,8 @@ nodejs.manifest: nodejs.manifest.template
 		$< >$@
 
 nodejs.manifest.sgx: nodejs.manifest helloworld.js
+	@test -s $(SGX_SIGNER_KEY) || \
+	    { echo "SGX signer private key was not found, please specify SGX_SIGNER_KEY!"; exit 1; }
 	graphene-sgx-sign \
 		--key $(SGX_SIGNER_KEY) \
 		--manifest $< \

--- a/Examples/openvino/Makefile
+++ b/Examples/openvino/Makefile
@@ -1,5 +1,7 @@
 THIS_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 
+ARCH_LIBDIR ?= /lib/$(shell $(CC) -dumpmachine)
+
 MODEL_DIR ?= $(THIS_DIR)model
 MODEL_COMMIT ?= acf297c73db8cb3f68791ae1fad4a7cc4a6039e5     # corresponds to tag "2019_R3"
 MODEL_NAME ?= VGG_VOC0712Plus_SSD_300x300_ft_iter_160000
@@ -7,8 +9,7 @@ MODEL_NAME ?= VGG_VOC0712Plus_SSD_300x300_ft_iter_160000
 OPENVINO_DIR ?= $(THIS_DIR)openvino
 OPENVINO_COMMIT ?= 023e7c2c3f8a8ac83564db09799d2049115d9cf6  # corresponds to tag "2020.4"
 
-GRAPHENE_DIR ?= ../..
-SGX_SIGNER_KEY ?= $(GRAPHENE_DIR)/Pal/src/host/Linux-SGX/signer/enclave-key.pem
+SGX_SIGNER_KEY ?= ../../Pal/src/host/Linux-SGX/signer/enclave-key.pem
 
 ifeq ($(DEBUG),1)
 GRAPHENE_LOG_LEVEL = debug
@@ -25,8 +26,6 @@ ifeq ($(SGX),1)
 all: object_detection_sample_ssd.manifest.sgx object_detection_sample_ssd.sig \
      object_detection_sample_ssd.token
 endif
-
-include ../../Scripts/Makefile.configs
 
 $(MODEL_DIR)/README.md:
 	git clone https://github.com/opencv/open_model_zoo.git $(MODEL_DIR)
@@ -61,6 +60,8 @@ object_detection_sample_ssd.manifest: object_detection_sample_ssd.manifest.templ
 
 object_detection_sample_ssd.manifest.sgx: object_detection_sample_ssd.manifest \
 		$(OPENVINO_DIR)/inference-engine/bin/intel64/$(OPENVINO_BUILD)/object_detection_sample_ssd
+	@test -s $(SGX_SIGNER_KEY) || \
+	    { echo "SGX signer private key was not found, please specify SGX_SIGNER_KEY!"; exit 1; }
 	graphene-sgx-sign \
 		--key $(SGX_SIGNER_KEY) \
 		--manifest $< \

--- a/Examples/python/Makefile
+++ b/Examples/python/Makefile
@@ -1,7 +1,6 @@
-include ../../Scripts/Makefile.configs
+ARCH_LIBDIR ?= /lib/$(shell $(CC) -dumpmachine)
 
-GRAPHENEDIR ?= ../..
-SGX_SIGNER_KEY ?= $(GRAPHENEDIR)/Pal/src/host/Linux-SGX/signer/enclave-key.pem
+SGX_SIGNER_KEY ?= ../../Pal/src/host/Linux-SGX/signer/enclave-key.pem
 
 ifeq ($(DEBUG),1)
 GRAPHENE_LOG_LEVEL = debug
@@ -23,6 +22,8 @@ python.manifest: python.manifest.template
 		$< >$@
 
 python.manifest.sgx: python.manifest
+	@test -s $(SGX_SIGNER_KEY) || \
+	    { echo "SGX signer private key was not found, please specify SGX_SIGNER_KEY!"; exit 1; }
 	graphene-sgx-sign \
 		--key $(SGX_SIGNER_KEY) \
 		--manifest $< \

--- a/Examples/pytorch/Makefile
+++ b/Examples/pytorch/Makefile
@@ -1,9 +1,8 @@
 # PyTorch and the pre-trained model must be installed on the system. See README for details.
 
-include ../../Scripts/Makefile.configs
+ARCH_LIBDIR ?= /lib/$(shell $(CC) -dumpmachine)
 
-GRAPHENEDIR ?= ../..
-SGX_SIGNER_KEY ?= $(GRAPHENEDIR)/Pal/src/host/Linux-SGX/signer/enclave-key.pem
+SGX_SIGNER_KEY ?= ../../Pal/src/host/Linux-SGX/signer/enclave-key.pem
 
 ifeq ($(DEBUG),1)
 GRAPHENE_LOG_LEVEL = debug
@@ -31,6 +30,8 @@ pytorch.sig pytorch.manifest.sgx: sgx_outputs
 
 .INTERMEDIATE: sgx_outputs
 sgx_outputs: pytorch.manifest
+	@test -s $(SGX_SIGNER_KEY) || \
+	    { echo "SGX signer private key was not found, please specify SGX_SIGNER_KEY!"; exit 1; }
 	graphene-sgx-sign \
 		--key $(SGX_SIGNER_KEY) \
 		--output pytorch.manifest.sgx \

--- a/Examples/r/Makefile
+++ b/Examples/r/Makefile
@@ -2,8 +2,9 @@
 R_HOME ?= /usr/lib/R
 R_EXEC = $(R_HOME)/bin/exec/R
 
-GRAPHENEDIR ?= ../..
-SGX_SIGNER_KEY ?= $(GRAPHENEDIR)/Pal/src/host/Linux-SGX/signer/enclave-key.pem
+SGX_SIGNER_KEY ?= ../../Pal/src/host/Linux-SGX/signer/enclave-key.pem
+
+ARCH_LIBDIR ?= /lib/$(shell $(CC) -dumpmachine)
 
 ifeq ($(DEBUG),1)
 GRAPHENE_LOG_LEVEL = debug
@@ -20,8 +21,6 @@ ifeq ($(SGX),1)
 all: R.manifest.sgx R.sig R.token
 endif
 
-include ../../Scripts/Makefile.configs
-
 R.manifest: R.manifest.template
 	graphene-manifest \
 		-Dlog_level=$(GRAPHENE_LOG_LEVEL) \
@@ -31,6 +30,8 @@ R.manifest: R.manifest.template
 		$< >$@
 
 %.manifest.sgx: %.manifest
+	@test -s $(SGX_SIGNER_KEY) || \
+	    { echo "SGX signer private key was not found, please specify SGX_SIGNER_KEY!"; exit 1; }
 	graphene-sgx-sign \
 		--key $(SGX_SIGNER_KEY) \
 		--manifest $< \

--- a/Examples/ra-tls-mbedtls/Makefile
+++ b/Examples/ra-tls-mbedtls/Makefile
@@ -1,5 +1,7 @@
 GRAPHENEDIR ?= ../..
-GRAPHENEKEY ?= $(GRAPHENEDIR)/Pal/src/host/Linux-SGX/signer/enclave-key.pem
+SGX_SIGNER_KEY ?= $(GRAPHENEDIR)/Pal/src/host/Linux-SGX/signer/enclave-key.pem
+
+ARCH_LIBDIR ?= /lib/$(shell $(CC) -dumpmachine)
 
 # for EPID attestation, specify your SPID and linkable/unlinkable attestation policy;
 # for DCAP/ECDSA attestation, specify SPID as empty string (linkable value is ignored)
@@ -13,8 +15,6 @@ else
 GRAPHENE_LOG_LEVEL = error
 CFLAGS += -O2
 endif
-
-include ../../Scripts/Makefile.configs
 
 .PHONY: all
 all: app epid  # by default, only build EPID because it doesn't rely on additional (DCAP) libs
@@ -44,7 +44,7 @@ MBED_BUILD_TYPE=Release
 endif
 
 $(MBEDTLS_SRC):
-	$(GRAPHENEDIR)/Scripts/download --output $@ $(foreach mirror,$(MBEDTLS_URI),--url $(mirror)/$(MBEDTLS_SRC)) --sha256 $(MBEDTLS_CHECKSUM)
+	../common_tools/download --output $@ $(foreach mirror,$(MBEDTLS_URI),--url $(mirror)/$(MBEDTLS_SRC)) --sha256 $(MBEDTLS_CHECKSUM)
 
 .SECONDARY: mbedtls/.mbedtls_downloaded
 mbedtls/.mbedtls_downloaded: $(MBEDTLS_SRC)
@@ -120,8 +120,10 @@ server.manifest: server.manifest.template
 		$< > $@
 
 server.manifest.sgx: server.manifest server mbedtls/.mbedtls_built libs/.epid_libs_copied
+	@test -s $(SGX_SIGNER_KEY) || \
+	    { echo "SGX signer private key was not found, please specify SGX_SIGNER_KEY!"; exit 1; }
 	graphene-sgx-sign \
-		--key $(GRAPHENEKEY) \
+		--key $(SGX_SIGNER_KEY) \
 		--manifest $< \
 		--output $@
 
@@ -139,8 +141,10 @@ client_dcap.manifest: client.manifest.template
 		$< >$@
 
 client_dcap.manifest.sgx: client_dcap.manifest client mbedtls/.mbedtls_built libs/.dcap_libs_copied
+	@test -s $(SGX_SIGNER_KEY) || \
+	    { echo "SGX signer private key was not found, please specify SGX_SIGNER_KEY!"; exit 1; }
 	graphene-sgx-sign \
-		--key $(GRAPHENEKEY) \
+		--key $(SGX_SIGNER_KEY) \
 		--manifest $< \
 		--output $@
 
@@ -158,8 +162,10 @@ client_epid.manifest: client.manifest.template
 		$< >$@
 
 client_epid.manifest.sgx: client_epid.manifest client libs/.epid_libs_copied
+	@test -s $(SGX_SIGNER_KEY) || \
+	    { echo "SGX signer private key was not found, please specify SGX_SIGNER_KEY!"; exit 1; }
 	graphene-sgx-sign \
-		--key $(GRAPHENEKEY) \
+		--key $(SGX_SIGNER_KEY) \
 		--manifest $< \
 		--output $@
 

--- a/Examples/ra-tls-secret-prov/Makefile
+++ b/Examples/ra-tls-secret-prov/Makefile
@@ -1,5 +1,7 @@
 GRAPHENEDIR ?= ../..
-GRAPHENEKEY ?= $(GRAPHENEDIR)/Pal/src/host/Linux-SGX/signer/enclave-key.pem
+SGX_SIGNER_KEY ?= $(GRAPHENEDIR)/Pal/src/host/Linux-SGX/signer/enclave-key.pem
+
+ARCH_LIBDIR ?= /lib/$(shell $(CC) -dumpmachine)
 
 # for EPID attestation, specify your SPID and linkable/unlinkable attestation policy;
 # for DCAP/ECDSA attestation, specify SPID as empty string (linkable value is ignored)
@@ -13,8 +15,6 @@ else
 GRAPHENE_LOG_LEVEL = error
 CFLAGS += -O2
 endif
-
-include ../../Scripts/Makefile.configs
 
 .PHONY: clients
 clients: secret_prov_min_client secret_prov_client secret_prov_pf_client
@@ -50,7 +50,7 @@ MBED_BUILD_TYPE=Release
 endif
 
 $(MBEDTLS_SRC):
-	$(GRAPHENEDIR)/Scripts/download --output $@ $(foreach mirror,$(MBEDTLS_URI),--url $(mirror)/$(MBEDTLS_SRC)) --sha256 $(MBEDTLS_CHECKSUM)
+	../common_tools/download --output $@ $(foreach mirror,$(MBEDTLS_URI),--url $(mirror)/$(MBEDTLS_SRC)) --sha256 $(MBEDTLS_CHECKSUM)
 
 .SECONDARY: mbedtls/.mbedtls_downloaded
 mbedtls/.mbedtls_downloaded: $(MBEDTLS_SRC)
@@ -141,8 +141,10 @@ secret_prov_client.manifest: secret_prov_client.manifest.template
 		$< > $@
 
 secret_prov_client.manifest.sgx: secret_prov_client.manifest secret_prov_client libs/.common_libs_copied
+	@test -s $(SGX_SIGNER_KEY) || \
+	    { echo "SGX signer private key was not found, please specify SGX_SIGNER_KEY!"; exit 1; }
 	graphene-sgx-sign \
-		--key $(GRAPHENEKEY) \
+		--key $(SGX_SIGNER_KEY) \
 		--manifest $< \
 		--output $@
 
@@ -162,8 +164,10 @@ secret_prov_min_client.manifest: secret_prov_min_client.manifest.template
 		$< > $@
 
 secret_prov_min_client.manifest.sgx: secret_prov_min_client.manifest secret_prov_min_client libs/.common_libs_copied
+	@test -s $(SGX_SIGNER_KEY) || \
+	    { echo "SGX signer private key was not found, please specify SGX_SIGNER_KEY!"; exit 1; }
 	graphene-sgx-sign \
-		--key $(GRAPHENEKEY) \
+		--key $(SGX_SIGNER_KEY) \
 		--manifest $< \
 		--output $@
 
@@ -188,8 +192,10 @@ secret_prov_pf_client.manifest: secret_prov_pf_client.manifest.template
 		$< > $@
 
 secret_prov_pf_client.manifest.sgx: secret_prov_pf_client.manifest secret_prov_pf_client libs/.common_libs_copied
+	@test -s $(SGX_SIGNER_KEY) || \
+	    { echo "SGX signer private key was not found, please specify SGX_SIGNER_KEY!"; exit 1; }
 	graphene-sgx-sign \
-		--key $(GRAPHENEKEY) \
+		--key $(SGX_SIGNER_KEY) \
 		--manifest $< \
 		--output $@
 

--- a/Examples/redis/Makefile
+++ b/Examples/redis/Makefile
@@ -16,9 +16,13 @@
 
 ################################# CONSTANTS ###################################
 
-# Relative path to Graphene root
-GRAPHENEDIR = ../..
-SGX_SIGNER_KEY ?= $(GRAPHENEDIR)/Pal/src/host/Linux-SGX/signer/enclave-key.pem
+# In production env, SGX_SIGNER_KEY must point to production signing key
+SGX_SIGNER_KEY ?= ../../Pal/src/host/Linux-SGX/signer/enclave-key.pem
+
+# directory with arch-specific libraries, used by Redis
+# the below path works for Debian/Ubuntu; for CentOS/RHEL/Fedora, you should
+# overwrite this default like this: `ARCH_LIBDIR=/lib64 make`
+ARCH_LIBDIR ?= /lib/$(shell $(CC) -dumpmachine)
 
 SRCDIR = src
 COMMIT = 6.0.5
@@ -36,8 +40,6 @@ ifeq ($(SGX),1)
 all: redis-server.manifest.sgx redis-server.sig redis-server.token
 endif
 
-include ../../Scripts/Makefile.configs
-
 ############################## REDIS EXECUTABLE ###############################
 
 # Redis is built as usual, without any changes to the build process (except to
@@ -46,7 +48,7 @@ include ../../Scripts/Makefile.configs
 # is the final executable "src/redis-server".
 
 $(SRCDIR)/Makefile:
-	$(GRAPHENEDIR)/Scripts/download --output redis.tar.gz \
+	../common_tools/download --output redis.tar.gz \
 		--sha256 $(TAR_SHA256) \
 		--url https://github.com/antirez/redis/archive/$(COMMIT).tar.gz \
 		--url https://packages.grapheneproject.io/distfiles/redis-$(COMMIT).tar.gz
@@ -94,6 +96,8 @@ redis-server.sig redis-server.manifest.sgx: sgx_outputs
 
 .INTERMEDIATE: sgx_outputs
 sgx_outputs: redis-server.manifest $(SRCDIR)/src/redis-server
+	@test -s $(SGX_SIGNER_KEY) || \
+	    { echo "SGX signer private key was not found, please specify SGX_SIGNER_KEY!"; exit 1; }
 	graphene-sgx-sign \
 		--key $(SGX_SIGNER_KEY) \
 		--manifest redis-server.manifest \

--- a/Examples/sqlite/Makefile
+++ b/Examples/sqlite/Makefile
@@ -1,5 +1,6 @@
-GRAPHENEDIR ?= ../..
-SGX_SIGNER_KEY ?= $(GRAPHENEDIR)/Pal/src/host/Linux-SGX/signer/enclave-key.pem
+SGX_SIGNER_KEY ?= ../../Pal/src/host/Linux-SGX/signer/enclave-key.pem
+
+ARCH_LIBDIR ?= /lib/$(shell $(CC) -dumpmachine)
 
 ifeq ($(DEBUG),1)
 GRAPHENE_LOG_LEVEL = debug
@@ -13,8 +14,6 @@ ifeq ($(SGX),1)
 all: sqlite3.manifest.sgx sqlite3.sig sqlite3.token
 endif
 
-include ../../Scripts/Makefile.configs
-
 sqlite3.manifest: manifest.template
 	graphene-manifest \
 		-Dlog_level=$(GRAPHENE_LOG_LEVEL) \
@@ -23,6 +22,8 @@ sqlite3.manifest: manifest.template
 		$< >$@
 
 sqlite3.manifest.sgx: sqlite3.manifest
+	@test -s $(SGX_SIGNER_KEY) || \
+	    { echo "SGX signer private key was not found, please specify SGX_SIGNER_KEY!"; exit 1; }
 	graphene-sgx-sign \
 		--key $(SGX_SIGNER_KEY) \
 		--manifest sqlite3.manifest \

--- a/Examples/tensorflow-lite/Makefile
+++ b/Examples/tensorflow-lite/Makefile
@@ -2,8 +2,10 @@ manifests = $(addsuffix .manifest,label_image)
 exec_target = $(manifests)
 target = label_image
 
-GRAPHENEDIR ?= ../..
-SGX_SIGNER_KEY ?= $(GRAPHENEDIR)/Pal/src/host/Linux-SGX/signer/enclave-key.pem
+SGX_SIGNER_KEY ?= ../../Pal/src/host/Linux-SGX/signer/enclave-key.pem
+
+ARCH_LIBDIR ?= /lib/$(shell $(CC) -dumpmachine)
+
 TF_DIR ?= tensorflow
 BAZEL_BIN ?= $(HOME)/bin/bazel
 
@@ -28,10 +30,8 @@ else
 GRAPHENE = graphene-sgx
 endif
 
-include ../../Scripts/Makefile.configs
-
 $(TF_DIR)/configure:
-	$(GRAPHENEDIR)/Scripts/download --output tensorflow.tar.gz --sha256 $(TAR_SHA256)\
+	../common_tools/download --output tensorflow.tar.gz --sha256 $(TAR_SHA256)\
 		--url https://github.com/tensorflow/tensorflow/archive/$(GIT_COMMIT).tar.gz
 	mkdir $(TF_DIR)
 	tar -C $(TF_DIR) --strip-components=1 -xf tensorflow.tar.gz
@@ -47,7 +47,7 @@ libtensorflow_framework.so: label_image
 
 INCEPTION_HASH=b1a1f91276e48a9ddf0cb0d854f044ebfbf985dc2c2cedceb52b3d668894299a
 inception_v3.tflite:
-	$(GRAPHENEDIR)/Scripts/download --output inception_v3_2018_04_27.tgz --sha256 $(INCEPTION_HASH)\
+	../common_tools/download --output inception_v3_2018_04_27.tgz --sha256 $(INCEPTION_HASH)\
 		--url https://storage.googleapis.com/download.tensorflow.org/models/tflite/model_zoo/upload_20180427/inception_v3_2018_04_27.tgz
 	tar xfz inception_v3_2018_04_27.tgz
 
@@ -57,19 +57,16 @@ labels.txt: $(TF_DIR)/tensorflow/contrib/lite/java/ovic/src/testdata/labels.txt
 image.bmp: $(TF_DIR)/tensorflow/contrib/lite/examples/label_image/testdata/grace_hopper.bmp
 	cp $^ $@
 
-$(GRAPHENEDIR)/Runtime/libgcc_s.so.1:
-	cp $(ARCH_LIBDIR)/libgcc_s.so.1 $@
-
-$(GRAPHENEDIR)/Runtime/libstdc++.so.6:
-	cp /usr/$(ARCH_LIBDIR)/libstdc++.so.6 $@
-
 label_image.manifest: label_image.manifest.template libtensorflow_framework.so label_image \
                       inception_v3.tflite labels.txt image.bmp
 	graphene-manifest \
 		-Dlog_level=$(GRAPHENE_LOG_LEVEL) \
+		-Darch_libdir=$(ARCH_LIBDIR) \
 		$< > $@
 
 label_image.manifest.sgx: label_image.manifest inception_v3.tflite labels.txt
+	@test -s $(SGX_SIGNER_KEY) || \
+	    { echo "SGX signer private key was not found, please specify SGX_SIGNER_KEY!"; exit 1; }
 	graphene-sgx-sign \
 		--key $(SGX_SIGNER_KEY) \
 		--manifest $< \
@@ -106,7 +103,7 @@ install-dependencies-ubuntu:
 	apt-get install -y python-dev python-pip wget git
 	# https://docs.bazel.build/versions/master/install-ubuntu.html
 	apt-get install -y pkg-config zip g++ zlib1g-dev unzip python
-	$(GRAPHENEDIR)/Scripts/download --output bazel-0.16.1-installer-linux-x86_64.sh --sha256 $(BAZEL_INSTALLER_HASH)\
+	../common_tools/download --output bazel-0.16.1-installer-linux-x86_64.sh --sha256 $(BAZEL_INSTALLER_HASH)\
 		--url https://github.com/bazelbuild/bazel/releases/download/0.16.1/bazel-0.16.1-installer-linux-x86_64.sh
 	chmod +x bazel-0.16.1-installer-linux-x86_64.sh
 	./bazel-0.16.1-installer-linux-x86_64.sh --user
@@ -114,7 +111,7 @@ install-dependencies-ubuntu:
 .PHONY: install-dependencies-fedora
 install-dependencies-fedora:
 	dnf -y install python3-devel python3-pip wget git pkg-config zip gcc-g++ zlib-devel unzip
-	$(GRAPHENEDIR)/Scripts/download --output bazel-0.16.1-installer-linux-x86_64.sh --sha256 $(BAZEL_INSTALLER_HASH)\
+	../common_tools/download --output bazel-0.16.1-installer-linux-x86_64.sh --sha256 $(BAZEL_INSTALLER_HASH)\
 		--url https://github.com/bazelbuild/bazel/releases/download/0.16.1/bazel-0.16.1-installer-linux-x86_64.sh
 	chmod +x bazel-0.16.1-installer-linux-x86_64.sh
 	./bazel-0.16.1-installer-linux-x86_64.sh --user

--- a/Examples/tensorflow-lite/label_image.manifest.template
+++ b/Examples/tensorflow-lite/label_image.manifest.template
@@ -4,7 +4,7 @@ loader.preload = "file:{{ graphene.libos }}"
 libos.entrypoint = "label_image"
 loader.log_level = "{{ log_level }}"
 
-loader.env.LD_LIBRARY_PATH = "/lib:."
+loader.env.LD_LIBRARY_PATH = "/lib:{{ arch_libdir }}:/usr/{{ arch_libdir }}:."
 loader.env.PATH = "/bin:/usr/bin"
 
 loader.insecure__use_cmdline_argv = true
@@ -13,13 +13,25 @@ fs.mount.lib1.type = "chroot"
 fs.mount.lib1.path = "/lib"
 fs.mount.lib1.uri = "file:{{ graphene.runtimedir() }}"
 
+fs.mount.lib2.type = "chroot"
+fs.mount.lib2.path = "{{ arch_libdir }}"
+fs.mount.lib2.uri = "file:{{ arch_libdir }}"
+
+fs.mount.lib3.type = "chroot"
+fs.mount.lib3.path = "/usr{{ arch_libdir }}"
+fs.mount.lib3.uri = "file:/usr{{ arch_libdir }}"
+
 sgx.nonpie_binary = true
 sgx.enclave_size = "512M"
 sgx.thread_num = 16
 
-sgx.trusted_files.runtime = "file:{{ graphene.runtimedir() }}/"
-sgx.trusted_files.libtensorflowframework = "file:libtensorflow_framework.so"
 sgx.trusted_files.label_image = "file:label_image"
+sgx.trusted_files.runtime = "file:{{ graphene.runtimedir() }}/"
+sgx.trusted_files.arch_libdir = "file:{{ arch_libdir }}/"
+sgx.trusted_files.usr_arch_libdir = "file:/usr/{{ arch_libdir }}/"
+sgx.trusted_files.libtensorflowframework = "file:libtensorflow_framework.so"
+
 sgx.trusted_files.model = "file:inception_v3.tflite"
-sgx.allowed_files.image = "file:image.bmp"
 sgx.trusted_files.labels = "file:labels.txt"
+
+sgx.allowed_files.image = "file:image.bmp"


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Examples are supposed to be stand-alone and work with packaged Graphene. To this end, this commit removes the `GRAPHENEDIR` envvar and the associated includes of Graphene-internal Makefiles. This commit also copies the `download` bash script under `Examples/` so that it is closer to the actual examples (this will be handy when moving examples out of this core repository).

Ideally, `SGX_SIGNER_KEY` should be explicitly asked from the user, but for now we default to Graphene-internal `Pal/src/host/Linux-SGX/signer` for simplicity.

Also, `ra-tls-mbedtls` and `ra-tls-secret-prov` are still tightly coupled to Graphene-internal paths. This will be fixed when Linux-SGX PAL build is finally moved to Meson.

For more context, see:
- https://github.com/oscarlab/graphene/issues/2563
- https://github.com/oscarlab/graphene/commit/206eb81eecd8cbb65e07e13ae34ce56101ed211a
- https://github.com/oscarlab/graphene/pull/2288


## How to test this PR? <!-- (if applicable) -->

All CI tests must pass. I also manually tested almost all examples.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2582)
<!-- Reviewable:end -->
