### PR TITLE
[LibOS] Simplify RTLD code

### DIFF
--- a/LibOS/shim/include/shim_internal.h
+++ b/LibOS/shim/include/shim_internal.h
@@ -342,11 +342,8 @@ extern void* __load_address_end;
 
 extern const char** migrated_envp;
 
-struct shim_handle;
-int init_brk_from_executable(struct shim_handle* exec);
 int init_brk_region(void* brk_region, size_t data_segment_size);
 void reset_brk(void);
-int init_loader(void);
 int init_rlimit(void);
 
 bool is_user_memory_readable(const void* addr, size_t size);
@@ -357,6 +354,8 @@ uint64_t get_rlimit_cur(int resource);
 void set_rlimit_cur(int resource, uint64_t rlim);
 
 int object_wait_with_retry(PAL_HANDLE handle);
+
+struct shim_handle;
 
 void _update_epolls(struct shim_handle* handle);
 void delete_from_epoll_handles(struct shim_handle* handle);

--- a/LibOS/shim/include/shim_utils.h
+++ b/LibOS/shim/include/shim_utils.h
@@ -141,11 +141,14 @@ void free(void* mem);
 void* malloc_copy(const void* mem, size_t size);
 
 /* ELF binary loading */
+struct link_map;
+int init_elf_objects(void);
 int check_elf_object(struct shim_handle* file);
-int load_elf_object(struct shim_handle* file);
-int load_elf_interp(struct shim_handle* exec);
-noreturn void execute_elf_object(struct shim_handle* exec, void* argp, elf_auxv_t* auxp);
-int remove_loaded_libraries(void);
+int load_elf_object(struct shim_handle* file, struct link_map** out_map);
+int load_elf_interp(struct link_map* exec_map);
+noreturn void execute_elf_object(struct link_map* exec_map, void* argp, elf_auxv_t* auxp);
+void remove_loaded_elf_objects(void);
+int init_brk_from_executable(struct link_map* exec_map);
 
 /* gdb debugging support */
 int init_r_debug(void);

--- a/LibOS/shim/src/bookkeep/shim_vma.c
+++ b/LibOS/shim/src/bookkeep/shim_vma.c
@@ -700,6 +700,11 @@ int bkeep_munmap(void* addr, size_t length, bool is_internal, void** tmp_vma_ptr
         free_vma(vma2);
     }
 
+    /*
+     * TODO: We call `remove_r_debug()` on the assumption that `addr` might be the beginning of a
+     * loaded ELF object. However, `remove_r_debug()` assumes that `addr` is the load base, while
+     * the first mapping of an ELF object might begin later than its load base.
+     */
     remove_r_debug(addr);
     return ret;
 }

--- a/LibOS/shim/src/sys/shim_clone.c
+++ b/LibOS/shim/src/sys/shim_clone.c
@@ -114,7 +114,7 @@ static BEGIN_MIGRATION_DEF(fork, struct shim_process* process_description,
     DEFINE_MIGRATE(thread, thread_description, sizeof(*thread_description));
     DEFINE_MIGRATE(migratable, NULL, 0);
     DEFINE_MIGRATE(brk, NULL, 0);
-    DEFINE_MIGRATE(loaded_libraries, NULL, 0);
+    DEFINE_MIGRATE(loaded_elf_objects, NULL, 0);
 #ifdef DEBUG
     DEFINE_MIGRATE(gdb_map, NULL, 0);
 #endif


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

* Remove searchable ELF map list (we only need to access two maps: executable and interpreter)
* Refactor interpreter loading code
* Convert some globals to `g_*` naming scheme

This is a byproduct of upcoming FS refactoring.

## How to test this PR? <!-- (if applicable) -->

Existing tests should be enough.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2625)
<!-- Reviewable:end -->
