### PR TITLE
Fixes for warnings enabled by Meson

### DIFF
--- a/Pal/src/host/Linux-SGX/protected-files/lru_cache.c
+++ b/Pal/src/host/Linux-SGX/protected-files/lru_cache.c
@@ -138,7 +138,7 @@ void* lruc_get_first(lruc_context_t* lruc) {
     lruc->current = LISTP_FIRST_ENTRY(&lruc->list, /*unused*/ 0, list);
     lruc_map_node_t* mn = get_map_node(lruc, lruc->current->key);
     assert(mn != NULL);
-    return mn->data;
+    return mn ? mn->data : NULL;
 }
 
 void* lruc_get_next(lruc_context_t* lruc) {
@@ -151,7 +151,7 @@ void* lruc_get_next(lruc_context_t* lruc) {
 
     lruc_map_node_t* mn = get_map_node(lruc, lruc->current->key);
     assert(mn != NULL);
-    return mn->data;
+    return mn ? mn->data : NULL;
 }
 
 void* lruc_get_last(lruc_context_t* lruc) {
@@ -161,7 +161,7 @@ void* lruc_get_last(lruc_context_t* lruc) {
     lruc_list_node_t* ln = LISTP_LAST_ENTRY(&lruc->list, /*unused*/ 0, list);
     lruc_map_node_t* mn = get_map_node(lruc, ln->key);
     assert(mn != NULL);
-    return mn->data;
+    return mn ? mn->data : NULL;
 }
 
 void lruc_remove_last(lruc_context_t* lruc) {
@@ -172,7 +172,8 @@ void lruc_remove_last(lruc_context_t* lruc) {
     LISTP_DEL(ln, &lruc->list, list);
     lruc_map_node_t* mn = get_map_node(lruc, ln->key);
     assert(mn != NULL);
-    HASH_DEL(lruc->map, mn);
+    if (mn)
+        HASH_DEL(lruc->map, mn);
     free(ln);
     free(mn);
 }

--- a/Pal/src/host/Linux-SGX/tools/pf_tamper/pf_tamper.c
+++ b/Pal/src/host/Linux-SGX/tools/pf_tamper/pf_tamper.c
@@ -44,7 +44,7 @@ static void usage(void) {
     exit(-1); \
 } while (0)
 
-ssize_t g_input_size = 0;
+size_t g_input_size = 0;
 char* g_input_name = NULL;
 void* g_input_data = MAP_FAILED;
 char* g_output_dir = NULL;
@@ -444,11 +444,12 @@ int main(int argc, char* argv[]) {
         goto out;
     }
 
-    g_input_size = get_file_size(input_fd);
-    if (g_input_size < 0) {
+    ssize_t input_size = get_file_size(input_fd);
+    if (input_size < 0) {
         ERROR("Failed to stat input file '%s': %s\n", input_path, strerror(errno));
         goto out;
     }
+    g_input_size = input_size;
 
     g_input_data = mmap(NULL, g_input_size, PROT_READ, MAP_PRIVATE, input_fd, 0);
     if (g_input_data == MAP_FAILED) {

--- a/Pal/src/host/Linux-SGX/tools/ra-tls/secret_prov_attest.c
+++ b/Pal/src/host/Linux-SGX/tools/ra-tls/secret_prov_attest.c
@@ -335,7 +335,7 @@ __attribute__((constructor)) static void secret_provision_constructor(void) {
             if (fd < 0)
                 return;
 
-            ssize_t total_written = 0;
+            size_t total_written = 0;
             while (total_written < secret_len) {
                 ssize_t written = write(fd, secret + total_written, secret_len - total_written);
                 if (written > 0) {


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Split off from #2645. This fixes two small issues that surfaced due to us enabling additional warnings (`-Wsign-compare`, `-Wnull-dereference`).

## How to test this PR? <!-- (if applicable) -->

Jenkins should pass here, and in #2645 (which compiles this code with additional warnings enabled).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2668)
<!-- Reviewable:end -->
