### PR TITLE
[LibOS] Return `-EINVAL` on encountering O_PATH flag in `open`/`openat`

### DIFF
--- a/LibOS/shim/src/sys/shim_open.c
+++ b/LibOS/shim/src/sys/shim_open.c
@@ -104,6 +104,10 @@ long shim_do_creat(const char* path, mode_t mode) {
 }
 
 long shim_do_openat(int dfd, const char* filename, int flags, int mode) {
+    if (flags & O_PATH) {
+        return -EINVAL;
+    }
+
     if (!is_user_string_readable(filename))
         return -EFAULT;
 


### PR DESCRIPTION

<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://graphene.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->
Fixes #2538. Return `-EINVAL` on encountering O_PATH flag in `open`/`openat`
<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->
Do the issue  repro steps mentioned in this PR #2538 .

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2614)
<!-- Reviewable:end -->
