### PR TITLE
Stricten manifest size-str parsing

### DIFF
--- a/Documentation/manifest-syntax.rst
+++ b/Documentation/manifest-syntax.rst
@@ -220,7 +220,7 @@ Graphene loudly fails with "out of PAL memory" error. To run huge workloads,
 increase this limit by setting this option to e.g. ``64M`` (this would result in
 a total of 128MB used by Graphene for internal metadata). Note that this limit
 is included in ``sgx.enclave_size``, so if your enclave size is e.g. 512MB and
-you specify ``loader.pal_internal_mem_size = "64MB"``, then your application is
+you specify ``loader.pal_internal_mem_size = "64M"``, then your application is
 left with 384MB of usable memory.
 
 Stack size

--- a/LibOS/shim/src/fs/shim_fs.c
+++ b/LibOS/shim/src/fs/shim_fs.c
@@ -96,14 +96,14 @@ static int __mount_root(void) {
 
     ret = toml_string_in(g_manifest_root, "fs.root.type", &fs_root_type);
     if (ret < 0) {
-        log_error("Cannot parse 'fs.root.type' (the value must be put in double quotes!)");
+        log_error("Cannot parse 'fs.root.type'");
         ret = -EINVAL;
         goto out;
     }
 
     ret = toml_string_in(g_manifest_root, "fs.root.uri", &fs_root_uri);
     if (ret < 0) {
-        log_error("Cannot parse 'fs.root.uri' (the value must be put in double quotes!)");
+        log_error("Cannot parse 'fs.root.uri'");
         ret = -EINVAL;
         goto out;
     }
@@ -189,21 +189,21 @@ static int __mount_one_other(toml_table_t* mount) {
 
     ret = toml_rtos(mount_type_raw, &mount_type);
     if (ret < 0) {
-        log_error("Cannot parse 'fs.mount.%s.type' (the value must be put in double quotes!)", key);
+        log_error("Cannot parse 'fs.mount.%s.type'", key);
         ret = -EINVAL;
         goto out;
     }
 
     ret = toml_rtos(mount_path_raw, &mount_path);
     if (ret < 0) {
-        log_error("Cannot parse 'fs.mount.%s.path' (the value must be put in double quotes!)", key);
+        log_error("Cannot parse 'fs.mount.%s.path'", key);
         ret = -EINVAL;
         goto out;
     }
 
     ret = toml_rtos(mount_uri_raw, &mount_uri);
     if (ret < 0) {
-        log_error("Cannot parse 'fs.mount.%s.uri' (the value must be put in double quotes!)", key);
+        log_error("Cannot parse 'fs.mount.%s.uri'", key);
         ret = -EINVAL;
         goto out;
     }
@@ -350,7 +350,7 @@ int init_mount(void) {
     char* fs_start_dir = NULL;
     ret = toml_string_in(g_manifest_root, "fs.start_dir", &fs_start_dir);
     if (ret < 0) {
-        log_error("Can't parse 'fs.start_dir' (note that the value must be put in double quotes)!");
+        log_error("Can't parse 'fs.start_dir'");
         return ret;
     }
 

--- a/LibOS/shim/src/fs/shim_fs_mem.c
+++ b/LibOS/shim/src/fs/shim_fs_mem.c
@@ -7,12 +7,6 @@
 #include "shim_fs.h"
 #include "shim_fs_mem.h"
 
-#define OVERFLOWS(type, val)                        \
-    ({                                              \
-        type __dummy;                               \
-        __builtin_add_overflow((val), 0, &__dummy); \
-    })
-
 static int mem_file_resize(struct shim_mem_file* mem, size_t buf_size) {
     char* buf = malloc(buf_size);
     if (!buf)

--- a/LibOS/shim/src/shim_init.c
+++ b/LibOS/shim/src/shim_init.c
@@ -292,7 +292,7 @@ int init_stack(const char** argv, const char** envp, const char*** out_argp,
     ret = toml_sizestring_in(g_manifest_root, "sys.stack.size", get_rlimit_cur(RLIMIT_STACK),
                              &stack_size);
     if (ret < 0) {
-        log_error("Cannot parse \'sys.stack.size\' (the value must be put in double quotes!)");
+        log_error("Cannot parse 'sys.stack.size'");
         return -EINVAL;
     }
 

--- a/LibOS/shim/src/sys/shim_brk.c
+++ b/LibOS/shim/src/sys/shim_brk.c
@@ -48,7 +48,7 @@ int init_brk_region(void* brk_start, size_t data_segment_size) {
     ret = toml_sizestring_in(g_manifest_root, "sys.brk.max_size", DEFAULT_BRK_MAX_SIZE,
                              &brk_max_size);
     if (ret < 0) {
-        log_error("Cannot parse \'sys.brk.max_size\' (the value must be put in double quotes!)");
+        log_error("Cannot parse 'sys.brk.max_size'");
         return -EINVAL;
     }
 

--- a/Pal/include/pal_internal.h
+++ b/Pal/include/pal_internal.h
@@ -239,12 +239,10 @@ int _DkSetProtectedFilesKey(PAL_PTR pf_key_hex);
         _DkProcessExit(exitcode);                                                                \
     } while (0)
 
-#define INIT_FAIL_MANIFEST(exitcode, reason)                                                     \
-    do {                                                                                         \
-        log_error("PAL failed at parsing the manifest: %s\n"                                     \
-                  "  Graphene switched to the TOML format recently, please update the manifest\n"\
-                  "  (in particular, string values must be put in double quotes)", reason);      \
-        _DkProcessExit(exitcode);                                                                \
+#define INIT_FAIL_MANIFEST(exitcode, reason)                           \
+    do {                                                               \
+        log_error("PAL failed at parsing the manifest: %s", reason);   \
+        _DkProcessExit(exitcode);                                      \
     } while (0)
 
 /* Loading ELF binaries */

--- a/Pal/src/host/Linux-SGX/db_main.c
+++ b/Pal/src/host/Linux-SGX/db_main.c
@@ -682,9 +682,7 @@ noreturn void pal_linux_main(char* uptr_libpal_uri, size_t libpal_uri_len, char*
     char errbuf[256];
     toml_table_t* manifest_root = toml_parse(manifest_addr, errbuf, sizeof(errbuf));
     if (!manifest_root) {
-        log_error("PAL failed at parsing the manifest: %s\n"
-                  "  Graphene switched to the TOML format recently, please update the manifest\n"
-                  "  (in particular, string values must be put in double quotes)", errbuf);
+        log_error("PAL failed at parsing the manifest: %s", errbuf);
         ocall_exit(1, /*is_exitgroup=*/true);
     }
     g_pal_state.raw_manifest_data = manifest_addr;
@@ -694,7 +692,7 @@ noreturn void pal_linux_main(char* uptr_libpal_uri, size_t libpal_uri_len, char*
     ret = toml_bool_in(g_pal_state.manifest_root, "sgx.preheat_enclave", /*defaultval=*/false,
                        &preheat_enclave);
     if (ret < 0) {
-        log_error("Cannot parse \'sgx.preheat_enclave\' (the value must be `true` or `false`)");
+        log_error("Cannot parse 'sgx.preheat_enclave' (the value must be `true` or `false`)");
         ocall_exit(1, true);
     }
     if (preheat_enclave) {
@@ -705,8 +703,7 @@ noreturn void pal_linux_main(char* uptr_libpal_uri, size_t libpal_uri_len, char*
     ret = toml_sizestring_in(g_pal_state.manifest_root, "loader.pal_internal_mem_size",
                              /*defaultval=*/0, &g_pal_internal_mem_size);
     if (ret < 0) {
-        log_error("Cannot parse \'loader.pal_internal_mem_size\' "
-                  "(the value must be put in double quotes!)");
+        log_error("Cannot parse 'loader.pal_internal_mem_size'");
         ocall_exit(1, true);
     }
 

--- a/Pal/src/host/Linux-SGX/db_misc.c
+++ b/Pal/src/host/Linux-SGX/db_misc.c
@@ -491,7 +491,7 @@ int _DkAttestationQuote(const PAL_PTR user_report_data, PAL_NUM user_report_data
     char* ra_client_spid_str = NULL;
     ret = toml_string_in(g_pal_state.manifest_root, "sgx.ra_client_spid", &ra_client_spid_str);
     if (ret < 0) {
-        log_error("Cannot parse \'sgx.ra_client_spid\' (the value must be put in double quotes!)");
+        log_error("Cannot parse 'sgx.ra_client_spid'");
         return -PAL_ERROR_INVAL;
     }
 
@@ -505,7 +505,7 @@ int _DkAttestationQuote(const PAL_PTR user_report_data, PAL_NUM user_report_data
         is_epid = true;
 
         if (strlen(ra_client_spid_str) != sizeof(sgx_spid_t) * 2) {
-            log_error("Malformed \'sgx.ra_client_spid\' value in the manifest: %s",
+            log_error("Malformed 'sgx.ra_client_spid' value in the manifest: %s",
                       ra_client_spid_str);
             free(ra_client_spid_str);
             return -PAL_ERROR_INVAL;
@@ -514,7 +514,7 @@ int _DkAttestationQuote(const PAL_PTR user_report_data, PAL_NUM user_report_data
         for (size_t i = 0; i < strlen(ra_client_spid_str); i++) {
             int8_t val = hex2dec(ra_client_spid_str[i]);
             if (val < 0) {
-                log_error("Malformed \'sgx.ra_client_spid\' value in the manifest: %s",
+                log_error("Malformed 'sgx.ra_client_spid' value in the manifest: %s",
                           ra_client_spid_str);
                 free(ra_client_spid_str);
                 return -PAL_ERROR_INVAL;
@@ -526,7 +526,7 @@ int _DkAttestationQuote(const PAL_PTR user_report_data, PAL_NUM user_report_data
         ret = toml_bool_in(g_pal_state.manifest_root, "sgx.ra_client_linkable",
                            /*defaultval=*/false, &linkable);
         if (ret < 0) {
-            log_error("Cannot parse \'sgx.ra_client_linkable\' (the value must be `true` or "
+            log_error("Cannot parse 'sgx.ra_client_linkable' (the value must be `true` or "
                       "`false`)");
             free(ra_client_spid_str);
             return -PAL_ERROR_INVAL;

--- a/Pal/src/host/Linux-SGX/enclave_framework.c
+++ b/Pal/src/host/Linux-SGX/enclave_framework.c
@@ -623,7 +623,7 @@ static int init_trusted_files_from_toml_table(void) {
 
         ret = toml_rtos(toml_trusted_file_raw, &toml_trusted_file_str);
         if (ret < 0) {
-            log_error("Invalid trusted file in manifest: \'%s\'", toml_trusted_file_key);
+            log_error("Invalid trusted file in manifest: '%s'", toml_trusted_file_key);
             continue;
         }
 
@@ -709,7 +709,7 @@ static int init_allowed_files_from_toml_table(void) {
 
         ret = toml_rtos(toml_allowed_file_raw, &toml_allowed_file_str);
         if (ret < 0) {
-            log_error("Invalid allowed file in manifest: \'%s\'", toml_allowed_file_key);
+            log_error("Invalid allowed file in manifest: '%s'", toml_allowed_file_key);
             continue;
         }
 
@@ -788,8 +788,7 @@ int init_file_check_policy(void) {
     ret = toml_string_in(g_pal_state.manifest_root, "sgx.file_check_policy",
                          &file_check_policy_str);
     if (ret < 0) {
-        log_error("Cannot parse \'sgx.file_check_policy\' "
-                  "(the value must be put in double quotes!)");
+        log_error("Cannot parse 'sgx.file_check_policy'");
         return -PAL_ERROR_INVAL;
     }
 
@@ -801,7 +800,7 @@ int init_file_check_policy(void) {
     } else if (!strcmp(file_check_policy_str, "allow_all_but_log")) {
         set_file_check_policy(FILE_CHECK_POLICY_ALLOW_ALL_BUT_LOG);
     } else {
-        log_error("Unknown value for \'sgx.file_check_policy\' "
+        log_error("Unknown value for 'sgx.file_check_policy' "
                   "(allowed: `strict`, `allow_all_but_log`)'");
         free(file_check_policy_str);
         return -PAL_ERROR_INVAL;

--- a/Pal/src/host/Linux-SGX/enclave_pf.c
+++ b/Pal/src/host/Linux-SGX/enclave_pf.c
@@ -489,14 +489,13 @@ int init_protected_files(void) {
     ret = toml_string_in(g_pal_state.manifest_root, "sgx.protected_files_key",
                          &protected_files_key_str);
     if (ret < 0) {
-        log_error("Cannot parse \'sgx.protected_files_key\' "
-                  "(the value must be put in double quotes!)");
+        log_error("Cannot parse 'sgx.protected_files_key'");
         return -PAL_ERROR_INVAL;
     }
 
     if (protected_files_key_str) {
         if (strlen(protected_files_key_str) != PF_KEY_SIZE * 2) {
-            log_error("Malformed \'sgx.protected_files_key\' value in the manifest");
+            log_error("Malformed 'sgx.protected_files_key' value in the manifest");
             free(protected_files_key_str);
             return -PAL_ERROR_INVAL;
         }
@@ -505,7 +504,7 @@ int init_protected_files(void) {
         for (size_t i = 0; i < strlen(protected_files_key_str); i++) {
             int8_t val = hex2dec(protected_files_key_str[i]);
             if (val < 0) {
-                log_error("Malformed \'sgx.protected_files_key\' value in the manifest");
+                log_error("Malformed 'sgx.protected_files_key' value in the manifest");
                 free(protected_files_key_str);
                 return -PAL_ERROR_INVAL;
             }

--- a/Pal/src/host/Linux-SGX/sgx_main.c
+++ b/Pal/src/host/Linux-SGX/sgx_main.c
@@ -585,10 +585,7 @@ static int parse_loader_config(char* manifest, struct pal_enclave* enclave_info)
     char errbuf[256];
     manifest_root = toml_parse(manifest, errbuf, sizeof(errbuf));
     if (!manifest_root) {
-        log_error(
-            "PAL failed at parsing the manifest: %s\n"
-            "  Graphene switched to the TOML format recently, please update the manifest\n"
-            "  (in particular, string values must be put in double quotes)", errbuf);
+        log_error("PAL failed at parsing the manifest: %s", errbuf);
         ret = -EINVAL;
         goto out;
     }
@@ -596,7 +593,7 @@ static int parse_loader_config(char* manifest, struct pal_enclave* enclave_info)
     ret = toml_sizestring_in(manifest_root, "sgx.enclave_size", /*defaultval=*/0,
                              &enclave_info->size);
     if (ret < 0) {
-        log_error("Cannot parse 'sgx.enclave_size' (the value must be put in double quotes!)");
+        log_error("Cannot parse 'sgx.enclave_size'");
         ret = -EINVAL;
         goto out;
     }
@@ -702,7 +699,7 @@ static int parse_loader_config(char* manifest, struct pal_enclave* enclave_info)
 
     ret = toml_string_in(manifest_root, "sgx.ra_client_spid", &sgx_ra_client_spid_str);
     if (ret < 0) {
-        log_error("Cannot parse 'sgx.ra_client_spid' (the value must be put in double quotes!)");
+        log_error("Cannot parse 'sgx.ra_client_spid'");
         ret = -EINVAL;
         goto out;
     }

--- a/common/include/api.h
+++ b/common/include/api.h
@@ -65,6 +65,12 @@ typedef ptrdiff_t ssize_t;
 #define SATURATED_P_SUB(ptr_a, b, limit) \
     ((__typeof__(ptr_a))SATURATED_SUB((uintptr_t)(ptr_a), (uintptr_t)(b), (uintptr_t)(limit)))
 
+#define OVERFLOWS(type, val)                        \
+    ({                                              \
+        type __dummy;                               \
+        __builtin_add_overflow((val), 0, &__dummy); \
+    })
+
 #define IS_POWER_OF_2(x)          \
     ({                            \
         assert((x) != 0);         \
@@ -336,16 +342,16 @@ int get_norm_path(const char* path, char* buf, size_t* inout_size);
 int get_base_name(const char* path, char* buf, size_t* inout_size);
 
 /*!
- * \brief Parse a size (number with optional "G"/"M"/"K" suffix) into an unsigned long.
+ * \brief Parse a size (number with optional "G"/"M"/"K" suffix) into an uint64_t.
  *
  * \param str A string containing a non-negative number. The string may end with "G"/"g" suffix
  *            denoting value in GBs, "M"/"m" for MBs, or "K"/"k" for KBs.
+ * \param[out] out_val Parsed size (in bytes).
  *
- * By default the number should be decimal, but if it starts with 0x it is parsed as hexadecimal
- * and if it otherwise starts with 0, it is parsed as octal. Function returns -1 if string cannot
- * be parsed into a size (e.g., suffix is wrong).
+ * The number should be decimal. Returns -1 if string cannot be parsed into a size
+ * (e.g., suffix is wrong).
  */
-int64_t parse_size_str(const char* str);
+int parse_size_str(const char* str, uint64_t* out_val);
 
 /*!
  * \brief Check if a key was specified in TOML manifest.

--- a/common/src/string/toml_utils.c
+++ b/common/src/string/toml_utils.c
@@ -127,12 +127,13 @@ int toml_sizestring_in(const toml_table_t* root, const char* key, uint64_t defau
     }
     assert(str);
 
-    int64_t ret = parse_size_str(str);
+    uint64_t size;
+    int ret = parse_size_str(str, &size);
     free(str);
 
     if (ret < 0)
         return -1;
 
-    *retval = (uint64_t)ret;
+    *retval = size;
     return 0;
 }


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

And additionally remove some now-outdated warnings.

## How to test this PR? <!-- (if applicable) -->

Try putting invalid entries in the manifest and check if/how parsing fails.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2659)
<!-- Reviewable:end -->
