### PR TITLE
[Pal/Linux-SGX] Define SGX allowed/trusted/protected files as TOML arrays

### DIFF
--- a/Documentation/manifest-syntax.rst
+++ b/Documentation/manifest-syntax.rst
@@ -454,7 +454,10 @@ Allowed files
 
 ::
 
-    sgx.allowed_files.[identifier] = "[URI]"
+    sgx.allowed_files = [
+      "[URI]",
+      "[URI]",
+    ]
 
 This syntax specifies the files that are allowed to be created or loaded into
 the enclave unconditionally. In other words, allowed files can be opened for
@@ -471,16 +474,30 @@ Trusted files
 
 ::
 
-    sgx.trusted_files.[identifier] = "[URI]"
+    # entries can be strings
+    sgx.trusted_files = [
+      "[URI]",
+      "[URI]",
+    ]
+
+    # entries can also be tables
+    [[sgx.trusted_files]]
+    uri = "[URI]"
+    sha256 = "[HASH]"
 
 This syntax specifies the files to be cryptographically hashed at build time,
 and allowed to be accessed by the app in runtime only if their hashes match.
 This implies that trusted files can be only opened for reading (not for writing)
 and cannot be created if they do not exist already. The signer tool will
 automatically generate hashes of these files and add them to the SGX-specific
-manifest (``.manifest.sgx``). Marking files as trusted is especially useful for
-shared libraries: a |~| trusted library cannot be silently replaced by a
-malicious host because the hash verification will fail.
+manifest (``.manifest.sgx``). The manifest writer may also specify the hash for
+a file using the TOML-table syntax, in the field ``sha256``; in this case,
+hashing of the file will be skipped by the signer tool and the value in
+``sha256`` field will be used instead.
+
+Marking files as trusted is especially useful for shared libraries: a |~|
+trusted library cannot be silently replaced by a malicious host because the hash
+verification will fail.
 
 Protected files
 ^^^^^^^^^^^^^^^
@@ -488,7 +505,10 @@ Protected files
 ::
 
     sgx.protected_files_key = "[16-byte hex value]"
-    sgx.protected_files.[identifier] = "[URI]"
+    sgx.protected_files = [
+      "[URI]",
+      "[URI]",
+    ]
 
 This syntax specifies the files that are encrypted on disk and transparently
 decrypted when accessed by Graphene or by application running inside Graphene.

--- a/Documentation/manifest-syntax.rst
+++ b/Documentation/manifest-syntax.rst
@@ -693,3 +693,20 @@ Linux scheduler: the effective maximum is 250 samples per second.
 .. note::
    This option applies only to ``aex`` mode. In the ``ocall_*`` modes, currently
    all samples are taken.
+
+
+Deprecated options
+------------------
+
+Allowed/Trusted/Protected Files (deprecated schema)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+::
+
+    sgx.allowed_files.[identifier] = "[URI]"
+    sgx.trusted_files.[identifier] = "[URI]"
+    sgx.protected_files.[identifier] = "[URI]"
+
+These manifest options used the TOML-table schema that had a bogus
+``[identifier]`` key. This excessive TOML-table schema was replaced with a more
+appropriate TOML-array one.

--- a/LibOS/shim/test/fs/manifest.template
+++ b/LibOS/shim/test/fs/manifest.template
@@ -27,17 +27,21 @@ fs.mount.tmpfs.type = "tmpfs"
 fs.mount.tmpfs.path = "/mnt-tmpfs"
 fs.mount.tmpfs.uri = "file:dummy-unused-by-tmpfs-uri"
 
-sgx.trusted_files.entrypoint = "file:{{ entrypoint }}"
+sgx.nonpie_binary = true
+sgx.thread_num = 16
 
-sgx.trusted_files.runtime = "file:{{ graphene.runtimedir() }}/"
-sgx.trusted_files.libgcc_s = "file:{{ arch_libdir }}/libgcc_s.so.1"
+sgx.allowed_files = [
+  "file:tmp/",
+]
 
-sgx.allowed_files.tmp_dir = "file:tmp/"
+sgx.trusted_files = [
+  "file:{{ entrypoint }}",
+  "file:{{ graphene.runtimedir() }}/",
+  "file:{{ arch_libdir }}/libgcc_s.so.1",
+]
 
 sgx.protected_files_key = "ffeeddccbbaa99887766554433221100"
-sgx.protected_files.input = "file:tmp/pf_input"
-sgx.protected_files.output = "file:tmp/pf_output"
-
-sgx.nonpie_binary = true
-
-sgx.thread_num = 16
+sgx.protected_files = [
+  "file:tmp/pf_input",
+  "file:tmp/pf_output",
+]

--- a/LibOS/shim/test/ltp/manifest.template
+++ b/LibOS/shim/test/ltp/manifest.template
@@ -28,17 +28,19 @@ fs.mount.tmp.uri = "file:/tmp"
 
 sys.brk.max_size = "32M"
 sys.stack.size = "4M"
-
 sgx.nonpie_binary = true
 
