### PR TITLE
[Pal/{Linux,Linux-SGX}] Fix early log messages crashing PAL

### DIFF
--- a/Pal/src/printf.c
+++ b/Pal/src/printf.c
@@ -6,6 +6,12 @@
 #include "pal.h"
 #include "pal_internal.h"
 
+/*
+ * NOTE: The logging subsystem cannot be used during early PAL startup, because the pointers in the
+ * `log_level_to_prefix` array need to be relocated first. If that becomes an issue (that is, if we
+ * want to use logging before or during relocation), this array can be converted to a switch.
+ */
+
 /* NOTE: We could add "pal" prefix to the below strings for more fine-grained log info */
 static const char* log_level_to_prefix[] = {
     [LOG_LEVEL_NONE]    = "",


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

The logging subsystem (`log_error`) requires relocations to be applied before use, due to use of `log_level_to_prefix` array. This caused early calls to `log_error()` to crash.

To fix that, we apply relocations earlier in the startup process.

## Alternatives

- **Compile PAL so that no relocations are necessary** - I'm not sure if that's possible if PAL is position-independent? Apparently GCC has [-static-pie](https://stackoverflow.com/questions/62586808/how-are-relocations-supposed-to-work-in-static-pie-binaries), but it just shifts the work of applying these relocations to runtime (by calling a glibc function)...
- **Compile PAL so that it's at a static position** - probably it's not worth it just for that?
- **Make `log_*` code position-independent**. Maybe that's worth doing regardless of this fix, just in case? So that e.g. we can use log messages in relocation code.

   The problem is that the array (`static const char* log_level_to_prefix[]`) contains the right pointers only after applying relocations. The simplest fix would be to use a `switch` instead of a global array. Experimentally, this does produce position-independent code (although with `-O3` it still produces a sequence of conditions, not a lookup table).

  Alternatively, changing it to `const char log_level_to_prefix[][16]` produces a flat array.
- **Install stack canary **after** relocations** - under Linux host, we start by setting up the stack canary; this can be moved further down if the relocation code itself is marked as `__attribute_no_stack_protector`, but I'm not sure if that's a good idea

## How to test this PR? <!-- (if applicable) -->

`log_error` calls just after `ELF_DYNAMIC_RELOCATE()` should work correctly, and there should be no calls _before_ it.

On master, calls to `log_error` before `ELF_DYNAMIC_RELOCATE()` produce a segfault under Linux, and print a message with no prefix under Linux-SGX (as the non-relocated pointers end up pointing to null bytes by accident).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2618)
<!-- Reviewable:end -->
