### PR TITLE
[GSC] Update GSC for latest master build changes

### DIFF
--- a/Documentation/manpages/gsc.rst
+++ b/Documentation/manpages/gsc.rst
@@ -9,13 +9,6 @@
     see `issue #1520 <https://github.com/oscarlab/graphene/issues/1520>`__ for a
     description of missing features and security caveats.
 
-.. warning::
-    GSC is currently set to a version of Graphene from 26. May, 2021 (commit
-    2e737e69f076c60918f87d6829bb769925e75fec). This means that GSC does *not*
-    track the latest Graphene and does not incorporate the latest changes and
-    bug fixes. This is a temporary limitation and will be fixed around July
-    2021.
-
 Synopsis
 ========
 
@@ -267,12 +260,13 @@ follows three main stages and produces an image named ``gsc-<image-name>``.
    via the configuration file).  It then prepares image-specific variables such
    as the executable path and the library path, and scans the entire image to
    generate a list of trusted files.  GSC excludes files and paths starting with
-   :file:`/boot`, :file:`/dev`, :file:`/proc`, :file:`/var`, :file:`/sys` and
-   :file:`/etc/rc`, since checksums are required which either don't exist or may
+   :file:`/boot`, :file:`/dev`, :file:`.dockerenv`, :file:`.dockerinit`,
+   :file:`/etc/mtab`, :file:`/etc/rc`, :file:`/proc`, :file:`/sys`, and
+   :file:`/var`, since checksums are required which either don't exist or may
    vary across different deployment machines. GSC combines these variables and
    list of trusted files into a new manifest file. In a last step the entrypoint
    is changed to launch the :file:`apploader.sh` script which generates an Intel
-   SGX token and starts the :program:`pal-Linux-SGX` loader. Note that the
+   SGX token and starts the :program:`graphene-sgx` loader. Note that the
    generated image (``gsc-<image-name>-unsigned``) cannot successfully load an
    Intel SGX enclave, since essential files and the signature of the enclave are
    still missing (see next stage).
@@ -327,13 +321,13 @@ in :file:`config.yaml.template`.
 
 .. describe:: SGXDriver.Repository
 
-   Source repository of the Intel SGX driver. Default value:
-   `https://github.com/intel/linux-sgx-driver.git
-   <https://github.com/intel/linux-sgx-driver.git>`__.
+   Source repository of the Intel SGX driver. Default value: ""
+   (in-kernel driver)
 
 .. describe:: SGXDriver.Branch
 
-   Use this branch of the repository. Default value: sgx_driver_1.9.
+   Use this branch of the repository. Default value: ""
+   (in-kernel driver)
 
 Run graphenized Docker images
 =============================
@@ -392,7 +386,7 @@ Example
 
 The :file:`test` folder in :file:`Tools/gsc` describes how to graphenize Docker
 images and test them with sample inputs. The samples include Ubuntu-based Docker
-images of Bash, Python, Node.js, Numpy and Pytorch.
+images of Bash, Python, Node.js, Numpy, Pytorch, and a few more.
 
 .. warning::
    All test images rely on insecure arguments to be able to set test-specific
@@ -511,11 +505,11 @@ files may be added to the manifest.
 Access to files in excluded paths
 ---------------------------------
 
-The manifest generation excludes all files and paths starting with
-:file:`/boot`, :file:`/dev`, :file:`/proc`, :file:`/var`, :file:`/sys`, and
-:file:`/etc/rc` from the list of trusted files. If your application
-relies on some files in these directories, you must manually add them to the
-manifest::
+The manifest generation excludes all files and paths starting with :file:`/boot`
+, :file:`/dev`, :file:`.dockerenv`, :file:`.dockerinit`, :file:`/etc/mtab`,
+:file:`/etc/rc`, :file:`/proc`, :file:`/sys`, and :file:`/var` from the list of
+trusted files. If your application relies on some files in these directories,
+you must manually add them to the manifest::
 
    sgx.trusted_files.[identifier] = "[URI]"
    or

