### PR TITLE
[Pal] Fix GCC -Wmaybe-uninitialized warning

### DIFF
--- a/Pal/src/db_rtld.c
+++ b/Pal/src/db_rtld.c
@@ -159,6 +159,7 @@ static struct link_map* map_elf_object_by_handle(PAL_HANDLE handle, enum object_
 
     int nloadcmds = 0;
     bool has_holes = false;
+    ElfW(Addr) mapend_prev = 0;
 
     /* The struct is initialized to zero so this is not necessary:
        l->l_ld = 0;
@@ -203,8 +204,10 @@ static struct link_map* map_elf_object_by_handle(PAL_HANDLE handle, enum object_
 
                 /* Determine whether there is a gap between the last segment
                    and this one.  */
-                if (nloadcmds > 1 && c[-1].mapend != c->mapstart)
+                if (nloadcmds > 1 && mapend_prev != c->mapstart)
                     has_holes = true;
+
+                mapend_prev = c->mapend;
 
                 /* Optimize a common case.  */
                 c->prot = 0;


### PR DESCRIPTION
Fixes a warning/error in Pal/src/db_rtld.c that prevents building
with GCC 11.1.0.

## Description of the changes

Trying to compile with `GCC 11.1.0` results in the following warning/error:

```
../Pal/src/db_rtld.c: In function ‘map_elf_object_by_handle.constprop’:
../Pal/src/db_rtld.c:206:43: error: ‘(((char *)c + 16))[461168601842738789].mapend’ may be used uninitialized [-Werror=maybe-uninitialized]
  206 |                 if (nloadcmds > 1 && c[-1].mapend != c->mapstart)
```

This pull request fixes that without making any changes in functionality.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2651)
<!-- Reviewable:end -->
