### PR TITLE
[Examples] pytorch: Fix permission denied error for python local libs…

### DIFF
--- a/Examples/pytorch/pytorch.manifest.template
+++ b/Examples/pytorch/pytorch.manifest.template
@@ -42,8 +42,8 @@ fs.mount.pip.path = "{{ env.HOME }}/.local/lib"
 fs.mount.pip.uri = "file:{{ env.HOME }}/.local/lib"
 
 sgx.nonpie_binary = true
-sgx.enclave_size = "4G"
-sgx.thread_num = 128
+sgx.enclave_size = "16G"
+sgx.thread_num = 256
 
 sgx.trusted_files.python = "file:{{ entrypoint }}"
 sgx.trusted_files.runtime = "file:{{ graphene.runtimedir() }}/"
@@ -53,7 +53,7 @@ sgx.trusted_files.python_dir = "file:{{ python.stdlib }}/"
 sgx.trusted_files.dist = "file:{{ python.distlib }}/"
 sgx.trusted_files.home_lib = "file:{{ env.HOME }}/.local/lib/"
 sgx.trusted_files.python_local_lib = "file:{{
-    python.get_path('stdlib', vars={'prefix': '/usr/local'}) }}"
+    python.get_path('stdlib', vars={'installed_base': '/usr/local'}) }}"
 
 sgx.trusted_files.script = "file:pytorchexample.py"
 sgx.trusted_files.classes = "file:classes.txt"
@@ -78,6 +78,7 @@ sgx.allowed_files.hosts = "file:/etc/hosts"
 sgx.allowed_files.gaiconf = "file:/etc/gai.conf"
 sgx.allowed_files.resolv = "file:/etc/resolv.conf"
 sgx.allowed_files.fstab = "file:/etc/fstab"
+sgx.allowed_files.result = "file:result.txt"
 
 # Graphene optionally provides patched OpenMP runtime library that runs faster
 # inside SGX enclaves (execute `make -C LibOS gcc` to generate it). Uncomment


### PR DESCRIPTION
… and result.txt in Graphene-SGX

Signed-off-by: Sonali Saha <sonali.saha@intel.com>

<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://graphene.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->
Fix permission denied error for python local libs. In manifest file python local libs paths are not populated correctly, used `installed_base` instead of `prefix` for `vars` parameter while getting the path using `sysconfig.getpath()`.
Please check https://github.com/python/cpython/blob/ebe7e6d86cf8f54d449d49866698d7f4c700cc7c/Lib/sysconfig.py#L28

Fix accessing `result.txt` is denied as the file is not trusted/allowed. Increased thread numbers and enclave size to run the application successfully.

Fixes #2643 
Fixes #2630
<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->

Build and run pytorch example according to the instructions
in https://github.com/oscarlab/graphene/blob/master/Examples/pytorch/README.md
Example application should run without error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2655)
<!-- Reviewable:end -->