--- a/Tools/gsc/config.yaml.template
+++ b/Tools/gsc/config.yaml.template
@@ -6,7 +6,7 @@ Distro: "ubuntu18.04"
 # below; typically, you want to keep the default values though
 Graphene:
     Repository: "https://github.com/oscarlab/graphene.git"
-    Branch:     "2e737e69f076c60918f87d6829bb769925e75fec" # last working commit
+    Branch:     "master"
 
 # Specify the Intel SGX driver installed on your machine (more specifically, on the machine where
 # the graphenized Docker container will run); there are several variants of the SGX driver:

--- a/Tools/gsc/templates/Dockerfile.ubuntu18.04.build.template
+++ b/Tools/gsc/templates/Dockerfile.ubuntu18.04.build.template
@@ -29,48 +29,18 @@ ENV LC_ALL en_US.UTF-8
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US.UTF-8
 
-# Copy Graphene runtime and signer tools to /graphene
-RUN mkdir -p /graphene \
-    && mkdir -p /graphene/Pal/src \
-    && mkdir -p /graphene/Runtime \
-    && mkdir -p /graphene/Scripts \
-    && mkdir -p /graphene/Tools \
-    && mkdir -p /graphene/python
-COPY --from=graphene /graphene/Pal/src/host/Linux-SGX/generated_offsets.py /graphene/python/
-COPY --from=graphene /graphene/Runtime/ /graphene/Runtime
-COPY --from=graphene /graphene/Scripts/Makefile.configs /graphene/Scripts
-COPY --from=graphene /graphene/Scripts/Makefile.Host /graphene/Scripts
+# Copy Graphene runtime and signer tools to /graphene/meson_build_output
+RUN mkdir -p /graphene/Tools \
+    && mkdir -p /graphene/meson_build_output
+
+# TODO: remove this copy after argv_serializer becomes a part of Meson build
 COPY --from=graphene /graphene/Tools/argv_serializer /graphene/Tools
-COPY --from=graphene /graphene/python /graphene/python
-
-{% if debug %}
-COPY --from=graphene /graphene/Pal/gdb_integration/debug_map_gdb.py \
-                     /graphene/Pal/gdb_integration/
-COPY --from=graphene /graphene/Pal/gdb_integration/pagination_gdb.py \
-                     /graphene/Pal/gdb_integration/
-COPY --from=graphene /graphene/Pal/gdb_integration/graphene.gdb \
-                     /graphene/Pal/gdb_integration/
-
-COPY --from=graphene /graphene/Pal/src/host/Linux/gdb_integration/graphene_linux_gdb.py \
-                     /graphene/Pal/src/host/Linux/gdb_integration/
-RUN ln -sf /graphene/Pal/gdb_integration /graphene/Pal/src/host/Linux/gdb_integration/common
-
-COPY --from=graphene /graphene/Pal/src/host/Linux-SGX/gdb_integration/sgx_gdb.so \
-                     /graphene/Pal/src/host/Linux-SGX/gdb_integration/
-COPY --from=graphene /graphene/Pal/src/host/Linux-SGX/gdb_integration/graphene_sgx_gdb.py \
-                     /graphene/Pal/src/host/Linux-SGX/gdb_integration/
-COPY --from=graphene /graphene/Pal/src/host/Linux-SGX/gdb_integration/graphene_sgx.gdb \
-                     /graphene/Pal/src/host/Linux-SGX/gdb_integration/
-RUN ln -sf /graphene/Pal/gdb_integration /graphene/Pal/src/host/Linux-SGX/gdb_integration/common
-{% endif %}
+COPY --from=graphene /graphene/meson_build_output /graphene/meson_build_output
 
 # Copy helper scripts and Graphene manifest
 COPY *.py /
 COPY apploader.sh /
 COPY entrypoint.manifest /
