### PR TITLE
[Pal/SGX] Inline `__restore_xregs` in ocall EEXIT code

### DIFF
--- a/Pal/src/host/Linux-SGX/enclave_entry.S
+++ b/Pal/src/host/Linux-SGX/enclave_entry.S
@@ -620,12 +620,14 @@ sgx_ocall:
 	# init_enclave has been called by pal_linux_main. So during early init
 	# nothing should use features not covered by fxrstor, like AVX.
 
-	movq %rdi, %r10
-	leaq g_xsave_reset_state(%rip), %rdi
-	leaq 1f(%rip), %r11
-	jmp __restore_xregs
+	cmpl $0, g_xsave_enabled(%rip)
+	jne 1f
+	fxrstor64 g_xsave_reset_state(%rip)
+	jmp 2f
 1:
-	movq %r10, %rdi
+	mov $0xffffffff, %eax
+	mov %eax, %edx
+	xrstor64 g_xsave_reset_state(%rip)
 2:
 
 	# %rax is argument to EEXIT


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->
Checks whether RIP is in range `[Locall_about_to_eexit_begin, Locall_about_to_eexit_end)` did not consider the case of calling `__restore_xregs`, which lead to incorrect handling of exception happening while being in `__restore_xregs` just before EEXIT while doing an ocall.
Fixes #2603 

## How to test this PR? <!-- (if applicable) -->
Try running `poll_closed_fd` thousands of times (it takes a while). On current master it fails from time to time (after around ~4k times).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2608)
<!-- Reviewable:end -->
