### PR TITLE
[LibOS] Remove `DENTRY_ISDIRECTORY`, `DENTRY_ISLINK`

### DIFF
--- a/LibOS/shim/include/shim_fs.h
+++ b/LibOS/shim/include/shim_fs.h
@@ -88,8 +88,6 @@ struct shim_fs_ops {
 #define DENTRY_VALID       0x0001 /* this dentry is verified to be valid */
 #define DENTRY_NEGATIVE    0x0002 /* recently deleted or inaccessible */
 #define DENTRY_PERSIST     0x0008 /* added as a persistent dentry */
-#define DENTRY_ISLINK      0x0080 /* this dentry is a link */
-#define DENTRY_ISDIRECTORY 0x0100 /* this dentry is a directory */
 #define DENTRY_LOCKED      0x0200 /* locked by mountpoints at children */
 /* These flags are not used */
 //#define DENTRY_REACHABLE    0x0400  /* permission checked to be reachable */

--- a/LibOS/shim/src/bookkeep/shim_handle.c
+++ b/LibOS/shim/src/bookkeep/shim_handle.c
@@ -711,7 +711,7 @@ BEGIN_CP_FUNC(handle) {
         DO_CP_IN_MEMBER(qstr, new_hdl, uri);
 
         if (hdl->dentry) {
-            if (hdl->dentry->state & DENTRY_ISDIRECTORY) {
+            if (hdl->dentry->type == S_IFDIR) {
                 /*
                  * We don't checkpoint children dentries of a directory dentry, so the child process
                  * will need to list the directory again. However, we keep `dir_info.pos` unchanged

--- a/LibOS/shim/src/fs/chroot/fs.c
+++ b/LibOS/shim/src/fs/chroot/fs.c
@@ -203,7 +203,7 @@ static int create_data(struct shim_dentry* dent, const char* uri, size_t len) {
 
     struct mount_data* mdata = DENTRY_MOUNT_DATA(dent);
     assert(mdata);
-    data->type = (dent->state & DENTRY_ISDIRECTORY) ? FILE_DIR : mdata->base_type;
+    data->type = (dent->type == S_IFDIR) ? FILE_DIR : mdata->base_type;
     data->queried = false;
 
     if (uri) {
@@ -273,7 +273,6 @@ static int __query_attr(struct shim_dentry* dent, struct shim_file_data* data,
         /* Move up the uri update; need to convert manifest-level file:
          * directives to 'dir:' uris */
         if (old_type != FILE_DIR) {
-            dent->state |= DENTRY_ISDIRECTORY;
             if ((ret = make_uri(dent)) < 0)
                 return ret;
         }

--- a/LibOS/shim/src/fs/shim_dcache.c
+++ b/LibOS/shim/src/fs/shim_dcache.c
@@ -80,8 +80,7 @@ int init_dcache(void) {
      *  will fail. */
     g_dentry_root->state |= DENTRY_VALID;
 
-    /* The root should be a directory too*/
-    g_dentry_root->state |= DENTRY_ISDIRECTORY;
+    /* The root should be a directory too */
     g_dentry_root->perm = PERM_rwx______;
     g_dentry_root->type = S_IFDIR;
 
@@ -402,8 +401,11 @@ static void dump_dentry(struct shim_dentry* dent, unsigned int level) {
         buf_puts(&buf, "  ");
 
     buf_puts(&buf, qstrgetstr(&dent->name));
-    DUMP_FLAG(DENTRY_ISDIRECTORY, "/", "");
-    DUMP_FLAG(DENTRY_ISLINK, " -> ", "");
+    switch (dent->type) {
+        case S_IFDIR: buf_puts(&buf, "/"); break;
+        case S_IFLNK: buf_puts(&buf, " -> "); break;
+        default: break;
+    }
     buf_flush(&buf);
 
     if (dent->attached_mount) {

--- a/LibOS/shim/src/fs/shim_fs_pseudo.c
+++ b/LibOS/shim/src/fs/shim_fs_pseudo.c
@@ -178,11 +178,9 @@ static int pseudo_lookup(struct shim_dentry* dent) {
 
     switch (node->type) {
         case PSEUDO_DIR:
-            dent->state |= DENTRY_ISDIRECTORY;
             dent->type = S_IFDIR;
             break;
         case PSEUDO_LINK:
-            dent->state |= DENTRY_ISLINK;
             dent->type = S_IFLNK;
             break;
         case PSEUDO_STR:

--- a/LibOS/shim/src/fs/shim_namei.c
+++ b/LibOS/shim/src/fs/shim_namei.c
@@ -218,7 +218,7 @@ static int lookup_enter_dentry(struct lookup* lookup) {
     if ((ret = traverse_mount_and_validate(&lookup->dent)) < 0)
         return ret;
 
-    if (!(lookup->dent->state & DENTRY_NEGATIVE) && (lookup->dent->state & DENTRY_ISLINK)) {
+    if (!(lookup->dent->state & DENTRY_NEGATIVE) && (lookup->dent->type == S_IFLNK)) {
         /* Traverse the symbolic link. This applies to all intermediate segments, final segments
          * ending with slash, and to all final segments if LOOKUP_FOLLOW is set. */
         if (!is_final || has_slash || (lookup->flags & LOOKUP_FOLLOW)) {
@@ -257,7 +257,6 @@ static int lookup_enter_dentry(struct lookup* lookup) {
             lookup->dent->state &= ~DENTRY_NEGATIVE;
             lookup->dent->state |= DENTRY_VALID | DENTRY_SYNTHETIC;
             if (!is_final || has_slash) {
-                lookup->dent->state |= DENTRY_ISDIRECTORY;
                 lookup->dent->type = S_IFDIR;
             } else {
                 lookup->dent->type = S_IFREG;
@@ -267,7 +266,7 @@ static int lookup_enter_dentry(struct lookup* lookup) {
         } else {
             return -ENOENT;
         }
-    } else if (!(lookup->dent->state & DENTRY_ISDIRECTORY)) {
+    } else if (lookup->dent->type != S_IFDIR) {
         /*
          * The file exists, but is not a directory. We expect a directory (and need to fail with
          * -ENOTDIR) in the following cases:
@@ -465,7 +464,7 @@ int dentry_open(struct shim_handle* hdl, struct shim_dentry* dent, int flags) {
 
     assoc_handle_with_dentry(hdl, dent, flags);
 
-    if (dent->state & DENTRY_ISDIRECTORY) {
+    if (dent->type == S_IFDIR) {
         /* Initialize directory handle */
         hdl->is_dir = true;
 
@@ -474,8 +473,8 @@ int dentry_open(struct shim_handle* hdl, struct shim_dentry* dent, int flags) {
 
     /* truncate regular writable file if O_TRUNC is given */
     if ((flags & O_TRUNC) && ((flags & O_RDWR) | (flags & O_WRONLY))
-            && !(dent->state & DENTRY_ISDIRECTORY)
-            && !(dent->state & DENTRY_ISLINK)) {
+            && (dent->type != S_IFDIR)
+            && (dent->type != S_IFLNK)) {
 
         if (!(fs->fs_ops && fs->fs_ops->truncate)) {
             ret = -EINVAL;
@@ -522,14 +521,14 @@ int open_namei(struct shim_handle* hdl, struct shim_dentry* start, const char* p
 
     assert(dent->state & DENTRY_VALID);
 
-    if (dent->state & DENTRY_ISDIRECTORY) {
+    if (dent->type == S_IFDIR) {
         if (flags & O_WRONLY || flags & O_RDWR) {
             ret = -EISDIR;
             goto err;
         }
     }
 
-    if (dent->state & DENTRY_ISLINK) {
+    if (dent->type == S_IFLNK) {
         /*
          * Can happen if user specified O_NOFOLLOW, or O_TRUNC | O_EXCL. Posix requires us to fail
          * with -ELOOP when trying to open a symlink.
@@ -571,7 +570,6 @@ int open_namei(struct shim_handle* hdl, struct shim_dentry* start, const char* p
             if (ret < 0)
                 goto err;
             dent->state &= ~DENTRY_NEGATIVE;
-            dent->state |= DENTRY_ISDIRECTORY;
             dent->type = S_IFDIR;
         } else {
             if (!dir->fs->d_ops->creat) {

--- a/LibOS/shim/src/fs/tmpfs/fs.c
+++ b/LibOS/shim/src/fs/tmpfs/fs.c
@@ -321,7 +321,6 @@ static int tmpfs_stat(struct shim_dentry* dent, struct stat* statbuf) {
 static int tmpfs_lookup(struct shim_dentry* dent) {
     if (!dent->parent) {
         /* root of pseudo-FS */
-        dent->state |= DENTRY_ISDIRECTORY;
         dent->type = S_IFDIR;
         dent->perm = PERM_rwx______;
         return 0;

--- a/LibOS/shim/src/sys/shim_getcwd.c
+++ b/LibOS/shim/src/sys/shim_getcwd.c
@@ -17,6 +17,7 @@
 #include "shim_table.h"
 #include "shim_thread.h"
 #include "shim_utils.h"
+#include "stat.h"
 
 #ifndef ERANGE
 #define ERANGE 34
@@ -87,7 +88,7 @@ long shim_do_fchdir(int fd) {
 
     struct shim_dentry* dent = hdl->dentry;
 
-    if (!(dent->state & DENTRY_ISDIRECTORY)) {
+    if (dent->type != S_IFDIR) {
         char* path = NULL;
         dentry_abs_path(dent, &path, /*size=*/NULL);
         log_debug("%s is not a directory", path);

--- a/LibOS/shim/src/sys/shim_stat.c
+++ b/LibOS/shim/src/sys/shim_stat.c
@@ -15,6 +15,7 @@
 #include "shim_internal.h"
 #include "shim_process.h"
 #include "shim_table.h"
+#include "stat.h"
 
 static int do_stat(struct shim_dentry* dent, struct stat* stat) {
     struct shim_fs* fs = dent->fs;
@@ -119,7 +120,7 @@ long shim_do_readlinkat(int dirfd, const char* file, char* buf, int bufsize) {
     ret = -EINVAL;
     /* The correct behavior is to return -EINVAL if file is not a
        symbolic link */
-    if (!(dent->state & DENTRY_ISLINK))
+    if (dent->type != S_IFLNK)
         goto out;
 
     if (!dent->fs || !dent->fs->d_ops || !dent->fs->d_ops->follow_link)


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

This is a follow-up to previous changes that introduced the `type` field. This change removes the redundancy in data. It also simplifies the `state` bit field - hopefully, I can change it to an enum soon.

It's a small change but I didn't want to bundle it with others - it looks like it would be a pain to keep the commits separate.

## How to test this PR? <!-- (if applicable) -->

This should be well covered by existing tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2587)
<!-- Reviewable:end -->
