### PR TITLE
[LTP] Increase timeout of slow `sendfile09` and `fsync02`

### DIFF
--- a/LibOS/shim/test/ltp/ltp.cfg
+++ b/LibOS/shim/test/ltp/ltp.cfg
@@ -583,6 +583,10 @@ skip = yes
 [fsync01]
 skip = yes
 
+# can write up to 65,536 8K blocks; the test itself assumes that it takes no more than 120 seconds
+[fsync02]
+timeout = 120
+
 # 1. fsync() on a pipe returns EROFS, not EINVAL
 # 2. fsync() on a socket returns EROFS, not EINVAL
 # 5. fsync() on a fifo returns EROFS, not EINVAL
@@ -1886,6 +1890,13 @@ skip = yes
 
 [sendfile07_64]
 skip = yes
+
+# sendfile09 copies 1GB of data from one file to another twice, may be slow on HDD machines
+[sendfile09]
+timeout = 60
+
+[sendfile09_64]
+timeout = 60
 
 # EINVAL from native sendmsg()
 [sendmmsg01]


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

`sendfile09` is already slow on my machine with SSD (2-5 seconds). So I can imagine how it exceeds the 30-second default timeout on our tiny NUCs with probably super-slow HDDs. Also recall that LTP tests are run in parallel in our CI, so the perf gets even worse.

I checked other `sendfile*` LTP tests, and they all operate on small data (up to 100 bytes). That's why they never timeout, but `sendfile09` does.

UPDATE: Added `fsync02` here, with timeout of 120 seconds. Looking at the sources of this test, I see this:
```c
/* fsync() has to finish within TIME_LIMIT. */
#define TIME_LIMIT 120
```

## How to test this PR? <!-- (if applicable) -->

Jenkins. Can try several times to make sure we solved this issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2600)
<!-- Reviewable:end -->