-sgx.trusted_files.entrypoint = "file:{{ entrypoint }}"
+sgx.allowed_files = [
+  "file:/tmp",
+]
 
-sgx.trusted_files.ld = "file:{{ graphene.runtimedir() }}/ld-linux-x86-64.so.2"
-sgx.trusted_files.libc = "file:{{ graphene.runtimedir() }}/libc.so.6"
-sgx.trusted_files.libdl = "file:{{ graphene.runtimedir() }}/libdl.so.2"
-sgx.trusted_files.libm = "file:{{ graphene.runtimedir() }}/libm.so.6"
-sgx.trusted_files.libpthread = "file:{{ graphene.runtimedir() }}/libpthread.so.0"
-sgx.trusted_files.librt = "file:{{ graphene.runtimedir() }}/librt.so.1"
-sgx.trusted_files.libstdbuf = "file:{{ coreutils_libdir }}/libstdbuf.so"
-
-sgx.allowed_files.tmp = "file:/tmp"
+sgx.trusted_files = [
+  "file:{{ entrypoint }}",
+  "file:{{ graphene.runtimedir() }}/ld-linux-x86-64.so.2",
+  "file:{{ graphene.runtimedir() }}/libc.so.6",
+  "file:{{ graphene.runtimedir() }}/libdl.so.2",
+  "file:{{ graphene.runtimedir() }}/libm.so.6",
+  "file:{{ graphene.runtimedir() }}/libpthread.so.0",
+  "file:{{ graphene.runtimedir() }}/librt.so.1",
+  "file:{{ coreutils_libdir }}/libstdbuf.so",
+]

--- a/LibOS/shim/test/regression/.gitignore
+++ b/LibOS/shim/test/regression/.gitignore
@@ -3,6 +3,7 @@
 
 /nonexisting_testfile
 /testfile
+/trusted_testfile
 
 /.cache
 /abort

--- a/LibOS/shim/test/regression/Makefile
+++ b/LibOS/shim/test/regression/Makefile
@@ -197,5 +197,6 @@ clean-tmp:
 		__pycache__ \
 		libos-regression.xml \
 		testfile \
