### PR TITLE
[LibOS] Relax check on UNIX domain socket's `addrlen` in `bind`

### DIFF
--- a/LibOS/shim/src/sys/shim_socket.c
+++ b/LibOS/shim/src/sys/shim_socket.c
@@ -465,16 +465,31 @@ long shim_do_bind(int sockfd, struct sockaddr* addr, int _addrlen) {
     }
 
     if (sock->domain == AF_UNIX) {
-        if (addrlen != sizeof(struct sockaddr_un))
-            goto out;
-
-        struct sockaddr_un* saddr = (struct sockaddr_un*)addr;
-        char* spath               = saddr->sun_path;
-        struct shim_dentry* dent  = NULL;
-
-        if ((ret = path_lookupat(/*start=*/NULL, spath, LOOKUP_NO_FOLLOW | LOOKUP_CREATE, &dent)) < 0) {
+        if (addrlen < offsetof(struct sockaddr_un, sun_path) + 1 ||
+                addrlen > sizeof(struct sockaddr_un)) {
+            /* address length of the UNIX domain socket is typically calculated as
+             * `offsetof(struct sockaddr_un, sun_path) + strlen(sun_path) + 1`, see `man unix` */
             goto out;
         }
+
+        struct sockaddr_un* saddr = (struct sockaddr_un*)addr;
+        if (saddr->sun_path[0] == '\0') {
+            /* currently abstract UNIX domain sockets are not supported */
+            ret = -EOPNOTSUPP;
+            goto out;
+        }
+
+        size_t sun_path_size = addrlen - offsetof(struct sockaddr_un, sun_path);
+        if (strnlen(saddr->sun_path, sun_path_size) == sun_path_size) {
+            /* user-supplied UNIX domain name is not a NULL-terminating string */
+            goto out;
+        }
+
+        struct shim_dentry* dent = NULL;
+        ret = path_lookupat(/*start=*/NULL, saddr->sun_path, LOOKUP_NO_FOLLOW | LOOKUP_CREATE,
+                            &dent);
+        if (ret < 0)
+            goto out;
 
         if (!(dent->state & DENTRY_NEGATIVE)) {
             ret = -EADDRINUSE;
@@ -517,7 +532,7 @@ long shim_do_bind(int sockfd, struct sockaddr* addr, int _addrlen) {
     if (sock->domain == AF_UNIX) {
         struct shim_dentry* dent = sock->addr.un.dentry;
 
-        dent->state ^= DENTRY_NEGATIVE;
+        dent->state &= ~DENTRY_NEGATIVE;
         dent->state |= DENTRY_VALID;
         dent->fs   = &socket_builtin_fs;
         dent->type = S_IFSOCK;
@@ -733,16 +748,31 @@ long shim_do_connect(int sockfd, struct sockaddr* addr, int _addrlen) {
     }
 
     if (sock->domain == AF_UNIX) {
-        if (addrlen != sizeof(struct sockaddr_un))
-            goto out;
-
-        struct sockaddr_un* saddr = (struct sockaddr_un*)addr;
-        char* spath               = saddr->sun_path;
-        struct shim_dentry* dent  = NULL;
-
-        if ((ret = path_lookupat(/*start=*/NULL, spath, LOOKUP_CREATE | LOOKUP_FOLLOW, &dent)) < 0) {
+        if (addrlen < offsetof(struct sockaddr_un, sun_path) + 1 ||
+                addrlen > sizeof(struct sockaddr_un)) {
+            /* address length of the UNIX domain socket is typically calculated as
+             * `offsetof(struct sockaddr_un, sun_path) + strlen(sun_path) + 1`, see `man unix` */
             goto out;
         }
+
+        struct sockaddr_un* saddr = (struct sockaddr_un*)addr;
+        if (saddr->sun_path[0] == '\0') {
+            /* currently abstract UNIX domain sockets are not supported */
+            ret = -EOPNOTSUPP;
+            goto out;
+        }
+
+        size_t sun_path_size = addrlen - offsetof(struct sockaddr_un, sun_path);
+        if (strnlen(saddr->sun_path, sun_path_size) == sun_path_size) {
+            /* user-supplied UNIX domain name is not a NULL-terminating string */
+            goto out;
+        }
+
+        struct shim_dentry* dent = NULL;
+        ret = path_lookupat(/*start=*/NULL, saddr->sun_path, LOOKUP_FOLLOW | LOOKUP_CREATE,
+                            &dent);
+        if (ret < 0)
+            goto out;
 
         if (!(dent->state & DENTRY_NEGATIVE) && dent->type != S_IFSOCK) {
             ret = -ECONNREFUSED;
@@ -793,7 +823,7 @@ long shim_do_connect(int sockfd, struct sockaddr* addr, int _addrlen) {
     if (sock->domain == AF_UNIX) {
         struct shim_dentry* dent = sock->addr.un.dentry;
         lock(&dent->lock);
-        dent->state ^= DENTRY_NEGATIVE;
+        dent->state &= ~DENTRY_NEGATIVE;
         dent->state |= DENTRY_VALID;
         dent->fs   = &socket_builtin_fs;
         dent->type = S_IFSOCK;

--- a/LibOS/shim/test/regression/test_libos.py
+++ b/LibOS/shim/test/regression/test_libos.py
@@ -900,6 +900,11 @@ class TC_80_Socket(RegressionTestCase):
         self.assertIn('[parent] TEST OK', stdout)
 
     def test_100_socket_unix(self):
+        if os.path.exists("dummy"):
+            os.remove("dummy")
+        if os.path.exists("u"):
+            os.remove("u")
+
         stdout, _ = self.run_binary(['unix'])
         self.assertIn('Data: This is packet 0', stdout)
         self.assertIn('Data: This is packet 1', stdout)

--- a/LibOS/shim/test/regression/unix.c
+++ b/LibOS/shim/test/regression/unix.c
@@ -7,6 +7,7 @@
 #include <err.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -47,8 +48,10 @@ static int server_dummy_socket(void) {
 
     address.sun_family = AF_UNIX;
     strncpy(address.sun_path, "dummy", sizeof(address.sun_path));
+    socklen_t minimal_address_size = offsetof(struct sockaddr_un, sun_path) +
+                                     strlen(address.sun_path) + 1;
 
-    if (bind(create_socket, (struct sockaddr*)&address, sizeof(address)) < 0) {
+    if (bind(create_socket, (struct sockaddr*)&address, minimal_address_size) < 0) {
         perror("bind");
         close(create_socket);
         exit(1);


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Previously, LibOS expected `addrlen` for UNIX domain sockets to be exactly the same as the size of `sockaddr_un` struct. This is not true in the common case: `addrlen` may be less, see `man unix`.

Fixes #2609.

## How to test this PR? <!-- (if applicable) -->

Added a test case in our existing `unix.c` LibOS regression test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2620)
<!-- Reviewable:end -->
