### PR TITLE
[LibOS] Use size_t in do_handle_{read,write}

### DIFF
--- a/LibOS/shim/include/shim_handle.h
+++ b/LibOS/shim/include/shim_handle.h
@@ -331,7 +331,7 @@ int open_executable(struct shim_handle* hdl, const char* path);
 
 int get_file_size(struct shim_handle* file, uint64_t* size);
 
-int do_handle_read(struct shim_handle* hdl, void* buf, int count);
-int do_handle_write(struct shim_handle* hdl, const void* buf, int count);
+ssize_t do_handle_read(struct shim_handle* hdl, void* buf, size_t count);
+ssize_t do_handle_write(struct shim_handle* hdl, const void* buf, size_t count);
 
 #endif /* _SHIM_HANDLE_H_ */

--- a/LibOS/shim/src/sys/shim_open.c
+++ b/LibOS/shim/src/sys/shim_open.c
@@ -25,7 +25,7 @@
 #include "shim_utils.h"
 #include "stat.h"
 
-int do_handle_read(struct shim_handle* hdl, void* buf, int count) {
+ssize_t do_handle_read(struct shim_handle* hdl, void* buf, size_t count) {
     if (!(hdl->acc_mode & MAY_READ))
         return -EACCES;
 
@@ -55,7 +55,7 @@ long shim_do_read(int fd, void* buf, size_t count) {
         return shim_do_recvfrom(fd, buf, count, 0, NULL, NULL);
     }
 
-    int ret = do_handle_read(hdl, buf, count);
+    ssize_t ret = do_handle_read(hdl, buf, count);
     put_handle(hdl);
     if (ret == -EINTR) {
         ret = -ERESTARTSYS;
@@ -63,7 +63,7 @@ long shim_do_read(int fd, void* buf, size_t count) {
     return ret;
 }
 
-int do_handle_write(struct shim_handle* hdl, const void* buf, int count) {
+ssize_t do_handle_write(struct shim_handle* hdl, const void* buf, size_t count) {
     if (!(hdl->acc_mode & MAY_WRITE))
         return -EACCES;
 
@@ -87,7 +87,7 @@ long shim_do_write(int fd, const void* buf, size_t count) {
     if (!hdl)
         return -EBADF;
 
-    int ret = do_handle_write(hdl, buf, count);
+    ssize_t ret = do_handle_write(hdl, buf, count);
     put_handle(hdl);
     if (ret == -EINTR) {
         ret = -ERESTARTSYS;


### PR DESCRIPTION
Signed-off-by: Sankaranarayanan Venkatasubramanian <sankaranarayanan.venkatasubramanian@intel.com>

<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://graphene.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->
I encountered an issue while executing a workload where the `read` call was returning error causing the `fread` operation in the application to fail. This is rootcaused to mismatching data types between `shim_do_read` (and `shim_do_write`) and `do_handle_read` (and `do_handle_write`) calls. The incoming argument `count ` in `read` and `write` calls is of data type `size_t` whereas `do_handle_read` and `do_handle_write` takes this `count` as `int` causing an overflow and resulting in error.

This PR is to fix this issue by changing the data type of the argument `count`  in `do_handle_read` and `do_handle_write` to `size_t`.

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2590)
<!-- Reviewable:end -->