+		trusted_testfile \
 		tmp/* \
 		*.o

--- a/LibOS/shim/test/regression/argv_from_file.manifest.template
+++ b/LibOS/shim/test/regression/argv_from_file.manifest.template
@@ -9,9 +9,13 @@ fs.mount.lib.type = "chroot"
 fs.mount.lib.path = "/lib"
 fs.mount.lib.uri = "file:{{ graphene.runtimedir() }}"
 
-sgx.allowed_files.argv = "file:argv_test_input"
-
-sgx.trusted_files.runtime = "file:{{ graphene.runtimedir() }}/"
-sgx.trusted_files.bootstrap = "file:bootstrap"
-
 sgx.nonpie_binary = true
+
+sgx.allowed_files = [
+  "file:argv_test_input",
+]
+
+sgx.trusted_files = [
+  "file:{{ graphene.runtimedir() }}/",
+  "file:bootstrap",
+]

--- a/LibOS/shim/test/regression/attestation.manifest.template
+++ b/LibOS/shim/test/regression/attestation.manifest.template
@@ -13,12 +13,13 @@ fs.mount.bin.type = "chroot"
 fs.mount.bin.path = "/bin"
 fs.mount.bin.uri = "file:/bin"
 
-# sgx-related
-sgx.trusted_files.runtime = "file:{{ graphene.runtimedir() }}/"
-sgx.trusted_files.attestation = "file:attestation"
-
 sgx.nonpie_binary = true
-
 sgx.remote_attestation = true
+
 sgx.ra_client_spid = "{{ ra_client_spid }}"
 sgx.ra_client_linkable = {{ ra_client_linkable }}
+
+sgx.trusted_files = [
+  "file:{{ graphene.runtimedir() }}/",
+  "file:attestation",
+]

--- a/LibOS/shim/test/regression/bootstrap_cpp.manifest.template
+++ b/LibOS/shim/test/regression/bootstrap_cpp.manifest.template
@@ -18,14 +18,14 @@ fs.mount.host_usr_lib.type = "chroot"
 fs.mount.host_usr_lib.path = "/usr/{{ arch_libdir }}"
 fs.mount.host_usr_lib.uri = "file:/usr/{{ arch_libdir }}"
 
-sgx.trusted_files.runtime = "file:{{ graphene.runtimedir() }}/"
-sgx.trusted_files.libgcc_s = "file:{{ arch_libdir }}/libgcc_s.so.1"
-sgx.trusted_files.libstdcxx = "file:/usr{{ arch_libdir }}/libstdc++.so.6"
-sgx.trusted_files.libunwindso = "file:/usr{{ arch_libdir }}/libunwind.so.8"
-sgx.trusted_files.liblzma = "file:{{ arch_libdir }}/liblzma.so.5"
-
-sgx.trusted_files.entrypoint = "file:bootstrap_cpp"
-
 sgx.thread_num = 8
-
 sgx.nonpie_binary = true
+
+sgx.trusted_files = [
+  "file:{{ graphene.runtimedir() }}/",
+  "file:{{ arch_libdir }}/libgcc_s.so.1",
+  "file:/usr{{ arch_libdir }}/libstdc++.so.6",
+  "file:/usr{{ arch_libdir }}/libunwind.so.8",
+  "file:{{ arch_libdir }}/liblzma.so.5",
+  "file:bootstrap_cpp",
+]

--- a/LibOS/shim/test/regression/debug_log_file.manifest.template
+++ b/LibOS/shim/test/regression/debug_log_file.manifest.template
@@ -10,7 +10,9 @@ fs.mount.lib.type = "chroot"
 fs.mount.lib.path = "/lib"
 fs.mount.lib.uri = "file:{{ graphene.runtimedir() }}"
 
-sgx.trusted_files.runtime = "file:{{ graphene.runtimedir() }}/"
-sgx.trusted_files.bootstrap = "file:bootstrap"
-
 sgx.nonpie_binary = true
+
+sgx.trusted_files = [
+  "file:{{ graphene.runtimedir() }}/",
+  "file:bootstrap",
+]

--- a/LibOS/shim/test/regression/debug_log_inline.manifest.template
+++ b/LibOS/shim/test/regression/debug_log_inline.manifest.template
@@ -9,7 +9,9 @@ fs.mount.lib.type = "chroot"
 fs.mount.lib.path = "/lib"
 fs.mount.lib.uri = "file:{{ graphene.runtimedir() }}"
 
-sgx.trusted_files.runtime = "file:{{ graphene.runtimedir() }}/"
-sgx.trusted_files.bootstrap = "file:bootstrap"
-
 sgx.nonpie_binary = true
+
+sgx.trusted_files = [
+  "file:{{ graphene.runtimedir() }}/",
+  "file:bootstrap",
+]

--- a/LibOS/shim/test/regression/device_passthrough.manifest.template
+++ b/LibOS/shim/test/regression/device_passthrough.manifest.template
@@ -11,8 +11,9 @@ fs.mount.dev.type = "chroot"
 fs.mount.dev.path = "/dev/host-zero"
 fs.mount.dev.uri = "dev:/dev/zero"
 
-sgx.trusted_files.runtime = "file:{{ graphene.runtimedir() }}/"
-
-sgx.trusted_files.entrypoint = "file:device_passthrough"
-
 sgx.nonpie_binary = true
+
+sgx.trusted_files = [
+  "file:{{ graphene.runtimedir() }}/",
+  "file:device_passthrough",
+]

--- a/LibOS/shim/test/regression/env_from_file.manifest.template
+++ b/LibOS/shim/test/regression/env_from_file.manifest.template
@@ -8,9 +8,12 @@ fs.mount.lib.type = "chroot"
 fs.mount.lib.path = "/lib"
 fs.mount.lib.uri = "file:{{ graphene.runtimedir() }}"
 
+sgx.nonpie_binary = true
+
+# this tests the old syntax for allowed_files (TOML table)
 sgx.allowed_files.env = "file:env_test_input"
 
-sgx.trusted_files.runtime = "file:{{ graphene.runtimedir() }}/"
-sgx.trusted_files.bootstrap = "file:bootstrap"
-
-sgx.nonpie_binary = true
+sgx.trusted_files = [
+  "file:{{ graphene.runtimedir() }}/",
+  "file:bootstrap",
+]

--- a/LibOS/shim/test/regression/env_from_host.manifest.template
+++ b/LibOS/shim/test/regression/env_from_host.manifest.template
@@ -9,7 +9,9 @@ fs.mount.lib.type = "chroot"
 fs.mount.lib.path = "/lib"
 fs.mount.lib.uri = "file:{{ graphene.runtimedir() }}"
 
-sgx.trusted_files.runtime = "file:{{ graphene.runtimedir() }}/"
-sgx.trusted_files.bootstrap = "file:bootstrap"
-
 sgx.nonpie_binary = true
+
+sgx.trusted_files = [
+  "file:{{ graphene.runtimedir() }}/",
+  "file:bootstrap",
+]

--- a/LibOS/shim/test/regression/file_check_policy_allow_all_but_log.manifest.template
+++ b/LibOS/shim/test/regression/file_check_policy_allow_all_but_log.manifest.template
@@ -9,11 +9,19 @@ fs.mount.lib.type = "chroot"
 fs.mount.lib.path = "/lib"
 fs.mount.lib.uri = "file:{{ graphene.runtimedir() }}"
 
+sgx.nonpie_binary = true
 sgx.file_check_policy = "allow_all_but_log"
 
-sgx.trusted_files.runtime = "file:{{ graphene.runtimedir() }}/"
-sgx.trusted_files.file_check_policy = "file:file_check_policy"
+sgx.trusted_files = [
+  "file:{{ graphene.runtimedir() }}/",
+]
 
-sgx.trusted_files.test = "file:trusted_testfile"
+# below entry in sgx.trusted_files is to test TOML-table syntax without `sha256`
+[[sgx.trusted_files]]
+uri = "file:file_check_policy"
 
-sgx.nonpie_binary = true
+# below entry in sgx.trusted_files is for testing purposes (trusted_testfile has
+# hard-coded contents, so we can use pre-calculated SHA256 hash)
+[[sgx.trusted_files]]
+uri = "file:trusted_testfile"
+sha256 = "41dacdf1e6d0481d3b1ab1a91f93139db02b96f29cfdd3fb0b819ba1e33cafc4"

--- a/LibOS/shim/test/regression/file_check_policy_strict.manifest.template
+++ b/LibOS/shim/test/regression/file_check_policy_strict.manifest.template
@@ -9,11 +9,19 @@ fs.mount.lib.type = "chroot"
 fs.mount.lib.path = "/lib"
 fs.mount.lib.uri = "file:{{ graphene.runtimedir() }}"
 
+sgx.nonpie_binary = true
 sgx.file_check_policy = "strict"
 
-sgx.trusted_files.runtime = "file:{{ graphene.runtimedir() }}/"
-sgx.trusted_files.file_check_policy = "file:file_check_policy"
+sgx.trusted_files = [
+  "file:{{ graphene.runtimedir() }}/",
+]
 
-sgx.trusted_files.test = "file:trusted_testfile"
+# below entry in sgx.trusted_files is to test TOML-table syntax without `sha256`
+[[sgx.trusted_files]]
+uri = "file:file_check_policy"
 
-sgx.nonpie_binary = true
+# below entry in sgx.trusted_files is for testing purposes (trusted_testfile has
+# hard-coded contents, so we can use pre-calculated SHA256 hash)
+[[sgx.trusted_files]]
+uri = "file:trusted_testfile"
+sha256 = "41dacdf1e6d0481d3b1ab1a91f93139db02b96f29cfdd3fb0b819ba1e33cafc4"

--- a/LibOS/shim/test/regression/host_root_fs.manifest.template
+++ b/LibOS/shim/test/regression/host_root_fs.manifest.template
@@ -12,7 +12,9 @@ fs.mount.graphene_lib.type = "chroot"
 fs.mount.graphene_lib.path = "/lib"
 fs.mount.graphene_lib.uri = "file:{{ graphene.runtimedir() }}"
 
-sgx.trusted_files.runtime = "file:{{ graphene.runtimedir() }}/"
-sgx.trusted_files.host_root_fs = "file:{{ env.PWD }}/host_root_fs"
-
 sgx.nonpie_binary = true
+
+sgx.trusted_files = [
+  "file:{{ graphene.runtimedir() }}/",
+  "file:{{ env.PWD }}/host_root_fs",
+]

--- a/LibOS/shim/test/regression/init_fail.manifest.template
+++ b/LibOS/shim/test/regression/init_fail.manifest.template
@@ -13,7 +13,9 @@ fs.mount.test.type = "chroot"
 fs.mount.test.path = "/test"
 fs.mount.test.uri = "file:I_DONT_EXIST"
 
-sgx.trusted_files.runtime = "file:{{ graphene.runtimedir() }}/"
-sgx.trusted_files.init_fail = "file:init_fail"
-
 sgx.nonpie_binary = true
+
+sgx.trusted_files = [
+  "file:{{ graphene.runtimedir() }}/",
+  "file:init_fail",
+]

--- a/LibOS/shim/test/regression/init_fail2.manifest.template
+++ b/LibOS/shim/test/regression/init_fail2.manifest.template
@@ -8,11 +8,13 @@ fs.mount.lib.type = "chroot"
 fs.mount.lib.path = "/lib"
 fs.mount.lib.uri = "file:{{ graphene.runtimedir() }}"
 
-sgx.trusted_files.runtime = "file:{{ graphene.runtimedir() }}/"
-sgx.trusted_files.init_fail = "file:init_fail"
-
 sgx.nonpie_binary = true
 
 # this is an impossible combination of options, LibOS must fail very early in init process
 sgx.enclave_size = "256M"
 sys.brk.max_size = "512M"
+
+sgx.trusted_files = [
+  "file:{{ graphene.runtimedir() }}/",
+  "file:init_fail",
+]

--- a/LibOS/shim/test/regression/large_mmap.manifest.template
+++ b/LibOS/shim/test/regression/large_mmap.manifest.template
@@ -12,11 +12,14 @@ fs.mount.lib.type = "chroot"
 fs.mount.lib.path = "/lib"
 fs.mount.lib.uri = "file:{{ graphene.runtimedir() }}"
 
-sgx.trusted_files.runtime = "file:{{ graphene.runtimedir() }}/"
-sgx.trusted_files.large_mmap = "file:large_mmap"
-
-sgx.allowed_files.testfile = "file:testfile"
-
 sgx.enclave_size = "8G"
-
 sgx.nonpie_binary = true
+
+sgx.allowed_files = [
+  "file:testfile",
+]
+
+sgx.trusted_files = [
+  "file:{{ graphene.runtimedir() }}/",
+  "file:large_mmap",
+]

--- a/LibOS/shim/test/regression/manifest.template
+++ b/LibOS/shim/test/regression/manifest.template
@@ -22,17 +22,19 @@ fs.mount.bin.type = "chroot"
 fs.mount.bin.path = "/bin"
 fs.mount.bin.uri = "file:/bin"
 
-sgx.trusted_files.runtime = "file:{{ graphene.runtimedir() }}/"
-sgx.trusted_files.libgcc_s = "file:{{ arch_libdir }}/libgcc_s.so.1"
-sgx.trusted_files.libstdcxx = "file:/usr{{ arch_libdir }}/libstdc++.so.6"
-
-sgx.trusted_files.entrypoint = "file:{{ entrypoint }}"
-sgx.trusted_files.exec_victim = "file:exec_victim"
-
-sgx.allowed_files.tmp_dir = "file:tmp/"
-sgx.allowed_files.root = "file:root" # for getdents test
-sgx.allowed_files.testfile = "file:testfile" # for mmap_file test
-
 sgx.thread_num = 16
-
 sgx.nonpie_binary = true
+
+sgx.allowed_files = [
+  "file:tmp/",
+  "file:root", # for getdents test
+  "file:testfile", # for mmap_file test
+]
+
+sgx.trusted_files = [
+  "file:{{ graphene.runtimedir() }}/",
+  "file:{{ arch_libdir }}/libgcc_s.so.1",
+  "file:/usr{{ arch_libdir }}/libstdc++.so.6",
+  "file:{{ entrypoint }}",
+  "file:exec_victim",
+]

--- a/LibOS/shim/test/regression/multi_pthread.manifest.template
+++ b/LibOS/shim/test/regression/multi_pthread.manifest.template
@@ -7,11 +7,13 @@ fs.mount.lib.type = "chroot"
 fs.mount.lib.path = "/lib"
 fs.mount.lib.uri = "file:{{ graphene.runtimedir() }}"
 
-sgx.trusted_files.runtime = "file:{{ graphene.runtimedir() }}/"
-sgx.trusted_files.multi_pthread = "file:multi_pthread"
-
 # app runs with 4 parallel threads + Graphene has couple internal threads
 sgx.thread_num = 8
 
 sgx.nonpie_binary = true
 sgx.enable_stats = true
+
+sgx.trusted_files = [
+  "file:{{ graphene.runtimedir() }}/",
+  "file:multi_pthread",
+]

--- a/LibOS/shim/test/regression/multi_pthread_exitless.manifest.template
+++ b/LibOS/shim/test/regression/multi_pthread_exitless.manifest.template
@@ -7,12 +7,14 @@ fs.mount.lib.type = "chroot"
 fs.mount.lib.path = "/lib"
 fs.mount.lib.uri = "file:{{ graphene.runtimedir() }}"
 
-sgx.trusted_files.runtime = "file:{{ graphene.runtimedir() }}/"
-sgx.trusted_files.multi_pthread = "file:multi_pthread"
-
 # app runs with 4 parallel threads + Graphene has couple internal threads
 sgx.thread_num = 8
 sgx.rpc_thread_num = 8
 
 sgx.nonpie_binary = true
 sgx.enable_stats = true
+
+sgx.trusted_files = [
+  "file:{{ graphene.runtimedir() }}/",
+  "file:multi_pthread",
+]

--- a/LibOS/shim/test/regression/openmp.manifest.template
+++ b/LibOS/shim/test/regression/openmp.manifest.template
@@ -26,10 +26,10 @@ fs.mount.usrlib.path = "/usrlib"
 fs.mount.usrlib.uri = "file:/usr/{{ arch_libdir }}"
 
 sgx.thread_num = 32
-
-sgx.trusted_files.runtime = "file:{{ graphene.runtimedir() }}/"
-sgx.trusted_files.openmp = "file:openmp"
-
-sgx.trusted_files.libgomp_native = "file:/usr{{ arch_libdir }}/libgomp.so.1"
-
 sgx.nonpie_binary = true
+
+sgx.trusted_files = [
+  "file:{{ graphene.runtimedir() }}/",
+  "file:openmp",
+  "file:/usr{{ arch_libdir }}/libgomp.so.1",
+]

--- a/LibOS/shim/test/regression/rename.manifest.template
+++ b/LibOS/shim/test/regression/rename.manifest.template
@@ -12,9 +12,13 @@ fs.mount.tmpfs.type = "tmpfs"
 fs.mount.tmpfs.path = "/mnt/tmpfs"
 fs.mount.tmpfs.uri = "file:dummy-unused-by-tmpfs-uri"
 
-sgx.trusted_files.runtime = "file:{{ graphene.runtimedir() }}/"
-sgx.trusted_files.entrypoint = "file:{{ entrypoint }}"
-
-sgx.allowed_files.tmp_dir = "file:tmp/"
-
 sgx.nonpie_binary = true
+
+sgx.allowed_files = [
+  "file:tmp/",
+]
+
+sgx.trusted_files = [
+  "file:{{ graphene.runtimedir() }}/",
+  "file:{{ entrypoint }}",
+]

--- a/LibOS/shim/test/regression/test_libos.py
+++ b/LibOS/shim/test/regression/test_libos.py
@@ -267,6 +267,15 @@ class TC_02_OpenMP(RegressionTestCase):
     'This test is only meaningful on SGX PAL because file-check-policy is '
     'only relevant to SGX.')
 class TC_03_FileCheckPolicy(RegressionTestCase):
+    @classmethod
+    def setUpClass(cls):
+        with open('trusted_testfile', 'w') as f:
+            f.write('trusted_testfile')
+
+    @classmethod
+    def tearDownClass(cls):
+        os.remove('trusted_testfile')
+
     def test_000_strict_success(self):
         stdout, _ = self.run_binary(['file_check_policy_strict', 'read', 'trusted_testfile'])
         self.assertIn('file_check_policy succeeded', stdout)

--- a/LibOS/shim/test/regression/trusted_testfile
+++ b/LibOS/shim/test/regression/trusted_testfile
@@ -1,1 +1,0 @@
-trusted_testfile

--- a/Pal/regression/manifest.template
+++ b/Pal/regression/manifest.template
@@ -7,7 +7,13 @@ loader.insecure__use_cmdline_argv = true
 loader.pal_internal_mem_size = "64M"
 
 fs.mount.root.uri = "file:"
-sgx.trusted_files.entrypoint = "file:{{ entrypoint }}"
+
 sgx.nonpie_binary = true # all tests are currently non-PIE unless overridden
 
-sgx.allowed_files.to_send_tmp = "file:to_send.tmp" # for SendHandle test
+sgx.allowed_files = [
+  "file:to_send.tmp", # for SendHandle test
+]
+
+sgx.trusted_files = [
+  "file:{{ entrypoint }}",
+]

--- a/Pal/src/host/Linux-SGX/protected-files/README.rst
+++ b/Pal/src/host/Linux-SGX/protected-files/README.rst
@@ -18,9 +18,11 @@ Example
 
 ::
 
-   sgx.protected_files.pf_1 = "file:tmp/some_file"
-   sgx.protected_files.pf_2 = "file:tmp/some_dir"
-   sgx.protected_files.pf_3 = "file:tmp/another_dir/some_file"
+   sgx.protected_files = [
+     "file:tmp/some_file",
+     "file:tmp/some_dir",
+     "file:tmp/another_dir/some_file",
+   ]
 
 Paths specifying PF entries can be files or directories. If a directory is specified,
 all existing files/directories within are registered as protected recursively (and are expected

--- a/common/src/Makefile
+++ b/common/src/Makefile
@@ -138,15 +138,15 @@ uthash.patched: uthash.h
 	cp uthash.h ../include/uthash.h
 	touch $@
 
-TOML_COMMIT ?= 5be06807ad5f2230cad99e15380c4f4076c9dd83
+TOML_COMMIT ?= 208203af46bdbdb29ba199660ed78d09c220b6c5
 TOML_H_URI ?= \
 	https://raw.githubusercontent.com/cktan/tomlc99/$(TOML_COMMIT)/toml.h \
 	https://packages.grapheneproject.io/distfiles/tomlc99-$(TOML_COMMIT)/toml.h
-TOML_H_CHECKSUM ?= e79d6d272576561e1b46ee001b0dd6b554330843e6fc7c658a548c659f282ac5
+TOML_H_CHECKSUM ?= 2156347bb23ac717aaa1260eef34daeb87565fc2c647e2bc92fa691787fc210c
 TOML_C_URI ?= \
 	https://raw.githubusercontent.com/cktan/tomlc99/$(TOML_COMMIT)/toml.c \
 	https://packages.grapheneproject.io/distfiles/tomlc99-$(TOML_COMMIT)/toml.c
-TOML_C_CHECKSUM ?= c21a546ab767a7e40d4f65df179d70357059c15e4439e1980d791625655fbbc6
+TOML_C_CHECKSUM ?= 98115b4483f4c23f6f22b19f1fb86e2a0e3855c02aa1eed21d8a19f9afbc6c35
 
 toml.h:
 	../../Scripts/download --output $@ --sha256 $(TOML_H_CHECKSUM) $(foreach mirror,$(TOML_H_URI),--url $(mirror))

--- a/common/src/toml.patch
+++ b/common/src/toml.patch
@@ -1,5 +1,5 @@
 diff --git a/toml.c b/toml.c
-index 1db5a5bf3e8414cb105511155d5e053523eff1e2..674e03e9b25f5d4b96a31b820f389a3a43d0e631 100644
+index 8ec554e88ec772931aebcff615a6d9624ffacbe6..382fdeda573b6b9aa8402c66e960b4edcb2c7d65 100644
 --- a/toml.c
 +++ b/toml.c
 @@ -24,15 +24,7 @@
@@ -19,11 +19,10 @@ index 1db5a5bf3e8414cb105511155d5e053523eff1e2..674e03e9b25f5d4b96a31b820f389a3a
  #include "toml.h"
  
  
-@@ -1406,62 +1398,6 @@ fail:
- 	return 0;
+@@ -1447,61 +1439,6 @@ fail:
  }
  
--
+ 
 -toml_table_t* toml_parse_file(FILE* fp,
 -							  char* errbuf,
 -							  int errbufsz)
@@ -46,7 +45,7 @@ index 1db5a5bf3e8414cb105511155d5e053523eff1e2..674e03e9b25f5d4b96a31b820f389a3a
 -			buf = x;
 -			bufsz = xsz;
 -		}
--	
+-
 -		errno = 0;
 -		int n = fread(buf + off, 1, bufsz - off, fp);
 -		if (ferror(fp)) {
@@ -70,7 +69,7 @@ index 1db5a5bf3e8414cb105511155d5e053523eff1e2..674e03e9b25f5d4b96a31b820f389a3a
 -		buf = x;
 -		bufsz = xsz;
 -	}
--	buf[off] = 0; 
+-	buf[off] = 0;
 -
 -	/* parse it, cleanup and finish */
 -	toml_table_t* ret = toml_parse(buf, errbuf, errbufsz);
