### PR TITLE
Fix GDB integration with non-C apps

### DIFF
--- a/Pal/gdb_integration/debug_map_gdb.py
+++ b/Pal/gdb_integration/debug_map_gdb.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# SPDX-License-Identifier: LGPL-3.0-or-later */
+# SPDX-License-Identifier: LGPL-3.0-or-later
 # Copyright (C) 2020 Intel Corporation
 #                    Paweł Marczewski <pawel@invisiblethingslab.com>
 

--- a/Pal/gdb_integration/language_gdb.py
+++ b/Pal/gdb_integration/language_gdb.py
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: LGPL-3.0-or-later
+# Copyright (C) 2021 Invisible Things Lab
+#                    Michał Kowalczyk <mkow@invisiblethingslab.com>
+
+# Commands for temporarily changing source language. Used by other Graphene GDB scripts to ensure
+# that a specific source language is used for parsing expressions - GDB interprets scripts using
+# the language taken from currently executing code, which may change in time, resulting in scripts
+# working only part of the time.
+#
+# Example: When a GDB script does `if *(uint16_t*)$rip == 0x1234` in a signal catchpoint then it
+# will fail with a syntax error if the binary debugged is written in Rust, but only if the signal
+# arrived while executing Rust code.
+
+import re
+
+import gdb # pylint: disable=import-error
+
+_g_languages = []
+
+
+class PushLanguage(gdb.Command):
+    """Temporarily change source language and save the old one"""
+
+    def __init__(self):
+        super().__init__('push-language', gdb.COMMAND_USER)
+
+    def invoke(self, arg, _from_tty):
+        self.dont_repeat()
+
+        lang_str = gdb.execute('show language', to_string=True).strip()
+        # ';' is for things like: "auto; currently c"
+        m = re.match(r'The current source language is "(.*?)[";]', lang_str)
+        assert m, 'Unexpected output from \'show language\': ' + lang_str
+        _g_languages.append(m.group(1))
+
+        gdb.execute('set language ' + arg)
+
+
+class PopLanguage(gdb.Command):
+    """Recover source language saved by PushLanguage"""
+
+    def __init__(self):
+        super().__init__('pop-language', gdb.COMMAND_USER)
+
+    def invoke(self, arg, _from_tty):
+        self.dont_repeat()
+
+        assert arg == ''
+        lang = _g_languages.pop()
+        gdb.execute('set language ' + lang)
+
+
+def main():
+    PushLanguage()
+    PopLanguage()
+
+
+if __name__ == '__main__':
+    main()

--- a/Pal/gdb_integration/pagination_gdb.py
+++ b/Pal/gdb_integration/pagination_gdb.py
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: LGPL-3.0-or-later */
+# SPDX-License-Identifier: LGPL-3.0-or-later
 # Copyright (C) 2020 Intel Corporation
 #                    Michał Kowalczyk <mkow@invisiblethingslab.com>
 #                    Paweł Marczewski <pawel@invisiblethingslab.com>
@@ -16,7 +16,7 @@ class PushPagination(gdb.Command):
     """Temporarily change pagination and save the old state"""
 
     def __init__(self):
-        super().__init__("push-pagination", gdb.COMMAND_USER)
+        super().__init__('push-pagination', gdb.COMMAND_USER)
 
     def invoke(self, arg, _from_tty):
         self.dont_repeat()
@@ -34,7 +34,7 @@ class PopPagination(gdb.Command):
     """Recover pagination state saved by PushPagination"""
 
     def __init__(self):
-        super().__init__("pop-pagination", gdb.COMMAND_USER)
+        super().__init__('pop-pagination', gdb.COMMAND_USER)
 
     def invoke(self, arg, _from_tty):
         self.dont_repeat()
@@ -49,5 +49,5 @@ def main():
     PopPagination()
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     main()

--- a/Pal/src/host/Linux-SGX/gdb_integration/graphene_sgx.gdb
+++ b/Pal/src/host/Linux-SGX/gdb_integration/graphene_sgx.gdb
@@ -1,9 +1,15 @@
-# SPDX-License-Identifier: LGPL-3.0-or-later */
+# SPDX-License-Identifier: LGPL-3.0-or-later
+# Copyright (C) 2021 Invisible Things Lab
+#                    Michał Kowalczyk <mkow@invisiblethingslab.com>
 # Copyright (C) 2021 Intel Corporation
 #                    Michał Kowalczyk <mkow@invisiblethingslab.com>
 #                    Paweł Marczewski <pawel@invisiblethingslab.com>
 
 # Graphene GDB configuration (Linux-SGX specific).
+
+# Without this GDB would interpret all the expressions below depending on the app code where it just
+# happened to stop.
+push-language c
 
 # Prevent the preloaded sgx_gdb.so from being preloaded to the debuggee.
 set env LD_PRELOAD=
@@ -26,6 +32,8 @@ condition $bpnum *(uint16_t*)$rip == 0xa20f || *(uint16_t*)$rip == 0x310f
 commands
     silent
 
+    push-language c
+
     # If we don't disable pagination then successive prints from this handler (even despite it's
     # called for different events) will stop and prompt the user for continuation, which is really
     # annoying.
@@ -39,5 +47,8 @@ commands
     end
 
     pop-pagination
+    pop-language
     continue
 end
+
+pop-language

--- a/Pal/src/host/Linux-SGX/gdb_integration/graphene_sgx_gdb.py
+++ b/Pal/src/host/Linux-SGX/gdb_integration/graphene_sgx_gdb.py
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: LGPL-3.0-or-later */
+# SPDX-License-Identifier: LGPL-3.0-or-later
 # Copyright (C) 2020 Intel Corporation
 #                    Michał Kowalczyk <mkow@invisiblethingslab.com>
 #                    Paweł Marczewski <pawel@invisiblethingslab.com>
@@ -9,15 +9,16 @@ import gdb # pylint: disable=import-error
 
 def main():
     for filename in [
+            'common/language_gdb.py',
             'common/pagination_gdb.py',
             'common/debug_map_gdb.py',
             'common/graphene.gdb',
             'graphene_sgx.gdb',
     ]:
-        print("[%s] Loading %s..." % (os.path.basename(__file__), filename))
+        print('[%s] Loading %s...' % (os.path.basename(__file__), filename))
         path = os.path.join(os.path.dirname(__file__), filename)
-        gdb.execute("source " + path)
+        gdb.execute('source ' + path)
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     main()

--- a/Pal/src/host/Linux/gdb_integration/graphene_linux_gdb.py
+++ b/Pal/src/host/Linux/gdb_integration/graphene_linux_gdb.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# SPDX-License-Identifier: LGPL-3.0-or-later */
+# SPDX-License-Identifier: LGPL-3.0-or-later
 # Copyright (C) 2020 Intel Corporation
 #                    Michał Kowalczyk <mkow@invisiblethingslab.com>
 
@@ -8,6 +8,7 @@ import gdb  # pylint: disable=import-error
 
 def main():
     for filename in [
+            'common/language_gdb.py',
             'common/pagination_gdb.py',
             'common/debug_map_gdb.py',
             'common/graphene.gdb',


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

I truly hate GDB :) It turns out that the scripts are interpreted with syntax which depends on the current *app* language. So, e.g. expressions in our signal handler in GDB script are parsed using C syntax if the signal happened when executing C code, but if the signal arrived in Rust code, then the expressions in same script code will be parsed as Rust...

## How to test this PR? <!-- (if applicable) -->

Try to debug a Rust application in Graphene.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2652)
<!-- Reviewable:end -->
