### PR TITLE
[LibOS] Add optional app input and output redirection

### DIFF
--- a/LibOS/shim/test/regression/fork_and_exec.c
+++ b/LibOS/shim/test/regression/fork_and_exec.c
@@ -1,4 +1,6 @@
-#define _XOPEN_SOURCE 700
+#define _GNU_SOURCE
+#include <assert.h>
+#include <err.h>
 #include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -8,6 +10,23 @@
 
 int main(int argc, const char** argv, const char** envp) {
     pid_t child_pid;
+
+    char c = 0;
+    ssize_t x = read(0, &c, 1);
+    if (x < 0) {
+        err(1, "stdin read failed");
+    } else if (x != 1) {
+        assert(x == 0);
+        errx(1, "unexpected eof on stdin");
+    }
+    assert(c == 'a');
+    x = read(0, &c, 1);
+    if (x < 0) {
+        err(1, "stdin 2nd read failed");
+    }
+    if (x != 0) {
+        errx(1, "stdin read succeeded unexpectedly");
+    }
 
     /* duplicate STDOUT into newfd and pass it as exec_victim argument
      * (it will be inherited by exec_victim) */

--- a/LibOS/shim/test/regression/fork_and_exec.manifest.template
+++ b/LibOS/shim/test/regression/fork_and_exec.manifest.template
@@ -1,0 +1,42 @@
+loader.preload = "file:{{ graphene.libos }}"
+libos.entrypoint = "fork_and_exec"
+loader.argv0_override = "fork_and_exec"
+loader.env.LD_LIBRARY_PATH = "/lib:{{ arch_libdir }}:/usr/{{ arch_libdir }}"
+
+fs.mount.graphene_lib.type = "chroot"
+fs.mount.graphene_lib.path = "/lib"
+fs.mount.graphene_lib.uri = "file:{{ graphene.runtimedir() }}"
+
+fs.mount.host_lib.type = "chroot"
+fs.mount.host_lib.path = "{{ arch_libdir }}"
+fs.mount.host_lib.uri = "file:{{ arch_libdir }}"
+
+fs.mount.host_usr_lib.type = "chroot"
+fs.mount.host_usr_lib.path = "/usr/{{ arch_libdir }}"
+fs.mount.host_usr_lib.uri = "file:/usr/{{ arch_libdir }}"
+
+fs.mount.bin.type = "chroot"
+fs.mount.bin.path = "/bin"
+fs.mount.bin.uri = "file:/bin"
+
+fs.mount.stdin.type = "chroot"
+fs.mount.stdin.path = "fork_and_exec.stdin"
+fs.mount.stdin.uri = "file:fork_and_exec.stdin"
+
+libos.redirect.stdin = "fork_and_exec.stdin"
+libos.redirect.stdout = "fork_and_exec.stdout"
+libos.redirect.stderr = "fork_and_exec.stderr"
+
+sgx.trusted_files.runtime = "file:{{ graphene.runtimedir() }}/"
+sgx.trusted_files.libgcc_s = "file:{{ arch_libdir }}/libgcc_s.so.1"
+sgx.trusted_files.libstdcxx = "file:/usr{{ arch_libdir }}/libstdc++.so.6"
+
+sgx.trusted_files.entrypoint = "file:{{ entrypoint }}"
+sgx.trusted_files.exec_victim = "file:exec_victim"
+
+sgx.allowed_files.stdin = "file:fork_and_exec.stdin"
+sgx.allowed_files.stdout = "file:fork_and_exec.stdout"
+sgx.allowed_files.stderr = "file:fork_and_exec.stderr"
+
+sgx.thread_num = 8
+sgx.nonpie_binary = true

--- a/LibOS/shim/test/regression/test_libos.py
+++ b/LibOS/shim/test/regression/test_libos.py
@@ -124,11 +124,27 @@ class TC_01_Bootstrap(RegressionTestCase):
             self.assertIn(arg + '\n', stdout)
 
     def test_202_fork_and_exec(self):
-        stdout, _ = self.run_binary(['fork_and_exec'], timeout=60)
+        paths = ['fork_and_exec.stdin', 'fork_and_exec.stdout', 'fork_and_exec.stderr']
+        for path in paths:
+            if os.path.exists(path):
+               os.remove(path)
+        with open(paths[0], 'wb') as f:
+            f.write(b'a')
 
-        # fork and exec 2 page child binary
-        self.assertIn('child exited with status: 0', stdout)
-        self.assertIn('test completed successfully', stdout)
+        _, _ = self.run_binary(['fork_and_exec'], timeout=60)
+
+        with open(paths[1], 'rb') as f:
+            file_stdout = f.read()
+        with open(paths[2], 'rb') as f:
+            file_stderr = f.read()
+
+        for path in paths:
+            if os.path.exists(path):
+               os.remove(path)
+
+        self.assertIn(b'child exited with status: 0', file_stdout)
+        self.assertIn(b'test completed successfully', file_stdout)
+        self.assertEqual(b'', file_stderr)
 
     def test_203_vfork_and_exec(self):
         stdout, _ = self.run_binary(['vfork_and_exec'], timeout=60)


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->
New manifest keys are added: "libos.redirect.stdin", "libos.redirect.stdout" and "libos.redirect.stderr", which enable redirecting stdin, stdout and stderr (respectively). Values associated with those keys should be in-Graphene fs paths.

## How to test this PR? <!-- (if applicable) -->
`fork_and_exec` LibOS regression test was modified.