### PR TITLE
[Docs] conf.py: Check the version of Sphinx to avoid invoking deprecated method

### DIFF
--- a/Documentation/conf.py
+++ b/Documentation/conf.py
@@ -95,7 +95,11 @@ def generate_doxygen(app):
         subprocess.check_call(['doxygen', 'Doxyfile-{}'.format(p)])
 
 def setup(app):
-    app.add_stylesheet('css/graphene.css')
+    import sphinx
+    if sphinx.__version__ < '1.8': 
+        app.add_stylesheet('css/graphene.css')
+    else:
+        app.add_css_file('css/graphene.css')
     app.connect('builder-inited', generate_doxygen)
 
 breathe_domain_by_extension = {


### PR DESCRIPTION
This PR is related to building the documentation. 

In the setup() function of conf.py, app.add_stylesheet() is used to add a CSS file. But this only works for Sphinx under version 1.8 as Sphinx has renamed app.add_stylesheet() into app.add_css_file() since version 1.8. Hence I added a version check before invoking that to avoid that such an error happens.

## How to test?
Change the directory into Documentation/, and use `make html`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2601)
<!-- Reviewable:end -->