-
-# For convenience (e.g. for debugging), create a link to pal_loader in the root dir
-RUN ln -sf /graphene/Runtime/pal_loader
 
 # Generate trusted arguments if required
 {% if not insecure_args %}
@@ -80,6 +50,9 @@ RUN /graphene/Tools/argv_serializer {{binary}} {{binary_arguments}} "{{"\" \"".j
 # Docker entrypoint/cmd typically contains only the basename of the executable so create a symlink
 RUN cd / \
     && which {{binary}} | xargs ln -s || true
+
+# Include Meson build output directory in $PATH
+ENV PATH="/graphene/meson_build_output/bin:$PATH"
 
 # Mark apploader.sh executable, finalize manifest, and remove intermediate scripts
 RUN chmod u+x /apploader.sh \

--- a/Tools/gsc/templates/Dockerfile.ubuntu18.04.compile.template
+++ b/Tools/gsc/templates/Dockerfile.ubuntu18.04.compile.template
@@ -10,6 +10,7 @@ RUN env DEBIAN_FRONTEND=noninteractive apt-get update \
         git \
         libcurl4-openssl-dev \
         libprotobuf-c-dev \
+        meson \
         protobuf-c-compiler \
         python3 \
         python3-pip \
@@ -34,12 +35,10 @@ ENV ISGX_DRIVER_PATH ""
 {% endif %}
 
 RUN cd /graphene \
-    && make -s -j WERROR=1 SGX=1 {% if debug %} DEBUG=1 {% endif %}
-
-{% if linux %}
-RUN cd /graphene \
-    && make -s -j WERROR=1 {% if debug %} DEBUG=1 {% endif %}
-{% endif %}
-
-# Translate runtime symlinks to files
-RUN for f in $(find /graphene/Runtime -type l); do cp --remove-destination $(realpath $f) $f; done
+    && make -s -j WERROR=1 SGX=1 {% if debug %} DEBUG=1 {% endif %} \
+    && make -s -j WERROR=1 {% if debug %} DEBUG=1 {% endif %} \
+    && meson build --prefix="/graphene/meson_build_output" \
+       --buildtype={% if debug %}debug{% else %}release{% endif %} \
+       -Ddirect=enabled -Dsgx=enabled \
+    && ninja -C build \
+    && ninja -C build install

--- a/Tools/gsc/templates/Dockerfile.ubuntu18.04.sign.template
+++ b/Tools/gsc/templates/Dockerfile.ubuntu18.04.sign.template
@@ -9,16 +9,14 @@ ENV LANGUAGE en_US.UTF-8
 
 COPY gsc-signer-key.pem /gsc-signer-key.pem
 
-RUN /graphene/python/graphene-sgx-sign \
-        -libpal /graphene/Runtime/libpal-Linux-SGX.so \
-        -key /gsc-signer-key.pem \
-        -manifest /entrypoint.manifest \
-        -output /entrypoint.manifest.sgx
+RUN export PYTHONPATH="${PYTHONPATH}:$(find /graphene/meson_build_output/lib -type d -path '*/site-packages')" \
+    && graphene-sgx-sign \
+         --key /gsc-signer-key.pem \
+         --manifest /entrypoint.manifest \
+         --output /entrypoint.manifest.sgx
 
 # This trick removes all temporary files from the previous commands (including gsc-signer-key.pem)
 FROM {{image}}
 
 COPY --from=unsigned_image /*.sig /
 COPY --from=unsigned_image /*.sgx /
-
-RUN rm /graphene/python/graphene-sgx-sign /graphene/python/graphenelibos/sgx_sign.py

--- a/Tools/gsc/templates/apploader.template
+++ b/Tools/gsc/templates/apploader.template
@@ -2,12 +2,14 @@
 
 set -ex
 
+# Include Meson build output directory in $PYTHONPATH, needed by graphene-sgx-get-token
+export PYTHONPATH="${PYTHONPATH}:$(find /graphene/meson_build_output/lib -type d  -path '*/site-packages')"
+
 # Set default PAL to Linux-SGX
 if [ -z "$GSC_PAL" ] || [ "$GSC_PAL" == "Linux-SGX" ]
 then
