### PR TITLE
[Pal/Linux-SGX] Suppress performing secret provisioning after execve

### DIFF
--- a/Examples/ra-tls-secret-prov/src/secret_prov_pf_client.c
+++ b/Examples/ra-tls-secret-prov/src/secret_prov_pf_client.c
@@ -5,6 +5,7 @@
 #include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <sys/wait.h>
@@ -55,6 +56,21 @@ static int print_pf_key_and_read_protected_file(char* who) {
 }
 
 int main(int argc, char** argv) {
+    /* execvp() is only for testing purposes: to validate that secret provisioning happens only once
+     * (for the first process) and that exec logic preserves the provisioned key */
+    if (argc < 2 || strcmp(argv[1], "skip-execve")) {
+        puts("--- [main] Re-starting myself using execvp() ---");
+        fflush(stdout);
+        char* new_argv[] = {argv[0], "skip-execve", NULL};
+        int ret = execvp(argv[0], new_argv);
+        if (ret < 0) {
+            perror("execvp error");
+            return 1;
+        }
+    }
+
+    /* fork() is only for testing purposes: to validate that secret provisioning doesn't happen
+     * after fork (in the child enclave) and that fork logic preserves the provisioned key */
     int pid = fork();
 
     if (pid < 0) {

--- a/Pal/src/host/Linux-SGX/tools/ra-tls/secret_prov_attest.c
+++ b/Pal/src/host/Linux-SGX/tools/ra-tls/secret_prov_attest.c
@@ -306,6 +306,11 @@ __attribute__((constructor)) static void secret_provision_constructor(void) {
         uint8_t* secret = NULL;
         size_t secret_size = 0;
 
+        /* immediately unset envvar so that execve'd child processes do not land here (otherwise
+         * secret provisioning would happen for each new child, but each child already got all the
+         * secrets from the parent process during checkpoint-and-restore) */
+        unsetenv(SECRET_PROVISION_CONSTRUCTOR);
+
         unsetenv(SECRET_PROVISION_SECRET_STRING);
 
         int ret = secret_provision_start(/*in_servers=*/NULL, /*in_ca_chain_path=*/NULL,


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

SGX Remote attestation and secret provisioning is performed via the `LD_PRELOAD = "libsecret_prov_attest.so"` trick. Previously, there was a bug in the `libsecret_prov_attest.so` library: its constructor was run before the `main()` code in each execve'd process. In multi-process apps that use execve syscall, this led to redundant remote attestation and secret provisioning requests to the Secret provisioning service.

Kudos to @yanzhichao who reported this bug. See https://github.com/oscarlab/graphene/issues/2583.

Fixes #2583.

## How to test this PR? <!-- (if applicable) -->

I added a dummy `execve()` in the ra-tls-secret-prov example: run it, and without this PR you'll see two secre-provisioning requests. With this PR, there will be only one request.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2586)
<!-- Reviewable:end -->