@@ -82,19 +81,7 @@ index 1db5a5bf3e8414cb105511155d5e053523eff1e2..674e03e9b25f5d4b96a31b820f389a3a
  static void xfree_kval(toml_keyval_t* p)
  {
  	if (!p) return;
-@@ -1893,11 +1829,7 @@ int toml_rtots(toml_raw_t src_, toml_timestamp_t* ret)
- 		if (*p == '.') {
- 			char* qq;
- 			p++;
--			errno = 0;
- 			*millisec = strtol(p, &qq, 0);
--			if (errno) {
--				return -1;
--			}
- 			while (*millisec > 999) {
- 				*millisec /= 10;
- 			}
-@@ -2020,72 +1952,19 @@ int toml_rtoi(toml_raw_t src, int64_t* ret_)
+@@ -2062,66 +1999,19 @@ int toml_rtoi(toml_raw_t src, int64_t* ret_)
  
  	/* Run strtoll on buf to get the integer */
  	char* endp;
@@ -108,13 +95,13 @@ index 1db5a5bf3e8414cb105511155d5e053523eff1e2..674e03e9b25f5d4b96a31b820f389a3a
  int toml_rtod_ex(toml_raw_t src, double* ret_, char* buf, int buflen)
  {
 -	if (!src) return -1;
--	
+-
 -	char* p = buf;
 -	char* q = p + buflen;
 -	const char* s = src;
 -	double dummy;
 -	double* ret = ret_ ? ret_ : &dummy;
--	
+-
 -
 -	/* allow +/- */
 -	if (s[0] == '+' || s[0] == '-')
@@ -124,10 +111,15 @@ index 1db5a5bf3e8414cb105511155d5e053523eff1e2..674e03e9b25f5d4b96a31b820f389a3a
 -	if (s[0] == '_')
 -		return -1;
 -
--	/* disallow +.99 */
--	if (s[0] == '.')
--		return -1;
--		
+-	/* decimal point, if used, must be surrounded by at least one digit on each side */
+-	{
+-		char* dot = strchr(s, '.');
+-		if (dot) {
+-			if (dot == s || !isdigit(dot[-1]) || !isdigit(dot[1]))
+-				return -1;
+-		}
+-	}
+-
 -	/* zero must be followed by . or 'e', or NUL */
 -	if (s[0] == '0' && s[1] && !strchr("eE.", s[1]))
 -		return -1;
@@ -135,27 +127,16 @@ index 1db5a5bf3e8414cb105511155d5e053523eff1e2..674e03e9b25f5d4b96a31b820f389a3a
 -	/* just strip underscores and pass to strtod */
 -	while (*s && p < q) {
 -		int ch = *s++;
--		switch (ch) {
--		case '.':
--			if (s[-2] == '_') return -1;
--			if (s[0] == '_') return -1;
--			break;
--		case '_':
+-		if (ch == '_') {
 -			// disallow '__'
--			if (s[0] == '_') return -1; 
+-			if (s[0] == '_') return -1;
+-			// disallow last char '_'
+-			if (s[0] == 0) return -1;
 -			continue;			/* skip _ */
--		default:
--			break;
 -		}
 -		*p++ = ch;
 -	}
 -	if (*s || p == q) return -1; /* reached end of string or buffer is full? */
--	
--	/* last char cannot be '_' */
--	if (s[-1] == '_') return -1;
--
--	if (p != buf && p[-1] == '.') 
--		return -1; /* no trailing zero */
 -
 -	/* cap with NUL */
 -	*p = 0;
@@ -174,8 +155,42 @@ index 1db5a5bf3e8414cb105511155d5e053523eff1e2..674e03e9b25f5d4b96a31b820f389a3a
  }
  
  int toml_rtod(toml_raw_t src, double* ret_)
+@@ -2240,33 +2130,6 @@ toml_datum_t toml_timestamp_at(const toml_array_t* arr, int idx)
+ 	return ret;
+ }
+ 
+-toml_datum_t toml_string_in(const toml_table_t* arr, const char* key)
+-{
+-	toml_datum_t ret;
+-	memset(&ret, 0, sizeof(ret));
+-	toml_raw_t raw = toml_raw_in(arr, key);
+-	if (raw) {
+-		ret.ok = (0 == toml_rtos(raw, &ret.u.s));
+-	}
+-	return ret;
+-}
+-
+-toml_datum_t toml_bool_in(const toml_table_t* arr, const char* key)
+-{
+-	toml_datum_t ret;
+-	memset(&ret, 0, sizeof(ret));
+-	ret.ok = (0 == toml_rtob(toml_raw_in(arr, key), &ret.u.b));
+-	return ret;
+-}
+-
+-toml_datum_t toml_int_in(const toml_table_t* arr, const char* key)
+-{
+-	toml_datum_t ret;
+-	memset(&ret, 0, sizeof(ret));
+-	ret.ok = (0 == toml_rtoi(toml_raw_in(arr, key), &ret.u.i));
+-	return ret;
+-}
+-
+ toml_datum_t toml_double_in(const toml_table_t* arr, const char* key)
+ {
+ 	toml_datum_t ret;
 diff --git a/toml.h b/toml.h
-index d541ec88b24283bb97050aa090f36e0aa7604d87..e7d5a40ed3781035e13d6a5003c05ee38f9a734a 100644
+index b91ef890303238e734f06bbfc95ab39b7851e031..735518d25d411d78ad417efb333683014c6d4c45 100644
 --- a/toml.h
 +++ b/toml.h
 @@ -26,7 +26,6 @@
@@ -186,17 +201,27 @@ index d541ec88b24283bb97050aa090f36e0aa7604d87..e7d5a40ed3781035e13d6a5003c05ee3
  #include <stdint.h>
  
  
-@@ -42,13 +41,6 @@ typedef struct toml_array_t toml_array_t;
- /* A raw value, must be processed by toml_rto* before using. */
- typedef const char* toml_raw_t;
+@@ -41,13 +40,6 @@ typedef struct toml_table_t toml_table_t;
+ typedef struct toml_array_t toml_array_t;
+ typedef struct toml_datum_t toml_datum_t;
  
--/* Parse a file. Return a table on success, or 0 otherwise. 
+-/* Parse a file. Return a table on success, or 0 otherwise.
 - * Caller must toml_free(the-return-value) after use.
 - */
--TOML_EXTERN toml_table_t* toml_parse_file(FILE* fp, 
+-TOML_EXTERN toml_table_t* toml_parse_file(FILE* fp,
 -										  char* errbuf,
 -										  int errbufsz);
 -
- /* Parse a string containing the full config. 
+ /* Parse a string containing the full config.
   * Return a table on success, or 0 otherwise.
   * Caller must toml_free(the-return-value) after use.
+@@ -110,9 +102,6 @@ TOML_EXTERN toml_table_t* toml_table_at(const toml_array_t* arr, int idx);
+ /* ... retrieve the key in table at keyidx. Return 0 if out of range. */
+ TOML_EXTERN const char* toml_key_in(const toml_table_t* tab, int keyidx);
+ /* ... retrieve values using key. */
+-TOML_EXTERN toml_datum_t toml_string_in(const toml_table_t* arr, const char* key);
+-TOML_EXTERN toml_datum_t toml_bool_in(const toml_table_t* arr, const char* key);
+-TOML_EXTERN toml_datum_t toml_int_in(const toml_table_t* arr, const char* key);
+ TOML_EXTERN toml_datum_t toml_double_in(const toml_table_t* arr, const char* key);
+ TOML_EXTERN toml_datum_t toml_timestamp_in(const toml_table_t* arr, const char* key);
+ /* .. retrieve array or table using key. */


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

This PR adds a new manifest syntax to define lists of SGX allowed, trusted, protected files. The previous syntax used TOML tables:

      sgx.trusted_files.file1 = "file:foo"
      sgx.trusted_files.file2 = "file:bar"

The new syntax uses TOML arrays:

      sgx.trusted_files = [ "file:foo", "file:bar" ]

The new syntax also allows to specify SHA256 hashes for a subset of trusted files (to skip hash generation during `graphene-sgx-sign`):

      [[sgx.trusted_files]]
      uri  = "file:trusted_testfile"
      sha256 = "c49a0aae384a14c8320f015ed5958d4402ba0726a31c4230cf772f76ff8aca2e"

The previous TOML-table syntax is still supported but deprecated. Graphene utility `graphene-sgx-sign` generates final SGX manifests using the new syntax, but `graphene-sgx` can still run old-syntax manifests.

All Graphene regression tests are updated to use the new syntax. **But all examples still use the old syntax** (to be fixed in next commits).

As a side effect, the TOML C library (`tomlc99`) is updated to the latest version -- it supports mixed TOML arrays.

Fixes #2593.

## How to test this PR? <!-- (if applicable) -->

All tests should pass. Since I updated Graphene tests to the new syntax, and left the examples with the old syntax, both syntaxes will be tested in CI and both must succeed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2644)
<!-- Reviewable:end -->
