### PR TITLE
[Pal/Linux-SGX] Refactor `init_trusted_files()`

### DIFF
--- a/Pal/src/host/Linux-SGX/db_main.c
+++ b/Pal/src/host/Linux-SGX/db_main.c
@@ -708,13 +708,18 @@ noreturn void pal_linux_main(char* uptr_libpal_uri, size_t libpal_uri_len, char*
         ocall_exit(1, true);
     }
 
-    if ((ret = init_trusted_files()) < 0) {
-        log_error("Failed to load the checksums of trusted files: %d", ret);
+    if ((ret = init_file_check_policy()) < 0) {
+        log_error("Failed to load the file check policy: %d", ret);
         ocall_exit(1, true);
     }
 
-    if ((ret = init_file_check_policy()) < 0) {
-        log_error("Failed to load the file check policy: %d", ret);
+    if ((ret = init_allowed_files()) < 0) {
+        log_error("Failed to initialize allowed files: %d", ret);
+        ocall_exit(1, true);
+    }
+
+    if ((ret = init_trusted_files()) < 0) {
+        log_error("Failed to initialize trusted files: %d", ret);
         ocall_exit(1, true);
     }
 


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

This function is split into several functions: initializing trusted files, initializing allowed files, and registering one file with
normalized path. This commit is in preparation for SGX allowed/trusted/protected files to be specified in TOML arrays.

## How to test this PR? <!-- (if applicable) -->

Jenkins.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2607)
<!-- Reviewable:end -->
