### PR TITLE
[LibOS] Return -EISDIR on opening a directory with O_CREAT flag

### DIFF
--- a/LibOS/shim/src/fs/shim_namei.c
+++ b/LibOS/shim/src/fs/shim_namei.c
@@ -522,7 +522,8 @@ int open_namei(struct shim_handle* hdl, struct shim_dentry* start, const char* p
     assert(dent->state & DENTRY_VALID);
 
     if (dent->type == S_IFDIR) {
-        if (flags & O_WRONLY || flags & O_RDWR) {
+        if (flags & O_WRONLY || flags & O_RDWR ||
+                ((flags & O_CREAT) && !(flags & O_DIRECTORY) && !(flags & O_EXCL))) {
             ret = -EISDIR;
             goto err;
         }


### PR DESCRIPTION
## Description of the changes <!-- (reasons and measures) -->

Opening a directory with `O_CREAT` should fail with `-EISDIR` instead of success.
Fixes #2550.

## How to test this PR? <!-- (if applicable) -->

Follow the steps to reproduce mentioned in issue #2550.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oscarlab/graphene/2671)
<!-- Reviewable:end -->
