### PR TITLE
[Pal/Linux-SGX] Remove adding trusted files when parsing `loader.preload`

### DIFF
--- a/Pal/src/host/Linux-SGX/enclave_framework.c
+++ b/Pal/src/host/Linux-SGX/enclave_framework.c
@@ -695,42 +695,6 @@ out:
 int init_trusted_files(void) {
     int ret;
 
-    /* read loader.preload string from manifest and register its files as trusted */
-    char* preload_str = NULL;
-    ret = toml_string_in(g_pal_state.manifest_root, "loader.preload", &preload_str);
-    if (ret < 0) {
-        log_error("Cannot parse \'loader.preload\' "
-                  "(the value must be put in double quotes!)");
-        return -PAL_ERROR_INVAL;
-    }
-
-    if (preload_str) {
-        int npreload = 0;
-        char key[20];
-        const char* start;
-        const char* end;
-        size_t len = strlen(preload_str);
-
-        for (start = preload_str; start < preload_str + len; start = end + 1) {
-            for (end = start; end < preload_str + len && *end && *end != ','; end++)
-                ;
-            if (end > start) {
-                char uri[end - start + 1];
-                memcpy(uri, start, end - start);
-                uri[end - start] = 0;
-                snprintf(key, 20, "preload%d", npreload++);
-
-                ret = init_trusted_file(key, uri);
-                if (ret < 0) {
-                    free(preload_str);
-                    return ret;
-                }
-            }
-        }
-
-        free(preload_str);
-    }
-
     /* read sgx.trusted_files entries from manifest and register them */
     toml_table_t* manifest_sgx = toml_table_in(g_pal_state.manifest_root, "sgx");
     if (!manifest_sgx)


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

This is already done by the `sgx_sign.py` script when generating the
final manifest; so the removed code was redundant.

## How to test this PR? <!-- (if applicable) -->

Jenkins. Everything should just work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2606)
<!-- Reviewable:end -->
