### PR TITLE
[LibOS] Report back the default permissions of a file consistently

### DIFF
--- a/LibOS/shim/src/fs/chroot/fs.c
+++ b/LibOS/shim/src/fs/chroot/fs.c
@@ -264,12 +264,9 @@ static int __query_attr(struct shim_dentry* dent, struct shim_file_data* data,
             BUG();
     }
 
-    mode_t perm = (pal_attr.readable ? S_IRUSR : 0) |
-                  (pal_attr.writable ? S_IWUSR : 0) |
-                  (pal_attr.runnable ? S_IXUSR : 0);
     if (dent) {
         dent->type = type;
-        dent->perm = perm;
+        dent->perm = pal_attr.share_flags & 0777;
     }
 
     __atomic_store_n(&data->size.counter, pal_attr.pending_size, __ATOMIC_SEQ_CST);


### PR DESCRIPTION
Signed-off-by: Sonali Saha <sonali.saha@intel.com>

<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://graphene.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->
Graphene created the file with default permissions (0755), but it reported different permissions 0700 as it includes only user permissions to the returned permissions. This fix includes group and other permissions to the file permissions returned.

Fixes #2543

<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

## How to test this PR? <!-- (if applicable) -->
Create a file with mode set as 0777 the permissions of this newly generated file will be 0755. Use stat to report back the file permissions it should report 0755 instead of 0700.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gramineproject/graphene/2686)
<!-- Reviewable:end -->
