### PR TITLE
[Pal/Linux-SGX] Fix memory leak issues flagged by Klocwork

### DIFF
--- a/Pal/src/host/Linux-SGX/db_streams.c
+++ b/Pal/src/host/Linux-SGX/db_streams.c
@@ -150,8 +150,10 @@ static ssize_t handle_serialize(PAL_HANDLE handle, void** data) {
 
     size_t hdlsz = handle_size(handle);
     void* buffer = malloc(hdlsz + dsz1 + dsz2);
-    if (!buffer)
-        return -PAL_ERROR_NOMEM;
+    if (!buffer) {
+        ret = -PAL_ERROR_NOMEM;
+        goto out;
+    }
 
     /* copy into buffer all handle fields and then serialized fields */
     memcpy(buffer, handle, hdlsz);
@@ -159,11 +161,13 @@ static ssize_t handle_serialize(PAL_HANDLE handle, void** data) {
         memcpy(buffer + hdlsz, d1, dsz1);
     if (dsz2)
         memcpy(buffer + hdlsz + dsz1, d2, dsz2);
-
+out:
     if (free_d1)
         free((void*)d1);
     if (free_d2)
         free((void*)d2);
+    if (ret < 0)
+        return ret;
 
     *data = buffer;
     return hdlsz + dsz1 + dsz2;

--- a/Pal/src/host/Linux-SGX/sgx_process.c
+++ b/Pal/src/host/Linux-SGX/sgx_process.c
@@ -180,7 +180,10 @@ int sgx_init_child_process(int parent_pipe_fd, struct pal_sec* pal_sec, char** a
     *manifest_out = manifest;
     ret = 0;
 out:
-    if (ret < 0)
+    if (ret < 0) {
+        free(application_path);
         free(manifest);
+    }
+
     return ret;
 }


### PR DESCRIPTION
Following issues are addressed 

1)  Dynamic memory stored in 'application_path' allocated through function 'malloc' at line 161 can be lost at line 199 in 
     graphene/Pal/src/host/Linux-SGX/sgx_process.c | sgx_init_child_process()

2) Dynamic memory stored in 'd1' allocated through function '_DkStreamSecureSave' at line 139 can be  lost at line 153 in  
    graphene/Pal/src/host/Linux-SGX/db_streams.c | handle_serialize()

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2658)
<!-- Reviewable:end -->
