### PR TITLE
[LibOS] Convert some `shim_qstr` instances to C strings

### DIFF
--- a/LibOS/shim/include/shim_fs.h
+++ b/LibOS/shim/include/shim_fs.h
@@ -117,8 +117,9 @@ struct shim_dentry {
     int state; /* flags for managing state */
 
     /* File name, maximum of NAME_MAX characters. By convention, the root has an empty name. Does
-     * not change. */
-    struct shim_qstr name;
+     * not change. Length is kept for performance reasons. */
+    char* name;
+    size_t name_len;
 
     /* Mounted filesystem this dentry belongs to. Does not change. */
     struct shim_mount* mount;
@@ -193,7 +194,7 @@ struct shim_d_ops {
     int (*stat)(struct shim_dentry* dent, struct stat* buf);
 
     /* extracts the symlink name and saves in link */
-    int (*follow_link)(struct shim_dentry* dent, struct shim_qstr* link);
+    int (*follow_link)(struct shim_dentry* dent, char** out_target);
     /* set up symlink name to a dentry */
     int (*set_link)(struct shim_dentry* dent, const char* link);
 
@@ -243,8 +244,8 @@ struct shim_mount {
 
     struct shim_dentry* mount_point;
 
-    struct shim_qstr path;
-    struct shim_qstr uri;
+    char* path;
+    char* uri;
 
     struct shim_dentry* root;
 
@@ -595,10 +596,6 @@ int dentry_abs_path(struct shim_dentry* dent, char** path, size_t* size);
  * including the root), separated by `/`. A relative path never begins with `/`.
  */
 int dentry_rel_path(struct shim_dentry* dent, char** path, size_t* size);
-
-static inline const char* dentry_get_name(struct shim_dentry* dent) {
-    return qstrgetstr(&dent->name);
-}
 
 ino_t dentry_ino(struct shim_dentry* dent);
 

--- a/LibOS/shim/src/bookkeep/shim_handle.c
+++ b/LibOS/shim/src/bookkeep/shim_handle.c
@@ -448,8 +448,8 @@ int set_new_fd_handle_above_fd(FDTYPE fd, struct shim_handle* hdl, int fd_flags,
 static inline __attribute__((unused)) const char* __handle_name(struct shim_handle* hdl) {
     if (!qstrempty(&hdl->uri))
         return qstrgetstr(&hdl->uri);
-    if (hdl->dentry && !qstrempty(&hdl->dentry->name))
-        return qstrgetstr(&hdl->dentry->name);
+    if (hdl->dentry && hdl->dentry->name[0] != '\0')
+        return hdl->dentry->name;
     if (hdl->fs)
         return hdl->fs->name;
     return "(unknown)";

--- a/LibOS/shim/src/fs/pipe/fs.c
+++ b/LibOS/shim/src/fs/pipe/fs.c
@@ -173,7 +173,7 @@ static int fifo_open(struct shim_handle* hdl, struct shim_dentry* dent, int flag
          * one end (read or write) in our emulation, so we treat such FIFOs as read-only. This
          * covers most apps seen in the wild (in particular, LTP apps). */
         log_warning("FIFO (named pipe) '%s' cannot be opened in read-write mode in Graphene. "
-                    "Treating it as read-only.", qstrgetstr(&dent->mount->path));
+                    "Treating it as read-only.", dent->mount->path);
         flags = O_RDONLY;
     }
 

--- a/LibOS/shim/src/fs/proc/ipc-thread.c
+++ b/LibOS/shim/src/fs/proc/ipc-thread.c
@@ -39,8 +39,8 @@ bool proc_ipc_thread_pid_name_exists(struct shim_dentry* parent, const char* nam
 
 int proc_ipc_thread_follow_link(struct shim_dentry* dent, char** out_target) {
     assert(dent->parent);
-    const char* parent_name = qstrgetstr(&dent->parent->name);
-    const char* name = qstrgetstr(&dent->name);
+    const char* parent_name = dent->parent->name;
+    const char* name = dent->name;
 
     unsigned long pid;
     if (pseudo_parse_ulong(parent_name, IDTYPE_MAX, &pid) < 0)

--- a/LibOS/shim/src/fs/proc/thread.c
+++ b/LibOS/shim/src/fs/proc/thread.c
@@ -21,7 +21,7 @@ int proc_thread_follow_link(struct shim_dentry* dent, char** out_target) {
 
     lock(&g_process.fs_lock);
 
-    const char* name = qstrgetstr(&dent->name);
+    const char* name = dent->name;
     if (strcmp(name, "root") == 0) {
         dent = g_process.root;
         get_dentry(dent);
@@ -287,7 +287,7 @@ static char* describe_handle(struct shim_handle* hdl) {
 
 int proc_thread_fd_follow_link(struct shim_dentry* dent, char** out_target) {
     unsigned long fd;
-    if (pseudo_parse_ulong(qstrgetstr(&dent->name), FDTYPE_MAX, &fd) < 0)
+    if (pseudo_parse_ulong(dent->name, FDTYPE_MAX, &fd) < 0)
         return -ENOENT;
 
     struct shim_handle_map* handle_map = get_thread_handle_map(NULL);

--- a/LibOS/shim/src/fs/shim_fs_hash.c
+++ b/LibOS/shim/src/fs/shim_fs_hash.c
@@ -45,7 +45,7 @@ HASHTYPE hash_abs_path(struct shim_dentry* dent) {
         if (!up)
             break;
 
-        digest += hash_str(qstrgetstr(&dent->name));
+        digest += hash_str(dent->name);
         digest *= 9;
         dent = up;
     }

--- a/LibOS/shim/src/fs/shim_namei.c
+++ b/LibOS/shim/src/fs/shim_namei.c
@@ -122,24 +122,24 @@ static int do_path_lookupat(struct shim_dentry* start, const char* path, int fla
 static int path_lookupat_follow(struct shim_dentry* link, int flags, struct shim_dentry** found,
                                 unsigned int link_depth) {
     int ret;
-    struct shim_qstr link_target = QSTR_INIT;
+    char* target = NULL;
 
     assert(locked(&g_dcache_lock));
 
     assert(link->fs);
     assert(link->fs->d_ops);
     assert(link->fs->d_ops->follow_link);
-    ret = link->fs->d_ops->follow_link(link, &link_target);
+    ret = link->fs->d_ops->follow_link(link, &target);
     if (ret < 0)
         goto out;
 
     struct shim_dentry* up = dentry_up(link);
     if (!up)
         up = g_dentry_root;
-    ret = do_path_lookupat(up, qstrgetstr(&link_target), flags, found, link_depth);
+    ret = do_path_lookupat(up, target, flags, found, link_depth);
 
 out:
-    qstrfree(&link_target);
+    free(target);
     return ret;
 }
 

--- a/LibOS/shim/src/fs/sys/cache_info.c
+++ b/LibOS/shim/src/fs/sys/cache_info.c
@@ -25,7 +25,7 @@ int sys_cache_load(struct shim_dentry* dent, char** out_data, size_t* out_size) 
     if (ret < 0)
         return ret;
 
-    const char* name = qstrgetstr(&dent->name);
+    const char* name = dent->name;
     PAL_CORE_CACHE_INFO* cache = &g_pal_control->topo_info.core_topology[cpu_num].cache[cache_num];
     const char* str;
     if (strcmp(name, "shared_cpu_map") == 0) {

--- a/LibOS/shim/src/fs/sys/cpu_info.c
+++ b/LibOS/shim/src/fs/sys/cpu_info.c
@@ -13,7 +13,7 @@
 #include "shim_fs_pseudo.h"
 
 int sys_cpu_general_load(struct shim_dentry* dent, char** out_data, size_t* out_size) {
-    const char* name = qstrgetstr(&dent->name);
+    const char* name = dent->name;
     const char* str;
 
     if (strcmp(name, "online") == 0) {
@@ -35,7 +35,7 @@ int sys_cpu_load(struct shim_dentry* dent, char** out_data, size_t* out_size) {
     if (ret < 0)
         return ret;
 
-    const char* name = qstrgetstr(&dent->name);
+    const char* name = dent->name;
     PAL_CORE_TOPO_INFO* core_topology = &g_pal_control->topo_info.core_topology[cpu_num];
     const char* str;
     if (strcmp(name, "online") == 0) {

--- a/LibOS/shim/src/fs/sys/fs.c
+++ b/LibOS/shim/src/fs/sys/fs.c
@@ -16,7 +16,7 @@
 
 static int sys_resource(struct shim_dentry* parent, const char* name, unsigned int* out_num,
                         readdir_callback_t callback, void* arg) {
-    const char* parent_name = qstrgetstr(&parent->name);
+    const char* parent_name = parent->name;
     PAL_NUM pal_total;
     unsigned int total;
     const char* prefix;
@@ -67,10 +67,8 @@ static int sys_resource(struct shim_dentry* parent, const char* name, unsigned i
 int sys_resource_find(struct shim_dentry* dent, const char* name, unsigned int* num) {
     struct shim_dentry* parent = dent->parent;
     while (parent) {
-        const char* parent_name = qstrgetstr(&parent->name);
-        if (strcmp(parent_name, name) == 0) {
-            return sys_resource(parent, qstrgetstr(&dent->name), num, /*callback=*/NULL,
-                                /*arg=*/NULL);
+        if (strcmp(parent->name, name) == 0) {
+            return sys_resource(parent, dent->name, num, /*callback=*/NULL, /*arg=*/NULL);
         }
 
         dent = parent;

--- a/LibOS/shim/src/fs/sys/node_info.c
+++ b/LibOS/shim/src/fs/sys/node_info.c
@@ -12,7 +12,7 @@
 #include "shim_fs_pseudo.h"
 
 int sys_node_general_load(struct shim_dentry* dent, char** out_data, size_t* out_size) {
-    const char* name = qstrgetstr(&dent->name);
+    const char* name = dent->name;
     const char* str;
     if (strcmp(name, "online") == 0) {
         str = g_pal_control->topo_info.online_nodes;
@@ -31,7 +31,7 @@ int sys_node_load(struct shim_dentry* dent, char** out_data, size_t* out_size) {
     if (ret < 0)
         return ret;
 
-    const char* name = qstrgetstr(&dent->name);
+    const char* name = dent->name;
     PAL_NUMA_TOPO_INFO* numa_topology = &g_pal_control->topo_info.numa_topology[node_num];
     const char* str = NULL;
     if (strcmp(name, "cpumap" ) == 0) {
@@ -39,7 +39,7 @@ int sys_node_load(struct shim_dentry* dent, char** out_data, size_t* out_size) {
     } else if (strcmp(name, "distance") == 0) {
         str = numa_topology->distance;
     } else if (strcmp(name, "nr_hugepages") == 0) {
-        const char* parent_name = qstrgetstr(&dent->parent->name);
+        const char* parent_name = dent->parent->name;
         if (strcmp(parent_name, "hugepages-2048kB") == 0) {
             str = numa_topology->hugepages[HUGEPAGES_2M].nr_hugepages;
         } else if (strcmp(parent_name, "hugepages-1048576kB") == 0) {

--- a/LibOS/shim/src/fs/tmpfs/fs.c
+++ b/LibOS/shim/src/fs/tmpfs/fs.c
@@ -417,7 +417,7 @@ static int tmpfs_readdir(struct shim_dentry* dent, readdir_callback_t callback, 
         if (!tmp_data || (tmp_data->type != FILE_DIR && tmp_data->type != FILE_REGULAR))
             continue;
 
-        if ((ret = callback(qstrgetstr(&tmp_dent->name), arg)) < 0)
+        if ((ret = callback(tmp_dent->name, arg)) < 0)
             return ret;
     }
     return 0;

--- a/LibOS/shim/src/shim_checkpoint.c
+++ b/LibOS/shim/src/shim_checkpoint.c
@@ -213,6 +213,32 @@ BEGIN_RS_FUNC(qstr) {
 }
 END_RS_FUNC(qstr)
 
+/* Checkpoints a C string (char*). */
+BEGIN_CP_FUNC(str) {
+    __UNUSED(size);
+    /* `size` is sizeof(char) because the macros take a char* value; however, we are going to copy
+     * the whole string */
+    assert(size == sizeof(char));
+
+    char* new_str;
+
+    size_t off = GET_FROM_CP_MAP(obj);
+
+    if (!off) {
+        size_t len = strlen(obj);
+        off = ADD_CP_OFFSET(len + 1);
+        ADD_TO_CP_MAP(obj, off);
+        new_str = (char*)(base + off);
+        memcpy(new_str, obj, len + 1);
+    } else {
+        new_str = (char*)(base + off);
+    }
+
+    if (objp)
+        *objp = new_str;
+}
+END_CP_FUNC_NO_RS(str)
+
 static int send_memory_on_stream(PAL_HANDLE stream, struct shim_cp_store* store) {
     int ret = 0;
 

--- a/LibOS/shim/src/sys/shim_open.c
+++ b/LibOS/shim/src/sys/shim_open.c
@@ -374,8 +374,8 @@ static ssize_t do_getdents(int fd, uint8_t* buf, size_t buf_size, bool is_getden
             name = "..";
             name_len = 2;
         } else {
-            name = qstrgetstr(&dent->name);
-            name_len = dent->name.len;
+            name = dent->name;
+            name_len = dent->name_len;
         }
 
         uint64_t d_ino = dentry_ino(dent);

--- a/LibOS/shim/src/sys/shim_stat.c
+++ b/LibOS/shim/src/sys/shim_stat.c
@@ -97,6 +97,8 @@ long shim_do_fstat(int fd, struct stat* stat) {
 
 long shim_do_readlinkat(int dirfd, const char* file, char* buf, int bufsize) {
     int ret;
+    char* target = NULL;
+
     if (!is_user_string_readable(file))
         return -EFAULT;
 
@@ -112,8 +114,6 @@ long shim_do_readlinkat(int dirfd, const char* file, char* buf, int bufsize) {
     if (*file != '/' && (ret = get_dirfd_dentry(dirfd, &dir)) < 0)
         goto out;
 
-    struct shim_qstr qstr = QSTR_INIT;
-
     if ((ret = path_lookupat(dir, file, LOOKUP_NO_FOLLOW, &dent)) < 0)
         goto out;
 
@@ -126,15 +126,17 @@ long shim_do_readlinkat(int dirfd, const char* file, char* buf, int bufsize) {
     if (!dent->fs || !dent->fs->d_ops || !dent->fs->d_ops->follow_link)
         goto out;
 
-    ret = dent->fs->d_ops->follow_link(dent, &qstr);
+    ret = dent->fs->d_ops->follow_link(dent, &target);
     if (ret < 0)
         goto out;
 
-    ret = bufsize;
-    if (qstr.len < (size_t)bufsize)
-        ret = qstr.len;
+    size_t target_len = strlen(target);
 
-    memcpy(buf, qstrgetstr(&qstr), ret);
+    ret = bufsize;
+    if (target_len < (size_t)bufsize)
+        ret = target_len;
+
+    memcpy(buf, target, ret);
 out:
     if (dent) {
         put_dentry(dent);
@@ -142,6 +144,7 @@ out:
     if (dir) {
         put_dentry(dir);
     }
+    free(target);
     return ret;
 }
 

--- a/LibOS/shim/src/utils/log.c
+++ b/LibOS/shim/src/utils/log.c
@@ -37,7 +37,7 @@ void log_setprefix(shim_tcb_t* tcb) {
     const char* exec_name;
     if (g_process.exec) {
         if (g_process.exec->dentry) {
-            exec_name = qstrgetstr(&g_process.exec->dentry->name);
+            exec_name = g_process.exec->dentry->name;
         } else {
             /* Unknown executable name */
             exec_name = "?";


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

This change gets rid of the following `shim_qstr` instances:

- `shim_dentry.name`
- `shim_mount.path`, `shim_dentry.uri`
- parameter to `follow_link` callback

The remaining ones are mostly `shim_handle.uri` and URIs used by pipe filesystem, but it's somewhat harder to change them, so I wanted to push this first.

## How to test this PR? <!-- (if applicable) -->

This should be well-covered by existing tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2585)
<!-- Reviewable:end -->