-    GSC_PAL=Linux-SGX
-    /graphene/python/graphene-sgx-get-token -output /entrypoint.token -sig /entrypoint.sig
-    /graphene/Runtime/pal-$GSC_PAL /graphene/Runtime/libpal-$GSC_PAL.so init /entrypoint {% if insecure_args %}{{binary_arguments}} "${@}"{% endif %}
+    graphene-sgx-get-token -output /entrypoint.token -sig /entrypoint.sig
+    graphene-sgx /entrypoint {% if insecure_args %}{{binary_arguments}} "${@}"{% endif %}
 else
-    /graphene/Runtime/pal-$GSC_PAL /graphene/Runtime/libpal-$GSC_PAL.so init /entrypoint {{binary_arguments}} "${@}"
+    graphene-direct /entrypoint {{binary_arguments}} "${@}"
 fi

--- a/Tools/gsc/templates/entrypoint.manifest.template
+++ b/Tools/gsc/templates/entrypoint.manifest.template
@@ -1,7 +1,7 @@
-libos.entrypoint = "file:/{{binary}}"
-loader.preload = "file:/graphene/Runtime/libsysdb.so"
+libos.entrypoint = "/{{binary}}"
+loader.preload = "file:/graphene/meson_build_output/lib/x86_64-linux-gnu/graphene/libsysdb.so"
 
-loader.env.LD_LIBRARY_PATH = "/graphene/Runtime:{{"{{library_paths}}"}}"
+loader.env.LD_LIBRARY_PATH = "/graphene/meson_build_output/lib/x86_64-linux-gnu/graphene/runtime/glibc:{{"{{library_paths}}"}}"
 loader.env.PATH = "{{"{{env_path}}"}}"
 loader.log_level = {% if debug %} "all" {% else %} "error" {% endif %}
 
@@ -12,14 +12,14 @@ fs.root.uri = "file:/"
 # Graphene's default working dir is '/', so change the working directory to the desired one
 fs.start_dir = "{{working_dir}}"
 
-sgx.nonpie_binary = 1
+sgx.nonpie_binary = true
 
 {% if insecure_args %}
 # !! INSECURE !! Allow passing command-line arguments from the host without validation.
 # Most Docker images rely on runtime arguments and hence, a more general technique is required.
 # The issue is documented at https://github.com/oscarlab/graphene/issues/1520.
 loader.argv0_override = "{{binary}}"
-loader.insecure__use_cmdline_argv = 1
+loader.insecure__use_cmdline_argv = true
 {% else %}
 loader.argv_src_file = "file:/trusted_argv"
 sgx.trusted_files.trusted_argv = "file:/trusted_argv"


### PR DESCRIPTION
Signed-off-by: Veena Saini <veena.saini@intel.com>

<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://graphene.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->

This PR allows GSC to work successfully with latest master. Meson build steps are included in gsc/templates/Dockerfile.ubuntu18.04.compile.template file. The output of meson build is stored inside */graphene/meson_build_output* directory and path to this output directory is included in $PATH and $PYTHONPATH environment variables. 

Few more changes:
(i) loader.preload variable in entrypoint.manifest.template points to meson build output sub-directory, i.e., */graphene/meson_build_output*/lib/x86_64-linux-gnu/graphene/.
(ii) graphene-sgx-sign and graphene-sgx-get-token binaries are included from meson build output sub-directory, i.e. ,
*/graphene/meson_build_output*/bin. 

## How to test this PR? <!-- (if applicable) -->
GSC build and sign steps should pass, and resultant gsc image should successfully run. 
Jenkins must pass.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2594)
<!-- Reviewable:end -->
