### PR TITLE
[LibOS] Don't expose host-level named pipes to user

### DIFF
--- a/LibOS/shim/src/fs/chroot/fs.c
+++ b/LibOS/shim/src/fs/chroot/fs.c
@@ -254,8 +254,13 @@ static int __query_attr(struct shim_dentry* dent, struct shim_file_data* data,
             }
             type = S_IFCHR;
             break;
+        case pal_type_pipe:
+            log_warning("trying to access '%s' which is a host-level FIFO (named pipe); "
+                        "Graphene supports only named pipes created by Graphene processes",
+                        qstrgetstr(&data->host_uri));
+            return -EACCES;
         default:
-            log_error("unknown PAL handle type: %d", pal_attr.handle_type);
+            log_error("unexpected handle type returned by PAL: %d", pal_attr.handle_type);
             BUG();
     }
 


### PR DESCRIPTION

## Description of the changes <!-- (reasons and measures) -->

A host-level named pipe is opened by PAL as a `pal_type_pipe` handle. Graphene did not handle this case, triggering a BUG(). Instead, we disallow accessing such files from LibOS.

Closes #570 (see the discussion).

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->

Using `busybox` example and warning log level:

```
$ mkfifo x
$ graphene-sgx busybox stat x
...
[P1:T1:busybox] warning: trying to access 'file:./x' which is a host-level FIFO (named pipe); Graphene supports only named pipes created by Graphene processes
stat: can't stat 'x': Permission denied
```

On `master`, the same triggers "Illegal instruction during Graphene internal execution" (due to `BUG()`).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2592)
<!-- Reviewable:end -->
